### PR TITLE
[VNext][Protocol/Runtime] Implement first-class input modes and inbox semantics

### DIFF
--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -1418,6 +1418,7 @@ mod tests {
             Json(SubmitRequest {
                 op: Op::Input {
                     parts: vec![alan_protocol::ContentPart::text("hello")],
+                    mode: alan_protocol::InputMode::Steer,
                 },
             }),
         )
@@ -1431,8 +1432,9 @@ mod tests {
                 .unwrap()
                 .unwrap();
         match submission.op {
-            Op::Input { parts } => {
+            Op::Input { parts, mode } => {
                 assert_eq!(alan_protocol::parts_to_text(&parts), "hello");
+                assert_eq!(mode, alan_protocol::InputMode::Steer);
             }
             other => panic!("Unexpected op: {:?}", other),
         }
@@ -1783,5 +1785,26 @@ mod tests {
             parsed.partial_stream_recovery_mode,
             Some(alan_runtime::PartialStreamRecoveryMode::Off)
         );
+    }
+
+    #[test]
+    fn submit_request_parses_legacy_steer_alias_as_input_mode_steer() {
+        let payload = serde_json::json!({
+            "op": {
+                "type": "steer",
+                "parts": [
+                    { "type": "text", "text": "legacy steer payload" }
+                ]
+            }
+        });
+
+        let parsed: SubmitRequest = serde_json::from_value(payload).unwrap();
+        match parsed.op {
+            Op::Input { parts, mode } => {
+                assert_eq!(mode, alan_protocol::InputMode::Steer);
+                assert_eq!(alan_protocol::parts_to_text(&parts), "legacy steer payload");
+            }
+            other => panic!("unexpected op: {other:?}"),
+        }
     }
 }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,6 +11,6 @@ mod op;
 pub use content::{ContentPart, parts_to_text};
 pub use event::{Event, EventEnvelope, ToolDecisionAudit, YieldKind};
 pub use op::{
-    DynamicToolSpec, GovernanceConfig, GovernanceProfile, Op, PlanItem, PlanItemStatus,
+    DynamicToolSpec, GovernanceConfig, GovernanceProfile, InputMode, Op, PlanItem, PlanItemStatus,
     StructuredInputOption, StructuredInputQuestion, Submission, ToolCapability, TurnContext,
 };

--- a/crates/protocol/src/op.rs
+++ b/crates/protocol/src/op.rs
@@ -37,6 +37,19 @@ pub struct GovernanceConfig {
     pub policy_path: Option<String>,
 }
 
+/// Input handling mode for `Op::Input`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InputMode {
+    /// Inject guidance into the currently active execution.
+    #[default]
+    Steer,
+    /// Queue intent and execute immediately after current execution completes.
+    FollowUp,
+    /// Queue context for the next explicit `Op::Turn` only.
+    NextTurn,
+}
+
 /// Status for a plan item in transport-level progress updates.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -102,11 +115,15 @@ pub enum Op {
         context: Option<TurnContext>,
     },
 
-    /// Append user input within an existing turn (steering message).
-    /// The engine should not reset state, but buffer or inject the input.
+    /// Append user input with explicit routing semantics.
+    /// Legacy `type=steer` remains accepted as an alias.
+    #[serde(alias = "steer")]
     Input {
         /// User's input content parts.
         parts: Vec<ContentPart>,
+        /// Input routing mode (`steer`, `follow_up`, `next_turn`).
+        #[serde(default, skip_serializing_if = "is_default_input_mode")]
+        mode: InputMode,
     },
 
     /// Resume a suspended Yield request.
@@ -171,6 +188,10 @@ impl Submission {
             op,
         }
     }
+}
+
+fn is_default_input_mode(mode: &InputMode) -> bool {
+    matches!(mode, InputMode::Steer)
 }
 
 #[cfg(test)]
@@ -331,16 +352,67 @@ mod tests {
     fn test_op_serialization_input() {
         let op = Op::Input {
             parts: vec![ContentPart::text("follow up")],
+            mode: InputMode::Steer,
         };
 
         let json = serde_json::to_string(&op).unwrap();
         assert!(json.contains("input"));
         assert!(json.contains("follow up"));
+        assert!(!json.contains("\"mode\""));
 
         let deserialized: Op = serde_json::from_str(&json).unwrap();
         match deserialized {
-            Op::Input { parts } => assert_eq!(parts[0].as_text(), Some("follow up")),
+            Op::Input { parts, mode } => {
+                assert_eq!(parts[0].as_text(), Some("follow up"));
+                assert_eq!(mode, InputMode::Steer);
+            }
             _ => panic!("Expected Input variant"),
+        }
+    }
+
+    #[test]
+    fn test_op_serialization_input_with_mode_follow_up() {
+        let op = Op::Input {
+            parts: vec![ContentPart::text("after this")],
+            mode: InputMode::FollowUp,
+        };
+
+        let json = serde_json::to_string(&op).unwrap();
+        assert!(json.contains("\"mode\":\"follow_up\""));
+
+        let deserialized: Op = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            Op::Input { parts, mode } => {
+                assert_eq!(parts[0].as_text(), Some("after this"));
+                assert_eq!(mode, InputMode::FollowUp);
+            }
+            _ => panic!("Expected Input variant"),
+        }
+    }
+
+    #[test]
+    fn test_input_mode_defaults_to_steer_for_legacy_payload_without_mode() {
+        let json = r#"{"type":"input","parts":[{"type":"text","text":"legacy"}]}"#;
+        let parsed: Op = serde_json::from_str(json).unwrap();
+        match parsed {
+            Op::Input { parts, mode } => {
+                assert_eq!(parts[0].as_text(), Some("legacy"));
+                assert_eq!(mode, InputMode::Steer);
+            }
+            _ => panic!("Expected Input"),
+        }
+    }
+
+    #[test]
+    fn test_legacy_steer_alias_maps_to_input_mode_steer() {
+        let json = r#"{"type":"steer","parts":[{"type":"text","text":"legacy steer"}]}"#;
+        let parsed: Op = serde_json::from_str(json).unwrap();
+        match parsed {
+            Op::Input { parts, mode } => {
+                assert_eq!(parts[0].as_text(), Some("legacy steer"));
+                assert_eq!(mode, InputMode::Steer);
+            }
+            _ => panic!("Expected Input"),
         }
     }
 

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -1182,9 +1182,19 @@ mod tests {
 
     #[test]
     fn test_should_drive_turn_submission() {
-        // Input should be driven as turn
+        // steer/follow_up should be driven as turn
         assert!(should_drive_turn_submission(&Op::Input {
             parts: vec![alan_protocol::ContentPart::text("test")],
+            mode: alan_protocol::InputMode::Steer,
+        }));
+        assert!(should_drive_turn_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("test")],
+            mode: alan_protocol::InputMode::FollowUp,
+        }));
+        // next_turn should be queue-only, not immediate execution.
+        assert!(!should_drive_turn_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("test")],
+            mode: alan_protocol::InputMode::NextTurn,
         }));
 
         // Turn should be driven as turn

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -1,4 +1,4 @@
-use alan_protocol::{Event, Op};
+use alan_protocol::{Event, InputMode, Op, Submission};
 use anyhow::Result;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
@@ -103,30 +103,101 @@ where
                 return Ok(RuntimeOpAction::NoTurn);
             }
 
+            let queued_next_turn_inputs = state.turn_state.drain_next_turn_inputs();
+            let queued_next_turn_count = queued_next_turn_inputs.len();
+            let mut merged_parts = Vec::new();
+            for queued_parts in queued_next_turn_inputs {
+                merged_parts.extend(queued_parts);
+            }
+            merged_parts.extend(parts);
+
             state.turn_state.clear();
+
+            if queued_next_turn_count > 0 {
+                emit(Event::Warning {
+                    message: format!(
+                        "Applied {queued_next_turn_count} queued next_turn input(s) to this turn."
+                    ),
+                })
+                .await;
+            }
 
             return Ok(RuntimeOpAction::RunTurn {
                 turn_kind: TurnRunKind::NewTurn,
-                user_input: Some(parts),
+                user_input: Some(merged_parts),
                 activate_task: true,
             });
         }
 
-        Op::Input { parts } => {
-            if !(state.turn_state.is_turn_active() || state.turn_state.has_pending_interaction()) {
-                emit(Event::Error {
-                    message: "Input requires an active or pending turn. Use Op::Turn to start a new turn.".to_string(),
-                    recoverable: true,
-                })
-                .await;
-                return Ok(RuntimeOpAction::NoTurn);
-            }
+        Op::Input { parts, mode } => {
+            match mode {
+                InputMode::Steer => {
+                    if !(state.turn_state.is_turn_active()
+                        || state.turn_state.has_pending_interaction())
+                    {
+                        emit(Event::Error {
+                            message: "Input(mode=steer) requires an active or pending turn. Use Op::Turn to start a new turn.".to_string(),
+                            recoverable: true,
+                        })
+                        .await;
+                        return Ok(RuntimeOpAction::NoTurn);
+                    }
 
-            return Ok(RuntimeOpAction::RunTurn {
-                turn_kind: TurnRunKind::ResumeTurn,
-                user_input: Some(parts),
-                activate_task: false,
-            });
+                    return Ok(RuntimeOpAction::RunTurn {
+                        turn_kind: TurnRunKind::ResumeTurn,
+                        user_input: Some(parts),
+                        activate_task: false,
+                    });
+                }
+                InputMode::FollowUp => {
+                    if state.turn_state.is_turn_active()
+                        || state.turn_state.has_pending_interaction()
+                    {
+                        // In normal runtime flow this path should be handled by in-band queueing in
+                        // turn_driver. Keep this as a safe fallback.
+                        state
+                            .turn_state
+                            .push_buffered_inband_submission(Submission::new(Op::Input {
+                                parts,
+                                mode: InputMode::FollowUp,
+                            }));
+                        emit(Event::Warning {
+                            message: "Queued follow_up input for execution after current turn."
+                                .to_string(),
+                        })
+                        .await;
+                        return Ok(RuntimeOpAction::NoTurn);
+                    }
+
+                    return Ok(RuntimeOpAction::RunTurn {
+                        turn_kind: TurnRunKind::NewTurn,
+                        user_input: Some(parts),
+                        activate_task: true,
+                    });
+                }
+                InputMode::NextTurn => {
+                    let queued_size = state.turn_state.queue_next_turn_input(parts);
+                    match queued_size {
+                        Some(size) => {
+                            emit(Event::Warning {
+                                message: format!(
+                                    "Queued next_turn input (queue_size={size}); it will apply to the next explicit turn."
+                                ),
+                            })
+                            .await;
+                        }
+                        None => {
+                            emit(Event::Error {
+                                message: "Too many queued next_turn inputs (limit=16); dropping newest input."
+                                    .to_string(),
+                                recoverable: true,
+                            })
+                            .await;
+                        }
+                    }
+                    return Ok(RuntimeOpAction::NoTurn);
+                }
+            }
         }
 
         Op::Resume {
@@ -680,6 +751,7 @@ mod tests {
 
         let op = Op::Input {
             parts: vec![ContentPart::text("Hello world")],
+            mode: InputMode::Steer,
         };
 
         let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
@@ -1192,6 +1264,7 @@ mod tests {
 
         let op = Op::Input {
             parts: vec![ContentPart::text("follow up")],
+            mode: InputMode::Steer,
         };
 
         let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
@@ -1212,6 +1285,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_handle_follow_up_without_active_turn_starts_new_turn() {
+        let mut state = create_test_state();
+        let cancel = CancellationToken::new();
+        let mut events = vec![];
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let op = Op::Input {
+            parts: vec![ContentPart::text("run after current")],
+            mode: InputMode::FollowUp,
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            RuntimeOpAction::RunTurn {
+                turn_kind,
+                user_input,
+                activate_task,
+            } => {
+                assert!(matches!(turn_kind, TurnRunKind::NewTurn));
+                assert_eq!(
+                    user_input,
+                    Some(vec![ContentPart::text("run after current")])
+                );
+                assert!(activate_task);
+            }
+            _ => panic!("Expected RunTurn"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_next_turn_is_queue_only_and_applies_on_next_turn() {
+        let mut state = create_test_state();
+        let cancel = CancellationToken::new();
+        let mut events = vec![];
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let queue_op = Op::Input {
+            parts: vec![ContentPart::text("context for next turn")],
+            mode: InputMode::NextTurn,
+        };
+        let queue_result =
+            handle_runtime_op_with_cancel(&mut state, queue_op, &mut emit, &cancel).await;
+        assert!(queue_result.is_ok());
+        assert!(matches!(queue_result.unwrap(), RuntimeOpAction::NoTurn));
+        assert_eq!(state.turn_state.queued_next_turn_input_count(), 1);
+
+        let turn_op = Op::Turn {
+            parts: vec![ContentPart::text("explicit turn")],
+            context: None,
+        };
+        let turn_result = handle_runtime_op_with_cancel(&mut state, turn_op, &mut emit, &cancel)
+            .await
+            .unwrap();
+
+        match turn_result {
+            RuntimeOpAction::RunTurn {
+                turn_kind,
+                user_input,
+                activate_task,
+            } => {
+                assert!(matches!(turn_kind, TurnRunKind::NewTurn));
+                assert!(activate_task);
+                let merged_text = alan_protocol::parts_to_text(&user_input.unwrap());
+                assert!(merged_text.contains("context for next turn"));
+                assert!(merged_text.contains("explicit turn"));
+            }
+            _ => panic!("Expected RunTurn"),
+        }
+        assert_eq!(state.turn_state.queued_next_turn_input_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_next_turn_overflow_emits_recoverable_error() {
+        let mut state = create_test_state();
+        let cancel = CancellationToken::new();
+        let mut events = vec![];
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        for _ in 0..16 {
+            let result = handle_runtime_op_with_cancel(
+                &mut state,
+                Op::Input {
+                    parts: vec![ContentPart::text("queued")],
+                    mode: InputMode::NextTurn,
+                },
+                &mut emit,
+                &cancel,
+            )
+            .await
+            .unwrap();
+            assert!(matches!(result, RuntimeOpAction::NoTurn));
+        }
+
+        let overflow_result = handle_runtime_op_with_cancel(
+            &mut state,
+            Op::Input {
+                parts: vec![ContentPart::text("overflow")],
+                mode: InputMode::NextTurn,
+            },
+            &mut emit,
+            &cancel,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(overflow_result, RuntimeOpAction::NoTurn));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::Error { message, recoverable }
+                if *recoverable && message.contains("Too many queued next_turn inputs")
+        )));
+    }
+
+    #[tokio::test]
     async fn test_handle_input_op_during_active_turn_uses_resume_turn() {
         let mut state = create_test_state();
         state
@@ -1227,6 +1424,7 @@ mod tests {
 
         let op = Op::Input {
             parts: vec![ContentPart::text("steer current turn")],
+            mode: InputMode::Steer,
         };
 
         let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -1,4 +1,4 @@
-use alan_protocol::{Event, Op};
+use alan_protocol::{Event, InputMode, Op};
 use anyhow::Result;
 use serde_json::json;
 use std::time::Instant;
@@ -452,7 +452,10 @@ where
     let mut steering_inputs: Vec<Vec<crate::tape::ContentPart>> = Vec::new();
     while let Some(submission) = broker.try_recv().await {
         match submission.op {
-            Op::Input { parts } => steering_inputs.push(parts),
+            Op::Input {
+                parts,
+                mode: InputMode::Steer,
+            } => steering_inputs.push(parts),
             _ => state.turn_state.push_buffered_inband_submission(submission),
         }
     }

--- a/crates/runtime/src/runtime/turn_driver.rs
+++ b/crates/runtime/src/runtime/turn_driver.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, sync::Arc};
 
-use alan_protocol::{Event, Op, Submission};
+use alan_protocol::{Event, InputMode, Op, Submission};
 use anyhow::Result;
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
@@ -36,10 +36,10 @@ impl Default for TurnInputBroker {
 impl TurnInputBroker {
     pub(super) async fn push(&self, submission: Submission) -> bool {
         let mut guard = self.inner.queue.lock().await;
-        if matches!(submission.op, Op::Input { .. })
+        if is_brokered_input(&submission.op)
             && guard
                 .iter()
-                .filter(|queued| matches!(queued.op, Op::Input { .. }))
+                .filter(|queued| is_brokered_input(&queued.op))
                 .count()
                 >= MAX_BROKERED_INBAND_USER_INPUTS
         {
@@ -82,7 +82,14 @@ impl TurnInputBroker {
 }
 
 pub(super) fn should_drive_turn_submission(op: &Op) -> bool {
-    matches!(op, Op::Turn { .. } | Op::Input { .. })
+    matches!(
+        op,
+        Op::Turn { .. }
+            | Op::Input {
+                mode: InputMode::Steer | InputMode::FollowUp,
+                ..
+            }
+    )
 }
 
 pub(super) fn is_turn_resume_submission(op: &Op) -> bool {
@@ -90,7 +97,17 @@ pub(super) fn is_turn_resume_submission(op: &Op) -> bool {
 }
 
 pub(super) fn is_turn_inband_submission(op: &Op) -> bool {
-    is_turn_resume_submission(op) || matches!(op, Op::Input { .. })
+    is_turn_resume_submission(op) || is_brokered_input(op)
+}
+
+fn is_brokered_input(op: &Op) -> bool {
+    matches!(
+        op,
+        Op::Input {
+            mode: InputMode::Steer | InputMode::FollowUp,
+            ..
+        }
+    )
 }
 
 pub(super) async fn drive_turn_submission_with_cancel<E, F, S>(
@@ -138,7 +155,7 @@ where
                     break Some(incoming);
                 }
 
-                if matches!(incoming.op, Op::Input { .. })
+                if is_brokered_input(&incoming.op)
                     && state.turn_state.buffered_inband_user_input_count()
                         >= MAX_BUFFERED_INBAND_USER_INPUTS
                 {
@@ -207,6 +224,15 @@ mod tests {
     fn test_turn_submission_classification() {
         assert!(should_drive_turn_submission(&Op::Input {
             parts: vec![alan_protocol::ContentPart::text("hi")],
+            mode: InputMode::Steer,
+        }));
+        assert!(should_drive_turn_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("follow-up")],
+            mode: InputMode::FollowUp,
+        }));
+        assert!(!should_drive_turn_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("next-turn")],
+            mode: InputMode::NextTurn,
         }));
         assert!(should_drive_turn_submission(&Op::Turn {
             parts: vec![alan_protocol::ContentPart::text("hi")],
@@ -220,6 +246,15 @@ mod tests {
         }));
         assert!(is_turn_inband_submission(&Op::Input {
             parts: vec![alan_protocol::ContentPart::text("follow up")],
+            mode: InputMode::FollowUp,
+        }));
+        assert!(is_turn_inband_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("steer")],
+            mode: InputMode::Steer,
+        }));
+        assert!(!is_turn_inband_submission(&Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("next turn")],
+            mode: InputMode::NextTurn,
         }));
         assert!(is_turn_inband_submission(&Op::Resume {
             request_id: "latest".to_string(),
@@ -274,6 +309,7 @@ mod tests {
                     id: "sub-2".to_string(),
                     op: Op::Input {
                         parts: vec![alan_protocol::ContentPart::text("follow up")],
+                        mode: InputMode::Steer,
                     },
                 })
                 .await
@@ -309,6 +345,7 @@ mod tests {
                         id: format!("u-{idx}"),
                         op: Op::Input {
                             parts: vec![alan_protocol::ContentPart::text(format!("msg {idx}"))],
+                            mode: InputMode::Steer,
                         },
                     })
                     .await
@@ -321,6 +358,7 @@ mod tests {
                     id: "u-overflow".to_string(),
                     op: Op::Input {
                         parts: vec![alan_protocol::ContentPart::text("overflow")],
+                        mode: InputMode::Steer,
                     },
                 })
                 .await
@@ -348,6 +386,7 @@ mod tests {
             id: "u-1".to_string(),
             op: Op::Input {
                 parts: vec![alan_protocol::ContentPart::text("queued")],
+                mode: InputMode::Steer,
             },
         });
         assert!(

--- a/crates/runtime/src/runtime/turn_state.rs
+++ b/crates/runtime/src/runtime/turn_state.rs
@@ -2,7 +2,10 @@ use std::collections::{HashMap, VecDeque};
 
 use super::agent_loop::NormalizedToolCall;
 use crate::approval::{PendingConfirmation, PendingDynamicToolCall, PendingStructuredInputRequest};
+use crate::tape::ContentPart;
 use alan_protocol::Submission;
+
+const MAX_QUEUED_NEXT_TURN_INPUTS: usize = 16;
 
 #[derive(Debug, Clone)]
 pub(super) enum PendingYield {
@@ -29,6 +32,8 @@ pub(crate) struct TurnState {
     /// Submissions buffered during turn execution that need to be requeued
     /// after the turn completes (e.g., user input during tool execution).
     buffered_inband_submissions: VecDeque<Submission>,
+    /// Queued context for `InputMode::NextTurn`.
+    queued_next_turn_inputs: VecDeque<Vec<ContentPart>>,
 }
 
 impl TurnState {
@@ -42,6 +47,26 @@ impl TurnState {
         self.pending_order.clear();
         self.turn_activity = TurnActivityState::Idle;
         self.buffered_inband_submissions.clear();
+    }
+
+    /// Queue `next_turn` input parts. Returns `Some(new_len)` on success, `None` on overflow.
+    pub(crate) fn queue_next_turn_input(&mut self, parts: Vec<ContentPart>) -> Option<usize> {
+        if self.queued_next_turn_inputs.len() >= MAX_QUEUED_NEXT_TURN_INPUTS {
+            return None;
+        }
+        self.queued_next_turn_inputs.push_back(parts);
+        Some(self.queued_next_turn_inputs.len())
+    }
+
+    /// Drain queued `next_turn` input parts in FIFO order.
+    pub(crate) fn drain_next_turn_inputs(&mut self) -> VecDeque<Vec<ContentPart>> {
+        std::mem::take(&mut self.queued_next_turn_inputs)
+    }
+
+    /// Number of queued `next_turn` payloads.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn queued_next_turn_input_count(&self) -> usize {
+        self.queued_next_turn_inputs.len()
     }
 
     /// Drain all buffered inband submissions.
@@ -264,6 +289,7 @@ mod tests {
             id: "s1".to_string(),
             op: alan_protocol::Op::Input {
                 parts: vec![alan_protocol::ContentPart::text("one")],
+                mode: alan_protocol::InputMode::Steer,
             },
         });
         state.push_buffered_inband_submission(Submission {
@@ -301,6 +327,7 @@ mod tests {
             id: "s1".to_string(),
             op: alan_protocol::Op::Input {
                 parts: vec![alan_protocol::ContentPart::text("one")],
+                mode: alan_protocol::InputMode::Steer,
             },
         });
         state.push_buffered_inband_submission(Submission {
@@ -327,18 +354,57 @@ mod tests {
             id: "s1".to_string(),
             op: alan_protocol::Op::Input {
                 parts: vec![alan_protocol::ContentPart::text("one")],
+                mode: alan_protocol::InputMode::Steer,
             },
         });
         state.push_buffered_inband_submission(Submission {
             id: "s2".to_string(),
             op: alan_protocol::Op::Input {
                 parts: vec![alan_protocol::ContentPart::text("two")],
+                mode: alan_protocol::InputMode::Steer,
             },
         });
 
         let count = state.clear_buffered_inband_submissions();
         assert_eq!(count, 2);
         assert!(state.pop_buffered_inband_submission().is_none());
+    }
+
+    #[test]
+    fn test_queue_next_turn_inputs_fifo_and_drain() {
+        let mut state = TurnState::default();
+        assert_eq!(
+            state.queue_next_turn_input(vec![ContentPart::text("ctx-1")]),
+            Some(1)
+        );
+        assert_eq!(
+            state.queue_next_turn_input(vec![ContentPart::text("ctx-2")]),
+            Some(2)
+        );
+        assert_eq!(state.queued_next_turn_input_count(), 2);
+
+        let drained = state.drain_next_turn_inputs();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(alan_protocol::parts_to_text(&drained[0]), "ctx-1");
+        assert_eq!(alan_protocol::parts_to_text(&drained[1]), "ctx-2");
+        assert_eq!(state.queued_next_turn_input_count(), 0);
+    }
+
+    #[test]
+    fn test_queue_next_turn_inputs_overflow_is_rejected() {
+        let mut state = TurnState::default();
+        for _ in 0..MAX_QUEUED_NEXT_TURN_INPUTS {
+            assert!(
+                state
+                    .queue_next_turn_input(vec![ContentPart::text("queued")])
+                    .is_some()
+            );
+        }
+        assert!(
+            state
+                .queue_next_turn_input(vec![ContentPart::text("overflow")])
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add first-class `Op::Input.mode` (`steer | follow_up | next_turn`) with backward-compatible defaults
- keep legacy `type=steer` payload compatible via serde alias mapping
- implement runtime inbox behavior: `steer` interrupts current path, `follow_up` defers, `next_turn` queues until next explicit turn
- enforce bounded `next_turn` queue with observable overflow errors
- update tool-batch steering handling so only `mode=steer` can skip pending tools

## Compatibility
- mode-less `Op::Input` still defaults to `steer`
- legacy `type=steer` maps to `Op::Input { mode: steer }`

## Tests
- `cargo test -p alan-protocol`
- `cargo test -p alan-runtime`
- `cargo test -p alan`
- `cargo test --workspace`
- `cargo clippy -p alan-protocol -p alan-runtime -p alan --all-targets -- -D warnings`

Closes #1
Closes #2
