### PR TITLE
[VNext][Architecture] Finalize remote-control tracking plan for #9

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ These are the primary source of truth for runtime behavior.
 - `docs/spec/capability_router.md`
 - `docs/spec/extension_contract.md`
 - `docs/spec/harness_bridge.md`
+- `docs/spec/remote_control_architecture.md`
+- `docs/spec/remote_control_security.md`
 
 These documents define the VNext layering and rollout path.
 
@@ -55,5 +57,6 @@ Use these to align product decisions with Alan's operator model.
 ## 6) Maintainer Operations
 
 - `docs/maintainer/github_automation.md`
+- `docs/maintainer/remote_control_phased_plan.md`
 
 Use this for repository governance, GitHub automation, and contributor-ready setup.

--- a/docs/maintainer/remote_control_phased_plan.md
+++ b/docs/maintainer/remote_control_phased_plan.md
@@ -3,6 +3,13 @@
 > Owner issue: `#9`  
 > Goal: mobile/cloud remote control with governance-safe continuity.
 
+## Implementation Tracking Issues
+
+1. Phase A (Direct Remote): `#32`
+2. Phase B (Relay MVP): `#33`
+3. Phase C (Multi-Node Management): `#35`
+4. Phase D (Mobile Reliability + Notifications): `#34`
+
 ## Dependency Baseline
 
 Required foundations (already scoped in VNext issues):
@@ -22,6 +29,7 @@ Required foundations (already scoped in VNext issues):
 
 1. Remote client can create/submit/resume sessions directly against `alan-agentd`.
 2. Event stream and `events/read` reconnect path is stable for mobile links.
+3. Tracking issue: `#32`.
 
 ### Outputs
 
@@ -35,6 +43,7 @@ Required foundations (already scoped in VNext issues):
 
 1. Node maintains outbound tunnel to relay for NAT traversal.
 2. Client controls node via relay without execution-state authority shifting.
+3. Tracking issue: `#33` (depends on `#32`).
 
 ### Outputs
 
@@ -48,6 +57,7 @@ Required foundations (already scoped in VNext issues):
 
 1. One client can discover/switch/control multiple nodes.
 2. Node-scoped auth and audit stay explicit.
+3. Tracking issue: `#35` (depends on `#33`).
 
 ### Outputs
 
@@ -61,6 +71,7 @@ Required foundations (already scoped in VNext issues):
 
 1. Robust offline reconnect UX for approvals/resume.
 2. Push-style signaling for pending escalations/yields.
+3. Tracking issue: `#34` (depends on `#35`).
 
 ### Outputs
 
@@ -72,14 +83,14 @@ Required foundations (already scoped in VNext issues):
 
 | Track | Primary Artifact | Validation |
 | --- | --- | --- |
-| Architecture | `docs/spec/remote_control_architecture.md` | design review + harness scenarios |
-| Security | `docs/spec/remote_control_security.md` | scope/revocation tests |
-| Protocol | `docs/spec/app_server_protocol.md` extension notes | compatibility tests |
-| Reliability | harness autonomy + reconnect suites | CI + nightly |
+| Architecture | `docs/spec/remote_control_architecture.md` | `#32`/`#33` design review + harness scenarios |
+| Security | `docs/spec/remote_control_security.md` | `#32`/`#33` scope/revocation tests |
+| Protocol | `docs/spec/app_server_protocol.md` extension notes | `#32` compatibility tests |
+| Reliability | harness autonomy + reconnect suites | `#34` CI + nightly |
 
 ## Exit Criteria (for #9)
 
 1. Architecture and security docs are approved.
 2. Protocol extension notes are explicit and non-breaking.
-3. Phase-by-phase implementation plan is linked to milestone dependencies.
+3. Phase-by-phase implementation plan is linked to concrete tracking issues (`#32/#33/#35/#34`).
 4. Direct vs relay trade-offs are documented for execution planning.

--- a/docs/spec/remote_control_architecture.md
+++ b/docs/spec/remote_control_architecture.md
@@ -9,6 +9,15 @@
 3. Keep multi-client state consistent with replayable event semantics.
 4. Preserve policy/sandbox/yield invariants end-to-end.
 
+## Execution Tracks
+
+Implementation is tracked in phase issues linked to owner issue `#9`:
+
+1. `#32` Phase A: direct remote mode (node-exposed)
+2. `#33` Phase B: relay MVP (outbound tunnel)
+3. `#35` Phase C: multi-node management
+4. `#34` Phase D: mobile reliability + notifications
+
 ## Topology
 
 ### Components
@@ -22,6 +31,17 @@
 3. **Relay (optional)**
    - Routing layer for NAT traversal and intermittent links.
    - Never becomes execution source of truth.
+
+### Responsibility Matrix
+
+| Capability | Agent Node | Relay | Remote Client |
+| --- | --- | --- | --- |
+| Runtime execution | Authoritative | Not allowed | Not allowed |
+| Policy/sandbox enforcement | Authoritative | Not allowed | Not allowed |
+| Event ordering (`event_id`) | Authoritative | Transport only | Consumer |
+| Cursor replay decisions | Authoritative | Pass-through | Initiates requests |
+| Session control ops | Validates + applies | Routes | Initiates |
+| Auth scope re-validation | Required | Coarse pre-check | Provides credentials |
 
 ### Planes
 
@@ -130,3 +150,8 @@ This architecture supports issue acceptance targets by design:
 3. Gap handling determinism: event-id contract remains authoritative.
 4. Governance invariants: yield/resume remains node-validated.
 5. Direct vs relay trade-offs: documented above for phased rollout.
+
+Implementation sequencing and ownership for these acceptance targets is tracked in:
+
+1. `docs/maintainer/remote_control_phased_plan.md`
+2. Phase issues `#32`, `#33`, `#35`, and `#34`


### PR DESCRIPTION
## Summary
- finalize remote-control architecture tracking by linking concrete phase issues to owner issue #9
- add execution-track links and responsibility matrix in docs/spec/remote_control_architecture.md
- update docs/maintainer/remote_control_phased_plan.md with explicit issue mapping and dependency chain
- expose remote-control docs and phased plan in docs/README.md

## New tracking issues
- #32 Phase A: Direct Remote Mode
- #33 Phase B: Relay MVP
- #35 Phase C: Multi-Node Management
- #34 Phase D: Mobile Reliability + Notifications

## Validation
- cargo fmt --all -- --check

Refs #9
