### PR TITLE
[VNext][Remote Control][Phase D][1/3] Mobile reconnect + notification contracts

### DIFF
--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -221,6 +221,12 @@ Current fixture-backed executable scenarios in repository:
 7. `coding/recovery_dedupe`
 8. `coding/governance_boundary`
 
+Planned Phase D (remote mobile reliability) additions:
+
+1. `autonomy/mobile_reconnect_snapshot`
+2. `autonomy/mobile_notification_signal`
+3. `autonomy/mobile_flaky_network_recovery`
+
 ## Release Gate Recommendations
 
 Treat these as blocking checks:

--- a/docs/maintainer/remote_control_phased_plan.md
+++ b/docs/maintainer/remote_control_phased_plan.md
@@ -79,6 +79,7 @@ Required foundations (already scoped in VNext issues):
 1. Durable reconnect state snapshots for mobile clients.
 2. Notification trigger contracts (non-bypass, informational only).
 3. Nightly reliability regressions in harness.
+4. Primary reliability contract doc: `docs/spec/mobile_reliability_contract.md`.
 
 ## Tracking Matrix
 

--- a/docs/spec/app_server_protocol.md
+++ b/docs/spec/app_server_protocol.md
@@ -56,6 +56,7 @@ Provide a unified protocol layer for multi-client Alan frontends (TUI/Native/Web
 1. `events/stream` (real-time)
 2. `events/read` (compensating pull)
 3. `thread/read` (snapshot read)
+4. `reconnect_snapshot` (mobile reconnect handoff snapshot)
 
 ## Current API Mapping (Compatibility Layer)
 
@@ -159,10 +160,17 @@ Cross-node routing safeguards (relay multi-node mode):
 3. Relay should expose resolved routing decision (`x-alan-routed-node-id`) in proxied responses.
 4. Core turn/run semantics remain node-authoritative.
 
+Mobile reliability extension notes (Phase D):
+
+1. `reconnect_snapshot` response should expose `latest_submission_id` for reconnect dedupe hints.
+2. Pending-yield notifications are informational transport signals and do not change turn state.
+3. Any signal-driven follow-up still uses explicit `turn/resume` or `turn/input` operations.
+
 Related specs:
 
 1. `remote_control_architecture.md`
 2. `remote_control_security.md`
+3. `mobile_reliability_contract.md`
 
 ## Versioning Strategy
 

--- a/docs/spec/mobile_reliability_contract.md
+++ b/docs/spec/mobile_reliability_contract.md
@@ -1,0 +1,103 @@
+# Mobile Reliability + Notification Contract
+
+> Status: Phase D contract for remote mobile reconnect reliability.
+
+## Goals
+
+1. Reconnect should restore actionable session state without replaying side effects.
+2. Pending approval/yield states should be discoverable through explicit signal fields.
+3. Notification signals must be informational and never bypass governance boundaries.
+
+## Reconnect Snapshot API
+
+### Endpoints
+
+1. Direct mode:
+   - `GET /api/v1/sessions/{id}/reconnect_snapshot`
+2. Relay mode:
+   - `GET /api/v1/relay/nodes/{node_id}/api/v1/sessions/{id}/reconnect_snapshot`
+
+### Response Contract (normative)
+
+```json
+{
+  "session_id": "sess-1",
+  "workspace_id": "ws-abc",
+  "captured_at_ms": 1731000000000,
+  "replay": {
+    "oldest_event_id": "evt_0000000000001001",
+    "latest_event_id": "evt_0000000000001050",
+    "latest_submission_id": "sub-123",
+    "buffered_event_count": 50
+  },
+  "execution": {
+    "run_status": "yielded",
+    "next_action": "await_user_resume",
+    "resume_required": true,
+    "latest_checkpoint": {
+      "checkpoint_id": "cp-1",
+      "checkpoint_type": "yield",
+      "summary": "runtime yielded awaiting external input",
+      "created_at": "2026-03-05T10:00:00Z",
+      "payload": {
+        "request_id": "req-1",
+        "kind": "confirmation"
+      }
+    }
+  },
+  "notifications": {
+    "latest_signal_cursor": "cp-1",
+    "signals": [
+      {
+        "signal_id": "cp-1",
+        "signal_type": "pending_yield",
+        "request_id": "req-1",
+        "yield_kind": "confirmation",
+        "summary": "runtime yielded awaiting external input",
+        "created_at": "2026-03-05T10:00:00Z",
+        "informational": true
+      }
+    ]
+  }
+}
+```
+
+Field requirements:
+
+1. `latest_event_id` + `latest_submission_id` are dedupe hints for reconnecting clients.
+2. `resume_required=true` means only explicit resume operation can advance execution.
+3. `notifications.signals` may be empty; clients must tolerate sparse signal streams.
+
+## Notification Signal Contract
+
+Signals can be emitted via reconnect snapshot and future push channels. Initial signal types:
+
+1. `pending_yield`
+2. `pending_structured_input`
+3. `resume_failed`
+4. `gap_detected`
+
+Signal constraints:
+
+1. Stable `signal_id` for dedupe.
+2. `informational=true` is required in transport payload.
+3. Signal delivery loss is recoverable by reconnect snapshot read.
+
+## Non-Bypass Governance Rules
+
+1. Signals never authorize execution changes by themselves.
+2. Approval/resume still requires `Op::Resume` on node authority path.
+3. Token scopes and policy checks remain unchanged (`session.resume` is still required).
+4. Relay/client cannot convert notification delivery into implicit resume.
+
+## Harness Mapping
+
+Phase D reliability scenarios should validate this contract:
+
+1. `autonomy/mobile_reconnect_snapshot`
+   - reconnect snapshot reflects latest event/submission and pending yield state.
+2. `autonomy/mobile_notification_signal`
+   - pending yield appears as informational signal; no execution-state mutation.
+3. `autonomy/mobile_flaky_network_recovery`
+   - reconnect + gap compensation remain deterministic under packet loss.
+

--- a/docs/spec/remote_control_architecture.md
+++ b/docs/spec/remote_control_architecture.md
@@ -121,6 +121,27 @@ for each operation.
 
 This prevents silent cross-node misrouting and makes switch behavior deterministic/user-visible.
 
+## Phase D: Mobile Reliability + Notifications
+
+### Reconnect snapshot contract (Phase D)
+
+1. Add explicit reconnect snapshot endpoint:
+   - `GET /api/v1/sessions/{id}/reconnect_snapshot`
+   - relay form: `GET /api/v1/relay/nodes/{node_id}/api/v1/sessions/{id}/reconnect_snapshot`
+2. Snapshot must include dedupe hints (`latest_event_id`, `latest_submission_id`) and actionable
+   execution state (`run_status`, `next_action`, pending yield checkpoint details).
+3. Snapshot reads are side-effect free and must not re-drive runtime execution.
+
+### Notification signal contract (Phase D)
+
+1. Pending-yield/approval states must surface as informational notification signals.
+2. Signals are recovery-friendly (can be rebuilt from reconnect snapshot).
+3. Notification delivery cannot imply authorization or automatic resume.
+
+Primary contract doc:
+
+1. `docs/spec/mobile_reliability_contract.md`
+
 ## Session Binding and Reconnect
 
 ### Handshake (recommended)
@@ -204,3 +225,4 @@ Implementation sequencing and ownership for these acceptance targets is tracked 
 
 1. `docs/maintainer/remote_control_phased_plan.md`
 2. Phase issues `#32`, `#33`, `#35`, and `#34`
+3. `docs/spec/mobile_reliability_contract.md`

--- a/docs/spec/remote_control_security.md
+++ b/docs/spec/remote_control_security.md
@@ -74,6 +74,7 @@ Additive remote metadata headers accepted by the API surface:
 2. Yield escalation payloads are signed/traceable to originating node event.
 3. Resume decisions are tied to `request_id` + scoped principal.
 4. Replay/recovery paths use same authorization checks as live paths.
+5. Notification signals (Phase D) are informational and never sufficient to advance execution.
 
 ## Token Lifecycle
 
@@ -136,6 +137,14 @@ Each remote control decision should log:
 6. `resolved_by` (`human|policy|runtime`)
 7. `switch_mode` (`strict|force`) for relay multi-node session routing
 8. `bound_node_id/requested_node_id` on conflict or explicit switch
+9. `notification_signal_id/signal_type` when mobile reliability signals are emitted
+
+## Phase D Notification Security Rules
+
+1. Reconnect snapshot and notification reads are read-only operations.
+2. Client acknowledgement of a signal must not mutate run state.
+3. Any state-advancing action after notification still requires normal scoped op submission.
+4. `session.resume` remains mandatory for pending yield resolution.
 
 ## Revocation Flow (Recommended)
 


### PR DESCRIPTION
## Summary
- add Phase D primary contract doc for mobile reconnect reliability and notification signals
- define reconnect snapshot API contract (direct + relay), including dedupe fields and actionable execution state
- define notification signal semantics and non-bypass governance constraints
- link contract updates into architecture, security, protocol, phased-plan, and harness docs

## Scope
- docs-only stacked PR 1/3 for #34
- implementation PRs will stack on this branch

## Validation
- docs consistency review across related specs

Refs #34