### PR TITLE
feat(runtime): expose rollback as non-durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,10 +414,17 @@ curl -X POST http://localhost:8090/api/v1/sessions/{id}/resume
 # Fork session from latest rollout
 curl -X POST http://localhost:8090/api/v1/sessions/{id}/fork
 
-# Roll back in-memory turns
+# Roll back in-memory turns (non-durable; does not survive restart)
 curl -X POST http://localhost:8090/api/v1/sessions/{id}/rollback \
   -H "Content-Type: application/json" \
   -d '{"turns": 2}'
+# Response includes:
+# {
+#   "submission_id": "...",
+#   "accepted": true,
+#   "durability": {"durable": false, "scope": "in_memory"},
+#   "warning": "Rollback is in-memory only and will not survive runtime restart."
+# }
 
 # Trigger manual context compaction
 curl -X POST http://localhost:8090/api/v1/sessions/{id}/compact

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -59,7 +59,7 @@ The client uses the existing `/api/v1/sessions/*` compatibility layer:
 - `GET /sessions/{id}/events/read`: incremental event polling
 - `GET /sessions/{id}/read`: load session metadata + history
 - `POST /sessions/{id}/fork`: fork session
-- `POST /sessions/{id}/rollback`: rollback turns
+- `POST /sessions/{id}/rollback`: rollback turns (in-memory only; non-durable)
 - `POST /sessions/{id}/compact`: trigger compaction
 - `DELETE /sessions/{id}`: delete session
 

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -55,7 +55,7 @@ bun run dev
 | `/input <text>` | Append input to current turn (`Op::Input`) |
 | `/interrupt` | Interrupt current execution (`Op::Interrupt`) |
 | `/compact` | Trigger manual context compaction (`Op::Compact`) |
-| `/rollback <n>` | Roll back the most recent N turns (`Op::Rollback`) |
+| `/rollback <n>` | Roll back the most recent N turns in memory only (`Op::Rollback`) |
 | `/approve` | Approve pending confirmation |
 | `/reject` | Reject pending confirmation |
 | `/modify <text>` | Modify and continue |

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -52,6 +52,12 @@ pub struct SessionDurabilityInfo {
     pub required: bool,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct RollbackDurabilityInfo {
+    pub durable: bool,
+    pub scope: &'static str,
+}
+
 #[derive(Deserialize, Default)]
 pub struct CreateSessionRequest {
     /// Optional workspace directory override for this agent session (agentd-local path)
@@ -259,6 +265,8 @@ pub struct RollbackSessionRequest {
 pub struct RollbackSessionResponse {
     pub submission_id: String,
     pub accepted: bool,
+    pub durability: RollbackDurabilityInfo,
+    pub warning: String,
 }
 
 #[derive(Serialize)]
@@ -903,7 +911,7 @@ pub async fn compact_session(
     }))
 }
 
-/// Request in-memory rollback of the latest N turns for a session.
+/// Request in-memory, non-durable rollback of the latest N turns for a session.
 pub async fn rollback_session(
     State(state): State<AppState>,
     Path(session_id): Path<String>,
@@ -926,6 +934,11 @@ pub async fn rollback_session(
     Ok(Json(RollbackSessionResponse {
         submission_id: resp.submission_id,
         accepted: resp.accepted,
+        durability: RollbackDurabilityInfo {
+            durable: false,
+            scope: "in_memory",
+        },
+        warning: alan_runtime::ROLLBACK_NON_DURABLE_WARNING.to_string(),
     }))
 }
 
@@ -2439,6 +2452,9 @@ mod tests {
         .await
         .unwrap();
         assert!(resp.accepted);
+        assert!(!resp.durability.durable);
+        assert_eq!(resp.durability.scope, "in_memory");
+        assert_eq!(resp.warning, alan_runtime::ROLLBACK_NON_DURABLE_WARNING);
 
         let submission = submission_rx.recv().await.unwrap();
         match submission.op {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -44,5 +44,5 @@ pub use runtime::{
     AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeHandle, WorkspaceRuntimeConfig,
     spawn, spawn_with_llm_client,
 };
-pub use session::Session;
+pub use session::{ROLLBACK_NON_DURABLE_WARNING, Session};
 pub use tools::ToolRegistry;

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -1172,13 +1172,16 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(state.session.tape.messages().len(), 2);
-        assert_eq!(events.len(), 1);
-        match &events[0] {
-            Event::TextDelta { chunk, is_final } => {
-                assert!(*is_final);
-                assert!(chunk.contains("Rolled back 1 turn(s), removed 2 message(s)."));
-            }
-            other => panic!("Expected TextDelta, got {:?}", other),
-        }
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::TextDelta { chunk, is_final }
+                if *is_final && chunk.contains("Rolled back 1 turn(s), removed 2 message(s).")
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::Warning { message }
+                if message == crate::ROLLBACK_NON_DURABLE_WARNING
+        )));
     }
 }

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
+use crate::ROLLBACK_NON_DURABLE_WARNING;
 use crate::tape::ContentPart;
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState, maybe_compact_context};
@@ -78,6 +79,10 @@ where
                     "Rolled back {turns} turn(s), removed {removed_messages} message(s)."
                 ),
                 is_final: true,
+            })
+            .await;
+            emit(Event::Warning {
+                message: ROLLBACK_NON_DURABLE_WARNING.to_string(),
             })
             .await;
         }
@@ -1140,15 +1145,22 @@ mod tests {
 
         match result.unwrap() {
             RuntimeOpAction::NoTurn => {
-                // Verify rollback confirmation text was emitted
-                let has_event = events.iter().any(
+                let has_confirmation = events.iter().any(
                     |e| matches!(
                         e,
                         Event::TextDelta { chunk, is_final }
                             if *is_final && chunk.contains("Rolled back 1 turn(s), removed 2 message(s).")
                     ),
                 );
-                assert!(has_event);
+                assert!(has_confirmation);
+                let has_warning = events.iter().any(|e| {
+                    matches!(
+                        e,
+                        Event::Warning { message }
+                            if message == ROLLBACK_NON_DURABLE_WARNING
+                    )
+                });
+                assert!(has_warning);
             }
             _ => panic!("Expected NoTurn"),
         }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -11,6 +11,10 @@ use crate::rollout::{
 };
 use crate::tape::{ContextItem, ContextItemsDelta, Tape};
 
+/// Warning emitted when rollback succeeds but remains in-memory only.
+pub const ROLLBACK_NON_DURABLE_WARNING: &str =
+    "Rollback is in-memory only and will not survive runtime restart.";
+
 /// Represents a conversation/task session
 #[derive(Debug)]
 pub struct Session {
@@ -844,6 +848,9 @@ impl Session {
 
     /// Roll back the last `num_turns` user turns from in-memory context.
     ///
+    /// This mutation is intentionally non-durable: recovery from persisted rollout
+    /// history does not re-apply rollback markers to session state.
+    ///
     /// A "turn" is approximated as one user message plus any following assistant/tool
     /// messages until the next user message.
     pub fn rollback_last_turns(&mut self, num_turns: u32) -> usize {
@@ -886,7 +893,10 @@ impl Session {
             "session_rollback",
             serde_json::json!({
                 "num_turns": num_turns,
-                "removed_messages": removed
+                "removed_messages": removed,
+                "durable": false,
+                "scope": "in_memory",
+                "warning": ROLLBACK_NON_DURABLE_WARNING
             }),
         );
 
@@ -2410,6 +2420,38 @@ mod tests {
         let event_pos = content.find("\"event_type\":\"evt\"").unwrap();
         assert!(user_pos < assistant_pos);
         assert!(assistant_pos < event_pos);
+    }
+
+    #[tokio::test]
+    async fn test_rollback_records_non_durable_audit_marker() {
+        let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+
+        let mut session = Session::new_with_recorder_in_dir("gemini-2.0-flash", temp_dir.path())
+            .await
+            .unwrap();
+        session.add_user_message("u1");
+        session.add_assistant_message("a1", None);
+        session.add_user_message("u2");
+        session.add_assistant_message("a2", None);
+
+        let removed = session.rollback_last_turns(1);
+        assert_eq!(removed, 2);
+        session.flush().await;
+
+        let rollout_path = session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        let rollback_event = items.into_iter().find_map(|item| match item {
+            RolloutItem::Event(event) if event.event_type == "session_rollback" => Some(event),
+            _ => None,
+        });
+
+        let event = rollback_event.expect("expected session_rollback event");
+        assert_eq!(event.payload["durable"], serde_json::json!(false));
+        assert_eq!(event.payload["scope"], serde_json::json!("in_memory"));
+        assert_eq!(
+            event.payload["warning"],
+            serde_json::json!(ROLLBACK_NON_DURABLE_WARNING)
+        );
     }
 
     // Tests for payload truncation

--- a/docs/spec/app_server_protocol.md
+++ b/docs/spec/app_server_protocol.md
@@ -74,6 +74,7 @@ Compatibility notes:
 
 1. Legacy `turn/steer` can be treated as `turn/input{mode=steer}` alias.
 2. Legacy mode-less `Op::Input` defaults to `mode=steer`.
+3. `thread/rollback` is explicitly non-durable; compatibility responses surface `durability.durable=false` and an in-memory warning.
 
 ## Input Modes (First-Class Semantics)
 

--- a/docs/spec/durable_run_contract.md
+++ b/docs/spec/durable_run_contract.md
@@ -106,6 +106,7 @@ Suggested by effect type:
 
 1. Rollback updates rollback-safe context only; effect audit chain is immutable.
 2. Repeated post-rollback actions still go through idempotency checks.
+3. Rollback itself is non-durable: it changes in-memory context and audit markers, but does not survive runtime restart.
 
 ### Fork
 

--- a/docs/spec/execution_model.md
+++ b/docs/spec/execution_model.md
@@ -126,6 +126,7 @@ Constraints:
 ### `rollback`
 
 - Rolls back rollback-safe state for recent N turns.
+- Rollback is in-memory only and non-durable across runtime restart.
 - Must write auditable markers (no silent history rewrite).
 
 ## Concurrency and Queueing


### PR DESCRIPTION
## Summary
- expose rollback as explicitly non-durable in the daemon API response
- emit a runtime warning event and persist an auditable non-durable rollback marker
- align docs and client-facing README examples with in-memory-only rollback semantics

## Testing
- cargo fmt --all
- cargo test -p alan-runtime
- cargo test -p alan
- cargo clippy -p alan-runtime -p alan --all-targets --all-features -- -D warnings

Closes #46