### PR TITLE
fix(runtime): cache prompt assembly inputs

### DIFF
--- a/crates/runtime/src/prompts/assembler.rs
+++ b/crates/runtime/src/prompts/assembler.rs
@@ -2,13 +2,8 @@
 
 use crate::config::Config;
 use std::path::Path;
-use tracing::warn;
 
-use super::workspace::{ensure_workspace_bootstrap_files, load_workspace_bootstrap_files};
-
-const DEFAULT_BOOTSTRAP_MAX_CHARS: usize = 6_000;
-const BOOTSTRAP_HEAD_RATIO: f32 = 0.7;
-const BOOTSTRAP_TAIL_RATIO: f32 = 0.2;
+use super::workspace::render_workspace_persona_context;
 
 /// Build agent system prompt with proper assembly order:
 /// 1. Runtime Base (hard constraints - cannot be overridden)
@@ -16,7 +11,8 @@ const BOOTSTRAP_TAIL_RATIO: f32 = 0.2;
 /// 3. Domain Prompt (skills/domain overlays loaded dynamically)
 /// 4. Workspace Profile (persona files)
 pub fn build_agent_system_prompt(config: &Config, domain_prompt: &str) -> String {
-    build_agent_system_prompt_with_limit(config, domain_prompt, DEFAULT_BOOTSTRAP_MAX_CHARS, None)
+    let workspace_persona_dir = resolve_workspace_persona_dir_for_workspace(config, None);
+    build_agent_system_prompt_internal(domain_prompt, workspace_persona_dir.as_deref())
 }
 
 pub fn build_agent_system_prompt_for_workspace(
@@ -24,75 +20,43 @@ pub fn build_agent_system_prompt_for_workspace(
     domain_prompt: &str,
     workspace_dir: Option<&Path>,
 ) -> String {
-    build_agent_system_prompt_with_limit(
-        config,
-        domain_prompt,
-        DEFAULT_BOOTSTRAP_MAX_CHARS,
-        workspace_dir,
-    )
+    let workspace_persona_dir = resolve_workspace_persona_dir_for_workspace(config, workspace_dir);
+    build_agent_system_prompt_internal(domain_prompt, workspace_persona_dir.as_deref())
 }
 
-fn build_agent_system_prompt_with_limit(
+pub(crate) fn resolve_workspace_persona_dir_for_workspace(
     config: &Config,
+    workspace_dir: Option<&Path>,
+) -> Option<std::path::PathBuf> {
+    workspace_dir
+        .map(Path::to_path_buf)
+        .or_else(|| resolve_workspace_persona_dir_from_config(config))
+}
+
+pub(crate) fn build_agent_system_prompt_with_workspace_context(
     domain_prompt: &str,
-    max_chars: usize,
-    workspace_override: Option<&Path>,
+    workspace_context: Option<&str>,
 ) -> String {
     let mut prompt = String::new();
 
-    // Step 1: Runtime base (hard constraints - always first, cannot be overridden)
     append_prompt_section(&mut prompt, super::RUNTIME_BASE_PROMPT);
-
-    // Step 2: Main system prompt (identity + default behavior)
     append_prompt_section(&mut prompt, super::SYSTEM_PROMPT);
-
-    // Step 3: Domain prompt overlays (skills/context-specific instructions)
     append_prompt_section(&mut prompt, domain_prompt);
-
-    // Step 4: Workspace profile (persona files)
-    let workspace_dir = if let Some(path) = workspace_override {
-        if !path.exists() {
-            return prompt;
-        }
-        path.to_path_buf()
-    } else {
-        match ensure_workspace_bootstrap_files(config) {
-            Ok(Some(path)) => path,
-            Ok(None) => return prompt,
-            Err(err) => {
-                warn!(?err, "Failed to ensure workspace bootstrap files");
-                return prompt;
-            }
-        }
-    };
-
-    let files = load_workspace_bootstrap_files(&workspace_dir);
-    if files.is_empty() {
-        return prompt;
-    }
-
-    prompt.push_str("\n\n## Workspace Persona Context\n");
-    prompt.push_str(&format!("Workspace: {}\n", workspace_dir.display()));
-    prompt
-        .push_str("The following workspace files define the persona, role, and operating style.\n");
-
-    for file in files {
-        prompt.push_str(&format!("\n### {}\n", file.name));
-        if file.missing {
-            prompt.push_str(&format!("[MISSING] Expected at: {}\n", file.path.display()));
-            continue;
-        }
-        let content = file.content.unwrap_or_default();
-        let trimmed = trim_workspace_content(&content, file.name, max_chars);
-        if trimmed.is_empty() {
-            prompt.push_str("[EMPTY]\n");
-        } else {
-            prompt.push_str(trimmed.as_str());
-            prompt.push('\n');
-        }
+    if let Some(workspace_context) = workspace_context {
+        append_prompt_section(&mut prompt, workspace_context);
     }
 
     prompt
+}
+
+fn build_agent_system_prompt_internal(
+    domain_prompt: &str,
+    workspace_persona_dir: Option<&Path>,
+) -> String {
+    let workspace_context = workspace_persona_dir
+        .filter(|path| path.exists())
+        .map(render_workspace_persona_context);
+    build_agent_system_prompt_with_workspace_context(domain_prompt, workspace_context.as_deref())
 }
 
 fn append_prompt_section(prompt: &mut String, section: &str) {
@@ -107,33 +71,23 @@ fn append_prompt_section(prompt: &mut String, section: &str) {
     prompt.push_str(trimmed);
 }
 
-fn trim_workspace_content(content: &str, file_name: &str, max_chars: usize) -> String {
-    let trimmed = content.trim_end();
-    if trimmed.chars().count() <= max_chars {
-        return trimmed.to_string();
+fn resolve_workspace_persona_dir_from_config(config: &Config) -> Option<std::path::PathBuf> {
+    if let Some(path) = config.memory.workspace_dir.clone() {
+        let is_memory_dir = path
+            .file_name()
+            .map(|name| name == std::ffi::OsStr::new("memory"))
+            .unwrap_or(false);
+        if is_memory_dir {
+            return path.parent().map(|parent| parent.join("persona"));
+        }
+        return Some(path);
     }
 
-    let head_chars = ((max_chars as f32) * BOOTSTRAP_HEAD_RATIO).floor() as usize;
-    let tail_chars = ((max_chars as f32) * BOOTSTRAP_TAIL_RATIO).floor() as usize;
+    if cfg!(test) {
+        return None;
+    }
 
-    let head = take_chars(trimmed, head_chars);
-    let tail = take_last_chars(trimmed, tail_chars);
-    let marker = format!(
-        "\n[...truncated, read {} for full content...]\n...(truncated {}: kept {}+{} chars)...\n",
-        file_name, file_name, head_chars, tail_chars
-    );
-
-    format!("{}{}{}", head, marker, tail)
-}
-
-fn take_chars(input: &str, count: usize) -> String {
-    input.chars().take(count).collect()
-}
-
-fn take_last_chars(input: &str, count: usize) -> String {
-    let chars: Vec<char> = input.chars().collect();
-    let start = chars.len().saturating_sub(count);
-    chars[start..].iter().collect()
+    dirs::home_dir().map(|home| home.join(".alan/persona"))
 }
 
 #[cfg(test)]
@@ -157,19 +111,17 @@ mod tests {
 
         let prompt = build_agent_system_prompt(&config, "Domain Prompt");
 
-        // Should include runtime base
         assert!(prompt.contains("Runtime Base Constraints"));
         assert!(prompt.contains("No Self-Modification"));
-        // Should include system prompt
         assert!(prompt.contains("Alan System Prompt"));
-        // Should include domain
-        assert!(prompt.contains("Domain Prompt")); // Skills content
+        assert!(prompt.contains("Domain Prompt"));
     }
 
     #[test]
     fn test_build_agent_system_prompt_injects_workspace_context() {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);
+        crate::prompts::ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
 
         let prompt = build_agent_system_prompt(&config, "Domain Prompt");
 
@@ -183,6 +135,7 @@ mod tests {
     fn test_build_agent_system_prompt_uses_existing_workspace_file_content() {
         let temp_dir = TempDir::new().unwrap();
         fs::create_dir_all(temp_dir.path()).unwrap();
+        crate::prompts::ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
         fs::write(
             temp_dir.path().join("SOUL.md"),
             "custom persona instructions",
@@ -198,12 +151,15 @@ mod tests {
     #[test]
     fn test_build_agent_system_prompt_truncates_large_workspace_content() {
         let temp_dir = TempDir::new().unwrap();
-        let config = test_config_with_workspace(&temp_dir);
-        fs::create_dir_all(temp_dir.path()).unwrap();
-        let large = "a".repeat(2000);
+        crate::prompts::ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
+        let large = "a".repeat(10_000);
         fs::write(temp_dir.path().join("ROLE.md"), large).unwrap();
 
-        let prompt = build_agent_system_prompt_with_limit(&config, "Domain Prompt", 120, None);
+        let workspace_context = render_workspace_persona_context(temp_dir.path());
+        let prompt = build_agent_system_prompt_with_workspace_context(
+            "Domain Prompt",
+            Some(&workspace_context),
+        );
 
         assert!(prompt.contains("[...truncated, read ROLE.md for full content...]"));
     }
@@ -212,28 +168,31 @@ mod tests {
     fn test_prompt_assembly_order() {
         let temp_dir = TempDir::new().unwrap();
         fs::create_dir_all(temp_dir.path()).unwrap();
+        crate::prompts::ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
         fs::write(temp_dir.path().join("SOUL.md"), "SOUL content").unwrap();
 
         let config = test_config_with_workspace(&temp_dir);
         let prompt = build_agent_system_prompt(&config, "DOMAIN content");
 
-        // Runtime base should come first, followed by system, domain, and workspace.
         let runtime_base_pos = prompt.find("Runtime Base Constraints").unwrap();
         let system_pos = prompt.find("Alan System Prompt").unwrap();
         let skills_pos = prompt.find("DOMAIN content").unwrap();
         let workspace_pos = prompt.find("Workspace Persona Context").unwrap();
 
-        assert!(
-            runtime_base_pos < system_pos,
-            "Runtime base should come before system prompt"
-        );
-        assert!(
-            system_pos < skills_pos,
-            "System prompt should come before domain prompt"
-        );
-        assert!(
-            skills_pos < workspace_pos,
-            "Domain prompt should come before workspace"
-        );
+        assert!(runtime_base_pos < system_pos);
+        assert!(system_pos < skills_pos);
+        assert!(skills_pos < workspace_pos);
+    }
+
+    #[test]
+    fn test_build_agent_system_prompt_does_not_create_workspace_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = test_config_with_workspace(&temp_dir);
+
+        let prompt = build_agent_system_prompt(&config, "Domain Prompt");
+
+        assert!(!prompt.contains("Workspace Persona Context"));
+        assert!(!temp_dir.path().join("SOUL.md").exists());
+        assert!(!temp_dir.path().join("ROLE.md").exists());
     }
 }

--- a/crates/runtime/src/prompts/mod.rs
+++ b/crates/runtime/src/prompts/mod.rs
@@ -7,9 +7,12 @@ mod assembler;
 mod loader;
 mod workspace;
 
+pub(crate) use assembler::build_agent_system_prompt_with_workspace_context;
+pub(crate) use assembler::resolve_workspace_persona_dir_for_workspace;
 pub use assembler::{build_agent_system_prompt, build_agent_system_prompt_for_workspace};
 pub use loader::PromptLoader;
 pub use workspace::ensure_workspace_bootstrap_files_at;
+pub(crate) use workspace::{render_workspace_persona_context, workspace_persona_tracked_paths};
 
 // ============================================================================
 // Compile-time embedded prompts

--- a/crates/runtime/src/prompts/workspace.rs
+++ b/crates/runtime/src/prompts/workspace.rs
@@ -1,6 +1,5 @@
 //! Workspace bootstrap file management for prompt assembly.
 
-use crate::config::Config;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -13,6 +12,10 @@ pub const DEFAULT_USER_FILENAME: &str = "USER.md";
 pub const DEFAULT_TOOLS_FILENAME: &str = "TOOLS.md";
 pub const DEFAULT_HEARTBEAT_FILENAME: &str = "HEARTBEAT.md";
 pub const DEFAULT_BOOTSTRAP_FILENAME: &str = "BOOTSTRAP.md";
+pub(crate) const WORKSPACE_PERSONA_MAX_CHARS: usize = 6_000;
+
+const BOOTSTRAP_HEAD_RATIO: f32 = 0.7;
+const BOOTSTRAP_TAIL_RATIO: f32 = 0.2;
 
 #[derive(Debug, Clone)]
 struct WorkspaceTemplate {
@@ -60,14 +63,6 @@ pub struct WorkspaceBootstrapFile {
     pub missing: bool,
 }
 
-pub fn ensure_workspace_bootstrap_files(config: &Config) -> io::Result<Option<PathBuf>> {
-    let Some(workspace_persona_dir) = resolve_workspace_persona_dir(config) else {
-        return Ok(None);
-    };
-    ensure_workspace_bootstrap_files_at(&workspace_persona_dir)?;
-    Ok(Some(workspace_persona_dir))
-}
-
 pub fn ensure_workspace_bootstrap_files_at(workspace_dir: &Path) -> io::Result<()> {
     fs::create_dir_all(workspace_dir)?;
 
@@ -112,33 +107,47 @@ pub fn load_workspace_bootstrap_files(workspace_dir: &Path) -> Vec<WorkspaceBoot
     files
 }
 
-fn resolve_workspace_persona_dir(config: &Config) -> Option<PathBuf> {
-    if let Some(path) = config.memory.workspace_dir.clone() {
-        let is_memory_dir = path
-            .file_name()
-            .map(|name| name == std::ffi::OsStr::new("memory"))
-            .unwrap_or(false);
-        if is_memory_dir {
-            return path.parent().map(|parent| parent.join("persona"));
-        }
-        // Backward-friendly fallback for callers that already pass persona dir directly.
-        return Some(path);
-    }
-
-    // Avoid writing to the real home directory for tests unless explicitly configured.
-    if cfg!(test) {
-        return None;
-    }
-
-    Some(default_workspace_alan_dir().join("persona"))
+pub(crate) fn workspace_persona_tracked_paths(workspace_dir: &Path) -> Vec<PathBuf> {
+    vec![
+        workspace_dir.join(DEFAULT_AGENTS_FILENAME),
+        workspace_dir.join(DEFAULT_SOUL_FILENAME),
+        workspace_dir.join(DEFAULT_ROLE_FILENAME),
+        workspace_dir.join(DEFAULT_USER_FILENAME),
+        workspace_dir.join(DEFAULT_TOOLS_FILENAME),
+        workspace_dir.join(DEFAULT_HEARTBEAT_FILENAME),
+        workspace_dir.join(DEFAULT_BOOTSTRAP_FILENAME),
+    ]
 }
 
-fn default_workspace_alan_dir() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        home.join(".alan")
-    } else {
-        PathBuf::from(".alan")
+pub(crate) fn render_workspace_persona_context(workspace_dir: &Path) -> String {
+    let files = load_workspace_bootstrap_files(workspace_dir);
+    if files.is_empty() || files.iter().all(|file| file.missing) {
+        return String::new();
     }
+
+    let mut prompt = String::new();
+    prompt.push_str("## Workspace Persona Context\n");
+    prompt.push_str(&format!("Workspace: {}\n", workspace_dir.display()));
+    prompt
+        .push_str("The following workspace files define the persona, role, and operating style.\n");
+
+    for file in files {
+        prompt.push_str(&format!("\n### {}\n", file.name));
+        if file.missing {
+            prompt.push_str(&format!("[MISSING] Expected at: {}\n", file.path.display()));
+            continue;
+        }
+        let content = file.content.unwrap_or_default();
+        let trimmed = trim_workspace_content(&content, file.name, WORKSPACE_PERSONA_MAX_CHARS);
+        if trimmed.is_empty() {
+            prompt.push_str("[EMPTY]\n");
+        } else {
+            prompt.push_str(trimmed.as_str());
+            prompt.push('\n');
+        }
+    }
+
+    prompt
 }
 
 fn write_file_if_missing(path: &Path, content: &str) -> io::Result<()> {
@@ -191,6 +200,35 @@ fn read_workspace_file(
             missing: false,
         },
     }
+}
+
+fn trim_workspace_content(content: &str, file_name: &str, max_chars: usize) -> String {
+    let trimmed = content.trim_end();
+    if trimmed.chars().count() <= max_chars {
+        return trimmed.to_string();
+    }
+
+    let head_chars = ((max_chars as f32) * BOOTSTRAP_HEAD_RATIO).floor() as usize;
+    let tail_chars = ((max_chars as f32) * BOOTSTRAP_TAIL_RATIO).floor() as usize;
+
+    let head = take_chars(trimmed, head_chars);
+    let tail = take_last_chars(trimmed, tail_chars);
+    let marker = format!(
+        "\n[...truncated, read {} for full content...]\n...(truncated {}: kept {}+{} chars)...\n",
+        file_name, file_name, head_chars, tail_chars
+    );
+
+    format!("{}{}{}", head, marker, tail)
+}
+
+fn take_chars(input: &str, count: usize) -> String {
+    input.chars().take(count).collect()
+}
+
+fn take_last_chars(input: &str, count: usize) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let start = chars.len().saturating_sub(count);
+    chars[start..].iter().collect()
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -48,6 +48,7 @@ pub struct RuntimeLoopState {
     pub runtime_config: RuntimeConfig,
     pub workspace_persona_dir: Option<std::path::PathBuf>,
     pub tools: ToolRegistry,
+    pub prompt_cache: super::prompt_cache::PromptAssemblyCache,
     pub turn_state: TurnState,
 }
 
@@ -860,6 +861,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: {
                 let mut turn_state = TurnState::default();
                 turn_state.set_confirmation(PendingConfirmation {
@@ -950,6 +952,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1003,6 +1006,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1043,6 +1047,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1084,6 +1089,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1126,6 +1132,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1168,6 +1175,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1202,6 +1210,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 
@@ -1255,6 +1264,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         };
 

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -623,10 +623,27 @@ pub fn spawn_with_llm_client_and_tools(
         workspace_alan_dir.as_deref(),
         &runtime_config.governance,
     );
-    let workspace_persona_dir = workspace_alan_dir.as_ref().map(|dir| dir.join("persona"));
+    let workspace_persona_override = workspace_alan_dir.as_ref().map(|dir| dir.join("persona"));
+    let prompt_cache_persona_dir = crate::prompts::resolve_workspace_persona_dir_for_workspace(
+        &core_config,
+        workspace_persona_override.as_deref(),
+    );
+    if let Some(persona_dir) = prompt_cache_persona_dir.as_deref()
+        && let Err(err) = crate::prompts::ensure_workspace_bootstrap_files_at(persona_dir)
+    {
+        warn!(
+            path = %persona_dir.display(),
+            error = %err,
+            "Failed to initialize workspace persona files; continuing without bootstrap writes"
+        );
+    }
     let session_dir = workspace_alan_dir.as_ref().map(|dir| dir.join("sessions"));
     let resume_rollout_path = config.resume_rollout_path.clone();
     let desired_session_id = config.session_id.clone();
+    let skills_cwd = super::prompt_cache::resolve_skills_registry_cwd(
+        tools.default_cwd().as_deref(),
+        core_config.memory.workspace_dir.as_deref(),
+    );
 
     // Spawn the main runtime task
     let task_handle = tokio::spawn(async move {
@@ -660,7 +677,11 @@ pub fn spawn_with_llm_client_and_tools(
             tools,
             core_config,
             runtime_config,
-            workspace_persona_dir,
+            workspace_persona_dir: prompt_cache_persona_dir.clone(),
+            prompt_cache: super::prompt_cache::PromptAssemblyCache::new(
+                skills_cwd,
+                prompt_cache_persona_dir,
+            ),
             turn_state: super::TurnState::default(),
         };
 
@@ -847,6 +868,7 @@ pub fn spawn_with_llm_client_and_tools(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alan_llm::MockLlmProvider;
     use alan_protocol::Op;
     use tempfile::TempDir;
 
@@ -1539,5 +1561,72 @@ mod tests {
             config.agent_config.runtime_config.governance.profile,
             alan_protocol::GovernanceProfile::Conservative
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_spawn_continues_when_workspace_persona_bootstrap_is_unwritable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let alan_dir = workspace_root.join(".alan");
+        let persona_dir = alan_dir.join("persona");
+
+        std::fs::create_dir_all(&persona_dir).unwrap();
+        std::fs::write(persona_dir.join("SOUL.md"), "existing persona").unwrap();
+
+        let mut permissions = std::fs::metadata(&persona_dir).unwrap().permissions();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(&persona_dir, permissions).unwrap();
+
+        let config = WorkspaceRuntimeConfig {
+            workspace_root_dir: Some(workspace_root),
+            workspace_alan_dir: Some(alan_dir),
+            ..WorkspaceRuntimeConfig::default()
+        };
+
+        let llm_client = LlmClient::new(MockLlmProvider::new());
+        let mut controller = spawn_with_llm_client(config, llm_client).unwrap();
+        let ready = controller.wait_until_ready().await;
+
+        let mut cleanup_permissions = std::fs::metadata(&persona_dir).unwrap().permissions();
+        cleanup_permissions.set_mode(0o755);
+        std::fs::set_permissions(&persona_dir, cleanup_permissions).unwrap();
+
+        assert!(ready.is_ok());
+        controller.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initializes_bootstrap_for_memory_dir_persona_fallback() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        let persona_dir = workspace_root.join(".alan/persona");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let config = WorkspaceRuntimeConfig {
+            agent_config: crate::AgentConfig {
+                core_config: crate::Config {
+                    memory: crate::config::MemoryConfig {
+                        workspace_dir: Some(memory_dir),
+                        strict_workspace: false,
+                        ..crate::config::MemoryConfig::default()
+                    },
+                    ..crate::Config::default()
+                },
+                ..crate::AgentConfig::default()
+            },
+            ..WorkspaceRuntimeConfig::default()
+        };
+
+        let llm_client = LlmClient::new(MockLlmProvider::new());
+        let mut controller = spawn_with_llm_client(config, llm_client).unwrap();
+        let ready = controller.wait_until_ready().await;
+
+        assert!(ready.is_ok());
+        assert!(persona_dir.join("SOUL.md").exists());
+        controller.shutdown().await.unwrap();
     }
 }

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -5,6 +5,7 @@
 mod agent_loop;
 mod engine;
 mod loop_guard;
+mod prompt_cache;
 mod response_guardrails;
 mod submission_handlers;
 mod tool_orchestrator;

--- a/crates/runtime/src/runtime/prompt_cache.rs
+++ b/crates/runtime/src/runtime/prompt_cache.rs
@@ -1,0 +1,721 @@
+use crate::prompts;
+use crate::skills::{
+    Skill, SkillMetadata, SkillScope, SkillsRegistry, extract_mentions, inject_skills,
+    render_skill_not_found, render_skills_list,
+};
+use crate::tape::{ContentPart, parts_to_text};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashMap};
+use std::fs::Metadata;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime};
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct PromptAssemblyMetrics {
+    pub builds: u64,
+    pub hits: u64,
+    pub misses: u64,
+    pub skills_hits: u64,
+    pub skills_misses: u64,
+    pub persona_hits: u64,
+    pub persona_misses: u64,
+}
+
+impl PromptAssemblyMetrics {
+    fn record_build(&mut self, skills_hit: bool, persona_hit: bool) {
+        self.builds += 1;
+        if skills_hit && persona_hit {
+            self.hits += 1;
+        } else {
+            self.misses += 1;
+        }
+        if skills_hit {
+            self.skills_hits += 1;
+        } else {
+            self.skills_misses += 1;
+        }
+        if persona_hit {
+            self.persona_hits += 1;
+        } else {
+            self.persona_misses += 1;
+        }
+    }
+
+    fn hit_ratio(&self) -> f64 {
+        if self.builds == 0 {
+            0.0
+        } else {
+            self.hits as f64 / self.builds as f64
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PromptAssemblyResult {
+    pub domain_prompt: String,
+    pub system_prompt: String,
+    pub metrics: PromptAssemblyMetrics,
+    pub elapsed_ms: u128,
+    pub skills_cache_hit: bool,
+    pub persona_cache_hit: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PathFingerprint {
+    path: PathBuf,
+    state: PathState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathState {
+    Missing,
+    File(MetadataFingerprint),
+    Directory(MetadataFingerprint),
+    Other(MetadataFingerprint),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetadataFingerprint {
+    modified: Option<SystemTime>,
+    len: u64,
+    content_digest: Option<[u8; 32]>,
+    platform: PlatformFingerprint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlatformFingerprint {
+    #[cfg(unix)]
+    device_id: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    change_secs: i64,
+    #[cfg(unix)]
+    change_nanos: i64,
+    #[cfg(not(unix))]
+    readonly: bool,
+}
+
+impl PlatformFingerprint {
+    fn capture(metadata: &Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            Self {
+                device_id: metadata.dev(),
+                inode: metadata.ino(),
+                change_secs: metadata.ctime(),
+                change_nanos: metadata.ctime_nsec(),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Self {
+                readonly: metadata.permissions().readonly(),
+            }
+        }
+    }
+}
+
+impl MetadataFingerprint {
+    fn capture(path: &Path, metadata: &Metadata, include_content_digest: bool) -> Self {
+        Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+            content_digest: include_content_digest
+                .then(|| hash_file_contents(path))
+                .flatten(),
+            platform: PlatformFingerprint::capture(metadata),
+        }
+    }
+}
+
+impl PathFingerprint {
+    fn capture(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let state = match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => {
+                PathState::File(MetadataFingerprint::capture(&path, &metadata, true))
+            }
+            Ok(metadata) if metadata.is_dir() => {
+                PathState::Directory(MetadataFingerprint::capture(&path, &metadata, false))
+            }
+            Ok(metadata) => PathState::Other(MetadataFingerprint::capture(&path, &metadata, false)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => PathState::Missing,
+            Err(_) => PathState::Missing,
+        };
+        Self { path, state }
+    }
+
+    fn matches_current(&self) -> bool {
+        Self::capture(self.path.clone()) == *self
+    }
+}
+
+fn hash_file_contents(path: &Path) -> Option<[u8; 32]> {
+    let bytes = std::fs::read(path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Some(hasher.finalize().into())
+}
+
+#[derive(Debug, Clone)]
+struct CachedWorkspacePersona {
+    tracked_paths: Vec<PathFingerprint>,
+    rendered_section: String,
+}
+
+impl CachedWorkspacePersona {
+    fn load(workspace_persona_dir: &Path) -> Self {
+        let tracked_paths = prompts::workspace_persona_tracked_paths(workspace_persona_dir)
+            .into_iter()
+            .map(PathFingerprint::capture)
+            .collect();
+        let rendered_section = prompts::render_workspace_persona_context(workspace_persona_dir);
+        Self {
+            tracked_paths,
+            rendered_section,
+        }
+    }
+
+    fn is_current(&self) -> bool {
+        self.tracked_paths
+            .iter()
+            .all(PathFingerprint::matches_current)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedSkillRender {
+    tracked_paths: Vec<PathFingerprint>,
+    rendered: String,
+}
+
+impl CachedSkillRender {
+    fn load(skill: &Skill) -> Self {
+        let tracked_paths = skill_prompt_tracked_paths(skill)
+            .into_iter()
+            .map(PathFingerprint::capture)
+            .collect();
+        Self {
+            tracked_paths,
+            rendered: inject_skills(std::slice::from_ref(skill)),
+        }
+    }
+
+    fn is_current(&self) -> bool {
+        self.tracked_paths
+            .iter()
+            .all(PathFingerprint::matches_current)
+    }
+}
+
+#[derive(Clone)]
+struct CachedSkillsRegistry {
+    registry: SkillsRegistry,
+    tracked_paths: Vec<PathFingerprint>,
+    available_skills: Vec<SkillMetadata>,
+    skills_list: Option<String>,
+    active_skill_cache: HashMap<String, CachedSkillRender>,
+}
+
+impl CachedSkillsRegistry {
+    fn load(skills_cwd: &Path) -> Result<Self, crate::skills::SkillsError> {
+        let registry = SkillsRegistry::load(skills_cwd)?;
+        let available_skills: Vec<SkillMetadata> =
+            registry.list_sorted().into_iter().cloned().collect();
+        let skills_list = render_skills_list(&available_skills);
+        let tracked_paths = registry
+            .tracked_paths()
+            .iter()
+            .cloned()
+            .map(PathFingerprint::capture)
+            .collect();
+        Ok(Self {
+            registry,
+            tracked_paths,
+            available_skills,
+            skills_list,
+            active_skill_cache: HashMap::new(),
+        })
+    }
+
+    fn is_current(&self) -> bool {
+        self.tracked_paths
+            .iter()
+            .all(PathFingerprint::matches_current)
+    }
+
+    fn render_domain_prompt(&mut self, user_input: Option<&[ContentPart]>) -> String {
+        if !self.registry.errors().is_empty() {
+            warn!(
+                errors = self.registry.errors().len(),
+                "Loaded skills with non-fatal parse/scan errors"
+            );
+        }
+
+        let mut sections = Vec::new();
+        if let Some(skills_list) = &self.skills_list {
+            sections.push(skills_list.clone());
+        }
+
+        let mention_text = user_input.map(parts_to_text).unwrap_or_default();
+        let mentioned_ids = extract_mentions(&mention_text);
+
+        let mut active_ids: BTreeSet<String> = self
+            .available_skills
+            .iter()
+            .filter(|skill| skill.scope == SkillScope::System)
+            .map(|skill| skill.id.clone())
+            .collect();
+        for mention in &mentioned_ids {
+            active_ids.insert(mention.clone());
+        }
+
+        let mut active_sections = Vec::new();
+        for skill_id in &active_ids {
+            match self.render_active_skill(skill_id) {
+                Ok(rendered) => active_sections.push(rendered),
+                Err(err) => {
+                    warn!(skill_id = %skill_id, error = %err, "Failed to load active skill");
+                }
+            }
+        }
+
+        if !active_sections.is_empty() {
+            sections.push(
+                "## Active Skill Instructions\nFollow these active skill instructions when relevant."
+                    .to_string(),
+            );
+            sections.push(active_sections.join("\n\n"));
+        }
+
+        if !mentioned_ids.is_empty() {
+            let known_ids: BTreeSet<&str> = self
+                .available_skills
+                .iter()
+                .map(|skill| skill.id.as_str())
+                .collect();
+            for mention in mentioned_ids {
+                if !known_ids.contains(mention.as_str()) {
+                    sections.push(render_skill_not_found(&mention, &self.available_skills));
+                }
+            }
+        }
+
+        sections.join("\n\n")
+    }
+
+    fn render_active_skill(
+        &mut self,
+        skill_id: &str,
+    ) -> Result<String, crate::skills::SkillsError> {
+        if let Some(cached) = self.active_skill_cache.get(skill_id)
+            && cached.is_current()
+        {
+            return Ok(cached.rendered.clone());
+        }
+
+        let skill = self.registry.load_skill(&skill_id.to_string())?;
+        let cached = CachedSkillRender::load(&skill);
+        let rendered = cached.rendered.clone();
+        self.active_skill_cache.insert(skill_id.to_string(), cached);
+        Ok(rendered)
+    }
+}
+
+pub(crate) struct PromptAssemblyCache {
+    skills_cwd: Option<PathBuf>,
+    workspace_persona_dir: Option<PathBuf>,
+    skills_snapshot: Option<CachedSkillsRegistry>,
+    workspace_persona_snapshot: Option<CachedWorkspacePersona>,
+    metrics: PromptAssemblyMetrics,
+}
+
+impl PromptAssemblyCache {
+    pub(crate) fn new(skills_cwd: Option<PathBuf>, workspace_persona_dir: Option<PathBuf>) -> Self {
+        Self {
+            skills_cwd,
+            workspace_persona_dir,
+            skills_snapshot: None,
+            workspace_persona_snapshot: None,
+            metrics: PromptAssemblyMetrics::default(),
+        }
+    }
+
+    pub(crate) fn rebind_paths(
+        &mut self,
+        skills_cwd: Option<PathBuf>,
+        workspace_persona_dir: Option<PathBuf>,
+    ) {
+        if self.skills_cwd != skills_cwd {
+            self.skills_cwd = skills_cwd;
+            self.skills_snapshot = None;
+        }
+        if self.workspace_persona_dir != workspace_persona_dir {
+            self.workspace_persona_dir = workspace_persona_dir;
+            self.workspace_persona_snapshot = None;
+        }
+    }
+
+    pub(crate) fn build(&mut self, user_input: Option<&[ContentPart]>) -> PromptAssemblyResult {
+        let started_at = Instant::now();
+        let (domain_prompt, skills_cache_hit) = self.domain_prompt_with_cache(user_input);
+        let (workspace_section, persona_cache_hit) = self.workspace_section_with_cache();
+        let system_prompt = prompts::build_agent_system_prompt_with_workspace_context(
+            &domain_prompt,
+            workspace_section.as_deref(),
+        );
+
+        self.metrics
+            .record_build(skills_cache_hit, persona_cache_hit);
+        let elapsed_ms = started_at.elapsed().as_millis();
+        debug!(
+            elapsed_ms,
+            skills_cache_hit,
+            persona_cache_hit,
+            builds = self.metrics.builds,
+            hit_ratio = self.metrics.hit_ratio(),
+            "Prompt assembly completed"
+        );
+
+        PromptAssemblyResult {
+            domain_prompt,
+            system_prompt,
+            metrics: self.metrics,
+            elapsed_ms,
+            skills_cache_hit,
+            persona_cache_hit,
+        }
+    }
+
+    fn domain_prompt_with_cache(&mut self, user_input: Option<&[ContentPart]>) -> (String, bool) {
+        let Some(skills_cwd) = self.skills_cwd.as_deref() else {
+            return (String::new(), true);
+        };
+
+        let cache_hit = self
+            .skills_snapshot
+            .as_ref()
+            .is_some_and(CachedSkillsRegistry::is_current);
+        if !cache_hit {
+            match CachedSkillsRegistry::load(skills_cwd) {
+                Ok(snapshot) => {
+                    self.skills_snapshot = Some(snapshot);
+                }
+                Err(err) => {
+                    warn!(
+                        path = %skills_cwd.display(),
+                        error = %err,
+                        "Failed to load skills registry; continuing without skill injection"
+                    );
+                    self.skills_snapshot = None;
+                    return (String::new(), false);
+                }
+            }
+        }
+
+        let domain_prompt = self
+            .skills_snapshot
+            .as_mut()
+            .map(|snapshot| snapshot.render_domain_prompt(user_input))
+            .unwrap_or_default();
+        (domain_prompt, cache_hit)
+    }
+
+    fn workspace_section_with_cache(&mut self) -> (Option<String>, bool) {
+        let Some(workspace_persona_dir) = self.workspace_persona_dir.as_deref() else {
+            return (None, true);
+        };
+        if !workspace_persona_dir.exists() {
+            self.workspace_persona_snapshot = None;
+            return (None, true);
+        }
+
+        let cache_hit = self
+            .workspace_persona_snapshot
+            .as_ref()
+            .is_some_and(CachedWorkspacePersona::is_current);
+        if !cache_hit {
+            self.workspace_persona_snapshot =
+                Some(CachedWorkspacePersona::load(workspace_persona_dir));
+        }
+
+        let rendered = self
+            .workspace_persona_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.rendered_section.clone())
+            .filter(|section| !section.is_empty());
+        (rendered, cache_hit)
+    }
+}
+
+fn skill_prompt_tracked_paths(skill: &Skill) -> Vec<PathBuf> {
+    if skill.metadata.scope == SkillScope::System {
+        return Vec::new();
+    }
+
+    let mut paths = vec![skill.metadata.path.clone()];
+    if let Some(skill_dir) = skill.metadata.path.parent() {
+        paths.push(skill_dir.join("scripts"));
+        paths.push(skill_dir.join("references"));
+        paths.push(skill_dir.join("assets"));
+    }
+    paths
+}
+
+pub(crate) fn resolve_skills_registry_cwd(
+    default_cwd: Option<&Path>,
+    memory_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(cwd) = default_cwd {
+        if cwd
+            .file_name()
+            .map(|name| name == std::ffi::OsStr::new(".alan"))
+            .unwrap_or(false)
+        {
+            return Some(
+                cwd.parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| cwd.to_path_buf()),
+            );
+        }
+        return Some(cwd.to_path_buf());
+    }
+
+    let memory_dir = memory_dir?;
+    let alan_dir = memory_dir.parent()?;
+    if alan_dir
+        .file_name()
+        .map(|name| name == std::ffi::OsStr::new(".alan"))
+        .unwrap_or(false)
+    {
+        Some(
+            alan_dir
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| alan_dir.to_path_buf()),
+        )
+    } else {
+        Some(alan_dir.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prompts::ensure_workspace_bootstrap_files_at;
+
+    fn create_repo_skill(
+        workspace_root: &std::path::Path,
+        dir_name: &str,
+        skill_name: &str,
+        description: &str,
+        body: &str,
+    ) {
+        let skill_dir = workspace_root.join(".alan/skills").join(dir_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!(
+                r#"---
+name: {skill_name}
+description: {description}
+---
+
+{body}
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prompt_cache_hits_on_repeated_builds() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let persona_dir = workspace_root.join(".alan/persona");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+        ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
+        create_repo_skill(
+            &workspace_root,
+            "my-skill",
+            "My Skill",
+            "Custom test skill",
+            "# Instructions\nUse this skill when asked.",
+        );
+
+        let mut cache =
+            PromptAssemblyCache::new(Some(workspace_root.clone()), Some(persona_dir.clone()));
+        let user_input = vec![ContentPart::text("please use $my-skill for this task")];
+
+        let first = cache.build(Some(&user_input));
+        let second = cache.build(Some(&user_input));
+
+        assert!(first.system_prompt.contains("Workspace Persona Context"));
+        assert!(first.system_prompt.contains("## Skill: My Skill"));
+        assert!(!first.skills_cache_hit);
+        assert!(!first.persona_cache_hit);
+        assert!(second.skills_cache_hit);
+        assert!(second.persona_cache_hit);
+        assert_eq!(second.metrics.builds, 2);
+        assert_eq!(second.metrics.hits, 1);
+    }
+
+    #[test]
+    fn prompt_cache_invalidates_when_skill_changes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+        create_repo_skill(
+            &workspace_root,
+            "my-skill",
+            "My Skill",
+            "Custom test skill",
+            "# Instructions\nUse this skill when asked.",
+        );
+
+        let mut cache = PromptAssemblyCache::new(Some(workspace_root.clone()), None);
+        let user_input = vec![ContentPart::text("please use $my-skill for this task")];
+
+        let first = cache.build(Some(&user_input));
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(
+            workspace_root.join(".alan/skills/my-skill/SKILL.md"),
+            r#"---
+name: My Skill
+description: Custom test skill
+---
+
+# Instructions
+Updated instructions.
+"#,
+        )
+        .unwrap();
+        let second = cache.build(Some(&user_input));
+
+        assert!(first.system_prompt.contains("Use this skill when asked."));
+        assert!(second.system_prompt.contains("Updated instructions."));
+        assert!(!second.skills_cache_hit);
+        assert_eq!(second.metrics.skills_misses, 2);
+    }
+
+    #[test]
+    fn prompt_cache_invalidates_when_skill_contents_change_with_same_length() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+
+        let initial = r#"---
+name: My Skill
+description: Custom test skill
+---
+
+# Instructions
+ABCD
+"#;
+        let updated = r#"---
+name: My Skill
+description: Custom test skill
+---
+
+# Instructions
+WXYZ
+"#;
+        assert_eq!(initial.len(), updated.len());
+
+        let skill_path = workspace_root.join(".alan/skills/my-skill/SKILL.md");
+        std::fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        std::fs::write(&skill_path, initial).unwrap();
+
+        let mut cache = PromptAssemblyCache::new(Some(workspace_root.clone()), None);
+        let user_input = vec![ContentPart::text("please use $my-skill for this task")];
+
+        let first = cache.build(Some(&user_input));
+        std::fs::write(&skill_path, updated).unwrap();
+        let second = cache.build(Some(&user_input));
+
+        assert!(first.system_prompt.contains("# Instructions\nABCD"));
+        assert!(second.system_prompt.contains("# Instructions\nWXYZ"));
+        assert!(!second.skills_cache_hit);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prompt_cache_invalidates_when_skill_symlink_is_retargeted() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let skills_root = workspace_root.join(".alan/skills");
+        let pack_v1 = temp.path().join("pack-v1");
+        let pack_v2 = temp.path().join("pack-v2");
+        let linked_pack = skills_root.join("linked-pack");
+
+        std::fs::create_dir_all(&skills_root).unwrap();
+        std::fs::create_dir_all(pack_v1.join("my-skill")).unwrap();
+        std::fs::create_dir_all(pack_v2.join("my-skill")).unwrap();
+        std::fs::write(
+            pack_v1.join("my-skill/SKILL.md"),
+            r#"---
+name: My Skill
+description: Custom test skill
+---
+
+# Instructions
+Version one.
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pack_v2.join("my-skill/SKILL.md"),
+            r#"---
+name: My Skill
+description: Custom test skill
+---
+
+# Instructions
+Version two.
+"#,
+        )
+        .unwrap();
+        symlink(&pack_v1, &linked_pack).unwrap();
+
+        let mut cache = PromptAssemblyCache::new(Some(workspace_root.clone()), None);
+        let user_input = vec![ContentPart::text("please use $my-skill for this task")];
+
+        let first = cache.build(Some(&user_input));
+        std::fs::remove_file(&linked_pack).unwrap();
+        symlink(&pack_v2, &linked_pack).unwrap();
+        let second = cache.build(Some(&user_input));
+
+        assert!(first.system_prompt.contains("Version one."));
+        assert!(second.system_prompt.contains("Version two."));
+        assert!(!second.skills_cache_hit);
+    }
+
+    #[test]
+    fn resolve_skills_registry_cwd_normalizes_alan_tool_cwd_to_workspace_root() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let alan_dir = workspace_root.join(".alan");
+        std::fs::create_dir_all(&alan_dir).unwrap();
+
+        let resolved = resolve_skills_registry_cwd(Some(&alan_dir), None).unwrap();
+        assert_eq!(resolved, workspace_root);
+    }
+
+    #[test]
+    fn resolve_skills_registry_cwd_falls_back_to_memory_workspace_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let resolved = resolve_skills_registry_cwd(None, Some(&memory_dir)).unwrap();
+        assert_eq!(resolved, workspace_root);
+    }
+}

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -508,6 +508,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         }
     }

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -1118,6 +1118,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         }
     }
@@ -1134,6 +1135,7 @@ mod tests {
             core_config: Config::default(),
             runtime_config: super::super::RuntimeConfig::default(),
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         }
     }

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1,11 +1,10 @@
 use alan_protocol::Event;
 use anyhow::Result;
-use std::ffi::OsStr;
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
-use crate::{llm::build_generation_request, prompts};
+use crate::llm::build_generation_request;
 
 use super::agent_loop::{
     RuntimeLoopState, generate_with_retry_with_cancel, maybe_compact_context_with_cancel,
@@ -118,124 +117,28 @@ fn strip_repeated_recovery_prefix(existing_text: &str, recovered_text: &str) -> 
 }
 
 fn resolve_skills_registry_cwd(state: &RuntimeLoopState) -> Option<std::path::PathBuf> {
-    // Prefer tool registry default cwd (runtime manager sets this to workspace root).
-    if let Some(cwd) = state.tools.default_cwd() {
-        if cwd
-            .file_name()
-            .map(|name| name == OsStr::new(".alan"))
-            .unwrap_or(false)
-        {
-            return Some(
-                cwd.parent()
-                    .map(std::path::Path::to_path_buf)
-                    .unwrap_or(cwd),
-            );
-        }
-        return Some(cwd);
-    }
+    super::prompt_cache::resolve_skills_registry_cwd(
+        state.tools.default_cwd().as_deref(),
+        state.core_config.memory.workspace_dir.as_deref(),
+    )
+}
 
-    // Fallback for callers that only configured memory dir.
-    let memory_dir = state.core_config.memory.workspace_dir.as_ref()?;
-    let alan_dir = memory_dir.parent()?;
-    if alan_dir
-        .file_name()
-        .map(|name| name == OsStr::new(".alan"))
-        .unwrap_or(false)
-    {
-        Some(
-            alan_dir
-                .parent()
-                .map(std::path::Path::to_path_buf)
-                .unwrap_or_else(|| alan_dir.to_path_buf()),
-        )
-    } else {
-        Some(alan_dir.to_path_buf())
-    }
+fn resolve_workspace_persona_dir(state: &RuntimeLoopState) -> Option<std::path::PathBuf> {
+    crate::prompts::resolve_workspace_persona_dir_for_workspace(
+        &state.core_config,
+        state.workspace_persona_dir.as_deref(),
+    )
 }
 
 fn build_domain_prompt_with_skills(
-    state: &RuntimeLoopState,
+    state: &mut RuntimeLoopState,
     user_input: Option<&[crate::tape::ContentPart]>,
-) -> String {
-    let Some(skills_cwd) = resolve_skills_registry_cwd(state) else {
-        return String::new();
-    };
-
-    let registry = match crate::skills::SkillsRegistry::load(&skills_cwd) {
-        Ok(registry) => registry,
-        Err(err) => {
-            warn!(
-                path = %skills_cwd.display(),
-                error = %err,
-                "Failed to load skills registry; continuing without skill injection"
-            );
-            return String::new();
-        }
-    };
-
-    if !registry.errors().is_empty() {
-        warn!(
-            path = %skills_cwd.display(),
-            errors = registry.errors().len(),
-            "Loaded skills with non-fatal parse/scan errors"
-        );
-    }
-
-    let available_skills: Vec<crate::skills::SkillMetadata> =
-        registry.list_sorted().into_iter().cloned().collect();
-    let mut sections = Vec::new();
-    if let Some(skills_list) = crate::skills::render_skills_list(&available_skills) {
-        sections.push(skills_list);
-    }
-
-    let mention_text = user_input
-        .map(crate::tape::parts_to_text)
-        .unwrap_or_default();
-    let mentioned_ids = crate::skills::extract_mentions(&mention_text);
-
-    let mut active_ids: std::collections::BTreeSet<String> = available_skills
-        .iter()
-        .filter(|skill| skill.scope == crate::skills::SkillScope::System)
-        .map(|skill| skill.id.clone())
-        .collect();
-    for mention in &mentioned_ids {
-        active_ids.insert(mention.clone());
-    }
-
-    let mut active_skills = Vec::new();
-    for skill_id in &active_ids {
-        match registry.load_skill(skill_id) {
-            Ok(skill) => active_skills.push(skill),
-            Err(err) => {
-                warn!(skill_id = %skill_id, error = %err, "Failed to load active skill");
-            }
-        }
-    }
-
-    if !active_skills.is_empty() {
-        sections.push(
-            "## Active Skill Instructions\nFollow these active skill instructions when relevant."
-                .to_string(),
-        );
-        sections.push(crate::skills::inject_skills(&active_skills));
-    }
-
-    if !mentioned_ids.is_empty() {
-        let known_ids: std::collections::BTreeSet<&str> = available_skills
-            .iter()
-            .map(|skill| skill.id.as_str())
-            .collect();
-        for mention in mentioned_ids {
-            if !known_ids.contains(mention.as_str()) {
-                sections.push(crate::skills::render_skill_not_found(
-                    &mention,
-                    &available_skills,
-                ));
-            }
-        }
-    }
-
-    sections.join("\n\n")
+) -> super::prompt_cache::PromptAssemblyResult {
+    state.prompt_cache.rebind_paths(
+        resolve_skills_registry_cwd(state),
+        resolve_workspace_persona_dir(state),
+    );
+    state.prompt_cache.build(user_input)
 }
 
 /// Run a single agent turn
@@ -279,13 +182,17 @@ where
         state.session.add_user_message_parts(user_input);
     }
 
-    let domain_prompt = build_domain_prompt_with_skills(state, user_input_for_skills.as_deref());
-
-    let system_prompt = prompts::build_agent_system_prompt_for_workspace(
-        &state.core_config,
-        &domain_prompt,
-        state.workspace_persona_dir.as_deref(),
+    let prompt_build = build_domain_prompt_with_skills(state, user_input_for_skills.as_deref());
+    debug!(
+        elapsed_ms = prompt_build.elapsed_ms,
+        skills_cache_hit = prompt_build.skills_cache_hit,
+        persona_cache_hit = prompt_build.persona_cache_hit,
+        cache_builds = prompt_build.metrics.builds,
+        cache_hits = prompt_build.metrics.hits,
+        "Prepared prompt assembly inputs"
     );
+    let _domain_prompt = prompt_build.domain_prompt;
+    let system_prompt = prompt_build.system_prompt;
 
     let mut tools = state.tools.get_tool_definitions();
     tools.extend(virtual_tool_definitions());
@@ -1342,6 +1249,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         }
     }
@@ -1443,12 +1351,36 @@ description: {description}
         state.tools.set_default_cwd(workspace_root);
 
         let user_input = vec![ContentPart::text("please use $my-skill for this task")];
-        let prompt = build_domain_prompt_with_skills(&state, Some(&user_input));
+        let prompt = build_domain_prompt_with_skills(&mut state, Some(&user_input));
 
-        assert!(prompt.contains("## Available Skills"));
-        assert!(prompt.contains("## Active Skill Instructions"));
-        assert!(prompt.contains("## Skill: My Skill"));
-        assert!(prompt.contains("Use this skill when asked."));
+        assert!(prompt.system_prompt.contains("## Available Skills"));
+        assert!(
+            prompt
+                .system_prompt
+                .contains("## Active Skill Instructions")
+        );
+        assert!(prompt.system_prompt.contains("## Skill: My Skill"));
+        assert!(prompt.system_prompt.contains("Use this skill when asked."));
+    }
+
+    #[test]
+    fn test_build_domain_prompt_with_skills_uses_persona_fallback_from_memory_dir() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let alan_dir = workspace_root.join(".alan");
+        let persona_dir = alan_dir.join("persona");
+        let memory_dir = alan_dir.join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
+        std::fs::write(persona_dir.join("SOUL.md"), "custom fallback persona").unwrap();
+
+        let mut state = create_test_state_with_provider(ContentMockProvider::new("ok"));
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+
+        let prompt = build_domain_prompt_with_skills(&mut state, None);
+
+        assert!(prompt.system_prompt.contains("Workspace Persona Context"));
+        assert!(prompt.system_prompt.contains("custom fallback persona"));
     }
 
     struct StreamEndsImmediatelyProvider {

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -557,6 +557,7 @@ mod tests {
             core_config: config,
             runtime_config,
             workspace_persona_dir: None,
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(None, None),
             turn_state: TurnState::default(),
         }
     }

--- a/crates/runtime/src/skills/loader.rs
+++ b/crates/runtime/src/skills/loader.rs
@@ -91,6 +91,7 @@ const MAX_SKILLS_DIRS_PER_ROOT: usize = 2000;
 /// Scan a directory for skills (recursive).
 pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
     let mut outcome = SkillLoadOutcome::default();
+    outcome.tracked_paths.push(dir.to_path_buf());
 
     if !dir.exists() {
         debug!("Skills directory does not exist: {}", dir.display());
@@ -110,6 +111,7 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
     let mut truncated = false;
 
     while let Some((current, depth)) = queue.pop_front() {
+        outcome.tracked_paths.push(current.clone());
         if depth > MAX_SCAN_DEPTH {
             continue;
         }
@@ -151,6 +153,7 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
                     continue;
                 }
 
+                outcome.tracked_paths.push(path.clone());
                 let metadata = match std::fs::metadata(&path) {
                     Ok(metadata) => metadata,
                     Err(e) => {
@@ -169,7 +172,28 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
                         Err(_) => continue,
                     };
                     if visited_dirs.insert(resolved.clone()) {
+                        outcome.tracked_paths.push(resolved.clone());
                         queue.push_back((resolved, depth + 1));
+                    }
+                } else if metadata.is_file() && file_name == "SKILL.md" {
+                    let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                    outcome.tracked_paths.push(resolved.clone());
+                    if !seen_skills.insert(resolved.clone()) {
+                        continue;
+                    }
+
+                    match load_skill_metadata(&resolved, scope) {
+                        Ok(metadata) => {
+                            debug!("Loaded skill: {} from {}", metadata.id, resolved.display());
+                            outcome.skills.push(metadata);
+                        }
+                        Err(e) => {
+                            error!("Failed to load skill from {}: {}", resolved.display(), e);
+                            outcome.errors.push(SkillError {
+                                path: resolved.clone(),
+                                message: e.to_string(),
+                            });
+                        }
                     }
                 }
                 continue;
@@ -181,6 +205,7 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
                     Err(_) => continue,
                 };
                 if visited_dirs.insert(resolved.clone()) {
+                    outcome.tracked_paths.push(resolved.clone());
                     queue.push_back((resolved, depth + 1));
                 }
                 continue;
@@ -188,6 +213,7 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
 
             if file_type.is_file() && file_name == "SKILL.md" {
                 let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                outcome.tracked_paths.push(resolved.clone());
                 if !seen_skills.insert(resolved.clone()) {
                     continue;
                 }
@@ -216,6 +242,9 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
             dir.display()
         );
     }
+
+    outcome.tracked_paths.sort();
+    outcome.tracked_paths.dedup();
 
     outcome
 }
@@ -295,6 +324,39 @@ Body
         let outcome = scan_skills_dir(&skills_dir, SkillScope::User);
         assert_eq!(outcome.skills.len(), 1);
         assert_eq!(outcome.skills[0].id, "test-skill");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_scan_skills_dir_tracks_symlink_path_and_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let skills_dir = temp.path().join("skills");
+        let pack_v1 = temp.path().join("pack-v1");
+        let linked_pack = skills_dir.join("linked-pack");
+
+        std::fs::create_dir_all(pack_v1.join("demo-skill")).unwrap();
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(
+            pack_v1.join("demo-skill/SKILL.md"),
+            r#"---
+name: Demo Skill
+description: Linked skill
+---
+
+Body
+"#,
+        )
+        .unwrap();
+        symlink(&pack_v1, &linked_pack).unwrap();
+
+        let outcome = scan_skills_dir(&skills_dir, SkillScope::Repo);
+        let resolved = std::fs::canonicalize(&linked_pack).unwrap();
+
+        assert_eq!(outcome.skills.len(), 1);
+        assert!(outcome.tracked_paths.contains(&linked_pack));
+        assert!(outcome.tracked_paths.contains(&resolved));
     }
 
     #[test]

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -13,6 +13,8 @@ pub struct SkillsRegistry {
     skills: HashMap<SkillId, SkillMetadata>,
     /// Non-fatal errors encountered during loading.
     errors: Vec<SkillError>,
+    /// Filesystem paths whose metadata determines whether the registry is stale.
+    tracked_paths: Vec<PathBuf>,
     /// Working directory for repo-level skills.
     cwd: PathBuf,
     /// User home directory for user-level skills.
@@ -25,6 +27,7 @@ impl SkillsRegistry {
         let mut registry = Self {
             skills: HashMap::new(),
             errors: Vec::new(),
+            tracked_paths: Vec::new(),
             cwd: cwd.to_path_buf(),
             user_home: dirs::home_dir(),
         };
@@ -39,6 +42,7 @@ impl SkillsRegistry {
         let mut registry = Self {
             skills: HashMap::new(),
             errors: Vec::new(),
+            tracked_paths: Vec::new(),
             cwd: agent_workspace_dir.to_path_buf(),
             user_home: dirs::home_dir(),
         };
@@ -52,6 +56,7 @@ impl SkillsRegistry {
     pub fn reload(&mut self) -> Result<(), SkillsError> {
         self.skills.clear();
         self.errors.clear();
+        self.tracked_paths.clear();
         info!("Loading skills from all scopes...");
 
         // Load in order of priority (lowest first, so higher priority overrides)
@@ -88,6 +93,7 @@ impl SkillsRegistry {
     pub fn reload_for_agent(&mut self) -> Result<(), SkillsError> {
         self.skills.clear();
         self.errors.clear();
+        self.tracked_paths.clear();
         info!("Loading skills for workspace...");
 
         // Load in order of priority (lowest first)
@@ -132,6 +138,9 @@ impl SkillsRegistry {
             // Higher priority skills override lower priority ones
             self.skills.insert(skill.id.clone(), skill);
         }
+        self.tracked_paths.extend(outcome.tracked_paths);
+        self.tracked_paths.sort();
+        self.tracked_paths.dedup();
         self.errors.extend(outcome.errors);
     }
 
@@ -147,6 +156,10 @@ impl SkillsRegistry {
             .get(id)
             .ok_or_else(|| SkillsError::NotFound(id.clone()))?;
 
+        if metadata.scope == SkillScope::System {
+            return load_embedded_system_skill(metadata);
+        }
+
         loader::load_skill(&metadata.path, metadata.scope)
     }
 
@@ -158,6 +171,11 @@ impl SkillsRegistry {
     /// List skill loading errors (if any).
     pub fn errors(&self) -> &[SkillError] {
         &self.errors
+    }
+
+    /// Return filesystem paths whose metadata determines whether the registry is stale.
+    pub fn tracked_paths(&self) -> &[PathBuf] {
+        &self.tracked_paths
     }
 
     /// List skills sorted by scope priority.
@@ -259,6 +277,27 @@ impl SkillsRegistry {
             _ => false,
         }
     }
+}
+
+fn load_embedded_system_skill(metadata: &SkillMetadata) -> Result<Skill, SkillsError> {
+    use crate::skills::{MEMORY_SKILL_MD, PLAN_SKILL_MD, WORKSPACE_MANAGER_SKILL_MD};
+
+    let content = match metadata.id.as_str() {
+        "memory" => MEMORY_SKILL_MD,
+        "plan" => PLAN_SKILL_MD,
+        "workspace-manager" => WORKSPACE_MANAGER_SKILL_MD,
+        _ => return Err(SkillsError::NotFound(metadata.id.clone())),
+    };
+
+    let (frontmatter_str, body) =
+        extract_frontmatter(content).ok_or(SkillsError::MissingFrontmatter)?;
+    let frontmatter: SkillFrontmatter = serde_yaml::from_str(&frontmatter_str)?;
+
+    Ok(Skill {
+        metadata: metadata.clone(),
+        content: body,
+        frontmatter,
+    })
 }
 
 impl Default for SkillsRegistry {
@@ -595,6 +634,7 @@ Body
         let mut registry = SkillsRegistry {
             skills: HashMap::new(),
             errors: Vec::new(),
+            tracked_paths: Vec::new(),
             cwd: home.clone(),
             user_home: Some(home),
         };
@@ -615,6 +655,7 @@ Body
         let mut registry = SkillsRegistry {
             skills: HashMap::new(),
             errors: Vec::new(),
+            tracked_paths: Vec::new(),
             cwd: alan_dir,
             user_home: Some(home),
         };

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -201,6 +201,7 @@ pub struct SkillError {
 pub struct SkillLoadOutcome {
     pub skills: Vec<SkillMetadata>,
     pub errors: Vec<SkillError>,
+    pub tracked_paths: Vec<PathBuf>,
 }
 
 impl SkillLoadOutcome {


### PR DESCRIPTION
## Summary
- add a runtime-scoped prompt assembly cache for skills and workspace persona context
- invalidate cached skills/persona snapshots from tracked filesystem fingerprints instead of rescanning on every turn
- move workspace persona bootstrap creation to runtime startup so prompt assembly stays read-only

## Testing
- cargo fmt --all
- cargo test -p alan-runtime -p alan
- cargo clippy -p alan-runtime -p alan --all-targets --all-features -- -D warnings

Closes #45