### PR TITLE
fix: correct anthropic streamed tool argument assembly

### DIFF
--- a/crates/llm/src/anthropic_compatible.rs
+++ b/crates/llm/src/anthropic_compatible.rs
@@ -710,7 +710,9 @@ impl StreamedToolUseState {
         if self.saw_partial_json {
             (!self.accumulated_arguments.is_empty()).then(|| self.accumulated_arguments.clone())
         } else {
-            self.preview_start_input.clone().filter(|value| is_non_empty(value))
+            self.preview_start_input
+                .clone()
+                .filter(|value| is_non_empty(value))
         }
     }
 }
@@ -1481,13 +1483,11 @@ mod tests {
 
     #[test]
     fn test_streamed_tool_use_state_finalizes_accumulated_partial_json() {
-        let mut state = StreamedToolUseState::new(
-            Some("tool-2".to_string()),
-            Some("bash".to_string()),
-            None,
-        );
+        let mut state =
+            StreamedToolUseState::new(Some("tool-2".to_string()), Some("bash".to_string()), None);
 
-        let first_preview = state.merge_partial_json_for_preview("{\"command\":\"echo ".to_string());
+        let first_preview =
+            state.merge_partial_json_for_preview("{\"command\":\"echo ".to_string());
         let second_preview = state.merge_partial_json_for_preview("hello\"}".to_string());
         let chunks = finalize_tool_use_chunks(0, state);
 


### PR DESCRIPTION
## Summary

- fix the Anthropic-compatible streamed tool-call argument assembly when `start_input` and `partial_json` events are mixed
- preserve `start_input` only for non-partial streams, and finalize accumulated arguments only after actual partial JSON arrives
- add regression coverage for both partial-json assembly and the start-input fallback path

## Related Issues

- Related #78

## Validation

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo test --workspace`
- [x] `cargo test -p alan-llm`
- [ ] Additional checks (if applicable):

## Risk and Rollback

- Risk level: low
- Rollback plan: revert this PR or the follow-up branch commits if Anthropic streaming regressions appear

## Checklist

- [x] Scope is focused and reviewable
- [x] Tests cover changed behavior and regressions
- [ ] Docs updated if behavior/config changed
- [x] No secrets or sensitive data added