### PR TITLE
feat: render schema-driven yield forms in the TUI

### DIFF
--- a/clients/tui/src/adaptive-surfaces/generic-surface.tsx
+++ b/clients/tui/src/adaptive-surfaces/generic-surface.tsx
@@ -1,17 +1,169 @@
 import React from "react";
-import { Text } from "ink";
+import { Box, Text } from "ink";
+import {
+  getStructuredAnswer,
+  getStructuredOptionCursor,
+  moveStructuredOptionCursor,
+  moveStructuredQuestion,
+  moveStructuredSingleSelection,
+  questionAnswerPreview,
+  questionValidationError,
+  selectStructuredSingleOption,
+  structuredFormValidationError,
+  toggleStructuredMultiOption,
+} from "../structured-input.js";
+import { parseSchemaDrivenYieldForm } from "../schema-driven-yield.js";
 import type {
   AdaptiveSurfaceDefinition,
+  AdaptiveSurfaceEventMessage,
   AdaptiveSurfaceInputContext,
+  AdaptiveSurfaceKeyContext,
   AdaptiveSurfaceRenderContext,
 } from "./types.js";
 import { AdaptiveSurfacePanel } from "./shared.js";
+import {
+  structuredQuestionControls,
+  structuredQuestionPositionLabel,
+} from "./structured-input-surface.js";
+import type { PendingYield } from "./yield-state.js";
 
-function renderGenericSurface({ pendingYield }: AdaptiveSurfaceRenderContext) {
+function schemaYieldTitle(pendingYield: PendingYield): string {
+  if (pendingYield.kind === "dynamic_tool") {
+    return "Action required: dynamic tool";
+  }
+  return "Action required: custom yield";
+}
+
+function dynamicToolContextRows(
+  payload: unknown,
+): Array<{ label: string; value: string }> {
+  const data =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : null;
+  if (!data || typeof data.tool_name !== "string") {
+    return [];
+  }
+
+  return [
+    { label: "tool", value: data.tool_name },
+    {
+      label: "arguments",
+      value: JSON.stringify(data.arguments ?? {}, null, 2),
+    },
+  ];
+}
+
+function renderSchemaDrivenSurface({
+  pendingYield,
+  schemaForm,
+}: AdaptiveSurfaceRenderContext) {
+  const activeQuestion = schemaForm?.activeQuestion ?? null;
+  const formState = schemaForm?.formState ?? null;
+  const questions = schemaForm?.questions ?? [];
+  const formError =
+    formState && questions.length > 0
+      ? structuredFormValidationError(formState, questions)
+      : null;
+  const contextRows = dynamicToolContextRows(pendingYield.payload);
+
   return (
     <AdaptiveSurfacePanel
-      title={`Action required: ${pendingYield.kind}`}
+      title={schemaYieldTitle(pendingYield)}
       requestId={pendingYield.requestId}
+    >
+      <Text>{schemaForm?.title ?? "Provide structured input"}</Text>
+      {schemaForm?.prompt ? (
+        <Text color="gray">{schemaForm.prompt}</Text>
+      ) : null}
+      {contextRows.map((row) => (
+        <Box key={row.label} flexDirection="column">
+          <Text color="gray">{row.label}</Text>
+          <Text color={row.label === "tool" ? "cyan" : "gray"}>
+            {row.value}
+          </Text>
+        </Box>
+      ))}
+      {activeQuestion && formState ? (
+        <>
+          <Text color="gray">
+            {structuredQuestionPositionLabel(
+              formState.activeQuestionIndex,
+              questions,
+            )}{" "}
+            | {activeQuestion.required ? "required" : "optional"} |{" "}
+            {activeQuestion.kind}
+          </Text>
+          {questions.map((question, index) => {
+            const isActive = index === formState.activeQuestionIndex;
+            const answerPreview = questionAnswerPreview(formState, question);
+            const error = questionValidationError(formState, question);
+
+            return (
+              <Box key={question.id} flexDirection="column">
+                <Text color={isActive ? "cyan" : undefined}>
+                  {isActive ? "›" : " "} {question.label}
+                  {question.required ? " *" : ""}: {answerPreview}
+                </Text>
+                <Text color="gray">
+                  {question.id}: {question.prompt}
+                </Text>
+                {error && isActive ? <Text color="yellow">{error}</Text> : null}
+              </Box>
+            );
+          })}
+          {activeQuestion.helpText ? (
+            <Text color="gray">{activeQuestion.helpText}</Text>
+          ) : null}
+          {activeQuestion.options?.map((option, index) => {
+            const answer = getStructuredAnswer(formState, activeQuestion);
+            const isSelected = Array.isArray(answer)
+              ? answer.includes(option.value)
+              : answer === option.value;
+            const isCursor =
+              getStructuredOptionCursor(formState, activeQuestion) === index;
+            const marker =
+              activeQuestion.kind === "multi_select"
+                ? isSelected
+                  ? "[x]"
+                  : "[ ]"
+                : isSelected
+                  ? "(x)"
+                  : "( )";
+
+            return (
+              <Text key={option.value} color={isCursor ? "cyan" : "gray"}>
+                {isCursor ? "›" : " "} {index + 1}. {marker} {option.label}
+                {option.description ? ` — ${option.description}` : ""}
+              </Text>
+            );
+          })}
+          {formError ? (
+            <Text color="yellow">Submit blocked: {formError}</Text>
+          ) : (
+            <Text color="green">Form ready to submit.</Text>
+          )}
+          <Text color="gray">{structuredQuestionControls(activeQuestion)}</Text>
+          <Text color="gray">Manual fallback: /resume &lt;json-object&gt;</Text>
+        </>
+      ) : (
+        <Text color="gray">
+          Loading schema-driven form... /resume &lt;json-object&gt;
+        </Text>
+      )}
+    </AdaptiveSurfacePanel>
+  );
+}
+
+function renderGenericSurface(context: AdaptiveSurfaceRenderContext) {
+  if (context.schemaForm) {
+    return renderSchemaDrivenSurface(context);
+  }
+
+  return (
+    <AdaptiveSurfacePanel
+      title={`Action required: ${context.pendingYield.kind}`}
+      requestId={context.pendingYield.requestId}
     >
       <Text color="gray">Command: /resume &lt;json-object&gt;</Text>
     </AdaptiveSurfacePanel>
@@ -21,57 +173,212 @@ function renderGenericSurface({ pendingYield }: AdaptiveSurfaceRenderContext) {
 function buildGenericAnnouncement(
   pendingYield: AdaptiveSurfaceRenderContext["pendingYield"],
 ) {
-  if (pendingYield.kind === "dynamic_tool") {
-    return [
-      {
-        type: "system_warning" as const,
-        message: `Dynamic tool call pending (${pendingYield.requestId}).`,
-      },
-      {
-        type: "system_message" as const,
-        message: "Use /resume <json> to return a custom content payload.",
-      },
-    ];
-  }
-
-  return [
+  const schemaForm = parseSchemaDrivenYieldForm(pendingYield.payload);
+  const messages: AdaptiveSurfaceEventMessage[] = [
     {
-      type: "system_warning" as const,
-      message: `Custom yield pending (${pendingYield.requestId}).`,
-    },
-    {
-      type: "system_message" as const,
-      message: "Use /resume <json> to continue with a custom payload.",
+      type: "system_warning",
+      message:
+        pendingYield.kind === "dynamic_tool"
+          ? `Dynamic tool call pending (${pendingYield.requestId}).`
+          : `Custom yield pending (${pendingYield.requestId}).`,
     },
   ];
+
+  if (schemaForm) {
+    messages.push({
+      type: "system_message",
+      message: schemaForm.title,
+    });
+    if (schemaForm.prompt) {
+      messages.push({
+        type: "system_message",
+        message: schemaForm.prompt,
+      });
+    }
+    messages.push({
+      type: "system_message",
+      message:
+        "Use the adaptive form in the Action panel, or /resume <json> for raw structured fallback.",
+    });
+    return messages;
+  }
+
+  messages.push({
+    type: "system_message",
+    message:
+      pendingYield.kind === "dynamic_tool"
+        ? "Use /resume <json> to return a custom content payload."
+        : "Use /resume <json> to continue with a custom payload.",
+  });
+  return messages;
+}
+
+function genericFooterHint(context: AdaptiveSurfaceRenderContext) {
+  if (context.schemaForm) {
+    return `${structuredQuestionControls(context.schemaForm.activeQuestion)} | /resume fallback`;
+  }
+  return "Resolve: /resume <json>";
+}
+
+function genericInputLabel({
+  schemaForm,
+  inputValue,
+}: AdaptiveSurfaceInputContext) {
+  if (!schemaForm) {
+    return "Action";
+  }
+  return inputValue.startsWith("/") ? "Command" : "Answer / Command";
+}
+
+function genericInputPlaceholder({ schemaForm }: AdaptiveSurfaceInputContext) {
+  if (!schemaForm) {
+    return "Resolve pending yield with command...";
+  }
+  return schemaForm.activeQuestion?.kind === "text"
+    ? `Answer: ${schemaForm.activeQuestion.label} (or /resume fallback)`
+    : "Use adaptive controls above, or type /resume <json>";
+}
+
+function genericInputFocus({
+  schemaForm,
+  inputValue,
+}: AdaptiveSurfaceInputContext) {
+  if (!schemaForm) {
+    return true;
+  }
+
+  return (
+    !schemaForm.activeQuestion ||
+    schemaForm.activeQuestion.kind === "text" ||
+    inputValue.startsWith("/")
+  );
+}
+
+function handleSchemaDrivenKey(context: AdaptiveSurfaceKeyContext) {
+  const schemaForm = context.schemaForm;
+  if (
+    !schemaForm?.formState ||
+    !schemaForm.activeQuestion ||
+    !context.schemaFormControls
+  ) {
+    return false;
+  }
+
+  const { formState, questions, activeQuestion } = schemaForm;
+  const { setFormState } = context.schemaFormControls;
+
+  if (context.inputValue.startsWith("/")) {
+    return false;
+  }
+
+  if (activeQuestion.kind !== "text" && context.input === "/") {
+    context.setInputValue("/");
+    return true;
+  }
+
+  if (context.key.ctrl && context.input === "n") {
+    setFormState((previous) =>
+      previous ? moveStructuredQuestion(previous, questions, 1) : previous,
+    );
+    return true;
+  }
+
+  if (context.key.ctrl && context.input === "p") {
+    setFormState((previous) =>
+      previous ? moveStructuredQuestion(previous, questions, -1) : previous,
+    );
+    return true;
+  }
+
+  if (context.key.ctrl && context.input === "s") {
+    context.schemaFormControls.submitForm();
+    return true;
+  }
+
+  if (activeQuestion.kind === "text") {
+    return false;
+  }
+
+  if (context.key.upArrow || context.input === "k") {
+    setFormState((previous) =>
+      previous
+        ? activeQuestion.kind === "single_select"
+          ? moveStructuredSingleSelection(previous, activeQuestion, -1)
+          : moveStructuredOptionCursor(previous, activeQuestion, -1)
+        : previous,
+    );
+    return true;
+  }
+
+  if (context.key.downArrow || context.input === "j") {
+    setFormState((previous) =>
+      previous
+        ? activeQuestion.kind === "single_select"
+          ? moveStructuredSingleSelection(previous, activeQuestion, 1)
+          : moveStructuredOptionCursor(previous, activeQuestion, 1)
+        : previous,
+    );
+    return true;
+  }
+
+  if (context.input >= "1" && context.input <= "9") {
+    const index = Number(context.input) - 1;
+    if (index >= (activeQuestion.options?.length ?? 0)) {
+      return true;
+    }
+    setFormState((previous) => {
+      if (!previous) return previous;
+      return activeQuestion.kind === "single_select"
+        ? selectStructuredSingleOption(previous, activeQuestion, index)
+        : toggleStructuredMultiOption(previous, activeQuestion, index);
+    });
+    return true;
+  }
+
+  if (activeQuestion.kind === "multi_select" && context.input === " ") {
+    const cursor = getStructuredOptionCursor(formState, activeQuestion);
+    const nextState = toggleStructuredMultiOption(
+      formState,
+      activeQuestion,
+      cursor,
+    );
+    if (nextState === formState) {
+      context.addSystemEvent(
+        "system_warning",
+        `${activeQuestion.label}: at most ${activeQuestion.maxSelections} selections allowed.`,
+      );
+      return true;
+    }
+    setFormState(nextState);
+    return true;
+  }
+
+  if (context.key.return) {
+    context.schemaFormControls.confirmActiveQuestion();
+    return true;
+  }
+
+  return false;
 }
 
 export const dynamicToolSurface: AdaptiveSurfaceDefinition = {
   kind: "dynamic_tool",
   buildAnnouncement: buildGenericAnnouncement,
   render: renderGenericSurface,
-  footerHint() {
-    return "Resolve: /resume <json>";
-  },
-  inputLabel(_: AdaptiveSurfaceInputContext) {
-    return "Action";
-  },
-  inputPlaceholder(_: AdaptiveSurfaceInputContext) {
-    return "Resolve pending yield with command...";
-  },
+  footerHint: genericFooterHint,
+  inputLabel: genericInputLabel,
+  inputPlaceholder: genericInputPlaceholder,
+  inputFocus: genericInputFocus,
+  handleInputKey: handleSchemaDrivenKey,
 };
 
 export const customYieldSurface: AdaptiveSurfaceDefinition = {
   kind: "custom",
   buildAnnouncement: buildGenericAnnouncement,
   render: renderGenericSurface,
-  footerHint() {
-    return "Resolve: /resume <json>";
-  },
-  inputLabel(_: AdaptiveSurfaceInputContext) {
-    return "Action";
-  },
-  inputPlaceholder(_: AdaptiveSurfaceInputContext) {
-    return "Resolve pending yield with command...";
-  },
+  footerHint: genericFooterHint,
+  inputLabel: genericInputLabel,
+  inputPlaceholder: genericInputPlaceholder,
+  inputFocus: genericInputFocus,
+  handleInputKey: handleSchemaDrivenKey,
 };

--- a/clients/tui/src/adaptive-surfaces/types.ts
+++ b/clients/tui/src/adaptive-surfaces/types.ts
@@ -21,6 +21,14 @@ export interface StructuredInputSurfaceState {
   activeQuestion: StructuredQuestion | null;
 }
 
+export interface SchemaDrivenSurfaceState {
+  title: string;
+  prompt?: string;
+  formState: StructuredFormState | null;
+  questions: StructuredQuestion[];
+  activeQuestion: StructuredQuestion | null;
+}
+
 export interface ConfirmationSurfaceState {
   actionIndex: number;
   options: string[];
@@ -29,6 +37,7 @@ export interface ConfirmationSurfaceState {
 export interface AdaptiveSurfaceRenderContext {
   pendingYield: PendingYield;
   confirmation?: ConfirmationSurfaceState;
+  schemaForm?: SchemaDrivenSurfaceState;
   structuredInput?: StructuredInputSurfaceState;
 }
 
@@ -42,12 +51,18 @@ export interface AdaptiveSurfaceKeyContext {
   key: Key;
   inputValue: string;
   confirmation?: ConfirmationSurfaceState;
+  schemaForm?: SchemaDrivenSurfaceState;
   structuredInput?: StructuredInputSurfaceState;
   setInputValue: Dispatch<SetStateAction<string>>;
   addSystemEvent: (type: SystemEventType, message: string) => void;
   submitPendingYield: (content: unknown) => void;
   confirmationControls?: {
     setActionIndex: Dispatch<SetStateAction<number>>;
+  };
+  schemaFormControls?: {
+    setFormState: Dispatch<SetStateAction<StructuredFormState | null>>;
+    submitForm: () => void;
+    confirmActiveQuestion: () => void;
   };
   structuredInputControls?: {
     setFormState: Dispatch<SetStateAction<StructuredFormState | null>>;

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -21,6 +21,10 @@ import { InitWizard } from "./init.js";
 import { preferredConfirmationActionIndex } from "./adaptive-surfaces/confirmation-surface.js";
 import { getAdaptiveSurface } from "./adaptive-surfaces/registry.js";
 import {
+  buildSchemaDrivenYieldPayload,
+  parseSchemaDrivenYieldForm,
+} from "./schema-driven-yield.js";
+import {
   parsePendingYieldKind,
   type PendingYield,
 } from "./adaptive-surfaces/yield-state.js";
@@ -145,6 +149,8 @@ function App() {
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus | null>(null);
   const [pendingYield, setPendingYield] = useState<PendingYield | null>(null);
   const [confirmationActionIndex, setConfirmationActionIndex] = useState(0);
+  const [schemaFormState, setSchemaFormState] =
+    useState<StructuredFormState | null>(null);
   const [structuredFormState, setStructuredFormState] =
     useState<StructuredFormState | null>(null);
 
@@ -154,12 +160,21 @@ function App() {
     pendingYield?.kind === "structured_input"
       ? structuredQuestions(pendingYield.payload)
       : [];
+  const pendingSchemaForm =
+    pendingYield &&
+    (pendingYield.kind === "dynamic_tool" || pendingYield.kind === "custom")
+      ? parseSchemaDrivenYieldForm(pendingYield.payload)
+      : null;
   const activeStructuredQuestion =
     structuredFormState && pendingYield?.kind === "structured_input"
       ? currentStructuredQuestion(
           structuredFormState,
           pendingStructuredQuestions,
         )
+      : null;
+  const activeSchemaQuestion =
+    schemaFormState && pendingSchemaForm
+      ? currentStructuredQuestion(schemaFormState, pendingSchemaForm.questions)
       : null;
   const activeSurface = getAdaptiveSurface(pendingYield);
   const adaptiveSurfaceContext = pendingYield
@@ -172,6 +187,15 @@ function App() {
                 options: confirmationActionOptions(pendingYield.payload),
               }
             : undefined,
+        schemaForm: pendingSchemaForm
+          ? {
+              title: pendingSchemaForm.title,
+              prompt: pendingSchemaForm.prompt,
+              formState: schemaFormState,
+              questions: pendingSchemaForm.questions,
+              activeQuestion: activeSchemaQuestion,
+            }
+          : undefined,
         structuredInput:
           pendingYield.kind === "structured_input"
             ? {
@@ -196,6 +220,38 @@ function App() {
     const options = confirmationActionOptions(pendingYield.payload);
     setConfirmationActionIndex(preferredConfirmationActionIndex(options));
   }, [pendingYield]);
+
+  useEffect(() => {
+    if (
+      pendingYield?.kind !== "dynamic_tool" &&
+      pendingYield?.kind !== "custom"
+    ) {
+      setSchemaFormState(null);
+      return;
+    }
+
+    if (!pendingSchemaForm) {
+      setSchemaFormState(null);
+      return;
+    }
+
+    setSchemaFormState((previous) => {
+      if (
+        previous &&
+        shouldReuseStructuredFormState(
+          previous,
+          pendingYield.requestId,
+          pendingSchemaForm.questions,
+        )
+      ) {
+        return previous;
+      }
+      return createStructuredFormState(
+        pendingYield.requestId,
+        pendingSchemaForm.questions,
+      );
+    });
+  }, [pendingSchemaForm, pendingYield]);
 
   useEffect(() => {
     if (pendingYield?.kind !== "structured_input") {
@@ -244,6 +300,26 @@ function App() {
       return typeof answer === "string" ? answer : "";
     });
   }, [activeStructuredQuestion, pendingYield, structuredFormState]);
+
+  useEffect(() => {
+    if (
+      !pendingSchemaForm ||
+      !schemaFormState ||
+      !activeSchemaQuestion ||
+      activeSchemaQuestion.kind !== "text"
+    ) {
+      return;
+    }
+
+    setInputValue((previous) => {
+      if (previous.startsWith("/")) {
+        return previous;
+      }
+
+      const answer = getStructuredAnswer(schemaFormState, activeSchemaQuestion);
+      return typeof answer === "string" ? answer : "";
+    });
+  }, [activeSchemaQuestion, pendingSchemaForm, schemaFormState]);
 
   const pushEvent = (event: EventEnvelope) => {
     setEvents((prev) => {
@@ -479,6 +555,13 @@ function App() {
     ) {
       return;
     }
+    if (
+      (pendingYield.kind === "dynamic_tool" || pendingYield.kind === "custom") &&
+      pendingSchemaForm &&
+      (!schemaFormState || !activeSchemaQuestion)
+    ) {
+      return;
+    }
 
     if (
       activeSurface.handleInputKey({
@@ -493,6 +576,15 @@ function App() {
                 options: confirmationActionOptions(pendingYield.payload),
               }
             : undefined,
+        schemaForm: pendingSchemaForm
+          ? {
+              title: pendingSchemaForm.title,
+              prompt: pendingSchemaForm.prompt,
+              formState: schemaFormState,
+              questions: pendingSchemaForm.questions,
+              activeQuestion: activeSchemaQuestion,
+            }
+          : undefined,
         structuredInput:
           pendingYield.kind === "structured_input"
             ? {
@@ -512,6 +604,17 @@ function App() {
                 setActionIndex: setConfirmationActionIndex,
               }
             : undefined,
+        schemaFormControls: pendingSchemaForm
+          ? {
+              setFormState: setSchemaFormState,
+              submitForm: () => {
+                void submitSchemaForm();
+              },
+              confirmActiveQuestion: () => {
+                void confirmActiveSchemaQuestion();
+              },
+            }
+          : undefined,
         structuredInputControls:
           pendingYield.kind === "structured_input"
             ? {
@@ -556,24 +659,34 @@ function App() {
     setInputValue(nextValue);
 
     if (
-      pendingYield?.kind !== "structured_input" ||
-      !structuredFormState ||
-      !activeStructuredQuestion ||
-      activeStructuredQuestion.kind !== "text" ||
-      nextValue.startsWith("/")
+      pendingYield?.kind === "structured_input" &&
+      structuredFormState &&
+      activeStructuredQuestion?.kind === "text" &&
+      !nextValue.startsWith("/")
     ) {
-      return;
+      setStructuredFormState((previous) =>
+        previous
+          ? setStructuredTextAnswer(
+              previous,
+              activeStructuredQuestion.id,
+              nextValue,
+            )
+          : previous,
+      );
     }
 
-    setStructuredFormState((previous) =>
-      previous
-        ? setStructuredTextAnswer(
-            previous,
-            activeStructuredQuestion.id,
-            nextValue,
-          )
-        : previous,
-    );
+    if (
+      pendingSchemaForm &&
+      schemaFormState &&
+      activeSchemaQuestion?.kind === "text" &&
+      !nextValue.startsWith("/")
+    ) {
+      setSchemaFormState((previous) =>
+        previous
+          ? setStructuredTextAnswer(previous, activeSchemaQuestion.id, nextValue)
+          : previous,
+      );
+    }
   };
 
   const submitStructuredForm = async (overrideState?: StructuredFormState) => {
@@ -596,6 +709,31 @@ function App() {
     await submitPendingYield(
       buildStructuredResumePayload(formState, pendingStructuredQuestions),
     );
+  };
+
+  const submitSchemaForm = async (overrideState?: StructuredFormState) => {
+    if (!pendingSchemaForm || !schemaFormState) {
+      addSystemEvent("system_warning", "No schema-driven yield request.");
+      return;
+    }
+
+    const formState = overrideState ?? schemaFormState;
+    const error = structuredFormValidationError(
+      formState,
+      pendingSchemaForm.questions,
+    );
+    if (error) {
+      addSystemEvent("system_warning", error);
+      return;
+    }
+
+    const result = buildSchemaDrivenYieldPayload(formState, pendingSchemaForm);
+    if ("error" in result) {
+      addSystemEvent("system_warning", result.error);
+      return;
+    }
+
+    await submitPendingYield(result.payload);
   };
 
   const confirmActiveStructuredQuestion = async (
@@ -631,6 +769,35 @@ function App() {
     setStructuredFormState((previous) =>
       previous
         ? moveStructuredQuestion(nextState, pendingStructuredQuestions, 1)
+        : previous,
+    );
+  };
+
+  const confirmActiveSchemaQuestion = async (
+    overrideState?: StructuredFormState,
+  ) => {
+    if (!pendingSchemaForm || !schemaFormState || !activeSchemaQuestion) {
+      return;
+    }
+
+    const baseState = overrideState ?? schemaFormState;
+    const error = questionValidationError(baseState, activeSchemaQuestion);
+    if (error) {
+      addSystemEvent(
+        "system_warning",
+        `${activeSchemaQuestion.label}: ${error}`,
+      );
+      return;
+    }
+
+    if (baseState.activeQuestionIndex >= pendingSchemaForm.questions.length - 1) {
+      await submitSchemaForm(baseState);
+      return;
+    }
+
+    setSchemaFormState((previous) =>
+      previous
+        ? moveStructuredQuestion(baseState, pendingSchemaForm.questions, 1)
         : previous,
     );
   };
@@ -675,10 +842,29 @@ function App() {
         return;
       }
 
+      if (
+        (pendingYield.kind === "dynamic_tool" || pendingYield.kind === "custom") &&
+        pendingSchemaForm &&
+        schemaFormState &&
+        activeSchemaQuestion?.kind === "text"
+      ) {
+        const nextFormState = setStructuredTextAnswer(
+          schemaFormState,
+          activeSchemaQuestion.id,
+          trimmed,
+        );
+        setSchemaFormState(nextFormState);
+        await confirmActiveSchemaQuestion(nextFormState);
+        setInputValue("");
+        return;
+      }
+
       addSystemEvent(
         "system_warning",
         pendingYield.kind === "structured_input"
           ? "Structured input is pending. Use the Action panel, /answers <json-array>, or /resume <json>."
+          : pendingSchemaForm
+            ? "Schema-driven yield is pending. Use the Action panel or /resume <json>."
           : "Yield is pending. Resolve it first (/approve, /reject, /modify, /answer, /answers, /resume).",
       );
       return;

--- a/clients/tui/src/schema-driven-yield.test.ts
+++ b/clients/tui/src/schema-driven-yield.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { createStructuredFormState } from "./structured-input";
+import {
+  buildSchemaDrivenYieldPayload,
+  parseSchemaDrivenYieldForm,
+} from "./schema-driven-yield";
+
+describe("schema driven yield helpers", () => {
+  test("parses a flat object schema into structured questions", () => {
+    const form = parseSchemaDrivenYieldForm({
+      title: "Return tool result",
+      prompt: "Provide a simple response payload",
+      resume_schema: {
+        type: "object",
+        required: ["success", "result"],
+        properties: {
+          success: {
+            type: "boolean",
+            title: "Success",
+            default: true,
+          },
+          result: {
+            type: "string",
+            title: "Result",
+            description: "Return a result string",
+          },
+          mode: {
+            enum: ["quick", "full"],
+            title: "Mode",
+          },
+        },
+      },
+    });
+
+    expect(form).toEqual({
+      title: "Return tool result",
+      prompt: "Provide a simple response payload",
+      questions: [
+        {
+          id: "success",
+          label: "Success",
+          prompt: "Success",
+          kind: "single_select",
+          required: true,
+          defaultValue: "true",
+          options: [
+            { value: "true", label: "Yes" },
+            { value: "false", label: "No" },
+          ],
+        },
+        {
+          id: "result",
+          label: "Result",
+          prompt: "Return a result string",
+          kind: "text",
+          required: true,
+          placeholder: undefined,
+          defaultValue: undefined,
+          helpText: undefined,
+        },
+        {
+          id: "mode",
+          label: "Mode",
+          prompt: "Mode",
+          kind: "single_select",
+          required: false,
+          defaultValue: undefined,
+          options: [
+            { value: "quick", label: "Quick" },
+            { value: "full", label: "Full" },
+          ],
+        },
+      ],
+      fields: expect.any(Array),
+    });
+  });
+
+  test("falls back when the schema contains unsupported nested objects", () => {
+    expect(
+      parseSchemaDrivenYieldForm({
+        resume_schema: {
+          type: "object",
+          properties: {
+            nested: {
+              type: "object",
+              properties: {
+                key: { type: "string" },
+              },
+            },
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("serializes answered values back into a payload object", () => {
+    const form = parseSchemaDrivenYieldForm({
+      resume_schema: {
+        type: "object",
+        required: ["success", "attempts"],
+        properties: {
+          success: {
+            type: "boolean",
+            default: true,
+          },
+          attempts: {
+            type: "integer",
+          },
+          note: {
+            type: "string",
+          },
+        },
+      },
+    });
+    expect(form).not.toBeNull();
+
+    const state = {
+      ...createStructuredFormState("req-1", form!.questions),
+      answers: {
+        success: "false",
+        attempts: "3",
+        note: "failed after retries",
+      },
+    };
+
+    expect(buildSchemaDrivenYieldPayload(state, form!)).toEqual({
+      payload: {
+        success: false,
+        attempts: 3,
+        note: "failed after retries",
+      },
+    });
+  });
+
+  test("returns a validation error for invalid numeric fields", () => {
+    const form = parseSchemaDrivenYieldForm({
+      resume_schema: {
+        type: "object",
+        required: ["attempts"],
+        properties: {
+          attempts: {
+            type: "integer",
+            title: "Attempts",
+          },
+        },
+      },
+    });
+    const state = {
+      ...createStructuredFormState("req-1", form!.questions),
+      answers: {
+        attempts: "not-a-number",
+      },
+    };
+
+    expect(buildSchemaDrivenYieldPayload(state, form!)).toEqual({
+      error: "Attempts: enter a valid number.",
+    });
+  });
+});

--- a/clients/tui/src/schema-driven-yield.ts
+++ b/clients/tui/src/schema-driven-yield.ts
@@ -1,0 +1,209 @@
+import { getStructuredAnswer, type StructuredFormState } from "./structured-input.js";
+import type { StructuredInputOption, StructuredQuestion } from "./yield.js";
+import { asStringArray } from "./yield.js";
+
+type SchemaPrimitiveType = "string" | "boolean" | "number" | "integer";
+
+interface SchemaDrivenField {
+  key: string;
+  type: SchemaPrimitiveType;
+  question: StructuredQuestion;
+}
+
+export interface SchemaDrivenYieldForm {
+  title: string;
+  prompt?: string;
+  questions: StructuredQuestion[];
+  fields: SchemaDrivenField[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function humanizeKey(value: string): string {
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseStringEnumOptions(value: unknown): StructuredInputOption[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const options = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => ({ value: item, label: humanizeKey(item) }));
+  return options.length === value.length && options.length > 0 ? options : null;
+}
+
+function parseSchemaField(
+  key: string,
+  rawSchema: unknown,
+  requiredKeys: string[],
+): SchemaDrivenField | null {
+  const schema = asRecord(rawSchema);
+  if (!schema) return null;
+
+  const enumOptions = parseStringEnumOptions(schema.enum);
+  const explicitType = asString(schema.type);
+  const type =
+    explicitType === "string" ||
+    explicitType === "boolean" ||
+    explicitType === "number" ||
+    explicitType === "integer"
+      ? explicitType
+      : enumOptions
+        ? "string"
+        : null;
+  if (!type) {
+    return null;
+  }
+
+  const label = asString(schema.title) ?? humanizeKey(key);
+  const description = asString(schema.description) ?? undefined;
+  const defaultValue = schema.default;
+  const required = requiredKeys.includes(key);
+
+  const question: StructuredQuestion =
+    type === "boolean"
+      ? {
+          id: key,
+          label,
+          prompt: description ?? label,
+          kind: "single_select",
+          required,
+          defaultValue:
+            typeof defaultValue === "boolean" ? String(defaultValue) : undefined,
+          options: [
+            { value: "true", label: "Yes" },
+            { value: "false", label: "No" },
+          ],
+        }
+      : enumOptions
+        ? {
+            id: key,
+            label,
+            prompt: description ?? label,
+            kind: "single_select",
+            required,
+            defaultValue: asString(defaultValue) ?? undefined,
+            options: enumOptions,
+          }
+        : {
+            id: key,
+            label,
+            prompt: description ?? label,
+            kind: "text",
+            required,
+            placeholder:
+              type === "number" || type === "integer" ? "0" : undefined,
+            defaultValue:
+              typeof defaultValue === "string" ||
+              typeof defaultValue === "number"
+                ? String(defaultValue)
+                : undefined,
+            helpText:
+              type === "number" || type === "integer"
+                ? "Enter a numeric value."
+                : undefined,
+          };
+
+  return {
+    key,
+    type,
+    question,
+  };
+}
+
+export function parseSchemaDrivenYieldForm(
+  payload: unknown,
+): SchemaDrivenYieldForm | null {
+  const data = asRecord(payload);
+  if (!data) {
+    return null;
+  }
+
+  const schema = asRecord(data.resume_schema ?? data.schema);
+  if (!schema || asString(schema.type) !== "object") {
+    return null;
+  }
+
+  const properties = asRecord(schema.properties);
+  if (!properties) {
+    return null;
+  }
+
+  const requiredKeys = asStringArray(schema.required);
+  const fields = Object.entries(properties)
+    .map(([key, value]) => parseSchemaField(key, value, requiredKeys))
+    .filter((field): field is SchemaDrivenField => field !== null);
+
+  if (fields.length === 0 || fields.length !== Object.keys(properties).length) {
+    return null;
+  }
+
+  return {
+    title:
+      asString(data.title) ??
+      asString(schema.title) ??
+      "Provide structured input",
+    prompt: asString(data.prompt) ?? asString(schema.description) ?? undefined,
+    questions: fields.map((field) => field.question),
+    fields,
+  };
+}
+
+export function buildSchemaDrivenYieldPayload(
+  formState: StructuredFormState,
+  form: SchemaDrivenYieldForm,
+): { payload: Record<string, unknown> } | { error: string } {
+  const payload: Record<string, unknown> = {};
+
+  for (const field of form.fields) {
+    const answer = getStructuredAnswer(formState, field.question);
+
+    if (field.type === "boolean") {
+      const value = typeof answer === "string" ? answer : "";
+      if (!value && !field.question.required) {
+        continue;
+      }
+      payload[field.key] = value === "true";
+      continue;
+    }
+
+    const value = typeof answer === "string" ? answer.trim() : "";
+    if (!value && !field.question.required) {
+      continue;
+    }
+
+    if (field.type === "integer" || field.type === "number") {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) {
+        return {
+          error: `${field.question.label}: enter a valid number.`,
+        };
+      }
+      if (field.type === "integer" && !Number.isInteger(parsed)) {
+        return {
+          error: `${field.question.label}: enter a whole number.`,
+        };
+      }
+      payload[field.key] = parsed;
+      continue;
+    }
+
+    payload[field.key] = value;
+  }
+
+  return { payload };
+}

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -53,6 +53,33 @@ pub(super) enum ToolBatchOrchestratorOutcome {
     EndTurn,
 }
 
+fn dynamic_tool_resume_schema(tool_name: &str) -> Value {
+    json!({
+        "type": "object",
+        "title": format!("Return result for {}", tool_name),
+        "description": "Provide a simple client-side result payload. Use raw /resume JSON for richer nested results.",
+        "required": ["success"],
+        "properties": {
+            "success": {
+                "type": "boolean",
+                "title": "Success",
+                "description": "Set to false if the client-side tool execution failed.",
+                "default": true
+            },
+            "result": {
+                "type": "string",
+                "title": "Result",
+                "description": "Simple string result to send back to the agent."
+            },
+            "error": {
+                "type": "string",
+                "title": "Error",
+                "description": "Optional error message when success is false."
+            }
+        }
+    })
+}
+
 pub(super) struct ToolTurnOrchestrator {
     loop_guard: ToolLoopGuard,
 }
@@ -441,6 +468,9 @@ where
             payload: json!({
                 "tool_name": tool_call.name,
                 "arguments": tool_arguments,
+                "title": format!("Resolve dynamic tool: {}", tool_call.name),
+                "prompt": "Use the adaptive form for simple success/result payloads, or /resume <json> for raw structured results.",
+                "resume_schema": dynamic_tool_resume_schema(&tool_call.name),
             }),
         })
         .await;
@@ -1551,17 +1581,21 @@ mod tests {
         // Should pause for dynamic tool
         match result.unwrap() {
             ToolBatchOrchestratorOutcome::PauseTurn => {
-                // Check Yield DynamicTool event
-                let has_dynamic_tool = events.iter().any(|e| {
-                    matches!(
-                        e,
-                        Event::Yield {
-                            kind: alan_protocol::YieldKind::DynamicTool,
-                            ..
-                        }
-                    )
+                let payload = events.iter().find_map(|event| match event {
+                    Event::Yield {
+                        kind: alan_protocol::YieldKind::DynamicTool,
+                        payload,
+                        ..
+                    } => Some(payload),
+                    _ => None,
                 });
-                assert!(has_dynamic_tool, "Expected Yield DynamicTool event");
+                let payload = payload.expect("Expected Yield DynamicTool event");
+                assert_eq!(payload["tool_name"], "custom_dynamic_tool");
+                assert_eq!(payload["resume_schema"]["type"], "object");
+                assert_eq!(
+                    payload["resume_schema"]["properties"]["success"]["type"],
+                    "boolean"
+                );
             }
             _ => panic!("Expected PauseTurn for dynamic tool"),
         }


### PR DESCRIPTION
## Summary
- render dynamic_tool and custom yields as adaptive schema-driven forms when the payload exposes a flat object schema
- reuse the structured-input interaction model for text, boolean, enum, number, and integer fields while preserving /resume as the raw fallback
- enrich dynamic tool yields with a minimal resume schema so the TUI can present a guided result form

Closes #88

## Testing
- bun run lint
- cargo test -p alan-runtime test_tool_batch_with_dynamic_tool -- --nocapture