### PR TITLE
feat: harden adaptive yield contracts

### DIFF
--- a/clients/tui/src/adaptive-surfaces/generic-surface.tsx
+++ b/clients/tui/src/adaptive-surfaces/generic-surface.tsx
@@ -13,6 +13,12 @@ import {
   toggleStructuredMultiOption,
 } from "../structured-input.js";
 import { parseSchemaDrivenYieldForm } from "../schema-driven-yield.js";
+import {
+  parseDynamicToolYieldPayload,
+  usesMultiSelectKind,
+  usesSingleSelectKind,
+  usesTextEntryKind,
+} from "../yield.js";
 import type {
   AdaptiveSurfaceDefinition,
   AdaptiveSurfaceEventMessage,
@@ -37,11 +43,8 @@ function schemaYieldTitle(pendingYield: PendingYield): string {
 function dynamicToolContextRows(
   payload: unknown,
 ): Array<{ label: string; value: string }> {
-  const data =
-    payload && typeof payload === "object" && !Array.isArray(payload)
-      ? (payload as Record<string, unknown>)
-      : null;
-  if (!data || typeof data.tool_name !== "string") {
+  const data = parseDynamicToolYieldPayload(payload);
+  if (!data) {
     return [];
   }
 
@@ -122,14 +125,13 @@ function renderSchemaDrivenSurface({
               : answer === option.value;
             const isCursor =
               getStructuredOptionCursor(formState, activeQuestion) === index;
-            const marker =
-              activeQuestion.kind === "multi_select"
-                ? isSelected
-                  ? "[x]"
-                  : "[ ]"
-                : isSelected
-                  ? "(x)"
-                  : "( )";
+            const marker = usesMultiSelectKind(activeQuestion.kind)
+              ? isSelected
+                ? "[x]"
+                : "[ ]"
+              : isSelected
+                ? "(x)"
+                : "( )";
 
             return (
               <Text key={option.value} color={isCursor ? "cyan" : "gray"}>
@@ -234,7 +236,8 @@ function genericInputPlaceholder({ schemaForm }: AdaptiveSurfaceInputContext) {
   if (!schemaForm) {
     return "Resolve pending yield with command...";
   }
-  return schemaForm.activeQuestion?.kind === "text"
+  return schemaForm.activeQuestion &&
+    usesTextEntryKind(schemaForm.activeQuestion.kind)
     ? `Answer: ${schemaForm.activeQuestion.label} (or /resume fallback)`
     : "Use adaptive controls above, or type /resume <json>";
 }
@@ -249,7 +252,7 @@ function genericInputFocus({
 
   return (
     !schemaForm.activeQuestion ||
-    schemaForm.activeQuestion.kind === "text" ||
+    usesTextEntryKind(schemaForm.activeQuestion.kind) ||
     inputValue.startsWith("/")
   );
 }
@@ -271,7 +274,7 @@ function handleSchemaDrivenKey(context: AdaptiveSurfaceKeyContext) {
     return false;
   }
 
-  if (activeQuestion.kind !== "text" && context.input === "/") {
+  if (!usesTextEntryKind(activeQuestion.kind) && context.input === "/") {
     context.setInputValue("/");
     return true;
   }
@@ -295,14 +298,14 @@ function handleSchemaDrivenKey(context: AdaptiveSurfaceKeyContext) {
     return true;
   }
 
-  if (activeQuestion.kind === "text") {
+  if (usesTextEntryKind(activeQuestion.kind)) {
     return false;
   }
 
   if (context.key.upArrow || context.input === "k") {
     setFormState((previous) =>
       previous
-        ? activeQuestion.kind === "single_select"
+        ? usesSingleSelectKind(activeQuestion.kind)
           ? moveStructuredSingleSelection(previous, activeQuestion, -1)
           : moveStructuredOptionCursor(previous, activeQuestion, -1)
         : previous,
@@ -313,7 +316,7 @@ function handleSchemaDrivenKey(context: AdaptiveSurfaceKeyContext) {
   if (context.key.downArrow || context.input === "j") {
     setFormState((previous) =>
       previous
-        ? activeQuestion.kind === "single_select"
+        ? usesSingleSelectKind(activeQuestion.kind)
           ? moveStructuredSingleSelection(previous, activeQuestion, 1)
           : moveStructuredOptionCursor(previous, activeQuestion, 1)
         : previous,
@@ -328,14 +331,14 @@ function handleSchemaDrivenKey(context: AdaptiveSurfaceKeyContext) {
     }
     setFormState((previous) => {
       if (!previous) return previous;
-      return activeQuestion.kind === "single_select"
+      return usesSingleSelectKind(activeQuestion.kind)
         ? selectStructuredSingleOption(previous, activeQuestion, index)
         : toggleStructuredMultiOption(previous, activeQuestion, index);
     });
     return true;
   }
 
-  if (activeQuestion.kind === "multi_select" && context.input === " ") {
+  if (usesMultiSelectKind(activeQuestion.kind) && context.input === " ") {
     const cursor = getStructuredOptionCursor(formState, activeQuestion);
     const nextState = toggleStructuredMultiOption(
       formState,

--- a/clients/tui/src/adaptive-surfaces/structured-input-surface.tsx
+++ b/clients/tui/src/adaptive-surfaces/structured-input-surface.tsx
@@ -14,6 +14,9 @@ import {
 } from "../structured-input.js";
 import type { StructuredQuestion } from "../yield.js";
 import {
+  usesMultiSelectKind,
+  usesSingleSelectKind,
+  usesTextEntryKind,
   structuredPrompt,
   structuredQuestions,
   structuredTitle,
@@ -33,14 +36,13 @@ export function structuredAnswersTemplate(payload: unknown): string {
 
   const template = questions.map((q) => ({
     question_id: q.id,
-    value:
-      q.kind === "multi_select"
-        ? (q.defaultValues ??
-          q.options?.slice(0, 1).map((option) => option.value) ??
-          [])
-        : q.kind === "single_select"
-          ? (q.defaultValue ?? q.options?.[0]?.value ?? "")
-          : (q.defaultValue ?? (q.required ? "<required-value>" : "")),
+    value: usesMultiSelectKind(q.kind)
+      ? (q.defaultValues ??
+        q.options?.slice(0, 1).map((option) => option.value) ??
+        [])
+      : usesSingleSelectKind(q.kind)
+        ? (q.defaultValue ?? q.options?.[0]?.value ?? "")
+        : (q.defaultValue ?? (q.required ? "<required-value>" : "")),
   }));
 
   return JSON.stringify(template);
@@ -60,11 +62,11 @@ export function structuredQuestionControls(
     return "Controls: type / for manual command mode";
   }
 
-  if (question.kind === "text") {
+  if (usesTextEntryKind(question.kind)) {
     return "Controls: Enter save/submit | Ctrl+N next | Ctrl+P previous | type / for commands";
   }
 
-  if (question.kind === "single_select") {
+  if (usesSingleSelectKind(question.kind)) {
     return "Controls: ↑/↓ or 1-9 choose | Enter confirm | Ctrl+N/P move | type / for commands";
   }
 
@@ -154,10 +156,11 @@ function renderStructuredInputSurface({
           {activeQuestion.helpText ? (
             <Text color="gray">{activeQuestion.helpText}</Text>
           ) : null}
-          {activeQuestion.kind === "text" && activeQuestion.placeholder ? (
+          {usesTextEntryKind(activeQuestion.kind) &&
+          activeQuestion.placeholder ? (
             <Text color="gray">placeholder: {activeQuestion.placeholder}</Text>
           ) : null}
-          {activeQuestion.kind === "multi_select" ? (
+          {usesMultiSelectKind(activeQuestion.kind) ? (
             <Text color="gray">
               constraint: min=
               {activeQuestion.minSelections ??
@@ -172,14 +175,13 @@ function renderStructuredInputSurface({
               : answer === option.value;
             const isCursor =
               getStructuredOptionCursor(formState, activeQuestion) === index;
-            const marker =
-              activeQuestion.kind === "multi_select"
-                ? isSelected
-                  ? "[x]"
-                  : "[ ]"
-                : isSelected
-                  ? "(x)"
-                  : "( )";
+            const marker = usesMultiSelectKind(activeQuestion.kind)
+              ? isSelected
+                ? "[x]"
+                : "[ ]"
+              : isSelected
+                ? "(x)"
+                : "( )";
 
             return (
               <Text key={option.value} color={isCursor ? "cyan" : "gray"}>
@@ -227,7 +229,7 @@ function structuredInputPlaceholder({
   structuredInput,
 }: AdaptiveSurfaceInputContext) {
   const activeQuestion = structuredInput?.activeQuestion ?? null;
-  return activeQuestion?.kind === "text"
+  return activeQuestion && usesTextEntryKind(activeQuestion.kind)
     ? `Answer: ${activeQuestion.label} (or /answers fallback)`
     : "Use adaptive controls above, or type /answers <json-array>";
 }
@@ -238,7 +240,7 @@ function structuredInputFocus({
 }: AdaptiveSurfaceInputContext) {
   return (
     !structuredInput?.activeQuestion ||
-    structuredInput.activeQuestion.kind === "text" ||
+    usesTextEntryKind(structuredInput.activeQuestion.kind) ||
     inputValue.startsWith("/")
   );
 }
@@ -267,7 +269,7 @@ function handleStructuredInputKey({
     return false;
   }
 
-  if (activeQuestion.kind !== "text" && input === "/") {
+  if (!usesTextEntryKind(activeQuestion.kind) && input === "/") {
     setInputValue("/");
     return true;
   }
@@ -291,14 +293,14 @@ function handleStructuredInputKey({
     return true;
   }
 
-  if (activeQuestion.kind === "text") {
+  if (usesTextEntryKind(activeQuestion.kind)) {
     return false;
   }
 
   if (key.upArrow || input === "k") {
     setFormState((previous) =>
       previous
-        ? activeQuestion.kind === "single_select"
+        ? usesSingleSelectKind(activeQuestion.kind)
           ? moveStructuredSingleSelection(previous, activeQuestion, -1)
           : moveStructuredOptionCursor(previous, activeQuestion, -1)
         : previous,
@@ -309,7 +311,7 @@ function handleStructuredInputKey({
   if (key.downArrow || input === "j") {
     setFormState((previous) =>
       previous
-        ? activeQuestion.kind === "single_select"
+        ? usesSingleSelectKind(activeQuestion.kind)
           ? moveStructuredSingleSelection(previous, activeQuestion, 1)
           : moveStructuredOptionCursor(previous, activeQuestion, 1)
         : previous,
@@ -324,14 +326,14 @@ function handleStructuredInputKey({
     }
     setFormState((previous) => {
       if (!previous) return previous;
-      return activeQuestion.kind === "single_select"
+      return usesSingleSelectKind(activeQuestion.kind)
         ? selectStructuredSingleOption(previous, activeQuestion, index)
         : toggleStructuredMultiOption(previous, activeQuestion, index);
     });
     return true;
   }
 
-  if (activeQuestion.kind === "multi_select" && input === " ") {
+  if (usesMultiSelectKind(activeQuestion.kind) && input === " ") {
     const cursor = getStructuredOptionCursor(formState, activeQuestion);
     const nextState = toggleStructuredMultiOption(
       formState,

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -9,6 +9,7 @@
 import { WebSocket } from "ws";
 import { DaemonManager, getDaemon } from "./daemon.js";
 import type {
+  ClientCapabilities,
   ContentPart,
   EventEnvelope,
   Op,
@@ -332,6 +333,16 @@ export class AlanClient {
     if (!response.ok) {
       throw new Error(`Failed to submit operation: ${response.statusText}`);
     }
+  }
+
+  public async setClientCapabilities(
+    sessionId: string,
+    capabilities: ClientCapabilities,
+  ): Promise<void> {
+    await this.submitOperation(sessionId, {
+      type: "set_client_capabilities",
+      capabilities,
+    });
   }
 
   /**

--- a/clients/tui/src/generated/types.ts
+++ b/clients/tui/src/generated/types.ts
@@ -21,6 +21,89 @@ export type YieldKind =
   | (string & {})
   | { custom: string };
 
+export type AdaptivePresentationHint =
+  | "radio"
+  | "toggle"
+  | "searchable"
+  | "multiline"
+  | "compact"
+  | "dangerous";
+
+export type StructuredInputKind =
+  | "text"
+  | "boolean"
+  | "number"
+  | "integer"
+  | "single_select"
+  | "multi_select";
+
+export interface StructuredInputOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface StructuredInputQuestion {
+  id: string;
+  label: string;
+  prompt: string;
+  kind?: StructuredInputKind;
+  required?: boolean;
+  placeholder?: string;
+  help_text?: string;
+  default?: string;
+  defaults?: string[];
+  min_selected?: number;
+  max_selected?: number;
+  options?: StructuredInputOption[];
+  presentation_hints?: AdaptivePresentationHint[];
+}
+
+export interface AdaptiveForm {
+  fields?: StructuredInputQuestion[];
+}
+
+export interface ConfirmationYieldPayload {
+  checkpoint_type: string;
+  summary: string;
+  details?: unknown;
+  options?: string[];
+  default_option?: string;
+  presentation_hints?: AdaptivePresentationHint[];
+}
+
+export interface StructuredInputYieldPayload {
+  title: string;
+  prompt?: string;
+  questions?: StructuredInputQuestion[];
+}
+
+export interface DynamicToolYieldPayload {
+  tool_name: string;
+  arguments: unknown;
+  title: string;
+  prompt?: string;
+  form?: AdaptiveForm;
+}
+
+export interface CustomYieldPayload {
+  title?: string;
+  prompt?: string;
+  details?: unknown;
+  form?: AdaptiveForm;
+}
+
+export interface AdaptiveYieldCapabilities {
+  rich_confirmation?: boolean;
+  structured_input?: boolean;
+  schema_driven_forms?: boolean;
+  presentation_hints?: boolean;
+}
+
+export interface ClientCapabilities {
+  adaptive_yields?: AdaptiveYieldCapabilities;
+}
+
 export interface ToolDecisionAudit {
   policy_source: string;
   rule_id?: string;

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -15,7 +15,11 @@ import {
   shouldRunFirstTimeSetup,
 } from "./config-path.js";
 import { detectWorkspaceDirFromCwd } from "./workspace-detect.js";
-import type { DaemonStatus, EventEnvelope } from "./types.js";
+import type {
+  ClientCapabilities,
+  DaemonStatus,
+  EventEnvelope,
+} from "./types.js";
 import { MessageList } from "./components.js";
 import { InitWizard } from "./init.js";
 import { preferredConfirmationActionIndex } from "./adaptive-surfaces/confirmation-surface.js";
@@ -41,8 +45,13 @@ import {
   structuredFormValidationError,
   type StructuredFormState,
 } from "./structured-input.js";
-import { structuredQuestions } from "./yield.js";
-import { confirmationActionOptions } from "./yield.js";
+import {
+  confirmationActionOptions,
+  structuredQuestions,
+  usesMultiSelectKind,
+  usesSingleSelectKind,
+  usesTextEntryKind,
+} from "./yield.js";
 
 const AGENTD_URL = process.env.ALAN_AGENTD_URL;
 const AUTO_MANAGE = !AGENTD_URL;
@@ -78,6 +87,15 @@ const CONFIG_PATH_HINT =
 const STARTUP_INFO = {
   mode: AGENTD_URL ? "remote" : ("embedded" as const),
   url: AGENTD_URL || "ws://127.0.0.1:8090",
+};
+
+const TUI_CLIENT_CAPABILITIES: ClientCapabilities = {
+  adaptive_yields: {
+    rich_confirmation: true,
+    structured_input: true,
+    schema_driven_forms: true,
+    presentation_hints: true,
+  },
 };
 
 function needsFirstTimeSetup(): boolean {
@@ -289,7 +307,7 @@ function App() {
         return previous;
       }
 
-      if (activeStructuredQuestion.kind !== "text") {
+      if (!usesTextEntryKind(activeStructuredQuestion.kind)) {
         return "";
       }
 
@@ -306,7 +324,7 @@ function App() {
       !pendingSchemaForm ||
       !schemaFormState ||
       !activeSchemaQuestion ||
-      activeSchemaQuestion.kind !== "text"
+      !usesTextEntryKind(activeSchemaQuestion.kind)
     ) {
       return;
     }
@@ -371,6 +389,17 @@ function App() {
     });
     clientRef.current = client;
 
+    const syncClientCapabilities = async (sessionId: string) => {
+      try {
+        await client.setClientCapabilities(sessionId, TUI_CLIENT_CAPABILITIES);
+      } catch (error) {
+        addSystemEvent(
+          "system_warning",
+          `Failed to sync adaptive UI capabilities: ${(error as Error).message}`,
+        );
+      }
+    };
+
     client.on("connected", () => {
       setStatus("connected");
       setStatusMessage(
@@ -378,6 +407,10 @@ function App() {
           ? "Ready"
           : `Connected to ${STARTUP_INFO.url}`,
       );
+
+      if (sessionIdRef.current) {
+        void syncClientCapabilities(sessionIdRef.current);
+      }
     });
 
     client.on("disconnected", () => {
@@ -556,7 +589,8 @@ function App() {
       return;
     }
     if (
-      (pendingYield.kind === "dynamic_tool" || pendingYield.kind === "custom") &&
+      (pendingYield.kind === "dynamic_tool" ||
+        pendingYield.kind === "custom") &&
       pendingSchemaForm &&
       (!schemaFormState || !activeSchemaQuestion)
     ) {
@@ -661,7 +695,8 @@ function App() {
     if (
       pendingYield?.kind === "structured_input" &&
       structuredFormState &&
-      activeStructuredQuestion?.kind === "text" &&
+      activeStructuredQuestion &&
+      usesTextEntryKind(activeStructuredQuestion.kind) &&
       !nextValue.startsWith("/")
     ) {
       setStructuredFormState((previous) =>
@@ -678,12 +713,17 @@ function App() {
     if (
       pendingSchemaForm &&
       schemaFormState &&
-      activeSchemaQuestion?.kind === "text" &&
+      activeSchemaQuestion &&
+      usesTextEntryKind(activeSchemaQuestion.kind) &&
       !nextValue.startsWith("/")
     ) {
       setSchemaFormState((previous) =>
         previous
-          ? setStructuredTextAnswer(previous, activeSchemaQuestion.id, nextValue)
+          ? setStructuredTextAnswer(
+              previous,
+              activeSchemaQuestion.id,
+              nextValue,
+            )
           : previous,
       );
     }
@@ -790,7 +830,10 @@ function App() {
       return;
     }
 
-    if (baseState.activeQuestionIndex >= pendingSchemaForm.questions.length - 1) {
+    if (
+      baseState.activeQuestionIndex >=
+      pendingSchemaForm.questions.length - 1
+    ) {
       await submitSchemaForm(baseState);
       return;
     }
@@ -829,7 +872,8 @@ function App() {
       if (
         pendingYield.kind === "structured_input" &&
         structuredFormState &&
-        activeStructuredQuestion?.kind === "text"
+        activeStructuredQuestion &&
+        usesTextEntryKind(activeStructuredQuestion.kind)
       ) {
         const nextFormState = setStructuredTextAnswer(
           structuredFormState,
@@ -843,10 +887,12 @@ function App() {
       }
 
       if (
-        (pendingYield.kind === "dynamic_tool" || pendingYield.kind === "custom") &&
+        (pendingYield.kind === "dynamic_tool" ||
+          pendingYield.kind === "custom") &&
         pendingSchemaForm &&
         schemaFormState &&
-        activeSchemaQuestion?.kind === "text"
+        activeSchemaQuestion &&
+        usesTextEntryKind(activeSchemaQuestion.kind)
       ) {
         const nextFormState = setStructuredTextAnswer(
           schemaFormState,
@@ -865,7 +911,7 @@ function App() {
           ? "Structured input is pending. Use the Action panel, /answers <json-array>, or /resume <json>."
           : pendingSchemaForm
             ? "Schema-driven yield is pending. Use the Action panel or /resume <json>."
-          : "Yield is pending. Resolve it first (/approve, /reject, /modify, /answer, /answers, /resume).",
+            : "Yield is pending. Resolve it first (/approve, /reject, /modify, /answer, /answers, /resume).",
       );
       return;
     }
@@ -1215,13 +1261,12 @@ function App() {
         }
 
         if (questions.length === 1) {
-          const singleAnswerValue =
-            targetQuestion.kind === "multi_select"
-              ? value
-                  .split(",")
-                  .map((item) => item.trim())
-                  .filter(Boolean)
-              : value;
+          const singleAnswerValue = usesMultiSelectKind(targetQuestion.kind)
+            ? value
+                .split(",")
+                .map((item) => item.trim())
+                .filter(Boolean)
+            : value;
           const nextState = {
             ...createStructuredFormState(pendingYield.requestId, questions),
             answers: {
@@ -1249,7 +1294,7 @@ function App() {
         }
 
         let nextFormState = structuredFormState;
-        if (targetQuestion.kind === "multi_select") {
+        if (usesMultiSelectKind(targetQuestion.kind)) {
           const selectedValues = value
             .split(",")
             .map((item) => item.trim())
@@ -1261,7 +1306,7 @@ function App() {
               [targetQuestion.id]: selectedValues,
             },
           };
-        } else if (targetQuestion.kind === "single_select") {
+        } else if (usesSingleSelectKind(targetQuestion.kind)) {
           const optionIndex =
             targetQuestion.options?.findIndex(
               (option) => option.value === value,

--- a/clients/tui/src/schema-driven-yield.test.ts
+++ b/clients/tui/src/schema-driven-yield.test.ts
@@ -6,29 +6,43 @@ import {
 } from "./schema-driven-yield";
 
 describe("schema driven yield helpers", () => {
-  test("parses a flat object schema into structured questions", () => {
+  test("parses a typed adaptive form contract from dynamic tool payloads", () => {
     const form = parseSchemaDrivenYieldForm({
+      tool_name: "custom_tool",
       title: "Return tool result",
       prompt: "Provide a simple response payload",
-      resume_schema: {
-        type: "object",
-        required: ["success", "result"],
-        properties: {
-          success: {
-            type: "boolean",
-            title: "Success",
-            default: true,
+      form: {
+        fields: [
+          {
+            id: "success",
+            label: "Success",
+            prompt: "Did it work?",
+            kind: "boolean",
+            required: true,
+            default: "true",
+            options: [
+              { value: "true", label: "Yes" },
+              { value: "false", label: "No" },
+            ],
+            presentation_hints: ["toggle"],
           },
-          result: {
-            type: "string",
-            title: "Result",
-            description: "Return a result string",
+          {
+            id: "result",
+            label: "Result",
+            prompt: "Return a result string",
+            kind: "text",
           },
-          mode: {
-            enum: ["quick", "full"],
-            title: "Mode",
+          {
+            id: "mode",
+            label: "Mode",
+            prompt: "Mode",
+            kind: "single_select",
+            options: [
+              { value: "quick", label: "Quick" },
+              { value: "full", label: "Full" },
+            ],
           },
-        },
+        ],
       },
     });
 
@@ -39,55 +53,66 @@ describe("schema driven yield helpers", () => {
         {
           id: "success",
           label: "Success",
-          prompt: "Success",
-          kind: "single_select",
+          prompt: "Did it work?",
+          kind: "boolean",
           required: true,
           defaultValue: "true",
           options: [
             { value: "true", label: "Yes" },
             { value: "false", label: "No" },
           ],
+          presentationHints: ["toggle"],
         },
         {
           id: "result",
           label: "Result",
           prompt: "Return a result string",
           kind: "text",
-          required: true,
+          required: undefined,
           placeholder: undefined,
-          defaultValue: undefined,
           helpText: undefined,
+          defaultValue: undefined,
+          defaultValues: undefined,
+          minSelections: undefined,
+          maxSelections: undefined,
+          options: undefined,
+          presentationHints: undefined,
         },
         {
           id: "mode",
           label: "Mode",
           prompt: "Mode",
           kind: "single_select",
-          required: false,
+          required: undefined,
+          placeholder: undefined,
+          helpText: undefined,
           defaultValue: undefined,
+          defaultValues: undefined,
+          minSelections: undefined,
+          maxSelections: undefined,
           options: [
             { value: "quick", label: "Quick" },
             { value: "full", label: "Full" },
           ],
+          presentationHints: undefined,
         },
       ],
-      fields: expect.any(Array),
     });
   });
 
-  test("falls back when the schema contains unsupported nested objects", () => {
+  test("falls back when the form contains unsupported entries", () => {
     expect(
       parseSchemaDrivenYieldForm({
-        resume_schema: {
-          type: "object",
-          properties: {
-            nested: {
-              type: "object",
-              properties: {
-                key: { type: "string" },
-              },
+        title: "Bad form",
+        form: {
+          fields: [
+            {
+              id: "nested",
+              label: "Nested",
+              prompt: "Nested",
+              kind: "object",
             },
-          },
+          ],
         },
       }),
     ).toBeNull();
@@ -95,21 +120,35 @@ describe("schema driven yield helpers", () => {
 
   test("serializes answered values back into a payload object", () => {
     const form = parseSchemaDrivenYieldForm({
-      resume_schema: {
-        type: "object",
-        required: ["success", "attempts"],
-        properties: {
-          success: {
-            type: "boolean",
-            default: true,
+      title: "Return tool result",
+      form: {
+        fields: [
+          {
+            id: "success",
+            label: "Success",
+            prompt: "Did it work?",
+            kind: "boolean",
+            required: true,
+            default: "true",
+            options: [
+              { value: "true", label: "Yes" },
+              { value: "false", label: "No" },
+            ],
           },
-          attempts: {
-            type: "integer",
+          {
+            id: "attempts",
+            label: "Attempts",
+            prompt: "How many attempts?",
+            kind: "integer",
+            required: true,
           },
-          note: {
-            type: "string",
+          {
+            id: "note",
+            label: "Note",
+            prompt: "Additional note",
+            kind: "text",
           },
-        },
+        ],
       },
     });
     expect(form).not.toBeNull();
@@ -134,15 +173,17 @@ describe("schema driven yield helpers", () => {
 
   test("returns a validation error for invalid numeric fields", () => {
     const form = parseSchemaDrivenYieldForm({
-      resume_schema: {
-        type: "object",
-        required: ["attempts"],
-        properties: {
-          attempts: {
-            type: "integer",
-            title: "Attempts",
+      title: "Numeric form",
+      form: {
+        fields: [
+          {
+            id: "attempts",
+            label: "Attempts",
+            prompt: "Attempts",
+            kind: "integer",
+            required: true,
           },
-        },
+        ],
       },
     });
     const state = {

--- a/clients/tui/src/schema-driven-yield.ts
+++ b/clients/tui/src/schema-driven-yield.ts
@@ -1,166 +1,42 @@
-import { getStructuredAnswer, type StructuredFormState } from "./structured-input.js";
-import type { StructuredInputOption, StructuredQuestion } from "./yield.js";
-import { asStringArray } from "./yield.js";
-
-type SchemaPrimitiveType = "string" | "boolean" | "number" | "integer";
-
-interface SchemaDrivenField {
-  key: string;
-  type: SchemaPrimitiveType;
-  question: StructuredQuestion;
-}
+import {
+  getStructuredAnswer,
+  type StructuredFormState,
+} from "./structured-input.js";
+import type { StructuredQuestion } from "./yield.js";
+import {
+  parseCustomYieldPayload,
+  parseDynamicToolYieldPayload,
+  usesMultiSelectKind,
+} from "./yield.js";
 
 export interface SchemaDrivenYieldForm {
   title: string;
   prompt?: string;
   questions: StructuredQuestion[];
-  fields: SchemaDrivenField[];
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === "string" ? value : null;
-}
-
-function humanizeKey(value: string): string {
-  return value
-    .split(/[_\s]+/)
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function parseStringEnumOptions(value: unknown): StructuredInputOption[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-
-  const options = value
-    .filter((item): item is string => typeof item === "string")
-    .map((item) => ({ value: item, label: humanizeKey(item) }));
-  return options.length === value.length && options.length > 0 ? options : null;
-}
-
-function parseSchemaField(
-  key: string,
-  rawSchema: unknown,
-  requiredKeys: string[],
-): SchemaDrivenField | null {
-  const schema = asRecord(rawSchema);
-  if (!schema) return null;
-
-  const enumOptions = parseStringEnumOptions(schema.enum);
-  const explicitType = asString(schema.type);
-  const type =
-    explicitType === "string" ||
-    explicitType === "boolean" ||
-    explicitType === "number" ||
-    explicitType === "integer"
-      ? explicitType
-      : enumOptions
-        ? "string"
-        : null;
-  if (!type) {
-    return null;
-  }
-
-  const label = asString(schema.title) ?? humanizeKey(key);
-  const description = asString(schema.description) ?? undefined;
-  const defaultValue = schema.default;
-  const required = requiredKeys.includes(key);
-
-  const question: StructuredQuestion =
-    type === "boolean"
-      ? {
-          id: key,
-          label,
-          prompt: description ?? label,
-          kind: "single_select",
-          required,
-          defaultValue:
-            typeof defaultValue === "boolean" ? String(defaultValue) : undefined,
-          options: [
-            { value: "true", label: "Yes" },
-            { value: "false", label: "No" },
-          ],
-        }
-      : enumOptions
-        ? {
-            id: key,
-            label,
-            prompt: description ?? label,
-            kind: "single_select",
-            required,
-            defaultValue: asString(defaultValue) ?? undefined,
-            options: enumOptions,
-          }
-        : {
-            id: key,
-            label,
-            prompt: description ?? label,
-            kind: "text",
-            required,
-            placeholder:
-              type === "number" || type === "integer" ? "0" : undefined,
-            defaultValue:
-              typeof defaultValue === "string" ||
-              typeof defaultValue === "number"
-                ? String(defaultValue)
-                : undefined,
-            helpText:
-              type === "number" || type === "integer"
-                ? "Enter a numeric value."
-                : undefined,
-          };
-
-  return {
-    key,
-    type,
-    question,
-  };
 }
 
 export function parseSchemaDrivenYieldForm(
   payload: unknown,
 ): SchemaDrivenYieldForm | null {
-  const data = asRecord(payload);
-  if (!data) {
-    return null;
+  const dynamic = parseDynamicToolYieldPayload(payload);
+  if (dynamic?.form?.fields.length) {
+    return {
+      title: dynamic.title,
+      prompt: dynamic.prompt,
+      questions: dynamic.form.fields,
+    };
   }
 
-  const schema = asRecord(data.resume_schema ?? data.schema);
-  if (!schema || asString(schema.type) !== "object") {
-    return null;
+  const custom = parseCustomYieldPayload(payload);
+  if (custom?.form?.fields.length) {
+    return {
+      title: custom.title ?? "Provide structured input",
+      prompt: custom.prompt,
+      questions: custom.form.fields,
+    };
   }
 
-  const properties = asRecord(schema.properties);
-  if (!properties) {
-    return null;
-  }
-
-  const requiredKeys = asStringArray(schema.required);
-  const fields = Object.entries(properties)
-    .map(([key, value]) => parseSchemaField(key, value, requiredKeys))
-    .filter((field): field is SchemaDrivenField => field !== null);
-
-  if (fields.length === 0 || fields.length !== Object.keys(properties).length) {
-    return null;
-  }
-
-  return {
-    title:
-      asString(data.title) ??
-      asString(schema.title) ??
-      "Provide structured input",
-    prompt: asString(data.prompt) ?? asString(schema.description) ?? undefined,
-    questions: fields.map((field) => field.question),
-    fields,
-  };
+  return null;
 }
 
 export function buildSchemaDrivenYieldPayload(
@@ -169,40 +45,44 @@ export function buildSchemaDrivenYieldPayload(
 ): { payload: Record<string, unknown> } | { error: string } {
   const payload: Record<string, unknown> = {};
 
-  for (const field of form.fields) {
-    const answer = getStructuredAnswer(formState, field.question);
+  for (const question of form.questions) {
+    const answer = getStructuredAnswer(formState, question);
 
-    if (field.type === "boolean") {
-      const value = typeof answer === "string" ? answer : "";
-      if (!value && !field.question.required) {
-        continue;
+    if (usesMultiSelectKind(question.kind)) {
+      const selected = Array.isArray(answer) ? answer : [];
+      if (selected.length > 0) {
+        payload[question.id] = selected;
       }
-      payload[field.key] = value === "true";
       continue;
     }
 
     const value = typeof answer === "string" ? answer.trim() : "";
-    if (!value && !field.question.required) {
+    if (!value && !question.required) {
       continue;
     }
 
-    if (field.type === "integer" || field.type === "number") {
+    if (question.kind === "boolean") {
+      payload[question.id] = value === "true";
+      continue;
+    }
+
+    if (question.kind === "integer" || question.kind === "number") {
       const parsed = Number(value);
       if (!Number.isFinite(parsed)) {
         return {
-          error: `${field.question.label}: enter a valid number.`,
+          error: `${question.label}: enter a valid number.`,
         };
       }
-      if (field.type === "integer" && !Number.isInteger(parsed)) {
+      if (question.kind === "integer" && !Number.isInteger(parsed)) {
         return {
-          error: `${field.question.label}: enter a whole number.`,
+          error: `${question.label}: enter a whole number.`,
         };
       }
-      payload[field.key] = parsed;
+      payload[question.id] = parsed;
       continue;
     }
 
-    payload[field.key] = value;
+    payload[question.id] = value;
   }
 
   return { payload };

--- a/clients/tui/src/structured-input.test.ts
+++ b/clients/tui/src/structured-input.test.ts
@@ -92,9 +92,9 @@ describe("structured input helpers", () => {
     expect(
       shouldReuseStructuredFormState(state, "req-1", changedQuestions),
     ).toBe(false);
-    expect(
-      shouldReuseStructuredFormState(state, "req-2", QUESTIONS),
-    ).toBe(false);
+    expect(shouldReuseStructuredFormState(state, "req-2", QUESTIONS)).toBe(
+      false,
+    );
   });
 
   test("single-select and multi-select helpers update answers", () => {
@@ -128,12 +128,10 @@ describe("structured input helpers", () => {
       1,
     );
 
-    expect(state.answers[OPTIONAL_SINGLE_SELECT_QUESTION.id]).toBe(
-      "anthropic",
-    );
-    expect(state.optionCursorByQuestionId[OPTIONAL_SINGLE_SELECT_QUESTION.id]).toBe(
-      1,
-    );
+    expect(state.answers[OPTIONAL_SINGLE_SELECT_QUESTION.id]).toBe("anthropic");
+    expect(
+      state.optionCursorByQuestionId[OPTIONAL_SINGLE_SELECT_QUESTION.id],
+    ).toBe(1);
   });
 
   test("multi-select helper respects maxSelections", () => {

--- a/clients/tui/src/structured-input.ts
+++ b/clients/tui/src/structured-input.ts
@@ -1,4 +1,9 @@
-import type { StructuredQuestion } from "./yield";
+import {
+  type StructuredQuestion,
+  usesMultiSelectKind,
+  usesSingleSelectKind,
+  usesTextEntryKind,
+} from "./yield";
 
 export type StructuredAnswerValue = string | string[];
 
@@ -63,7 +68,7 @@ export function createStructuredFormState(
   const optionCursorByQuestionId: Record<string, number> = {};
 
   for (const question of questions) {
-    if (question.kind === "multi_select") {
+    if (usesMultiSelectKind(question.kind)) {
       const defaults = question.defaultValues ?? [];
       answers[question.id] = [...defaults];
       optionCursorByQuestionId[question.id] = optionIndexForValue(
@@ -119,7 +124,7 @@ export function getStructuredAnswer(
   if (answer !== undefined) {
     return answer;
   }
-  return question.kind === "multi_select" ? [] : "";
+  return usesMultiSelectKind(question.kind) ? [] : "";
 }
 
 export function getStructuredOptionCursor(
@@ -261,11 +266,10 @@ export function questionValidationError(
   const answer = getStructuredAnswer(state, question);
   const allowedValues = allowedOptionValues(question);
 
-  if (question.kind === "multi_select") {
+  if (usesMultiSelectKind(question.kind)) {
     const selected = Array.isArray(answer) ? answer : [];
     const unknownValues = selected.filter(
-      (value) =>
-        allowedValues.length > 0 && !allowedValues.includes(value),
+      (value) => allowedValues.length > 0 && !allowedValues.includes(value),
     );
     if (unknownValues.length > 0) {
       return formatUnknownOptionError(unknownValues, allowedValues);
@@ -287,10 +291,24 @@ export function questionValidationError(
 
   const value = typeof answer === "string" ? answer.trim() : "";
   if (question.required && value.length === 0) {
-    return question.kind === "text" ? "Answer required." : "Select one option.";
+    return usesTextEntryKind(question.kind)
+      ? "Answer required."
+      : "Select one option.";
   }
   if (
-    question.kind === "single_select" &&
+    (question.kind === "number" || question.kind === "integer") &&
+    value.length > 0
+  ) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return "Enter a valid number.";
+    }
+    if (question.kind === "integer" && !Number.isInteger(parsed)) {
+      return "Enter a whole number.";
+    }
+  }
+  if (
+    usesSingleSelectKind(question.kind) &&
     value.length > 0 &&
     allowedValues.length > 0 &&
     !allowedValues.includes(value)
@@ -322,7 +340,7 @@ export function buildStructuredResumePayload(
 
   for (const question of questions) {
     const value = getStructuredAnswer(state, question);
-    if (question.kind === "multi_select") {
+    if (usesMultiSelectKind(question.kind)) {
       const selected = Array.isArray(value) ? value : [];
       if (selected.length > 0) {
         answers.push({ question_id: question.id, value: selected });
@@ -345,7 +363,7 @@ export function questionAnswerPreview(
 ): string {
   const answer = getStructuredAnswer(state, question);
 
-  if (question.kind === "multi_select") {
+  if (usesMultiSelectKind(question.kind)) {
     const selected = Array.isArray(answer) ? answer : [];
     if (selected.length === 0) return "No selection";
     return selected
@@ -355,12 +373,12 @@ export function questionAnswerPreview(
 
   const value = typeof answer === "string" ? answer.trim() : "";
   if (!value) {
-    return question.kind === "text"
+    return usesTextEntryKind(question.kind)
       ? question.placeholder || "Not answered"
       : "No selection";
   }
 
-  return question.kind === "single_select"
+  return usesSingleSelectKind(question.kind)
     ? optionLabelForValue(question, value)
     : value;
 }

--- a/clients/tui/src/types.ts
+++ b/clients/tui/src/types.ts
@@ -5,6 +5,23 @@
  * This file keeps protocol events explicit and isolates local synthetic events.
  */
 
+import type { ClientCapabilities, YieldKind } from "./generated/types";
+
+export type {
+  AdaptiveForm,
+  AdaptivePresentationHint,
+  AdaptiveYieldCapabilities,
+  ClientCapabilities,
+  ConfirmationYieldPayload,
+  CustomYieldPayload,
+  DynamicToolYieldPayload,
+  StructuredInputKind as ProtocolStructuredInputKind,
+  StructuredInputOption as ProtocolStructuredInputOption,
+  StructuredInputQuestion as ProtocolStructuredInputQuestion,
+  StructuredInputYieldPayload,
+  YieldKind,
+} from "./generated/types";
+
 export type ProtocolEventType =
   | "turn_started"
   | "turn_completed"
@@ -47,17 +64,6 @@ export interface ToolDecisionAudit {
   capability: "read" | "write" | "network" | "unknown" | string;
   sandbox_backend: string;
 }
-
-/**
- * `YieldKind` in Rust allows an extensible `Custom(String)` variant.
- * In JSON this can arrive as either a string or a `{ custom: string }` object.
- */
-export type YieldKind =
-  | "confirmation"
-  | "structured_input"
-  | "dynamic_tool"
-  | (string & {})
-  | { custom: string };
 
 export interface PlanItem {
   id: string;
@@ -156,6 +162,7 @@ export type Op =
   | { type: "resume"; request_id: string; content: ContentPart[] }
   | { type: "interrupt" }
   | { type: "register_dynamic_tools"; tools: DynamicToolSpec[] }
+  | { type: "set_client_capabilities"; capabilities: ClientCapabilities }
   | { type: "compact" }
   | { type: "rollback"; turns: number };
 

--- a/clients/tui/src/yield.test.ts
+++ b/clients/tui/src/yield.test.ts
@@ -7,6 +7,7 @@ import {
   confirmationOptions,
   confirmationSummary,
   normalizeYieldKind,
+  parseDynamicToolYieldPayload,
   structuredPrompt,
   structuredQuestions,
   structuredTitle,
@@ -66,15 +67,16 @@ describe("yield parsing helpers", () => {
           id: "q1",
           label: "Workspace",
           prompt: "workspace name",
-          kind: "single_select",
+          kind: "boolean",
           required: true,
           help_text: "Pick one workspace.",
-          default: "dev",
+          default: "true",
+          presentation_hints: ["toggle"],
           options: [
-            { value: "dev", label: "Development" },
+            { value: "true", label: "Yes" },
             {
-              value: "prod",
-              label: "Production",
+              value: "false",
+              label: "No",
               description: "Use with care",
             },
           ],
@@ -95,17 +97,18 @@ describe("yield parsing helpers", () => {
         id: "q1",
         label: "Workspace",
         prompt: "workspace name",
-        kind: "single_select",
+        kind: "boolean",
         required: true,
         helpText: "Pick one workspace.",
-        defaultValue: "dev",
+        defaultValue: "true",
         defaultValues: undefined,
         minSelections: undefined,
         maxSelections: undefined,
         options: [
-          { value: "dev", label: "Development" },
-          { value: "prod", label: "Production", description: "Use with care" },
+          { value: "true", label: "Yes" },
+          { value: "false", label: "No", description: "Use with care" },
         ],
+        presentationHints: ["toggle"],
       },
       {
         id: "q2",
@@ -120,6 +123,7 @@ describe("yield parsing helpers", () => {
         minSelections: undefined,
         maxSelections: undefined,
         options: undefined,
+        presentationHints: undefined,
       },
     ]);
   });
@@ -147,6 +151,7 @@ describe("yield parsing helpers", () => {
         minSelections: undefined,
         maxSelections: undefined,
         options: undefined,
+        presentationHints: undefined,
       },
     ]);
   });
@@ -184,6 +189,7 @@ describe("yield parsing helpers", () => {
           { value: "a", label: "A" },
           { value: "b", label: "B" },
         ],
+        presentationHints: undefined,
       },
     ]);
   });
@@ -224,6 +230,7 @@ describe("yield parsing helpers", () => {
           { value: "staging", label: "Staging" },
           { value: "prod", label: "Production" },
         ],
+        presentationHints: undefined,
       },
     ]);
   });
@@ -241,5 +248,57 @@ describe("yield parsing helpers", () => {
     };
 
     expect(structuredQuestions(payload)).toEqual([]);
+  });
+
+  test("parses typed dynamic tool payloads with adaptive forms", () => {
+    expect(
+      parseDynamicToolYieldPayload({
+        tool_name: "custom_tool",
+        arguments: { id: 1 },
+        title: "Resolve dynamic tool",
+        prompt: "Use the adaptive form.",
+        form: {
+          fields: [
+            {
+              id: "success",
+              label: "Success",
+              prompt: "Did it work?",
+              kind: "boolean",
+              options: [
+                { value: "true", label: "Yes" },
+                { value: "false", label: "No" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      tool_name: "custom_tool",
+      arguments: { id: 1 },
+      title: "Resolve dynamic tool",
+      prompt: "Use the adaptive form.",
+      form: {
+        fields: [
+          {
+            id: "success",
+            label: "Success",
+            prompt: "Did it work?",
+            kind: "boolean",
+            required: undefined,
+            placeholder: undefined,
+            helpText: undefined,
+            defaultValue: undefined,
+            defaultValues: undefined,
+            minSelections: undefined,
+            maxSelections: undefined,
+            options: [
+              { value: "true", label: "Yes" },
+              { value: "false", label: "No" },
+            ],
+            presentationHints: undefined,
+          },
+        ],
+      },
+    });
   });
 });

--- a/clients/tui/src/yield.ts
+++ b/clients/tui/src/yield.ts
@@ -1,12 +1,18 @@
-import type { YieldKind } from "./types";
+import type {
+  AdaptiveForm,
+  AdaptivePresentationHint,
+  ConfirmationYieldPayload as ProtocolConfirmationYieldPayload,
+  CustomYieldPayload as ProtocolCustomYieldPayload,
+  DynamicToolYieldPayload as ProtocolDynamicToolYieldPayload,
+  ProtocolStructuredInputKind,
+  ProtocolStructuredInputOption,
+  ProtocolStructuredInputQuestion,
+  StructuredInputYieldPayload as ProtocolStructuredInputYieldPayload,
+  YieldKind,
+} from "./types";
 
-export interface StructuredInputOption {
-  value: string;
-  label: string;
-  description?: string;
-}
-
-export type StructuredInputKind = "text" | "single_select" | "multi_select";
+export type StructuredInputOption = ProtocolStructuredInputOption;
+export type StructuredInputKind = ProtocolStructuredInputKind;
 
 export interface StructuredQuestion {
   id: string;
@@ -21,6 +27,39 @@ export interface StructuredQuestion {
   minSelections?: number;
   maxSelections?: number;
   options?: StructuredInputOption[];
+  presentationHints?: AdaptivePresentationHint[];
+}
+
+export interface ConfirmationYieldPayload extends Omit<
+  ProtocolConfirmationYieldPayload,
+  "details" | "options"
+> {
+  details?: Record<string, unknown> | null;
+  options?: string[];
+}
+
+export interface StructuredInputYieldPayload {
+  title: string;
+  prompt?: string;
+  questions: StructuredQuestion[];
+}
+
+export interface DynamicToolYieldPayload extends Omit<
+  ProtocolDynamicToolYieldPayload,
+  "form"
+> {
+  form?: AdaptiveFormState;
+}
+
+export interface CustomYieldPayload extends Omit<
+  ProtocolCustomYieldPayload,
+  "form"
+> {
+  form?: AdaptiveFormState;
+}
+
+export interface AdaptiveFormState {
+  fields: StructuredQuestion[];
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -43,12 +82,30 @@ export function asStringArray(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string");
 }
 
+function parsePresentationHints(
+  value: unknown,
+): AdaptivePresentationHint[] | undefined {
+  const hints = asStringArray(value).filter(
+    (hint): hint is AdaptivePresentationHint =>
+      hint === "radio" ||
+      hint === "toggle" ||
+      hint === "searchable" ||
+      hint === "multiline" ||
+      hint === "compact" ||
+      hint === "dangerous",
+  );
+  return hints.length > 0 ? hints : undefined;
+}
+
 function parseStructuredInputKind(
   value: unknown,
   hasOptions: boolean,
 ): StructuredInputKind | null {
   if (
     value === "text" ||
+    value === "boolean" ||
+    value === "number" ||
+    value === "integer" ||
     value === "single_select" ||
     value === "multi_select"
   ) {
@@ -62,10 +119,22 @@ function parseStructuredInputKind(
   return null;
 }
 
-function parseStructuredOptions(value: unknown): StructuredInputOption[] {
-  if (!Array.isArray(value)) return [];
+function defaultBooleanOptions(): StructuredInputOption[] {
+  return [
+    { value: "true", label: "Yes" },
+    { value: "false", label: "No" },
+  ];
+}
 
-  return value
+function parseStructuredOptions(
+  value: unknown,
+  kind: StructuredInputKind | null,
+): StructuredInputOption[] {
+  if (!Array.isArray(value)) {
+    return kind === "boolean" ? defaultBooleanOptions() : [];
+  }
+
+  const options = value
     .map((item) => {
       const raw = asRecord(item);
       if (!raw) return null;
@@ -87,6 +156,74 @@ function parseStructuredOptions(value: unknown): StructuredInputOption[] {
       return parsed;
     })
     .filter((item): item is StructuredInputOption => item !== null);
+
+  if (kind === "boolean" && options.length === 0) {
+    return defaultBooleanOptions();
+  }
+  return options;
+}
+
+export function usesTextEntryKind(kind: StructuredInputKind): boolean {
+  return kind === "text" || kind === "number" || kind === "integer";
+}
+
+export function usesSingleSelectKind(kind: StructuredInputKind): boolean {
+  return kind === "single_select" || kind === "boolean";
+}
+
+export function usesMultiSelectKind(kind: StructuredInputKind): boolean {
+  return kind === "multi_select";
+}
+
+function parseStructuredQuestion(value: unknown): StructuredQuestion | null {
+  const question = asRecord(value);
+  if (!question) return null;
+
+  const id = asString(question.id);
+  const label = asString(question.label);
+  const prompt = asString(question.prompt);
+  const kindCandidate = parseStructuredInputKind(
+    question.kind,
+    Array.isArray(question.options),
+  );
+  const options = parseStructuredOptions(question.options, kindCandidate);
+  const kind = parseStructuredInputKind(question.kind, options.length > 0);
+  const required =
+    typeof question.required === "boolean" ? question.required : undefined;
+  const placeholder = asString(question.placeholder) || undefined;
+  const helpText = asString(question.help_text) || undefined;
+  const defaultValue = asString(question.default) || undefined;
+  const defaultValues = asStringArray(question.defaults);
+  const minSelections = asNumber(question.min_selected) ?? undefined;
+  const maxSelections = asNumber(question.max_selected) ?? undefined;
+  const presentationHints = parsePresentationHints(question.presentation_hints);
+
+  if (!id || !label || !prompt || !kind) {
+    return null;
+  }
+
+  if (
+    (usesSingleSelectKind(kind) || usesMultiSelectKind(kind)) &&
+    options.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    label,
+    prompt,
+    kind,
+    required,
+    placeholder,
+    helpText,
+    defaultValue,
+    defaultValues: defaultValues.length > 0 ? defaultValues : undefined,
+    minSelections,
+    maxSelections,
+    options: options.length > 0 ? options : undefined,
+    presentationHints,
+  };
 }
 
 export function normalizeYieldKind(
@@ -110,16 +247,100 @@ export function normalizeYieldKind(
   return null;
 }
 
-export function confirmationSummary(payload: unknown): string | null {
+export function parseConfirmationPayload(
+  payload: unknown,
+): ConfirmationYieldPayload | null {
   const data = asRecord(payload);
-  if (!data) return null;
-  return asString(data.summary);
+  const summary = data ? asString(data.summary) : null;
+  if (!data || !summary) {
+    return null;
+  }
+
+  return {
+    checkpoint_type: asString(data.checkpoint_type) ?? "confirmation",
+    summary,
+    details: asRecord(data.details),
+    options: asStringArray(data.options),
+    default_option: asString(data.default_option) ?? undefined,
+    presentation_hints: parsePresentationHints(data.presentation_hints),
+  };
+}
+
+export function parseStructuredInputPayload(
+  payload: unknown,
+): StructuredInputYieldPayload | null {
+  const data = asRecord(payload);
+  const title = data ? asString(data.title) : null;
+  if (!data || !title || !Array.isArray(data.questions)) {
+    return null;
+  }
+
+  return {
+    title,
+    prompt: asString(data.prompt) ?? undefined,
+    questions: data.questions
+      .map(parseStructuredQuestion)
+      .filter((item): item is StructuredQuestion => item !== null),
+  };
+}
+
+export function parseAdaptiveForm(payload: unknown): AdaptiveFormState | null {
+  const data = asRecord(payload);
+  if (!data || !Array.isArray(data.fields)) {
+    return null;
+  }
+
+  const fields = data.fields
+    .map(parseStructuredQuestion)
+    .filter((item): item is StructuredQuestion => item !== null);
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return { fields };
+}
+
+export function parseDynamicToolYieldPayload(
+  payload: unknown,
+): DynamicToolYieldPayload | null {
+  const data = asRecord(payload);
+  const toolName = data ? asString(data.tool_name) : null;
+  const title = data ? asString(data.title) : null;
+  if (!data || !toolName || !title) {
+    return null;
+  }
+
+  return {
+    tool_name: toolName,
+    arguments: data.arguments,
+    title,
+    prompt: asString(data.prompt) ?? undefined,
+    form: parseAdaptiveForm(data.form) ?? undefined,
+  };
+}
+
+export function parseCustomYieldPayload(
+  payload: unknown,
+): CustomYieldPayload | null {
+  const data = asRecord(payload);
+  if (!data) {
+    return null;
+  }
+
+  return {
+    title: asString(data.title) ?? undefined,
+    prompt: asString(data.prompt) ?? undefined,
+    details: asRecord(data.details) ?? undefined,
+    form: parseAdaptiveForm(data.form) ?? undefined,
+  };
+}
+
+export function confirmationSummary(payload: unknown): string | null {
+  return parseConfirmationPayload(payload)?.summary ?? null;
 }
 
 export function confirmationOptions(payload: unknown): string[] {
-  const data = asRecord(payload);
-  if (!data) return [];
-  return asStringArray(data.options);
+  return parseConfirmationPayload(payload)?.options ?? [];
 }
 
 export function confirmationActionOptions(payload: unknown): string[] {
@@ -130,71 +351,24 @@ export function confirmationActionOptions(payload: unknown): string[] {
 export function confirmationDetails(
   payload: unknown,
 ): Record<string, unknown> | null {
-  const data = asRecord(payload);
-  if (!data) return null;
-  return asRecord(data.details);
+  return parseConfirmationPayload(payload)?.details ?? null;
 }
 
 export function structuredTitle(payload: unknown): string | null {
-  const data = asRecord(payload);
-  if (!data) return null;
-  return asString(data.title);
+  return parseStructuredInputPayload(payload)?.title ?? null;
 }
 
 export function structuredPrompt(payload: unknown): string | null {
-  const data = asRecord(payload);
-  if (!data) return null;
-  return asString(data.prompt);
+  return parseStructuredInputPayload(payload)?.prompt ?? null;
 }
 
 export function structuredQuestions(payload: unknown): StructuredQuestion[] {
   const data = asRecord(payload);
-  if (!data || !Array.isArray(data.questions)) return [];
+  if (!data || !Array.isArray(data.questions)) {
+    return [];
+  }
 
   return data.questions
-    .map((item) => {
-      const question = asRecord(item);
-      if (!question) return null;
-
-      const id = asString(question.id);
-      const label = asString(question.label);
-      const prompt = asString(question.prompt);
-      const required =
-        typeof question.required === "boolean" ? question.required : undefined;
-      const options = parseStructuredOptions(question.options);
-      const kind = parseStructuredInputKind(question.kind, options.length > 0);
-      const placeholder = asString(question.placeholder) || undefined;
-      const helpText = asString(question.help_text) || undefined;
-      const defaultValue = asString(question.default) || undefined;
-      const defaultValues = asStringArray(question.defaults);
-      const minSelections = asNumber(question.min_selected) ?? undefined;
-      const maxSelections = asNumber(question.max_selected) ?? undefined;
-
-      if (!id || !label || !prompt || !kind) {
-        return null;
-      }
-
-      if (
-        (kind === "single_select" || kind === "multi_select") &&
-        options.length === 0
-      ) {
-        return null;
-      }
-
-      return {
-        id,
-        label,
-        prompt,
-        kind,
-        required,
-        placeholder,
-        helpText,
-        defaultValue,
-        defaultValues: defaultValues.length > 0 ? defaultValues : undefined,
-        minSelections,
-        maxSelections,
-        options: options.length > 0 ? options : undefined,
-      } as StructuredQuestion;
-    })
+    .map(parseStructuredQuestion)
     .filter((item): item is StructuredQuestion => item !== null);
 }

--- a/crates/alan/src/daemon/remote_control.rs
+++ b/crates/alan/src/daemon/remote_control.rs
@@ -508,9 +508,11 @@ pub fn required_scope_for_op(op: &alan_protocol::Op) -> SessionScope {
     match op {
         Op::Resume { .. } => SessionScope::Resume,
         Op::Compact | Op::Rollback { .. } => SessionScope::Admin,
-        Op::Turn { .. } | Op::Input { .. } | Op::Interrupt | Op::RegisterDynamicTools { .. } => {
-            SessionScope::Write
-        }
+        Op::Turn { .. }
+        | Op::Input { .. }
+        | Op::Interrupt
+        | Op::RegisterDynamicTools { .. }
+        | Op::SetClientCapabilities { .. } => SessionScope::Write,
     }
 }
 
@@ -633,6 +635,12 @@ mod tests {
         assert_eq!(
             required_scope_for_op(&Op::Rollback { turns: 1 }),
             SessionScope::Admin
+        );
+        assert_eq!(
+            required_scope_for_op(&Op::SetClientCapabilities {
+                capabilities: alan_protocol::ClientCapabilities::default(),
+            }),
+            SessionScope::Write
         );
     }
 

--- a/crates/protocol/src/adaptive.rs
+++ b/crates/protocol/src/adaptive.rs
@@ -1,0 +1,246 @@
+use serde::{Deserialize, Serialize};
+
+/// Presentation-level UI hint for adaptive form fields and confirmation surfaces.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdaptivePresentationHint {
+    Radio,
+    Toggle,
+    Searchable,
+    Multiline,
+    Compact,
+    Dangerous,
+}
+
+/// Option for a structured/adaptive user-input field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuredInputOption {
+    pub value: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Input control semantics for a structured user-input field.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuredInputKind {
+    /// Free-form text entry.
+    #[default]
+    Text,
+    /// Boolean choice (typically yes/no).
+    Boolean,
+    /// Numeric entry that accepts any finite number.
+    Number,
+    /// Numeric entry that accepts integer values only.
+    Integer,
+    /// Exactly one value must be selected from a list of options.
+    SingleSelect,
+    /// Zero or more values may be selected from a list of options.
+    MultiSelect,
+}
+
+/// Structured question/field shown to the user.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuredInputQuestion {
+    pub id: String,
+    pub label: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub kind: StructuredInputKind,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help_text: Option<String>,
+    #[serde(default, rename = "default", skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<String>,
+    #[serde(default, rename = "defaults", skip_serializing_if = "Vec::is_empty")]
+    pub default_values: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_selected: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_selected: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<StructuredInputOption>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub presentation_hints: Vec<AdaptivePresentationHint>,
+}
+
+/// Typed adaptive form contract shared by `dynamic_tool` and `custom` yields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdaptiveForm {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<StructuredInputQuestion>,
+}
+
+/// Payload for `YieldKind::Confirmation`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfirmationYieldPayload {
+    pub checkpoint_type: String,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_option: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub presentation_hints: Vec<AdaptivePresentationHint>,
+}
+
+/// Payload for `YieldKind::StructuredInput`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StructuredInputYieldPayload {
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub questions: Vec<StructuredInputQuestion>,
+}
+
+/// Payload for `YieldKind::DynamicTool`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DynamicToolYieldPayload {
+    pub tool_name: String,
+    pub arguments: serde_json::Value,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub form: Option<AdaptiveForm>,
+}
+
+/// Payload for `YieldKind::Custom`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CustomYieldPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub form: Option<AdaptiveForm>,
+}
+
+/// Adaptive UI support negotiated between client and runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdaptiveYieldCapabilities {
+    /// Client can render richer confirmation cards/details.
+    #[serde(default = "default_true")]
+    pub rich_confirmation: bool,
+    /// Client can render protocol-level structured input forms.
+    #[serde(default = "default_true")]
+    pub structured_input: bool,
+    /// Client can render typed schema/form contracts for dynamic/custom yields.
+    #[serde(default)]
+    pub schema_driven_forms: bool,
+    /// Client understands presentation hints such as `toggle` or `dangerous`.
+    #[serde(default)]
+    pub presentation_hints: bool,
+}
+
+impl Default for AdaptiveYieldCapabilities {
+    fn default() -> Self {
+        Self {
+            rich_confirmation: true,
+            structured_input: true,
+            schema_driven_forms: false,
+            presentation_hints: false,
+        }
+    }
+}
+
+/// Top-level protocol capability declaration for frontends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ClientCapabilities {
+    #[serde(default)]
+    pub adaptive_yields: AdaptiveYieldCapabilities,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn structured_input_kind_supports_extended_semantics() {
+        let json = serde_json::to_string(&StructuredInputKind::Boolean).unwrap();
+        assert_eq!(json, "\"boolean\"");
+        assert_eq!(
+            serde_json::from_str::<StructuredInputKind>("\"integer\"").unwrap(),
+            StructuredInputKind::Integer
+        );
+    }
+
+    #[test]
+    fn confirmation_payload_serialization_skips_empty_optional_fields() {
+        let payload = ConfirmationYieldPayload {
+            checkpoint_type: "confirmation".to_string(),
+            summary: "Approve?".to_string(),
+            details: None,
+            options: vec![],
+            default_option: None,
+            presentation_hints: vec![],
+        };
+
+        let value = serde_json::to_value(payload).unwrap();
+        assert_eq!(value["checkpoint_type"], "confirmation");
+        assert_eq!(value["summary"], "Approve?");
+        assert!(value.get("details").is_none());
+        assert!(value.get("options").is_none());
+        assert!(value.get("presentation_hints").is_none());
+    }
+
+    #[test]
+    fn client_capabilities_default_to_safe_baseline() {
+        let capabilities = ClientCapabilities::default();
+        assert!(capabilities.adaptive_yields.rich_confirmation);
+        assert!(capabilities.adaptive_yields.structured_input);
+        assert!(!capabilities.adaptive_yields.schema_driven_forms);
+        assert!(!capabilities.adaptive_yields.presentation_hints);
+    }
+
+    #[test]
+    fn adaptive_form_serializes_explicit_fields() {
+        let form = AdaptiveForm {
+            fields: vec![StructuredInputQuestion {
+                id: "success".to_string(),
+                label: "Success".to_string(),
+                prompt: "Did it work?".to_string(),
+                kind: StructuredInputKind::Boolean,
+                required: true,
+                placeholder: None,
+                help_text: None,
+                default_value: Some("true".to_string()),
+                default_values: vec![],
+                min_selected: None,
+                max_selected: None,
+                options: vec![
+                    StructuredInputOption {
+                        value: "true".to_string(),
+                        label: "Yes".to_string(),
+                        description: None,
+                    },
+                    StructuredInputOption {
+                        value: "false".to_string(),
+                        label: "No".to_string(),
+                        description: None,
+                    },
+                ],
+                presentation_hints: vec![AdaptivePresentationHint::Toggle],
+            }],
+        };
+
+        let value = serde_json::to_value(form).unwrap();
+        assert_eq!(value["fields"][0]["kind"], json!("boolean"));
+        assert_eq!(value["fields"][0]["presentation_hints"], json!(["toggle"]));
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -4,14 +4,19 @@
 //! types that form the communication protocol between the agent core and
 //! various frontend interfaces (CLI, REST API, WebSocket).
 
+mod adaptive;
 mod content;
 mod event;
 mod op;
 
+pub use adaptive::{
+    AdaptiveForm, AdaptivePresentationHint, AdaptiveYieldCapabilities, ClientCapabilities,
+    ConfirmationYieldPayload, CustomYieldPayload, DynamicToolYieldPayload, StructuredInputKind,
+    StructuredInputOption, StructuredInputQuestion, StructuredInputYieldPayload,
+};
 pub use content::{ContentPart, parts_to_text};
 pub use event::{Event, EventEnvelope, ToolDecisionAudit, YieldKind};
 pub use op::{
     DynamicToolSpec, GovernanceConfig, GovernanceProfile, InputMode, Op, PlanItem, PlanItemStatus,
-    StructuredInputKind, StructuredInputOption, StructuredInputQuestion, Submission,
-    ToolCapability, TurnContext,
+    Submission, ToolCapability, TurnContext,
 };

--- a/crates/protocol/src/op.rs
+++ b/crates/protocol/src/op.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ContentPart;
+use crate::adaptive::ClientCapabilities;
 
 /// Coarse capability class for tool policy decisions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -67,54 +68,6 @@ pub struct PlanItem {
     pub status: PlanItemStatus,
 }
 
-/// Option for a structured user-input question.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StructuredInputOption {
-    pub value: String,
-    pub label: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
-
-/// Input control semantics for a structured user-input question.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum StructuredInputKind {
-    /// Free-form text entry.
-    #[default]
-    Text,
-    /// Exactly one value must be selected from a list of options.
-    SingleSelect,
-    /// Zero or more values may be selected from a list of options.
-    MultiSelect,
-}
-
-/// Structured question shown to the user.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct StructuredInputQuestion {
-    pub id: String,
-    pub label: String,
-    pub prompt: String,
-    #[serde(default)]
-    pub kind: StructuredInputKind,
-    #[serde(default)]
-    pub required: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub help_text: Option<String>,
-    #[serde(default, rename = "default", skip_serializing_if = "Option::is_none")]
-    pub default_value: Option<String>,
-    #[serde(default, rename = "defaults", skip_serializing_if = "Vec::is_empty")]
-    pub default_values: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub min_selected: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_selected: Option<u32>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub options: Vec<StructuredInputOption>,
-}
-
 /// Session-scoped dynamic tool definition provided by the client/frontend.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DynamicToolSpec {
@@ -171,6 +124,12 @@ pub enum Op {
         tools: Vec<DynamicToolSpec>,
     },
 
+    /// Update frontend capability negotiation for adaptive yields.
+    SetClientCapabilities {
+        /// Rich adaptive UI features supported by the connected client.
+        capabilities: ClientCapabilities,
+    },
+
     /// Compact the current session context (manual trigger)
     Compact,
 
@@ -224,6 +183,10 @@ fn is_default_input_mode(mode: &InputMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adaptive::{
+        AdaptivePresentationHint, StructuredInputKind, StructuredInputOption,
+        StructuredInputQuestion,
+    };
     use serde_json::json;
 
     #[test]
@@ -274,6 +237,7 @@ mod tests {
                     description: Some("Requires approval".to_string()),
                 },
             ],
+            presentation_hints: vec![AdaptivePresentationHint::Searchable],
         };
 
         let value = serde_json::to_value(&question).unwrap();
@@ -281,6 +245,7 @@ mod tests {
         assert_eq!(value["defaults"], json!(["staging"]));
         assert_eq!(value["min_selected"], 1);
         assert_eq!(value["max_selected"], 2);
+        assert_eq!(value["presentation_hints"], json!(["searchable"]));
     }
 
     #[test]
@@ -297,6 +262,29 @@ mod tests {
         assert_eq!(question.placeholder, None);
         assert_eq!(question.default_value, None);
         assert!(question.default_values.is_empty());
+        assert!(question.presentation_hints.is_empty());
+    }
+
+    #[test]
+    fn test_set_client_capabilities_op_roundtrip() {
+        let op = Op::SetClientCapabilities {
+            capabilities: ClientCapabilities::default(),
+        };
+
+        let value = serde_json::to_value(&op).unwrap();
+        assert_eq!(value["type"], "set_client_capabilities");
+        assert_eq!(
+            value["capabilities"]["adaptive_yields"]["schema_driven_forms"],
+            false
+        );
+
+        let parsed: Op = serde_json::from_value(value).unwrap();
+        match parsed {
+            Op::SetClientCapabilities { capabilities } => {
+                assert!(capabilities.adaptive_yields.structured_input);
+            }
+            other => panic!("Expected SetClientCapabilities, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtime/src/approval.rs
+++ b/crates/runtime/src/approval.rs
@@ -143,6 +143,7 @@ mod tests {
                 min_selected: None,
                 max_selected: None,
                 options: vec![],
+                presentation_hints: vec![],
             }],
         };
         assert_eq!(request.request_id, "req-123");

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -1581,6 +1581,9 @@ mod tests {
         assert!(!should_drive_turn_submission(&Op::RegisterDynamicTools {
             tools: vec![]
         }));
+        assert!(!should_drive_turn_submission(&Op::SetClientCapabilities {
+            capabilities: alan_protocol::ClientCapabilities::default(),
+        }));
         assert!(!should_drive_turn_submission(&Op::Resume {
             request_id: "req-123".to_string(),
             content: vec![alan_protocol::ContentPart::structured(

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -61,6 +61,9 @@ where
             })
             .await;
         }
+        Op::SetClientCapabilities { capabilities } => {
+            state.session.client_capabilities = capabilities;
+        }
         Op::Compact => {
             maybe_compact_context(state, emit).await?;
         }

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -1,4 +1,8 @@
-use alan_protocol::{Event, InputMode, Op, ToolCapability};
+use alan_protocol::{
+    AdaptiveForm, AdaptivePresentationHint, ConfirmationYieldPayload, DynamicToolYieldPayload,
+    Event, InputMode, Op, StructuredInputKind, StructuredInputOption, StructuredInputQuestion,
+    ToolCapability,
+};
 use anyhow::Result;
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
@@ -53,31 +57,116 @@ pub(super) enum ToolBatchOrchestratorOutcome {
     EndTurn,
 }
 
-fn dynamic_tool_resume_schema(tool_name: &str) -> Value {
-    json!({
-        "type": "object",
-        "title": format!("Return result for {}", tool_name),
-        "description": "Provide a simple client-side result payload. Use raw /resume JSON for richer nested results.",
-        "required": ["success"],
-        "properties": {
-            "success": {
-                "type": "boolean",
-                "title": "Success",
-                "description": "Set to false if the client-side tool execution failed.",
-                "default": true
+fn dynamic_tool_resume_form(
+    capabilities: &alan_protocol::ClientCapabilities,
+    tool_name: &str,
+) -> Option<AdaptiveForm> {
+    if !capabilities.adaptive_yields.schema_driven_forms {
+        return None;
+    }
+
+    let field_hints = if capabilities.adaptive_yields.presentation_hints {
+        vec![AdaptivePresentationHint::Toggle]
+    } else {
+        vec![]
+    };
+
+    Some(AdaptiveForm {
+        fields: vec![
+            StructuredInputQuestion {
+                id: "success".to_string(),
+                label: "Success".to_string(),
+                prompt: "Did the client-side tool execution succeed?".to_string(),
+                kind: StructuredInputKind::Boolean,
+                required: true,
+                placeholder: None,
+                help_text: Some(
+                    "Set to false if the client-side tool execution failed.".to_string(),
+                ),
+                default_value: Some("true".to_string()),
+                default_values: vec![],
+                min_selected: None,
+                max_selected: None,
+                options: vec![
+                    StructuredInputOption {
+                        value: "true".to_string(),
+                        label: "Yes".to_string(),
+                        description: None,
+                    },
+                    StructuredInputOption {
+                        value: "false".to_string(),
+                        label: "No".to_string(),
+                        description: None,
+                    },
+                ],
+                presentation_hints: field_hints,
             },
-            "result": {
-                "type": "string",
-                "title": "Result",
-                "description": "Simple string result to send back to the agent."
+            StructuredInputQuestion {
+                id: "result".to_string(),
+                label: "Result".to_string(),
+                prompt: format!("Return a simple result for {tool_name}."),
+                kind: StructuredInputKind::Text,
+                required: false,
+                placeholder: Some("Short result summary".to_string()),
+                help_text: Some(
+                    "Use raw /resume JSON if you need nested or richer structured output."
+                        .to_string(),
+                ),
+                default_value: None,
+                default_values: vec![],
+                min_selected: None,
+                max_selected: None,
+                options: vec![],
+                presentation_hints: vec![],
             },
-            "error": {
-                "type": "string",
-                "title": "Error",
-                "description": "Optional error message when success is false."
-            }
-        }
+            StructuredInputQuestion {
+                id: "error".to_string(),
+                label: "Error".to_string(),
+                prompt: format!("Optional error details for {tool_name}."),
+                kind: StructuredInputKind::Text,
+                required: false,
+                placeholder: Some("Only fill when success is false".to_string()),
+                help_text: None,
+                default_value: None,
+                default_values: vec![],
+                min_selected: None,
+                max_selected: None,
+                options: vec![],
+                presentation_hints: vec![],
+            },
+        ],
     })
+}
+
+fn confirmation_payload(
+    capabilities: &alan_protocol::ClientCapabilities,
+    checkpoint_type: String,
+    summary: String,
+    details: Value,
+    options: Vec<String>,
+) -> ConfirmationYieldPayload {
+    let presentation_hints = if capabilities.adaptive_yields.presentation_hints
+        && checkpoint_type == "tool_escalation"
+    {
+        vec![AdaptivePresentationHint::Dangerous]
+    } else {
+        vec![]
+    };
+
+    let default_option = options
+        .iter()
+        .find(|option| option.as_str() == "approve")
+        .cloned()
+        .or_else(|| options.first().cloned());
+
+    ConfirmationYieldPayload {
+        checkpoint_type,
+        summary,
+        details: Some(details),
+        options,
+        default_option,
+        presentation_hints,
+    }
 }
 
 pub(super) struct ToolTurnOrchestrator {
@@ -396,12 +485,14 @@ where
             emit(Event::Yield {
                 request_id: pending.checkpoint_id,
                 kind: alan_protocol::YieldKind::Confirmation,
-                payload: json!({
-                    "checkpoint_type": pending.checkpoint_type,
-                    "summary": pending.summary,
-                    "details": pending.details,
-                    "options": pending.options,
-                }),
+                payload: serde_json::to_value(confirmation_payload(
+                    &state.session.client_capabilities,
+                    pending.checkpoint_type,
+                    pending.summary,
+                    pending.details,
+                    pending.options,
+                ))
+                .unwrap_or_else(|_| json!({})),
             })
             .await;
             return Ok(ToolOrchestratorOutcome::PauseTurn);
@@ -465,13 +556,17 @@ where
         emit(Event::Yield {
             request_id: tool_call.id.clone(),
             kind: alan_protocol::YieldKind::DynamicTool,
-            payload: json!({
-                "tool_name": tool_call.name,
-                "arguments": tool_arguments,
-                "title": format!("Resolve dynamic tool: {}", tool_call.name),
-                "prompt": "Use the adaptive form for simple success/result payloads, or /resume <json> for raw structured results.",
-                "resume_schema": dynamic_tool_resume_schema(&tool_call.name),
-            }),
+            payload: serde_json::to_value(DynamicToolYieldPayload {
+                tool_name: tool_call.name.clone(),
+                arguments: tool_arguments.clone(),
+                title: format!("Resolve dynamic tool: {}", tool_call.name),
+                prompt: Some(
+                    "Use the adaptive form for simple success/result payloads, or /resume <json> for raw structured results."
+                        .to_string(),
+                ),
+                form: dynamic_tool_resume_form(&state.session.client_capabilities, &tool_call.name),
+            })
+            .unwrap_or_else(|_| json!({})),
         })
         .await;
         return Ok(ToolOrchestratorOutcome::PauseTurn);
@@ -546,12 +641,14 @@ where
         emit(Event::Yield {
             request_id: pending.checkpoint_id,
             kind: alan_protocol::YieldKind::Confirmation,
-            payload: json!({
-                "checkpoint_type": pending.checkpoint_type,
-                "summary": pending.summary,
-                "details": pending.details,
-                "options": pending.options,
-            }),
+            payload: serde_json::to_value(confirmation_payload(
+                &state.session.client_capabilities,
+                pending.checkpoint_type,
+                pending.summary,
+                pending.details,
+                pending.options,
+            ))
+            .unwrap_or_else(|_| json!({})),
         })
         .await;
         return Ok(ToolOrchestratorOutcome::PauseTurn);
@@ -1542,6 +1639,16 @@ mod tests {
     #[tokio::test]
     async fn test_tool_batch_with_dynamic_tool() {
         let mut state = create_test_state();
+        state
+            .session
+            .client_capabilities
+            .adaptive_yields
+            .schema_driven_forms = true;
+        state
+            .session
+            .client_capabilities
+            .adaptive_yields
+            .presentation_hints = true;
         // Register a dynamic tool
         state.session.dynamic_tools.insert(
             "custom_dynamic_tool".to_string(),
@@ -1591,10 +1698,10 @@ mod tests {
                 });
                 let payload = payload.expect("Expected Yield DynamicTool event");
                 assert_eq!(payload["tool_name"], "custom_dynamic_tool");
-                assert_eq!(payload["resume_schema"]["type"], "object");
+                assert_eq!(payload["form"]["fields"][0]["kind"], "boolean");
                 assert_eq!(
-                    payload["resume_schema"]["properties"]["success"]["type"],
-                    "boolean"
+                    payload["form"]["fields"][0]["presentation_hints"][0],
+                    "toggle"
                 );
             }
             _ => panic!("Expected PauseTurn for dynamic tool"),

--- a/crates/runtime/src/runtime/turn_driver.rs
+++ b/crates/runtime/src/runtime/turn_driver.rs
@@ -280,6 +280,12 @@ mod tests {
         assert!(!is_turn_inband_submission(&Op::RegisterDynamicTools {
             tools: vec![]
         }));
+        assert!(!is_turn_resume_submission(&Op::SetClientCapabilities {
+            capabilities: alan_protocol::ClientCapabilities::default(),
+        }));
+        assert!(!is_turn_inband_submission(&Op::SetClientCapabilities {
+            capabilities: alan_protocol::ClientCapabilities::default(),
+        }));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -1,4 +1,7 @@
-use alan_protocol::Event;
+use alan_protocol::{
+    AdaptivePresentationHint, ConfirmationYieldPayload, Event, StructuredInputKind,
+    StructuredInputOption, StructuredInputQuestion, StructuredInputYieldPayload,
+};
 use anyhow::Result;
 use serde_json::json;
 
@@ -64,12 +67,20 @@ where
                 emit(Event::Yield {
                     request_id: pending.checkpoint_id,
                     kind: alan_protocol::YieldKind::Confirmation,
-                    payload: json!({
-                        "checkpoint_type": pending.checkpoint_type,
-                        "summary": pending.summary,
-                        "details": pending.details,
-                        "options": pending.options,
-                    }),
+                    payload: serde_json::to_value(ConfirmationYieldPayload {
+                        checkpoint_type: pending.checkpoint_type,
+                        summary: pending.summary,
+                        details: Some(pending.details),
+                        default_option: pending
+                            .options
+                            .iter()
+                            .find(|option| option.as_str() == "approve")
+                            .cloned()
+                            .or_else(|| pending.options.first().cloned()),
+                        options: pending.options,
+                        presentation_hints: vec![],
+                    })
+                    .unwrap_or_else(|_| json!({})),
                 })
                 .await;
             } else {
@@ -128,11 +139,13 @@ where
                 emit(Event::Yield {
                     request_id: request.request_id,
                     kind: alan_protocol::YieldKind::StructuredInput,
-                    payload: json!({
-                        "title": request.title,
-                        "prompt": request.prompt,
-                        "questions": request.questions,
-                    }),
+                    payload: serde_json::to_value(structured_input_yield_payload(
+                        &state.session.client_capabilities,
+                        request.title,
+                        request.prompt,
+                        request.questions,
+                    ))
+                    .unwrap_or_else(|_| json!({})),
                 })
                 .await;
             } else {
@@ -301,7 +314,7 @@ fn parse_structured_user_input_request(
                 .map(|arr| {
                     arr.iter()
                         .filter_map(|opt| {
-                            Some(alan_protocol::StructuredInputOption {
+                            Some(StructuredInputOption {
                                 value: parse_non_empty_string(opt.get("value"))?,
                                 label: parse_non_empty_string(opt.get("label"))?,
                                 description: parse_optional_string(opt.get("description")),
@@ -317,11 +330,14 @@ fn parse_structured_user_input_request(
             let default_values = parse_string_array(raw.get("defaults"));
             let min_selected = parse_optional_u32(raw.get("min_selected"));
             let max_selected = parse_optional_u32(raw.get("max_selected"));
+            let presentation_hints = parse_presentation_hints(raw.get("presentation_hints"));
+            let options = normalize_question_options(kind, options);
 
             if matches!(
                 kind,
-                alan_protocol::StructuredInputKind::SingleSelect
-                    | alan_protocol::StructuredInputKind::MultiSelect
+                StructuredInputKind::Boolean
+                    | StructuredInputKind::SingleSelect
+                    | StructuredInputKind::MultiSelect
             ) && options.is_empty()
             {
                 return None;
@@ -332,26 +348,27 @@ fn parse_structured_user_input_request(
                 .map(|opt| opt.value.as_str())
                 .collect::<Vec<_>>();
             let normalized_default_value = match kind {
-                alan_protocol::StructuredInputKind::Text => default_value.clone(),
-                alan_protocol::StructuredInputKind::SingleSelect => {
+                StructuredInputKind::Text
+                | StructuredInputKind::Number
+                | StructuredInputKind::Integer => default_value.clone(),
+                StructuredInputKind::Boolean | StructuredInputKind::SingleSelect => {
                     normalize_single_default(default_value.clone(), option_values.as_slice())
                 }
-                alan_protocol::StructuredInputKind::MultiSelect => None,
+                StructuredInputKind::MultiSelect => None,
             };
-            let normalized_default_values =
-                if matches!(kind, alan_protocol::StructuredInputKind::MultiSelect) {
-                    normalize_multi_defaults(
-                        default_value.as_deref(),
-                        default_values,
-                        option_values.as_slice(),
-                    )
-                } else {
-                    Vec::new()
-                };
+            let normalized_default_values = if matches!(kind, StructuredInputKind::MultiSelect) {
+                normalize_multi_defaults(
+                    default_value.as_deref(),
+                    default_values,
+                    option_values.as_slice(),
+                )
+            } else {
+                Vec::new()
+            };
             let (min_selected, max_selected) =
                 normalize_selection_constraints(min_selected, max_selected, options.len());
 
-            Some(alan_protocol::StructuredInputQuestion {
+            Some(StructuredInputQuestion {
                 id,
                 label,
                 prompt,
@@ -361,17 +378,18 @@ fn parse_structured_user_input_request(
                 help_text,
                 default_value: normalized_default_value,
                 default_values: normalized_default_values,
-                min_selected: if matches!(kind, alan_protocol::StructuredInputKind::MultiSelect) {
+                min_selected: if matches!(kind, StructuredInputKind::MultiSelect) {
                     min_selected
                 } else {
                     None
                 },
-                max_selected: if matches!(kind, alan_protocol::StructuredInputKind::MultiSelect) {
+                max_selected: if matches!(kind, StructuredInputKind::MultiSelect) {
                     max_selected
                 } else {
                     None
                 },
                 options,
+                presentation_hints,
             })
         })
         .collect::<Vec<_>>();
@@ -421,17 +439,90 @@ fn parse_optional_u32(value: Option<&serde_json::Value>) -> Option<u32> {
 fn parse_structured_input_kind(
     value: Option<&serde_json::Value>,
     has_options: bool,
-) -> Option<alan_protocol::StructuredInputKind> {
+) -> Option<StructuredInputKind> {
     match value.and_then(|raw| raw.as_str()) {
-        Some("text") => Some(alan_protocol::StructuredInputKind::Text),
-        Some("single_select") => Some(alan_protocol::StructuredInputKind::SingleSelect),
-        Some("multi_select") => Some(alan_protocol::StructuredInputKind::MultiSelect),
+        Some("text") => Some(StructuredInputKind::Text),
+        Some("boolean") => Some(StructuredInputKind::Boolean),
+        Some("number") => Some(StructuredInputKind::Number),
+        Some("integer") => Some(StructuredInputKind::Integer),
+        Some("single_select") => Some(StructuredInputKind::SingleSelect),
+        Some("multi_select") => Some(StructuredInputKind::MultiSelect),
         Some(_) => None,
         None => Some(if has_options {
-            alan_protocol::StructuredInputKind::SingleSelect
+            StructuredInputKind::SingleSelect
         } else {
-            alan_protocol::StructuredInputKind::Text
+            StructuredInputKind::Text
         }),
+    }
+}
+
+fn parse_presentation_hints(value: Option<&serde_json::Value>) -> Vec<AdaptivePresentationHint> {
+    value
+        .and_then(|raw| raw.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| match item.as_str() {
+                    Some("radio") => Some(AdaptivePresentationHint::Radio),
+                    Some("toggle") => Some(AdaptivePresentationHint::Toggle),
+                    Some("searchable") => Some(AdaptivePresentationHint::Searchable),
+                    Some("multiline") => Some(AdaptivePresentationHint::Multiline),
+                    Some("compact") => Some(AdaptivePresentationHint::Compact),
+                    Some("dangerous") => Some(AdaptivePresentationHint::Dangerous),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn normalize_question_options(
+    kind: StructuredInputKind,
+    options: Vec<StructuredInputOption>,
+) -> Vec<StructuredInputOption> {
+    if matches!(kind, StructuredInputKind::Boolean) && options.is_empty() {
+        return boolean_options();
+    }
+    options
+}
+
+fn boolean_options() -> Vec<StructuredInputOption> {
+    vec![
+        StructuredInputOption {
+            value: "true".to_string(),
+            label: "Yes".to_string(),
+            description: None,
+        },
+        StructuredInputOption {
+            value: "false".to_string(),
+            label: "No".to_string(),
+            description: None,
+        },
+    ]
+}
+
+fn structured_input_yield_payload(
+    capabilities: &alan_protocol::ClientCapabilities,
+    title: String,
+    prompt: String,
+    questions: Vec<StructuredInputQuestion>,
+) -> StructuredInputYieldPayload {
+    let questions = if capabilities.adaptive_yields.presentation_hints {
+        questions
+    } else {
+        questions
+            .into_iter()
+            .map(|mut question| {
+                question.presentation_hints.clear();
+                question
+            })
+            .collect()
+    };
+
+    StructuredInputYieldPayload {
+        title,
+        prompt: Some(prompt),
+        questions,
     }
 }
 
@@ -575,11 +666,18 @@ fn request_user_input_tool_definition() -> ToolDefinition {
                             "prompt": { "type": "string" },
                             "kind": {
                                 "type": "string",
-                                "enum": ["text", "single_select", "multi_select"]
+                                "enum": ["text", "boolean", "number", "integer", "single_select", "multi_select"]
                             },
                             "required": { "type": "boolean" },
                             "placeholder": { "type": "string" },
                             "help_text": { "type": "string" },
+                            "presentation_hints": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string",
+                                    "enum": ["radio", "toggle", "searchable", "multiline", "compact", "dangerous"]
+                                }
+                            },
                             "default": { "type": "string" },
                             "defaults": {
                                 "type": "array",
@@ -754,7 +852,14 @@ mod tests {
         assert!(def.parameters["properties"].get("questions").is_some());
         assert_eq!(
             def.parameters["properties"]["questions"]["items"]["properties"]["kind"]["enum"],
-            json!(["text", "single_select", "multi_select"])
+            json!([
+                "text",
+                "boolean",
+                "number",
+                "integer",
+                "single_select",
+                "multi_select"
+            ])
         );
     }
 

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -28,6 +28,8 @@ pub struct Session {
     pub has_active_task: bool,
     /// Session-scoped client-provided dynamic tools exposed to the model.
     pub dynamic_tools: HashMap<String, alan_protocol::DynamicToolSpec>,
+    /// Session-scoped negotiated client capabilities for adaptive UI emission.
+    pub client_capabilities: alan_protocol::ClientCapabilities,
     /// Session-scoped cached approvals for governance escalations.
     tool_approval_decisions: HashMap<ToolApprovalCacheKey, ToolApprovalDecision>,
     /// Latest effect record by idempotency key (used for side-effect dedupe).
@@ -226,6 +228,7 @@ impl Session {
             recorder: None,
             has_active_task: false,
             dynamic_tools: HashMap::new(),
+            client_capabilities: alan_protocol::ClientCapabilities::default(),
             tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
@@ -244,6 +247,7 @@ impl Session {
             recorder: Some(recorder),
             has_active_task: false,
             dynamic_tools: HashMap::new(),
+            client_capabilities: alan_protocol::ClientCapabilities::default(),
             tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
@@ -265,6 +269,7 @@ impl Session {
             recorder: Some(recorder),
             has_active_task: false,
             dynamic_tools: HashMap::new(),
+            client_capabilities: alan_protocol::ClientCapabilities::default(),
             tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
@@ -282,6 +287,7 @@ impl Session {
             recorder: Some(recorder),
             has_active_task: false,
             dynamic_tools: HashMap::new(),
+            client_capabilities: alan_protocol::ClientCapabilities::default(),
             tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
@@ -303,6 +309,7 @@ impl Session {
             recorder: Some(recorder),
             has_active_task: false,
             dynamic_tools: HashMap::new(),
+            client_capabilities: alan_protocol::ClientCapabilities::default(),
             tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,

--- a/scripts/generate-ts-types.sh
+++ b/scripts/generate-ts-types.sh
@@ -34,6 +34,89 @@ export type YieldKind =
   | (string & {})
   | { custom: string };
 
+export type AdaptivePresentationHint =
+  | "radio"
+  | "toggle"
+  | "searchable"
+  | "multiline"
+  | "compact"
+  | "dangerous";
+
+export type StructuredInputKind =
+  | "text"
+  | "boolean"
+  | "number"
+  | "integer"
+  | "single_select"
+  | "multi_select";
+
+export interface StructuredInputOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface StructuredInputQuestion {
+  id: string;
+  label: string;
+  prompt: string;
+  kind?: StructuredInputKind;
+  required?: boolean;
+  placeholder?: string;
+  help_text?: string;
+  default?: string;
+  defaults?: string[];
+  min_selected?: number;
+  max_selected?: number;
+  options?: StructuredInputOption[];
+  presentation_hints?: AdaptivePresentationHint[];
+}
+
+export interface AdaptiveForm {
+  fields?: StructuredInputQuestion[];
+}
+
+export interface ConfirmationYieldPayload {
+  checkpoint_type: string;
+  summary: string;
+  details?: unknown;
+  options?: string[];
+  default_option?: string;
+  presentation_hints?: AdaptivePresentationHint[];
+}
+
+export interface StructuredInputYieldPayload {
+  title: string;
+  prompt?: string;
+  questions?: StructuredInputQuestion[];
+}
+
+export interface DynamicToolYieldPayload {
+  tool_name: string;
+  arguments: unknown;
+  title: string;
+  prompt?: string;
+  form?: AdaptiveForm;
+}
+
+export interface CustomYieldPayload {
+  title?: string;
+  prompt?: string;
+  details?: unknown;
+  form?: AdaptiveForm;
+}
+
+export interface AdaptiveYieldCapabilities {
+  rich_confirmation?: boolean;
+  structured_input?: boolean;
+  schema_driven_forms?: boolean;
+  presentation_hints?: boolean;
+}
+
+export interface ClientCapabilities {
+  adaptive_yields?: AdaptiveYieldCapabilities;
+}
+
 export interface ToolDecisionAudit {
   policy_source: string;
   rule_id?: string;


### PR DESCRIPTION
## Summary
- formalize adaptive yield payloads in alan-protocol and add client capability negotiation
- switch runtime yield emission to typed adaptive contracts instead of TUI-private payload conventions
- update the TUI to sync capabilities and render dynamic/custom forms from the shared adaptive contract

## Testing
- cargo test -p alan-protocol -p alan-runtime -p alan
- cargo clippy -p alan-protocol -p alan-runtime -p alan --all-targets --all-features -- -D warnings
- bun test src
- bun x tsc --noEmit
- bun run lint

Closes #103