### PR TITLE
Align governance docs and runtime with current contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,7 +536,7 @@ Runtime virtual tools (not from `alan-tools`, injected by runtime):
 Runtime applies tool decisions in two stages:
 
 1. `PolicyEngine` returns `allow | escalate | deny`.
-2. If execution proceeds, sandbox backend enforces the execution boundary.
+2. If execution proceeds, the current `workspace_path_guard` backend applies a best-effort execution guard for workspace paths and shell shape checks.
 
 Session governance is configured via:
 
@@ -549,7 +549,13 @@ Session governance is configured via:
 }
 ```
 
-If `policy_path` is omitted, runtime uses built-in profile rules.
+Policy resolution order is:
+
+1. `governance.policy_path`, if provided
+2. `{workspace}/.alan/policy.yaml`, if present
+3. builtin profile defaults
+
+When a policy file is found, it replaces the builtin profile rule set for that session.
 
 ### Skills
 
@@ -613,6 +619,7 @@ alan  # or: alan chat
 
 - **README.md**: Project philosophy and vision
 - **docs/architecture.md**: Full architecture documentation
+- **docs/governance_current_contract.md**: Authoritative current governance contract
 - **docs/policy_over_sandbox.md**: Policy-over-sandbox runtime model
 
 ### Inspirations

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 > This project is actively being developed. APIs may change without notice.
 >
 > Governance model note: policy/sandbox sections in this README reflect the accepted V2 breaking design and may be in migration until implementation is complete.
+> The authoritative current implementation contract lives in
+> `docs/governance_current_contract.md`.
 
 ---
 
@@ -121,7 +123,7 @@ Alan/
   - All built-ins: core + exploration tools (7 total)
 - **Skill System**: Markdown-based capabilities via `$skill-name` triggers
 - **Session Persistence**: Rollout recording with pause/resume/replay
-- **Policy Over Sandbox**: Policy decides (`allow/deny/escalate`), sandbox enforces execution boundaries (current backend: workspace path guard with protected subpaths and only plain shell commands with statically addressable paths; shell control flow is rejected, common wrapper forms such as `env`/`command`/`builtin`/`exec`/`time`/`nice`/`nohup`/`timeout`/`stdbuf`/`setsid` are rejected, process path references under protected subpaths are blocked, glob patterns are rejected, direct nested shell/code evaluators are disabled, direct opaque command dispatchers such as `xargs`/`find -exec` are rejected, and a curated set of common direct script interpreters such as `python file.py`/`bash script.sh`/`awk -f script.awk` are rejected; the backend checks explicit path-like argv references and redirection targets but does not infer utility-specific operand roles for arbitrary bare tokens, and arbitrary program-internal writes or dispatch such as `git init`/`git add`/`git config --local`, `find -delete`, build/task runners, or utility-specific script/DSL modes like `sed -f` are not inspected by this backend and still need policy or a stronger OS sandbox; OS sandboxing is still in migration)
+- **Policy Over Sandbox**: Policy decides (`allow/deny/escalate`), and the current sandbox backend applies a best-effort execution guard (current backend: workspace path guard with protected subpaths and only plain shell commands with statically addressable paths; shell control flow is rejected, common wrapper forms such as `env`/`command`/`builtin`/`exec`/`time`/`nice`/`nohup`/`timeout`/`stdbuf`/`setsid` are rejected, process path references under protected subpaths are blocked, glob patterns are rejected, direct nested shell/code evaluators are disabled, direct opaque command dispatchers such as `xargs`/`find -exec` are rejected, and a curated set of common direct script interpreters such as `python file.py`/`bash script.sh`/`awk -f script.awk` are rejected; the backend checks explicit path-like argv references and redirection targets but does not infer utility-specific operand roles for arbitrary bare tokens, and arbitrary program-internal writes or dispatch such as `git init`/`git add`/`git config --local`, `find -delete`, build/task runners, or utility-specific script/DSL modes like `sed -f` are not inspected by this backend and still need policy or a stronger OS sandbox; OS sandboxing is still in migration)
 - **Policy Profiles**: Builtin `autonomous`/`conservative` presets, overridable via `.alan/policy.yaml`
 - **Steering-First Execution**: In-turn `input` can interrupt tool batches and reprioritize the next step
 - **WebSocket + HTTP API**: Real-time bidirectional communication
@@ -346,7 +348,9 @@ curl -N http://localhost:8090/api/v1/sessions/{id}/events
 
 ### Policy Configuration (Optional)
 
-Create `{workspace}/.alan/policy.yaml` to override builtin policy profile rules:
+Create `{workspace}/.alan/policy.yaml` to override builtin policy profile rules.
+When present, the file replaces the builtin profile rule set for that session;
+Alan does not implicitly merge policy files with builtin rules.
 
 ```yaml
 rules:
@@ -365,7 +369,7 @@ rules:
 default_action: allow
 ```
 
-See [`docs/policy_over_sandbox.md`](docs/policy_over_sandbox.md) for details.
+See [`docs/governance_current_contract.md`](docs/governance_current_contract.md) for the current contract and [`docs/policy_over_sandbox.md`](docs/policy_over_sandbox.md) for the target V2 design.
 
 ---
 

--- a/crates/runtime/src/approval.rs
+++ b/crates/runtime/src/approval.rs
@@ -1,38 +1,45 @@
-//! Tool escalation cache and pending interactive request types.
+//! Pending interactive request types and checkpoint taxonomy.
 
-use serde::{Deserialize, Serialize};
-use std::fmt;
+pub const TOOL_ESCALATION_CHECKPOINT_TYPE: &str = "tool_escalation";
+pub const TOOL_ESCALATION_CHECKPOINT_PREFIX: &str = "tool_escalation_";
+pub const TOOL_ESCALATION_CONTROL_KIND: &str = "tool_escalation_confirmation";
 
-/// Cache key for a tool approval decision scoped to a session.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ToolApprovalCacheKey {
-    pub tool_name: String,
-    pub capability: String,
-    pub governance_profile: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dynamic_tool_spec_fingerprint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub arguments_fingerprint: Option<String>,
-}
+pub const EFFECT_REPLAY_CHECKPOINT_TYPE: &str = "effect_replay_confirmation";
+pub const EFFECT_REPLAY_CHECKPOINT_PREFIX: &str = "effect_replay_";
+pub const EFFECT_REPLAY_CONTROL_KIND: &str = "effect_replay_confirmation";
 
-impl fmt::Display for ToolApprovalCacheKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match serde_json::to_string(self) {
-            Ok(encoded) => f.write_str(&encoded),
-            Err(_) => write!(
-                f,
-                "tool={} capability={} governance_profile={}",
-                self.tool_name, self.capability, self.governance_profile
-            ),
-        }
+pub const RUNTIME_CONFIRMATION_CONTROL_SOURCE: &str = "runtime/submission_handlers";
+pub const RUNTIME_CONFIRMATION_CONTROL_VERSION: u64 = 1;
+
+pub fn runtime_confirmation_control_kind(checkpoint_type: &str) -> Option<&'static str> {
+    match checkpoint_type {
+        TOOL_ESCALATION_CHECKPOINT_TYPE => Some(TOOL_ESCALATION_CONTROL_KIND),
+        EFFECT_REPLAY_CHECKPOINT_TYPE => Some(EFFECT_REPLAY_CONTROL_KIND),
+        _ => None,
     }
 }
 
-/// Represents the decision for a tool approval.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ToolApprovalDecision {
-    /// The tool is approved for the entire session.
-    ApprovedForSession,
+pub fn runtime_confirmation_checkpoint_prefix(checkpoint_type: &str) -> Option<&'static str> {
+    match checkpoint_type {
+        TOOL_ESCALATION_CHECKPOINT_TYPE => Some(TOOL_ESCALATION_CHECKPOINT_PREFIX),
+        EFFECT_REPLAY_CHECKPOINT_TYPE => Some(EFFECT_REPLAY_CHECKPOINT_PREFIX),
+        _ => None,
+    }
+}
+
+pub fn is_runtime_confirmation_checkpoint_type(checkpoint_type: &str) -> bool {
+    runtime_confirmation_control_kind(checkpoint_type).is_some()
+}
+
+pub fn replays_tool_calls(checkpoint_type: &str) -> bool {
+    matches!(
+        checkpoint_type,
+        TOOL_ESCALATION_CHECKPOINT_TYPE | EFFECT_REPLAY_CHECKPOINT_TYPE
+    )
+}
+
+pub fn is_effect_replay_confirmation(checkpoint_type: &str) -> bool {
+    checkpoint_type == EFFECT_REPLAY_CHECKPOINT_TYPE
 }
 
 #[derive(Debug, Clone)]
@@ -65,63 +72,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tool_approval_cache_key_display() {
-        let key = ToolApprovalCacheKey {
-            tool_name: "read_file".to_string(),
-            capability: "read".to_string(),
-            governance_profile: "strict".to_string(),
-            dynamic_tool_spec_fingerprint: None,
-            arguments_fingerprint: None,
-        };
-        let display = format!("{}", key);
-        assert!(display.contains("read_file"));
-        assert!(display.contains("read"));
+    fn test_runtime_confirmation_checkpoint_type_identification() {
+        assert!(is_runtime_confirmation_checkpoint_type(
+            TOOL_ESCALATION_CHECKPOINT_TYPE
+        ));
+        assert!(is_runtime_confirmation_checkpoint_type(
+            EFFECT_REPLAY_CHECKPOINT_TYPE
+        ));
+        assert!(!is_runtime_confirmation_checkpoint_type("review"));
     }
 
     #[test]
-    fn test_tool_approval_cache_key_with_fingerprints() {
-        let key = ToolApprovalCacheKey {
-            tool_name: "bash".to_string(),
-            capability: "exec".to_string(),
-            governance_profile: "strict".to_string(),
-            dynamic_tool_spec_fingerprint: Some("abc123".to_string()),
-            arguments_fingerprint: Some("def456".to_string()),
-        };
-        let json = serde_json::to_string(&key).unwrap();
-        assert!(json.contains("bash"));
-        assert!(json.contains("abc123"));
-        assert!(json.contains("def456"));
-    }
-
-    #[test]
-    fn test_tool_approval_cache_key_serde_roundtrip() {
-        let key = ToolApprovalCacheKey {
-            tool_name: "write_file".to_string(),
-            capability: "write".to_string(),
-            governance_profile: "permissive".to_string(),
-            dynamic_tool_spec_fingerprint: Some("fp1".to_string()),
-            arguments_fingerprint: Some("fp2".to_string()),
-        };
-        let json = serde_json::to_string(&key).unwrap();
-        let decoded: ToolApprovalCacheKey = serde_json::from_str(&json).unwrap();
-        assert_eq!(key.tool_name, decoded.tool_name);
-        assert_eq!(key.capability, decoded.capability);
-        assert_eq!(key.governance_profile, decoded.governance_profile);
+    fn test_runtime_confirmation_control_metadata_lookup() {
         assert_eq!(
-            key.dynamic_tool_spec_fingerprint,
-            decoded.dynamic_tool_spec_fingerprint
+            runtime_confirmation_control_kind(TOOL_ESCALATION_CHECKPOINT_TYPE),
+            Some(TOOL_ESCALATION_CONTROL_KIND)
         );
-        assert_eq!(key.arguments_fingerprint, decoded.arguments_fingerprint);
+        assert_eq!(
+            runtime_confirmation_checkpoint_prefix(EFFECT_REPLAY_CHECKPOINT_TYPE),
+            Some(EFFECT_REPLAY_CHECKPOINT_PREFIX)
+        );
     }
 
     #[test]
-    fn test_tool_approval_decision_serde() {
-        let decision = ToolApprovalDecision::ApprovedForSession;
-        let json = serde_json::to_string(&decision).unwrap();
-        assert_eq!(json, "\"ApprovedForSession\"");
-
-        let decoded: ToolApprovalDecision = serde_json::from_str(&json).unwrap();
-        assert!(matches!(decoded, ToolApprovalDecision::ApprovedForSession));
+    fn test_effect_replay_confirmation_identification() {
+        assert!(is_effect_replay_confirmation(EFFECT_REPLAY_CHECKPOINT_TYPE));
+        assert!(!is_effect_replay_confirmation(
+            TOOL_ESCALATION_CHECKPOINT_TYPE
+        ));
+        assert!(replays_tool_calls(TOOL_ESCALATION_CHECKPOINT_TYPE));
+        assert!(replays_tool_calls(EFFECT_REPLAY_CHECKPOINT_TYPE));
+        assert!(!replays_tool_calls("review"));
     }
 
     #[test]
@@ -155,13 +136,13 @@ mod tests {
     fn test_pending_confirmation_creation() {
         let pending = PendingConfirmation {
             checkpoint_id: "chk-123".to_string(),
-            checkpoint_type: "tool_escalation".to_string(),
+            checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
             summary: "Escalate file write?".to_string(),
             details: serde_json::json!({"path": "/test/file.txt"}),
             options: vec!["approve".to_string(), "reject".to_string()],
         };
         assert_eq!(pending.checkpoint_id, "chk-123");
-        assert_eq!(pending.checkpoint_type, "tool_escalation");
+        assert_eq!(pending.checkpoint_type, TOOL_ESCALATION_CHECKPOINT_TYPE);
         assert_eq!(pending.options.len(), 2);
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -27,7 +27,6 @@ pub mod runtime;
 pub mod skills;
 pub mod tools;
 
-pub use approval::{ToolApprovalCacheKey, ToolApprovalDecision};
 pub use config::{Config, PartialStreamRecoveryMode, StreamingMode};
 pub use llm::{
     GenerationRequest, GenerationResponse, LlmClient, LlmProjection, TokenUsage, ToolCall,

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -1,7 +1,7 @@
 //! Policy engine for runtime tool decisions.
 //!
 //! This layer expresses decision semantics ("should we do this now?"),
-//! while sandbox remains the hard capability boundary.
+//! while the current sandbox backend remains a best-effort execution guard.
 
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path, PathBuf};

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -4,6 +4,10 @@ use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
 use crate::ROLLBACK_NON_DURABLE_WARNING;
+use crate::approval::{
+    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
+    is_effect_replay_confirmation, replays_tool_calls, runtime_confirmation_control_kind,
+};
 use crate::tape::ContentPart;
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState, maybe_compact_context};
@@ -41,12 +45,6 @@ where
 {
     match op {
         Op::RegisterDynamicTools { tools } => {
-            let mut invalidated_tool_names: std::collections::BTreeSet<String> =
-                state.session.dynamic_tools.keys().cloned().collect();
-            invalidated_tool_names.extend(tools.iter().map(|tool| tool.name.clone()));
-            state.session.revoke_dynamic_tool_approvals_for_tool_names(
-                invalidated_tool_names.iter().map(String::as_str),
-            );
             state.session.dynamic_tools = tools
                 .iter()
                 .cloned()
@@ -338,7 +336,7 @@ fn handle_confirmation_resolution(
     choice_str: &str,
     modifications: Option<String>,
 ) -> Result<RuntimeOpAction> {
-    let replay_tool_batch = if pending.checkpoint_type == "tool_escalation" {
+    let replay_tool_batch = if replays_tool_calls(&pending.checkpoint_type) {
         state
             .turn_state
             .take_tool_replay_batch(&pending.checkpoint_id)
@@ -356,11 +354,11 @@ fn handle_confirmation_resolution(
         payload["modifications"] = serde_json::Value::String(modifications);
     }
 
-    if pending.checkpoint_type == "tool_escalation" {
+    if let Some(control_kind) = runtime_confirmation_control_kind(&pending.checkpoint_type) {
         payload["__alan_internal_control"] = json!({
-            "kind": "tool_escalation_confirmation",
-            "version": 1,
-            "source": "runtime/submission_handlers"
+            "kind": control_kind,
+            "version": RUNTIME_CONFIRMATION_CONTROL_VERSION,
+            "source": RUNTIME_CONFIRMATION_CONTROL_SOURCE
         });
         state
             .session
@@ -371,10 +369,10 @@ fn handle_confirmation_resolution(
             .add_tool_message(&pending.checkpoint_id, "request_confirmation", payload);
     }
 
-    let allow_unknown_effect_replay =
-        pending.checkpoint_type == "tool_escalation" && is_unknown_effect_confirmation(&pending);
+    let allow_unknown_effect_replay = is_effect_replay_confirmation(&pending.checkpoint_type)
+        && is_unknown_effect_confirmation(&pending);
 
-    if pending.checkpoint_type == "tool_escalation"
+    if replays_tool_calls(&pending.checkpoint_type)
         && choice_str == "approve"
         && let Some(tool_calls) = replay_tool_batch
     {
@@ -387,7 +385,7 @@ fn handle_confirmation_resolution(
             tool_calls,
         });
     }
-    if pending.checkpoint_type == "tool_escalation"
+    if replays_tool_calls(&pending.checkpoint_type)
         && choice_str == "approve"
         && let Some(tool_call) = parse_replay_tool_call_from_confirmation_details(&pending.details)
     {
@@ -1627,6 +1625,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_effect_replay_resume_records_structured_trace_message() {
+        use crate::approval::PendingConfirmation;
+
+        let mut state = create_test_state();
+        state.turn_state.set_confirmation(PendingConfirmation {
+            checkpoint_id: "effect_replay_call-123".to_string(),
+            checkpoint_type: "effect_replay_confirmation".to_string(),
+            summary: "Replay side effect?".to_string(),
+            details: json!({"effect_status":"unknown"}),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        });
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let op = Op::Resume {
+            request_id: "effect_replay_call-123".to_string(),
+            content: vec![ContentPart::structured(json!({"choice": "reject"}))],
+        };
+
+        let result = handle_runtime_op_with_cancel(&mut state, op, &mut emit, &cancel).await;
+        assert!(result.is_ok());
+        assert!(matches!(
+            result.unwrap(),
+            RuntimeOpAction::RunTurn {
+                turn_kind: TurnRunKind::ResumeTurn,
+                ..
+            }
+        ));
+
+        let messages = state.session.tape.messages();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].is_user());
+        match messages[0].parts().first() {
+            Some(ContentPart::Structured { data }) => {
+                assert_eq!(
+                    data.get("__alan_internal_control")
+                        .and_then(|marker| marker.get("kind"))
+                        .and_then(serde_json::Value::as_str),
+                    Some("effect_replay_confirmation")
+                );
+            }
+            _ => panic!("expected structured control message"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_non_tool_escalation_resume_still_records_tool_message() {
         use crate::approval::PendingConfirmation;
 
@@ -1714,13 +1758,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tool_escalation_replay_batch_marks_unknown_bypass_for_unknown_effect() {
+    async fn test_effect_replay_confirmation_marks_unknown_bypass_for_unknown_effect() {
         use crate::approval::PendingConfirmation;
 
         let mut state = create_test_state();
         state.turn_state.set_confirmation(PendingConfirmation {
-            checkpoint_id: "tool_escalation_call-1".to_string(),
-            checkpoint_type: "tool_escalation".to_string(),
+            checkpoint_id: "effect_replay_call-1".to_string(),
+            checkpoint_type: "effect_replay_confirmation".to_string(),
             summary: "Approve unknown-effect replay".to_string(),
             details: json!({
                 "effect_status": "unknown",
@@ -1733,7 +1777,7 @@ mod tests {
             options: vec!["approve".to_string(), "reject".to_string()],
         });
         state.turn_state.set_tool_replay_batch(
-            "tool_escalation_call-1",
+            "effect_replay_call-1",
             vec![NormalizedToolCall {
                 id: "call-1".to_string(),
                 name: "write_file".to_string(),
@@ -1746,7 +1790,7 @@ mod tests {
         let result = handle_runtime_op_with_cancel(
             &mut state,
             Op::Resume {
-                request_id: "tool_escalation_call-1".to_string(),
+                request_id: "effect_replay_call-1".to_string(),
                 content: vec![ContentPart::structured(json!({"choice": "approve"}))],
             },
             &mut emit,

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -10,11 +10,15 @@ use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::approval::PendingConfirmation;
+use crate::approval::{
+    EFFECT_REPLAY_CHECKPOINT_PREFIX, EFFECT_REPLAY_CHECKPOINT_TYPE, PendingConfirmation,
+    TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE,
+    is_runtime_confirmation_checkpoint_type, replays_tool_calls,
+};
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
 use super::loop_guard::ToolLoopGuard;
-use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy, tool_approval_cache_key};
+use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_driver::{MAX_BUFFERED_INBAND_USER_INPUTS, TurnInputBroker};
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 use super::virtual_tools::{VirtualToolOutcome, try_handle_virtual_tool_call};
@@ -146,7 +150,7 @@ fn confirmation_payload(
     options: Vec<String>,
 ) -> ConfirmationYieldPayload {
     let presentation_hints = if capabilities.adaptive_yields.presentation_hints
-        && checkpoint_type == "tool_escalation"
+        && is_runtime_confirmation_checkpoint_type(&checkpoint_type)
     {
         vec![AdaptivePresentationHint::Dangerous]
     } else {
@@ -453,23 +457,14 @@ where
             mut details,
             audit,
         } => {
-            let dynamic_tool_spec = state.session.dynamic_tools.get(&tool_call.name);
-            let approval_key = tool_approval_cache_key(
-                &tool_call.name,
-                tool_capability,
-                &state.runtime_config.governance,
-                dynamic_tool_spec,
-                &tool_arguments,
-            );
-            details["approval_key"] = serde_json::to_value(&approval_key).unwrap_or_default();
             details["replay_tool_call"] = json!({
                 "call_id": tool_call.id,
                 "tool_name": tool_call.name,
                 "arguments": tool_arguments,
             });
             let pending = PendingConfirmation {
-                checkpoint_id: format!("tool_escalation_{}", tool_call.id),
-                checkpoint_type: "tool_escalation".to_string(),
+                checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
+                checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
                 summary,
                 details,
                 options: vec!["approve".to_string(), "reject".to_string()],
@@ -477,7 +472,7 @@ where
             state.session.record_tool_call_with_audit(
                 &tool_call.name,
                 tool_arguments.clone(),
-                json!({"status":"escalation_required", "approval_key": serde_json::to_value(&approval_key).unwrap_or_default()}),
+                json!({"status":"escalation_required"}),
                 true,
                 Some(audit),
             );
@@ -608,8 +603,8 @@ where
         );
 
         let pending = PendingConfirmation {
-            checkpoint_id: format!("tool_escalation_{}", tool_call.id),
-            checkpoint_type: "tool_escalation".to_string(),
+            checkpoint_id: format!("{EFFECT_REPLAY_CHECKPOINT_PREFIX}{}", tool_call.id),
+            checkpoint_type: EFFECT_REPLAY_CHECKPOINT_TYPE.to_string(),
             summary: "Potential duplicate side effect requires confirmation".to_string(),
             details: json!({
                 "reason": escalation_reason,
@@ -990,7 +985,7 @@ where
             }
             ToolOrchestratorOutcome::PauseTurn => {
                 if let Some(pending) = state.turn_state.pending_confirmation()
-                    && pending.checkpoint_type == "tool_escalation"
+                    && replays_tool_calls(&pending.checkpoint_type)
                 {
                     state
                         .turn_state
@@ -2040,7 +2035,7 @@ mod tests {
         let first = build_effect_identity(&session, "write_file", &arguments, EffectCategory::File);
 
         session.add_user_control_message_parts(vec![crate::tape::ContentPart::structured(
-            json!({"checkpoint_type":"tool_escalation","choice":"approve"}),
+            json!({"checkpoint_type":"effect_replay_confirmation","choice":"approve"}),
         )]);
         let replayed =
             build_effect_identity(&session, "write_file", &arguments, EffectCategory::File);

--- a/crates/runtime/src/runtime/tool_policy.rs
+++ b/crates/runtime/src/runtime/tool_policy.rs
@@ -1,6 +1,4 @@
-use crate::approval::ToolApprovalCacheKey;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 pub(super) enum ToolPolicyDecision {
@@ -99,42 +97,6 @@ pub(super) fn capability_label(capability: Option<alan_protocol::ToolCapability>
     }
 }
 
-pub(super) fn tool_approval_cache_key(
-    tool_name: &str,
-    capability: Option<alan_protocol::ToolCapability>,
-    governance: &alan_protocol::GovernanceConfig,
-    dynamic_tool_spec: Option<&alan_protocol::DynamicToolSpec>,
-    arguments: &serde_json::Value,
-) -> ToolApprovalCacheKey {
-    let governance_profile = match governance.profile {
-        alan_protocol::GovernanceProfile::Conservative => "conservative",
-        alan_protocol::GovernanceProfile::Autonomous => "autonomous",
-    };
-    ToolApprovalCacheKey {
-        tool_name: tool_name.to_string(),
-        capability: capability_label(capability).to_string(),
-        governance_profile: governance_profile.to_string(),
-        dynamic_tool_spec_fingerprint: dynamic_tool_spec.map(dynamic_tool_spec_fingerprint),
-        arguments_fingerprint: if !matches!(capability, Some(alan_protocol::ToolCapability::Read)) {
-            Some(json_value_fingerprint(arguments))
-        } else {
-            None
-        },
-    }
-}
-
-fn dynamic_tool_spec_fingerprint(spec: &alan_protocol::DynamicToolSpec) -> String {
-    let encoded = serde_json::to_vec(spec).unwrap_or_default();
-    let digest = Sha256::digest(&encoded);
-    format!("{digest:x}")
-}
-
-fn json_value_fingerprint(value: &serde_json::Value) -> String {
-    let encoded = serde_json::to_vec(value).unwrap_or_default();
-    let digest = Sha256::digest(&encoded);
-    format!("{digest:x}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,86 +169,5 @@ mod tests {
             }
             other => panic!("expected escalation, got {:?}", other),
         }
-    }
-
-    #[test]
-    fn test_tool_approval_cache_key_is_stable() {
-        let key = tool_approval_cache_key(
-            "web_search",
-            Some(alan_protocol::ToolCapability::Network),
-            &alan_protocol::GovernanceConfig {
-                profile: alan_protocol::GovernanceProfile::Autonomous,
-                policy_path: None,
-            },
-            None,
-            &json!({"query":"rust"}),
-        );
-        assert_eq!(key.tool_name, "web_search");
-        assert_eq!(key.capability, "network");
-        assert_eq!(key.governance_profile, "autonomous");
-        assert!(key.arguments_fingerprint.is_some());
-    }
-
-    #[test]
-    fn test_builtin_tool_approval_cache_key_changes_with_arguments() {
-        let governance = alan_protocol::GovernanceConfig {
-            profile: alan_protocol::GovernanceProfile::Autonomous,
-            policy_path: None,
-        };
-        let key_a = tool_approval_cache_key(
-            "web_search",
-            Some(alan_protocol::ToolCapability::Network),
-            &governance,
-            None,
-            &json!({"query":"rust"}),
-        );
-        let key_b = tool_approval_cache_key(
-            "web_search",
-            Some(alan_protocol::ToolCapability::Network),
-            &governance,
-            None,
-            &json!({"query":"golang"}),
-        );
-        assert_ne!(key_a.arguments_fingerprint, key_b.arguments_fingerprint);
-    }
-
-    #[test]
-    fn test_dynamic_tool_approval_cache_key_changes_with_spec() {
-        let spec_v1 = alan_protocol::DynamicToolSpec {
-            name: "dyn_tool".to_string(),
-            description: "v1".to_string(),
-            parameters: json!({"type": "object"}),
-            capability: Some(alan_protocol::ToolCapability::Network),
-        };
-        let spec_v2 = alan_protocol::DynamicToolSpec {
-            description: "v2".to_string(),
-            ..spec_v1.clone()
-        };
-
-        let governance = alan_protocol::GovernanceConfig {
-            profile: alan_protocol::GovernanceProfile::Autonomous,
-            policy_path: None,
-        };
-        let key_v1 = tool_approval_cache_key(
-            "dyn_tool",
-            Some(alan_protocol::ToolCapability::Network),
-            &governance,
-            Some(&spec_v1),
-            &json!({"id":"1"}),
-        );
-        let key_v2 = tool_approval_cache_key(
-            "dyn_tool",
-            Some(alan_protocol::ToolCapability::Network),
-            &governance,
-            Some(&spec_v2),
-            &json!({"id":"1"}),
-        );
-
-        assert_ne!(
-            key_v1.dynamic_tool_spec_fingerprint,
-            key_v2.dynamic_tool_spec_fingerprint
-        );
-        assert!(key_v1.dynamic_tool_spec_fingerprint.is_some());
-        assert!(key_v2.dynamic_tool_spec_fingerprint.is_some());
     }
 }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -1,11 +1,15 @@
 //! Session state management.
 
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::error;
 
-use crate::approval::{ToolApprovalCacheKey, ToolApprovalDecision};
+use crate::approval::{
+    RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
+    is_runtime_confirmation_checkpoint_type, runtime_confirmation_checkpoint_prefix,
+    runtime_confirmation_control_kind,
+};
 use crate::rollout::{
     ContextItemRecord, EffectRecord, ReferenceContextSnapshotRecord, RolloutItem, RolloutRecorder,
 };
@@ -30,8 +34,6 @@ pub struct Session {
     pub dynamic_tools: HashMap<String, alan_protocol::DynamicToolSpec>,
     /// Session-scoped negotiated client capabilities for adaptive UI emission.
     pub client_capabilities: alan_protocol::ClientCapabilities,
-    /// Session-scoped cached approvals for governance escalations.
-    tool_approval_decisions: HashMap<ToolApprovalCacheKey, ToolApprovalDecision>,
     /// Latest effect record by idempotency key (used for side-effect dedupe).
     effect_index: HashMap<String, EffectRecord>,
     /// Last prompt snapshot fingerprint written to rollout (used to skip duplicates).
@@ -43,12 +45,9 @@ pub struct Session {
 pub use crate::tape::{Message, MessageRole};
 
 impl Session {
-    const TOOL_ESCALATION_CONTROL_KIND: &'static str = "tool_escalation_confirmation";
-    const TOOL_ESCALATION_CONTROL_SOURCE: &'static str = "runtime/submission_handlers";
-    const TOOL_ESCALATION_CHECKPOINT_TYPE: &'static str = "tool_escalation";
-    const TOOL_ESCALATION_CHECKPOINT_PREFIX: &'static str = "tool_escalation_";
-
-    fn tool_escalation_control_checkpoint_id(payload: &serde_json::Value) -> Option<&str> {
+    fn runtime_confirmation_control_checkpoint(
+        payload: &serde_json::Value,
+    ) -> Option<(&str, &str)> {
         let checkpoint_id = payload
             .get("checkpoint_id")
             .and_then(serde_json::Value::as_str)?;
@@ -57,20 +56,24 @@ impl Session {
             .and_then(serde_json::Value::as_str)?;
         let choice = payload.get("choice").and_then(serde_json::Value::as_str)?;
 
-        if checkpoint_type != Self::TOOL_ESCALATION_CHECKPOINT_TYPE {
+        if !is_runtime_confirmation_checkpoint_type(checkpoint_type) {
             return None;
         }
         if !matches!(choice, "approve" | "reject") {
             return None;
         }
-        if !checkpoint_id.starts_with(Self::TOOL_ESCALATION_CHECKPOINT_PREFIX) {
+        let prefix = runtime_confirmation_checkpoint_prefix(checkpoint_type)?;
+        if !checkpoint_id.starts_with(prefix) {
             return None;
         }
 
-        Some(checkpoint_id)
+        Some((checkpoint_id, checkpoint_type))
     }
 
-    fn has_tool_escalation_control_kind_and_version(payload: &serde_json::Value) -> bool {
+    fn has_runtime_confirmation_control_kind_and_version(
+        payload: &serde_json::Value,
+        checkpoint_type: &str,
+    ) -> bool {
         let marker = payload.get("__alan_internal_control");
         let marker_kind = marker
             .and_then(|value| value.get("kind"))
@@ -79,52 +82,64 @@ impl Session {
             .and_then(|value| value.get("version"))
             .and_then(serde_json::Value::as_u64);
 
-        marker_kind == Some(Self::TOOL_ESCALATION_CONTROL_KIND) && marker_version == Some(1)
+        marker_kind == runtime_confirmation_control_kind(checkpoint_type)
+            && marker_version == Some(RUNTIME_CONFIRMATION_CONTROL_VERSION)
     }
 
-    fn tool_escalation_control_source(payload: &serde_json::Value) -> Option<&str> {
+    fn runtime_confirmation_control_source(payload: &serde_json::Value) -> Option<&str> {
         payload
             .get("__alan_internal_control")
             .and_then(|marker| marker.get("source"))
             .and_then(serde_json::Value::as_str)
     }
 
-    fn is_tool_escalation_control_payload(payload: &serde_json::Value) -> bool {
-        Self::tool_escalation_control_checkpoint_id(payload).is_some()
-            && Self::has_tool_escalation_control_kind_and_version(payload)
-            && Self::tool_escalation_control_source(payload)
-                == Some(Self::TOOL_ESCALATION_CONTROL_SOURCE)
-    }
-
-    fn is_legacy_tool_escalation_control_payload_for_restore(
-        payload: &serde_json::Value,
-        known_checkpoint_ids: &HashSet<String>,
-    ) -> bool {
-        let Some(checkpoint_id) = Self::tool_escalation_control_checkpoint_id(payload) else {
+    fn is_runtime_confirmation_control_payload(payload: &serde_json::Value) -> bool {
+        let Some((_, checkpoint_type)) = Self::runtime_confirmation_control_checkpoint(payload)
+        else {
             return false;
         };
 
-        Self::has_tool_escalation_control_kind_and_version(payload)
-            && Self::tool_escalation_control_source(payload).is_none()
-            && known_checkpoint_ids.contains(checkpoint_id)
+        Self::has_runtime_confirmation_control_kind_and_version(payload, checkpoint_type)
+            && Self::runtime_confirmation_control_source(payload)
+                == Some(RUNTIME_CONFIRMATION_CONTROL_SOURCE)
     }
 
-    fn normalize_tool_escalation_control_payload_for_restore(
-        payload: &mut serde_json::Value,
-        known_checkpoint_ids: &HashSet<String>,
+    fn is_legacy_runtime_confirmation_control_payload_for_restore(
+        payload: &serde_json::Value,
+        known_checkpoints: &HashMap<String, String>,
     ) -> bool {
-        let has_known_checkpoint = Self::tool_escalation_control_checkpoint_id(payload)
-            .is_some_and(|checkpoint_id| known_checkpoint_ids.contains(checkpoint_id));
+        let Some((checkpoint_id, checkpoint_type)) =
+            Self::runtime_confirmation_control_checkpoint(payload)
+        else {
+            return false;
+        };
+
+        known_checkpoints.get(checkpoint_id).map(String::as_str) == Some(checkpoint_type)
+            && Self::has_runtime_confirmation_control_kind_and_version(payload, checkpoint_type)
+            && Self::runtime_confirmation_control_source(payload).is_none()
+    }
+
+    fn normalize_runtime_confirmation_control_payload_for_restore(
+        payload: &mut serde_json::Value,
+        known_checkpoints: &HashMap<String, String>,
+    ) -> bool {
+        let Some((checkpoint_id, checkpoint_type)) =
+            Self::runtime_confirmation_control_checkpoint(payload)
+        else {
+            return false;
+        };
+        let has_known_checkpoint =
+            known_checkpoints.get(checkpoint_id).map(String::as_str) == Some(checkpoint_type);
         if !has_known_checkpoint {
             return false;
         }
 
-        if Self::is_tool_escalation_control_payload(payload) {
+        if Self::is_runtime_confirmation_control_payload(payload) {
             return true;
         }
-        if !Self::is_legacy_tool_escalation_control_payload_for_restore(
+        if !Self::is_legacy_runtime_confirmation_control_payload_for_restore(
             payload,
-            known_checkpoint_ids,
+            known_checkpoints,
         ) {
             return false;
         }
@@ -135,32 +150,32 @@ impl Session {
         {
             marker.insert(
                 "source".to_string(),
-                serde_json::Value::String(Self::TOOL_ESCALATION_CONTROL_SOURCE.to_string()),
+                serde_json::Value::String(RUNTIME_CONFIRMATION_CONTROL_SOURCE.to_string()),
             );
         }
         true
     }
 
-    fn is_tool_escalation_control_parts(parts: &[crate::tape::ContentPart]) -> bool {
+    fn is_runtime_confirmation_control_parts(parts: &[crate::tape::ContentPart]) -> bool {
         parts.iter().any(|part| {
             matches!(
                 part,
                 crate::tape::ContentPart::Structured { data }
-                    if Self::is_tool_escalation_control_payload(data)
+                    if Self::is_runtime_confirmation_control_payload(data)
             )
         })
     }
 
-    fn is_tool_escalation_control_message(message: &Message) -> bool {
+    fn is_runtime_confirmation_control_message(message: &Message) -> bool {
         match message {
-            Message::User { parts } => Self::is_tool_escalation_control_parts(parts),
+            Message::User { parts } => Self::is_runtime_confirmation_control_parts(parts),
             _ => false,
         }
     }
 
-    fn normalize_tool_escalation_control_message_for_restore(
+    fn normalize_runtime_confirmation_control_message_for_restore(
         message: &mut Message,
-        known_checkpoint_ids: &HashSet<String>,
+        known_checkpoints: &HashMap<String, String>,
     ) -> bool {
         let Message::User { parts } = message else {
             return false;
@@ -170,18 +185,18 @@ impl Session {
         for part in parts.iter_mut() {
             match part {
                 crate::tape::ContentPart::Structured { data } => {
-                    if Self::normalize_tool_escalation_control_payload_for_restore(
+                    if Self::normalize_runtime_confirmation_control_payload_for_restore(
                         data,
-                        known_checkpoint_ids,
+                        known_checkpoints,
                     ) {
                         is_control = true;
                     }
                 }
                 crate::tape::ContentPart::Text { text } => {
                     if let Ok(mut payload) = serde_json::from_str::<serde_json::Value>(text.trim())
-                        && Self::normalize_tool_escalation_control_payload_for_restore(
+                        && Self::normalize_runtime_confirmation_control_payload_for_restore(
                             &mut payload,
-                            known_checkpoint_ids,
+                            known_checkpoints,
                         )
                     {
                         *part = crate::tape::ContentPart::structured(payload);
@@ -194,18 +209,18 @@ impl Session {
         is_control
     }
 
-    fn normalize_tool_escalation_control_content_for_restore(
+    fn normalize_runtime_confirmation_control_content_for_restore(
         content: &str,
-        known_checkpoint_ids: &HashSet<String>,
+        known_checkpoints: &HashMap<String, String>,
     ) -> Option<serde_json::Value> {
         let trimmed = content.trim();
         if trimmed.is_empty() {
             return None;
         }
         let mut payload = serde_json::from_str::<serde_json::Value>(trimmed).ok()?;
-        if Self::normalize_tool_escalation_control_payload_for_restore(
+        if Self::normalize_runtime_confirmation_control_payload_for_restore(
             &mut payload,
-            known_checkpoint_ids,
+            known_checkpoints,
         ) {
             return Some(payload);
         }
@@ -229,7 +244,6 @@ impl Session {
             has_active_task: false,
             dynamic_tools: HashMap::new(),
             client_capabilities: alan_protocol::ClientCapabilities::default(),
-            tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -248,7 +262,6 @@ impl Session {
             has_active_task: false,
             dynamic_tools: HashMap::new(),
             client_capabilities: alan_protocol::ClientCapabilities::default(),
-            tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -270,7 +283,6 @@ impl Session {
             has_active_task: false,
             dynamic_tools: HashMap::new(),
             client_capabilities: alan_protocol::ClientCapabilities::default(),
-            tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -288,7 +300,6 @@ impl Session {
             has_active_task: false,
             dynamic_tools: HashMap::new(),
             client_capabilities: alan_protocol::ClientCapabilities::default(),
-            tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -310,7 +321,6 @@ impl Session {
             has_active_task: false,
             dynamic_tools: HashMap::new(),
             client_capabilities: alan_protocol::ClientCapabilities::default(),
-            tool_approval_decisions: HashMap::new(),
             effect_index: HashMap::new(),
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
@@ -383,17 +393,20 @@ impl Session {
         let mut fallback_tool_calls: Vec<crate::rollout::ToolCallRecord> = Vec::new();
         let mut effect_records: Vec<EffectRecord> = Vec::new();
         let mut has_tool_message_content = false;
-        let known_tool_escalation_checkpoint_ids = items
+        let known_runtime_confirmation_checkpoints = items
             .iter()
             .filter_map(|item| match item {
                 RolloutItem::Checkpoint(checkpoint)
-                    if checkpoint.checkpoint_type == Self::TOOL_ESCALATION_CHECKPOINT_TYPE =>
+                    if is_runtime_confirmation_checkpoint_type(&checkpoint.checkpoint_type) =>
                 {
-                    Some(checkpoint.checkpoint_id.clone())
+                    Some((
+                        checkpoint.checkpoint_id.clone(),
+                        checkpoint.checkpoint_type.clone(),
+                    ))
                 }
                 _ => None,
             })
-            .collect::<HashSet<_>>();
+            .collect::<HashMap<_, _>>();
 
         // Replay messages from history
         for item in items {
@@ -404,9 +417,9 @@ impl Session {
                             continue;
                         }
                         let is_control_message =
-                            Self::normalize_tool_escalation_control_message_for_restore(
+                            Self::normalize_runtime_confirmation_control_message_for_restore(
                                 &mut message,
-                                &known_tool_escalation_checkpoint_ids,
+                                &known_runtime_confirmation_checkpoints,
                             );
                         if message.is_user() && !is_control_message {
                             session.user_turn_ordinal = session.user_turn_ordinal.saturating_add(1);
@@ -429,9 +442,9 @@ impl Session {
 
                     let content = msg.content.unwrap_or_default();
                     let normalized_control_payload = if matches!(role, MessageRole::User) {
-                        Self::normalize_tool_escalation_control_content_for_restore(
+                        Self::normalize_runtime_confirmation_control_content_for_restore(
                             &content,
-                            &known_tool_escalation_checkpoint_ids,
+                            &known_runtime_confirmation_checkpoints,
                         )
                     } else {
                         None
@@ -799,58 +812,7 @@ impl Session {
     pub fn clear(&mut self) {
         self.tape.clear();
         self.has_active_task = false;
-        self.tool_approval_decisions.clear();
         self.last_turn_context_snapshot_fingerprint = None;
-    }
-
-    /// Record a tool approval decision for the given key.
-    pub fn record_tool_approval_decision(
-        &mut self,
-        approval_key: ToolApprovalCacheKey,
-        decision: ToolApprovalDecision,
-    ) {
-        self.tool_approval_decisions.insert(approval_key, decision);
-    }
-
-    /// Get the tool approval decision for the given key.
-    pub fn tool_approval_decision(
-        &self,
-        approval_key: &ToolApprovalCacheKey,
-    ) -> Option<&ToolApprovalDecision> {
-        self.tool_approval_decisions.get(approval_key)
-    }
-
-    /// Grant tool approval for the given key (convenience method for ApprovedForSession).
-    pub fn grant_tool_approval(&mut self, approval_key: ToolApprovalCacheKey) {
-        self.record_tool_approval_decision(approval_key, ToolApprovalDecision::ApprovedForSession);
-    }
-
-    /// Check if the tool has approval for the given key.
-    pub fn has_tool_approval(&self, approval_key: &ToolApprovalCacheKey) -> bool {
-        matches!(
-            self.tool_approval_decision(approval_key),
-            Some(ToolApprovalDecision::ApprovedForSession)
-        )
-    }
-
-    /// Revoke tool approvals for dynamic tools that match the given tool names.
-    /// This should be called when dynamic tools are re-registered to invalidate
-    /// cached approvals.
-    pub fn revoke_dynamic_tool_approvals_for_tool_names<'a>(
-        &mut self,
-        tool_names: impl Iterator<Item = &'a str>,
-    ) -> usize {
-        let tool_names: std::collections::HashSet<&str> = tool_names.into_iter().collect();
-        if tool_names.is_empty() {
-            return 0;
-        }
-
-        let before = self.tool_approval_decisions.len();
-        self.tool_approval_decisions.retain(|key, _| {
-            !(tool_names.contains(key.tool_name.as_str())
-                && key.dynamic_tool_spec_fingerprint.is_some())
-        });
-        before.saturating_sub(self.tool_approval_decisions.len())
     }
 
     /// Roll back the last `num_turns` user turns from in-memory context.
@@ -875,7 +837,8 @@ impl Session {
 
         for (idx, msg) in messages.iter().enumerate().rev() {
             remove_from = idx;
-            if matches!(msg, Message::User { .. }) && !Self::is_tool_escalation_control_message(msg)
+            if matches!(msg, Message::User { .. })
+                && !Self::is_runtime_confirmation_control_message(msg)
             {
                 user_turns_seen += 1;
                 if user_turns_seen >= num_turns {
@@ -1706,7 +1669,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_from_rollout_does_not_count_tool_escalation_control_messages_as_turns() {
+    fn test_load_from_rollout_does_not_count_runtime_confirmation_control_messages_as_turns() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
@@ -1764,7 +1727,7 @@ mod tests {
                 RolloutItem::Message(MessageRecord {
                     role: "user".to_string(),
                     content: Some(
-                        "{\"checkpoint_id\":\"tool_escalation_call-2\",\"checkpoint_type\":\"tool_escalation\",\"choice\":\"reject\",\"__alan_internal_control\":{\"kind\":\"tool_escalation_confirmation\",\"version\":1,\"source\":\"runtime/submission_handlers\"}}"
+                        "{\"checkpoint_id\":\"effect_replay_call-2\",\"checkpoint_type\":\"effect_replay_confirmation\",\"choice\":\"reject\",\"__alan_internal_control\":{\"kind\":\"effect_replay_confirmation\",\"version\":1,\"source\":\"runtime/submission_handlers\"}}"
                             .to_string(),
                     ),
                     tool_name: None,
@@ -1772,8 +1735,8 @@ mod tests {
                     timestamp: "2026-01-29T14:30:56Z".to_string(),
                 }),
                 RolloutItem::Checkpoint(CheckpointRecord {
-                    checkpoint_id: "tool_escalation_call-2".to_string(),
-                    checkpoint_type: "tool_escalation".to_string(),
+                    checkpoint_id: "effect_replay_call-2".to_string(),
+                    checkpoint_type: "effect_replay_confirmation".to_string(),
                     summary: "reject side effect".to_string(),
                     choice: Some("rejected".to_string()),
                     timestamp: "2026-01-29T14:30:56Z".to_string(),
@@ -2798,56 +2761,28 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_approval_cache_roundtrip_and_clear() {
+    fn test_rollback_last_turns_ignores_effect_replay_control_messages_for_turn_boundaries() {
         let mut session = Session::new();
-        let key = ToolApprovalCacheKey {
-            tool_name: "web_search".to_string(),
-            capability: "network".to_string(),
-            governance_profile: "autonomous".to_string(),
-            dynamic_tool_spec_fingerprint: None,
-            arguments_fingerprint: Some("abc".to_string()),
-        };
+        session.add_user_message("u1");
+        session.add_assistant_message("a1", None);
+        session.add_user_control_message_parts(vec![ContentPart::structured(serde_json::json!({
+            "checkpoint_id": "effect_replay_call-1",
+            "checkpoint_type": "effect_replay_confirmation",
+            "choice": "approve",
+            "__alan_internal_control": {
+                "kind": "effect_replay_confirmation",
+                "version": 1,
+                "source": "runtime/submission_handlers"
+            }
+        }))]);
+        session.add_assistant_message("a2", None);
 
-        assert!(!session.has_tool_approval(&key));
-        session.grant_tool_approval(key.clone());
-        assert!(session.has_tool_approval(&key));
+        let removed = session.rollback_last_turns(1);
 
-        session.clear();
-        assert!(!session.has_tool_approval(&key));
-    }
-
-    #[test]
-    fn test_revoke_dynamic_tool_approvals_for_tool_names_keeps_builtin_keys() {
-        let mut session = Session::new();
-        let builtin_key = ToolApprovalCacheKey {
-            tool_name: "web_search".to_string(),
-            capability: "network".to_string(),
-            governance_profile: "autonomous".to_string(),
-            dynamic_tool_spec_fingerprint: None,
-            arguments_fingerprint: Some("a".to_string()),
-        };
-        let dyn_v1_key = ToolApprovalCacheKey {
-            tool_name: "web_search".to_string(),
-            capability: "network".to_string(),
-            governance_profile: "autonomous".to_string(),
-            dynamic_tool_spec_fingerprint: Some("abc123deadbeef".to_string()),
-            arguments_fingerprint: Some("b".to_string()),
-        };
-        let dyn_other_key = ToolApprovalCacheKey {
-            tool_name: "another_tool".to_string(),
-            capability: "network".to_string(),
-            governance_profile: "autonomous".to_string(),
-            dynamic_tool_spec_fingerprint: Some("feedface".to_string()),
-            arguments_fingerprint: Some("c".to_string()),
-        };
-
-        session.grant_tool_approval(builtin_key.clone());
-        session.grant_tool_approval(dyn_v1_key.clone());
-        session.grant_tool_approval(dyn_other_key.clone());
-
-        session.revoke_dynamic_tool_approvals_for_tool_names(["web_search"].iter().copied());
-        assert!(session.has_tool_approval(&builtin_key));
-        assert!(!session.has_tool_approval(&dyn_v1_key));
-        assert!(session.has_tool_approval(&dyn_other_key));
+        assert_eq!(
+            removed, 4,
+            "rollback should ignore effect replay control messages the same way as policy controls"
+        );
+        assert!(session.tape.messages().is_empty());
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,12 @@
 # Alan Architecture — The AI Turing Machine
 
-> Status: this document tracks the accepted V2 architecture target (breaking governance changes included).
+> Status: this document tracks the current architecture plus the accepted V2
+> governance direction.
+>
+> Current governance semantics are defined in
+> [`governance_current_contract.md`](./governance_current_contract.md). When this
+> document discusses stricter future sandboxing, treat that as target-state
+> design rather than a statement about today's implementation.
 
 ## Philosophy
 
@@ -136,13 +142,20 @@ A **Session** is a single, bounded execution of an Agent within a Workspace. It 
 Alan uses policy-as-code as the only decision layer for tool governance.
 
 1. **Policy gate (`PolicyEngine`)**: per-call decision `allow | deny | escalate` based on tool name, capability, and command patterns.
-2. **Sandbox backend**: execution boundary (filesystem/process/network constraints) that enforces hard limits during tool execution.
+2. **Sandbox backend**: the current `workspace_path_guard` backend is a best-effort execution guard for workspace paths and shell shape checks, not a strict OS sandbox.
 
 `escalate` always maps to `Event::Yield` and waits for `Op::Resume`. There is no `approval_policy` downgrade branch.
 
-Builtin policy profiles (`autonomous`, `conservative`) are presets only; effective behavior is the resolved rule set from `{workspace}/.alan/policy.yaml` plus defaults.
+Policy file resolution is:
 
-Detailed spec: [`policy_over_sandbox.md`](./policy_over_sandbox.md).
+1. `governance.policy_path`, if provided
+2. `{workspace}/.alan/policy.yaml`, if present
+3. builtin profile defaults
+
+When a policy file is found, it replaces the builtin profile rule set for that session. There is no implicit merge with builtin rules.
+
+Detailed current behavior: [`governance_current_contract.md`](./governance_current_contract.md).  
+Target V2 design: [`policy_over_sandbox.md`](./policy_over_sandbox.md).
 
 ---
 

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -1,0 +1,92 @@
+# Governance Current Contract
+
+> Status: authoritative current implementation contract
+>
+> Scope: current Alan runtime / daemon / built-in tools. This document describes
+> what the repository guarantees today. VNext target docs may describe future
+> strict sandbox backends and richer governance semantics, but they must not be
+> read as statements about current behavior unless they explicitly say so.
+
+## Purpose
+
+This document pins the current governance semantics so design, docs, and code
+can stay aligned while Alan evolves toward stricter future sandboxing.
+
+## Current Decisions
+
+### 1. Policy File Resolution Is Override, Not Merge
+
+Policy resolution order is:
+
+1. `governance.policy_path`, if set
+2. `{workspace}/.alan/policy.yaml`, if present
+3. builtin profile defaults
+
+When a policy file is found, its `rules` and `default_action` replace the
+builtin profile rule set for that session. Alan does not implicitly merge a
+policy file with builtin profile rules.
+
+Rationale:
+
+- override semantics are predictable and testable
+- implicit merge semantics would require extra precedence rules
+- explicit inheritance can be added later if needed as a separate feature
+
+### 2. `tool_escalation` Is Reserved For Policy Escalation
+
+`tool_escalation` means one thing only: `PolicyEngine` returned `escalate` for a
+tool call.
+
+Other confirmation checkpoints must use their own types. In particular:
+
+- replaying a side effect after an `unknown` prior result uses
+  `effect_replay_confirmation`
+
+Rationale:
+
+- a checkpoint type should map to one semantic source
+- audit logs and UI surfaces should distinguish policy boundaries from runtime
+  safety checks
+
+### 3. No Session-Scoped Approval Cache
+
+Alan does not keep a session-wide approval cache for governance escalations.
+Each `escalate` outcome yields an explicit confirmation request and each approval
+applies only to the pending checkpoint being resumed.
+
+Turn-local replay bookkeeping is still allowed for resuming the exact pending
+tool call or tool batch. That bookkeeping is execution control, not an approval
+policy.
+
+Rationale:
+
+- the V2 governance model is explicit `Yield` / `Resume`
+- cached approvals blur auditability and make behavior harder to predict
+
+### 4. The Current Sandbox Backend Is Best-Effort
+
+The current built-in sandbox backend is `workspace_path_guard`.
+
+It provides:
+
+- workspace path containment checks
+- protected subpath blocking for `.git`, `.alan`, and `.agents`
+- conservative shell-shape validation for direct commands with statically
+  addressable paths
+
+It does **not** provide a strict OS sandbox, and it does **not** guarantee full
+network or process isolation. It is a best-effort execution guard, not a hard
+containment boundary.
+
+Future strict sandbox backends may be added later, but they must be documented
+as separate backend levels and not conflated with `workspace_path_guard`.
+
+## Alignment Rules
+
+- README and current-user docs must describe the semantics in this document.
+- Code comments about current behavior must not claim stricter guarantees than
+  this document.
+- VNext / target docs must link here when their target state differs from the
+  current implementation.
+- Governance changes are incomplete until docs, behavior, and tests all match
+  this contract.

--- a/docs/policy_over_sandbox.md
+++ b/docs/policy_over_sandbox.md
@@ -1,7 +1,9 @@
 # Policy Over Sandbox (V2)
 
-> Status: accepted breaking design for Alan governance model.  
-> This document is the target contract for the next protocol/runtime revision.
+> Status: accepted target design for Alan's next governance revision.  
+> This document is not the authoritative description of today's implementation.
+> For current behavior, see
+> [`governance_current_contract.md`](./governance_current_contract.md).
 
 ## Why
 
@@ -16,6 +18,14 @@ In runtime terms:
 3. `Steering` (`Op::Input`) can interrupt long-running execution.
 
 "Policy over sandbox" means policy is the first-class decision layer, while sandbox is an execution boundary, not a user-facing approval mode.
+
+Current implementation note:
+
+- the current backend is `workspace_path_guard`, which is a best-effort guard,
+  not a strict OS sandbox
+- policy files replace builtin profile rules; they are not implicitly merged
+- `tool_escalation` is reserved for `PolicyEngine::Escalate`
+- runtime side-effect replay confirmations use `effect_replay_confirmation`
 
 ---
 

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -1,6 +1,8 @@
 # Skills & Tools — Extending the Machine
 
-> Status: this document aligns with the accepted V2 governance direction; sandbox backend upgrades are marked where still in migration.
+> Status: current tool behavior plus accepted V2 governance direction.
+> The authoritative current governance contract lives in
+> [`governance_current_contract.md`](./governance_current_contract.md).
 
 ## Overview
 
@@ -102,11 +104,12 @@ All implementations live in [alan-tools/src/lib.rs](../crates/tools/src/lib.rs).
 Alan V2 governance is:
 
 1. **Policy gate**: per-call decision (`allow`, `deny`, `escalate`).
-2. **Sandbox backend**: enforces execution boundaries for calls that are allowed to run.
+2. **Sandbox backend**: the current `workspace_path_guard` backend is a best-effort execution guard, not a strict OS sandbox.
 
 When policy returns `escalate`, runtime emits `Event::Yield` and waits for `Op::Resume`. This path is explicit and does not depend on session-level approval toggles.
 
-Detailed model and policy file format: [policy_over_sandbox.md](./policy_over_sandbox.md).
+Current contract: [governance_current_contract.md](./governance_current_contract.md).  
+Target V2 design and policy file format: [policy_over_sandbox.md](./policy_over_sandbox.md).
 
 ### Steering During Tool Execution
 
@@ -219,6 +222,6 @@ crates/runtime/src/skills/
 
 4. **No MCP** — No external protocol dependencies. Tools are direct Rust trait implementations; skills are local filesystem documents.
 
-5. **Policy Over Sandbox** — policy decides intent, sandbox enforces execution boundaries.
+5. **Policy Over Sandbox** — policy decides intent, and the current sandbox backend provides a best-effort execution guard.
 
 6. **Path-Based Filesystem Isolation** — simple, portable workspace containment without OS-specific mechanisms; trades maximum isolation for zero external dependencies.

--- a/docs/spec/extension_contract.md
+++ b/docs/spec/extension_contract.md
@@ -153,7 +153,7 @@ Rules:
 
 1. Router applies `policy -> allow/deny/escalate` before invocation.
 2. Extension must not bypass governance.
-3. Declared permissions are upper bounds; sandbox remains hard execution boundary.
+3. Declared permissions are upper bounds; sandbox remains the authoritative execution-boundary contract. In the current runtime that contract is implemented by the best-effort `workspace_path_guard` backend, while future strict backends are a target-state upgrade.
 4. Recovery paths use same governance as normal paths (no "recovery bypass").
 
 ## State and Persistence Boundaries


### PR DESCRIPTION
## Summary
- add an authoritative current-governance contract doc that defines override semantics, runtime confirmation taxonomy, and the current sandbox boundary
- align runtime checkpoint handling with that contract by reserving `tool_escalation` for policy escalation and using `effect_replay_confirmation` for side-effect replay confirmation
- remove session-scoped approval cache remnants and update docs to distinguish current behavior from target-state design

## Testing
- cargo test -p alan-runtime
