### PR TITLE
Persist structured compaction attempts across recovery

### DIFF
--- a/crates/protocol/src/compaction.rs
+++ b/crates/protocol/src/compaction.rs
@@ -80,3 +80,33 @@ pub enum CompactionOutcome {
     Failed(FailedCompactionOutcome),
     Skipped(SkippedCompactionOutcome),
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompactionAttemptSnapshot {
+    pub attempt_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submission_id: Option<String>,
+    pub request: CompactionRequestMetadata,
+    pub result: CompactionResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_messages: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_messages: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_prompt_tokens: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_prompt_tokens: Option<usize>,
+    pub retry_count: u32,
+    pub tape_mutated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warning_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_streak: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference_context_revision_before: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference_context_revision_after: Option<u64>,
+    pub timestamp: String,
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -16,9 +16,9 @@ pub use adaptive::{
     StructuredInputOption, StructuredInputQuestion, StructuredInputYieldPayload,
 };
 pub use compaction::{
-    AppliedCompactionOutcome, CompactionMode, CompactionOutcome, CompactionReason,
-    CompactionRequestMetadata, CompactionResult, CompactionSkipReason, CompactionTrigger,
-    FailedCompactionOutcome, SkippedCompactionOutcome,
+    AppliedCompactionOutcome, CompactionAttemptSnapshot, CompactionMode, CompactionOutcome,
+    CompactionReason, CompactionRequestMetadata, CompactionResult, CompactionSkipReason,
+    CompactionTrigger, FailedCompactionOutcome, SkippedCompactionOutcome,
 };
 pub use content::{ContentPart, parts_to_text};
 pub use event::{Event, EventEnvelope, ToolDecisionAudit, YieldKind};

--- a/crates/runtime/src/rollout.rs
+++ b/crates/runtime/src/rollout.rs
@@ -1,6 +1,8 @@
 //! Session persistence using JSONL format (similar to Codex rollout files)
 
-use alan_protocol::{CompactionReason, CompactionResult, CompactionTrigger};
+use alan_protocol::{
+    CompactionAttemptSnapshot, CompactionReason, CompactionResult, CompactionTrigger,
+};
 use anyhow::{Result, anyhow};
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,7 @@ pub enum RolloutItem {
     SessionMeta(SessionMeta),
     Message(MessageRecord),
     TurnContext(TurnContextItem),
+    CompactionAttempt(CompactionAttemptSnapshot),
     Compacted(CompactedItem),
     ToolCall(ToolCallRecord),
     Effect(EffectRecord),
@@ -83,6 +86,8 @@ pub struct ContextItemRecord {
 pub struct CompactedItem {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger: Option<CompactionTrigger>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<CompactionReason>,
@@ -111,6 +116,7 @@ impl CompactedItem {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            attempt_id: None,
             trigger: None,
             reason: None,
             focus: None,
@@ -455,6 +461,26 @@ impl RolloutRecorder {
         let item = RolloutItem::Compacted(CompactedItem::new(message));
         self.record(item).await?;
         self.flush().await?;
+        Ok(())
+    }
+
+    /// Record a structured compaction attempt.
+    pub async fn record_compaction_attempt(
+        &self,
+        attempt: CompactionAttemptSnapshot,
+    ) -> Result<()> {
+        self.record(RolloutItem::CompactionAttempt(attempt)).await?;
+        self.flush().await?;
+        Ok(())
+    }
+
+    /// Record a structured compaction attempt without waiting on IO completion.
+    pub fn record_compaction_attempt_nowait(
+        &self,
+        attempt: CompactionAttemptSnapshot,
+    ) -> Result<()> {
+        self.record_nowait(RolloutItem::CompactionAttempt(attempt))?;
+        self.flush_nowait()?;
         Ok(())
     }
 
@@ -1030,6 +1056,7 @@ this is not valid json
     fn test_compacted_item_serialization() {
         let item = CompactedItem {
             message: "Summary".to_string(),
+            attempt_id: Some("attempt-123".to_string()),
             trigger: Some(CompactionTrigger::Manual),
             reason: Some(CompactionReason::ExplicitRequest),
             focus: Some("preserve todos".to_string()),
@@ -1052,6 +1079,7 @@ this is not valid json
 
         let deserialized: CompactedItem = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.message, "Summary");
+        assert_eq!(deserialized.attempt_id.as_deref(), Some("attempt-123"));
         assert_eq!(deserialized.trigger, Some(CompactionTrigger::Manual));
         assert_eq!(deserialized.reason, Some(CompactionReason::ExplicitRequest));
         assert_eq!(deserialized.focus.as_deref(), Some("preserve todos"));
@@ -1067,10 +1095,54 @@ this is not valid json
 
         let deserialized: CompactedItem = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized.message, "Summary");
+        assert_eq!(deserialized.attempt_id, None);
         assert_eq!(deserialized.trigger, None);
         assert_eq!(deserialized.reason, None);
         assert_eq!(deserialized.focus, None);
         assert_eq!(deserialized.result, None);
+    }
+
+    #[test]
+    fn test_compaction_attempt_item_serialization() {
+        let attempt = CompactionAttemptSnapshot {
+            attempt_id: "attempt-123".to_string(),
+            submission_id: Some("sub-456".to_string()),
+            request: alan_protocol::CompactionRequestMetadata {
+                mode: alan_protocol::CompactionMode::Manual,
+                trigger: CompactionTrigger::Manual,
+                reason: CompactionReason::ExplicitRequest,
+                focus: Some("preserve todos".to_string()),
+            },
+            result: CompactionResult::Retry,
+            input_messages: Some(12),
+            output_messages: Some(4),
+            input_prompt_tokens: Some(900),
+            output_prompt_tokens: Some(300),
+            retry_count: 1,
+            tape_mutated: true,
+            warning_message: None,
+            error_message: None,
+            failure_streak: None,
+            reference_context_revision_before: Some(3),
+            reference_context_revision_after: Some(3),
+            timestamp: "2026-01-29T14:31:00Z".to_string(),
+        };
+
+        let json = serde_json::to_string(&RolloutItem::CompactionAttempt(attempt.clone())).unwrap();
+        assert!(json.contains("\"compaction_attempt\""));
+        assert!(json.contains("\"attempt-123\""));
+        assert!(json.contains("\"retry\""));
+
+        let deserialized: RolloutItem = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            RolloutItem::CompactionAttempt(snapshot) => {
+                assert_eq!(snapshot.attempt_id, "attempt-123");
+                assert_eq!(snapshot.submission_id.as_deref(), Some("sub-456"));
+                assert_eq!(snapshot.result, CompactionResult::Retry);
+                assert_eq!(snapshot.retry_count, 1);
+            }
+            other => panic!("expected compaction attempt item, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -1263,12 +1263,29 @@ mod tests {
         state.session.flush().await;
 
         let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        let compacted = items.into_iter().find_map(|item| match item {
+        let attempt = items.iter().find_map(|item| match item {
+            RolloutItem::CompactionAttempt(attempt) => Some(attempt),
+            _ => None,
+        });
+        let compacted = items.iter().find_map(|item| match item {
             RolloutItem::Compacted(compacted) => Some(compacted),
             _ => None,
         });
 
+        let attempt = attempt.expect("expected compaction attempt rollout item");
         let compacted = compacted.expect("expected compacted rollout item");
+        assert_eq!(attempt.result, CompactionResult::Success);
+        assert_eq!(attempt.request.trigger, CompactionTrigger::Manual);
+        assert_eq!(attempt.request.reason, CompactionReason::ExplicitRequest);
+        assert_eq!(
+            attempt.request.focus.as_deref(),
+            Some("preserve todos and constraints")
+        );
+        assert!(attempt.tape_mutated);
+        assert_eq!(
+            compacted.attempt_id.as_deref(),
+            Some(attempt.attempt_id.as_str())
+        );
         assert_eq!(compacted.message, "Manual compaction summary");
         assert_eq!(compacted.trigger, Some(CompactionTrigger::Manual));
         assert_eq!(compacted.reason, Some(CompactionReason::ExplicitRequest));
@@ -1333,12 +1350,24 @@ mod tests {
         }
 
         let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        let compacted = items.into_iter().find_map(|item| match item {
+        let attempt = items.iter().find_map(|item| match item {
+            RolloutItem::CompactionAttempt(attempt) => Some(attempt),
+            _ => None,
+        });
+        let compacted = items.iter().find_map(|item| match item {
             RolloutItem::Compacted(compacted) => Some(compacted),
             _ => None,
         });
 
+        let attempt = attempt.expect("expected compaction attempt rollout item");
         let compacted = compacted.expect("expected compacted rollout item");
+        assert_eq!(attempt.result, CompactionResult::Retry);
+        assert_eq!(attempt.retry_count, 1);
+        assert!(attempt.tape_mutated);
+        assert_eq!(
+            compacted.attempt_id.as_deref(),
+            Some(attempt.attempt_id.as_str())
+        );
         assert_eq!(compacted.message, "Compaction summary after retry");
         assert_eq!(compacted.retry_count, Some(1));
         assert_eq!(compacted.result, Some(CompactionResult::Retry));
@@ -1411,14 +1440,20 @@ mod tests {
         let compacted = compacted.expect("expected compacted rollout item");
         assert_eq!(compacted.result, Some(CompactionResult::Degraded));
 
-        let attempt_event = items.iter().find_map(|item| match item {
-            RolloutItem::Event(event) if event.event_type == "compaction_attempt" => Some(event),
+        let attempt = items.iter().find_map(|item| match item {
+            RolloutItem::CompactionAttempt(attempt) => Some(attempt),
             _ => None,
         });
-        let attempt_event = attempt_event.expect("expected compaction attempt event");
+        let attempt = attempt.expect("expected compaction attempt item");
+        assert_eq!(attempt.result, CompactionResult::Degraded);
+        assert!(attempt.tape_mutated);
         assert_eq!(
-            attempt_event.payload["result"],
-            serde_json::json!("degraded")
+            attempt.request.focus.as_deref(),
+            Some("preserve open todos")
+        );
+        assert_eq!(
+            compacted.attempt_id.as_deref(),
+            Some(attempt.attempt_id.as_str())
         );
     }
 
@@ -1521,20 +1556,18 @@ mod tests {
 
         state.session.flush().await;
         let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
-        let failure_events: Vec<_> = items
+        let failure_attempts: Vec<_> = items
             .iter()
             .filter_map(|item| match item {
-                RolloutItem::Event(event) if event.event_type == "compaction_attempt" => {
-                    Some(event)
-                }
+                RolloutItem::CompactionAttempt(attempt) => Some(attempt),
                 _ => None,
             })
             .collect();
-        assert_eq!(failure_events.len(), 2);
+        assert_eq!(failure_attempts.len(), 2);
         assert!(
-            failure_events
+            failure_attempts
                 .iter()
-                .all(|event| event.payload["result"] == serde_json::json!("failure"))
+                .all(|attempt| attempt.result == CompactionResult::Failure && !attempt.tape_mutated)
         );
     }
 

--- a/crates/runtime/src/runtime/compaction.rs
+++ b/crates/runtime/src/runtime/compaction.rs
@@ -1,7 +1,7 @@
 use alan_protocol::{
-    AppliedCompactionOutcome, CompactionMode, CompactionOutcome, CompactionReason,
-    CompactionRequestMetadata, CompactionResult, CompactionSkipReason, CompactionTrigger, Event,
-    FailedCompactionOutcome, SkippedCompactionOutcome,
+    AppliedCompactionOutcome, CompactionAttemptSnapshot, CompactionMode, CompactionOutcome,
+    CompactionReason, CompactionRequestMetadata, CompactionResult, CompactionSkipReason,
+    CompactionTrigger, Event, FailedCompactionOutcome, SkippedCompactionOutcome,
 };
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
@@ -410,14 +410,6 @@ fn truncate_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> Stri
     truncated
 }
 
-fn compaction_mode_str(mode: CompactionMode) -> &'static str {
-    match mode {
-        CompactionMode::Manual => "manual",
-        CompactionMode::AutoPreTurn => "auto_pre_turn",
-        CompactionMode::AutoMidTurn => "auto_mid_turn",
-    }
-}
-
 fn compaction_warning_message(
     result: CompactionResult,
     error: &str,
@@ -502,6 +494,67 @@ fn failed_outcome(
     })
 }
 
+fn duration_ms_since(started_at: std::time::Instant) -> u64 {
+    started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+struct CompactionAttemptDetails {
+    result: CompactionResult,
+    input_messages: Option<usize>,
+    output_messages: Option<usize>,
+    input_prompt_tokens: Option<usize>,
+    output_prompt_tokens: Option<usize>,
+    retry_count: u32,
+    tape_mutated: bool,
+    warning_message: Option<String>,
+    error_message: Option<String>,
+    failure_streak: Option<u32>,
+    reference_context_revision_before: Option<u64>,
+    reference_context_revision_after: Option<u64>,
+    timestamp: String,
+}
+
+fn build_compaction_attempt_snapshot(
+    attempt_id: String,
+    request: &CompactionRequest,
+    details: CompactionAttemptDetails,
+) -> CompactionAttemptSnapshot {
+    let CompactionAttemptDetails {
+        result,
+        input_messages,
+        output_messages,
+        input_prompt_tokens,
+        output_prompt_tokens,
+        retry_count,
+        tape_mutated,
+        warning_message,
+        error_message,
+        failure_streak,
+        reference_context_revision_before,
+        reference_context_revision_after,
+        timestamp,
+    } = details;
+
+    CompactionAttemptSnapshot {
+        attempt_id,
+        submission_id: None,
+        request: request.metadata(),
+        result,
+        input_messages,
+        output_messages,
+        input_prompt_tokens,
+        output_prompt_tokens,
+        retry_count,
+        tape_mutated,
+        warning_message,
+        error_message,
+        failure_streak,
+        reference_context_revision_before,
+        reference_context_revision_after,
+        timestamp,
+    }
+}
+
 async fn handle_compaction_generation_failure<E, F>(
     state: &mut RuntimeLoopState,
     emit: &mut E,
@@ -525,6 +578,7 @@ where
     if let Some(summary) =
         build_degraded_compaction_summary(sanitized_to_summarize, state.session.tape.summary())
     {
+        let attempt_id = uuid::Uuid::new_v4().to_string();
         let failure_streak = state.session.note_compaction_failure();
         let warning_message = compaction_warning_message(
             CompactionResult::Degraded,
@@ -536,37 +590,48 @@ where
             message: warning_message.clone(),
         })
         .await;
-        state.session.record_event(
-            "compaction_attempt",
-            serde_json::json!({
-                "mode": compaction_mode_str(request.mode()),
-                "trigger": request.trigger(),
-                "reason": request.reason(),
-                "focus": request.focus(),
-                "retry_count": retry_count,
-                "result": "degraded",
-                "error": error_message,
-                "failure_streak": failure_streak,
-                "reference_context_revision": reference_context_revision,
-            }),
-        );
 
         state.session.tape.compact(summary.clone(), keep_last);
         let output_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+        let output_messages = state.session.tape.len();
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let duration_ms = duration_ms_since(started_at);
+        state
+            .session
+            .record_compaction_attempt(build_compaction_attempt_snapshot(
+                attempt_id.clone(),
+                request,
+                CompactionAttemptDetails {
+                    result: CompactionResult::Degraded,
+                    input_messages: Some(sanitized_to_summarize.len()),
+                    output_messages: Some(output_messages),
+                    input_prompt_tokens: Some(input_prompt_tokens),
+                    output_prompt_tokens: Some(output_prompt_tokens),
+                    retry_count,
+                    tape_mutated: true,
+                    warning_message: Some(warning_message),
+                    error_message: Some(error_message),
+                    failure_streak: Some(failure_streak),
+                    reference_context_revision_before: Some(reference_context_revision),
+                    reference_context_revision_after: Some(state.session.tape.context_revision()),
+                    timestamp: timestamp.clone(),
+                },
+            ));
         state.session.record_compaction(CompactedItem {
             message: summary,
+            attempt_id: Some(attempt_id),
             trigger: Some(request.trigger()),
             reason: Some(request.reason()),
             focus: request.focus().map(str::to_string),
             input_messages: Some(sanitized_to_summarize.len()),
-            output_messages: Some(state.session.tape.len()),
+            output_messages: Some(output_messages),
             input_tokens: Some(input_prompt_tokens),
             output_tokens: Some(output_prompt_tokens),
-            duration_ms: Some(started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64),
+            duration_ms: Some(duration_ms),
             retry_count: Some(retry_count),
             result: Some(CompactionResult::Degraded),
             reference_context_revision: Some(reference_context_revision),
-            timestamp: chrono::Utc::now().to_rfc3339(),
+            timestamp,
         });
 
         return Ok(applied_outcome(
@@ -589,20 +654,27 @@ where
         message: warning_message.clone(),
     })
     .await;
-    state.session.record_event(
-        "compaction_attempt",
-        serde_json::json!({
-            "mode": compaction_mode_str(request.mode()),
-            "trigger": request.trigger(),
-            "reason": request.reason(),
-            "focus": request.focus(),
-            "retry_count": retry_count,
-            "result": "failure",
-            "error": error_message,
-            "failure_streak": failure_streak,
-            "reference_context_revision": reference_context_revision,
-        }),
-    );
+    state
+        .session
+        .record_compaction_attempt(build_compaction_attempt_snapshot(
+            uuid::Uuid::new_v4().to_string(),
+            request,
+            CompactionAttemptDetails {
+                result: CompactionResult::Failure,
+                input_messages: Some(sanitized_to_summarize.len()),
+                output_messages: None,
+                input_prompt_tokens: Some(input_prompt_tokens),
+                output_prompt_tokens: None,
+                retry_count,
+                tape_mutated: false,
+                warning_message: Some(warning_message),
+                error_message: Some(error_message),
+                failure_streak: Some(failure_streak),
+                reference_context_revision_before: Some(reference_context_revision),
+                reference_context_revision_after: None,
+                timestamp: chrono::Utc::now().to_rfc3339(),
+            },
+        ));
 
     Ok(failed_outcome(request, input_prompt_tokens, retry_count))
 }
@@ -823,23 +895,50 @@ where
 
     let input_prompt_tokens = estimated_prompt_tokens;
     let success_result = compaction_success_result(trimmed_count);
+    let reference_context_revision = state.session.tape.context_revision();
+    let attempt_id = uuid::Uuid::new_v4().to_string();
     state.session.tape.compact(summary.clone(), keep_last);
     let output_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+    let output_messages = state.session.tape.len();
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let duration_ms = duration_ms_since(started_at);
     state.session.reset_compaction_failure_streak();
+    state
+        .session
+        .record_compaction_attempt(build_compaction_attempt_snapshot(
+            attempt_id.clone(),
+            request,
+            CompactionAttemptDetails {
+                result: success_result,
+                input_messages: Some(to_summarize.len()),
+                output_messages: Some(output_messages),
+                input_prompt_tokens: Some(input_prompt_tokens),
+                output_prompt_tokens: Some(output_prompt_tokens),
+                retry_count: trimmed_count as u32,
+                tape_mutated: true,
+                warning_message: None,
+                error_message: None,
+                failure_streak: None,
+                reference_context_revision_before: Some(reference_context_revision),
+                reference_context_revision_after: Some(state.session.tape.context_revision()),
+                timestamp: timestamp.clone(),
+            },
+        ));
     state.session.record_compaction(CompactedItem {
         message: summary,
+        attempt_id: Some(attempt_id),
         trigger: Some(request.trigger()),
         reason: Some(request.reason()),
         focus: request.focus().map(str::to_string),
         input_messages: Some(to_summarize.len()),
-        output_messages: Some(state.session.tape.len()),
+        output_messages: Some(output_messages),
         input_tokens: Some(input_prompt_tokens),
         output_tokens: Some(output_prompt_tokens),
-        duration_ms: Some(started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64),
+        duration_ms: Some(duration_ms),
         retry_count: Some(trimmed_count as u32),
         result: Some(success_result),
-        reference_context_revision: Some(state.session.tape.context_revision()),
-        timestamp: chrono::Utc::now().to_rfc3339(),
+        reference_context_revision: Some(reference_context_revision),
+        timestamp,
     });
 
     Ok(applied_outcome(

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -5,6 +5,11 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::error;
 
+use alan_protocol::{
+    CompactionAttemptSnapshot, CompactionMode, CompactionReason, CompactionRequestMetadata,
+    CompactionResult, CompactionTrigger,
+};
+
 use crate::approval::{
     RUNTIME_CONFIRMATION_CONTROL_SOURCE, RUNTIME_CONFIRMATION_CONTROL_VERSION,
     is_runtime_confirmation_checkpoint_type, runtime_confirmation_checkpoint_prefix,
@@ -43,6 +48,8 @@ pub struct Session {
     user_turn_ordinal: u64,
     /// Consecutive compaction degradation/failure count.
     compaction_failure_streak: u32,
+    /// Latest persisted compaction attempt snapshot.
+    latest_compaction_attempt: Option<CompactionAttemptSnapshot>,
 }
 
 pub use crate::tape::{Message, MessageRole};
@@ -238,6 +245,69 @@ impl Session {
         turn_segment.parse::<u64>().ok()
     }
 
+    fn legacy_compaction_attempt_from_event(
+        event: &EventRecord,
+    ) -> Option<CompactionAttemptSnapshot> {
+        if event.event_type != "compaction_attempt" {
+            return None;
+        }
+
+        let payload = &event.payload;
+        let mode = serde_json::from_value::<CompactionMode>(payload.get("mode")?.clone()).ok()?;
+        let trigger =
+            serde_json::from_value::<CompactionTrigger>(payload.get("trigger")?.clone()).ok()?;
+        let reason =
+            serde_json::from_value::<CompactionReason>(payload.get("reason")?.clone()).ok()?;
+        let result =
+            serde_json::from_value::<CompactionResult>(payload.get("result")?.clone()).ok()?;
+        let retry_count = payload
+            .get("retry_count")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0);
+        let failure_streak = payload
+            .get("failure_streak")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok());
+        let reference_context_revision = payload
+            .get("reference_context_revision")
+            .and_then(serde_json::Value::as_u64);
+        let focus = payload
+            .get("focus")
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string);
+
+        Some(CompactionAttemptSnapshot {
+            attempt_id: format!("legacy-{}", uuid::Uuid::new_v4()),
+            submission_id: None,
+            request: CompactionRequestMetadata {
+                mode,
+                trigger,
+                reason,
+                focus,
+            },
+            result,
+            input_messages: None,
+            output_messages: None,
+            input_prompt_tokens: None,
+            output_prompt_tokens: None,
+            retry_count,
+            tape_mutated: matches!(
+                result,
+                CompactionResult::Success | CompactionResult::Retry | CompactionResult::Degraded
+            ),
+            warning_message: None,
+            error_message: payload
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            failure_streak,
+            reference_context_revision_before: reference_context_revision,
+            reference_context_revision_after: reference_context_revision,
+            timestamp: event.timestamp.clone(),
+        })
+    }
+
     /// Create a new session without persistence
     pub fn new() -> Self {
         Self {
@@ -251,6 +321,7 @@ impl Session {
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
             compaction_failure_streak: 0,
+            latest_compaction_attempt: None,
         }
     }
 
@@ -270,6 +341,7 @@ impl Session {
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
             compaction_failure_streak: 0,
+            latest_compaction_attempt: None,
         })
     }
 
@@ -292,6 +364,7 @@ impl Session {
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
             compaction_failure_streak: 0,
+            latest_compaction_attempt: None,
         })
     }
 
@@ -310,6 +383,7 @@ impl Session {
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
             compaction_failure_streak: 0,
+            latest_compaction_attempt: None,
         })
     }
 
@@ -332,6 +406,7 @@ impl Session {
             last_turn_context_snapshot_fingerprint: None,
             user_turn_ordinal: 0,
             compaction_failure_streak: 0,
+            latest_compaction_attempt: None,
         })
     }
 
@@ -399,6 +474,7 @@ impl Session {
 
         let mut context_items: Vec<ContextItem> = Vec::new();
         let mut fallback_tool_calls: Vec<crate::rollout::ToolCallRecord> = Vec::new();
+        let mut compaction_attempt_records: Vec<CompactionAttemptSnapshot> = Vec::new();
         let mut recovered_compaction: Option<CompactedItem> = None;
         let mut effect_records: Vec<EffectRecord> = Vec::new();
         let mut event_records: Vec<EventRecord> = Vec::new();
@@ -509,9 +585,20 @@ impl Session {
                     session.tape.set_summary(compacted.message.clone());
                     recovered_compaction = Some(compacted);
                 }
+                RolloutItem::CompactionAttempt(attempt) => {
+                    session.latest_compaction_attempt = Some(attempt.clone());
+                    compaction_attempt_records.push(attempt);
+                }
                 RolloutItem::ToolCall(tool_call) => fallback_tool_calls.push(tool_call),
                 RolloutItem::Effect(effect) => effect_records.push(effect),
-                RolloutItem::Event(event) => event_records.push(event),
+                RolloutItem::Event(event) => {
+                    if let Some(attempt) = Self::legacy_compaction_attempt_from_event(&event) {
+                        session.latest_compaction_attempt = Some(attempt.clone());
+                        compaction_attempt_records.push(attempt);
+                    } else {
+                        event_records.push(event);
+                    }
+                }
                 _ => {} // Skip other item types during loading
             }
         }
@@ -552,6 +639,7 @@ impl Session {
         let recovered_messages = session.tape.messages().to_vec();
         if (!recovered_messages.is_empty()
             || recovered_compaction.is_some()
+            || !compaction_attempt_records.is_empty()
             || !effect_records.is_empty()
             || !event_records.is_empty())
             && let Some(recorder) = session.recorder.as_ref()
@@ -559,6 +647,11 @@ impl Session {
             for message in recovered_messages {
                 if let Err(err) = recorder.record_tape_message_nowait(&message) {
                     error!(error = %err, "Failed to re-persist recovered message");
+                }
+            }
+            for attempt in compaction_attempt_records {
+                if let Err(err) = recorder.record_compaction_attempt_nowait(attempt) {
+                    error!(error = %err, "Failed to re-persist recovered compaction attempt");
                 }
             }
             if let Some(compacted) = recovered_compaction
@@ -948,6 +1041,11 @@ impl Session {
         self.user_turn_ordinal
     }
 
+    /// Latest persisted compaction attempt, if any.
+    pub fn latest_compaction_attempt(&self) -> Option<&CompactionAttemptSnapshot> {
+        self.latest_compaction_attempt.as_ref()
+    }
+
     pub fn note_compaction_failure(&mut self) -> u32 {
         self.compaction_failure_streak = self.compaction_failure_streak.saturating_add(1);
         self.compaction_failure_streak
@@ -979,6 +1077,16 @@ impl Session {
             && let Err(err) = recorder.record_event_nowait(event_type, payload)
         {
             error!(error = %err, event_type = %event_type, "Failed to record event");
+        }
+    }
+
+    /// Record a structured compaction attempt and update in-memory recovery state.
+    pub fn record_compaction_attempt(&mut self, attempt: CompactionAttemptSnapshot) {
+        self.latest_compaction_attempt = Some(attempt.clone());
+        if let Some(recorder) = self.recorder.as_ref()
+            && let Err(err) = recorder.record_compaction_attempt_nowait(attempt)
+        {
+            error!(error = %err, "Failed to record compaction attempt");
         }
     }
 
@@ -1260,6 +1368,10 @@ mod tests {
         RolloutItem, RolloutRecorder, SessionMeta,
     };
     use crate::tape::{ContentPart, ToolResponse};
+    use alan_protocol::{
+        CompactionAttemptSnapshot, CompactionMode, CompactionReason, CompactionRequestMetadata,
+        CompactionResult, CompactionTrigger,
+    };
     use tempfile::TempDir;
 
     #[test]
@@ -2090,6 +2202,7 @@ mod tests {
                 }),
                 RolloutItem::Compacted(CompactedItem {
                     message: "Older turns compacted".to_string(),
+                    attempt_id: None,
                     trigger: None,
                     reason: None,
                     focus: None,
@@ -2154,7 +2267,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_from_rollout_preserves_event_records_across_recovery() {
+    fn test_load_from_rollout_preserves_generic_event_records_across_recovery() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
@@ -2168,11 +2281,10 @@ mod tests {
                     model: "gemini-2.0-flash".to_string(),
                 }),
                 RolloutItem::Event(EventRecord {
-                    event_type: "compaction_attempt".to_string(),
+                    event_type: "custom_event".to_string(),
                     payload: serde_json::json!({
-                        "result": "failure",
-                        "retry_count": 5,
-                        "error": "context window exceeded"
+                        "phase": "testing",
+                        "value": 5
                     }),
                     timestamp: "2026-01-29T14:31:00Z".to_string(),
                 }),
@@ -2205,17 +2317,163 @@ mod tests {
                 .unwrap();
 
             let event = recovered_items.into_iter().find_map(|item| match item {
-                RolloutItem::Event(event) if event.event_type == "compaction_attempt" => {
-                    Some(event)
-                }
+                RolloutItem::Event(event) if event.event_type == "custom_event" => Some(event),
                 _ => None,
             });
 
-            let event = event.expect("expected recovered compaction_attempt event");
-            assert_eq!(event.payload["result"], "failure");
-            assert_eq!(event.payload["retry_count"], 5);
-            assert_eq!(event.payload["error"], "context window exceeded");
+            let event = event.expect("expected recovered custom event");
+            assert_eq!(event.payload["phase"], "testing");
+            assert_eq!(event.payload["value"], 5);
             assert_eq!(event.timestamp, "2026-01-29T14:31:00Z");
+        });
+    }
+
+    #[test]
+    fn test_load_from_rollout_migrates_legacy_compaction_attempt_events() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+            let rollout_path = temp_dir
+                .path()
+                .join("rollout-legacy-compaction-event.jsonl");
+
+            let items = [
+                RolloutItem::SessionMeta(SessionMeta {
+                    session_id: "sess-legacy-compaction-event".to_string(),
+                    started_at: "2026-01-29T14:30:52Z".to_string(),
+                    cwd: "/tmp".to_string(),
+                    model: "gemini-2.0-flash".to_string(),
+                }),
+                RolloutItem::Event(EventRecord {
+                    event_type: "compaction_attempt".to_string(),
+                    payload: serde_json::json!({
+                        "mode": "manual",
+                        "trigger": "manual",
+                        "reason": "explicit_request",
+                        "focus": "preserve todos",
+                        "retry_count": 2,
+                        "result": "failure",
+                        "error": "context window exceeded",
+                        "failure_streak": 3,
+                        "reference_context_revision": 7
+                    }),
+                    timestamp: "2026-01-29T14:31:00Z".to_string(),
+                }),
+            ];
+
+            let content = items
+                .iter()
+                .map(serde_json::to_string)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+                + "\n";
+            tokio::fs::write(&rollout_path, content).await.unwrap();
+
+            let session = Session::load_from_rollout_in_dir(
+                &rollout_path,
+                "gemini-2.0-flash",
+                temp_dir.path(),
+            )
+            .await
+            .unwrap();
+
+            let latest = session
+                .latest_compaction_attempt()
+                .expect("expected latest compaction attempt to be recovered");
+            assert_eq!(latest.request.mode, CompactionMode::Manual);
+            assert_eq!(latest.request.trigger, CompactionTrigger::Manual);
+            assert_eq!(latest.request.reason, CompactionReason::ExplicitRequest);
+            assert_eq!(latest.request.focus.as_deref(), Some("preserve todos"));
+            assert_eq!(latest.result, CompactionResult::Failure);
+            assert_eq!(latest.retry_count, 2);
+            assert_eq!(
+                latest.error_message.as_deref(),
+                Some("context window exceeded")
+            );
+            assert_eq!(latest.failure_streak, Some(3));
+            assert_eq!(latest.reference_context_revision_before, Some(7));
+
+            session.flush().await;
+            let recovered_path = session
+                .rollout_path()
+                .expect("recovered session should have rollout path")
+                .clone();
+            let recovered_items = RolloutRecorder::load_history(&recovered_path)
+                .await
+                .unwrap();
+
+            let attempt = recovered_items.into_iter().find_map(|item| match item {
+                RolloutItem::CompactionAttempt(attempt) => Some(attempt),
+                _ => None,
+            });
+
+            let attempt = attempt.expect("expected recovered compaction attempt item");
+            assert_eq!(attempt.result, CompactionResult::Failure);
+            assert_eq!(attempt.retry_count, 2);
+            assert_eq!(attempt.request.focus.as_deref(), Some("preserve todos"));
+        });
+    }
+
+    #[test]
+    fn test_load_from_rollout_restores_latest_compaction_attempt_item() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+            let rollout_path = temp_dir.path().join("rollout-compaction-attempt.jsonl");
+
+            let attempt = CompactionAttemptSnapshot {
+                attempt_id: "attempt-123".to_string(),
+                submission_id: None,
+                request: CompactionRequestMetadata {
+                    mode: CompactionMode::AutoPreTurn,
+                    trigger: CompactionTrigger::Auto,
+                    reason: CompactionReason::WindowPressure,
+                    focus: None,
+                },
+                result: CompactionResult::Retry,
+                input_messages: Some(18),
+                output_messages: Some(5),
+                input_prompt_tokens: Some(1500),
+                output_prompt_tokens: Some(480),
+                retry_count: 1,
+                tape_mutated: true,
+                warning_message: None,
+                error_message: None,
+                failure_streak: None,
+                reference_context_revision_before: Some(4),
+                reference_context_revision_after: Some(4),
+                timestamp: "2026-01-29T14:31:00Z".to_string(),
+            };
+
+            let items = [
+                RolloutItem::SessionMeta(SessionMeta {
+                    session_id: "sess-compaction-attempt".to_string(),
+                    started_at: "2026-01-29T14:30:52Z".to_string(),
+                    cwd: "/tmp".to_string(),
+                    model: "gemini-2.0-flash".to_string(),
+                }),
+                RolloutItem::CompactionAttempt(attempt.clone()),
+            ];
+
+            let content = items
+                .iter()
+                .map(serde_json::to_string)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("\n")
+                + "\n";
+            tokio::fs::write(&rollout_path, content).await.unwrap();
+
+            let session = Session::load_from_rollout_in_dir(
+                &rollout_path,
+                "gemini-2.0-flash",
+                temp_dir.path(),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(session.latest_compaction_attempt(), Some(&attempt));
         });
     }
 
@@ -2355,6 +2613,50 @@ mod tests {
         let session = Session::new();
         // Should not panic without recorder
         session.record_summary("Test summary");
+    }
+
+    #[tokio::test]
+    async fn test_record_compaction_attempt_updates_latest_and_rollout() {
+        let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+        let mut session = Session::new_with_recorder_in_dir("gemini-2.0-flash", temp_dir.path())
+            .await
+            .unwrap();
+        let attempt = CompactionAttemptSnapshot {
+            attempt_id: "attempt-123".to_string(),
+            submission_id: Some("sub-456".to_string()),
+            request: CompactionRequestMetadata {
+                mode: CompactionMode::Manual,
+                trigger: CompactionTrigger::Manual,
+                reason: CompactionReason::ExplicitRequest,
+                focus: Some("preserve todos".to_string()),
+            },
+            result: CompactionResult::Success,
+            input_messages: Some(10),
+            output_messages: Some(3),
+            input_prompt_tokens: Some(800),
+            output_prompt_tokens: Some(250),
+            retry_count: 0,
+            tape_mutated: true,
+            warning_message: None,
+            error_message: None,
+            failure_streak: None,
+            reference_context_revision_before: Some(2),
+            reference_context_revision_after: Some(2),
+            timestamp: "2026-03-03T10:00:00Z".to_string(),
+        };
+
+        session.record_compaction_attempt(attempt.clone());
+        assert_eq!(session.latest_compaction_attempt(), Some(&attempt));
+
+        session.flush().await;
+        let rollout_path = session.rollout_path().unwrap().clone();
+        let items = RolloutRecorder::load_history(&rollout_path).await.unwrap();
+        let persisted = items.into_iter().find_map(|item| match item {
+            RolloutItem::CompactionAttempt(snapshot) => Some(snapshot),
+            _ => None,
+        });
+
+        assert_eq!(persisted, Some(attempt));
     }
 
     #[test]


### PR DESCRIPTION
Closes #129

## Summary
- add a structured `CompactionAttemptSnapshot` and persist it as a first-class rollout item
- thread compaction attempt ids through runtime compaction so compacted summaries can be linked back to the attempt that produced them
- restore and re-persist latest compaction attempt state across rollout recovery, including migration from legacy `compaction_attempt` event records

## Validation
- cargo test -p alan-runtime compact
- cargo test -p alan-runtime load_from_rollout
- cargo test -p alan-runtime record_compaction_attempt
- cargo test -p alan compact_session
- cargo clippy -p alan-runtime --tests -- -D warnings
- cargo clippy -p alan --tests -- -D warnings