### PR TITLE
[VNext][Compaction] Add harness suite and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,21 @@ jobs:
       - name: Run coding reference blocking suite
         run: bash scripts/harness/run_coding_reference_suite.sh --ci-blocking
 
+  harness-compaction:
+    name: Harness Compaction (Blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run compaction blocking suite
+        run: bash scripts/harness/run_compaction_suite.sh --ci-blocking
+
   tui:
     name: TUI Lint / Test / Typecheck
     runs-on: ubuntu-latest

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -157,6 +157,18 @@ Run coding reference CI-blocking subset:
 bash scripts/harness/run_coding_reference_suite.sh --ci-blocking
 ```
 
+Run compaction harness scenarios:
+
+```bash
+bash scripts/harness/run_compaction_suite.sh
+```
+
+Run compaction CI-blocking subset:
+
+```bash
+bash scripts/harness/run_compaction_suite.sh --ci-blocking
+```
+
 Artifacts are written to:
 
 ```text
@@ -173,6 +185,12 @@ Coding reference artifacts are written to:
 
 ```text
 target/harness/coding_reference/latest/
+```
+
+Compaction artifacts are written to:
+
+```text
+target/harness/compaction/latest/
 ```
 
 ## Executable Scenario Matrix (MVP)
@@ -218,6 +236,15 @@ Start with an automatically executable batch (each must include input script, as
 13. `autonomy/mobile_flaky_network_recovery`
    - Goal: validate gap handling and reconnect snapshot fallback under flaky connectivity.
    - Assertions: deterministic `gap=true` detection and non-mutating recovery reads.
+14. `compaction/retry_after_trim`
+   - Goal: validate trim-and-retry compaction audit semantics after an initial failure.
+   - Assertions: `Retry` result classification and cross-surface consistency.
+15. `compaction/degraded_fallback`
+   - Goal: validate degraded fallback remains visible as degraded across runtime surfaces.
+   - Assertions: degraded strategy visibility and attempt/summary linkage.
+16. `compaction/failure_preserves_tape`
+   - Goal: validate failure path preserves tape state while still surfacing the attempt durably.
+   - Assertions: no tape mutation, failed attempt remains externally observable.
 
 Current fixture-backed executable scenarios in repository:
 
@@ -232,6 +259,11 @@ Current fixture-backed executable scenarios in repository:
 9. `autonomy/mobile_reconnect_snapshot`
 10. `autonomy/mobile_notification_signal`
 11. `autonomy/mobile_flaky_network_recovery`
+12. `compaction/manual_success`
+13. `compaction/retry_after_trim`
+14. `compaction/degraded_fallback`
+15. `compaction/failure_preserves_tape`
+16. `compaction/repeated_failure_escalation`
 
 ## Release Gate Recommendations
 
@@ -245,6 +277,10 @@ Treat these as blocking checks:
 6. `coding/minimum_loop`
 7. `coding/input_modes_stability`
 8. `coding/recovery_dedupe`
+9. `compaction/retry_after_trim`
+10. `compaction/degraded_fallback`
+11. `compaction/failure_preserves_tape`
+12. `compaction/repeated_failure_escalation`
 
 ## Acceptance Criteria
 

--- a/docs/harness/metrics/kpi.md
+++ b/docs/harness/metrics/kpi.md
@@ -1,10 +1,12 @@
 # Harness KPI Output
 
-Autonomy harness runner writes KPI output to:
+Harness runners write KPI output to:
 
 - `target/harness/autonomy/latest/kpi.json`
+- `target/harness/coding_reference/latest/kpi.json`
+- `target/harness/compaction/latest/kpi.json`
 
-Current KPI fields:
+Current shared KPI fields:
 
 1. `suite`
 2. `mode` (`all` or `ci_blocking`)
@@ -15,7 +17,9 @@ Current KPI fields:
 7. `pass_rate_percent`
 8. `duration_secs`
 
-Per-scenario artifacts (under `target/harness/autonomy/latest/<scenario>/`):
+Additional suite-specific fields may appear. For example, autonomy also records `profile`.
+
+Per-scenario artifacts (under `target/harness/<suite>/latest/<scenario>/`):
 
 1. `input_script.json`
 2. `event_trace.log`

--- a/docs/harness/scenarios/compaction/degraded_fallback.json
+++ b/docs/harness/scenarios/compaction/degraded_fallback.json
@@ -1,0 +1,17 @@
+{
+  "id": "compaction/degraded_fallback",
+  "category": "compaction",
+  "description": "Validate degraded fallback compaction remains visible as degraded and keeps the resulting attempt consistent across all external surfaces.",
+  "blocking": true,
+  "command": "cargo test -p alan --test compaction_integration_test compaction_degraded_surfaces_match -- --exact",
+  "assertions": [
+    "degraded fallback emits CompactionResult::Degraded",
+    "degraded strategy is visible in event, read, reconnect, rollout, and recovery views",
+    "compacted summary remains linked to the degraded attempt"
+  ],
+  "kpi_tags": [
+    "degraded_path",
+    "fallback",
+    "surface_consistency"
+  ]
+}

--- a/docs/harness/scenarios/compaction/failure_preserves_tape.json
+++ b/docs/harness/scenarios/compaction/failure_preserves_tape.json
@@ -1,0 +1,17 @@
+{
+  "id": "compaction/failure_preserves_tape",
+  "category": "compaction",
+  "description": "Validate compaction failure keeps tape state intact while still surfacing the failed attempt durably and externally.",
+  "blocking": true,
+  "command": "cargo test -p alan --test compaction_integration_test compaction_failure_preserves_tape_and_recovery_state -- --exact",
+  "assertions": [
+    "failed compaction emits CompactionResult::Failure",
+    "failure path does not mutate tape or durable compacted summary state",
+    "failed attempt remains available in event, read, reconnect, rollout, and recovery views"
+  ],
+  "kpi_tags": [
+    "failure_path",
+    "tape_preservation",
+    "surface_consistency"
+  ]
+}

--- a/docs/harness/scenarios/compaction/manual_success.json
+++ b/docs/harness/scenarios/compaction/manual_success.json
@@ -1,0 +1,17 @@
+{
+  "id": "compaction/manual_success",
+  "category": "compaction",
+  "description": "Validate the manual compaction success path surfaces the same attempt across event, read, reconnect, rollout, and recovery views.",
+  "blocking": false,
+  "command": "cargo test -p alan --test compaction_integration_test compaction_manual_success_surfaces_match -- --exact",
+  "assertions": [
+    "manual compaction completes successfully",
+    "event/read/reconnect/rollout/recovery surfaces agree on the same attempt id",
+    "durable compaction summary is linked to the producing attempt"
+  ],
+  "kpi_tags": [
+    "manual_compaction",
+    "surface_consistency",
+    "success_path"
+  ]
+}

--- a/docs/harness/scenarios/compaction/repeated_failure_escalation.json
+++ b/docs/harness/scenarios/compaction/repeated_failure_escalation.json
@@ -1,0 +1,17 @@
+{
+  "id": "compaction/repeated_failure_escalation",
+  "category": "compaction",
+  "description": "Validate repeated compaction failures escalate warning visibility while preserving the latest failed attempt across external surfaces.",
+  "blocking": true,
+  "command": "cargo test -p alan --test compaction_integration_test compaction_repeated_failure_escalation_surfaces_match -- --exact",
+  "assertions": [
+    "repeated compaction failure emits escalation warnings",
+    "latest failed attempt remains stable across event, read, reconnect, rollout, and recovery views",
+    "warning escalation does not hide the underlying failure result"
+  ],
+  "kpi_tags": [
+    "repeated_failure",
+    "warning_escalation",
+    "surface_consistency"
+  ]
+}

--- a/docs/harness/scenarios/compaction/retry_after_trim.json
+++ b/docs/harness/scenarios/compaction/retry_after_trim.json
@@ -1,0 +1,17 @@
+{
+  "id": "compaction/retry_after_trim",
+  "category": "compaction",
+  "description": "Validate a failed first compaction attempt that succeeds after trim is audited as retry and remains surface-consistent.",
+  "blocking": true,
+  "command": "cargo test -p alan --test compaction_integration_test compaction_retry_surfaces_match_after_trimmed_retry -- --exact",
+  "assertions": [
+    "trimmed retry path returns CompactionResult::Retry",
+    "retry_count is preserved across event, read, reconnect, rollout, and recovery",
+    "post-trim success does not collapse into plain success audit"
+  ],
+  "kpi_tags": [
+    "retry_path",
+    "trimmed_retry",
+    "surface_consistency"
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -98,6 +98,14 @@ harness-coding-reference:
 harness-coding-reference-ci:
     bash scripts/harness/run_coding_reference_suite.sh --ci-blocking
 
+# Run compaction harness scenarios (all)
+harness-compaction:
+    bash scripts/harness/run_compaction_suite.sh
+
+# Run only CI-blocking compaction harness scenarios
+harness-compaction-ci:
+    bash scripts/harness/run_compaction_suite.sh --ci-blocking
+
 # Coding agent verification loop (run after code changes)
 verify: fmt lint test smoke
     @echo "✅ Core flows verified"

--- a/scripts/harness/run_compaction_suite.sh
+++ b/scripts/harness/run_compaction_suite.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  scripts/harness/run_compaction_suite.sh [--ci-blocking]
+
+Options:
+  --ci-blocking   Run only scenarios marked as blocking for CI gates.
+USAGE
+}
+
+mode="all"
+if [[ "${1:-}" == "--ci-blocking" ]]; then
+    mode="ci_blocking"
+    shift
+fi
+
+if [[ $# -gt 0 ]]; then
+    usage
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to parse harness fixture JSON." >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+artifact_root="$repo_root/target/harness/compaction/latest"
+mkdir -p "$artifact_root"
+rm -rf "$artifact_root"/*
+
+fixtures=(
+    "docs/harness/scenarios/compaction/manual_success.json"
+    "docs/harness/scenarios/compaction/retry_after_trim.json"
+    "docs/harness/scenarios/compaction/degraded_fallback.json"
+    "docs/harness/scenarios/compaction/failure_preserves_tape.json"
+    "docs/harness/scenarios/compaction/repeated_failure_escalation.json"
+)
+
+suite_start_epoch="$(date +%s)"
+total=0
+passed=0
+failed=0
+skipped=0
+
+extract_json_string_field() {
+    local file="$1"
+    local key="$2"
+    jq -er --arg key "$key" '.[$key] | strings' "$file"
+}
+
+extract_json_bool_field() {
+    local file="$1"
+    local key="$2"
+    local value
+    value="$(jq -r --arg key "$key" '.[$key]' "$file" 2>/dev/null || true)"
+    if [[ "$value" != "true" && "$value" != "false" ]]; then
+        return 1
+    fi
+    printf "%s\n" "$value"
+}
+
+validate_exact_cargo_filters() {
+    local scenario_id="$1"
+    local scenario_cmd="$2"
+    local segment list_output
+
+    while IFS= read -r segment; do
+        segment="$(printf "%s" "$segment" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+        if [[ -z "$segment" ]]; then
+            continue
+        fi
+        if [[ "$segment" == cargo\ test* && "$segment" == *"-- --exact"* ]]; then
+            if ! list_output="$(cd "$repo_root" && bash -lc "$segment --list" 2>&1)"; then
+                echo "Scenario ${scenario_id} has invalid exact cargo test filter: ${segment}" >&2
+                echo "$list_output" >&2
+                return 1
+            fi
+            if ! printf "%s\n" "$list_output" | grep -Eq ':[[:space:]]+test$'; then
+                echo "Scenario ${scenario_id} exact cargo filter matched zero tests: ${segment}" >&2
+                return 1
+            fi
+        fi
+    done < <(printf "%s" "$scenario_cmd" | sed 's/&&/\n/g')
+}
+
+for fixture_rel in "${fixtures[@]}"; do
+    fixture_path="$repo_root/$fixture_rel"
+    if [[ ! -f "$fixture_path" ]]; then
+        echo "Missing harness fixture: $fixture_rel" >&2
+        exit 1
+    fi
+
+    scenario_id="$(extract_json_string_field "$fixture_path" "id" || true)"
+    scenario_cmd="$(extract_json_string_field "$fixture_path" "command" || true)"
+    scenario_blocking="$(extract_json_bool_field "$fixture_path" "blocking" || true)"
+
+    if [[ -z "$scenario_id" || -z "$scenario_cmd" || -z "$scenario_blocking" ]]; then
+        echo "Invalid harness fixture format: $fixture_rel" >&2
+        exit 1
+    fi
+
+    if [[ "$mode" == "ci_blocking" && "$scenario_blocking" != "true" ]]; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    scenario_dir="$artifact_root/${scenario_id//\//__}"
+    mkdir -p "$scenario_dir"
+    cp "$fixture_path" "$scenario_dir/input_script.json"
+
+    started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    scenario_start_epoch="$(date +%s)"
+    set +e
+    validate_exact_cargo_filters "$scenario_id" "$scenario_cmd" >"$scenario_dir/precheck.log" 2>&1
+    precheck_exit=$?
+    set -e
+
+    if [[ $precheck_exit -ne 0 ]]; then
+        cp "$scenario_dir/precheck.log" "$scenario_dir/event_trace.log"
+        exit_code=1
+    else
+        set +e
+        (cd "$repo_root" && bash -lc "$scenario_cmd") >"$scenario_dir/event_trace.log" 2>&1
+        exit_code=$?
+        set -e
+    fi
+    finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    scenario_duration_secs=$(( $(date +%s) - scenario_start_epoch ))
+
+    total=$((total + 1))
+    if [[ $exit_code -eq 0 ]]; then
+        passed=$((passed + 1))
+        decision="pass"
+        reason="command_exit_zero"
+        assertion_passed=true
+    else
+        failed=$((failed + 1))
+        decision="fail"
+        reason="command_exit_nonzero"
+        assertion_passed=false
+    fi
+
+    jq -cn \
+        --arg scenario "$scenario_id" \
+        --arg decision "$decision" \
+        --arg reason "$reason" \
+        --arg started_at "$started_at" \
+        --arg finished_at "$finished_at" \
+        --argjson duration_secs "$scenario_duration_secs" \
+        '{scenario:$scenario,decision:$decision,reason:$reason,started_at:$started_at,finished_at:$finished_at,duration_secs:$duration_secs}' \
+        >"$scenario_dir/decision_trace.jsonl"
+
+    jq -cn \
+        --arg scenario "$scenario_id" \
+        --argjson passed "$assertion_passed" \
+        --argjson exit_code "$exit_code" \
+        --arg detail "$scenario_cmd" \
+        '{scenario:$scenario,passed:$passed,exit_code:$exit_code,assertions:[{name:"command_exit_zero",passed:$passed,detail:$detail}]}' \
+        >"$scenario_dir/assertion_report.json"
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo "Scenario failed: $scenario_id"
+        echo "  command: $scenario_cmd"
+        echo "  artifact: $scenario_dir"
+    fi
+done
+
+suite_duration_secs=$(( $(date +%s) - suite_start_epoch ))
+if [[ $total -gt 0 ]]; then
+    pass_rate_percent="$(awk "BEGIN { printf \"%.2f\", ($passed / $total) * 100 }")"
+else
+    pass_rate_percent="0.00"
+fi
+
+cat >"$artifact_root/kpi.json" <<KPI
+{"suite":"compaction","mode":"$mode","total":$total,"passed":$passed,"failed":$failed,"skipped":$skipped,"pass_rate_percent":$pass_rate_percent,"duration_secs":$suite_duration_secs}
+KPI
+
+echo "Compaction harness summary:"
+echo "  mode: $mode"
+echo "  total: $total"
+echo "  passed: $passed"
+echo "  failed: $failed"
+echo "  skipped: $skipped"
+echo "  pass_rate_percent: $pass_rate_percent"
+echo "  artifacts: $artifact_root"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add dedicated compaction harness fixtures for success/retry/degraded/failure/escalation paths
- add scripts/harness/run_compaction_suite.sh plus justfile/docs wiring and KPI references
- add a blocking Harness Compaction CI job using the retry/degraded/failure/escalation subset

## Validation
- bash scripts/harness/run_compaction_suite.sh
- bash scripts/harness/run_compaction_suite.sh --ci-blocking