### PR TITLE
Add long-term apprenticeship learning docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,3 +60,19 @@ Use these to align product decisions with Alan's operator model.
 - `docs/maintainer/remote_control_phased_plan.md`
 
 Use this for repository governance, GitHub automation, and contributor-ready setup.
+
+## 7) Long-Term Directions (Intent, Non-Contract)
+
+- `docs/directions/README.md`
+- `docs/directions/apprenticeship_learning.md`
+
+Use these to capture strategic directions that are expected to matter to Alan over time,
+but are still too early for contracts, rollout plans, or implementation commitments.
+
+## 8) Exploration / Idea Backlog (Non-Contract)
+
+- `docs/ideas/README.md`
+- `docs/ideas/multi_model_deliberation.md`
+
+Use these to capture speculative directions, hypotheses, and ideas that should not be
+treated as committed architecture or roadmap.

--- a/docs/directions/README.md
+++ b/docs/directions/README.md
@@ -1,0 +1,20 @@
+# Long-Term Directions
+
+This directory is for durable strategic directions that are expected to matter to Alan,
+but are still too early to express as contracts, rollout plans, or implementation work.
+
+These documents are intentionally stronger than an idea backlog entry, but weaker than
+an accepted architecture or roadmap item.
+
+Use this directory when a direction is:
+
+1. Expected to matter to Alan in the long run.
+2. Important enough to shape future thinking and terminology.
+3. Still too underdefined for `docs/spec/`, execution plans, or committed milestones.
+
+Do not use this directory for:
+
+1. Current runtime behavior.
+2. Source-of-truth contracts.
+3. Near-term implementation plans.
+4. Highly speculative brainstorming with no durable product significance.

--- a/docs/directions/apprenticeship_learning.md
+++ b/docs/directions/apprenticeship_learning.md
@@ -1,0 +1,191 @@
+# Apprenticeship Learning
+
+> Status: long-term direction.
+> Purpose: define a durable Alan capability direction without implying current behavior,
+> architecture contract, or near-term implementation work.
+
+## Summary
+
+Alan should eventually be able to learn from repeated interaction, examples, corrections,
+and successful task histories in a way that reduces future supervision.
+
+This is not just "more memory." The long-term goal is for Alan to extract reusable
+behavioral patterns from interaction history and promote them into more capable default
+behavior over time.
+
+The working metaphor is apprenticeship:
+
+1. A human demonstrates or corrects.
+2. Alan observes repeated patterns.
+3. Alan internalizes stable ways of working.
+4. Later tasks require less explicit instruction and less human intervention.
+
+## Why This Matters
+
+A general agent does not become practically useful only by having more tools or a larger
+context window. It becomes more useful when it can:
+
+1. remember what quality looks like,
+2. infer what the operator consistently wants,
+3. reuse successful workflows,
+4. avoid repeating previously corrected mistakes,
+5. operate with less micromanagement over time.
+
+This direction is therefore about capability growth through interaction, not just storage.
+
+## Core Claim
+
+The long-term value of Alan is not only that it can execute a turn, but that it can be
+trained through usage.
+
+Over many turns and sessions, Alan should be able to accumulate something closer to
+practical know-how:
+
+1. preferences,
+2. judgment criteria,
+3. workflow patterns,
+4. escalation boundaries,
+5. benchmark-solving strategies,
+6. domain-specific ways of working.
+
+## Working Definition Of The Agent
+
+This direction assumes a specific framing:
+
+1. Alan, at the workspace level, is the persistent agent.
+2. Sessions, turns, and subagents are execution forms of that agent.
+3. Subagents are not necessarily separate enduring selves; they may be task-local modes,
+   workers, or projections of the same underlying agent identity.
+
+This framing matters because learning should attach primarily to the persistent agent,
+not to short-lived execution fragments.
+
+## What Should Be Learned
+
+Examples of learnable artifacts may include:
+
+1. operator preferences,
+2. recurring task decomposition patterns,
+3. effective tool-use sequences,
+4. correction-derived "do not repeat" rules,
+5. quality rubrics for acceptance or escalation,
+6. benchmark-specific solution heuristics,
+7. reusable intermediate abstractions that later become skills or policies.
+
+The goal is not to memorize transcripts. The goal is to promote stable patterns.
+
+## Tentative Learning Pipeline
+
+This direction suggests a future pipeline like:
+
+1. Observe:
+   collect candidate signals from interaction history, memory, outcomes, and corrections.
+2. Extract:
+   identify recurring patterns rather than isolated examples.
+3. Evaluate:
+   decide whether a pattern is reliable enough to reuse.
+4. Promote:
+   store the pattern in a durable, structured form.
+5. Apply:
+   use it in future planning, routing, tool use, or evaluation.
+6. Revalidate:
+   confirm that promoted patterns continue to help rather than drift.
+
+This should be treated as capability promotion, not unbounded online self-modification.
+
+## Root Agent vs Execution Agent
+
+One open design axis is where learning authority should live.
+
+Possible split:
+
+1. execution agents / subagents:
+   detect candidate lessons while doing local work.
+2. root agent:
+   decides which lessons are durable enough to adopt at workspace scope.
+
+This suggests a bias toward centralized promotion:
+
+1. local workers discover,
+2. the persistent agent judges,
+3. promoted knowledge becomes shared future capability.
+
+That structure would reduce fragmentation and make learning more auditable.
+
+## Relationship To Memory
+
+Memory is an input to this direction, but not the same thing.
+
+Memory answers:
+
+1. what happened before,
+2. what matters now,
+3. what context should be carried forward.
+
+Apprenticeship learning asks a harder question:
+
+1. what stable pattern should change how Alan behaves next time.
+
+In other words:
+
+1. memory preserves experience,
+2. apprenticeship turns experience into behavior.
+
+## Relationship To Skills, Policies, And Prompts
+
+If this direction succeeds, some learned patterns may eventually become:
+
+1. skill refinements,
+2. routing heuristics,
+3. evaluation rubrics,
+4. governance hints,
+5. reusable benchmark strategies,
+6. stronger defaults for specific operators or workspaces.
+
+The important constraint is that promotion should stay explicit, inspectable, and
+testable. Alan should not rely on opaque drift as its main learning mechanism.
+
+## Non-Goals
+
+This direction does not imply:
+
+1. uncontrolled self-editing of prompts or code,
+2. blind trust in raw conversation history,
+3. turning every subagent into an independent long-term persona,
+4. replacing harness evaluation with online improvisation,
+5. treating all user feedback as equally durable learning signal.
+
+## Open Questions
+
+Major unresolved questions include:
+
+1. What is the right representation for a learned pattern?
+2. How is promotion decided and by whom?
+3. How should conflicting lessons be resolved?
+4. What should remain operator-specific versus globally reusable?
+5. How much autonomy should learning have before human review is required?
+6. How should learned behavior be benchmarked and rolled back?
+
+## Relationship To Benchmarks
+
+A long-term motivation for this direction is that apprenticeship may let Alan improve
+through guided use before tackling harder public agent benchmarks.
+
+The expected sequence is:
+
+1. learn from real operator interaction,
+2. reduce supervision on repeated internal tasks,
+3. validate behavior with harness and internal benchmarks,
+4. gradually apply the resulting capabilities to public agent and AI benchmarks.
+
+The benchmark goal should remain downstream of genuine capability growth, not the sole
+reason to build the system.
+
+## Promotion Criteria
+
+This direction should move closer to architecture or implementation only when:
+
+1. Alan has a clearer representation for durable learned behavior.
+2. The root-agent versus subagent learning boundary is better defined.
+3. Harness-based evaluation can measure whether learning truly reduces intervention.
+4. The design can preserve auditability, reversibility, and small-kernel discipline.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1,0 +1,18 @@
+# Exploration / Idea Backlog
+
+This directory is for speculative design notes, hypotheses, and ideas worth preserving.
+
+If something is expected to become an important Alan capability over time, but is not yet
+ready for contracts or a delivery plan, prefer `docs/directions/` instead.
+
+These documents are explicitly non-contractual:
+
+1. They are not roadmap commitments.
+2. They are not source-of-truth runtime behavior.
+3. They should not be cited as accepted architecture without a later contract or RFC.
+
+Use this directory when an idea is:
+
+1. Interesting enough to preserve.
+2. Not yet validated by harness or implementation.
+3. Too early to promote into `docs/spec/` or the main architecture documents.

--- a/docs/ideas/multi_model_deliberation.md
+++ b/docs/ideas/multi_model_deliberation.md
@@ -1,0 +1,95 @@
+# Multi-Model Deliberation
+
+> Status: speculative idea backlog entry.
+> Purpose: preserve a design direction for later validation, not to define current Alan behavior.
+
+## Summary
+
+Alan may benefit from a multi-model execution pattern where:
+
+1. Smaller, faster models handle narrow, low-risk, high-volume subtasks.
+2. Larger models handle planning, coordination, ambiguity resolution, and final judgment.
+3. The system upgrades from cheap execution to expensive deliberation only when needed.
+
+This is best understood as a compute-budget and control-layer design, not as literal
+simulation of Daniel Kahneman's "System 1 / System 2" psychology.
+
+## Working Hypothesis
+
+Instead of one model handling every phase of an agent turn, Alan could separate:
+
+1. Fast path:
+   low-cost routing, classification, extraction, retrieval summarization, local codebase search,
+   supporting subagent work, simple drafts.
+2. Deliberate path:
+   multi-step planning, tool orchestration, conflict resolution, side-effect review,
+   final answer synthesis, and high-risk decisions.
+
+The architecture value would come from selective escalation, not from anthropomorphic role-play.
+
+## Why This Might Matter For Alan
+
+Alan already has runtime ingredients that could support this direction:
+
+1. Turn execution is already explicit and state-machine driven.
+2. Tool orchestration, governance, and yield/resume create natural escalation boundaries.
+3. Skills define workflow logic while runtime owns invariants and recovery.
+4. Harness infrastructure already exists for profile comparison and regression gating.
+
+This suggests that a future multi-model path, if pursued, should be expressed as:
+
+1. routing policy
+2. escalation rules
+3. evaluation thresholds
+
+and not as a personality prompt that asks one model to "be intuitive" and another to "be rational."
+
+## Candidate Division Of Labor
+
+Potential future shape:
+
+1. `nano` or similarly cheap model:
+   triage, extraction, ranking, simple tool-result condensation, narrow subagents.
+2. `mini` model:
+   medium-difficulty coding subtasks, codebase exploration, document review, intermediate synthesis.
+3. frontier model:
+   planning, final judgment, ambiguity handling, recovery after failures, risky or expensive actions.
+
+This should remain policy-driven. The system should decide when to upgrade rather than hard-code one
+model per user-visible task category.
+
+## Main Risks
+
+1. Router overhead can erase cost or latency wins if escalation is too frequent.
+2. Small-model errors can poison later stages if outputs are trusted too early.
+3. Added complexity can reduce debuggability unless routing decisions are observable.
+4. Benchmark gains may fail to translate into end-to-end agent improvements.
+5. Long-context and high-ambiguity tasks may need large-model involvement earlier than expected.
+
+## Validation Questions
+
+Before treating this as a roadmap item, Alan should answer:
+
+1. Does multi-model routing improve end-to-end task success, not just component metrics?
+2. Which subtasks are reliably "small-model safe" inside Alan workflows?
+3. What escalation signals are predictive enough to keep failure rates low?
+4. How much orchestration overhead is acceptable before the design stops paying for itself?
+5. Can harness scenarios detect regressions in routing quality, duplicate side effects, and recovery?
+
+## Evidence To Revisit Later
+
+Relevant external directions worth revisiting when this idea becomes active:
+
+1. LLM cascades and cost-quality routing.
+2. Multi-LLM routers and model selection benchmarks.
+3. Strong-verifier patterns for weaker reasoners.
+4. Product evidence from coding-subagent systems using mixed model sizes.
+
+## Promotion Criteria
+
+This idea should only move out of the backlog if all of the following become true:
+
+1. There is a concrete Alan use case that is bottlenecked by single-model cost, latency, or reliability.
+2. A routing policy can be expressed at the runtime/daemon/skill boundary without muddying contracts.
+3. Harness scenarios exist to compare single-model and multi-model profiles.
+4. The resulting design is explainable enough to preserve Alan's small-kernel philosophy.


### PR DESCRIPTION
## Summary
- add a `docs/directions/` layer for durable long-term directions that are not yet specs or plans
- define `Apprenticeship Learning` as a long-term Alan capability direction
- keep multi-model deliberation under `docs/ideas/` and update the docs index to distinguish directions from ideas

## Testing
- not run (docs only)