### PR TITLE
[VNext][Agent Model] Document agent-root layout and resolution rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,20 @@ LLM/provider/timeouts/memory/tool-loop settings are loaded from `~/.alan/agent/a
 (or `ALAN_CONFIG_PATH`), not from per-key environment variables. Host-facing daemon/client
 settings live in `~/.alan/host.toml`.
 
+Agent definitions are resolved from `AgentRoot`s on disk:
+
+```text
+~/.alan/agent/                   # global base agent root
+~/.alan/agents/<name>/           # global named agent root
+<workspace>/.alan/agent/         # workspace base agent root
+<workspace>/.alan/agents/<name>/ # workspace named agent root
+```
+
+Each root may contribute `agent.toml`, `persona/`, `skills/`, and `policy.yaml`.
+Default workspace agents resolve `~/.alan/agent -> <workspace>/.alan/agent`.
+Named agents extend that chain with `~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`.
+This is definition overlay, not runtime parent-child inheritance.
+
 ### Config File
 
 Configuration can also be loaded from `~/.alan/agent/agent.toml`:
@@ -395,7 +409,7 @@ curl -X POST http://localhost:8090/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "workspace_dir": "/path/to/workspace",
-    "governance": {"profile": "conservative", "policy_path": ".alan/policy.yaml"},
+    "governance": {"profile": "conservative", "policy_path": ".alan/agent/policy.yaml"},
     "streaming_mode": "on"
   }'
 
@@ -539,7 +553,7 @@ Session governance is configured via:
 {
   "governance": {
     "profile": "autonomous",
-    "policy_path": ".alan/policy.yaml"
+    "policy_path": ".alan/agent/policy.yaml"
   }
 }
 ```
@@ -547,7 +561,7 @@ Session governance is configured via:
 Policy resolution order is:
 
 1. `governance.policy_path`, if provided
-2. `{workspace}/.alan/policy.yaml`, if present
+2. the highest-precedence existing `policy.yaml` in the resolved `AgentRoot` chain
 3. builtin profile defaults
 
 When a policy file is found, it replaces the builtin profile rule set for that session.
@@ -576,8 +590,8 @@ Skills can be triggered:
 
 Skill scopes:
 - `[system]` — Built into the binary
-- `[user]` — In `~/.alan/skills/`
-- `[repo]` — In `{workspace}/.alan/skills/`
+- `[user]` — In `~/.alan/agent/skills/` and `~/.alan/agents/<name>/skills/`
+- `[repo]` — In `{workspace}/.alan/agent/skills/` and `{workspace}/.alan/agents/<name>/skills/`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Alan/
 - **Skill System**: Markdown-based capabilities via `$skill-name` triggers
 - **Session Persistence**: Rollout recording with pause/resume/replay
 - **Policy Over Sandbox**: Policy decides (`allow/deny/escalate`), and the current sandbox backend applies a best-effort execution guard (current backend: workspace path guard with protected subpaths and only plain shell commands with statically addressable paths; shell control flow is rejected, common wrapper forms such as `env`/`command`/`builtin`/`exec`/`time`/`nice`/`nohup`/`timeout`/`stdbuf`/`setsid` are rejected, process path references under protected subpaths are blocked, glob patterns are rejected, direct nested shell/code evaluators are disabled, direct opaque command dispatchers such as `xargs`/`find -exec` are rejected, and a curated set of common direct script interpreters such as `python file.py`/`bash script.sh`/`awk -f script.awk` are rejected; the backend checks explicit path-like argv references and redirection targets but does not infer utility-specific operand roles for arbitrary bare tokens, and arbitrary program-internal writes or dispatch such as `git init`/`git add`/`git config --local`, `find -delete`, build/task runners, or utility-specific script/DSL modes like `sed -f` are not inspected by this backend and still need policy or a stronger OS sandbox; OS sandboxing is still in migration)
-- **Policy Profiles**: Builtin `autonomous`/`conservative` presets, overridable via `.alan/policy.yaml`
+- **Policy Profiles**: Builtin `autonomous`/`conservative` presets, overridable via `policy.yaml` in the resolved agent-root chain
 - **Steering-First Execution**: In-turn `input` can interrupt tool batches and reprioritize the next step
 - **WebSocket + HTTP API**: Real-time bidirectional communication
 - **Context Compaction**: Automatic summarization when context grows large
@@ -231,6 +231,32 @@ openai_responses_model = "gpt-5.4"
 Host-facing daemon/client settings live in `~/.alan/host.toml`. You can also set
 `ALAN_CONFIG_PATH` to use a custom agent config file location.
 
+### AgentRoot Layout
+
+Alan resolves an agent definition from on-disk `AgentRoot`s:
+
+```text
+~/.alan/agent/                  # global base agent root
+~/.alan/agents/<name>/          # global named agent root
+
+<workspace>/.alan/agent/        # workspace base agent root
+<workspace>/.alan/agents/<name>/# workspace named agent root
+```
+
+Each root may contain:
+
+- `agent.toml`
+- `persona/`
+- `skills/`
+- `policy.yaml`
+
+Resolution order is:
+
+- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
+- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+
+This is definition overlay, not runtime parent-child inheritance.
+
 Alan resolves model metadata in this order:
 
 1. Bundled catalog
@@ -290,7 +316,7 @@ curl -X POST http://localhost:8090/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "workspace_dir": "/path/to/workspace",
-    "governance": {"profile": "autonomous", "policy_path": ".alan/policy.yaml"},
+    "governance": {"profile": "autonomous", "policy_path": ".alan/agent/policy.yaml"},
     "streaming_mode": "on"
   }'
 
@@ -339,7 +365,7 @@ curl -N http://localhost:8090/api/v1/sessions/{id}/events
 
 ### Policy Configuration (Optional)
 
-Create `{workspace}/.alan/policy.yaml` to override builtin policy profile rules.
+Create `{workspace}/.alan/agent/policy.yaml` to override builtin policy profile rules.
 When present, the file replaces the builtin profile rule set for that session;
 Alan does not implicitly merge policy files with builtin rules.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,32 @@ pub struct AgentConfig {
 - **Swappable** — changing the LLM provider is like swapping a CPU
 - **Defines capability, not identity**
 
+### AgentRoot — The On-Disk Definition
+
+An **AgentRoot** is the filesystem form of an agent definition. Alan resolves one
+effective agent by overlaying multiple roots.
+
+```text
+~/.alan/agent/                   # global base agent root
+~/.alan/agents/<name>/           # global named agent root
+<workspace>/.alan/agent/         # workspace base agent root
+<workspace>/.alan/agents/<name>/ # workspace named agent root
+```
+
+Each root may contain:
+
+- `agent.toml`
+- `persona/`
+- `skills/`
+- `policy.yaml`
+
+Overlay order is:
+
+- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
+- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+
+This overlay chain defines an agent. It is not runtime process ancestry.
+
 ### Workspace — The Machine
 
 A **Workspace** is the persistent, stateful context in which an Agent operates. It gives the agent its identity, memory, and working environment — like an operating system running on hardware.
@@ -103,19 +129,40 @@ pub struct WorkspaceRuntimeConfig {
 **Workspace directory layout:**
 
 ```
+{home}/.alan/
+├── agent/
+│   ├── agent.toml          # global base agent config
+│   ├── persona/            # global base persona overlays
+│   ├── skills/             # global base skills
+│   └── policy.yaml         # optional global base policy override
+├── agents/
+│   └── <name>/
+│       ├── agent.toml      # global named agent config
+│       ├── persona/
+│       ├── skills/
+│       └── policy.yaml
+├── host.toml               # daemon/client host config
+├── models.toml             # optional global model overlay catalog
+├── sessions/
+│   └── <session-id>.json   # daemon session bindings (workspace + governance)
+
 {workspace_root}/.alan/
 ├── state.json              # workspace state (status, config, current session), when persisted
-├── context/
-│   └── skills/             # markdown-based capabilities
-├── persona/                # bootstrap prompt templates
+├── agent/
+│   ├── agent.toml          # workspace base agent config
+│   ├── persona/            # workspace base persona overlays
+│   ├── skills/             # workspace base skills
+│   └── policy.yaml         # optional workspace base policy override
+├── agents/
+│   └── <name>/
+│       ├── agent.toml      # workspace named agent config
+│       ├── persona/
+│       ├── skills/
+│       └── policy.yaml
 ├── memory/
 │   └── MEMORY.md           # long-term knowledge
 ├── sessions/
 │   └── rollout-*.jsonl     # persisted rollout files
-├── policy.yaml             # optional per-workspace policy override
-
-{home}/.alan/sessions/
-└── <session-id>.json       # daemon session bindings (workspace + governance)
 
 {workspace_root}/.alan/sessions/
 └── rollout-*.jsonl         # current + archived session rollouts
@@ -149,7 +196,7 @@ Alan uses policy-as-code as the only decision layer for tool governance.
 Policy file resolution is:
 
 1. `governance.policy_path`, if provided
-2. `{workspace}/.alan/policy.yaml`, if present
+2. the highest-precedence existing `policy.yaml` in the resolved `AgentRoot` chain
 3. builtin profile defaults
 
 When a policy file is found, it replaces the builtin profile rule set for that session. There is no implicit merge with builtin rules.

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -19,8 +19,16 @@ can stay aligned while Alan evolves toward stricter future sandboxing.
 Policy resolution order is:
 
 1. `governance.policy_path`, if set
-2. `{workspace}/.alan/policy.yaml`, if present
+2. the highest-precedence existing `policy.yaml` in the resolved `AgentRoot` chain
 3. builtin profile defaults
+
+Default workspace agents resolve:
+
+- `~/.alan/agent/policy.yaml -> {workspace}/.alan/agent/policy.yaml`
+
+Named agents extend that chain with:
+
+- `~/.alan/agents/<name>/policy.yaml -> {workspace}/.alan/agents/<name>/policy.yaml`
 
 When a policy file is found, its `rules` and `default_action` replace the
 builtin profile rule set for that session. Alan does not implicitly merge a

--- a/docs/policy_over_sandbox.md
+++ b/docs/policy_over_sandbox.md
@@ -59,7 +59,7 @@ Session/runtime configuration moves to a single governance entry:
 {
   "governance": {
     "profile": "autonomous",
-    "policy_path": ".alan/policy.yaml"
+    "policy_path": ".alan/agent/policy.yaml"
   }
 }
 ```
@@ -85,7 +85,14 @@ This guarantees responsiveness without breaking tape/turn consistency.
 
 ## Policy File
 
-Workspace policy lives at `{workspace}/.alan/policy.yaml`.
+When `governance.policy_path` is not provided, workspace policy is resolved from
+the `AgentRoot` chain. Default workspace agents use:
+
+- `~/.alan/agent/policy.yaml -> {workspace}/.alan/agent/policy.yaml`
+
+Named agents extend that chain with:
+
+- `~/.alan/agents/<name>/policy.yaml -> {workspace}/.alan/agents/<name>/policy.yaml`
 
 ```yaml
 rules:

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -167,15 +167,22 @@ Step-by-step guidance for the agent...
 
 ### Three-Level Scope
 
-Skills are discovered from three sources, in priority order (highest first):
+Skills are discovered from three effective scopes. Within the user and repo
+scopes, Alan follows the resolved `AgentRoot` overlay chain, and later roots
+override earlier ones.
 
 | Scope      | Location                                              | Purpose                       |
 | ---------- | ----------------------------------------------------- | ----------------------------- |
-| **Repo**   | `.alan/skills/` | Project/workspace-specific capabilities |
-| **User**   | `~/.alan/skills/`                                     | Personal cross-project skills |
+| **Repo**   | `.alan/agent/skills/` and `.alan/agents/<name>/skills/` | Project/workspace-specific capabilities |
+| **User**   | `~/.alan/agent/skills/` and `~/.alan/agents/<name>/skills/` | Personal cross-project skills |
 | **System** | Compiled into binary                                  | Always-on core behaviors      |
 
 Higher-priority scopes override lower ones when skill IDs collide.
+
+Overlay order is:
+
+- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
+- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
 
 ### System Skills
 

--- a/docs/spec/kernel_contract.md
+++ b/docs/spec/kernel_contract.md
@@ -35,6 +35,12 @@ This document has higher priority than philosophy docs. Protocol details remain 
 - Defines "how to think": LLM/provider params, tools, governance config.
 - **No identity, no session history, no business state**.
 
+### AgentRoot
+
+- Defines the on-disk agent root: `agent.toml`, `persona/`, `skills/`, `policy.yaml`.
+- Multiple `AgentRoot`s may overlay into one effective agent definition.
+- Definition overlay is separate from runtime supervision or process ancestry.
+
 ### Workspace
 
 - Defines "who I am": identity, persona, memory, skills, session archive.


### PR DESCRIPTION
## Summary
- document the AgentRoot filesystem layout in README, AGENTS, and architecture docs
- describe the overlay order for default and named agents, and make it explicit that definition overlay is not runtime ancestry
- update policy and skills docs to use the canonical .alan/agent and .alan/agents paths

## Testing
- docs only

Related to #109