### PR TITLE
Add agent root overlay integration coverage

### DIFF
--- a/crates/alan/tests/agent_root_overlay_integration_test.rs
+++ b/crates/alan/tests/agent_root_overlay_integration_test.rs
@@ -321,7 +321,7 @@ fn latest_rollout_path(sessions_dir: &Path, session_id: &str) -> PathBuf {
             }
         }
     }
-    panic!("rollout path not found for session {session_id}");
+    panic!("rollout path not found for requested integration-test session");
 }
 
 fn assert_overlay_request(request: &GenerationRequest) {


### PR DESCRIPTION
## Summary
- add runtime-level integration coverage for named-agent config/persona/skills/policy overlays
- verify highest-precedence workspace named overlays win during execution
- verify overlay behavior survives resume and fork flows

## Testing
- cargo test -p alan --test agent_root_overlay_integration_test
- cargo test -p alan