### PR TITLE
Cleanup legacy agent overlay helpers

### DIFF
--- a/crates/runtime/src/agent_definition.rs
+++ b/crates/runtime/src/agent_definition.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ConfigSourceKind, ResolvedAgentRoots, prompts,
+    ConfigSourceKind, ResolvedAgentRoots,
     runtime::WorkspaceRuntimeConfig,
     skills::{ScopedSkillDir, SkillScope},
 };
@@ -48,10 +48,7 @@ impl ResolvedAgentDefinition {
         );
         let config_overlay_paths = overlay_config_paths(&roots, config.core_config_source);
         let persona_dirs = if roots.is_empty() {
-            prompts::resolve_workspace_persona_dirs_for_workspace(
-                &config.agent_config.core_config,
-                None,
-            )
+            legacy_persona_dirs_without_agent_roots(&config.agent_config.core_config)
         } else {
             roots.persona_dirs()
         };
@@ -100,6 +97,44 @@ fn overlay_config_paths(roots: &ResolvedAgentRoots, base_source: ConfigSourceKin
         })
         .map(|root| root.config_path.clone())
         .collect()
+}
+
+fn legacy_persona_dirs_without_agent_roots(config: &crate::config::Config) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(global_dir) = legacy_global_persona_dir() {
+        dirs.push(global_dir);
+    }
+    if let Some(config_dir) = legacy_persona_dir_from_core_config(config)
+        && !dirs.contains(&config_dir)
+    {
+        dirs.push(config_dir);
+    }
+    dirs
+}
+
+fn legacy_persona_dir_from_core_config(config: &crate::config::Config) -> Option<PathBuf> {
+    if let Some(path) = config.memory.workspace_dir.clone() {
+        let is_memory_dir = path
+            .file_name()
+            .map(|name| name == std::ffi::OsStr::new("memory"))
+            .unwrap_or(false);
+        if is_memory_dir {
+            return path
+                .parent()
+                .map(crate::workspace_persona_dir_from_alan_dir);
+        }
+        return Some(path);
+    }
+
+    if cfg!(test) {
+        return None;
+    }
+
+    legacy_global_persona_dir()
+}
+
+fn legacy_global_persona_dir() -> Option<PathBuf> {
+    crate::AlanHomePaths::detect().map(|paths| paths.global_agent_root_dir.join("persona"))
 }
 
 fn infer_workspace_alan_dir_from_memory_dir(memory_dir: Option<&Path>) -> Option<PathBuf> {
@@ -204,6 +239,20 @@ mod tests {
         assert_eq!(
             resolved.writable_root_dir,
             Some(workspace_root.path().join(".alan/agent"))
+        );
+    }
+
+    #[test]
+    fn legacy_persona_dirs_without_agent_roots_prefer_workspace_persona_from_memory_dir() {
+        let workspace_root = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.memory.workspace_dir = Some(workspace_root.path().join(".alan/memory"));
+
+        let persona_dirs = legacy_persona_dirs_without_agent_roots(&config);
+
+        assert_eq!(
+            persona_dirs.last(),
+            Some(&workspace_root.path().join(".alan/agent/persona"))
         );
     }
 }

--- a/crates/runtime/src/prompts/assembler.rs
+++ b/crates/runtime/src/prompts/assembler.rs
@@ -1,51 +1,60 @@
 //! Prompt assembly logic.
 
 use crate::config::Config;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Build agent system prompt with proper assembly order:
 /// 1. Runtime Base (hard constraints - cannot be overridden)
 /// 2. System Prompt (default identity and behavior)
 /// 3. Domain Prompt (skills/domain overlays loaded dynamically)
 /// 4. Workspace Profile (persona files)
+///
+/// This is a legacy convenience helper for the base workspace persona layout.
+/// Runtime launches should prefer the explicit persona dirs resolved on
+/// `ResolvedAgentDefinition`.
 pub fn build_agent_system_prompt(config: &Config, domain_prompt: &str) -> String {
-    let workspace_persona_dirs = resolve_workspace_persona_dirs_for_workspace(config, None);
-    build_agent_system_prompt_internal(domain_prompt, &workspace_persona_dirs)
+    let workspace_persona_dirs = legacy_workspace_persona_dirs(config, None);
+    build_agent_system_prompt_from_persona_dirs(domain_prompt, &workspace_persona_dirs)
 }
 
+/// Legacy convenience helper for the base workspace persona layout.
+///
+/// Runtime launches should prefer the explicit persona dirs resolved on
+/// `ResolvedAgentDefinition`.
 pub fn build_agent_system_prompt_for_workspace(
     config: &Config,
     domain_prompt: &str,
     workspace_dir: Option<&Path>,
 ) -> String {
-    let workspace_persona_dirs =
-        resolve_workspace_persona_dirs_for_workspace(config, workspace_dir);
-    build_agent_system_prompt_internal(domain_prompt, &workspace_persona_dirs)
+    let workspace_persona_dirs = legacy_workspace_persona_dirs(config, workspace_dir);
+    build_agent_system_prompt_from_persona_dirs(domain_prompt, &workspace_persona_dirs)
 }
 
-#[allow(dead_code)]
-pub(crate) fn resolve_workspace_persona_dir_for_workspace(
-    config: &Config,
-    workspace_dir: Option<&Path>,
-) -> Option<std::path::PathBuf> {
-    resolve_workspace_persona_dirs_for_workspace(config, workspace_dir)
-        .into_iter()
-        .last()
+pub(crate) fn build_agent_system_prompt_from_persona_dirs(
+    domain_prompt: &str,
+    workspace_persona_dirs: &[PathBuf],
+) -> String {
+    let workspace_context = if workspace_persona_dirs.iter().any(|path| path.exists()) {
+        Some(super::workspace::render_workspace_persona_context_from_dirs(workspace_persona_dirs))
+    } else {
+        None
+    };
+    build_agent_system_prompt_with_workspace_context(domain_prompt, workspace_context.as_deref())
 }
 
-pub(crate) fn resolve_workspace_persona_dirs_for_workspace(
+pub(crate) fn legacy_workspace_persona_dirs(
     config: &Config,
     workspace_dir: Option<&Path>,
-) -> Vec<std::path::PathBuf> {
+) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    if let Some(global_dir) = global_agent_persona_dir() {
+    if let Some(global_dir) = legacy_global_agent_persona_dir() {
         dirs.push(global_dir);
     }
     if let Some(workspace_dir) = workspace_dir {
-        dirs.push(resolve_workspace_agent_persona_dir(workspace_dir));
+        dirs.push(legacy_workspace_agent_persona_dir(workspace_dir));
         return dirs;
     }
-    if let Some(config_dir) = resolve_workspace_persona_dir_from_config(config)
+    if let Some(config_dir) = legacy_workspace_persona_dir_from_config(config)
         && !dirs.contains(&config_dir)
     {
         dirs.push(config_dir);
@@ -69,18 +78,6 @@ pub(crate) fn build_agent_system_prompt_with_workspace_context(
     prompt
 }
 
-fn build_agent_system_prompt_internal(
-    domain_prompt: &str,
-    workspace_persona_dirs: &[std::path::PathBuf],
-) -> String {
-    let workspace_context = if workspace_persona_dirs.iter().any(|path| path.exists()) {
-        Some(super::workspace::render_workspace_persona_context_from_dirs(workspace_persona_dirs))
-    } else {
-        None
-    };
-    build_agent_system_prompt_with_workspace_context(domain_prompt, workspace_context.as_deref())
-}
-
 fn append_prompt_section(prompt: &mut String, section: &str) {
     let trimmed = section.trim();
     if trimmed.is_empty() {
@@ -93,7 +90,7 @@ fn append_prompt_section(prompt: &mut String, section: &str) {
     prompt.push_str(trimmed);
 }
 
-fn resolve_workspace_persona_dir_from_config(config: &Config) -> Option<std::path::PathBuf> {
+fn legacy_workspace_persona_dir_from_config(config: &Config) -> Option<PathBuf> {
     if let Some(path) = config.memory.workspace_dir.clone() {
         let is_memory_dir = path
             .file_name()
@@ -111,14 +108,14 @@ fn resolve_workspace_persona_dir_from_config(config: &Config) -> Option<std::pat
         return None;
     }
 
-    global_agent_persona_dir()
+    legacy_global_agent_persona_dir()
 }
 
-fn global_agent_persona_dir() -> Option<std::path::PathBuf> {
+fn legacy_global_agent_persona_dir() -> Option<PathBuf> {
     crate::AlanHomePaths::detect().map(|paths| paths.global_agent_root_dir.join("persona"))
 }
 
-fn resolve_workspace_agent_persona_dir(workspace_dir: &Path) -> std::path::PathBuf {
+fn legacy_workspace_agent_persona_dir(workspace_dir: &Path) -> PathBuf {
     let is_alan_dir = workspace_dir
         .file_name()
         .map(|name| name == std::ffi::OsStr::new(".alan"))
@@ -148,8 +145,10 @@ mod tests {
     fn test_build_agent_system_prompt_includes_runtime_base() {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);
+        let workspace_persona_dirs = legacy_workspace_persona_dirs(&config, None);
 
-        let prompt = build_agent_system_prompt(&config, "Domain Prompt");
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("Domain Prompt", &workspace_persona_dirs);
 
         assert!(prompt.contains("Runtime Base Constraints"));
         assert!(prompt.contains("No Self-Modification"));
@@ -162,8 +161,10 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);
         crate::prompts::ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
+        let workspace_persona_dirs = legacy_workspace_persona_dirs(&config, None);
 
-        let prompt = build_agent_system_prompt(&config, "Domain Prompt");
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("Domain Prompt", &workspace_persona_dirs);
 
         assert!(prompt.contains("Workspace Persona Context"));
         assert!(prompt.contains("### SOUL.md"));
@@ -183,7 +184,9 @@ mod tests {
         .unwrap();
 
         let config = test_config_with_workspace(&temp_dir);
-        let prompt = build_agent_system_prompt(&config, "Domain Prompt");
+        let workspace_persona_dirs = legacy_workspace_persona_dirs(&config, None);
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("Domain Prompt", &workspace_persona_dirs);
 
         assert!(prompt.contains("custom persona instructions"));
     }
@@ -212,7 +215,9 @@ mod tests {
         fs::write(temp_dir.path().join("SOUL.md"), "SOUL content").unwrap();
 
         let config = test_config_with_workspace(&temp_dir);
-        let prompt = build_agent_system_prompt(&config, "DOMAIN content");
+        let workspace_persona_dirs = legacy_workspace_persona_dirs(&config, None);
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("DOMAIN content", &workspace_persona_dirs);
 
         let runtime_base_pos = prompt.find("Runtime Base Constraints").unwrap();
         let system_pos = prompt.find("Alan System Prompt").unwrap();
@@ -228,11 +233,27 @@ mod tests {
     fn test_build_agent_system_prompt_does_not_create_workspace_files() {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);
+        let workspace_persona_dirs = legacy_workspace_persona_dirs(&config, None);
 
-        let prompt = build_agent_system_prompt(&config, "Domain Prompt");
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("Domain Prompt", &workspace_persona_dirs);
 
         assert!(!prompt.contains("Workspace Persona Context"));
         assert!(!temp_dir.path().join("SOUL.md").exists());
         assert!(!temp_dir.path().join("ROLE.md").exists());
+    }
+
+    #[test]
+    fn test_legacy_workspace_persona_dirs_prefer_workspace_from_memory_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.memory.workspace_dir = Some(temp_dir.path().join(".alan/memory"));
+
+        let persona_dirs = legacy_workspace_persona_dirs(&config, None);
+
+        assert_eq!(
+            persona_dirs.last(),
+            Some(&temp_dir.path().join(".alan/agent/persona"))
+        );
     }
 }

--- a/crates/runtime/src/prompts/mod.rs
+++ b/crates/runtime/src/prompts/mod.rs
@@ -9,10 +9,6 @@ mod workspace;
 
 pub(crate) use assembler::build_agent_system_prompt_with_workspace_context;
 pub use assembler::{build_agent_system_prompt, build_agent_system_prompt_for_workspace};
-#[allow(unused_imports)]
-pub(crate) use assembler::{
-    resolve_workspace_persona_dir_for_workspace, resolve_workspace_persona_dirs_for_workspace,
-};
 pub use loader::PromptLoader;
 pub use workspace::ensure_workspace_bootstrap_files_at;
 #[allow(unused_imports)]

--- a/crates/runtime/src/skills/mod.rs
+++ b/crates/runtime/src/skills/mod.rs
@@ -61,7 +61,11 @@ pub(crate) const PLAN_SKILL_MD: &str = include_str!("../../skills/plan/SKILL.md"
 pub(crate) const WORKSPACE_MANAGER_SKILL_MD: &str =
     include_str!("../../skills/workspace-manager/SKILL.md");
 
-/// Initialize the skills framework and return a loaded registry.
+/// Initialize cwd-scoped skill discovery and return a loaded registry.
+///
+/// This is a convenience API for the legacy user/repo/system scan rooted at `cwd`.
+/// Runtime launches that resolve an `AgentRoot` overlay chain use explicit overlay
+/// dirs instead of this helper.
 pub fn init(cwd: &std::path::Path) -> Result<SkillsRegistry, SkillsError> {
     SkillsRegistry::load(cwd)
 }

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -22,7 +22,11 @@ pub struct SkillsRegistry {
 }
 
 impl SkillsRegistry {
-    /// Create a new registry and load skills from all scopes.
+    /// Create a new registry and load skills from the legacy cwd-scoped user/repo/system layout.
+    ///
+    /// This does not interpret a resolved `AgentRoot` overlay chain; runtime launches use
+    /// `load_overlay_dirs` once explicit skill roots have been derived from
+    /// `ResolvedAgentDefinition`.
     pub fn load(cwd: &Path) -> Result<Self, SkillsError> {
         let mut registry = Self {
             skills: HashMap::new(),
@@ -37,7 +41,9 @@ impl SkillsRegistry {
     }
 
     /// Create a registry for a specific agent with workspace isolation.
-    /// Loads skills from: agent workspace -> user home -> builtin
+    ///
+    /// This remains a cwd-based helper. It does not resolve named-agent overlay roots.
+    /// Loads skills from: agent workspace -> user home -> builtin.
     pub fn for_agent(agent_workspace_dir: &Path) -> Result<Self, SkillsError> {
         let mut registry = Self {
             skills: HashMap::new(),
@@ -51,6 +57,7 @@ impl SkillsRegistry {
         Ok(registry)
     }
 
+    /// Create a registry from an already-resolved overlay chain of skill directories.
     pub(crate) fn load_overlay_dirs(skill_dirs: &[ScopedSkillDir]) -> Result<Self, SkillsError> {
         let mut registry = Self {
             skills: HashMap::new(),


### PR DESCRIPTION
## Summary
- decouple ResolvedAgentDefinition from the prompt module legacy single-layout persona resolution
- rename the remaining prompt/persona fallback helpers to make their legacy semantics explicit
- document that cwd-based skill registry helpers are legacy convenience APIs and that runtime launches use resolved overlay dirs

## Testing
- cargo fmt --all
- cargo test -p alan-runtime
- cargo clippy -p alan-runtime --all-targets --all-features -- -D warnings
- cargo test -p alan --test agent_root_overlay_integration_test