### PR TITLE
[VNext][Skill System] Resolve delegated skill execution mode and target inference

### DIFF
--- a/crates/runtime/src/approval.rs
+++ b/crates/runtime/src/approval.rs
@@ -229,7 +229,9 @@ mod tests {
                 alan_metadata: crate::skills::AlanSkillRuntimeMetadata {
                     permission_hints: vec!["may require network approval".to_string()],
                     ui: Default::default(),
+                    execution: Default::default(),
                 },
+                execution: Default::default(),
             },
             crate::skills::SkillActivationReason::Keyword {
                 keyword: "deploy".to_string(),

--- a/crates/runtime/src/runtime/prompt_cache.rs
+++ b/crates/runtime/src/runtime/prompt_cache.rs
@@ -917,7 +917,8 @@ mod tests {
     use super::*;
     use crate::prompts::ensure_workspace_bootstrap_files_at;
     use crate::skills::{
-        PackageMount, PackageMountMode, ScopedPackageDir, SkillHostCapabilities, SkillScope,
+        PackageMount, PackageMountMode, ResolvedSkillExecution, ScopedPackageDir,
+        SkillExecutionResolutionSource, SkillHostCapabilities, SkillScope,
         default_builtin_package_mounts,
     };
     use sha2::{Digest, Sha256};
@@ -957,6 +958,21 @@ description: {description}
         std::fs::write(
             skill_dir.join("SKILL.md"),
             format!("---\n{frontmatter}\n---\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    fn create_repo_child_agent(
+        workspace_root: &std::path::Path,
+        skill_dir: &str,
+        agent_name: &str,
+    ) {
+        std::fs::create_dir_all(
+            workspace_root
+                .join(".alan/agent/skills")
+                .join(skill_dir)
+                .join("agents")
+                .join(agent_name),
         )
         .unwrap();
     }
@@ -1097,6 +1113,52 @@ description: {description}
                 .system_prompt
                 .contains(&format!("resource_root: {}", expected_root.display()))
         );
+        assert_eq!(
+            active_skill.metadata.execution,
+            ResolvedSkillExecution::Inline {
+                source: SkillExecutionResolutionSource::NoChildAgentExports,
+            }
+        );
+    }
+
+    #[test]
+    fn prompt_cache_invalidates_when_child_agent_exports_change() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+        create_repo_skill(
+            &workspace_root,
+            "my-skill",
+            "My Skill",
+            "Custom test skill",
+            "# Instructions\nUse this skill when asked.",
+        );
+
+        let mut cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+        let user_input = vec![ContentPart::text("please use $my-skill for this task")];
+
+        let first = cache.build(Some(&user_input));
+        assert_eq!(
+            first.active_skills[0].metadata.execution,
+            ResolvedSkillExecution::Inline {
+                source: SkillExecutionResolutionSource::NoChildAgentExports,
+            }
+        );
+
+        create_repo_child_agent(&workspace_root, "my-skill", "my-skill");
+
+        let second = cache.build(Some(&user_input));
+        assert!(!second.skills_cache_hit);
+        assert_eq!(
+            second.active_skills[0].metadata.execution,
+            ResolvedSkillExecution::Delegate {
+                target: "my-skill".to_string(),
+                source: SkillExecutionResolutionSource::SameNameSkillAndChildAgent,
+            }
+        );
+        assert!(second.system_prompt.contains(
+            "execution: delegate(target=my-skill, source=same_name_skill_and_child_agent)"
+        ));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/turn_state.rs
+++ b/crates/runtime/src/runtime/turn_state.rs
@@ -334,6 +334,7 @@ mod tests {
                 )),
                 mount_mode: crate::skills::PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             crate::skills::SkillActivationReason::Keyword {
                 keyword: "deploy".to_string(),

--- a/crates/runtime/src/skills/injector.rs
+++ b/crates/runtime/src/skills/injector.rs
@@ -230,6 +230,7 @@ fn format_active_skill_context(envelope: &ActiveSkillEnvelope) -> String {
             "activation_reason: {}",
             envelope.activation_reason.render_label()
         ),
+        format!("execution: {}", envelope.metadata.execution.render_label()),
     ];
 
     if envelope.metadata.resource_root().is_some() {
@@ -839,6 +840,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/tmp/test/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "# Instructions\n\nDo this and that.".to_string(),
             frontmatter: SkillFrontmatter {
@@ -874,6 +876,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/tmp/eval/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Follow these steps.".to_string(),
             frontmatter: SkillFrontmatter {
@@ -909,6 +912,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/a/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             SkillMetadata {
                 id: "skill-b".to_string(),
@@ -926,6 +930,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/b/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
         ];
 
@@ -1012,6 +1017,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Read `references/ref.md` before running `scripts/test.sh`.".to_string(),
             frontmatter: SkillFrontmatter {
@@ -1065,6 +1071,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Fallback instructions.".to_string(),
             frontmatter: SkillFrontmatter {
@@ -1138,6 +1145,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Use https://example.com/scripts/setup.sh, then read references/guide.md. After that run ./scripts/setup.sh."
                 .to_string(),
@@ -1210,6 +1218,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Fallback instructions.".to_string(),
             frontmatter: SkillFrontmatter {
@@ -1260,6 +1269,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             content: "Content".to_string(),
             frontmatter: SkillFrontmatter {
@@ -1307,6 +1317,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/test/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
             SkillMetadata {
                 id: "testing".to_string(),
@@ -1324,6 +1335,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/testing/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                execution: Default::default(),
             },
         ];
 
@@ -1351,6 +1363,7 @@ mod tests {
             source: SkillContentSource::File(std::path::PathBuf::from("/other/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         }];
 
         let msg = render_skill_not_found("xyz", &available);
@@ -1378,6 +1391,7 @@ mod tests {
             source: SkillContentSource::File(std::path::PathBuf::from("/rust/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         }];
 
         // "rustacean" contains "rust"

--- a/crates/runtime/src/skills/loader.rs
+++ b/crates/runtime/src/skills/loader.rs
@@ -206,6 +206,13 @@ pub fn scan_skills_dir(dir: &Path, scope: SkillScope) -> SkillLoadOutcome {
             continue;
         }
         let current_is_package_root = current.join("SKILL.md").is_file();
+        if current_is_package_root {
+            let child_agents_dir = current.join(CHILD_AGENT_EXPORT_DIR);
+            outcome.tracked_paths.push(child_agents_dir.clone());
+            if let Ok(resolved) = std::fs::canonicalize(&child_agents_dir) {
+                outcome.tracked_paths.push(resolved);
+            }
+        }
         if visited_dirs.len() >= MAX_SKILLS_DIRS_PER_ROOT {
             truncated = true;
             break;
@@ -523,6 +530,32 @@ Body
             .collect();
 
         assert_eq!(skill_ids, vec!["agents"]);
+    }
+
+    #[test]
+    fn test_scan_skills_dir_tracks_child_agent_export_dir_even_when_missing() {
+        let temp = TempDir::new().unwrap();
+        let skills_dir = temp.path().join("skills");
+
+        std::fs::create_dir_all(skills_dir.join("parent-skill")).unwrap();
+        std::fs::write(
+            skills_dir.join("parent-skill/SKILL.md"),
+            r#"---
+name: Parent Skill
+description: Parent-visible skill
+---
+
+Body
+"#,
+        )
+        .unwrap();
+
+        let outcome = scan_skills_dir(&skills_dir, SkillScope::Repo);
+        let expected_agents_dir = std::fs::canonicalize(skills_dir.join("parent-skill"))
+            .unwrap()
+            .join("agents");
+
+        assert!(outcome.tracked_paths.contains(&expected_agents_dir));
     }
 
     #[test]

--- a/crates/runtime/src/skills/loader.rs
+++ b/crates/runtime/src/skills/loader.rs
@@ -74,6 +74,7 @@ pub fn parse_skill_metadata_with_source(
         source,
         mount_mode: PackageMountMode::Discoverable,
         alan_metadata: AlanSkillRuntimeMetadata::default(),
+        execution: ResolvedSkillExecution::default(),
     })
 }
 
@@ -130,6 +131,7 @@ pub fn load_skill_from_content(
         source,
         mount_mode: PackageMountMode::Discoverable,
         alan_metadata: AlanSkillRuntimeMetadata::default(),
+        execution: ResolvedSkillExecution::default(),
     };
 
     Ok(Skill {

--- a/crates/runtime/src/skills/mod.rs
+++ b/crates/runtime/src/skills/mod.rs
@@ -262,6 +262,7 @@ Body
             source: SkillContentSource::File(std::path::PathBuf::from("/test")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         });
         assert!(!outcome.is_empty());
     }

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -66,6 +66,7 @@ impl SkillsRegistry {
         skill.metadata.capabilities = metadata.capabilities.clone();
         skill.metadata.compatibility = metadata.compatibility.clone();
         skill.metadata.alan_metadata = metadata.alan_metadata.clone();
+        skill.metadata.execution = metadata.execution.clone();
         Ok(skill)
     }
 
@@ -185,6 +186,8 @@ impl SkillsRegistry {
                     }
                 });
 
+            let mut loaded_skills = Vec::new();
+
             for portable_skill in package.portable_skills {
                 match &portable_skill.source {
                     SkillContentSource::File(path) => {
@@ -210,7 +213,7 @@ impl SkillsRegistry {
                                     mount_mode,
                                     metadata.path.display()
                                 );
-                                self.skills.insert(metadata.id.clone(), metadata);
+                                loaded_skills.push(metadata);
                             }
                             Err(err) => {
                                 warn!(
@@ -253,7 +256,7 @@ impl SkillsRegistry {
                                     mount_mode,
                                     metadata.path.display()
                                 );
-                                self.skills.insert(metadata.id.clone(), metadata);
+                                loaded_skills.push(metadata);
                             }
                             Err(err) => {
                                 warn!(
@@ -270,6 +273,16 @@ impl SkillsRegistry {
                         }
                     }
                 }
+            }
+
+            let package_skill_ids: Vec<String> =
+                loaded_skills.iter().map(|skill| skill.id.clone()).collect();
+            let child_agent_exports = package.exports.child_agent_export_names();
+
+            for mut metadata in loaded_skills {
+                metadata.execution =
+                    resolve_skill_execution(&metadata, &package_skill_ids, &child_agent_exports);
+                self.skills.insert(metadata.id.clone(), metadata);
             }
         }
 
@@ -341,6 +354,7 @@ impl SkillsRegistry {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
     fn create_test_skill(dir: &std::path::Path, name: &str, skill_name: &str, description: &str) {
@@ -359,6 +373,77 @@ Body
             skill_name, description
         )
         .unwrap();
+    }
+
+    fn create_skill_file(
+        dir: &Path,
+        skill_dir_name: &str,
+        skill_name: &str,
+        description: &str,
+    ) -> PathBuf {
+        let skill_dir = dir.join(skill_dir_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!(
+                r#"---
+name: {skill_name}
+description: {description}
+---
+
+Body
+"#
+            ),
+        )
+        .unwrap();
+        skill_dir.join("SKILL.md")
+    }
+
+    fn capability_view_for_manual_package(
+        package_id: &str,
+        package_root: &Path,
+        skill_paths: &[PathBuf],
+        child_agent_names: &[&str],
+    ) -> ResolvedCapabilityView {
+        let canonical_root = std::fs::canonicalize(package_root).unwrap();
+        let child_agent_roots: Vec<PathBuf> = child_agent_names
+            .iter()
+            .map(|name| {
+                let dir = package_root.join("agents").join(name);
+                std::fs::create_dir_all(&dir).unwrap();
+                std::fs::canonicalize(dir).unwrap()
+            })
+            .collect();
+        let portable_skills = skill_paths
+            .iter()
+            .map(|path| {
+                let canonical = std::fs::canonicalize(path).unwrap();
+                PortableSkill {
+                    path: canonical.clone(),
+                    source: SkillContentSource::File(canonical),
+                }
+            })
+            .collect();
+
+        ResolvedCapabilityView {
+            package_dirs: Vec::new(),
+            mounts: vec![PackageMount {
+                package_id: package_id.to_string(),
+                mode: PackageMountMode::Discoverable,
+            }],
+            packages: vec![CapabilityPackage {
+                id: package_id.to_string(),
+                scope: SkillScope::Repo,
+                root_dir: Some(canonical_root),
+                exports: CapabilityPackageExports {
+                    child_agent_roots,
+                    resources: CapabilityPackageResources::default(),
+                },
+                portable_skills,
+            }],
+            errors: Vec::new(),
+            tracked_paths: Vec::new(),
+        }
     }
 
     #[test]
@@ -826,5 +911,206 @@ runtime:
                 .ends_with(std::path::Path::new(PACKAGE_SIDECAR_FILE))
                 && error.message.contains("Invalid regex pattern")
         }));
+    }
+
+    #[test]
+    fn load_capability_view_defaults_skill_without_child_agents_to_inline_execution() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("inline-package");
+        let skill_path = create_skill_file(
+            &package_root.join("skills"),
+            "repo-review",
+            "Repo Review",
+            "Review a repo",
+        );
+        let capability_view = capability_view_for_manual_package(
+            "pkg:inline-package",
+            &package_root,
+            &[skill_path],
+            &[],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let skill = registry.get(&"repo-review".to_string()).unwrap();
+
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Inline {
+                source: SkillExecutionResolutionSource::NoChildAgentExports,
+            }
+        );
+    }
+
+    #[test]
+    fn load_capability_view_infers_same_name_delegated_skill_target() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("delegated-package");
+        let skill_path = create_skill_file(
+            &package_root.join("skills"),
+            "repo-review",
+            "Repo Review",
+            "Review a repo",
+        );
+        let capability_view = capability_view_for_manual_package(
+            "pkg:delegated-package",
+            &package_root,
+            &[skill_path],
+            &["repo-review"],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let skill = registry.get(&"repo-review".to_string()).unwrap();
+
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Delegate {
+                target: "repo-review".to_string(),
+                source: SkillExecutionResolutionSource::SameNameSkillAndChildAgent,
+            }
+        );
+    }
+
+    #[test]
+    fn load_capability_view_infers_single_skill_single_child_agent_delegate() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("single-skill-single-agent");
+        let skill_path = create_skill_file(
+            &package_root.join("skills"),
+            "lint-summary",
+            "Lint Summary",
+            "Summarize lint output",
+        );
+        let capability_view = capability_view_for_manual_package(
+            "pkg:single-skill-single-agent",
+            &package_root,
+            &[skill_path],
+            &["reviewer"],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let skill = registry.get(&"lint-summary".to_string()).unwrap();
+
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Delegate {
+                target: "reviewer".to_string(),
+                source: SkillExecutionResolutionSource::SingleSkillSingleChildAgent,
+            }
+        );
+    }
+
+    #[test]
+    fn load_capability_view_marks_ambiguous_package_shapes_unresolved() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("ambiguous-package");
+        let foo = create_skill_file(&package_root.join("skills"), "foo", "Foo", "First");
+        let bar = create_skill_file(&package_root.join("skills"), "bar", "Bar", "Second");
+        let capability_view = capability_view_for_manual_package(
+            "pkg:ambiguous-package",
+            &package_root,
+            &[foo, bar],
+            &["reviewer"],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let foo_skill = registry.get(&"foo".to_string()).unwrap();
+
+        assert_eq!(
+            foo_skill.execution,
+            ResolvedSkillExecution::Unresolved {
+                reason: SkillExecutionUnresolvedReason::AmbiguousPackageShape {
+                    package_skill_ids: vec!["foo".to_string(), "bar".to_string()],
+                    child_agent_exports: vec!["reviewer".to_string()],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn load_capability_view_explicit_delegate_target_overrides_default_inference() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("explicit-delegate-package");
+        let skill_dir = package_root.join("skills");
+        let skill_path = create_skill_file(
+            &skill_dir,
+            "skill-creator",
+            "Skill Creator",
+            "Create a skill",
+        );
+        std::fs::write(
+            skill_dir.join("skill-creator").join(SKILL_SIDECAR_FILE),
+            r#"
+runtime:
+  execution:
+    mode: delegate
+    target: creator
+"#,
+        )
+        .unwrap();
+        let capability_view = capability_view_for_manual_package(
+            "pkg:explicit-delegate-package",
+            &package_root,
+            &[skill_path],
+            &["creator", "grader", "analyzer"],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let skill = registry.get(&"skill-creator".to_string()).unwrap();
+
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Delegate {
+                target: "creator".to_string(),
+                source: SkillExecutionResolutionSource::ExplicitMetadata,
+            }
+        );
+    }
+
+    #[test]
+    fn load_capability_view_invalid_explicit_delegate_target_is_unresolved() {
+        let temp = TempDir::new().unwrap();
+        let package_root = temp.path().join("invalid-explicit-target-package");
+        let skill_dir = package_root.join("skills");
+        let skill_path = create_skill_file(
+            &skill_dir,
+            "skill-creator",
+            "Skill Creator",
+            "Create a skill",
+        );
+        std::fs::write(
+            skill_dir.join("skill-creator").join(SKILL_SIDECAR_FILE),
+            r#"
+runtime:
+  execution:
+    mode: delegate
+    target: missing-target
+"#,
+        )
+        .unwrap();
+        let capability_view = capability_view_for_manual_package(
+            "pkg:invalid-explicit-target-package",
+            &package_root,
+            &[skill_path],
+            &["creator", "grader"],
+        );
+
+        let mut registry = SkillsRegistry::default();
+        registry.apply_capability_view(capability_view);
+        let skill = registry.get(&"skill-creator".to_string()).unwrap();
+
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Unresolved {
+                reason: SkillExecutionUnresolvedReason::DelegateTargetNotFound {
+                    target: "missing-target".to_string(),
+                    available_targets: vec!["creator".to_string(), "grader".to_string()],
+                },
+            }
+        );
     }
 }

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -773,6 +773,24 @@ capabilities:
     }
 
     #[test]
+    fn load_capability_view_tracks_child_agent_export_dir_for_execution_invalidation() {
+        let temp = TempDir::new().unwrap();
+        let repo_skills = temp.path().join("skills");
+        create_test_skill(&repo_skills, "test-skill", "Test Skill", "From repo");
+
+        let registry = SkillsRegistry::load_package_dirs(&[ScopedPackageDir {
+            path: repo_skills.clone(),
+            scope: SkillScope::Repo,
+        }])
+        .unwrap();
+        let expected_agents_dir = std::fs::canonicalize(repo_skills.join("test-skill"))
+            .unwrap()
+            .join("agents");
+
+        assert!(registry.tracked_paths().contains(&expected_agents_dir));
+    }
+
+    #[test]
     fn load_capability_view_does_not_track_synthetic_builtin_skill_sidecars() {
         let mut capability_view =
             ResolvedCapabilityView::from_package_dirs(Vec::new()).with_default_mounts();

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -1545,6 +1545,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         };
 
         let remediation = skill_remediation(

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -130,6 +130,19 @@ impl CapabilityPackageExports {
     pub fn is_empty(&self) -> bool {
         self.child_agent_roots.is_empty() && self.resources.is_empty()
     }
+
+    pub fn child_agent_export_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .child_agent_roots
+            .iter()
+            .filter_map(|path| path.file_name())
+            .filter_map(|name| name.to_str())
+            .map(ToOwned::to_owned)
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
 }
 
 /// Capability package available to an agent definition.
@@ -195,6 +208,9 @@ pub struct SkillMetadata {
     /// Alan-native runtime/UI metadata loaded from optional sidecars.
     #[serde(skip, default)]
     pub alan_metadata: AlanSkillRuntimeMetadata,
+    /// Resolved skill execution state for the current capability package shape.
+    #[serde(default)]
+    pub execution: ResolvedSkillExecution,
 }
 
 impl SkillMetadata {
@@ -566,6 +582,38 @@ impl AlanSkillUiMetadata {
     }
 }
 
+/// Author-declared execution mode from Alan sidecar metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlanSkillExecutionMode {
+    Inline,
+    Delegate,
+}
+
+/// Alan-native execution metadata for a skill.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AlanSkillExecutionMetadata {
+    #[serde(default)]
+    pub mode: Option<AlanSkillExecutionMode>,
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+impl AlanSkillExecutionMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none() && self.target.is_none()
+    }
+
+    pub fn apply_overlay(&mut self, overlay: &Self) {
+        if let Some(mode) = overlay.mode {
+            self.mode = Some(mode);
+        }
+        if let Some(target) = overlay.target.as_ref() {
+            self.target = Some(target.clone());
+        }
+    }
+}
+
 /// Alan-native runtime metadata for a skill.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct AlanSkillRuntimeMetadata {
@@ -573,11 +621,13 @@ pub struct AlanSkillRuntimeMetadata {
     pub permission_hints: Vec<String>,
     #[serde(default)]
     pub ui: AlanSkillUiMetadata,
+    #[serde(default)]
+    pub execution: AlanSkillExecutionMetadata,
 }
 
 impl AlanSkillRuntimeMetadata {
     pub fn is_empty(&self) -> bool {
-        self.permission_hints.is_empty() && self.ui.is_empty()
+        self.permission_hints.is_empty() && self.ui.is_empty() && self.execution.is_empty()
     }
 
     pub fn apply_overlay(&mut self, overlay: &Self) {
@@ -587,6 +637,7 @@ impl AlanSkillRuntimeMetadata {
             }
         }
         self.ui.apply_overlay(&overlay.ui);
+        self.execution.apply_overlay(&overlay.execution);
     }
 }
 
@@ -693,6 +744,193 @@ impl std::fmt::Display for SkillDependencyError {
 }
 
 impl std::error::Error for SkillDependencyError {}
+
+/// Why a delegated or inline execution state resolved the way it did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillExecutionResolutionSource {
+    ExplicitMetadata,
+    NoChildAgentExports,
+    SameNameSkillAndChildAgent,
+    SingleSkillSingleChildAgent,
+}
+
+impl SkillExecutionResolutionSource {
+    pub fn render_label(&self) -> &'static str {
+        match self {
+            Self::ExplicitMetadata => "explicit_metadata",
+            Self::NoChildAgentExports => "no_child_agent_exports",
+            Self::SameNameSkillAndChildAgent => "same_name_skill_and_child_agent",
+            Self::SingleSkillSingleChildAgent => "single_skill_single_child_agent",
+        }
+    }
+}
+
+/// Why delegated execution could not be resolved for a skill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkillExecutionUnresolvedReason {
+    NotResolved,
+    MissingChildAgentExports,
+    DelegateTargetNotFound {
+        target: String,
+        available_targets: Vec<String>,
+    },
+    AmbiguousPackageShape {
+        package_skill_ids: Vec<String>,
+        child_agent_exports: Vec<String>,
+    },
+}
+
+impl SkillExecutionUnresolvedReason {
+    pub fn render_label(&self) -> String {
+        match self {
+            Self::NotResolved => "not_resolved".to_string(),
+            Self::MissingChildAgentExports => "missing_child_agent_exports".to_string(),
+            Self::DelegateTargetNotFound { target, .. } => {
+                format!("delegate_target_not_found({target})")
+            }
+            Self::AmbiguousPackageShape { .. } => "ambiguous_package_shape".to_string(),
+        }
+    }
+}
+
+/// Resolved execution state for a skill after package-local inference.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolvedSkillExecution {
+    Inline {
+        source: SkillExecutionResolutionSource,
+    },
+    Delegate {
+        target: String,
+        source: SkillExecutionResolutionSource,
+    },
+    Unresolved {
+        reason: SkillExecutionUnresolvedReason,
+    },
+}
+
+impl Default for ResolvedSkillExecution {
+    fn default() -> Self {
+        Self::Unresolved {
+            reason: SkillExecutionUnresolvedReason::NotResolved,
+        }
+    }
+}
+
+impl ResolvedSkillExecution {
+    pub fn render_label(&self) -> String {
+        match self {
+            Self::Inline { source } => format!("inline({})", source.render_label()),
+            Self::Delegate { target, source } => {
+                format!(
+                    "delegate(target={target}, source={})",
+                    source.render_label()
+                )
+            }
+            Self::Unresolved { reason } => format!("unresolved({})", reason.render_label()),
+        }
+    }
+}
+
+pub fn resolve_skill_execution(
+    metadata: &SkillMetadata,
+    package_skill_ids: &[String],
+    child_agent_exports: &[String],
+) -> ResolvedSkillExecution {
+    match metadata.alan_metadata.execution.mode {
+        Some(AlanSkillExecutionMode::Inline) => ResolvedSkillExecution::Inline {
+            source: SkillExecutionResolutionSource::ExplicitMetadata,
+        },
+        Some(AlanSkillExecutionMode::Delegate) => {
+            resolve_explicit_delegate_execution(metadata, package_skill_ids, child_agent_exports)
+        }
+        None => infer_skill_execution(metadata, package_skill_ids, child_agent_exports),
+    }
+}
+
+fn resolve_explicit_delegate_execution(
+    metadata: &SkillMetadata,
+    package_skill_ids: &[String],
+    child_agent_exports: &[String],
+) -> ResolvedSkillExecution {
+    if let Some(target) = metadata.alan_metadata.execution.target.as_ref() {
+        if child_agent_exports.iter().any(|name| name == target) {
+            return ResolvedSkillExecution::Delegate {
+                target: target.clone(),
+                source: SkillExecutionResolutionSource::ExplicitMetadata,
+            };
+        }
+
+        return ResolvedSkillExecution::Unresolved {
+            reason: SkillExecutionUnresolvedReason::DelegateTargetNotFound {
+                target: target.clone(),
+                available_targets: child_agent_exports.to_vec(),
+            },
+        };
+    }
+
+    if child_agent_exports.is_empty() {
+        return ResolvedSkillExecution::Unresolved {
+            reason: SkillExecutionUnresolvedReason::MissingChildAgentExports,
+        };
+    }
+
+    if child_agent_exports.iter().any(|name| name == &metadata.id) {
+        return ResolvedSkillExecution::Delegate {
+            target: metadata.id.clone(),
+            source: SkillExecutionResolutionSource::ExplicitMetadata,
+        };
+    }
+
+    if package_skill_ids.len() == 1 && child_agent_exports.len() == 1 {
+        return ResolvedSkillExecution::Delegate {
+            target: child_agent_exports[0].clone(),
+            source: SkillExecutionResolutionSource::ExplicitMetadata,
+        };
+    }
+
+    ResolvedSkillExecution::Unresolved {
+        reason: SkillExecutionUnresolvedReason::AmbiguousPackageShape {
+            package_skill_ids: package_skill_ids.to_vec(),
+            child_agent_exports: child_agent_exports.to_vec(),
+        },
+    }
+}
+
+fn infer_skill_execution(
+    metadata: &SkillMetadata,
+    package_skill_ids: &[String],
+    child_agent_exports: &[String],
+) -> ResolvedSkillExecution {
+    if child_agent_exports.is_empty() {
+        return ResolvedSkillExecution::Inline {
+            source: SkillExecutionResolutionSource::NoChildAgentExports,
+        };
+    }
+
+    if child_agent_exports.iter().any(|name| name == &metadata.id) {
+        return ResolvedSkillExecution::Delegate {
+            target: metadata.id.clone(),
+            source: SkillExecutionResolutionSource::SameNameSkillAndChildAgent,
+        };
+    }
+
+    if package_skill_ids.len() == 1 && child_agent_exports.len() == 1 {
+        return ResolvedSkillExecution::Delegate {
+            target: child_agent_exports[0].clone(),
+            source: SkillExecutionResolutionSource::SingleSkillSingleChildAgent,
+        };
+    }
+
+    ResolvedSkillExecution::Unresolved {
+        reason: SkillExecutionUnresolvedReason::AmbiguousPackageShape {
+            package_skill_ids: package_skill_ids.to_vec(),
+            child_agent_exports: child_agent_exports.to_vec(),
+        },
+    }
+}
 
 /// Runtime-facing availability state for a selected skill.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1255,6 +1493,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         };
 
         let unavailable = skill_availability_issues(
@@ -1369,6 +1608,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         };
         let host_capabilities = SkillHostCapabilities {
             alan_version: "1.2.3-alpha.1".to_string(),
@@ -1407,6 +1647,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         };
         let host_capabilities = SkillHostCapabilities {
             alan_version: "1.2.3".to_string(),
@@ -1516,6 +1757,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/test/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            execution: Default::default(),
         };
 
         let json = serde_json::to_string(&metadata).unwrap();

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -204,6 +204,37 @@ Alan currently uses sidecar runtime metadata for two product behaviors:
   unavailable label when declared dependencies such as required tools or minimum
   Alan version are missing
 
+### Delegated Skill Execution
+
+Alan now resolves a package-local execution contract for each discovered skill.
+
+The current resolved states are:
+
+- `inline`
+- `delegate(target=...)`
+- `unresolved(...)`
+
+Execution metadata lives in Alan sidecars rather than `SKILL.md`, for example:
+
+```yaml
+runtime:
+  execution:
+    mode: delegate
+    target: reviewer
+```
+
+Default inference is package-local and deterministic:
+
+- if a package exports no child-agent roots, the skill resolves to `inline`
+- if a skill id matches a child-agent export name, it resolves to `delegate`
+- if a package exports exactly one skill and exactly one child-agent root, that
+  skill resolves to `delegate`
+- ambiguous package shapes do not guess; they resolve to `unresolved(...)`
+  until explicit sidecar metadata is present
+
+This keeps delegated execution strict and predictable before Alan introduces the
+runtime-side delegated invocation path.
+
 ### Progressive Disclosure
 
 Alan now consumes `capabilities.disclosure` during prompt assembly instead of
@@ -343,6 +374,7 @@ The active-skill envelope now carries:
 - canonical package root and resource root when available
 - availability state
 - activation reason
+- resolved execution state
 
 Prompt injection consumes that structured shape instead of pathless Markdown
 fragments. Active skill sections therefore include an `Alan Runtime Context`


### PR DESCRIPTION
Refs #182.

## Summary
- add first-class resolved delegated-skill execution metadata to skill registry state
- infer `inline`, `delegate(target=...)`, or `unresolved(...)` from package shape and Alan sidecar metadata
- thread execution labels through runtime docs and injection context so later PRs can consume them

## Testing
- cargo test -p alan-runtime