### PR TITLE
Consolidate the skill system contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,6 +562,9 @@ Runtime virtual tools (not from `alan-tools`, injected by runtime):
 - `request_confirmation` — pause and emit `Yield(confirmation)`
 - `request_user_input` — pause and emit `Yield(structured_input)`
 - `update_plan` — update in-memory plan state in current turn
+- `invoke_delegated_skill` — top-level runtimes only; launches a delegated
+  package-local child-agent execution path. Child runtimes intentionally keep
+  nested delegation disabled in V1.
 
 ### Tool Governance
 
@@ -591,6 +594,11 @@ When a policy file is found, it replaces the builtin profile rule set for that s
 
 ### Skills
 
+For the authoritative current skill-system contract, see
+`docs/spec/skill_system_contract.md`. For implementation details and current
+runtime surfaces, see `docs/skills_and_tools.md`. This section is only the
+agent-guide summary.
+
 Skills are Markdown-based capabilities with YAML frontmatter:
 
 ```markdown
@@ -609,7 +617,11 @@ Step-by-step guidance for the agent...
 
 Skills can be triggered:
 1. Explicitly: `$skill-name` in user input
-2. Implicitly: LLM selects based on description matching
+2. Deterministically: declared trigger keywords/patterns on discoverable skills
+3. Through `always_active` package mounts
+
+The rendered skills catalog is informational. It does not itself auto-activate
+skills.
 
 Capability sources:
 - Built-in first-party packages embedded in the binary
@@ -626,9 +638,12 @@ Each resolved package is then exposed through a `PackageMount` mode:
 
 Package directories may also export supporting resources such as `scripts/`,
 `references/`, `assets/`, `viewers/`, and child-agent roots under `agents/`.
-Skills can declare compatibility constraints in frontmatter
+Skills can declare runtime requirements in frontmatter
 (`required_tools`, `min_version`); unresolved constraints mark the skill
 unavailable in runtime and `alan skills` output.
+Resolved skill execution may be `inline` or
+`delegate(target=package-child-agent)`; see
+`docs/spec/skill_system_contract.md` for the full contract.
 
 ---
 
@@ -637,7 +652,7 @@ unavailable in runtime and `alan skills` output.
 1. **Before committing**: `just check`
 2. **Adding a new LLM provider**: Implement `LlmProvider` trait in `crates/llm/src/`
 3. **Adding new tools**: Implement `Tool` trait in `crates/tools/src/`, register via `create_core_tools()`
-4. **Adding skills**: Create `SKILL.md` in `crates/runtime/skills/`, an agent-root `skills/` directory, or the zero-conversion public install directories under `.agents/skills/`
+4. **Adding skills**: Create `SKILL.md` in `crates/runtime/skills/`, an agent-root `skills/` directory, or the zero-conversion public install directories under `.agents/skills/`. For the stable contract, use `docs/spec/skill_system_contract.md`; for current implementation details, use `docs/skills_and_tools.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ Alan/
   - Core (default): `read_file`, `write_file`, `edit_file`, `bash`
   - Read-only exploration: `read_file`, `grep`, `glob`, `list_dir`
   - All built-ins: core + exploration tools (7 total)
-- **Skill System**: Markdown-based capabilities via `$skill-name` triggers
+- **Skill System**: Markdown-based capability packages with public Codex/Claude-compatible `SKILL.md` portability, deterministic triggers, progressive disclosure, and delegated child-agent execution
 - **Capability-Package Hosting**: Built-in first-party packages, agent-root `skills/` directories, and public `.agents/skills/` installs resolve into one `ResolvedCapabilityView`; packages can expose portable skills, child-agent roots, and resource directories without requiring `package.toml`
+- **Skill Management Surface**: daemon APIs expose the local skill catalog, change polling, and package mount override writes
 - **Session Persistence**: Rollout recording with pause/resume/replay
 - **Policy Over Sandbox**: Policy decides (`allow/deny/escalate`), and the current sandbox backend applies a best-effort execution guard (current backend: workspace path guard with protected subpaths and only plain shell commands with statically addressable paths; shell control flow is rejected, common wrapper forms such as `env`/`command`/`builtin`/`exec`/`time`/`nice`/`nohup`/`timeout`/`stdbuf`/`setsid` are rejected, process path references under protected subpaths are blocked, glob patterns are rejected, direct nested shell/code evaluators are disabled, direct opaque command dispatchers such as `xargs`/`find -exec` are rejected, and a curated set of common direct script interpreters such as `python file.py`/`bash script.sh`/`awk -f script.awk` are rejected; the backend checks explicit path-like argv references and redirection targets but does not infer utility-specific operand roles for arbitrary bare tokens, and arbitrary program-internal writes or dispatch such as `git init`/`git add`/`git config --local`, `find -delete`, build/task runners, or utility-specific script/DSL modes like `sed -f` are not inspected by this backend and still need policy or a stronger OS sandbox; OS sandboxing is still in migration)
 - **Policy Profiles**: Builtin `autonomous`/`conservative` presets, overridable via `policy.yaml` in the resolved agent-root chain
@@ -275,6 +276,11 @@ first-party packages into one `ResolvedCapabilityView`, and a
 standards-compatible skill directory is adapted automatically as a single-skill
 package without an Alan-specific manifest.
 
+The authoritative skill-system contract lives in
+`docs/spec/skill_system_contract.md`. `docs/skills_and_tools.md` is the current
+implementation guide, and the plan documents under `plans/` are historical
+rollout/design references.
+
 Alan also supports optional Alan-native sidecars inside a skill package:
 
 - `skill.yaml` for skill-specific machine metadata
@@ -294,6 +300,10 @@ These directories are scanned into the same package host as single-skill
 packages. A resolved package can also expose package-level resources such as
 `scripts/`, `references/`, `assets/`, `viewers/`, and child-agent roots under
 `agents/`.
+
+At runtime, a resolved skill may execute inline or as a delegated
+package-local child-agent run. The detailed execution, fallback, and
+availability semantics live in `docs/spec/skill_system_contract.md`.
 
 Each root can also mount packages explicitly in `agent.toml`:
 
@@ -319,7 +329,7 @@ The default global base agent root mounts the built-in first-party packages as
 `~/.alan/agent/agent.toml`, and `alan init` creates `<workspace>/.agents/skills/`
 as the default zero-conversion install target for public skills.
 
-Skill frontmatter can also declare compatibility constraints such as
+Skill frontmatter can also declare runtime requirements such as
 `required_tools` or `min_version`. Alan now evaluates those constraints when
 building the runtime skill catalog and in
 `alan skills ...` output, so unavailable skills are surfaced with explicit

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -12,7 +12,7 @@ description: |
   - User references prior decisions, context, or history
   - Important facts, preferences, or decisions need to be preserved
 
-  This skill is always active as a system skill.
+  This built-in capability is always active.
 
 metadata:
   short-description: Persistent memory across sessions

--- a/crates/runtime/skills/workspace-manager/SKILL.md
+++ b/crates/runtime/skills/workspace-manager/SKILL.md
@@ -12,7 +12,7 @@ description: |
   - User wants to switch between projects
   - User asks about available workspaces or their status
 
-  This skill is always active as a system skill.
+  This built-in capability is always active.
 
 metadata:
   short-description: Manage workspaces via alan CLI

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ These are the primary source of truth for runtime behavior.
 
 ## 2) Mainline Architecture Contracts (Target + Current)
 
+- `docs/spec/skill_system_contract.md`
+- `docs/skills_and_tools.md`
 - `docs/spec/durable_run_contract.md`
 - `docs/spec/scheduler_contract.md`
 - `docs/spec/interaction_inbox_contract.md`
@@ -33,6 +35,10 @@ These are the primary source of truth for runtime behavior.
 - `docs/spec/remote_control_security.md`
 
 These documents define the VNext layering and rollout path.
+`docs/spec/skill_system_contract.md` is the authoritative skill-system
+contract. `docs/skills_and_tools.md` is the current implementation guide for
+runtime behavior and surfaces. Older skill plan documents should be treated as
+historical rollout rationale unless they are explicitly called out elsewhere.
 
 ## 3) Design RFCs (Migration Explanations)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,12 @@ This overlay chain defines an agent. It is not runtime process ancestry.
 
 ### Capability Packages In The Definition Layer
 
+For the authoritative skill-system contract, see
+[`spec/skill_system_contract.md`](./spec/skill_system_contract.md). For the
+current implementation guide, see [`skills_and_tools.md`](./skills_and_tools.md).
+This section keeps only the architecture-level summary so the detailed behavior
+does not drift in multiple places.
+
 Each resolved `AgentRoot` contributes its `skills/` directory as a capability
 package source. Alan also adapts `~/.agents/skills/` and
 `<workspace>/.agents/skills/` as public single-skill package sources for the
@@ -97,11 +103,12 @@ which is then consumed by runtime instead of the older mixed
 `repo/user/builtin` skill-loading paths.
 
 A standards-compatible skill directory with `SKILL.md` and optional supporting
-resources is adapted automatically as a single-skill package. Resolved
-packages can expose portable skills, child-agent roots from `agents/`, and
-resource directories such as `scripts/`, `references/`, `assets/`, and
-`viewers/`. Package hosting therefore stays in the definition layer without
-requiring an Alan-specific manifest for every public skill directory.
+resources is adapted automatically as a single-skill package. Directory-backed
+packages currently expose one portable skill plus optional Alan-native
+child-agent roots from `agents/` and resource directories such as `scripts/`,
+`references/`, `assets/`, and `viewers/`. Package hosting therefore stays in
+the definition layer without requiring an Alan-specific manifest for every
+public skill directory.
 
 Each root can then expose packages through explicit `PackageMount`s in
 `agent.toml`. The current modes are:
@@ -117,7 +124,12 @@ legacy scope-specific loading paths.
 The default global base agent root mounts Alan's built-in first-party packages
 as `always_active`, while later overlays can still override those mounts.
 
-Skill frontmatter compatibility data is enforced at the runtime boundary. When
+At runtime, those resolved skills may execute inline or delegate to
+package-local child-agent exports, but the execution contract itself lives in
+[`spec/skill_system_contract.md`](./spec/skill_system_contract.md) rather than
+this architecture summary.
+
+Skill frontmatter/runtime requirement data is enforced at the runtime boundary. When
 `required_tools` or `min_version` constraints are not met, the package remains
 in the resolved definition view, but its skills are reported as unavailable in
 both prompt assembly and `alan skills` inspection surfaces.

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -3,6 +3,12 @@
 > Status: current tool behavior plus accepted V2 governance direction.
 > The authoritative current governance contract lives in
 > [`governance_current_contract.md`](./governance_current_contract.md).
+>
+> The authoritative skill-system contract now lives in
+> [`spec/skill_system_contract.md`](./spec/skill_system_contract.md). This
+> document focuses on current implementation details, runtime surfaces, and
+> operator-facing behavior. The skill plan documents in `plans/` capture
+> rollout history and design rationale.
 
 ## Overview
 
@@ -11,7 +17,7 @@ In the AI Turing Machine model, the core runtime is a generic state-transition e
 | Concept     | TM Role               | Implementation                                        |
 | ----------- | --------------------- | ----------------------------------------------------- |
 | **Tools**   | Side effects          | `Tool` trait in `alan-runtime`, impls in `alan-tools` |
-| **Skills**  | Instruction extension | Markdown + YAML, loaded into prompt context           |
+| **Skills**  | Instruction extension | Markdown + YAML, rendered inline or as delegated capability stubs |
 | **Sandbox** | Boundary constraint   | Execution backend (filesystem/process/network limits)  |
 | **Policy**  | Decision boundary     | `PolicyEngine` rules (`allow/deny/escalate`)           |
 
@@ -75,13 +81,19 @@ Each tool invocation receives a `ToolContext` ([context.rs](../crates/runtime/sr
 
 ### Virtual Tools
 
-Runtime injects three virtual tools into the LLM toolset for planning and human-in-the-loop control:
+Runtime always injects three baseline virtual tools into the LLM toolset for
+planning and human-in-the-loop control:
 
 - `request_confirmation` — pause execution and emit `Event::Yield` with kind `confirmation`
 - `request_user_input` — pause execution and emit `Event::Yield` with kind `structured_input`
 - `update_plan` — update in-memory plan metadata before continuing in the current turn
 
-These are implemented in `runtime/virtual_tools.rs` and are handled by the runtime itself, not `alan-tools`.
+Top-level runtimes also expose `invoke_delegated_skill` when delegated skill
+execution is supported. Child runtimes intentionally keep nested delegated
+execution off in V1, so they do not expose that tool by default.
+
+These are implemented in `runtime/virtual_tools.rs` and are handled by the
+runtime itself, not `alan-tools`.
 
 ### Tool Catalog
 
@@ -134,7 +146,9 @@ V2 direction: keep path-based checks as baseline backend, then add optional OS-l
 
 ### Design
 
-Skills are self-contained, filesystem-based capability packages. Each skill is a directory with a required `SKILL.md` file and optional supporting resources:
+Alan's definition layer works with filesystem-based capability packages. The
+current stable directory-backed shape is a single-skill package with optional
+Alan-native extensions:
 
 ```
 my-skill/
@@ -143,8 +157,13 @@ my-skill/
 ├── package.yaml          # Optional: package-level defaults for Alan-native metadata
 ├── scripts/              # Optional: executable code the agent can invoke via bash
 ├── references/           # Optional: reference documentation
-└── assets/               # Optional: templates, resources
+├── assets/               # Optional: templates, resources
+└── agents/               # Optional: Alan-native child-agent exports
 ```
+
+Public `.agents/skills/<skill-id>/` installs are adapted automatically as
+single-skill packages. Alan-native extensions currently live inside that same
+directory, most importantly sidecars and child-agent roots under `agents/`.
 
 ### SKILL.md Format
 
@@ -204,6 +223,37 @@ Alan currently uses sidecar runtime metadata for two product behaviors:
   unavailable label when declared dependencies such as required tools or minimum
   Alan version are missing
 
+### Current Status And Partial Areas
+
+The following pieces are implemented and should be treated as the current
+contract:
+
+- capability-package discovery from built-ins, agent roots, and public
+  `.agents/skills/` directories
+- package mounts (`always_active`, `discoverable`, `explicit_only`, `internal`)
+- deterministic trigger matching from explicit mentions, trigger aliases,
+  keywords, patterns, and negative keywords
+- path-aware prompt injection and progressive disclosure
+- delegated skill execution with package-local child-agent targets
+- daemon skill catalog, changed-cursor polling, and mount-override writes
+
+The following fields are parsed and preserved, but they are not yet first-class
+runtime contracts:
+
+- `capabilities.optional_tools` is descriptive only; it does not affect
+  activation or availability
+- `capabilities.domains` is stored metadata only
+- `capabilities.triggers.semantic` is stored and merged, but automatic
+  activation is currently deterministic only
+- `viewers/` exports are discovered and surfaced in CLI/catalog output, but
+  Alan does not yet define a runtime or daemon viewer-consumption contract
+- `compatibility.requirements` is advisory remediation text, not a typed
+  dependency gate
+- `runtime.ui` is parsed sidecar metadata without a stable runtime consumer
+- public compatibility metadata such as `agents/openai.yaml` and authoring
+  assets such as `agents/*.md` are tolerated, but Alan does not yet treat them
+  as first-class runtime inputs
+
 ### Delegated Skill Execution
 
 Alan now resolves a package-local execution contract for each discovered skill.
@@ -248,8 +298,9 @@ explicit runtime-owned path instead of an inline prompt convention.
 
 The delegated tool now launches the resolved package-local child-agent export
 through `SpawnSpec` with a fresh child runtime and explicit handles only.
-V1 keeps that default launch narrow: the child gets the workspace handle, but
-it does not inherit parent tape, active skills, or plan state by default.
+V1 keeps that default launch narrow: the child gets `Workspace` and
+`ApprovalScope`, but it does not inherit parent tape, active skills, plan
+state, or memory by default.
 
 Alan still preserves a compatibility fallback for runtimes that do not expose
 delegated invocation, for example child runtimes where nested delegated
@@ -289,9 +340,9 @@ the child run separately when needed.
 execution mode and flag unresolved delegated-package shapes with explicit
 diagnostics.
 
-If execution resolves to `unresolved(...)`, Alan also avoids injecting the full
-body. The parent receives an execution-status stub that surfaces the unresolved
-reason so ambiguous package shapes do not silently fall back to inline behavior.
+If execution resolves to `unresolved(...)`, Alan treats that skill as
+unavailable and surfaces diagnostics in CLI, catalog, and remediation paths
+rather than silently falling back to inline behavior.
 
 ### Progressive Disclosure
 
@@ -344,9 +395,8 @@ Overlay order is:
 
 A standards-compatible skill directory with `SKILL.md` and optional
 `scripts/`, `references/`, `assets/`, `viewers/`, or child-agent roots under
-`agents/` is adapted automatically into a
-single-skill package. This keeps public skill compatibility without requiring a
-custom `package.toml`.
+`agents/` is adapted automatically into a single-skill package. This keeps
+public skill compatibility without requiring a custom `package.toml`.
 
 Direct installation can therefore stay zero-conversion:
 
@@ -426,6 +476,10 @@ Alan now exposes the same local-first management surface from the daemon:
 - `POST /api/v1/skills/mount_overrides` writes a package mount override through
   the highest-precedence writable agent root and returns the refreshed snapshot
 
+These routes are intentionally local-first: `workspace_dir` is the default
+workspace or a registered workspace alias / short id, not an arbitrary
+filesystem path.
+
 The write path persists to the resolved writable `agent.toml` for the target
 agent definition layer. For example, a workspace-base request writes
 `<workspace>/.alan/agent/agent.toml`, while a workspace named agent writes
@@ -440,8 +494,10 @@ Skills are activated according to the resolved mount mode. The injector ([inject
 
 1. Extracts `$skill-name` / `$skill_name` patterns from input
 2. Resolves a structured active-skill envelope for each selected skill
-3. Loads full skill content on demand
-4. Injects skill instructions together with stable path and package context
+3. Loads full content on demand for inline skills or delegated-fallback
+   runtimes
+4. Injects inline instructions or delegated capability stubs together with
+   stable path and package context
 
 The active-skill envelope now carries:
 
@@ -461,7 +517,7 @@ deterministic.
 in the skills catalog and can be activated on demand. `explicit_only` packages
 skip the catalog but still respond to exact `$skill-name` mentions.
 
-Skill availability is also filtered by frontmatter compatibility:
+Skill availability is also filtered by declared runtime requirements:
 
 - `required_tools`
 - `min_version`
@@ -472,6 +528,7 @@ mentions then surface a concrete unavailable reason instead of silently
 injecting an unusable skill.
 
 A skills catalog is also rendered into the system prompt so the LLM can reference available skills.
+That catalog is informational; it does not itself auto-activate skills.
 
 Resource listings are now emitted relative to the envelope's `resource_root`
 instead of bare filenames, for example `scripts/check.sh` rather than only
@@ -497,10 +554,15 @@ crates/runtime/src/skills/
 
 2. **Skills over Plugins** — Capabilities are Markdown instructions that shape behavior, not compiled code that extends the runtime. Adding a skill requires no recompilation.
 
-3. **Self-Sufficient Skills** — Skills carry their own scripts and references. They extend capability through `bash` + existing tools, not through new native code.
+3. **Self-Sufficient Capability Packages** — Packages carry their own skills,
+   scripts, references, assets, and optional child-agent roots. They extend
+   capability through `bash` + existing tools, not through new native code.
 
 4. **No MCP** — No external protocol dependencies. Tools are direct Rust trait implementations; skills are local filesystem documents.
 
 5. **Policy Over Sandbox** — policy decides intent, and the current sandbox backend provides a best-effort execution guard.
 
 6. **Path-Based Filesystem Isolation** — simple, portable workspace containment without OS-specific mechanisms; trades maximum isolation for zero external dependencies.
+
+For the stable contract and compatibility target, see
+[`spec/skill_system_contract.md`](./spec/skill_system_contract.md).

--- a/docs/spec/skill_system_contract.md
+++ b/docs/spec/skill_system_contract.md
@@ -1,0 +1,400 @@
+# Skill System Contract
+
+> Status: authoritative skill-system contract.
+>
+> This document defines the stable package, activation, execution, and
+> management model that future Alan skill work should target.
+> [`../skills_and_tools.md`](../skills_and_tools.md) is the current
+> implementation guide. The older skill plan documents under `plans/` are
+> historical rollout rationale, not the source of truth for shipped behavior.
+
+## Goals
+
+Alan's skill system must optimize for five things at the same time:
+
+1. **Portable public compatibility** with Codex- and Claude-style skill
+   directories.
+2. **Zero-conversion installation** for public skills under `.agents/skills/`.
+3. **Explicit Alan-native extensions** for mounts, delegated execution, and
+   child-agent exports without breaking portable `SKILL.md`.
+4. **Deterministic activation** and **bounded delegated execution**.
+5. **Small prompt footprint** through progressive disclosure and narrow result
+   boundaries.
+
+## Stable Vocabulary
+
+- **Skill package**: one directory-backed portable skill plus optional
+  Alan-native sidecars, resources, and child-agent exports.
+- **Portable skill**: the shared public contract centered on `SKILL.md`.
+- **Alan sidecar**: optional `skill.yaml` / `package.yaml` metadata that extends
+  runtime behavior without changing `SKILL.md`.
+- **Mount**: how a discovered package is exposed to the current runtime.
+- **Active skill**: a selected skill with resolved availability and execution
+  state for the current turn.
+- **Delegated skill**: a skill that resolves to a package-local child-agent
+  executor instead of parent-side inline instructions.
+
+## Compatibility Profile
+
+### Tier 1: Portable Runtime Compatibility
+
+Alan **must** discover and run public skill directories shaped like:
+
+```text
+skill-name/
+├── SKILL.md
+├── scripts/
+├── references/
+└── assets/
+```
+
+This package shape must work without Alan-specific manifests when installed
+under:
+
+- `~/.agents/skills/`
+- `<workspace>/.agents/skills/`
+- Alan `AgentRoot` `skills/` directories
+
+Unknown extra files must be ignored rather than treated as fatal.
+
+### Tier 2: Compatibility Metadata
+
+Alan **should** tolerate and eventually consume public compatibility metadata
+when present, especially:
+
+- `agents/openai.yaml` from Codex-style skills for UI-facing metadata
+
+This metadata is not part of the core `SKILL.md` portability contract. Unknown
+fields must remain fail-open.
+
+### Tier 3: Authoring / Eval Companion Assets
+
+Alan **should** preserve and ignore-by-default auxiliary authoring assets such
+as:
+
+- `agents/*.md`
+- validator / benchmark scripts
+- grader / analyzer prompts
+
+These are not part of the default runtime activation contract. They are
+authoring and evaluation surfaces. First-party Alan tooling may consume them
+explicitly, but runtime discovery must not require them.
+
+This keeps Alan compatible with Claude/Codex authoring conventions without
+mistaking every authoring artifact for a runtime capability.
+
+## Stable Package Layout
+
+The stable directory-backed skill package contract is:
+
+```text
+skill-name/
+├── SKILL.md
+├── skill.yaml          # optional Alan-native skill metadata
+├── package.yaml        # optional Alan-native package defaults
+├── scripts/
+├── references/
+├── assets/
+└── agents/             # optional Alan-native child-agent exports
+```
+
+Rules:
+
+1. A directory-backed package currently exports **exactly one portable skill**:
+   the `SKILL.md` in the package root.
+2. `scripts/`, `references/`, and `assets/` are the stable bundled resource
+   directories.
+3. `agents/` is an Alan-native extension directory for package-local child-agent
+   exports.
+4. Unknown additional files or directories must be ignored by runtime
+   discovery.
+5. Multi-skill filesystem packages are **not** part of the stable public
+   contract. If multiple skills are needed, author multiple sibling packages.
+
+This intentionally removes an over-designed abstraction that is broader than the
+current implementation and broader than the public Codex/Claude baseline.
+
+## `SKILL.md` Contract
+
+### Required Frontmatter
+
+- `name`
+- `description`
+
+These are the portable trigger contract and must remain sufficient for basic
+public skill interoperability.
+
+### Stable Optional Frontmatter
+
+- `metadata.short-description`
+- `metadata.tags`
+- `capabilities.required_tools`
+- `capabilities.triggers.explicit`
+- `capabilities.triggers.keywords`
+- `capabilities.triggers.patterns`
+- `capabilities.triggers.negative_keywords`
+- `capabilities.disclosure.level2`
+- `capabilities.disclosure.level3.references`
+- `capabilities.disclosure.level3.scripts`
+- `capabilities.disclosure.level3.assets`
+- `compatibility.min_version`
+- `compatibility.requirements`
+
+### Stable Semantics
+
+- `compatibility.min_version` is a hard availability gate.
+- `compatibility.requirements` is advisory remediation text only. It is not a
+  typed dependency gate.
+
+### Parsed But Not Stable Contract
+
+The following fields may be tolerated for forward compatibility, but they are
+not part of Alan's stable skill contract and must not be treated as required
+authoring surface:
+
+- `capabilities.optional_tools`
+- `capabilities.domains`
+- `capabilities.triggers.semantic`
+
+If Alan continues parsing them, that is compatibility tolerance rather than a
+stable behavior guarantee.
+
+## Alan Sidecar Contract
+
+Alan-native sidecars extend runtime behavior without changing the public
+`SKILL.md` contract.
+
+### `skill.yaml`
+
+Stable Alan-native keys:
+
+- `runtime.execution.mode = inline | delegate`
+- `runtime.execution.target`
+- `runtime.permission_hints`
+
+### `package.yaml`
+
+`package.yaml` may provide `skill_defaults` with the same stable keys as
+`skill.yaml`. Package defaults apply before the skill-local sidecar.
+
+### Not Yet Stable
+
+- `runtime.ui`
+
+Alan may continue to parse this data, but it is not part of the stable contract
+until a real consumer exists.
+
+## Discovery Contract
+
+Alan discovers skill packages from:
+
+- built-in first-party packages
+- `AgentRoot` `skills/` directories
+- public `.agents/skills/` directories
+
+Discovery is separate from runtime exposure. After discovery, packages enter the
+resolved capability view and are then filtered by mount mode and availability.
+
+## Mount Contract
+
+Stable mount modes are:
+
+- `always_active`
+- `discoverable`
+- `explicit_only`
+- `internal`
+
+Semantics:
+
+- `always_active`: visible and selected every turn
+- `discoverable`: visible and activatable
+- `explicit_only`: not listed in the catalog, but activatable by explicit
+  mention
+- `internal`: not exposed through the current runtime skill surface
+
+Built-in first-party packages are mounted `always_active` by default from the
+default global base agent root. Later overlays may still override those mounts.
+
+## Activation Contract
+
+Skill activation must be deterministic.
+
+### Activation Sources
+
+1. `always_active` package mounts
+2. Explicit `$skill-id` mentions
+3. Explicit aliases declared in `triggers.explicit`
+4. Deterministic keyword / regex pattern matches on discoverable skills
+
+### Activation Rules
+
+1. Explicit mention always wins when the skill is exposed and available.
+2. `negative_keywords` suppress automatic keyword/pattern activation, but do not
+   suppress explicit mention.
+3. Only `discoverable` skills participate in automatic keyword/pattern
+   activation.
+4. The rendered skills catalog is informational only. It is **not** itself an
+   activation source or a model-side classifier contract.
+5. Semantic-trigger activation is outside the stable contract.
+
+## Availability Contract
+
+Hard availability gates are:
+
+- `capabilities.required_tools`
+- `compatibility.min_version`
+- resolved delegated execution state
+
+If a skill resolves to delegated execution ambiguously, Alan must mark it
+unavailable rather than silently guessing or falling back inline.
+
+Advisory only:
+
+- `compatibility.requirements`
+
+Future env-var, MCP, or other typed dependencies should be introduced as typed
+contracts rather than by growing free-form string fields.
+
+## Progressive Disclosure Contract
+
+Alan uses three disclosure levels:
+
+1. **Metadata**: `name`, `description`, `short-description`, tags
+2. **Primary instruction body**: `SKILL.md` body or `disclosure.level2`
+3. **Bundled resources**: `references/`, `scripts/`, `assets/`
+
+Rules:
+
+1. `SKILL.md` should stay concise and procedural.
+2. Detailed schemas, examples, and domain reference material should move into
+   `references/`.
+3. Deterministic scripts should live in `scripts/`.
+4. Templates and output resources should live in `assets/`.
+5. Relative resource paths resolve against the canonical package resource root.
+6. Authoring should keep references shallow: `SKILL.md` should point directly to
+   the resources that matter rather than rely on deep reference chains.
+
+This follows the same context-discipline emphasized by public Claude/Codex
+skills.
+
+## Execution Contract
+
+Each discovered skill resolves to exactly one of:
+
+- `inline`
+- `delegate(target=package-child-agent)`
+
+### Default Inference
+
+Package-local inference is deterministic:
+
+1. no child-agent exports -> `inline`
+2. same-name skill and child-agent export -> `delegate`
+3. exactly one skill and one child-agent export -> `delegate`
+4. otherwise -> unresolved -> unavailable
+
+Alan must not guess across ambiguous package shapes.
+
+### Delegated Execution
+
+Delegated execution is an Alan-native runtime contract:
+
+1. top-level runtimes expose `invoke_delegated_skill`
+2. parent prompt receives a lightweight capability stub instead of the full
+   `SKILL.md` body
+3. delegated launch uses a package-local `SpawnTarget` and a fresh child
+   runtime
+4. default launch stays narrow: current default handles are `Workspace` and
+   `ApprovalScope`
+5. parent tape records a bounded delegated result rather than replaying the
+   child transcript
+6. child rollout remains separately inspectable out of band
+
+Delegated execution must not implicitly inherit:
+
+- parent tape
+- active skills
+- plan state
+- memory handle
+- nested delegated execution
+
+### Runtime Capability Fallback
+
+There is no third user-facing execution mode beyond `inline` and `delegate`.
+However, when a runtime does not expose delegated invocation support, a
+delegated skill may fall back to inline rendering for that runtime only. This is
+a runtime capability fallback, not a stable author-facing execution mode.
+
+## Child-Agent Export Contract
+
+Alan-native child-agent exports live under:
+
+```text
+skill-name/
+└── agents/
+    └── reviewer/
+        ├── agent.toml
+        ├── persona/
+        └── policy.yaml
+```
+
+Rules:
+
+1. child-agent exports are package-local launch targets
+2. exported roots must remain inside the package tree after canonicalization
+3. symlinks that escape the package tree must be ignored
+4. compatibility assets such as `agents/grader.md` are **not** runtime
+   child-agent exports by themselves
+
+This is the key distinction between Alan's runtime child-agent model and the
+authoring/eval assets commonly found in Claude/Codex skills.
+
+## Management Contract
+
+Alan's local-first management surface includes:
+
+- `alan skills list`
+- `alan skills packages`
+- `GET /api/v1/skills/catalog`
+- `GET /api/v1/skills/changed?after=<cursor>`
+- `POST /api/v1/skills/mount_overrides`
+
+Rules:
+
+1. daemon skill APIs use the default workspace or a registered workspace alias /
+   short id, not arbitrary filesystem paths
+2. mount-override writes persist through the highest-precedence writable
+   `AgentRoot`
+3. change detection is cursor-based so clients do not need full catalog reloads
+   on every poll
+
+## First-Party Authoring Expectations
+
+Alan's first-party skill authoring guidance should follow these rules:
+
+1. Treat `description` as the trigger contract. It must say what the skill does
+   and when to use it.
+2. Keep `SKILL.md` lean. Move detailed reference material into `references/`.
+3. Prefer deterministic helper scripts over repeatedly rewritten code.
+4. Avoid clutter files such as `README.md`, `CHANGELOG.md`, and
+   process-history notes inside skill packages.
+5. First-party tooling should eventually provide `init`, `validate`, and
+   benchmark/eval flows.
+6. Grader/analyzer/eval assets are valuable, but they should be treated as
+   explicit authoring/evaluation surfaces or upgraded into real Alan child-agent
+   exports, not silently loaded into runtime.
+
+## Explicit Non-Goals / Removed From The Stable Contract
+
+These are intentionally outside the stable skill contract for now:
+
+- `package.toml` manifests
+- multi-skill filesystem packages
+- semantic trigger activation
+- `domains` and `optional_tools` as activation or availability semantics
+- `viewers/` as a runtime contract
+- `runtime.ui` as stable behavior
+- nested delegated execution in V1
+
+If Alan keeps parsing some of these for compatibility, that must not be
+mistaken for a stable behavior promise.

--- a/plans/2026-03-12-skill-package-mount-plan.md
+++ b/plans/2026-03-12-skill-package-mount-plan.md
@@ -1,5 +1,12 @@
 # Alan Skill / Package / Mount Model Plan (2026-03-12)
 
+> Status: historical rollout plan.
+>
+> The package/mount baseline described here is largely implemented. Use
+> `docs/spec/skill_system_contract.md` for the stable contract and
+> `docs/skills_and_tools.md` for the current implementation guide. Keep this
+> document for design rationale and rollout sequencing context.
+
 ## Context
 
 Alan's current skill system is functional, but it is still optimized for the older

--- a/plans/2026-03-24-delegated-skill-execution-plan.md
+++ b/plans/2026-03-24-delegated-skill-execution-plan.md
@@ -1,5 +1,13 @@
 # Alan Delegated Skill Execution Plan (2026-03-24)
 
+> Status: historical delegated-skill rollout / design plan.
+>
+> Delegated skill execution is now largely implemented. Use
+> `docs/spec/skill_system_contract.md` for the stable contract and
+> `docs/skills_and_tools.md` plus the current runtime implementation for shipped
+> behavior. Keep this document for design rationale, sequencing context, and
+> unresolved future questions.
+
 ## Context
 
 Alan's current skill system now has a much cleaner definition-layer model than before:


### PR DESCRIPTION
## Summary

Consolidate Alan's skill documentation around a single authoritative contract and clean up stale or redundant skill-system wording across README, architecture, AGENTS, and historical plan docs.

## What changed

- add `docs/spec/skill_system_contract.md` as the authoritative skill-system spec
- reposition `docs/skills_and_tools.md` as the current implementation/runtime guide
- update README / architecture / AGENTS / docs index to point at the new contract
- downgrade older skill rollout plans to historical rationale
- tighten the documented stable contract around the actual shipped model:
  - single-skill filesystem packages
  - deterministic activation
  - `inline | delegate` execution
  - package-local child-agent exports
  - local-first skill catalog / change polling / mount overrides
- explicitly mark dormant areas as non-contract / compatibility-only

## Why

The previous docs mixed current behavior, historical rollout plans, and broader design ideas in a way that made the skill surface look larger and less stable than the implementation actually is.

This PR makes the contract explicit so future work can target one stable spec, while still preserving current implementation guidance and historical rationale.

## Follow-ups opened from this audit

- #209 Codex-style `agents/openai.yaml` compatibility ingestion
- #210 typed skill dependency / remediation model
- #211 umbrella for the next compatibility/authoring/cleanup round
- #212 first-party skill authoring / init / validate / eval workflows
- #213 cleanup of dormant non-contract skill schema

## Validation

- `git diff --check`

No Rust tests were run because this PR is documentation-only.
