### PR TITLE
[Skill System][Compatibility] Ingest Codex-style agents/openai.yaml metadata

### DIFF
--- a/crates/alan/src/skill_catalog.rs
+++ b/crates/alan/src/skill_catalog.rs
@@ -1,6 +1,6 @@
 use alan_runtime::skills::{
-    CapabilityPackage, CapabilityPackageResources, PackageMountMode, ResolvedSkillExecution,
-    SkillHostCapabilities, SkillMetadata, SkillRemediation, SkillsRegistry,
+    CapabilityPackage, CapabilityPackageResources, CompatibleSkillMetadata, PackageMountMode,
+    ResolvedSkillExecution, SkillHostCapabilities, SkillMetadata, SkillRemediation, SkillsRegistry,
     skill_availability_issues, skill_remediation,
 };
 use alan_runtime::{Config, ResolvedAgentDefinition, ToolRegistry, WorkspaceRuntimeConfig};
@@ -97,6 +97,8 @@ pub struct SkillCatalogSkillSnapshot {
     pub mount_mode: PackageMountMode,
     #[serde(default)]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "CompatibleSkillMetadata::is_empty")]
+    pub compatible_metadata: CompatibleSkillMetadata,
     pub execution: ResolvedSkillExecution,
     pub available: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -335,6 +337,7 @@ fn build_skill_snapshot(
         scope: skill.scope,
         mount_mode: skill.mount_mode,
         tags: skill.tags.clone(),
+        compatible_metadata: skill.compatible_metadata.clone(),
         execution: skill.execution.clone(),
         available: issues.is_empty(),
         availability_issues: issues.iter().map(ToString::to_string).collect::<Vec<_>>(),
@@ -472,6 +475,7 @@ mod tests {
         let skills_dir = workspace_alan_dir.join("agent/skills");
         let review_dir = skills_dir.join("repo-review");
         fs::create_dir_all(review_dir.join("agents/repo-review")).unwrap();
+        fs::create_dir_all(review_dir.join("agents")).unwrap();
         create_skill(
             &skills_dir,
             "repo-review",
@@ -483,6 +487,16 @@ description: Review the current diff
 Body
 "#,
         );
+        fs::write(
+            review_dir.join("agents/openai.yaml"),
+            r#"
+interface:
+  display_name: "Repository Review"
+  short_description: "Review the current diff"
+  icon_small: "./assets/review-small.svg"
+"#,
+        )
+        .unwrap();
 
         let mut runtime_config = WorkspaceRuntimeConfig::from(Config::default());
         runtime_config.workspace_root_dir = Some(workspace_root);
@@ -511,6 +525,28 @@ Body
                 source:
                     alan_runtime::skills::SkillExecutionResolutionSource::SameNameSkillAndChildAgent,
             }
+        );
+        assert_eq!(
+            skill.compatible_metadata.interface.display_name.as_deref(),
+            Some("Repository Review")
+        );
+        assert_eq!(
+            skill
+                .compatible_metadata
+                .interface
+                .short_description
+                .as_deref(),
+            Some("Review the current diff")
+        );
+        let expected_icon_small = std::fs::canonicalize(review_dir.join("assets/review-small.svg"))
+            .unwrap_or_else(|_| {
+                std::fs::canonicalize(&review_dir)
+                    .unwrap()
+                    .join("assets/review-small.svg")
+            });
+        assert_eq!(
+            skill.compatible_metadata.interface.icon_small.as_deref(),
+            Some(expected_icon_small.as_path())
         );
     }
 

--- a/crates/runtime/src/approval.rs
+++ b/crates/runtime/src/approval.rs
@@ -231,6 +231,7 @@ mod tests {
                     ui: Default::default(),
                     execution: Default::default(),
                 },
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             crate::skills::SkillActivationReason::Keyword {

--- a/crates/runtime/src/runtime/turn_state.rs
+++ b/crates/runtime/src/runtime/turn_state.rs
@@ -393,6 +393,7 @@ mod tests {
                 )),
                 mount_mode: crate::skills::PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             crate::skills::SkillActivationReason::Keyword {

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -1375,6 +1375,7 @@ mod tests {
             source: Default::default(),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: ResolvedSkillExecution::Delegate {
                 target: target.to_string(),
                 source: SkillExecutionResolutionSource::ExplicitMetadata,

--- a/crates/runtime/src/skills/injector.rs
+++ b/crates/runtime/src/skills/injector.rs
@@ -991,6 +991,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/tmp/test/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "# Instructions\n\nDo this and that.".to_string(),
@@ -1029,6 +1030,7 @@ mod tests {
                 )),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: ResolvedSkillExecution::Delegate {
                     target: "reviewer".to_string(),
                     source: SkillExecutionResolutionSource::ExplicitMetadata,
@@ -1072,6 +1074,7 @@ mod tests {
                 )),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: ResolvedSkillExecution::Unresolved {
                     reason: SkillExecutionUnresolvedReason::AmbiguousPackageShape {
                         package_skill_ids: vec!["skill-creator".to_string()],
@@ -1119,6 +1122,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/tmp/eval/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Follow these steps.".to_string(),
@@ -1155,6 +1159,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/a/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             SkillMetadata {
@@ -1173,6 +1178,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/b/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
         ];
@@ -1260,6 +1266,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Read `references/ref.md` before running `scripts/test.sh`.".to_string(),
@@ -1314,6 +1321,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Fallback instructions.".to_string(),
@@ -1388,6 +1396,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Use https://example.com/scripts/setup.sh, then read references/guide.md. After that run ./scripts/setup.sh."
@@ -1461,6 +1470,7 @@ mod tests {
                 source: SkillContentSource::File(skill_dir.join("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Fallback instructions.".to_string(),
@@ -1512,6 +1522,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             content: "Content".to_string(),
@@ -1560,6 +1571,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/test/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
             SkillMetadata {
@@ -1578,6 +1590,7 @@ mod tests {
                 source: SkillContentSource::File(std::path::PathBuf::from("/testing/SKILL.md")),
                 mount_mode: PackageMountMode::Discoverable,
                 alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
                 execution: Default::default(),
             },
         ];
@@ -1606,6 +1619,7 @@ mod tests {
             source: SkillContentSource::File(std::path::PathBuf::from("/other/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         }];
 
@@ -1634,6 +1648,7 @@ mod tests {
             source: SkillContentSource::File(std::path::PathBuf::from("/rust/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         }];
 

--- a/crates/runtime/src/skills/loader.rs
+++ b/crates/runtime/src/skills/loader.rs
@@ -74,6 +74,7 @@ pub fn parse_skill_metadata_with_source(
         source,
         mount_mode: PackageMountMode::Discoverable,
         alan_metadata: AlanSkillRuntimeMetadata::default(),
+        compatible_metadata: CompatibleSkillMetadata::default(),
         execution: ResolvedSkillExecution::default(),
     })
 }
@@ -131,6 +132,7 @@ pub fn load_skill_from_content(
         source,
         mount_mode: PackageMountMode::Discoverable,
         alan_metadata: AlanSkillRuntimeMetadata::default(),
+        compatible_metadata: CompatibleSkillMetadata::default(),
         execution: ResolvedSkillExecution::default(),
     };
 
@@ -145,12 +147,26 @@ const MAX_SCAN_DEPTH: usize = 6;
 const MAX_SKILLS_DIRS_PER_ROOT: usize = 2000;
 const CHILD_AGENT_EXPORT_DIR: &str = "agents";
 
+#[derive(Debug, Default, serde::Deserialize)]
+struct OpenAiMetadataFile {
+    #[serde(default)]
+    interface: CompatibleSkillInterface,
+    #[serde(default)]
+    dependencies: CompatibleSkillDependencies,
+}
+
 pub fn skill_sidecar_path(skill_path: &Path) -> Option<PathBuf> {
     skill_path.parent().map(|dir| dir.join(SKILL_SIDECAR_FILE))
 }
 
 pub fn package_sidecar_path(package_root: &Path) -> PathBuf {
     package_root.join(PACKAGE_SIDECAR_FILE)
+}
+
+pub fn compatibility_metadata_path(package_root: &Path) -> PathBuf {
+    package_root
+        .join(COMPATIBILITY_METADATA_DIR)
+        .join(COMPATIBILITY_METADATA_FILE)
 }
 
 pub fn load_skill_sidecar(skill_path: &Path) -> Result<Option<AlanSkillSidecar>, SkillsError> {
@@ -166,6 +182,29 @@ pub fn load_package_sidecar(
     load_optional_yaml(&package_sidecar_path(package_root))
 }
 
+pub fn load_compatibility_metadata(
+    package_root: &Path,
+) -> Result<Option<CompatibleSkillMetadata>, SkillsError> {
+    let Some(mut parsed) =
+        load_optional_yaml::<OpenAiMetadataFile>(&compatibility_metadata_path(package_root))?
+    else {
+        return Ok(None);
+    };
+
+    normalize_compatibility_interface_paths(package_root, &mut parsed.interface);
+
+    let metadata = CompatibleSkillMetadata {
+        interface: parsed.interface,
+        dependencies: parsed.dependencies,
+    };
+
+    if metadata.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(metadata))
+    }
+}
+
 fn load_optional_yaml<T>(path: &Path) -> Result<Option<T>, SkillsError>
 where
     T: DeserializeOwned,
@@ -176,6 +215,34 @@ where
         Err(err) => return Err(SkillsError::Io(err)),
     };
     Ok(Some(serde_yaml::from_str(&content)?))
+}
+
+fn normalize_compatibility_interface_paths(
+    package_root: &Path,
+    interface: &mut CompatibleSkillInterface,
+) {
+    interface.icon_small = interface
+        .icon_small
+        .take()
+        .map(|path| normalize_compatibility_asset_path(package_root, path));
+    interface.icon_large = interface
+        .icon_large
+        .take()
+        .map(|path| normalize_compatibility_asset_path(package_root, path));
+}
+
+fn normalize_compatibility_asset_path(package_root: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    package_root.join(normalized)
 }
 
 /// Scan a directory for skills (recursive).

--- a/crates/runtime/src/skills/mod.rs
+++ b/crates/runtime/src/skills/mod.rs
@@ -156,11 +156,15 @@ pub fn list_skills(registry: &SkillsRegistry, host_capabilities: &SkillHostCapab
             types::SkillScope::Builtin => "[builtin]",
         };
 
-        lines.push(format!("{} ${} - {}", scope_str, skill.id, skill.name));
+        lines.push(format!(
+            "{} ${} - {}",
+            scope_str,
+            skill.id,
+            skill.display_name()
+        ));
 
         let desc = skill
-            .short_description
-            .as_ref()
+            .effective_short_description()
             .unwrap_or(&skill.description);
         lines.push(format!("         {}", desc));
         lines.extend(render_skill_execution_lines(skill));
@@ -180,10 +184,14 @@ pub fn list_skills(registry: &SkillsRegistry, host_capabilities: &SkillHostCapab
                 types::SkillScope::User => "[user]",
                 types::SkillScope::Builtin => "[builtin]",
             };
-            lines.push(format!("{} ${} - {}", scope_str, skill.id, skill.name));
+            lines.push(format!(
+                "{} ${} - {}",
+                scope_str,
+                skill.id,
+                skill.display_name()
+            ));
             let desc = skill
-                .short_description
-                .as_ref()
+                .effective_short_description()
                 .unwrap_or(&skill.description);
             lines.push(format!("         {}", desc));
             lines.extend(render_skill_execution_lines(skill));
@@ -372,6 +380,7 @@ Body
             source: SkillContentSource::File(std::path::PathBuf::from("/test")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         });
         assert!(!outcome.is_empty());

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -163,7 +163,13 @@ impl SkillsRegistry {
             let package_root = package.root_dir.clone();
             let resource_root = package.root_dir.clone();
             let package_sidecar_path = package_root.as_deref().map(loader::package_sidecar_path);
+            let compatibility_metadata_path = package_root
+                .as_deref()
+                .map(loader::compatibility_metadata_path);
             if let Some(path) = package_sidecar_path.as_ref() {
+                self.tracked_paths.push(path.clone());
+            }
+            if let Some(path) = compatibility_metadata_path.as_ref() {
                 self.tracked_paths.push(path.clone());
             }
             let package_sidecar = package_root
@@ -185,6 +191,26 @@ impl SkillsRegistry {
                         None
                     }
                 });
+            let compatibility_metadata =
+                package_root
+                    .as_deref()
+                    .and_then(|root| match loader::load_compatibility_metadata(root) {
+                        Ok(metadata) => metadata,
+                        Err(err) => {
+                            let metadata_path = loader::compatibility_metadata_path(root);
+                            warn!(
+                                path = %metadata_path.display(),
+                                package_id = %package.id,
+                                error = %err,
+                                "Failed to load compatibility metadata; continuing without compatibility hints"
+                            );
+                            self.errors.push(SkillError {
+                                path: metadata_path,
+                                message: err.to_string(),
+                            });
+                            None
+                        }
+                    });
 
             let mut loaded_skills = Vec::new();
 
@@ -198,6 +224,9 @@ impl SkillsRegistry {
                                 metadata.mount_mode = mount_mode;
                                 metadata.package_root = package_root.clone();
                                 metadata.resource_root = resource_root.clone();
+                                if let Some(compatible_metadata) = compatibility_metadata.as_ref() {
+                                    metadata.compatible_metadata = compatible_metadata.clone();
+                                }
                                 self.apply_sidecar_metadata(
                                     &mut metadata,
                                     package_sidecar
@@ -241,6 +270,9 @@ impl SkillsRegistry {
                                 metadata.mount_mode = mount_mode;
                                 metadata.package_root = package_root.clone();
                                 metadata.resource_root = resource_root.clone();
+                                if let Some(compatible_metadata) = compatibility_metadata.as_ref() {
+                                    metadata.compatible_metadata = compatible_metadata.clone();
+                                }
                                 self.apply_sidecar_metadata(
                                     &mut metadata,
                                     package_sidecar
@@ -778,6 +810,119 @@ capabilities:
     }
 
     #[test]
+    fn load_capability_view_ingests_openai_compatibility_metadata() {
+        let temp = TempDir::new().unwrap();
+        let repo_skills = temp.path().join("skills");
+        let skill_root = repo_skills.join("test-skill");
+        create_test_skill(&repo_skills, "test-skill", "Test Skill", "From repo");
+        std::fs::create_dir_all(skill_root.join("agents")).unwrap();
+        std::fs::write(
+            skill_root.join("agents").join(COMPATIBILITY_METADATA_FILE),
+            r##"
+interface:
+  display_name: "Compatibility Title"
+  short_description: "Compatibility short description"
+  icon_small: "./assets/icon-small.svg"
+  icon_large: "assets/icon-large.svg"
+  brand_color: "#00aa44"
+  default_prompt: "Use this skill carefully."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "openaiDeveloperDocs"
+      description: "OpenAI Docs MCP server"
+"##,
+        )
+        .unwrap();
+
+        let registry = SkillsRegistry::load_package_dirs(&[ScopedPackageDir {
+            path: repo_skills,
+            scope: SkillScope::Repo,
+        }])
+        .unwrap();
+        let skill = registry.get(&"test-skill".to_string()).unwrap();
+        let expected_icon_small = std::fs::canonicalize(skill_root.join("assets/icon-small.svg"))
+            .unwrap_or_else(|_| {
+                std::fs::canonicalize(&skill_root)
+                    .unwrap()
+                    .join("assets/icon-small.svg")
+            });
+        let expected_icon_large = std::fs::canonicalize(skill_root.join("assets/icon-large.svg"))
+            .unwrap_or_else(|_| {
+                std::fs::canonicalize(&skill_root)
+                    .unwrap()
+                    .join("assets/icon-large.svg")
+            });
+
+        assert_eq!(
+            skill.compatible_metadata.interface.display_name.as_deref(),
+            Some("Compatibility Title")
+        );
+        assert_eq!(
+            skill
+                .compatible_metadata
+                .interface
+                .short_description
+                .as_deref(),
+            Some("Compatibility short description")
+        );
+        assert_eq!(
+            skill.compatible_metadata.interface.icon_small.as_deref(),
+            Some(expected_icon_small.as_path())
+        );
+        assert_eq!(
+            skill.compatible_metadata.interface.icon_large.as_deref(),
+            Some(expected_icon_large.as_path())
+        );
+        assert_eq!(
+            skill.compatible_metadata.interface.brand_color.as_deref(),
+            Some("#00aa44")
+        );
+        assert_eq!(
+            skill
+                .compatible_metadata
+                .interface
+                .default_prompt
+                .as_deref(),
+            Some("Use this skill carefully.")
+        );
+        assert_eq!(skill.display_name(), "Compatibility Title");
+        assert_eq!(
+            skill.effective_short_description(),
+            Some("Compatibility short description")
+        );
+        assert_eq!(skill.compatible_metadata.dependencies.tools.len(), 1);
+        assert_eq!(
+            skill.compatible_metadata.dependencies.tools[0]
+                .kind
+                .as_deref(),
+            Some("mcp")
+        );
+    }
+
+    #[test]
+    fn load_capability_view_tracks_openai_compatibility_metadata_for_invalidation() {
+        let temp = TempDir::new().unwrap();
+        let repo_skills = temp.path().join("skills");
+        create_test_skill(&repo_skills, "test-skill", "Test Skill", "From repo");
+        let compatibility_path = repo_skills
+            .join("test-skill")
+            .join(COMPATIBILITY_METADATA_DIR)
+            .join(COMPATIBILITY_METADATA_FILE);
+        std::fs::create_dir_all(compatibility_path.parent().unwrap()).unwrap();
+        std::fs::write(&compatibility_path, "interface: {}\n").unwrap();
+
+        let registry = SkillsRegistry::load_package_dirs(&[ScopedPackageDir {
+            path: repo_skills,
+            scope: SkillScope::Repo,
+        }])
+        .unwrap();
+        let expected_path = std::fs::canonicalize(compatibility_path).unwrap();
+
+        assert!(registry.tracked_paths().contains(&expected_path));
+    }
+
+    #[test]
     fn load_capability_view_tracks_child_agent_export_dir_for_execution_invalidation() {
         let temp = TempDir::new().unwrap();
         let repo_skills = temp.path().join("skills");
@@ -834,6 +979,37 @@ capabilities:
             error
                 .path
                 .ends_with(std::path::Path::new(SKILL_SIDECAR_FILE))
+        }));
+    }
+
+    #[test]
+    fn load_capability_view_invalid_openai_compatibility_metadata_is_non_fatal() {
+        let temp = TempDir::new().unwrap();
+        let repo_skills = temp.path().join("skills");
+        let skill_root = repo_skills.join("test-skill");
+        create_test_skill(&repo_skills, "test-skill", "Test Skill", "From repo");
+        std::fs::create_dir_all(skill_root.join(COMPATIBILITY_METADATA_DIR)).unwrap();
+        std::fs::write(
+            skill_root
+                .join(COMPATIBILITY_METADATA_DIR)
+                .join(COMPATIBILITY_METADATA_FILE),
+            "interface: [",
+        )
+        .unwrap();
+
+        let registry = SkillsRegistry::load_package_dirs(&[ScopedPackageDir {
+            path: repo_skills,
+            scope: SkillScope::Repo,
+        }])
+        .unwrap();
+        let skill = registry.get(&"test-skill".to_string()).unwrap();
+
+        assert_eq!(skill.description, "From repo");
+        assert!(skill.compatible_metadata.is_empty());
+        assert!(registry.errors().iter().any(|error| {
+            error
+                .path
+                .ends_with(std::path::Path::new(COMPATIBILITY_METADATA_FILE))
         }));
     }
 

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -15,6 +15,10 @@ pub type CapabilityPackageId = String;
 pub const SKILL_SIDECAR_FILE: &str = "skill.yaml";
 /// Optional package sidecar filename.
 pub const PACKAGE_SIDECAR_FILE: &str = "package.yaml";
+/// Compatibility metadata directory used by public Codex-style skills.
+pub const COMPATIBILITY_METADATA_DIR: &str = "agents";
+/// Compatibility metadata filename used by public Codex-style skills.
+pub const COMPATIBILITY_METADATA_FILE: &str = "openai.yaml";
 
 /// How a mounted capability package is exposed to the runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
@@ -226,6 +230,10 @@ pub struct SkillMetadata {
     /// Alan-native runtime/UI metadata loaded from optional sidecars.
     #[serde(skip, default)]
     pub alan_metadata: AlanSkillRuntimeMetadata,
+    /// Public compatibility metadata loaded from tolerated sidecars such as
+    /// `agents/openai.yaml`.
+    #[serde(skip, default)]
+    pub compatible_metadata: CompatibleSkillMetadata,
     /// Resolved skill execution state for the current capability package shape.
     #[serde(default)]
     pub execution: ResolvedSkillExecution,
@@ -240,6 +248,22 @@ impl SkillMetadata {
         self.resource_root
             .as_deref()
             .or_else(|| self.package_root())
+    }
+
+    pub fn display_name(&self) -> &str {
+        self.compatible_metadata
+            .interface
+            .display_name
+            .as_deref()
+            .unwrap_or(&self.name)
+    }
+
+    pub fn effective_short_description(&self) -> Option<&str> {
+        self.short_description.as_deref().or(self
+            .compatible_metadata
+            .interface
+            .short_description
+            .as_deref())
     }
 
     pub fn delegated_spawn_target(&self) -> Option<alan_protocol::SpawnTarget> {
@@ -582,6 +606,80 @@ impl SkillCompatibilityOverlay {
     pub fn is_empty(&self) -> bool {
         self.min_version.is_none() && self.requirements.is_none()
     }
+}
+
+/// Public compatibility metadata loaded from tolerated sidecars such as
+/// Codex-style `agents/openai.yaml`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CompatibleSkillMetadata {
+    #[serde(default)]
+    pub interface: CompatibleSkillInterface,
+    #[serde(default)]
+    pub dependencies: CompatibleSkillDependencies,
+}
+
+impl CompatibleSkillMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.interface.is_empty() && self.dependencies.is_empty()
+    }
+}
+
+/// UI-facing compatibility metadata for catalog surfaces.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CompatibleSkillInterface {
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub short_description: Option<String>,
+    #[serde(default)]
+    pub icon_small: Option<PathBuf>,
+    #[serde(default)]
+    pub icon_large: Option<PathBuf>,
+    #[serde(default)]
+    pub brand_color: Option<String>,
+    #[serde(default)]
+    pub default_prompt: Option<String>,
+}
+
+impl CompatibleSkillInterface {
+    pub fn is_empty(&self) -> bool {
+        self.display_name.is_none()
+            && self.short_description.is_none()
+            && self.icon_small.is_none()
+            && self.icon_large.is_none()
+            && self.brand_color.is_none()
+            && self.default_prompt.is_none()
+    }
+}
+
+/// Public compatibility dependency metadata parsed for later typed dependency
+/// ingestion and remediation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CompatibleSkillDependencies {
+    #[serde(default)]
+    pub tools: Vec<CompatibleSkillToolDependency>,
+}
+
+impl CompatibleSkillDependencies {
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CompatibleSkillToolDependency {
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub transport: Option<String>,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
 }
 
 /// Alan-native UI metadata for a skill.
@@ -1625,6 +1723,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
 
@@ -1677,6 +1776,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
 
@@ -1733,6 +1833,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/repo-review/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
 
@@ -1769,6 +1870,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/skill-creator/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: ResolvedSkillExecution::Unresolved {
                 reason: SkillExecutionUnresolvedReason::AmbiguousPackageShape {
                     package_skill_ids: vec!["skill-creator".to_string()],
@@ -1898,6 +2000,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/repo-review/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: AlanSkillRuntimeMetadata::default(),
+            compatible_metadata: Default::default(),
             execution: ResolvedSkillExecution::Delegate {
                 target: "reviewer".to_string(),
                 source: SkillExecutionResolutionSource::SameNameSkillAndChildAgent,
@@ -1934,6 +2037,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
         let host_capabilities = SkillHostCapabilities {
@@ -1973,6 +2077,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/tmp/test-skill/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
         let host_capabilities = SkillHostCapabilities {
@@ -2083,6 +2188,7 @@ description: A test skill
             source: SkillContentSource::File(PathBuf::from("/test/SKILL.md")),
             mount_mode: PackageMountMode::Discoverable,
             alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
             execution: Default::default(),
         };
 

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -250,9 +250,11 @@ runtime contracts:
 - `compatibility.requirements` is advisory remediation text, not a typed
   dependency gate
 - `runtime.ui` is parsed sidecar metadata without a stable runtime consumer
-- public compatibility metadata such as `agents/openai.yaml` and authoring
-  assets such as `agents/*.md` are tolerated, but Alan does not yet treat them
-  as first-class runtime inputs
+- `agents/openai.yaml` compatibility metadata is ingested for catalog/UI-facing
+  interface fields and dependency hints, but it does not replace `SKILL.md` or
+  Alan sidecars as the canonical runtime contract
+- authoring assets such as `agents/*.md` are tolerated, but Alan does not load
+  them as runtime capabilities by default
 
 ### Delegated Skill Execution
 

--- a/docs/spec/skill_system_contract.md
+++ b/docs/spec/skill_system_contract.md
@@ -59,13 +59,17 @@ Unknown extra files must be ignored rather than treated as fatal.
 
 ### Tier 2: Compatibility Metadata
 
-Alan **should** tolerate and eventually consume public compatibility metadata
-when present, especially:
+Alan **should** tolerate and consume public compatibility metadata when
+present, especially:
 
-- `agents/openai.yaml` from Codex-style skills for UI-facing metadata
+- `agents/openai.yaml` from Codex-style skills for UI-facing metadata and
+  dependency hints
 
 This metadata is not part of the core `SKILL.md` portability contract. Unknown
-fields must remain fail-open.
+fields must remain fail-open. `SKILL.md` remains the canonical trigger
+contract; Alan sidecars remain the canonical Alan-native extension surface.
+Compatibility metadata augments catalog/UI surfaces rather than replacing those
+contracts.
 
 ### Tier 3: Authoring / Eval Companion Assets
 


### PR DESCRIPTION
## Summary
- ingest Codex-style `agents/openai.yaml` compatibility metadata during skill loading
- preserve compatibility UI/interface fields in resolved skill metadata and daemon catalog output
- track compatibility metadata files for cache invalidation without changing `SKILL.md` or Alan sidecars as canonical contract

## Testing
- cargo test -p alan-runtime
- cargo test -p alan --test skills_cli_integration_test
- cargo test -p alan skill_catalog
- cargo clippy -p alan-runtime --all-targets -- -D warnings
- cargo clippy -p alan --all-targets -- -D warnings

Refs #209