### PR TITLE
[Skill System][Cleanup] Prune dormant non-contract skill schema

### DIFF
--- a/crates/alan/src/cli/skills.rs
+++ b/crates/alan/src/cli/skills.rs
@@ -268,9 +268,6 @@ fn render_package_exports(package: &alan_runtime::skills::CapabilityPackage) -> 
     if package.exports.resources.assets_dir.is_some() {
         resources.push("assets");
     }
-    if package.exports.resources.viewers_dir.is_some() {
-        resources.push("viewers");
-    }
     if !resources.is_empty() {
         exports.push(format!("resources={}", resources.join("+")));
     }

--- a/crates/alan/src/skill_catalog.rs
+++ b/crates/alan/src/skill_catalog.rs
@@ -75,8 +75,6 @@ pub struct SkillCatalogResourceExportsSnapshot {
     pub references_dir: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assets_dir: Option<PathBuf>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub viewers_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -371,7 +369,6 @@ fn build_resource_snapshot(
         scripts_dir: resources.scripts_dir.clone(),
         references_dir: resources.references_dir.clone(),
         assets_dir: resources.assets_dir.clone(),
-        viewers_dir: resources.viewers_dir.clone(),
     }
 }
 

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -19,7 +19,6 @@ metadata:
   tags: [memory, persistence, long-running, context-management]
 capabilities:
   required_tools: [read_file, write_file, edit_file, bash]
-  optional_tools: [grep]
   triggers:
     keywords: [remember, recall, memory, session history, last time, before, previous]
     patterns: ["remember.*last", "what.*we.*did", "continue.*from", "pick.*up.*where"]

--- a/crates/runtime/src/approval.rs
+++ b/crates/runtime/src/approval.rs
@@ -228,7 +228,6 @@ mod tests {
                 mount_mode: crate::skills::PackageMountMode::Discoverable,
                 alan_metadata: crate::skills::AlanSkillRuntimeMetadata {
                     permission_hints: vec!["may require network approval".to_string()],
-                    ui: Default::default(),
                     execution: Default::default(),
                 },
                 compatible_metadata: Default::default(),

--- a/crates/runtime/src/skills/capability_view.rs
+++ b/crates/runtime/src/skills/capability_view.rs
@@ -140,7 +140,6 @@ fn package_exports_for_root_dir(
             scripts_dir: existing_dir(root_dir.join("scripts")),
             references_dir: existing_dir(root_dir.join("references")),
             assets_dir: existing_dir(root_dir.join("assets")),
-            viewers_dir: existing_dir(root_dir.join("viewers")),
         },
     }
 }
@@ -252,7 +251,6 @@ Body
         std::fs::create_dir_all(skill_dir.join("scripts")).unwrap();
         std::fs::create_dir_all(skill_dir.join("references")).unwrap();
         std::fs::create_dir_all(skill_dir.join("assets")).unwrap();
-        std::fs::create_dir_all(skill_dir.join("viewers")).unwrap();
         std::fs::create_dir_all(skill_dir.join("agents/reviewer")).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -320,16 +318,6 @@ Body
                 .and_then(|path| std::fs::canonicalize(path).ok())
                 .as_deref(),
             Some(canonical_skill_dir.join("assets").as_path())
-        );
-        assert_eq!(
-            package
-                .exports
-                .resources
-                .viewers_dir
-                .as_deref()
-                .and_then(|path| std::fs::canonicalize(path).ok())
-                .as_deref(),
-            Some(canonical_skill_dir.join("viewers").as_path())
         );
     }
 

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -655,9 +655,6 @@ skill_defaults:
   runtime:
     permission_hints:
       - "package hint"
-    ui:
-      title: "Package Title"
-      category: "package-category"
 "#,
         )
         .unwrap();
@@ -670,8 +667,6 @@ capabilities:
 runtime:
   permission_hints:
     - "skill hint"
-  ui:
-    title: "Skill Title"
 "#,
         )
         .unwrap();
@@ -691,11 +686,6 @@ runtime:
             skill.alan_metadata.permission_hints,
             vec!["package hint".to_string(), "skill hint".to_string()]
         );
-        assert_eq!(skill.alan_metadata.ui.title.as_deref(), Some("Skill Title"));
-        assert_eq!(
-            skill.alan_metadata.ui.category.as_deref(),
-            Some("package-category")
-        );
     }
 
     #[test]
@@ -713,7 +703,6 @@ capabilities:
   triggers:
     explicit: ["base-alias"]
     patterns: ["base.*pattern"]
-    semantic: "base semantic"
     negative_keywords: ["skip-base"]
   disclosure:
     level2: "instructions/expanded.md"
@@ -763,10 +752,6 @@ capabilities:
         assert_eq!(
             capabilities.triggers.patterns,
             vec!["base.*pattern".to_string()]
-        );
-        assert_eq!(
-            capabilities.triggers.semantic.as_deref(),
-            Some("base semantic")
         );
         assert_eq!(
             capabilities.triggers.negative_keywords,

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -111,15 +111,11 @@ pub struct CapabilityPackageResources {
     pub scripts_dir: Option<PathBuf>,
     pub references_dir: Option<PathBuf>,
     pub assets_dir: Option<PathBuf>,
-    pub viewers_dir: Option<PathBuf>,
 }
 
 impl CapabilityPackageResources {
     pub fn is_empty(&self) -> bool {
-        self.scripts_dir.is_none()
-            && self.references_dir.is_none()
-            && self.assets_dir.is_none()
-            && self.viewers_dir.is_none()
+        self.scripts_dir.is_none() && self.references_dir.is_none() && self.assets_dir.is_none()
     }
 }
 
@@ -349,12 +345,6 @@ pub struct SkillCapabilities {
     /// Required tools - must be available for skill to function
     #[serde(default)]
     pub required_tools: Vec<String>,
-    /// Optional tools - enhance functionality but not required
-    #[serde(default)]
-    pub optional_tools: Vec<String>,
-    /// Applicable domains (empty = universal)
-    #[serde(default)]
-    pub domains: Vec<String>,
     /// Trigger conditions for automatic skill selection
     #[serde(default)]
     pub triggers: SkillTriggers,
@@ -367,12 +357,6 @@ impl SkillCapabilities {
     pub fn apply_overlay(&mut self, overlay: &SkillCapabilitiesOverlay) {
         if let Some(required_tools) = overlay.required_tools.as_ref() {
             self.required_tools = required_tools.clone();
-        }
-        if let Some(optional_tools) = overlay.optional_tools.as_ref() {
-            self.optional_tools = optional_tools.clone();
-        }
-        if let Some(domains) = overlay.domains.as_ref() {
-            self.domains = domains.clone();
         }
         if let Some(triggers) = overlay.triggers.as_ref() {
             self.triggers.apply_overlay(triggers);
@@ -389,10 +373,6 @@ pub struct SkillCapabilitiesOverlay {
     #[serde(default)]
     pub required_tools: Option<Vec<String>>,
     #[serde(default)]
-    pub optional_tools: Option<Vec<String>>,
-    #[serde(default)]
-    pub domains: Option<Vec<String>>,
-    #[serde(default)]
     pub triggers: Option<SkillTriggersOverlay>,
     #[serde(default)]
     pub disclosure: Option<DisclosureConfigOverlay>,
@@ -401,8 +381,6 @@ pub struct SkillCapabilitiesOverlay {
 impl SkillCapabilitiesOverlay {
     pub fn is_empty(&self) -> bool {
         self.required_tools.is_none()
-            && self.optional_tools.is_none()
-            && self.domains.is_none()
             && self
                 .triggers
                 .as_ref()
@@ -428,9 +406,6 @@ pub struct SkillTriggers {
     /// Regex patterns for advanced matching
     #[serde(default)]
     pub patterns: Vec<String>,
-    /// Semantic description for LLM-based triggering
-    #[serde(default)]
-    pub semantic: Option<String>,
     /// Negative keywords - if matched, skill should not trigger
     #[serde(default)]
     pub negative_keywords: Vec<String>,
@@ -446,9 +421,6 @@ impl SkillTriggers {
         }
         if let Some(patterns) = overlay.patterns.as_ref() {
             self.patterns = patterns.clone();
-        }
-        if let Some(semantic) = overlay.semantic.as_ref() {
-            self.semantic = Some(semantic.clone());
         }
         if let Some(negative_keywords) = overlay.negative_keywords.as_ref() {
             self.negative_keywords = negative_keywords.clone();
@@ -466,8 +438,6 @@ pub struct SkillTriggersOverlay {
     #[serde(default)]
     pub patterns: Option<Vec<String>>,
     #[serde(default)]
-    pub semantic: Option<String>,
-    #[serde(default)]
     pub negative_keywords: Option<Vec<String>>,
 }
 
@@ -476,7 +446,6 @@ impl SkillTriggersOverlay {
         self.explicit.is_none()
             && self.keywords.is_none()
             && self.patterns.is_none()
-            && self.semantic.is_none()
             && self.negative_keywords.is_none()
     }
 }
@@ -722,30 +691,6 @@ pub struct CompatibleSkillToolDependency {
     pub url: Option<String>,
 }
 
-/// Alan-native UI metadata for a skill.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct AlanSkillUiMetadata {
-    #[serde(default)]
-    pub title: Option<String>,
-    #[serde(default)]
-    pub category: Option<String>,
-}
-
-impl AlanSkillUiMetadata {
-    pub fn is_empty(&self) -> bool {
-        self.title.is_none() && self.category.is_none()
-    }
-
-    pub fn apply_overlay(&mut self, overlay: &Self) {
-        if let Some(title) = overlay.title.as_ref() {
-            self.title = Some(title.clone());
-        }
-        if let Some(category) = overlay.category.as_ref() {
-            self.category = Some(category.clone());
-        }
-    }
-}
-
 /// Author-declared execution mode from Alan sidecar metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -784,14 +729,12 @@ pub struct AlanSkillRuntimeMetadata {
     #[serde(default)]
     pub permission_hints: Vec<String>,
     #[serde(default)]
-    pub ui: AlanSkillUiMetadata,
-    #[serde(default)]
     pub execution: AlanSkillExecutionMetadata,
 }
 
 impl AlanSkillRuntimeMetadata {
     pub fn is_empty(&self) -> bool {
-        self.permission_hints.is_empty() && self.ui.is_empty() && self.execution.is_empty()
+        self.permission_hints.is_empty() && self.execution.is_empty()
     }
 
     pub fn apply_overlay(&mut self, overlay: &Self) {
@@ -800,7 +743,6 @@ impl AlanSkillRuntimeMetadata {
                 self.permission_hints.push(hint.clone());
             }
         }
-        self.ui.apply_overlay(&overlay.ui);
         self.execution.apply_overlay(&overlay.execution);
     }
 }
@@ -1581,10 +1523,6 @@ pub fn validate_skill_metadata(
 pub fn validate_capabilities(cap: &SkillCapabilities) -> Result<(), SkillsError> {
     // Validate tool names (should not contain spaces or special chars)
     for tool in &cap.required_tools {
-        validate_tool_name(tool)?;
-    }
-
-    for tool in &cap.optional_tools {
         validate_tool_name(tool)?;
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ A standards-compatible skill directory with `SKILL.md` and optional supporting
 resources is adapted automatically as a single-skill package. Directory-backed
 packages currently expose one portable skill plus optional Alan-native
 child-agent roots from `agents/` and resource directories such as `scripts/`,
-`references/`, `assets/`, and `viewers/`. Package hosting therefore stays in
+`references/`, and `assets/`. Package hosting therefore stays in
 the definition layer without requiring an Alan-specific manifest for every
 public skill directory.
 

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -237,19 +237,17 @@ contract:
 - delegated skill execution with package-local child-agent targets
 - daemon skill catalog, changed-cursor polling, and mount-override writes
 
-The following fields are parsed and preserved, but they are not yet first-class
-runtime contracts:
+The following inputs are tolerated for compatibility, but they are not
+preserved as resolved runtime contract:
 
-- `capabilities.optional_tools` is descriptive only; it does not affect
-  activation or availability
-- `capabilities.domains` is stored metadata only
-- `capabilities.triggers.semantic` is stored and merged, but automatic
-  activation is currently deterministic only
-- `viewers/` exports are discovered and surfaced in CLI/catalog output, but
-  Alan does not yet define a runtime or daemon viewer-consumption contract
+- `capabilities.optional_tools`, `capabilities.domains`, and
+  `capabilities.triggers.semantic` are ignored compatibility fields
+- `viewers/` directories are tolerated in package trees, but Alan does not
+  export them through the capability view, CLI, or daemon skill catalog
 - `compatibility.requirements` is advisory remediation text, not a typed
   dependency gate
-- `runtime.ui` is parsed sidecar metadata without a stable runtime consumer
+- `runtime.ui` is tolerated sidecar input without a stable runtime consumer and
+  is not preserved in resolved runtime metadata
 - `agents/openai.yaml` compatibility metadata is ingested for catalog/UI-facing
   interface fields and dependency hints; currently recognized dependency kinds
   are folded into the same typed availability model only for env vars, tools,
@@ -399,7 +397,7 @@ Overlay order is:
 - Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
 
 A standards-compatible skill directory with `SKILL.md` and optional
-`scripts/`, `references/`, `assets/`, `viewers/`, or child-agent roots under
+`scripts/`, `references/`, `assets/`, or child-agent roots under
 `agents/` is adapted automatically into a single-skill package. This keeps
 public skill compatibility without requiring a custom `package.toml`.
 

--- a/docs/spec/skill_system_contract.md
+++ b/docs/spec/skill_system_contract.md
@@ -153,18 +153,16 @@ public skill interoperability.
 - `compatibility.requirements` is advisory remediation text only. It is not a
   typed availability gate.
 
-### Parsed But Not Stable Contract
+### Tolerated But Ignored Compatibility Input
 
-The following fields may be tolerated for forward compatibility, but they are
-not part of Alan's stable skill contract and must not be treated as required
-authoring surface:
+The following fields may appear in public skill assets, but Alan does not
+preserve or consume them as part of the resolved runtime contract:
 
 - `capabilities.optional_tools`
 - `capabilities.domains`
 - `capabilities.triggers.semantic`
 
-If Alan continues parsing them, that is compatibility tolerance rather than a
-stable behavior guarantee.
+They are tolerated as compatibility input, not as stable behavior.
 
 ## Alan Sidecar Contract
 
@@ -184,12 +182,12 @@ Stable Alan-native keys:
 `package.yaml` may provide `skill_defaults` with the same stable keys as
 `skill.yaml`. Package defaults apply before the skill-local sidecar.
 
-### Not Yet Stable
+### Tolerated But Ignored
 
 - `runtime.ui`
 
-Alan may continue to parse this data, but it is not part of the stable contract
-until a real consumer exists.
+Alan may tolerate this input, but it is not part of the stable contract and is
+not preserved in resolved runtime metadata.
 
 ## Discovery Contract
 
@@ -404,9 +402,9 @@ These are intentionally outside the stable skill contract for now:
 - multi-skill filesystem packages
 - semantic trigger activation
 - `domains` and `optional_tools` as activation or availability semantics
-- `viewers/` as a runtime contract
+- `viewers/` as a capability export or runtime contract
 - `runtime.ui` as stable behavior
 - nested delegated execution in V1
 
-If Alan keeps parsing some of these for compatibility, that must not be
+If Alan tolerates some of these as compatibility input, that must not be
 mistaken for a stable behavior promise.


### PR DESCRIPTION
## Summary
- drop dormant non-contract fields from resolved skill metadata and sidecar overlays
- stop exporting `viewers/` through capability view, CLI, and daemon catalog surfaces
- tighten docs and built-in skill assets to match the consolidated skill-system contract

## Testing
- cargo test -p alan-runtime
- cargo test -p alan --test skills_cli_integration_test
- cargo test -p alan skill_catalog
- cargo clippy -p alan-runtime --all-targets -- -D warnings
- cargo clippy -p alan --all-targets -- -D warnings

Refs #213