### PR TITLE
Align TUI confirmation handling with the UX contract

### DIFF
--- a/clients/tui/src/adaptive-surfaces/confirmation-surface.test.ts
+++ b/clients/tui/src/adaptive-surfaces/confirmation-surface.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import {
-  buildConfirmationDetailRows,
-  preferredConfirmationActionIndex,
-} from "./confirmation-surface";
+import { buildConfirmationDetailRows } from "./confirmation-surface";
+import { preferredConfirmationActionIndex } from "../yield";
 
 describe("confirmation surface helpers", () => {
   test("preferred action respects explicit defaults before approve", () => {
@@ -80,6 +78,18 @@ describe("confirmation surface helpers", () => {
     ).toEqual([
       { label: "command", value: "rm -rf /tmp/demo", color: "cyan" },
       { label: "diff", value: "--- before\n+++ after", color: "gray" },
+      { label: "policy.action", value: "escalate" },
+    ]);
+  });
+
+  test("detail rows keep tool name above policy metadata", () => {
+    expect(
+      buildConfirmationDetailRows({
+        policy: { action: "escalate" },
+        tool_name: "bash",
+      }),
+    ).toEqual([
+      { label: "tool name", value: "bash", color: "cyan" },
       { label: "policy.action", value: "escalate" },
     ]);
   });

--- a/clients/tui/src/adaptive-surfaces/confirmation-surface.test.ts
+++ b/clients/tui/src/adaptive-surfaces/confirmation-surface.test.ts
@@ -5,9 +5,15 @@ import {
 } from "./confirmation-surface";
 
 describe("confirmation surface helpers", () => {
-  test("preferred action focuses approve when available", () => {
+  test("preferred action respects explicit defaults before approve", () => {
     expect(
-      preferredConfirmationActionIndex(["reject", "approve", "modify"]),
+      preferredConfirmationActionIndex(
+        ["reject", "approve", "modify"],
+        "modify",
+      ),
+    ).toBe(2);
+    expect(
+      preferredConfirmationActionIndex(["reject", "approve", "modify"], "skip"),
     ).toBe(1);
     expect(preferredConfirmationActionIndex(["modify", "reject"])).toBe(0);
   });
@@ -55,12 +61,26 @@ describe("confirmation surface helpers", () => {
       }),
     ).toEqual([
       { label: "replay tool", value: "edit_file", color: "cyan" },
+      { label: "replay tool attempts", value: "2" },
       {
         label: "replay tool preview",
         value: "diff preview",
         color: "gray",
       },
-      { label: "replay tool attempts", value: "2" },
+    ]);
+  });
+
+  test("detail rows prioritize common command and policy fields", () => {
+    expect(
+      buildConfirmationDetailRows({
+        policy: { action: "escalate" },
+        command: "rm -rf /tmp/demo",
+        diff: "--- before\n+++ after",
+      }),
+    ).toEqual([
+      { label: "command", value: "rm -rf /tmp/demo", color: "cyan" },
+      { label: "diff", value: "--- before\n+++ after", color: "gray" },
+      { label: "policy.action", value: "escalate" },
     ]);
   });
 });

--- a/clients/tui/src/adaptive-surfaces/confirmation-surface.tsx
+++ b/clients/tui/src/adaptive-surfaces/confirmation-surface.tsx
@@ -5,6 +5,9 @@ import {
   confirmationDefaultOption,
   confirmationDetails,
   confirmationIsDangerous,
+  preferredConfirmationActionIndex,
+  resolveConfirmationDefaultOption,
+  resolveDangerousConfirmationAction,
   confirmationSummary,
 } from "../yield.js";
 import type {
@@ -89,7 +92,9 @@ function detailRowColor(key: string): string | undefined {
 function detailRowPriority(label: string): number {
   if (label === "command") return 0;
   if (label === "path") return 1;
-  if (label === "tool" || label === "replay tool") return 2;
+  if (label === "tool" || label === "tool name" || label === "replay tool") {
+    return 2;
+  }
   if (label === "call id" || label === "replay call id") return 3;
   if (label === "arguments") return 4;
   if (label === "diff") return 5;
@@ -186,37 +191,58 @@ export function buildConfirmationDetailRows(
   });
 }
 
-export function preferredConfirmationActionIndex(
-  options: string[],
-  defaultOption?: string | null,
-): number {
-  if (defaultOption) {
-    const defaultIndex = options.findIndex((option) => option === defaultOption);
-    if (defaultIndex >= 0) {
-      return defaultIndex;
-    }
-  }
-  const approveIndex = options.findIndex((option) => option === "approve");
-  return approveIndex >= 0 ? approveIndex : 0;
-}
-
 function confirmationActionStyle(
   option: string,
   isActive: boolean,
-  dangerousConfirmation: boolean,
+  dangerousAction: string | null,
 ): { color: string; backgroundColor?: string } {
-  const dangerousAction = dangerousConfirmation && option === "approve";
+  const isDangerousAction = dangerousAction === option;
 
-  if (isActive && dangerousAction) {
+  if (isActive && isDangerousAction) {
     return { color: "white", backgroundColor: "red" };
   }
   if (isActive) {
     return { color: "black", backgroundColor: "yellow" };
   }
-  if (dangerousAction) {
+  if (isDangerousAction) {
     return { color: "red" };
   }
   return { color: "yellow" };
+}
+
+function confirmationShortcutHints(
+  options: string[],
+  activeAction?: string,
+): string[] {
+  const hints = [activeAction ? `Enter ${activeAction}` : "Enter confirm"];
+  if (options.length > 1) {
+    hints.push("←/→ select");
+    hints.push("1-9 choose");
+  }
+  if (options.includes("approve")) {
+    hints.push("A approve");
+  }
+  if (options.includes("modify")) {
+    hints.push("M modify");
+  }
+  if (options.includes("reject")) {
+    hints.push("R reject");
+  }
+  return hints;
+}
+
+function confirmationSlashCommands(options: string[]): string[] {
+  const commands: string[] = [];
+  if (options.includes("approve")) {
+    commands.push("/approve");
+  }
+  if (options.includes("reject")) {
+    commands.push("/reject");
+  }
+  if (options.includes("modify")) {
+    commands.push("/modify <text>");
+  }
+  return commands;
 }
 
 function executeConfirmationAction(
@@ -246,7 +272,14 @@ function renderConfirmationSurface({
   const summary = confirmationSummary(pendingYield.payload);
   const options = confirmationActionOptions(pendingYield.payload);
   const defaultOption = confirmationDefaultOption(pendingYield.payload);
+  const resolvedDefaultOption = resolveConfirmationDefaultOption(
+    options,
+    defaultOption,
+  );
   const dangerousConfirmation = confirmationIsDangerous(pendingYield.payload);
+  const dangerousAction = dangerousConfirmation
+    ? resolveDangerousConfirmationAction(options, defaultOption)
+    : null;
   const detailRows = buildConfirmationDetailRows(
     confirmationDetails(pendingYield.payload),
   );
@@ -277,28 +310,38 @@ function renderConfirmationSurface({
           const style = confirmationActionStyle(
             option,
             isActive,
-            dangerousConfirmation,
+            dangerousAction,
           );
           return (
             <Box key={option} marginRight={1}>
-              <Text bold color={style.color} backgroundColor={style.backgroundColor}>
+              <Text
+                bold
+                color={style.color}
+                backgroundColor={style.backgroundColor}
+              >
                 {actionShortcut(option, index)} {humanizeAction(option)}
               </Text>
             </Box>
           );
         })}
       </Box>
-      {defaultOption ? (
-        <Text color="gray">Default action: {humanizeAction(defaultOption)}</Text>
+      {resolvedDefaultOption ? (
+        <Text color="gray">
+          Default action: {humanizeAction(resolvedDefaultOption)}
+        </Text>
       ) : null}
       {dangerousConfirmation ? (
         <Text color="red">
-          Approving will allow a dangerous action. Review details carefully.
+          {dangerousAction
+            ? `${humanizeAction(dangerousAction)} will allow a dangerous action. Review details carefully.`
+            : "This confirmation includes a dangerous action. Review details carefully."}
         </Text>
       ) : null}
       <Text color="gray">
-        Enter confirm | ←/→ select | A approve | M modify | R reject | slash
-        commands still work
+        {[
+          ...confirmationShortcutHints(options),
+          ...confirmationSlashCommands(options),
+        ].join(" | ")}
       </Text>
     </AdaptiveSurfacePanel>
   );
@@ -325,8 +368,13 @@ function buildConfirmationAnnouncement(
   });
   messages.push({
     type: "system_message",
-    message:
-      "Use Enter/arrow shortcuts in the Action panel, or /approve, /reject, /modify <text>.",
+    message: (() => {
+      const hints = confirmationShortcutHints(options).join(", ");
+      const slashCommands = confirmationSlashCommands(options);
+      return slashCommands.length > 0
+        ? `Use ${hints} in the Action panel, or ${slashCommands.join(", ")}.`
+        : `Use ${hints} in the Action panel.`;
+    })(),
   });
   return messages;
 }
@@ -336,7 +384,10 @@ function confirmationFooterHint({
 }: AdaptiveSurfaceRenderContext) {
   const activeAction =
     confirmation?.options[confirmation.actionIndex] ?? "approve";
-  return `Confirm: Enter ${activeAction} | ←/→ select | A approve | M modify | R reject`;
+  return `Confirm: ${confirmationShortcutHints(
+    confirmation?.options ?? ["approve", "modify", "reject"],
+    activeAction,
+  ).join(" | ")}`;
 }
 
 function confirmationLabel({ inputValue }: AdaptiveSurfaceInputContext) {

--- a/clients/tui/src/adaptive-surfaces/confirmation-surface.tsx
+++ b/clients/tui/src/adaptive-surfaces/confirmation-surface.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Box, Text } from "ink";
 import {
   confirmationActionOptions,
+  confirmationDefaultOption,
   confirmationDetails,
+  confirmationIsDangerous,
   confirmationSummary,
 } from "../yield.js";
 import type {
@@ -84,6 +86,18 @@ function detailRowColor(key: string): string | undefined {
   return undefined;
 }
 
+function detailRowPriority(label: string): number {
+  if (label === "command") return 0;
+  if (label === "path") return 1;
+  if (label === "tool" || label === "replay tool") return 2;
+  if (label === "call id" || label === "replay call id") return 3;
+  if (label === "arguments") return 4;
+  if (label === "diff") return 5;
+  if (label.startsWith("policy.")) return 6;
+  if (label.startsWith("replay tool ")) return 7;
+  return 20;
+}
+
 export function buildConfirmationDetailRows(
   details: Record<string, unknown> | null,
 ): ConfirmationDetailRow[] {
@@ -162,12 +176,47 @@ export function buildConfirmationDetailRows(
     });
   }
 
-  return rows;
+  return rows.sort((left, right) => {
+    const priorityDelta =
+      detailRowPriority(left.label) - detailRowPriority(right.label);
+    if (priorityDelta !== 0) {
+      return priorityDelta;
+    }
+    return left.label.localeCompare(right.label);
+  });
 }
 
-export function preferredConfirmationActionIndex(options: string[]): number {
+export function preferredConfirmationActionIndex(
+  options: string[],
+  defaultOption?: string | null,
+): number {
+  if (defaultOption) {
+    const defaultIndex = options.findIndex((option) => option === defaultOption);
+    if (defaultIndex >= 0) {
+      return defaultIndex;
+    }
+  }
   const approveIndex = options.findIndex((option) => option === "approve");
   return approveIndex >= 0 ? approveIndex : 0;
+}
+
+function confirmationActionStyle(
+  option: string,
+  isActive: boolean,
+  dangerousConfirmation: boolean,
+): { color: string; backgroundColor?: string } {
+  const dangerousAction = dangerousConfirmation && option === "approve";
+
+  if (isActive && dangerousAction) {
+    return { color: "white", backgroundColor: "red" };
+  }
+  if (isActive) {
+    return { color: "black", backgroundColor: "yellow" };
+  }
+  if (dangerousAction) {
+    return { color: "red" };
+  }
+  return { color: "yellow" };
 }
 
 function executeConfirmationAction(
@@ -196,11 +245,14 @@ function renderConfirmationSurface({
 }: AdaptiveSurfaceRenderContext) {
   const summary = confirmationSummary(pendingYield.payload);
   const options = confirmationActionOptions(pendingYield.payload);
+  const defaultOption = confirmationDefaultOption(pendingYield.payload);
+  const dangerousConfirmation = confirmationIsDangerous(pendingYield.payload);
   const detailRows = buildConfirmationDetailRows(
     confirmationDetails(pendingYield.payload),
   );
   const actionIndex =
-    confirmation?.actionIndex ?? preferredConfirmationActionIndex(options);
+    confirmation?.actionIndex ??
+    preferredConfirmationActionIndex(options, defaultOption);
 
   return (
     <AdaptiveSurfacePanel
@@ -222,19 +274,28 @@ function renderConfirmationSurface({
       <Box marginTop={1} flexWrap="wrap">
         {options.map((option, index) => {
           const isActive = index === actionIndex;
+          const style = confirmationActionStyle(
+            option,
+            isActive,
+            dangerousConfirmation,
+          );
           return (
             <Box key={option} marginRight={1}>
-              <Text
-                bold
-                color={isActive ? "black" : "yellow"}
-                backgroundColor={isActive ? "yellow" : undefined}
-              >
+              <Text bold color={style.color} backgroundColor={style.backgroundColor}>
                 {actionShortcut(option, index)} {humanizeAction(option)}
               </Text>
             </Box>
           );
         })}
       </Box>
+      {defaultOption ? (
+        <Text color="gray">Default action: {humanizeAction(defaultOption)}</Text>
+      ) : null}
+      {dangerousConfirmation ? (
+        <Text color="red">
+          Approving will allow a dangerous action. Review details carefully.
+        </Text>
+      ) : null}
       <Text color="gray">
         Enter confirm | ←/→ select | A approve | M modify | R reject | slash
         commands still work

--- a/clients/tui/src/adaptive-surfaces/view-model.test.ts
+++ b/clients/tui/src/adaptive-surfaces/view-model.test.ts
@@ -28,6 +28,7 @@ describe("adaptive surface view model", () => {
     const viewModel = buildAdaptiveSurfaceViewModel({
       pendingYield,
       confirmationActionIndex: 0,
+      confirmationActionRequestId: null,
       structuredFormState: createStructuredFormState("req-1", [
         {
           id: "branch",
@@ -67,6 +68,7 @@ describe("adaptive surface view model", () => {
         },
       },
       confirmationActionIndex: 0,
+      confirmationActionRequestId: null,
       structuredFormState: null,
       schemaFormState: null,
     });
@@ -104,6 +106,7 @@ describe("adaptive surface view model", () => {
     const viewModel = buildAdaptiveSurfaceViewModel({
       pendingYield,
       confirmationActionIndex: 0,
+      confirmationActionRequestId: null,
       structuredFormState: null,
       schemaFormState: createStructuredFormState("req-2", [
         {
@@ -136,11 +139,35 @@ describe("adaptive surface view model", () => {
         },
       },
       confirmationActionIndex: 0,
+      confirmationActionRequestId: null,
       structuredFormState: null,
       schemaFormState: null,
     });
 
     expect(viewModel.pendingSchemaForm).toBeNull();
     expect(isAdaptiveSurfaceReadyForInput(viewModel)).toBe(true);
+  });
+
+  test("uses the payload default for a new confirmation request before local state syncs", () => {
+    const viewModel = buildAdaptiveSurfaceViewModel({
+      pendingYield: {
+        requestId: "req-4",
+        kind: "confirmation",
+        payload: {
+          summary: "Proceed?",
+          options: ["approve", "reject"],
+          default_option: "reject",
+        },
+      },
+      confirmationActionIndex: 0,
+      confirmationActionRequestId: "req-3",
+      structuredFormState: null,
+      schemaFormState: null,
+    });
+
+    expect(viewModel.adaptiveSurfaceContext?.confirmation).toEqual({
+      actionIndex: 1,
+      options: ["approve", "reject"],
+    });
   });
 });

--- a/clients/tui/src/adaptive-surfaces/view-model.ts
+++ b/clients/tui/src/adaptive-surfaces/view-model.ts
@@ -8,6 +8,8 @@ import {
 } from "../schema-driven-yield.js";
 import {
   confirmationActionOptions,
+  confirmationDefaultOption,
+  preferredConfirmationActionIndex,
   structuredQuestions,
   type StructuredQuestion,
 } from "../yield.js";
@@ -30,16 +32,45 @@ export interface AdaptiveSurfaceViewModel {
 export interface BuildAdaptiveSurfaceViewModelInput {
   pendingYield: PendingYield | null;
   confirmationActionIndex: number;
+  confirmationActionRequestId: string | null;
   structuredFormState: StructuredFormState | null;
   schemaFormState: StructuredFormState | null;
+}
+
+function clampConfirmationActionIndex(
+  actionIndex: number,
+  optionCount: number,
+): number {
+  if (optionCount <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(actionIndex, 0), optionCount - 1);
 }
 
 export function buildAdaptiveSurfaceViewModel({
   pendingYield,
   confirmationActionIndex,
+  confirmationActionRequestId,
   structuredFormState,
   schemaFormState,
 }: BuildAdaptiveSurfaceViewModelInput): AdaptiveSurfaceViewModel {
+  const confirmationOptions =
+    pendingYield?.kind === "confirmation"
+      ? confirmationActionOptions(pendingYield.payload)
+      : [];
+  const confirmationActionIndexForRequest =
+    pendingYield?.kind === "confirmation"
+      ? confirmationActionRequestId === pendingYield.requestId
+        ? clampConfirmationActionIndex(
+            confirmationActionIndex,
+            confirmationOptions.length,
+          )
+        : preferredConfirmationActionIndex(
+            confirmationOptions,
+            confirmationDefaultOption(pendingYield.payload),
+          )
+      : 0;
   const pendingStructuredQuestions =
     pendingYield?.kind === "structured_input"
       ? structuredQuestions(pendingYield.payload)
@@ -67,8 +98,8 @@ export function buildAdaptiveSurfaceViewModel({
         confirmation:
           pendingYield.kind === "confirmation"
             ? {
-                actionIndex: confirmationActionIndex,
-                options: confirmationActionOptions(pendingYield.payload),
+                actionIndex: confirmationActionIndexForRequest,
+                options: confirmationOptions,
               }
             : undefined,
         schemaForm: pendingSchemaForm

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -27,7 +27,6 @@ import type {
 } from "./types.js";
 import { MessageList } from "./components.js";
 import { InitWizard } from "./init.js";
-import { preferredConfirmationActionIndex } from "./adaptive-surfaces/confirmation-surface.js";
 import { getAdaptiveSurface } from "./adaptive-surfaces/registry.js";
 import {
   buildSchemaDrivenYieldPayload,
@@ -55,6 +54,7 @@ import {
 import {
   confirmationActionOptions,
   confirmationDefaultOption,
+  preferredConfirmationActionIndex,
   structuredQuestions,
   usesMultiSelectKind,
   usesSingleSelectKind,
@@ -271,6 +271,8 @@ function App() {
   const [shellRunStatus, setShellRunStatus] =
     useState<ShellRunStatus>("starting");
   const [confirmationActionIndex, setConfirmationActionIndex] = useState(0);
+  const [confirmationActionRequestId, setConfirmationActionRequestId] =
+    useState<string | null>(null);
   const [schemaFormState, setSchemaFormState] =
     useState<StructuredFormState | null>(null);
   const [structuredFormState, setStructuredFormState] =
@@ -283,6 +285,7 @@ function App() {
   const adaptiveSurfaceViewModel = buildAdaptiveSurfaceViewModel({
     pendingYield,
     confirmationActionIndex,
+    confirmationActionRequestId,
     structuredFormState,
     schemaFormState,
   });
@@ -316,21 +319,6 @@ function App() {
       Boolean(pendingYield),
     );
   }, [currentSessionId, pendingYield, shellBindingTarget, shellRunStatus]);
-
-  useEffect(() => {
-    if (pendingYield?.kind !== "confirmation") {
-      setConfirmationActionIndex(0);
-      return;
-    }
-
-    const options = confirmationActionOptions(pendingYield.payload);
-    setConfirmationActionIndex(
-      preferredConfirmationActionIndex(
-        options,
-        confirmationDefaultOption(pendingYield.payload),
-      ),
-    );
-  }, [pendingYield]);
 
   useEffect(() => {
     if (
@@ -671,11 +659,15 @@ function App() {
 
       if (envelope.type === "turn_started") {
         setPendingYield(null);
+        setConfirmationActionRequestId(null);
+        setConfirmationActionIndex(0);
         setShellRunStatus("running");
       }
 
       if (envelope.type === "turn_completed") {
         setPendingYield(null);
+        setConfirmationActionRequestId(null);
+        setConfirmationActionIndex(0);
         setShellRunStatus("ready");
       }
 
@@ -685,6 +677,19 @@ function App() {
           kind: parsePendingYieldKind(envelope.kind),
           payload: envelope.payload,
         };
+        if (incoming.kind === "confirmation") {
+          const options = confirmationActionOptions(incoming.payload);
+          setConfirmationActionRequestId(incoming.requestId);
+          setConfirmationActionIndex(
+            preferredConfirmationActionIndex(
+              options,
+              confirmationDefaultOption(incoming.payload),
+            ),
+          );
+        } else {
+          setConfirmationActionRequestId(null);
+          setConfirmationActionIndex(0);
+        }
         setPendingYield(incoming);
         setShellRunStatus("yielded");
         announceYield(incoming);
@@ -699,6 +704,8 @@ function App() {
       setCurrentSessionId(sessionId);
       setCurrentPlan(null);
       setCurrentRuntimeState(createCurrentRuntimeState());
+      setConfirmationActionRequestId(null);
+      setConfirmationActionIndex(0);
       setShellRunStatus("starting");
       addSystemEvent("session_created", sessionId);
     });
@@ -754,6 +761,8 @@ function App() {
           sessionIdRef.current = sessionId;
           setCurrentPlan(null);
           setCurrentRuntimeState(createCurrentRuntimeState());
+          setConfirmationActionRequestId(null);
+          setConfirmationActionIndex(0);
           setCurrentSessionId(sessionId);
           await client.connectToSession(sessionId);
           setShellRunStatus("ready");
@@ -920,6 +929,8 @@ function App() {
         `Resumed ${pendingYield.kind} (${pendingYield.requestId}).`,
       );
       setPendingYield(null);
+      setConfirmationActionRequestId(null);
+      setConfirmationActionIndex(0);
     } catch (error) {
       addSystemEvent(
         "system_error",
@@ -1441,6 +1452,8 @@ function App() {
           sessionIdRef.current = sessionId;
           setCurrentPlan(null);
           setCurrentRuntimeState(createCurrentRuntimeState());
+          setConfirmationActionRequestId(null);
+          setConfirmationActionIndex(0);
           setCurrentSessionId(sessionId);
           setPendingYield(null);
           await client.connectToSession(sessionId);
@@ -1492,6 +1505,8 @@ function App() {
         const previousPlan = currentPlan;
         const previousRuntimeState = currentRuntimeState;
         const previousPendingYield = pendingYield;
+        const previousConfirmationActionRequestId = confirmationActionRequestId;
+        const previousConfirmationActionIndex = confirmationActionIndex;
         const previousShellRunStatus = shellRunStatus;
         const previousReplayState = client.captureReplayState();
         try {
@@ -1504,6 +1519,8 @@ function App() {
           setCurrentPlan(null);
           setCurrentRuntimeState(createCurrentRuntimeState());
           setPendingYield(null);
+          setConfirmationActionRequestId(null);
+          setConfirmationActionIndex(0);
           await client.connectToSession(targetSessionId);
           setShellRunStatus("ready");
 
@@ -1531,6 +1548,10 @@ function App() {
               setCurrentPlan(previousPlan ?? null);
               setCurrentRuntimeState(previousRuntimeState);
               setPendingYield(previousPendingYield ?? null);
+              setConfirmationActionRequestId(
+                previousConfirmationActionRequestId,
+              );
+              setConfirmationActionIndex(previousConfirmationActionIndex);
               await client.connectToSession(previousSessionId, {
                 replayState: previousReplayState,
               });
@@ -1546,6 +1567,8 @@ function App() {
               setCurrentPlan(null);
               setCurrentRuntimeState(createCurrentRuntimeState());
               setPendingYield(null);
+              setConfirmationActionRequestId(null);
+              setConfirmationActionIndex(0);
               setShellRunStatus("error");
               addSystemEvent(
                 "system_error",
@@ -1559,6 +1582,8 @@ function App() {
             setCurrentPlan(null);
             setCurrentRuntimeState(createCurrentRuntimeState());
             setPendingYield(null);
+            setConfirmationActionRequestId(null);
+            setConfirmationActionIndex(0);
             setShellRunStatus("error");
             addSystemEvent(
               "system_error",
@@ -1648,6 +1673,8 @@ function App() {
           await client.interrupt(currentSessionId);
           addSystemEvent("system_message", "Interrupt requested.");
           setPendingYield(null);
+          setConfirmationActionRequestId(null);
+          setConfirmationActionIndex(0);
           setShellRunStatus("ready");
         } catch (error) {
           addSystemEvent(

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -54,6 +54,7 @@ import {
 } from "./structured-input.js";
 import {
   confirmationActionOptions,
+  confirmationDefaultOption,
   structuredQuestions,
   usesMultiSelectKind,
   usesSingleSelectKind,
@@ -323,7 +324,12 @@ function App() {
     }
 
     const options = confirmationActionOptions(pendingYield.payload);
-    setConfirmationActionIndex(preferredConfirmationActionIndex(options));
+    setConfirmationActionIndex(
+      preferredConfirmationActionIndex(
+        options,
+        confirmationDefaultOption(pendingYield.payload),
+      ),
+    );
   }, [pendingYield]);
 
   useEffect(() => {

--- a/clients/tui/src/yield.test.ts
+++ b/clients/tui/src/yield.test.ts
@@ -3,8 +3,11 @@ import {
   confirmationActionOptions,
   asString,
   asStringArray,
+  preferredConfirmationActionIndex,
   confirmationDefaultOption,
   confirmationDetails,
+  resolveConfirmationDefaultOption,
+  resolveDangerousConfirmationAction,
   confirmationIsDangerous,
   confirmationOptions,
   confirmationSummary,
@@ -62,6 +65,45 @@ describe("yield parsing helpers", () => {
       "reject",
     ]);
     expect(confirmationDetails({ summary: "Need approval" })).toBeNull();
+  });
+
+  test("confirmation helpers validate explicit defaults before using them", () => {
+    expect(
+      resolveConfirmationDefaultOption(
+        ["reject", "approve", "modify"],
+        "modify",
+      ),
+    ).toBe("modify");
+    expect(
+      resolveConfirmationDefaultOption(
+        ["reject", "approve", "modify"],
+        "skip",
+      ),
+    ).toBeNull();
+    expect(
+      preferredConfirmationActionIndex(
+        ["reject", "approve", "modify"],
+        "modify",
+      ),
+    ).toBe(2);
+    expect(
+      preferredConfirmationActionIndex(
+        ["reject", "approve", "modify"],
+        "skip",
+      ),
+    ).toBe(1);
+  });
+
+  test("confirmation helpers infer the dangerous action from available options", () => {
+    expect(
+      resolveDangerousConfirmationAction(["continue", "cancel"], "continue"),
+    ).toBe("continue");
+    expect(
+      resolveDangerousConfirmationAction(["approve", "reject"], "reject"),
+    ).toBe("approve");
+    expect(
+      resolveDangerousConfirmationAction(["modify", "reject"], "reject"),
+    ).toBeNull();
   });
 
   test("structured helpers parse title/prompt and valid questions", () => {

--- a/clients/tui/src/yield.test.ts
+++ b/clients/tui/src/yield.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   confirmationActionOptions,
-  confirmationDetails,
   asString,
   asStringArray,
+  confirmationDefaultOption,
+  confirmationDetails,
+  confirmationIsDangerous,
   confirmationOptions,
   confirmationSummary,
   normalizeYieldKind,
@@ -39,11 +41,15 @@ describe("yield parsing helpers", () => {
       summary: "Approve file write?",
       details: { path: "/tmp/example.txt" },
       options: ["approve", "reject", 1],
+      default_option: "reject",
+      presentation_hints: ["dangerous"],
     };
 
     expect(confirmationSummary(payload)).toBe("Approve file write?");
     expect(confirmationOptions(payload)).toEqual(["approve", "reject"]);
     expect(confirmationActionOptions(payload)).toEqual(["approve", "reject"]);
+    expect(confirmationDefaultOption(payload)).toBe("reject");
+    expect(confirmationIsDangerous(payload)).toBe(true);
     expect(confirmationDetails(payload)).toEqual({
       path: "/tmp/example.txt",
     });

--- a/clients/tui/src/yield.ts
+++ b/clients/tui/src/yield.ts
@@ -343,9 +343,23 @@ export function confirmationOptions(payload: unknown): string[] {
   return parseConfirmationPayload(payload)?.options ?? [];
 }
 
+export function confirmationDefaultOption(payload: unknown): string | null {
+  return parseConfirmationPayload(payload)?.default_option ?? null;
+}
+
 export function confirmationActionOptions(payload: unknown): string[] {
   const options = confirmationOptions(payload);
   return options.length > 0 ? options : ["approve", "modify", "reject"];
+}
+
+export function confirmationPresentationHints(
+  payload: unknown,
+): AdaptivePresentationHint[] {
+  return parseConfirmationPayload(payload)?.presentation_hints ?? [];
+}
+
+export function confirmationIsDangerous(payload: unknown): boolean {
+  return confirmationPresentationHints(payload).includes("dangerous");
 }
 
 export function confirmationDetails(

--- a/clients/tui/src/yield.ts
+++ b/clients/tui/src/yield.ts
@@ -347,6 +347,98 @@ export function confirmationDefaultOption(payload: unknown): string | null {
   return parseConfirmationPayload(payload)?.default_option ?? null;
 }
 
+export function resolveConfirmationDefaultOption(
+  options: string[],
+  defaultOption?: string | null,
+): string | null {
+  if (!defaultOption) {
+    return null;
+  }
+
+  return options.includes(defaultOption) ? defaultOption : null;
+}
+
+export function preferredConfirmationActionIndex(
+  options: string[],
+  defaultOption?: string | null,
+): number {
+  const resolvedDefaultOption = resolveConfirmationDefaultOption(
+    options,
+    defaultOption,
+  );
+  if (resolvedDefaultOption) {
+    return options.findIndex((option) => option === resolvedDefaultOption);
+  }
+
+  const approveIndex = options.findIndex((option) => option === "approve");
+  return approveIndex >= 0 ? approveIndex : 0;
+}
+
+function normalizedConfirmationAction(action: string): string {
+  return action.trim().toLowerCase();
+}
+
+function isRejectLikeConfirmationAction(action: string): boolean {
+  const normalized = normalizedConfirmationAction(action);
+  return (
+    normalized === "reject" ||
+    normalized === "deny" ||
+    normalized === "decline" ||
+    normalized === "cancel" ||
+    normalized === "abort" ||
+    normalized === "skip" ||
+    normalized === "stop" ||
+    normalized === "block" ||
+    normalized === "no"
+  );
+}
+
+function isUtilityConfirmationAction(action: string): boolean {
+  return (
+    normalizedConfirmationAction(action) === "modify" ||
+    isRejectLikeConfirmationAction(action)
+  );
+}
+
+export function resolveDangerousConfirmationAction(
+  options: string[],
+  defaultOption?: string | null,
+): string | null {
+  const resolvedDefaultOption = resolveConfirmationDefaultOption(
+    options,
+    defaultOption,
+  );
+  if (
+    resolvedDefaultOption &&
+    !isUtilityConfirmationAction(resolvedDefaultOption)
+  ) {
+    return resolvedDefaultOption;
+  }
+
+  for (const preferred of [
+    "approve",
+    "continue",
+    "proceed",
+    "allow",
+    "accept",
+    "run",
+    "confirm",
+    "yes",
+  ]) {
+    const match = options.find(
+      (option) => normalizedConfirmationAction(option) === preferred,
+    );
+    if (match) {
+      return match;
+    }
+  }
+
+  const actionableOptions = options.filter(
+    (option) => !isUtilityConfirmationAction(option),
+  );
+  return actionableOptions.length === 1 ? actionableOptions[0] : null;
+}
+
 export function confirmationActionOptions(payload: unknown): string[] {
   const options = confirmationOptions(payload);
   return options.length > 0 ? options : ["approve", "modify", "reject"];


### PR DESCRIPTION
## Summary
- respect `default_option` when choosing the initial confirmation focus
- surface dangerous confirmation semantics more explicitly in the confirmation card
- prioritize common confirmation detail rows for faster scanability

## Testing
- `bun test clients/tui/src/adaptive-surfaces/confirmation-surface.test.ts clients/tui/src/yield.test.ts`
- `clients/tui/node_modules/.bin/tsc --noEmit -p clients/tui/tsconfig.json`
