### PR TITLE
[codex] align spec status with implemented surfaces

### DIFF
--- a/docs/spec/app_server_protocol.md
+++ b/docs/spec/app_server_protocol.md
@@ -1,6 +1,10 @@
 # App Server Protocol Contract
 
-> Status: VNext target contract (current HTTP/WS API remains a transition layer).
+> Status: partially implemented target contract.
+>
+> Current reality: the public API is still the `/api/v1/sessions/*`
+> compatibility surface, but it already exposes most of the data-plane and a
+> meaningful subset of the target control-plane behavior described here.
 
 ## Goals
 
@@ -25,6 +29,30 @@ Provide a unified protocol layer for multi-client Alan frontends (TUI/Native/Web
 2. **Explicit state**: thread/turn/item are first-class objects.
 3. **Recoverable streams**: clients can fill gaps using event cursors.
 4. **Backward compatibility**: keep `/sessions/*` APIs while evolving.
+
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. Session creation accepts `profile_id?` and returns
+   `profile_id/provider/resolved_model/durability`.
+2. Public protocol ops already include `Turn`, `Input { mode }`, `Resume`,
+   `Interrupt`, `RegisterDynamicTools`, `CompactWithOptions`, and `Rollback`.
+3. Event envelopes already carry `event_id`, `sequence`, `session_id`,
+   `submission_id`, `turn_id`, `item_id`, and `timestamp_ms`.
+4. The compatibility surface already includes `read`, `history`, `events/read`,
+   `reconnect_snapshot`, `rollback`, `compact`, `schedule_at`, `sleep_until`,
+   streaming HTTP events, and WebSocket streaming.
+5. Compaction and memory-flush attempt recovery are already exposed through
+   replay buffers, session reads, and reconnect snapshots.
+
+Still target-only:
+
+1. Public naming is still `session/submission`, not first-class
+   `thread/turn/item` resources.
+2. `archive` and a dedicated scheduler/run namespace are not yet first-class
+   public routes.
+3. Relay mode is still MVP and does not proxy `/events` or `/ws`.
 
 ## Core Objects
 
@@ -85,12 +113,20 @@ Compaction visibility requirements:
 Current endpoints map to target semantics:
 
 1. `POST /sessions` -> `thread/start`
-2. `POST /sessions/{id}/submit` -> `turn/start` / `turn/input`
-3. `GET /sessions/{id}/events` -> `events/stream`
-4. `GET /sessions/{id}/events/read` -> `events/read`
-5. `POST /sessions/{id}/resume` -> `turn/resume`
-6. `POST /sessions/{id}/rollback` -> `thread/rollback`
-7. `POST /sessions/{id}/compact` -> `thread/compact`
+2. `GET /sessions/{id}` -> `thread/read` (metadata-focused compatibility view)
+3. `GET /sessions/{id}/read` -> `thread/read`
+4. `GET /sessions/{id}/history` -> history-only snapshot read
+5. `POST /sessions/{id}/submit` -> `turn/start` / `turn/input` / `turn/resume`
+   / `turn/interrupt` / `thread/compact` / `thread/rollback`
+6. `GET /sessions/{id}/events` -> `events/stream`
+7. `GET /sessions/{id}/ws` -> `events/stream` over WebSocket
+8. `GET /sessions/{id}/events/read` -> `events/read`
+9. `GET /sessions/{id}/reconnect_snapshot` -> `reconnect_snapshot`
+10. `POST /sessions/{id}/resume` -> compatibility `turn/resume`
+11. `POST /sessions/{id}/rollback` -> `thread/rollback`
+12. `POST /sessions/{id}/compact` -> `thread/compact`
+13. `POST /sessions/{id}/schedule_at` -> scheduler extension
+14. `POST /sessions/{id}/sleep_until` -> scheduler extension
 
 Compatibility notes:
 
@@ -196,6 +232,12 @@ Related specs:
 
 1. `remote_control_architecture.md`
 2. `remote_control_security.md`
+
+Current relay caveat:
+
+1. The direct/relay remote-control layer is implemented as an MVP.
+2. Relay currently supports node listing, tunneling, and proxying ordinary HTTP
+   paths, but intentionally rejects `/events` and `/ws`.
 
 ## Versioning Strategy
 

--- a/docs/spec/compaction_contract.md
+++ b/docs/spec/compaction_contract.md
@@ -1,6 +1,11 @@
 # Compaction Contract
 
-> Status: VNext contract (extends current `compact` capability with trigger/quality/audit semantics).
+> Status: partially implemented current contract with ongoing quality work.
+>
+> Current reality: manual compaction, automatic pressure evaluation,
+> soft/hard thresholds, pre-compaction memory flush, structured audit
+> snapshots, and reconnect/session-read recovery are all implemented. The main
+> remaining work is around quality calibration and finalizing the public shape.
 
 ## Goals
 
@@ -11,6 +16,27 @@ It must guarantee:
 1. Context-size reduction.
 2. Preservation of key decisions and unfinished work.
 3. No breakage of downstream recoverability.
+
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. Manual compaction via `Op::CompactWithOptions { focus? }`.
+2. Automatic pre-turn and mid-turn compaction pressure evaluation using both
+   message-count guardrails and context-window utilization ratios.
+3. Soft-threshold automatic memory flush before `AutoPreTurn` compaction, with
+   structured skip/failure/success outcomes.
+4. Structured `compaction_observed` and `memory_flush_observed` events, plus
+   recovery of the latest attempts through session reads and reconnect
+   snapshots.
+5. Rollout/session persistence of compaction attempts and degraded/failure
+   outcomes.
+
+Still evolving:
+
+1. Summary-quality enforcement is still heuristic rather than a separately
+   scored contract.
+2. Reference markers remain optional and are not yet a separate public object.
 
 ## Trigger Types
 
@@ -75,7 +101,7 @@ Summary minimum content:
 
 ## Coordination with Memory
 
-Recommended pre-compaction flush on automatic compaction:
+Current pre-compaction flush behavior on automatic compaction:
 
 1. Persist high-value long-term info to L1 memory.
 2. Flush turn should be silent by default.

--- a/docs/spec/connection_profile_contract.md
+++ b/docs/spec/connection_profile_contract.md
@@ -1,6 +1,12 @@
 # Connection Profile Contract
 
-> Status: proposed V1 target contract.
+> Status: partially implemented V1 contract.
+>
+> Current reality: connection metadata persistence, provider descriptors,
+> profile selection/default/pin semantics, daemon control-plane routes, CLI
+> commands, and session profile binding are already implemented. Full migration
+> away from legacy inline provider config and final onboarding/TUI cleanup
+> remains in progress.
 >
 > Scope: unified operator-facing management of provider selection, provider
 > configuration, credentials, login flows, onboarding, and session binding.
@@ -13,10 +19,35 @@ It does not collapse provider semantics. It standardizes how users create,
 authenticate, select, inspect, and bind provider-backed connections across
 CLI, TUI, onboarding, and daemon APIs.
 
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. `~/.alan/connections.toml` stores profile/credential metadata, while
+   secret-bearing credentials and managed ChatGPT auth remain in separate host
+   stores.
+2. The daemon exposes the generic `/api/v1/connections/*` control plane for
+   catalog, CRUD, current/default/pin selection, credential status, login,
+   logout, secret entry, test, and event replay/streaming.
+3. `alan connection ...` is the primary CLI surface for the same model.
+4. Session creation already accepts `profile_id?` and persists
+   `profile_id/provider/resolved_model` in session metadata.
+5. `agent.toml.connection_profile` is already used as the pin field for global
+   and workspace scopes.
+
+Still in migration:
+
+1. Runtime config still accepts legacy inline provider fields for backward
+   compatibility, and applies resolved connection profiles onto that config.
+2. Onboarding and all client UX surfaces are not yet reduced to the
+   connection-profile-only flow described later in this document.
+3. The "breaking change" section below remains target-state, not completed
+   product behavior.
+
 ## Problem Statement
 
-Alan currently splits the user-facing model-access story across three unrelated
-surfaces:
+Historically Alan split the user-facing model-access story across three
+unrelated surfaces:
 
 1. `agent.toml` selects `llm_provider` and carries most provider config.
 2. `/auth` and `alan auth` manage ChatGPT login only.
@@ -30,7 +61,9 @@ This produces confusing states such as:
 3. provider-specific auth UX grows by special-case branching instead of a
    stable host control plane
 
-The connection-profile layer exists to remove that ambiguity.
+Current code has started closing those gaps through the connection control
+plane, but migration is incomplete enough that the ambiguity above can still
+surface in compatibility paths.
 
 ## Goals
 
@@ -294,10 +327,11 @@ V1 concrete backend choices:
 
 ## Agent Config Contract
 
-`agent.toml` remains the agent-definition file, but it is no longer a
-provider-config file.
+`agent.toml` remains the agent-definition file. The current implementation is
+moving it toward a provider-agnostic shape, but legacy inline provider fields
+still exist during migration.
 
-Canonical V1 shape:
+Target V1 shape:
 
 ```toml
 llm_request_timeout_secs = 180
@@ -317,9 +351,11 @@ Rules:
 
 1. `connection_profile` is optional and means "pin this agent/workspace to a
    specific profile".
-2. Provider-specific settings such as `base_url`, `model`, `account_id`,
-   `project_id`, or `api_key` must not appear in `agent.toml`.
-3. Agent overlays may change `connection_profile`, but they must do so
+2. Target end-state: provider-specific settings such as `base_url`, `model`,
+   `account_id`, `project_id`, or `api_key` disappear from the user-facing
+   `agent.toml` surface. Current code still accepts them for backward
+   compatibility.
+3. Agent overlays may change `connection_profile`, but they should do so
    explicitly as a profile reference rather than by reintroducing inline
    provider keys.
 4. Runtime-only knobs such as timeouts, compaction thresholds, memory, and
@@ -691,8 +727,11 @@ Canonical session metadata example:
 
 ## Breaking Change Contract
 
-V1 adopts the connection-profile format as the only supported operator-facing
-shape.
+This section describes the remaining migration target, not the current
+compatibility surface.
+
+V1 fully adopts the connection-profile format as the only supported
+operator-facing shape.
 
 Required replacements:
 

--- a/docs/spec/memory_architecture.md
+++ b/docs/spec/memory_architecture.md
@@ -1,6 +1,11 @@
 # Memory Architecture
 
-> Status: VNext contract (evolves from current Tape + Workspace Memory capabilities).
+> Status: mixed current/target contract.
+>
+> Current reality: L0 Tape/Rollout and basic L1 workspace memory already exist,
+> and automatic pre-compaction flush to daily memory notes is implemented. L2
+> retrieval/index conventions and a unified retrieval contract remain future
+> work.
 
 ## Goals
 
@@ -11,6 +16,24 @@ Core principles:
 1. **Files are the factual source of truth**, not implicit model memory.
 2. **Retrieval is a capability layer**, not a state layer.
 3. **Writes must be policy-driven**, not opportunistic.
+
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. L0 execution memory is persisted through Tape + rollout.
+2. L1 workspace memory uses `.alan/memory/` plus the memory skill.
+3. Automatic pre-compaction memory flush writes high-value durable notes to
+   `.alan/memory/YYYY-MM-DD.md` for soft-threshold `AutoPreTurn` compaction.
+4. The latest memory-flush attempt is recoverable via event replay,
+   session-read APIs, reconnect snapshots, and rollout fallback.
+
+Still target-only or incomplete:
+
+1. No unified memory retrieval/search contract yet.
+2. No standardized L2 index backend interface in the shipped runtime.
+3. Governance/audit metadata on memory writes is still lighter than the full
+   target model below.
 
 ## Three-Layer Memory Model
 
@@ -46,12 +69,14 @@ Currently available:
 
 1. L0: persisted `Tape` and `rollout`.
 2. L1 (basic): workspace memory directory + memory skill.
+3. Automatic pre-compaction flush to daily memory notes with structured
+   observed outcomes.
 
 Missing pieces:
 
 1. Unified memory tool contract (`search/get`).
-2. Pre-compaction auto flush policy.
-3. L2 index conventions and backend interfaces.
+2. L2 index conventions and backend interfaces.
+3. Richer long-lived memory governance metadata and rewrite/deletion flows.
 
 ## Write Policy Contract
 
@@ -77,7 +102,7 @@ Missing pieces:
 
 ## Coordination with Compaction
 
-### Pre-compaction memory flush (recommended)
+### Pre-compaction memory flush (current behavior)
 
 Before soft compaction threshold:
 

--- a/docs/spec/provider_auth_contract.md
+++ b/docs/spec/provider_auth_contract.md
@@ -1,6 +1,12 @@
 # Provider And Auth Contract
 
-> Status: VNext contract for provider/auth layering.
+> Status: partially implemented current contract with VNext tail.
+>
+> Current reality: the provider split, managed ChatGPT auth core, request-auth
+> bridging, local status/logout/login flows, and host-side auth control through
+> the connection layer are implemented. What remains is mostly generalization
+> and cleanup around the final product surface.
+>
 > Scope: model-provider selection, authentication surfaces, and request-auth bridging outside the kernel.
 
 ## Goal
@@ -23,6 +29,26 @@ specified separately in
 document defines what Alan should preserve, emulate, reject, or expose
 explicitly for Responses, Chat Completions, Anthropic Messages, and
 compatibility providers.
+
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. `chatgpt` remains a distinct provider surface from `openai_*`.
+2. Managed ChatGPT auth state lives outside `agent.toml` in host-local storage.
+3. Local status/logout/login flows exist, including browser and device-code
+   login.
+4. The daemon exposes the same auth core through the connection-management
+   control plane, including status, login start/completion, logout, and event
+   observation.
+5. The provider path performs auth-state bridging and managed refresh/retry
+   behavior instead of leaking provider auth into Tape/kernel state.
+
+Still evolving:
+
+1. The canonical operator experience is now connection-profile driven, but some
+   surrounding docs still describe the older split too literally.
+2. Capability-level provider fidelity remains a separate target contract.
 
 ## Layer Boundary
 
@@ -111,7 +137,7 @@ Rationale:
 
 ## Login Flows
 
-The local managed ChatGPT path should support:
+The local managed ChatGPT path currently supports:
 
 1. Browser-based login as the primary interactive flow.
 2. Device-code login as the headless fallback.
@@ -120,9 +146,9 @@ The local managed ChatGPT path should support:
 
 ## Host Auth Control Plane
 
-When Alan is hosted behind a daemon or app-server, the host layer may expose
-managed ChatGPT auth state through the generic connection-management control
-plane defined in
+When Alan is hosted behind a daemon or app-server, the host layer currently
+exposes managed ChatGPT auth state through the generic connection-management
+control plane defined in
 [`connection_profile_contract.md`](./connection_profile_contract.md).
 
 Normative behavior:
@@ -211,6 +237,13 @@ The first real consumer of this provider/auth surface is the reference coding ag
 1. This document defines the provider/auth half.
 2. `reference_coding_agent.md` defines the product-layer coding-agent half.
 3. They should evolve in lockstep, but remain separate contracts.
+
+## Current Landing Status
+
+The current tree effectively satisfies the experimental local-path criteria and
+most of the host-control-plane follow-on criteria below. The remaining work is
+primarily around final product-surface cleanup and keeping this document aligned
+with the now-shipped connection layer.
 
 ## Initial Acceptance Criteria
 

--- a/docs/spec/scheduler_contract.md
+++ b/docs/spec/scheduler_contract.md
@@ -1,6 +1,11 @@
 # Scheduler Contract (Schedule / Sleep / Wake / Boot Recovery)
 
-> Status: VNext contract (defines scheduling source-of-truth semantics for long-running execution).
+> Status: partially implemented contract.
+>
+> Current reality: Alan already has a durable task/run/schedule store,
+> scheduler boot recovery, session-scoped `schedule_at` / `sleep_until`
+> endpoints, and run checkpointing around sleeps. Interval/backoff/cancellation
+> ergonomics remain future work.
 
 ## Goals
 
@@ -11,6 +16,28 @@ Scheduler is a Host/Daemon system capability responsible for:
 3. Recovering non-terminal schedule items after daemon/system restart.
 
 This contract defines mechanism semantics, not business workflow content (owned by skills).
+
+## Current Implementation Snapshot
+
+Implemented in the current tree:
+
+1. Durable `TaskRecord`, `RunRecord`, `RunCheckpointRecord`, and
+   `ScheduleItemRecord` persistence, including `sleeping` run state and
+   `waiting/due/dispatching/...` schedule states.
+2. Scheduler boot reconciliation for non-terminal schedule items.
+3. Public session-scoped `schedule_at` and `sleep_until` routes.
+4. `sleep_until` transitions runs into sleeping state, sets `next_wake_at`,
+   records checkpoints, and supersedes older waiting wakeups for the same run.
+5. Runtime/tool execution persists effect records with idempotency keys, which
+   is the current dedupe boundary for redelivery safety.
+
+Still target-only or incomplete:
+
+1. No public `retry_with_backoff` API yet.
+2. `interval` and `retry_backoff` exist in the data model but are not yet a
+   complete operator-facing surface.
+3. Explicit cancellation APIs and clock-skew reporting are not yet a fully
+   exposed external contract.
 
 ## Scope and Boundaries
 
@@ -75,6 +102,8 @@ Constraints:
 3. On wake, transition run back to `running` or enqueue it for execution.
 
 ### `retry_with_backoff(run_id, policy)`
+
+Target extension, not yet a public host API:
 
 1. Compute next `next_wake_at` from `attempt`.
 2. Persist backoff inputs (`attempt`, `base`, `factor`, `max`).


### PR DESCRIPTION
## What changed
Updated six priority specs so they distinguish shipped behavior from remaining target-state work:

- `connection_profile_contract.md`
- `provider_auth_contract.md`
- `app_server_protocol.md`
- `scheduler_contract.md`
- `compaction_contract.md`
- `memory_architecture.md`

The revisions mainly:
- change overly future-tense status lines
- add explicit current-implementation snapshots
- call out remaining migration gaps where compatibility behavior still exists
- avoid claiming that fully target-state migrations are already complete

## Why
The docs had drifted behind the codebase. Several control-plane, scheduling, compaction, and connection-management surfaces are already implemented, but the specs still read as if they were purely VNext designs.

## Impact
Readers should now be able to tell which parts are already real in the tree versus which parts are still target contract.

## Validation
- `git diff --check`
- code-path verification by reading current implementations in `crates/runtime` and `crates/alan`
