### PR TITLE
[codex] Fix session runtime prompt and memory regressions

### DIFF
--- a/crates/runtime/prompts/persona/AGENTS.md
+++ b/crates/runtime/prompts/persona/AGENTS.md
@@ -4,7 +4,11 @@ This workspace defines how Alan should operate for this user and project.
 
 ## Session Start
 
-Before responding, read these files when available:
+These persona files are already injected into the prompt context when available.
+Do not spend tool calls re-reading them by default.
+Only read or edit the on-disk files when you need to verify or persist changes.
+
+Core files:
 1. `SOUL.md` for identity and values
 2. `ROLE.md` for responsibilities and boundaries
 3. `USER.md` for user preferences and context

--- a/crates/runtime/prompts/persona/BOOTSTRAP.md
+++ b/crates/runtime/prompts/persona/BOOTSTRAP.md
@@ -6,6 +6,6 @@ Initial setup checklist for a new workspace.
 
 1. Fill out `SOUL.md` with stable identity and behavior
 2. Fill out `ROLE.md` with project-specific responsibilities
-3. Add user preferences to `USER.md`
+3. Add stable user preferences and identity details to `USER.md`
 4. Add environment/tool notes to `TOOLS.md`
 5. Optionally define recurring checks in `HEARTBEAT.md`

--- a/crates/runtime/prompts/persona/USER.md
+++ b/crates/runtime/prompts/persona/USER.md
@@ -1,6 +1,9 @@
 # USER
 
-Record user preferences and stable context here.
+Record stable user preferences, identity details, and long-lived context here.
+
+Update this file when the user explicitly asks you to remember stable information across
+sessions, especially identity and communication preferences.
 
 ## Suggested Fields
 

--- a/crates/runtime/prompts/system.md
+++ b/crates/runtime/prompts/system.md
@@ -14,6 +14,7 @@ You are Alan, an AI agent running inside the Alan runtime.
 - Prefer verification over guessing when tools can check facts.
 - Use tools when they provide meaningful evidence for the answer.
 - Ask concise clarifying questions only when required inputs are missing.
+- If the user explicitly asks you to remember stable information across sessions, persist it to the appropriate workspace memory or user-context file with tools instead of only acknowledging it in text.
 
 ## Communication Style
 

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -27,13 +27,25 @@ Manage durable, file-based memory that persists across sessions.
 
 ## Memory Layout
 
-All memory files live under `.alan/memory/` in the workspace:
+All memory files live under the active workspace Alan state directory's `memory/` folder.
 
+Examples:
+
+```text
+repo workspace:    .alan/memory/
+default workspace: memory/
 ```
-.alan/memory/
+
+Layout:
+
+```text
+memory/
 ├── MEMORY.md              # Persistent knowledge index (survives across all sessions)
 └── YYYY-MM-DD.md          # Daily incremental work log
 ```
+
+Do not assume the current workspace always has a visible `.alan/` prefix in relative paths.
+Resolve the active memory location from the runtime/workspace context when possible.
 
 ## Session Start Protocol
 
@@ -41,12 +53,12 @@ When starting a new session (especially if resuming prior work):
 
 1. **Read persistent memory**:
    ```
-   read_file .alan/memory/MEMORY.md
+   read_file {active_memory_dir}/MEMORY.md
    ```
 
 2. **Check recent daily notes**:
    ```
-   bash ls -lt .alan/memory/*.md | head -5
+   bash ls -lt {active_memory_dir}/*.md | head -5
    ```
    Then read the most recent daily note for context.
 
@@ -64,13 +76,17 @@ When starting a new session (especially if resuming prior work):
 
 Before ending a session or when wrapping up significant work:
 
-1. **Update MEMORY.md** with any new key information:
+1. **Update stable user context**:
+   - If the user explicitly asks you to remember stable identity or preference details across
+     sessions, update `USER.md`.
+
+2. **Update MEMORY.md** with any new key information:
    - New decisions made
    - Important discoveries or constraints
    - User preferences learned
    - Current project state
 
-2. **Append a dated work log** to `.alan/memory/YYYY-MM-DD.md`:
+3. **Append a dated work log** to `{active_memory_dir}/YYYY-MM-DD.md`:
    ```markdown
    ## {timestamp}
 

--- a/crates/runtime/src/llm.rs
+++ b/crates/runtime/src/llm.rs
@@ -256,16 +256,13 @@ fn project_messages_impl(
 ) -> Vec<Message> {
     use crate::tape;
 
-    const MAX_PROJECTED_TOOL_PAYLOAD_SIZE: usize = 30_000;
-
     messages
         .iter()
         .flat_map(|m| match m {
             tape::Message::Tool { responses } => responses
                 .iter()
                 .map(|r| {
-                    let content =
-                        project_tool_response_content(&r.content, MAX_PROJECTED_TOOL_PAYLOAD_SIZE);
+                    let content = project_tool_response_for_prompt(&r.content);
 
                     let tool_call_id = {
                         let trimmed = r.id.trim();
@@ -352,6 +349,12 @@ fn project_messages_impl(
             }
         })
         .collect()
+}
+
+const MAX_PROJECTED_TOOL_PAYLOAD_SIZE: usize = 30_000;
+
+pub(crate) fn project_tool_response_for_prompt(parts: &[crate::tape::ContentPart]) -> String {
+    project_tool_response_content(parts, MAX_PROJECTED_TOOL_PAYLOAD_SIZE)
 }
 
 fn project_tool_response_content(parts: &[crate::tape::ContentPart], max_size: usize) -> String {

--- a/crates/runtime/src/prompts/assembler.rs
+++ b/crates/runtime/src/prompts/assembler.rs
@@ -207,6 +207,24 @@ mod tests {
     }
 
     #[test]
+    fn test_build_agent_system_prompt_includes_memory_persistence_guidance() {
+        let temp_dir = TempDir::new().unwrap();
+        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        fs::create_dir_all(&persona_dir).unwrap();
+        crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
+
+        let config = test_config_with_workspace(&temp_dir);
+        let workspace_persona_dirs = resolved_workspace_persona_dirs(&config, None);
+        let prompt =
+            build_agent_system_prompt_from_persona_dirs("DOMAIN content", &workspace_persona_dirs);
+
+        assert!(
+            prompt.contains("persist it to the appropriate workspace memory or user-context file")
+        );
+        assert!(prompt.contains("Do not re-read them with tools by default"));
+    }
+
+    #[test]
     fn test_build_agent_system_prompt_does_not_create_workspace_files() {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);

--- a/crates/runtime/src/prompts/workspace.rs
+++ b/crates/runtime/src/prompts/workspace.rs
@@ -154,8 +154,15 @@ pub(crate) fn render_workspace_persona_context_from_dirs(workspace_dirs: &[PathB
     let mut prompt = String::new();
     prompt.push_str("## Workspace Persona Context\n");
     prompt.push_str(&format!("Workspace: {workspace_label}\n"));
-    prompt
-        .push_str("The following workspace files define the persona, role, and operating style.\n");
+    prompt.push_str(
+        "The following workspace files are already injected into this prompt and define the persona, role, and operating style.\n",
+    );
+    prompt.push_str(
+        "Do not re-read them with tools by default; only open or edit the on-disk files when you need to verify or persist changes.\n",
+    );
+    prompt.push_str(
+        "When the user explicitly asks you to remember stable information across sessions, update the relevant user-context or memory files with tools instead of only acknowledging it in text.\n",
+    );
 
     for file in files {
         prompt.push_str(&format!("\n### {}\n", file.name));
@@ -318,5 +325,17 @@ mod tests {
 
         let content = fs::read_to_string(soul_path).unwrap();
         assert_eq!(content, "custom soul");
+    }
+
+    #[test]
+    fn test_render_workspace_persona_context_adds_runtime_guidance() {
+        let temp_dir = TempDir::new().unwrap();
+        ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
+
+        let prompt = render_workspace_persona_context(temp_dir.path());
+
+        assert!(prompt.contains("already injected into this prompt"));
+        assert!(prompt.contains("Do not re-read them with tools by default"));
+        assert!(prompt.contains("remember stable information across sessions"));
     }
 }

--- a/crates/runtime/src/rollout.rs
+++ b/crates/runtime/src/rollout.rs
@@ -253,7 +253,18 @@ impl RolloutRecorder {
     /// Create a new recorder for a session
     pub async fn new(session_id: &str, model: &str) -> anyhow::Result<Self> {
         let rollout_path = Self::build_rollout_path(session_id).await?;
-        Self::new_with_rollout_path(session_id, model, rollout_path).await
+        Self::new_with_rollout_path(session_id, model, rollout_path, None).await
+    }
+
+    /// Create a new recorder for a session and capture an explicit runtime tool cwd in session
+    /// metadata.
+    pub async fn new_with_cwd(
+        session_id: &str,
+        model: &str,
+        cwd: Option<&std::path::Path>,
+    ) -> anyhow::Result<Self> {
+        let rollout_path = Self::build_rollout_path(session_id).await?;
+        Self::new_with_rollout_path(session_id, model, rollout_path, cwd).await
     }
 
     /// Create a new recorder for a session under a specific sessions directory.
@@ -263,13 +274,26 @@ impl RolloutRecorder {
         sessions_dir: &std::path::Path,
     ) -> anyhow::Result<Self> {
         let rollout_path = Self::build_rollout_path_in_dir(session_id, sessions_dir).await?;
-        Self::new_with_rollout_path(session_id, model, rollout_path).await
+        Self::new_with_rollout_path(session_id, model, rollout_path, None).await
+    }
+
+    /// Create a new recorder under a specific sessions directory and capture the runtime tool cwd
+    /// in session metadata.
+    pub async fn new_in_dir_with_cwd(
+        session_id: &str,
+        model: &str,
+        sessions_dir: &std::path::Path,
+        cwd: Option<&std::path::Path>,
+    ) -> anyhow::Result<Self> {
+        let rollout_path = Self::build_rollout_path_in_dir(session_id, sessions_dir).await?;
+        Self::new_with_rollout_path(session_id, model, rollout_path, cwd).await
     }
 
     async fn new_with_rollout_path(
         session_id: &str,
         model: &str,
         rollout_path: PathBuf,
+        cwd: Option<&std::path::Path>,
     ) -> anyhow::Result<Self> {
         // Create the file
         let file = OpenOptions::new()
@@ -328,9 +352,14 @@ impl RolloutRecorder {
         let meta = SessionMeta {
             session_id: session_id.to_string(),
             started_at: chrono::Utc::now().to_rfc3339(),
-            cwd: std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string()),
+            cwd: cwd
+                .map(|path| path.to_string_lossy().to_string())
+                .or_else(|| {
+                    std::env::current_dir()
+                        .ok()
+                        .map(|path| path.to_string_lossy().to_string())
+                })
+                .unwrap_or_else(|| ".".to_string()),
             model: model.to_string(),
         };
         recorder.record_nowait(RolloutItem::SessionMeta(meta))?;
@@ -885,6 +914,37 @@ mod tests {
 
             // Clean up - remove the created file
             let _ = fs::remove_file(path).await;
+        });
+    }
+
+    #[test]
+    fn test_rollout_recorder_creation_records_explicit_cwd() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let temp_dir = TempDir::new().unwrap();
+            let explicit_cwd = temp_dir.path().join("workspace/src");
+            fs::create_dir_all(&explicit_cwd).await.unwrap();
+
+            let recorder = RolloutRecorder::new_in_dir_with_cwd(
+                "test-session-cwd",
+                "gemini-2.0-flash",
+                temp_dir.path(),
+                Some(explicit_cwd.as_path()),
+            )
+            .await
+            .unwrap();
+
+            let items = RolloutRecorder::load_history(recorder.path())
+                .await
+                .unwrap();
+            match &items[0] {
+                RolloutItem::SessionMeta(meta) => {
+                    assert_eq!(meta.cwd, explicit_cwd.to_string_lossy());
+                }
+                _ => panic!("Expected SessionMeta"),
+            }
+
+            let _ = fs::remove_file(recorder.path()).await;
         });
     }
 

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -188,20 +188,14 @@ async fn initialize_session(
     let mut warnings = Vec::new();
 
     let session = if let Some(path) = resume_rollout_path {
-        let load_result = if let Some(dir) = session_dir {
-            Session::load_from_rollout_with_recorder_cwd(
-                path,
-                desired_session_id,
-                model,
-                Some(dir.as_path()),
-                rollout_cwd,
-            )
-            .await
-        } else if let Some(session_id) = desired_session_id {
-            Session::load_from_rollout_with_id(path, session_id, model).await
-        } else {
-            Session::load_from_rollout(path, model).await
-        };
+        let load_result = Session::load_from_rollout_with_recorder_cwd(
+            path,
+            desired_session_id,
+            model,
+            session_dir.map(|dir| dir.as_path()),
+            rollout_cwd,
+        )
+        .await;
 
         match load_result {
             Ok(session) => session,
@@ -2229,6 +2223,60 @@ thinking_budget_tokens = 1024
         };
 
         assert_eq!(config.session_id.as_deref(), Some("sess-123"));
+    }
+
+    #[tokio::test]
+    async fn test_initialize_session_resume_without_session_dir_preserves_rollout_cwd() {
+        let temp = TempDir::new().unwrap();
+        let rollout_path = temp.path().join("resume-rollout.jsonl");
+        let resumed_cwd = temp.path().join("workspace/src");
+        let desired_session_id = format!("daemon-session-{}", uuid::Uuid::new_v4());
+        tokio::fs::create_dir_all(&resumed_cwd).await.unwrap();
+        tokio::fs::write(
+            &rollout_path,
+            r#"{"type":"session_meta","session_id":"legacy-runtime-id","started_at":"2026-01-29T14:30:52Z","cwd":"/tmp/original","model":"gemini-2.0-flash"}
+{"type":"message","role":"user","content":"Hello","tool_name":null,"timestamp":"2026-01-29T14:30:55Z"}
+"#,
+        )
+        .await
+        .unwrap();
+
+        let startup = initialize_session(
+            "gemini-2.0-flash",
+            Some(&rollout_path),
+            None,
+            Some(desired_session_id.as_str()),
+            true,
+            Some(resumed_cwd.as_path()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            startup.session.id,
+            crate::rollout::session_storage_key(&desired_session_id)
+        );
+
+        let persisted_path = startup
+            .metadata
+            .rollout_path
+            .clone()
+            .expect("resumed session should create a new rollout recorder");
+        let persisted_items = crate::rollout::RolloutRecorder::load_history(&persisted_path)
+            .await
+            .unwrap();
+        let persisted_meta = persisted_items.into_iter().find_map(|item| match item {
+            crate::rollout::RolloutItem::SessionMeta(meta) => Some(meta),
+            _ => None,
+        });
+
+        assert_eq!(
+            persisted_meta.as_ref().map(|meta| meta.cwd.as_str()),
+            Some(resumed_cwd.to_string_lossy().as_ref())
+        );
+
+        drop(startup);
+        let _ = tokio::fs::remove_file(persisted_path).await;
     }
 
     #[test]

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -166,15 +166,15 @@ async fn create_persistent_session(
     session_id: Option<&str>,
     model: &str,
     session_dir: Option<&std::path::PathBuf>,
+    rollout_cwd: Option<&std::path::Path>,
 ) -> anyhow::Result<Session> {
-    match (session_id, session_dir) {
-        (Some(session_id), Some(dir)) => {
-            Session::new_with_id_and_recorder_in_dir(session_id, model, dir).await
-        }
-        (None, Some(dir)) => Session::new_with_recorder_in_dir(model, dir).await,
-        (Some(session_id), None) => Session::new_with_id_and_recorder(session_id, model).await,
-        (None, None) => Session::new_with_recorder(model).await,
-    }
+    Session::new_with_recorder_options(
+        session_id,
+        model,
+        session_dir.map(|dir| dir.as_path()),
+        rollout_cwd,
+    )
+    .await
 }
 
 async fn initialize_session(
@@ -183,16 +183,20 @@ async fn initialize_session(
     session_dir: Option<&std::path::PathBuf>,
     desired_session_id: Option<&str>,
     durability_required: bool,
+    rollout_cwd: Option<&std::path::Path>,
 ) -> anyhow::Result<SessionStartupOutcome> {
     let mut warnings = Vec::new();
 
     let session = if let Some(path) = resume_rollout_path {
         let load_result = if let Some(dir) = session_dir {
-            if let Some(session_id) = desired_session_id {
-                Session::load_from_rollout_in_dir_with_id(path, session_id, model, dir).await
-            } else {
-                Session::load_from_rollout_in_dir(path, model, dir).await
-            }
+            Session::load_from_rollout_with_recorder_cwd(
+                path,
+                desired_session_id,
+                model,
+                Some(dir.as_path()),
+                rollout_cwd,
+            )
+            .await
         } else if let Some(session_id) = desired_session_id {
             Session::load_from_rollout_with_id(path, session_id, model).await
         } else {
@@ -215,7 +219,9 @@ async fn initialize_session(
                     path = %path.display(),
                     "Failed to load session from rollout; creating fresh persistent session"
                 );
-                match create_persistent_session(desired_session_id, model, session_dir).await {
+                match create_persistent_session(desired_session_id, model, session_dir, rollout_cwd)
+                    .await
+                {
                     Ok(session) => session,
                     Err(create_err) => {
                         warn!(
@@ -229,7 +235,7 @@ async fn initialize_session(
             }
         }
     } else {
-        match create_persistent_session(desired_session_id, model, session_dir).await {
+        match create_persistent_session(desired_session_id, model, session_dir, rollout_cwd).await {
             Ok(session) => session,
             Err(err) => {
                 if durability_required {
@@ -957,6 +963,10 @@ pub fn spawn_with_llm_client_and_tools(
         .workspace_alan_dir
         .as_ref()
         .map(|dir| crate::workspace_sessions_dir_from_alan_dir(dir));
+    let rollout_cwd = config
+        .default_cwd_override
+        .clone()
+        .or_else(|| resolved_agent_definition.workspace_root_dir.clone());
     let resume_rollout_path = config.resume_rollout_path.clone();
     let desired_session_id = config.session_id.clone();
     let host_capabilities = runtime_host_capabilities(&config, &tools);
@@ -977,6 +987,7 @@ pub fn spawn_with_llm_client_and_tools(
             session_dir.as_ref(),
             desired_session_id.as_deref(),
             runtime_config.durability_required,
+            rollout_cwd.as_deref(),
         )
         .await
         {

--- a/crates/runtime/src/runtime/prompt_cache.rs
+++ b/crates/runtime/src/runtime/prompt_cache.rs
@@ -1502,6 +1502,42 @@ capabilities:
     }
 
     #[test]
+    fn prompt_cache_builtin_skills_do_not_expose_materialized_temp_paths() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+
+        let host_capabilities =
+            SkillHostCapabilities::with_tools(["read_file", "write_file", "edit_file", "bash"])
+                .with_runtime_defaults();
+        let mut cache = PromptAssemblyCache::with_fixed_capability_view(
+            capability_view_for_workspace_root(&workspace_root),
+            Vec::new(),
+            host_capabilities,
+        );
+        let prompt = cache.build(Some(&[ContentPart::text(
+            "please use $memory for this task",
+        )]));
+
+        assert_eq!(prompt.active_skills.len(), 1);
+        assert_eq!(prompt.active_skills[0].metadata.id, "memory");
+        assert!(prompt.system_prompt.contains("## Skill: memory"));
+        assert!(prompt.system_prompt.contains("skill_id: memory"));
+        assert!(
+            prompt
+                .system_prompt
+                .contains("canonical_path: builtin:memory")
+        );
+        assert!(
+            prompt
+                .system_prompt
+                .contains("resource_root: <builtin capability package>")
+        );
+        assert!(!prompt.system_prompt.contains("builtin-skill-packages"));
+        assert!(!prompt.system_prompt.contains("/private/tmp/alan"));
+    }
+
+    #[test]
     fn prompt_cache_invalidates_when_skill_changes() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
@@ -1971,7 +2007,12 @@ Use this skill when asked.
         assert!(
             prompt
                 .system_prompt
-                .contains(&format!("resource_root: {}", resource_root.display()))
+                .contains("resource_root: <builtin capability package>")
+        );
+        assert!(
+            !prompt
+                .system_prompt
+                .contains(&resource_root.display().to_string())
         );
     }
 

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use crate::llm::build_generation_request;
+use crate::llm::{build_generation_request, project_tool_response_for_prompt};
 
 use super::agent_loop::{RuntimeLoopState, generate_with_retry_with_cancel};
 use super::compaction::{CompactionRequest, maybe_compact_context_with_cancel};
@@ -440,10 +440,11 @@ fn build_responses_input_items_from_tape(
         match message {
             crate::session::Message::Tool { responses } => {
                 for response in responses {
+                    let projected_output = project_tool_response_for_prompt(&response.content);
                     input.push(serde_json::json!({
                         "type": "function_call_output",
                         "call_id": response.id,
-                        "output": response.text_content(),
+                        "output": projected_output,
                     }));
                 }
             }
@@ -503,9 +504,10 @@ fn build_chat_completions_messages_from_tape(
         match message {
             crate::session::Message::Tool { responses } => {
                 for response in responses {
+                    let projected_content = project_tool_response_for_prompt(&response.content);
                     projected.push(serde_json::json!({
                         "role": "tool",
-                        "content": response.text_content(),
+                        "content": projected_content,
                         "tool_call_id": response.id,
                     }));
                 }
@@ -582,17 +584,18 @@ fn build_anthropic_messages_from_tape(
         match message {
             crate::session::Message::Tool { responses } => {
                 for response in responses {
+                    let projected_content = project_tool_response_for_prompt(&response.content);
                     let mut blocks = Vec::new();
                     if known_tool_use_ids.contains(&response.id) {
                         blocks.push(serde_json::json!({
                             "type": "tool_result",
                             "tool_use_id": response.id,
-                            "content": response.text_content(),
+                            "content": projected_content,
                         }));
-                    } else if !response.text_content().trim().is_empty() {
+                    } else if !projected_content.trim().is_empty() {
                         blocks.push(serde_json::json!({
                             "type": "text",
-                            "text": response.text_content(),
+                            "text": projected_content,
                         }));
                     }
                     if !blocks.is_empty() {
@@ -1666,7 +1669,7 @@ mod tests {
         runtime::{RuntimeConfig, TurnState},
         session::Session,
         skills::{ResolvedCapabilityView, ScopedPackageDir, SkillScope},
-        tape::ContentPart,
+        tape::{ContentPart, ToolRequest, ToolResponse},
         tools::{Tool, ToolContext, ToolRegistry, ToolResult},
     };
     use alan_llm::{
@@ -3008,6 +3011,85 @@ description: {description}
                 ]
             })]
         );
+    }
+
+    #[test]
+    fn test_build_responses_input_items_from_tape_caps_tool_payloads() {
+        let large_output = "x".repeat(40_000);
+        let messages = vec![crate::session::Message::Tool {
+            responses: vec![ToolResponse {
+                id: "call-1".to_string(),
+                content: vec![ContentPart::text(large_output.clone())],
+            }],
+        }];
+
+        let items = build_responses_input_items_from_tape(&messages);
+        let output = items[0]
+            .get("output")
+            .and_then(serde_json::Value::as_str)
+            .expect("responses item should contain string output");
+
+        assert_eq!(
+            output,
+            project_tool_response_for_prompt(&[ContentPart::text(large_output)])
+        );
+        assert!(output.len() <= 30_003);
+    }
+
+    #[test]
+    fn test_build_chat_completions_messages_from_tape_caps_tool_payloads() {
+        let large_output = "x".repeat(40_000);
+        let messages = vec![crate::session::Message::Tool {
+            responses: vec![ToolResponse {
+                id: "call-1".to_string(),
+                content: vec![ContentPart::text(large_output.clone())],
+            }],
+        }];
+
+        let projected = build_chat_completions_messages_from_tape(&messages);
+        let output = projected[0]
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .expect("chat completions tool message should contain string content");
+
+        assert_eq!(
+            output,
+            project_tool_response_for_prompt(&[ContentPart::text(large_output)])
+        );
+        assert!(output.len() <= 30_003);
+    }
+
+    #[test]
+    fn test_build_anthropic_messages_from_tape_caps_tool_payloads() {
+        let large_output = "x".repeat(40_000);
+        let messages = vec![
+            crate::session::Message::Assistant {
+                parts: Vec::new(),
+                tool_requests: vec![ToolRequest {
+                    id: "call-1".to_string(),
+                    name: "tool".to_string(),
+                    arguments: json!({}),
+                }],
+            },
+            crate::session::Message::Tool {
+                responses: vec![ToolResponse {
+                    id: "call-1".to_string(),
+                    content: vec![ContentPart::text(large_output.clone())],
+                }],
+            },
+        ];
+
+        let projected = build_anthropic_messages_from_tape(&messages);
+        let output = projected[1]["content"][0]
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .expect("anthropic tool_result should contain string content");
+
+        assert_eq!(
+            output,
+            project_tool_response_for_prompt(&[ContentPart::text(large_output)])
+        );
+        assert!(output.len() <= 30_003);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -532,10 +532,19 @@ impl Session {
         }
     }
 
-    /// Create a new session with recorder for persistence
-    pub async fn new_with_recorder(model: &str) -> anyhow::Result<Self> {
-        let id = uuid::Uuid::new_v4().to_string();
-        let recorder = RolloutRecorder::new(&id, model).await?;
+    pub(crate) async fn new_with_recorder_options(
+        session_id: Option<&str>,
+        model: &str,
+        sessions_dir: Option<&Path>,
+        rollout_cwd: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        let id = session_id
+            .map(str::to_string)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let recorder = match sessions_dir {
+            Some(dir) => RolloutRecorder::new_in_dir_with_cwd(&id, model, dir, rollout_cwd).await?,
+            None => RolloutRecorder::new_with_cwd(&id, model, rollout_cwd).await?,
+        };
 
         Ok(Self {
             id,
@@ -553,6 +562,11 @@ impl Session {
             auto_memory_flush_attempted_in_cycle: false,
             responses_continuation: None,
         })
+    }
+
+    /// Create a new session with recorder for persistence
+    pub async fn new_with_recorder(model: &str) -> anyhow::Result<Self> {
+        Self::new_with_recorder_options(None, model, None, None).await
     }
 
     /// Create a new session with recorder under a specific sessions directory.
@@ -560,47 +574,12 @@ impl Session {
         model: &str,
         sessions_dir: &Path,
     ) -> anyhow::Result<Self> {
-        let id = uuid::Uuid::new_v4().to_string();
-        let recorder = RolloutRecorder::new_in_dir(&id, model, sessions_dir).await?;
-
-        Ok(Self {
-            id,
-            tape: Tape::new(),
-            recorder: Some(recorder),
-            has_active_task: false,
-            dynamic_tools: HashMap::new(),
-            client_capabilities: alan_protocol::ClientCapabilities::default(),
-            effect_index: HashMap::new(),
-            last_turn_context_snapshot_fingerprint: None,
-            user_turn_ordinal: 0,
-            compaction_failure_streak: 0,
-            latest_compaction_attempt: None,
-            latest_memory_flush_attempt: None,
-            auto_memory_flush_attempted_in_cycle: false,
-            responses_continuation: None,
-        })
+        Self::new_with_recorder_options(None, model, Some(sessions_dir), None).await
     }
 
     /// Create a new session with a specific ID and recorder
     pub async fn new_with_id_and_recorder(session_id: &str, model: &str) -> anyhow::Result<Self> {
-        let recorder = RolloutRecorder::new(session_id, model).await?;
-
-        Ok(Self {
-            id: session_id.to_string(),
-            tape: Tape::new(),
-            recorder: Some(recorder),
-            has_active_task: false,
-            dynamic_tools: HashMap::new(),
-            client_capabilities: alan_protocol::ClientCapabilities::default(),
-            effect_index: HashMap::new(),
-            last_turn_context_snapshot_fingerprint: None,
-            user_turn_ordinal: 0,
-            compaction_failure_streak: 0,
-            latest_compaction_attempt: None,
-            latest_memory_flush_attempt: None,
-            auto_memory_flush_attempted_in_cycle: false,
-            responses_continuation: None,
-        })
+        Self::new_with_recorder_options(Some(session_id), model, None, None).await
     }
 
     /// Create a new session with a specific ID and recorder in a specific sessions directory.
@@ -609,29 +588,12 @@ impl Session {
         model: &str,
         sessions_dir: &Path,
     ) -> anyhow::Result<Self> {
-        let recorder = RolloutRecorder::new_in_dir(session_id, model, sessions_dir).await?;
-
-        Ok(Self {
-            id: session_id.to_string(),
-            tape: Tape::new(),
-            recorder: Some(recorder),
-            has_active_task: false,
-            dynamic_tools: HashMap::new(),
-            client_capabilities: alan_protocol::ClientCapabilities::default(),
-            effect_index: HashMap::new(),
-            last_turn_context_snapshot_fingerprint: None,
-            user_turn_ordinal: 0,
-            compaction_failure_streak: 0,
-            latest_compaction_attempt: None,
-            latest_memory_flush_attempt: None,
-            auto_memory_flush_attempted_in_cycle: false,
-            responses_continuation: None,
-        })
+        Self::new_with_recorder_options(Some(session_id), model, Some(sessions_dir), None).await
     }
 
     /// Load a session from a rollout file
     pub async fn load_from_rollout(path: &PathBuf, model: &str) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, None, model, None).await
+        Self::load_from_rollout_impl(path, None, model, None, None).await
     }
 
     /// Load a session from a rollout file while overriding the session ID for new persistence.
@@ -640,7 +602,7 @@ impl Session {
         session_id: &str,
         model: &str,
     ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, Some(session_id), model, None).await
+        Self::load_from_rollout_impl(path, Some(session_id), model, None, None).await
     }
 
     /// Load a session from a rollout file, writing future persistence to a specific sessions dir.
@@ -649,7 +611,7 @@ impl Session {
         model: &str,
         sessions_dir: &Path,
     ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, None, model, Some(sessions_dir)).await
+        Self::load_from_rollout_impl(path, None, model, Some(sessions_dir), None).await
     }
 
     /// Load a session from a rollout file with an explicit session ID and sessions dir.
@@ -659,7 +621,18 @@ impl Session {
         model: &str,
         sessions_dir: &Path,
     ) -> anyhow::Result<Self> {
-        Self::load_from_rollout_impl(path, Some(session_id), model, Some(sessions_dir)).await
+        Self::load_from_rollout_impl(path, Some(session_id), model, Some(sessions_dir), None).await
+    }
+
+    pub(crate) async fn load_from_rollout_with_recorder_cwd(
+        path: &PathBuf,
+        session_id_override: Option<&str>,
+        model: &str,
+        sessions_dir: Option<&Path>,
+        rollout_cwd: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        Self::load_from_rollout_impl(path, session_id_override, model, sessions_dir, rollout_cwd)
+            .await
     }
 
     async fn load_from_rollout_impl(
@@ -667,6 +640,7 @@ impl Session {
         session_id_override: Option<&str>,
         model: &str,
         sessions_dir: Option<&Path>,
+        rollout_cwd: Option<&Path>,
     ) -> anyhow::Result<Self> {
         let items = RolloutRecorder::load_history(path).await?;
 
@@ -686,10 +660,9 @@ impl Session {
         };
 
         // Create a new session with recorder
-        let mut session = match sessions_dir {
-            Some(dir) => Self::new_with_id_and_recorder_in_dir(&session_id, model, dir).await?,
-            None => Self::new_with_id_and_recorder(&session_id, model).await?,
-        };
+        let mut session =
+            Self::new_with_recorder_options(Some(&session_id), model, sessions_dir, rollout_cwd)
+                .await?;
 
         let recovered_latest_compaction_attempt =
             Self::latest_compaction_attempt_from_rollout_items_internal(&items);
@@ -2045,6 +2018,49 @@ mod tests {
             });
             assert_eq!(persisted_session_id.as_deref(), Some(storage_key.as_str()));
             assert_eq!(session.tape.messages().len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_load_from_rollout_with_recorder_cwd_persists_runtime_tool_cwd() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let temp_dir = TempDir::new_in(std::env::temp_dir()).unwrap();
+            let rollout_path = temp_dir.path().join("rollout-cwd.jsonl");
+            let resumed_cwd = temp_dir.path().join("workspace/src");
+            tokio::fs::create_dir_all(&resumed_cwd).await.unwrap();
+
+            let content = r#"{"type":"session_meta","session_id":"legacy-runtime-id","started_at":"2026-01-29T14:30:52Z","cwd":"/tmp/original","model":"gemini-2.0-flash"}
+{"type":"message","role":"user","content":"Hello","tool_name":null,"timestamp":"2026-01-29T14:30:55Z"}
+"#;
+
+            tokio::fs::write(&rollout_path, content).await.unwrap();
+            let session = Session::load_from_rollout_with_recorder_cwd(
+                &rollout_path,
+                Some("daemon-session-id"),
+                "gemini-2.0-flash",
+                Some(temp_dir.path()),
+                Some(resumed_cwd.as_path()),
+            )
+            .await
+            .unwrap();
+
+            let persisted_items = RolloutRecorder::load_history(
+                session
+                    .rollout_path()
+                    .expect("session should create a new recorder path"),
+            )
+            .await
+            .unwrap();
+            let persisted_meta = persisted_items.into_iter().find_map(|item| match item {
+                RolloutItem::SessionMeta(meta) => Some(meta),
+                _ => None,
+            });
+
+            assert_eq!(
+                persisted_meta.as_ref().map(|meta| meta.cwd.as_str()),
+                Some(resumed_cwd.to_string_lossy().as_ref())
+            );
         });
     }
 

--- a/crates/runtime/src/skills/injector.rs
+++ b/crates/runtime/src/skills/injector.rs
@@ -996,36 +996,49 @@ pub fn render_skills_list(
     ];
 
     for skill in skills {
+        let builtin_package = skill.is_builtin_package();
         lines.push(format!("- skill_id: {}", skill.id));
         lines.push(format!("  name: {}", skill.name));
         lines.push(format!("  description: {}", skill.description));
-        if skill.is_builtin_package() {
+        if builtin_package {
             lines.push("  skill_source: builtin_capability_package".to_string());
-            lines.push(
-                "  use: activate when needed; rely on the runtime-disclosed instructions instead of opening builtin package files via tools"
-                    .to_string(),
-            );
-            lines.push(String::new());
-            continue;
         }
         match &skill.execution {
             ResolvedSkillExecution::Delegate { .. } if !delegated_invocation_available => {
-                lines.push(format!("  skill_path: {}", skill.path.display()));
-                lines.push(
-                    "  use: open `SKILL.md` only when needed, then follow its instructions"
-                        .to_string(),
-                );
+                if !builtin_package {
+                    lines.push(format!("  skill_path: {}", skill.path.display()));
+                    lines.push(
+                        "  use: open `SKILL.md` only when needed, then follow its instructions"
+                            .to_string(),
+                    );
+                } else {
+                    lines.push(
+                        "  use: activate when needed; this runtime cannot delegate the builtin capability directly, so rely on the runtime-disclosed instructions instead of opening builtin package files via tools"
+                            .to_string(),
+                    );
+                }
             }
             ResolvedSkillExecution::Delegate { target, .. } => {
                 lines.push(format!("  execution: delegate(target={target})"));
-                lines.push("  use: call `invoke_delegated_skill` directly with this `skill_id`, the delegated `target`, and a concise bounded task".to_string());
+                if builtin_package {
+                    lines.push("  use: call `invoke_delegated_skill` directly with this `skill_id`, the delegated `target`, and a concise bounded task; do not open builtin package files via tools".to_string());
+                } else {
+                    lines.push("  use: call `invoke_delegated_skill` directly with this `skill_id`, the delegated `target`, and a concise bounded task".to_string());
+                }
             }
             _ => {
-                lines.push(format!("  skill_path: {}", skill.path.display()));
-                lines.push(
-                    "  use: open `SKILL.md` only when needed, then follow its instructions"
-                        .to_string(),
-                );
+                if builtin_package {
+                    lines.push(
+                        "  use: activate when needed; rely on the runtime-disclosed instructions instead of opening builtin package files via tools"
+                            .to_string(),
+                    );
+                } else {
+                    lines.push(format!("  skill_path: {}", skill.path.display()));
+                    lines.push(
+                        "  use: open `SKILL.md` only when needed, then follow its instructions"
+                            .to_string(),
+                    );
+                }
             }
         }
         lines.push(String::new());
@@ -1494,6 +1507,90 @@ mod tests {
         let list = render_skills_list(&skills, false).unwrap();
         assert!(list.contains("  skill_source: builtin_capability_package"));
         assert!(list.contains("rely on the runtime-disclosed instructions"));
+        assert!(!list.contains("skill_path:"));
+        assert!(!list.contains("builtin-skill-packages"));
+    }
+
+    #[test]
+    fn test_render_skills_list_keeps_builtin_delegated_target_guidance() {
+        let skills = vec![SkillMetadata {
+            id: "skill-creator".to_string(),
+            package_id: Some("builtin:alan-skill-creator".to_string()),
+            name: "Skill Creator".to_string(),
+            description: "Create or update Alan skill packages".to_string(),
+            short_description: None,
+            path: std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator/SKILL.md",
+            ),
+            package_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator",
+            )),
+            resource_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator",
+            )),
+            scope: SkillScope::Builtin,
+            tags: vec![],
+            capabilities: None,
+            compatibility: Default::default(),
+            source: SkillContentSource::File(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator/SKILL.md",
+            )),
+            enabled: true,
+            allow_implicit_invocation: true,
+            alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
+            execution: ResolvedSkillExecution::Delegate {
+                target: "skill-creator".to_string(),
+                source: SkillExecutionResolutionSource::ExplicitMetadata,
+            },
+        }];
+
+        let list = render_skills_list(&skills, true).unwrap();
+        assert!(list.contains("  skill_source: builtin_capability_package"));
+        assert!(list.contains("  execution: delegate(target=skill-creator)"));
+        assert!(list.contains("invoke_delegated_skill"));
+        assert!(!list.contains("skill_path:"));
+        assert!(!list.contains("builtin-skill-packages"));
+    }
+
+    #[test]
+    fn test_render_skills_list_builtin_delegated_skill_degrades_without_path_leak() {
+        let skills = vec![SkillMetadata {
+            id: "skill-creator".to_string(),
+            package_id: Some("builtin:alan-skill-creator".to_string()),
+            name: "Skill Creator".to_string(),
+            description: "Create or update Alan skill packages".to_string(),
+            short_description: None,
+            path: std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator/SKILL.md",
+            ),
+            package_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator",
+            )),
+            resource_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator",
+            )),
+            scope: SkillScope::Builtin,
+            tags: vec![],
+            capabilities: None,
+            compatibility: Default::default(),
+            source: SkillContentSource::File(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/skill-creator/SKILL.md",
+            )),
+            enabled: true,
+            allow_implicit_invocation: true,
+            alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
+            execution: ResolvedSkillExecution::Delegate {
+                target: "skill-creator".to_string(),
+                source: SkillExecutionResolutionSource::ExplicitMetadata,
+            },
+        }];
+
+        let list = render_skills_list(&skills, false).unwrap();
+        assert!(list.contains("  skill_source: builtin_capability_package"));
+        assert!(list.contains("this runtime cannot delegate the builtin capability directly"));
+        assert!(!list.contains("invoke_delegated_skill"));
         assert!(!list.contains("skill_path:"));
         assert!(!list.contains("builtin-skill-packages"));
     }

--- a/crates/runtime/src/skills/injector.rs
+++ b/crates/runtime/src/skills/injector.rs
@@ -323,6 +323,7 @@ Do not inline the `SKILL.md` body. Treat this skill as unavailable until its pac
 }
 
 fn format_active_skill_context(envelope: &ActiveSkillEnvelope) -> String {
+    let builtin_package = envelope.metadata.is_builtin_package();
     let mut lines = vec![
         "### Alan Runtime Context".to_string(),
         format!("skill_id: {}", envelope.metadata.id),
@@ -335,14 +336,17 @@ fn format_active_skill_context(envelope: &ActiveSkillEnvelope) -> String {
             "allow_implicit_invocation: {}",
             envelope.metadata.allow_implicit_invocation
         ),
-        format!("canonical_path: {}", envelope.metadata.path.display()),
+        format!(
+            "canonical_path: {}",
+            render_prompt_visible_skill_path(&envelope.metadata)
+        ),
         format!(
             "package_root: {}",
-            render_optional_path(envelope.metadata.package_root())
+            render_prompt_visible_package_root(&envelope.metadata)
         ),
         format!(
             "resource_root: {}",
-            render_optional_path(envelope.metadata.resource_root())
+            render_prompt_visible_resource_root(&envelope.metadata)
         ),
         format!("availability: {}", envelope.availability.render_label()),
         format!(
@@ -352,7 +356,12 @@ fn format_active_skill_context(envelope: &ActiveSkillEnvelope) -> String {
         format!("execution: {}", envelope.metadata.execution.render_label()),
     ];
 
-    if envelope.metadata.resource_root().is_some() {
+    if builtin_package {
+        lines.push(
+            "Builtin capability packages are already disclosed through this prompt context. Do not use tools to open builtin package files by path."
+                .to_string(),
+        );
+    } else if envelope.metadata.resource_root().is_some() {
         lines.push(
             "Resolve relative skill resource references against `resource_root`.".to_string(),
         );
@@ -894,6 +903,30 @@ fn render_optional_path(path: Option<&Path>) -> String {
         .unwrap_or_else(|| "<none>".to_string())
 }
 
+fn render_prompt_visible_skill_path(skill: &SkillMetadata) -> String {
+    if skill.is_builtin_package() {
+        format!("builtin:{}", skill.id)
+    } else {
+        skill.path.display().to_string()
+    }
+}
+
+fn render_prompt_visible_package_root(skill: &SkillMetadata) -> String {
+    if skill.is_builtin_package() {
+        "<builtin capability package>".to_string()
+    } else {
+        render_optional_path(skill.package_root())
+    }
+}
+
+fn render_prompt_visible_resource_root(skill: &SkillMetadata) -> String {
+    if skill.is_builtin_package() {
+        "<builtin capability package>".to_string()
+    } else {
+        render_optional_path(skill.resource_root())
+    }
+}
+
 fn format_unresolved_execution_details(execution: &ResolvedSkillExecution) -> String {
     let ResolvedSkillExecution::Unresolved { reason } = execution else {
         return String::new();
@@ -966,6 +999,15 @@ pub fn render_skills_list(
         lines.push(format!("- skill_id: {}", skill.id));
         lines.push(format!("  name: {}", skill.name));
         lines.push(format!("  description: {}", skill.description));
+        if skill.is_builtin_package() {
+            lines.push("  skill_source: builtin_capability_package".to_string());
+            lines.push(
+                "  use: activate when needed; rely on the runtime-disclosed instructions instead of opening builtin package files via tools"
+                    .to_string(),
+            );
+            lines.push(String::new());
+            continue;
+        }
         match &skill.execution {
             ResolvedSkillExecution::Delegate { .. } if !delegated_invocation_available => {
                 lines.push(format!("  skill_path: {}", skill.path.display()));
@@ -1416,6 +1458,99 @@ mod tests {
         assert!(list.contains("  skill_path: /c/SKILL.md"));
         assert!(!list.contains("invoke_delegated_skill"));
         assert!(!list.contains("execution: delegate("));
+    }
+
+    #[test]
+    fn test_render_skills_list_hides_builtin_package_paths() {
+        let skills = vec![SkillMetadata {
+            id: "memory".to_string(),
+            package_id: Some("builtin:alan-memory".to_string()),
+            name: "Memory".to_string(),
+            description: "Persistent memory across sessions".to_string(),
+            short_description: None,
+            path: std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory/SKILL.md",
+            ),
+            package_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory",
+            )),
+            resource_root: Some(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory",
+            )),
+            scope: SkillScope::Builtin,
+            tags: vec![],
+            capabilities: None,
+            compatibility: Default::default(),
+            source: SkillContentSource::File(std::path::PathBuf::from(
+                "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory/SKILL.md",
+            )),
+            enabled: true,
+            allow_implicit_invocation: true,
+            alan_metadata: Default::default(),
+            compatible_metadata: Default::default(),
+            execution: Default::default(),
+        }];
+
+        let list = render_skills_list(&skills, false).unwrap();
+        assert!(list.contains("  skill_source: builtin_capability_package"));
+        assert!(list.contains("rely on the runtime-disclosed instructions"));
+        assert!(!list.contains("skill_path:"));
+        assert!(!list.contains("builtin-skill-packages"));
+    }
+
+    #[test]
+    fn test_active_skill_context_hides_builtin_package_paths() {
+        let skill = Skill {
+            metadata: SkillMetadata {
+                id: "memory".to_string(),
+                package_id: Some("builtin:alan-memory".to_string()),
+                name: "Memory".to_string(),
+                description: "Persistent memory across sessions".to_string(),
+                short_description: None,
+                path: std::path::PathBuf::from(
+                    "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory/SKILL.md",
+                ),
+                package_root: Some(std::path::PathBuf::from(
+                    "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory",
+                )),
+                resource_root: Some(std::path::PathBuf::from(
+                    "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory",
+                )),
+                scope: SkillScope::Builtin,
+                tags: vec![],
+                capabilities: None,
+                compatibility: Default::default(),
+                source: SkillContentSource::File(std::path::PathBuf::from(
+                    "/private/tmp/alan/builtin-skill-packages/0.1.0/123/memory/SKILL.md",
+                )),
+                enabled: true,
+                allow_implicit_invocation: true,
+                alan_metadata: Default::default(),
+                compatible_metadata: Default::default(),
+                execution: Default::default(),
+            },
+            content: "# Instructions\nPersist durable context.".to_string(),
+            frontmatter: SkillFrontmatter {
+                name: "Memory".to_string(),
+                description: "Persistent memory across sessions".to_string(),
+                metadata: Default::default(),
+                capabilities: Default::default(),
+                compatibility: Default::default(),
+            },
+        };
+        let envelope = ActiveSkillEnvelope::available(
+            skill.metadata.clone(),
+            SkillActivationReason::ExplicitMention {
+                mention: "memory".to_string(),
+            },
+        );
+
+        let rendered = render_active_skill_prompt_for_runtime(&skill, &envelope, false).rendered;
+        assert!(rendered.contains("canonical_path: builtin:memory"));
+        assert!(rendered.contains("package_root: <builtin capability package>"));
+        assert!(rendered.contains("resource_root: <builtin capability package>"));
+        assert!(rendered.contains("Do not use tools to open builtin package files by path."));
+        assert!(!rendered.contains("builtin-skill-packages"));
     }
 
     #[test]

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -259,6 +259,12 @@ pub struct SkillMetadata {
 }
 
 impl SkillMetadata {
+    pub fn is_builtin_package(&self) -> bool {
+        self.package_id
+            .as_deref()
+            .is_some_and(|package_id| package_id.starts_with("builtin:"))
+    }
+
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -463,7 +463,7 @@ resolved capability view:
 
 | Skill      | Purpose                                                       |
 | ---------- | ------------------------------------------------------------- |
-| **memory** | Persistent knowledge across sessions (`.alan/memory/`)        |
+| **memory** | Persistent knowledge across sessions (`{workspace_alan_dir}/memory/`) |
 | **plan**   | Structured execution plans for complex tasks (`.alan/plans/`) |
 | **alan-shell-control** | Native Alan terminal shell layout and pane control |
 | **skill-creator** | First-party authoring and eval workflow guidance |

--- a/docs/spec/memory_architecture.md
+++ b/docs/spec/memory_architecture.md
@@ -22,9 +22,10 @@ Core principles:
 Implemented in the current tree:
 
 1. L0 execution memory is persisted through Tape + rollout.
-2. L1 workspace memory uses `.alan/memory/` plus the memory skill.
+2. L1 workspace memory uses the active workspace Alan state directory's `memory/` folder plus the memory skill.
 3. Automatic pre-compaction memory flush writes high-value durable notes to
-   `.alan/memory/YYYY-MM-DD.md` for soft-threshold `AutoPreTurn` compaction.
+   `memory/YYYY-MM-DD.md` under the active workspace Alan state directory for soft-threshold
+   `AutoPreTurn` compaction.
 4. The latest memory-flush attempt is recoverable via event replay,
    session-read APIs, reconnect snapshots, and rollout fallback.
 
@@ -46,7 +47,7 @@ Still target-only or incomplete:
 
 ### L1: Workspace Memory
 
-- Carrier: `{workspace}/.alan/memory/`
+- Carrier: `{workspace_alan_dir}/memory/`
 - Lifecycle: Workspace-level
 - Purpose: stable preferences, decisions, constraints, key facts
 - Traits: human-readable, editable, versionable
@@ -55,6 +56,11 @@ Recommended base files:
 
 - `MEMORY.md`: long-lived stable memory (rules, preferences, context)
 - `memory/YYYY-MM-DD.md`: daily incremental log, including automatic pre-compaction flush entries
+
+Path examples:
+
+- normal repo workspace: `{workspace}/.alan/memory/`
+- default workspace: `~/.alan/memory/`
 
 ### L2: Retrieval Memory (Optional Index Layer)
 
@@ -109,7 +115,8 @@ Before soft compaction threshold:
 1. Run a silent pass to persist high-value info to L1.
 2. No user-visible reply by default unless necessary.
 3. Trigger once per compaction cycle.
-4. Append successful flush output to `.alan/memory/YYYY-MM-DD.md`, not directly to `MEMORY.md`.
+4. Append successful flush output to `{workspace_alan_dir}/memory/YYYY-MM-DD.md`, not directly to
+   `MEMORY.md`.
 
 ### Contract requirements
 


### PR DESCRIPTION
## Summary
- hide materialized builtin skill package paths from prompt-visible skill metadata while keeping runtime resource roots usable internally
- tighten persona and system prompt guidance so injected persona files are not re-read by default and explicit cross-session memory requests are treated as persistence work
- fix memory skill and memory architecture docs to use the active Alan state directory instead of assuming `.alan/memory/`
- record the actual runtime tool cwd in rollout/session metadata and preserve it across resume paths
- add regression coverage for builtin skill prompt rendering, workspace persona guidance, memory persistence guidance, and rollout cwd handling

## Root Cause
A few session-runtime contracts were drifting apart:
- builtin skills are materialized into temp directories for runtime use, but those temp paths were leaking into prompt-visible metadata
- persona prompts implied the model should read files that were already injected into the prompt
- the memory skill hard-coded `.alan/memory/`, which is wrong for the default workspace layout under `~/.alan`
- rollout metadata captured the process cwd instead of the runtime's effective tool cwd

## Impact
These fixes reduce wasted tool calls, stop sandbox-hostile builtin path leakage, align memory behavior with the real workspace layout, and make rollout/session metadata match the runtime the agent actually used.

## Validation
- `cargo fmt --all`
- `cargo test -p alan-runtime --lib`