### PR TITLE
Harden runtime durability and refine Mac shell UX

### DIFF
--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -22,6 +22,18 @@ enum ShellPalette {
     static let attention = Color(red: 0.82, green: 0.55, blue: 0.24)
 }
 
+private struct SidebarMaterialView: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .sidebar
+        view.blendingMode = .behindWindow
+        view.state = .followsWindowActiveState
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
 struct MacShellRootView: View {
     @StateObject private var host: ShellHostController
     @State private var isCommandSurfacePresented = false
@@ -29,20 +41,17 @@ struct MacShellRootView: View {
     private var showsInspector = false
 
     init() {
-        _host = StateObject(wrappedValue: ShellHostController.live())
+        _host = StateObject(
+            wrappedValue: ShellHostController.live(startupMode: .fresh)
+        )
     }
 
     var body: some View {
         ZStack {
-            LinearGradient(
-                colors: [
-                    ShellPalette.canvas,
-                    Color(red: 0.95, green: 0.95, blue: 0.98),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
+            ShellSpaceKeyboardShortcuts(host: host)
+
+            ShellPalette.canvas
+                .ignoresSafeArea()
 
             HStack(spacing: 0) {
                 ShellSidebarView(host: host) {
@@ -61,7 +70,10 @@ struct MacShellRootView: View {
                     ShellWorkspaceView(host: host)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(ShellPalette.workspace)
+                .background {
+                    ShellPalette.workspace
+                        .ignoresSafeArea(edges: .top)
+                }
 
                 if showsInspector {
                     ShellInspectorView(host: host)
@@ -69,9 +81,8 @@ struct MacShellRootView: View {
                         .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-            .padding(.top, 8)
             .frame(minWidth: 1260, minHeight: 800)
-            .background(ShellPalette.window.opacity(0.98))
+            .background(ShellPalette.window)
 
             if isCommandSurfacePresented {
                 Color.black.opacity(0.16)
@@ -132,6 +143,7 @@ private enum AlanShellWindowPlacement {
         window.title = "Alan"
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = true
         window.minSize = NSSize(width: 1180, height: 760)
         window.tabbingMode = .disallowed
@@ -243,166 +255,111 @@ private struct ShellSidebarView: View {
     @State private var hoveredSpaceID: String?
 
     var body: some View {
-        HStack(spacing: 0) {
-            spaceRail
-            tabList
+        VStack(alignment: .leading, spacing: 14) {
+            sidebarHeader
+            commandLauncher
+            tabSection
+            spaceDock
         }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 15)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(
-            ShellPalette.sidebar
-                .overlay(alignment: .trailing) {
-                    Rectangle()
-                        .fill(ShellPalette.line.opacity(0.48))
-                        .frame(width: 1)
-                }
-        )
+        .background {
+            ZStack {
+                SidebarMaterialView()
+                ShellPalette.sidebar.opacity(0.35)
+            }
+            .ignoresSafeArea(edges: .top)
+        }
     }
 
-    private var spaceRail: some View {
-        VStack(spacing: 12) {
+    private var sidebarHeader: some View {
+        HStack(alignment: .center, spacing: 10) {
             ZStack {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.white.opacity(0.76))
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .fill(Color.white.opacity(0.18))
                 Text("A")
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .font(.system(size: 12.5, weight: .bold, design: .rounded))
                     .foregroundStyle(ShellPalette.accent)
             }
-            .frame(width: 34, height: 34)
-            .padding(.top, 6)
+            .frame(width: 28, height: 28)
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 10) {
-                    ForEach(Array(host.spaces.enumerated()), id: \.element.spaceID) { index, space in
-                        Button {
-                            host.select(spaceID: space.spaceID)
-                        } label: {
-                            ShellSpaceRailItem(
-                                title: space.title,
-                                symbolName: spaceSymbol(for: space),
-                                attention: space.attention,
-                                isSelected: host.selectedSpace?.spaceID == space.spaceID,
-                                isHovered: hoveredSpaceID == space.spaceID
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { isHovering in
-                            hoveredSpaceID = isHovering ? space.spaceID : nil
-                        }
-                    }
-                }
-                .padding(.vertical, 4)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(host.selectedSpace?.title ?? "Alan")
+                    .font(.system(size: 15.5, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(spaceSubtitle)
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
 
+            Spacer(minLength: 8)
+
             Menu {
-                Button("New Space") {
-                    _ = host.createTerminalSpace()
+                Button("New Tab") {
+                    _ = host.openTerminalSurface()
                 }
-                Button("New Space with Alan") {
-                    _ = host.createAlanSpace()
+                Button("Open in Alan") {
+                    _ = host.openAlanSurface()
                 }
             } label: {
                 Image(systemName: "plus")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(ShellPalette.ink)
-                    .frame(width: 34, height: 34)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 26, height: 26)
                     .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color.white.opacity(0.68))
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.white.opacity(0.12))
                     )
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(ShellPalette.line.opacity(0.45), lineWidth: 1)
-                    }
             }
             .menuStyle(.borderlessButton)
             .buttonStyle(.plain)
             .menuIndicator(.hidden)
-            .help("Create a new space")
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 14)
-        .frame(width: 60)
-        .frame(maxHeight: .infinity, alignment: .top)
-        .background(
-            ShellPalette.sidebarRail
-                .overlay(alignment: .trailing) {
-                    Rectangle()
-                        .fill(ShellPalette.line.opacity(0.34))
-                        .frame(width: 1)
-                }
-        )
     }
 
-    private var tabList: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 10) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(host.selectedSpace?.title ?? "Alan")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(ShellPalette.ink)
-                    Text(spaceSubtitle)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                }
-
-                Spacer(minLength: 8)
-
-                Menu {
-                    Button("New Tab") {
-                        _ = host.openTerminalSurface()
-                    }
-                    Button("Open in Alan") {
-                        _ = host.openAlanSurface()
-                    }
-                    Divider()
-                    Button("New Space") {
-                        _ = host.createTerminalSpace()
-                    }
-                    Button("New Space with Alan") {
-                        _ = host.createAlanSpace()
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(ShellPalette.ink)
-                        .frame(width: 26, height: 26)
-                        .background(
-                            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                .fill(Color.white.opacity(0.72))
-                        )
-                }
-                .menuStyle(.borderlessButton)
-                .buttonStyle(.plain)
-                .menuIndicator(.hidden)
+    private var commandLauncher: some View {
+        Button(action: openCommandSurface) {
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text("Go to tab or command")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Text("⌘K")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.tertiary)
             }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.white.opacity(0.10))
+            )
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut("k", modifiers: [.command])
+    }
 
-            Button(action: openCommandSurface) {
-                HStack(spacing: 10) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(ShellPalette.accent)
-                    Text("Go to or command")
-                        .font(.system(size: 10.5, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                        .lineLimit(1)
-                    Spacer(minLength: 0)
-                    Text("⌘K")
+    private var tabSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Tabs")
+                    .font(.system(size: 11, weight: .semibold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                if let selectedSpace = host.selectedSpace {
+                    Text("\(selectedSpace.surfaces.count)")
                         .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                }
-                .padding(.horizontal, 11)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .fill(Color.white.opacity(0.74))
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(ShellPalette.line.opacity(0.34), lineWidth: 1)
+                        .foregroundStyle(.secondary)
                 }
             }
-            .buttonStyle(.plain)
-            .keyboardShortcut("k", modifiers: [.command])
 
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 4) {
@@ -447,11 +404,59 @@ private struct ShellSidebarView: View {
                     }
                 }
             }
-
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 15)
         .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private var spaceDock: some View {
+        ShellSidebarSection(title: "Spaces", accessory: "⌥⌘1-9") {
+            HStack(spacing: 10) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(host.spaces) { space in
+                            Button {
+                                host.select(spaceID: space.spaceID)
+                            } label: {
+                                ShellSpaceRailItem(
+                                    title: space.title,
+                                    symbolName: spaceSymbol(for: space),
+                                    attention: space.attention,
+                                    isSelected: host.selectedSpace?.spaceID == space.spaceID,
+                                    isHovered: hoveredSpaceID == space.spaceID
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .onHover { isHovering in
+                                hoveredSpaceID = isHovering ? space.spaceID : nil
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+
+                Menu {
+                    Button("New Space") {
+                        _ = host.createTerminalSpace()
+                    }
+                    Button("New Space with Alan") {
+                        _ = host.createAlanSpace()
+                    }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .frame(width: 30, height: 30)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color.white.opacity(0.10))
+                        )
+                }
+                .menuStyle(.borderlessButton)
+                .buttonStyle(.plain)
+                .menuIndicator(.hidden)
+                .help("Create a new space")
+            }
+        }
     }
 
     private var spaceSubtitle: String {
@@ -583,7 +588,7 @@ private struct ShellWorkspaceView: View {
             TerminalPaneView(host: host)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .padding(12)
+        .padding(16)
     }
 }
 
@@ -717,12 +722,40 @@ private struct ShellTopBarView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 11)
-        .background(ShellPalette.workspace)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(ShellPalette.line.opacity(0.48))
-                .frame(height: 1)
+    }
+}
+
+private struct ShellSpaceKeyboardShortcuts: View {
+    @ObservedObject var host: ShellHostController
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button("") {
+                host.selectAdjacentSpace(offset: -1)
+            }
+            .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+
+            Button("") {
+                host.selectAdjacentSpace(offset: 1)
+            }
+            .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+
+            ForEach(Array(host.spaces.prefix(9).enumerated()), id: \.element.spaceID) { index, _ in
+                Button("") {
+                    host.selectSpace(at: index)
+                }
+                .keyboardShortcut(
+                    KeyEquivalent(Character(String(index + 1))),
+                    modifiers: [.command, .option]
+                )
+            }
         }
+        .labelsHidden()
+        .buttonStyle(.plain)
+        .frame(width: 0, height: 0)
+        .opacity(0.001)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
     }
 }
 
@@ -740,23 +773,14 @@ private struct ShellSpaceRailItem: View {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(
                         isSelected
-                            ? Color.white.opacity(0.9)
-                            : (isHovered ? Color.white.opacity(0.62) : Color.white.opacity(0.42))
+                            ? Color.white.opacity(0.22)
+                            : (isHovered ? Color.white.opacity(0.14) : Color.white.opacity(0.08))
                     )
                 Image(systemName: symbolName)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(isSelected ? ShellPalette.accent : ShellPalette.ink)
+                    .foregroundStyle(isSelected ? ShellPalette.accent : .primary)
             }
             .frame(width: 34, height: 34)
-            .overlay {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(
-                        isSelected
-                            ? ShellPalette.line.opacity(0.56)
-                            : (isHovered ? ShellPalette.line.opacity(0.26) : Color.clear),
-                        lineWidth: 1
-                    )
-            }
 
             if attention != .idle {
                 Circle()
@@ -806,15 +830,15 @@ private struct ShellTabRow: View {
         HStack(spacing: 10) {
             Image(systemName: iconName)
                 .font(.system(size: 11.5, weight: .semibold))
-                .foregroundStyle(isSelected ? ShellPalette.accent : ShellPalette.mutedInk)
+                .foregroundStyle(isSelected ? ShellPalette.accent : .secondary)
                 .frame(width: 14)
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
                     Text(title)
-                        .font(.system(size: 12.5, weight: .semibold))
+                        .font(.system(size: 13, weight: .semibold))
                         .tracking(-0.1)
-                        .foregroundStyle(ShellPalette.ink)
+                        .foregroundStyle(.primary)
                         .lineLimit(1)
 
                     if showsAlanMarker {
@@ -825,8 +849,8 @@ private struct ShellTabRow: View {
                 }
 
                 Text(subtitle)
-                    .font(.system(size: 10.5, weight: .medium))
-                    .foregroundStyle(ShellPalette.mutedInk)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 
@@ -842,43 +866,21 @@ private struct ShellTabRow: View {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(ShellPalette.mutedInk)
+                        .foregroundStyle(.secondary)
                         .frame(width: 18, height: 18)
                 }
                 .buttonStyle(.plain)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6.5)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
         .background(
             RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .fill(
                     isSelected
-                        ? Color.white.opacity(0.88)
-                        : (isHovered ? Color.white.opacity(0.42) : Color.clear)
+                        ? Color.white.opacity(0.15)
+                        : (isHovered ? Color.white.opacity(0.08) : Color.clear)
                 )
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 11, style: .continuous)
-                .stroke(
-                    isSelected
-                        ? ShellPalette.line.opacity(0.38)
-                        : (isHovered ? ShellPalette.line.opacity(0.22) : Color.clear),
-                    lineWidth: 1
-                )
-        }
-        .overlay(alignment: .leading) {
-            if isSelected {
-                Capsule(style: .continuous)
-                    .fill(ShellPalette.accent)
-                    .frame(width: 3, height: 22)
-                    .padding(.leading, 4)
-            }
-        }
-        .shadow(
-            color: isSelected ? Color.black.opacity(0.028) : .clear,
-            radius: 7,
-            y: 3
         )
         .scaleEffect(isHovered && !isSelected ? 1.005 : 1)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
@@ -1126,10 +1128,10 @@ private struct ShellInspectorView: View {
         }
         .padding(16)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(ShellPalette.window.opacity(0.9))
+        .background(ShellPalette.window.opacity(0.95))
         .overlay(alignment: .leading) {
             Rectangle()
-                .fill(ShellPalette.line.opacity(0.44))
+                .fill(ShellPalette.line.opacity(0.15))
                 .frame(width: 1)
         }
     }
@@ -1146,12 +1148,12 @@ private struct ShellSidebarSection<Content: View>: View {
                 Text(title)
                     .font(.system(size: 11, weight: .semibold))
                     .textCase(.uppercase)
-                    .foregroundStyle(ShellPalette.mutedInk)
+                    .foregroundStyle(.secondary)
                 Spacer(minLength: 0)
                 if let accessory {
                     Text(accessory)
                         .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(ShellPalette.mutedInk)
+                        .foregroundStyle(.tertiary)
                 }
             }
 
@@ -1916,9 +1918,9 @@ private struct ShellToolbarButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: symbol)
-                .font(.system(size: 12.5, weight: .semibold))
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(ShellPalette.ink)
-                .frame(width: 28, height: 28)
+                .frame(width: 30, height: 30)
                 .background(
                     RoundedRectangle(cornerRadius: 9, style: .continuous)
                         .fill(isHovered ? Color.white.opacity(0.92) : ShellPalette.panel)
@@ -1944,9 +1946,9 @@ private struct ShellToolbarGlyph: View {
 
     var body: some View {
         Image(systemName: symbol)
-            .font(.system(size: 12.5, weight: .semibold))
+            .font(.system(size: 13, weight: .semibold))
             .foregroundStyle(ShellPalette.ink)
-            .frame(width: 28, height: 28)
+            .frame(width: 30, height: 30)
             .background(
                 RoundedRectangle(cornerRadius: 9, style: .continuous)
                     .fill(isHovered ? Color.white.opacity(0.92) : ShellPalette.panel)

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -35,6 +35,11 @@ private enum ShellPaneLiftResult {
 
 @MainActor
 final class ShellHostController: ObservableObject {
+    enum StartupMode {
+        case fresh
+        case restorePrevious
+    }
+
     private static let iso8601Formatter = ISO8601DateFormatter()
     private static let persistenceFileName = "shell-state-v0.1.json"
 
@@ -96,16 +101,30 @@ final class ShellHostController: ObservableObject {
         synchronizeSelection()
     }
 
-    static func live(fileManager: FileManager = .default) -> ShellHostController {
+    static func live(
+        fileManager: FileManager = .default,
+        startupMode: StartupMode = .fresh
+    ) -> ShellHostController {
         let persistenceURL = defaultPersistenceURL(fileManager: fileManager)
-        let shellState =
-            restoreShellState(fileManager: fileManager, persistenceURL: persistenceURL)
-            ?? .bootstrapDefault()
-        return ShellHostController(
+        let shellState: ShellStateSnapshot
+        switch startupMode {
+        case .fresh:
+            shellState = .bootstrapDefault()
+        case .restorePrevious:
+            shellState =
+                restoreShellState(fileManager: fileManager, persistenceURL: persistenceURL)
+                ?? .bootstrapDefault()
+        }
+
+        let controller = ShellHostController(
             shellState: shellState,
             fileManager: fileManager,
             persistenceURL: persistenceURL
         )
+        if startupMode == .fresh {
+            controller.persistShellState()
+        }
+        return controller
     }
 
     var spaces: [ShellSpace] {
@@ -218,6 +237,24 @@ final class ShellHostController: ObservableObject {
         guard selectedSpace?.surfaces.contains(where: { $0.surfaceID == surfaceID }) == true else { return }
         selectedSurfaceID = surfaceID
         terminalRuntime = runtime(for: selectedPane?.paneID)
+    }
+
+    func selectSpace(at index: Int) {
+        guard spaces.indices.contains(index) else { return }
+        select(spaceID: spaces[index].spaceID)
+    }
+
+    func selectAdjacentSpace(offset: Int) {
+        guard !spaces.isEmpty else { return }
+        guard let selectedSpaceID,
+              let currentIndex = spaces.firstIndex(where: { $0.spaceID == selectedSpaceID })
+        else {
+            select(spaceID: spaces[0].spaceID)
+            return
+        }
+
+        let nextIndex = (currentIndex + offset + spaces.count) % spaces.count
+        select(spaceID: spaces[nextIndex].spaceID)
     }
 
     func focusAttentionItem(_ item: ShellAttentionItem) {

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -183,7 +183,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
         layer?.backgroundColor = NSColor(calibratedRed: 0.06, green: 0.08, blue: 0.10, alpha: 1).cgColor
         layer?.cornerRadius = 16
         layer?.borderWidth = 1
-        layer?.borderColor = NSColor.white.withAlphaComponent(0.06).cgColor
+        layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        layer?.shadowColor = NSColor.black.cgColor
+        layer?.shadowOpacity = 0.12
+        layer?.shadowRadius = 16
+        layer?.shadowOffset = CGSize(width: 0, height: -4)
 
         translatesAutoresizingMaskIntoConstraints = false
 

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -426,9 +426,29 @@ fn run_status_from_event(event: &Event, current_status: RunStatus) -> Option<Run
     match event {
         Event::TurnStarted {} => Some(RunStatus::Running),
         Event::Yield { .. } => Some(RunStatus::Yielded),
-        Event::TurnCompleted { .. } if matches!(current_status, RunStatus::Yielded) => {
-            Some(RunStatus::Running)
+        Event::TurnCompleted { .. }
+            if !matches!(current_status, RunStatus::Cancelled | RunStatus::Failed) =>
+        {
+            Some(RunStatus::Succeeded)
         }
+        Event::Error {
+            recoverable: false, ..
+        } => Some(RunStatus::Failed),
+        _ => None,
+    }
+}
+
+fn task_status_from_event(event: &Event, current_status: TaskStatus) -> Option<TaskStatus> {
+    match event {
+        Event::TurnStarted {} => Some(TaskStatus::Running),
+        Event::TurnCompleted { .. }
+            if !matches!(current_status, TaskStatus::Cancelled | TaskStatus::Failed) =>
+        {
+            Some(TaskStatus::Completed)
+        }
+        Event::Error {
+            recoverable: false, ..
+        } => Some(TaskStatus::Failed),
         _ => None,
     }
 }
@@ -1970,6 +1990,35 @@ impl AppState {
                                     run_id = %session_id,
                                     error = %err,
                                     "Failed to read run state before applying runtime event status transition"
+                                );
+                            }
+                        }
+                        let task_id = format!("session-task-{session_id}");
+                        match task_store.get_task(&task_id) {
+                            Ok(Some(task)) => {
+                                if let Some(task_status) =
+                                    task_status_from_event(&event.event, task.status)
+                                    && let Err(err) = task_store.transition_task_status(
+                                        &task_id,
+                                        task_status,
+                                        RUNTIME_EVENT_ACTOR,
+                                        Some("runtime emitted lifecycle event".to_string()),
+                                    )
+                                {
+                                    warn!(
+                                        task_id = %task_id,
+                                        task_status = ?task_status,
+                                        error = %err,
+                                        "Failed to persist task status transition from runtime event"
+                                    );
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                warn!(
+                                    task_id = %task_id,
+                                    error = %err,
+                                    "Failed to read task state before applying runtime event status transition"
                                 );
                             }
                         }
@@ -3774,7 +3823,7 @@ Body
     }
 
     #[tokio::test]
-    async fn spawn_event_bridge_marks_yielded_run_running_after_resume_turn_completed() {
+    async fn spawn_event_bridge_marks_completed_turn_succeeded_after_resume() {
         let temp = TempDir::new().unwrap();
         let state = test_state_with_base_dir(temp.path());
         state
@@ -3814,12 +3863,62 @@ Body
             .get_run("sess-bridge-resume")
             .unwrap()
             .unwrap();
-        assert_eq!(run.status, RunStatus::Running);
+        assert_eq!(run.status, RunStatus::Succeeded);
+        let task = state
+            .task_store
+            .get_task("session-task-sess-bridge-resume")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Completed);
         let restored = state.restore_run("sess-bridge-resume").unwrap();
         assert_eq!(
             restored.next_action,
-            crate::daemon::task_store::RunResumeAction::ResumeRuntime
+            crate::daemon::task_store::RunResumeAction::Terminal
         );
+    }
+
+    #[tokio::test]
+    async fn spawn_event_bridge_marks_plain_turn_completed_succeeded() {
+        let temp = TempDir::new().unwrap();
+        let state = test_state_with_base_dir(temp.path());
+        state
+            .ensure_task_run_for_session("sess-bridge-complete")
+            .unwrap();
+
+        let (runtime_events_tx, _) = broadcast::channel(16);
+        let (client_events_tx, _) = broadcast::channel(16);
+        let event_log = Arc::new(RwLock::new(SessionEventLog::new(16)));
+        let bridge = AppState::spawn_event_bridge(
+            "sess-bridge-complete".to_string(),
+            runtime_events_tx.subscribe(),
+            client_events_tx,
+            event_log,
+            Arc::clone(&state.task_store),
+        );
+
+        runtime_events_tx
+            .send(runtime_event(Event::TurnStarted {}))
+            .unwrap();
+        runtime_events_tx
+            .send(runtime_event(Event::TurnCompleted {
+                summary: Some("plain turn complete".to_string()),
+            }))
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        bridge.abort();
+
+        let run = state
+            .task_store
+            .get_run("sess-bridge-complete")
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, RunStatus::Succeeded);
+        let task = state
+            .task_store
+            .get_task("session-task-sess-bridge-complete")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Completed);
     }
 
     #[tokio::test]

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -38,7 +38,7 @@ use std::{
 };
 use tokio::sync::{Mutex, RwLock, broadcast, mpsc};
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 const ENV_HOST_AUTH_EXTERNAL_TOKEN_HANDOFF_ENABLED: &str =
     "ALAN_HOST_AUTH_EXTERNAL_TOKEN_HANDOFF_ENABLED";
@@ -427,7 +427,10 @@ fn run_status_from_event(event: &Event, current_status: RunStatus) -> Option<Run
         Event::TurnStarted {} => Some(RunStatus::Running),
         Event::Yield { .. } => Some(RunStatus::Yielded),
         Event::TurnCompleted { .. }
-            if !matches!(current_status, RunStatus::Cancelled | RunStatus::Failed) =>
+            if !matches!(
+                current_status,
+                RunStatus::Sleeping | RunStatus::Cancelled | RunStatus::Failed
+            ) =>
         {
             Some(RunStatus::Succeeded)
         }
@@ -1965,8 +1968,13 @@ impl AppState {
             loop {
                 match runtime_events_rx.recv().await {
                     Ok(event) => {
+                        let mut preserve_sleeping_status = false;
                         match task_store.get_run(&session_id) {
                             Ok(Some(run)) => {
+                                preserve_sleeping_status = matches!(
+                                    (&event.event, run.status),
+                                    (Event::TurnCompleted { .. }, RunStatus::Sleeping)
+                                );
                                 if let Some(run_status) =
                                     run_status_from_event(&event.event, run.status)
                                     && let Err(err) = task_store.transition_run_status(
@@ -1996,7 +2004,13 @@ impl AppState {
                         let task_id = format!("session-task-{session_id}");
                         match task_store.get_task(&task_id) {
                             Ok(Some(task)) => {
-                                if let Some(task_status) =
+                                if preserve_sleeping_status {
+                                    debug!(
+                                        task_id = %task_id,
+                                        run_id = %session_id,
+                                        "Ignoring trailing TurnCompleted for sleeping run"
+                                    );
+                                } else if let Some(task_status) =
                                     task_status_from_event(&event.event, task.status)
                                     && let Err(err) = task_store.transition_task_status(
                                         &task_id,
@@ -3919,6 +3933,65 @@ Body
             .unwrap()
             .unwrap();
         assert_eq!(task.status, TaskStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn spawn_event_bridge_preserves_sleeping_run_when_turn_completed_arrives_during_stop() {
+        let temp = TempDir::new().unwrap();
+        let state = test_state_with_base_dir(temp.path());
+
+        let (entry, _rx) = test_session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert("sess-bridge-sleeping".to_string(), entry);
+
+        let wake_at = Utc::now() + chrono::Duration::minutes(2);
+        state
+            .sleep_until("sess-bridge-sleeping", wake_at)
+            .await
+            .unwrap();
+
+        let (runtime_events_tx, _) = broadcast::channel(16);
+        let (client_events_tx, _) = broadcast::channel(16);
+        let event_log = Arc::new(RwLock::new(SessionEventLog::new(16)));
+        let bridge = AppState::spawn_event_bridge(
+            "sess-bridge-sleeping".to_string(),
+            runtime_events_tx.subscribe(),
+            client_events_tx,
+            event_log,
+            Arc::clone(&state.task_store),
+        );
+
+        runtime_events_tx
+            .send(runtime_event(Event::TurnCompleted {
+                summary: Some("late completion during sleep".to_string()),
+            }))
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        bridge.abort();
+
+        let run = state
+            .task_store
+            .get_run("sess-bridge-sleeping")
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, RunStatus::Sleeping);
+        assert_eq!(run.next_wake_at, Some(wake_at.to_rfc3339()));
+
+        let task = state
+            .task_store
+            .get_task("session-task-sess-bridge-sleeping")
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Running);
+
+        let restored = state.restore_run("sess-bridge-sleeping").unwrap();
+        assert_eq!(
+            restored.next_action,
+            crate::daemon::task_store::RunResumeAction::AwaitScheduledWake
+        );
     }
 
     #[tokio::test]

--- a/crates/alan/src/daemon/task_store.rs
+++ b/crates/alan/src/daemon/task_store.rs
@@ -545,6 +545,17 @@ impl<B: TaskStoreBackend> TaskStore<B> {
                     now.clone(),
                 ));
                 run.status = to;
+                if matches!(to, RunStatus::Running) {
+                    run.started_at.get_or_insert_with(|| now.clone());
+                    run.ended_at = None;
+                } else if matches!(
+                    to,
+                    RunStatus::Succeeded | RunStatus::Failed | RunStatus::Cancelled
+                ) {
+                    run.ended_at = Some(now.clone());
+                } else {
+                    run.ended_at = None;
+                }
                 run.updated_at = now;
             }
             Ok(run.clone())
@@ -986,6 +997,25 @@ mod tests {
 
         assert_eq!(yielded.next_action, RunResumeAction::AwaitUserResume);
         assert_eq!(sleeping.next_action, RunResumeAction::AwaitScheduledWake);
+    }
+
+    #[test]
+    fn transition_run_status_sets_terminal_end_timestamp() {
+        let temp = TempDir::new().unwrap();
+        let store = TaskStore::with_dir(temp.path()).unwrap();
+
+        store
+            .save_run(RunRecord::new("run-terminal", "task-terminal", 1))
+            .unwrap();
+        store
+            .transition_run_status("run-terminal", RunStatus::Running, "daemon", None)
+            .unwrap();
+        let updated = store
+            .transition_run_status("run-terminal", RunStatus::Succeeded, "daemon", None)
+            .unwrap();
+
+        assert!(updated.started_at.is_some());
+        assert!(updated.ended_at.is_some());
     }
 
     #[test]

--- a/crates/alan/tests/live_runtime_smoke_test.rs
+++ b/crates/alan/tests/live_runtime_smoke_test.rs
@@ -216,3 +216,175 @@ async fn live_chatgpt_runtime_smoke() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[ignore = "live runtime memory smoke; requires ALAN_LIVE_PROVIDER_TESTS=1 and managed ChatGPT auth"]
+async fn live_chatgpt_runtime_cross_session_memory_smoke() -> Result<()> {
+    if !live_enabled() {
+        eprintln!(
+            "[live-runtime-smoke] skipping chatgpt memory: set {LIVE_ENABLE_ENV}=1 to enable"
+        );
+        return Ok(());
+    }
+
+    let Some(auth_storage_path) = non_empty_env(CHATGPT_AUTH_STORAGE_PATH_ENV) else {
+        eprintln!(
+            "[live-runtime-smoke] skipping chatgpt memory: {CHATGPT_AUTH_STORAGE_PATH_ENV} is unset"
+        );
+        return Ok(());
+    };
+
+    let temp_home = TempDir::new().context("create temp home")?;
+    let temp_workspace = TempDir::new().context("create temp workspace root")?;
+    let workspace_root = temp_workspace.path().join("workspace");
+    let workspace_alan_dir = workspace_root.join(".alan");
+    std::fs::create_dir_all(&workspace_alan_dir).context("create workspace .alan dir")?;
+
+    let base_url = non_empty_env(CHATGPT_BASE_URL_ENV);
+    let model = non_empty_env(CHATGPT_MODEL_ENV).unwrap_or_else(|| "gpt-5.3-codex".to_string());
+    let persona_user_path = workspace_alan_dir.join("agent/persona/USER.md");
+    let wrong_workspace_user_path = workspace_root.join("USER.md");
+    let marker = "ALAN_LIVE_RUNTIME_MEMORY_MARKER";
+
+    let mut core_config = Config::for_chatgpt(base_url.as_deref(), Some(&model));
+    if let Some(account_id) = non_empty_env(CHATGPT_ACCOUNT_ID_ENV) {
+        core_config.chatgpt_account_id = Some(account_id);
+    }
+
+    let mut first_runtime_config = WorkspaceRuntimeConfig::from(core_config.clone());
+    first_runtime_config.workspace_root_dir = Some(workspace_root.clone());
+    first_runtime_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    first_runtime_config.default_cwd_override = Some(workspace_root.clone());
+    first_runtime_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    first_runtime_config.chatgpt_auth_storage_path = Some(PathBuf::from(auth_storage_path.clone()));
+    first_runtime_config.agent_config.runtime_config.governance = alan_protocol::GovernanceConfig {
+        profile: alan_protocol::GovernanceProfile::Autonomous,
+        policy_path: None,
+    };
+
+    let first_tools = alan_tools::create_tool_registry_with_core_tools(workspace_root.clone());
+    let mut first_controller = spawn_with_tool_registry(first_runtime_config, first_tools)
+        .context("spawn first live runtime with tools")?;
+    first_controller
+        .wait_until_ready()
+        .await
+        .context("first live runtime should become ready")?;
+
+    let rx = first_controller.handle.event_sender.subscribe();
+    first_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(format!(
+                "Persist one stable preference across future sessions. Use tools to update the exact `USER.md` write target from the workspace persona context so it contains the line `Favorite live runtime marker: {marker}`. Do not create `./USER.md` or any sibling copy. After the tool call succeeds, reply with exactly: stored:{marker}"
+            ))],
+            context: None,
+        }))
+        .await
+        .context("submit live memory storage turn")?;
+
+    let first_turn = collect_events_until_terminal(rx, TURN_TIMEOUT).await;
+    print_event_summary(
+        "live_chatgpt_runtime_cross_session_memory_smoke (store)",
+        &first_turn,
+    );
+    first_controller
+        .shutdown()
+        .await
+        .context("shutdown first live runtime")?;
+
+    ensure!(
+        first_turn.errors.is_empty(),
+        "live memory store turn emitted unexpected errors: {:?}",
+        first_turn.errors
+    );
+    ensure!(
+        first_turn.saw_turn_completed,
+        "live memory store turn did not reach TurnCompleted; warnings={:?}, text={:?}",
+        first_turn.warnings,
+        first_turn.text
+    );
+    ensure!(
+        first_turn.text.contains(&format!("stored:{marker}")),
+        "live memory store confirmation did not contain expected marker: {:?}",
+        first_turn.text
+    );
+
+    let persona_user = std::fs::read_to_string(&persona_user_path).with_context(|| {
+        format!(
+            "read persisted persona file {}",
+            persona_user_path.display()
+        )
+    })?;
+    ensure!(
+        persona_user.contains(marker),
+        "persisted USER.md did not contain expected marker: {:?}",
+        persona_user
+    );
+    ensure!(
+        !wrong_workspace_user_path.exists(),
+        "unexpected workspace-root USER.md duplicate was created at {}",
+        wrong_workspace_user_path.display()
+    );
+
+    let mut second_runtime_config = WorkspaceRuntimeConfig::from(core_config);
+    second_runtime_config.workspace_root_dir = Some(workspace_root.clone());
+    second_runtime_config.workspace_alan_dir = Some(workspace_alan_dir);
+    second_runtime_config.default_cwd_override = Some(workspace_root);
+    second_runtime_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    second_runtime_config.chatgpt_auth_storage_path = Some(PathBuf::from(auth_storage_path));
+
+    let mut second_tools = ToolRegistry::new();
+    if let Some(cwd) = second_runtime_config.default_cwd_override.clone() {
+        second_tools.set_default_cwd(cwd);
+    }
+
+    let mut second_controller = spawn_with_tool_registry(second_runtime_config, second_tools)
+        .context("spawn second live runtime")?;
+    second_controller
+        .wait_until_ready()
+        .await
+        .context("second live runtime should become ready")?;
+
+    let rx = second_controller.handle.event_sender.subscribe();
+    second_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(
+                "What is my favorite live runtime marker? Reply with exactly the saved marker and nothing else.",
+            )],
+            context: None,
+        }))
+        .await
+        .context("submit live memory recall turn")?;
+
+    let second_turn = collect_events_until_terminal(rx, TURN_TIMEOUT).await;
+    print_event_summary(
+        "live_chatgpt_runtime_cross_session_memory_smoke (recall)",
+        &second_turn,
+    );
+    second_controller
+        .shutdown()
+        .await
+        .context("shutdown second live runtime")?;
+
+    ensure!(
+        second_turn.errors.is_empty(),
+        "live memory recall turn emitted unexpected errors: {:?}",
+        second_turn.errors
+    );
+    ensure!(
+        second_turn.saw_turn_completed,
+        "live memory recall turn did not reach TurnCompleted; warnings={:?}, text={:?}",
+        second_turn.warnings,
+        second_turn.text
+    );
+    ensure!(
+        second_turn.text.contains(marker),
+        "live memory recall text did not contain expected marker `{marker}`: {:?}",
+        second_turn.text
+    );
+
+    Ok(())
+}

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -7,9 +7,11 @@ use alan_llm::{GenerationResponse, MockLlmProvider, TokenUsage, ToolCall};
 use alan_protocol::{ContentPart, Event, Op, Submission};
 use alan_runtime::runtime::spawn_with_llm_client_and_tools;
 use alan_runtime::{
-    LlmClient, RuntimeEventEnvelope, WorkspaceRuntimeConfig, spawn_with_llm_client,
+    AlanHomePaths, LlmClient, RuntimeEventEnvelope, WorkspaceRuntimeConfig, spawn_with_llm_client,
 };
+use std::fs;
 use std::time::Duration;
+use tempfile::TempDir;
 
 /// Collect events from a runtime until TurnCompleted or timeout.
 async fn collect_events_until_turn_complete(
@@ -371,4 +373,188 @@ async fn smoke_multiple_turns() {
     }
 
     controller.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn smoke_cross_session_persona_memory_is_reinjected() {
+    let temp_home = TempDir::new().expect("temp home");
+    let temp_workspace = TempDir::new().expect("temp workspace");
+    let workspace_root = temp_workspace.path().join("workspace");
+    let workspace_alan_dir = workspace_root.join(".alan");
+    fs::create_dir_all(&workspace_alan_dir).expect("create workspace .alan");
+
+    let persona_user_path = workspace_alan_dir.join("agent/persona/USER.md");
+    let workspace_duplicate_user_path = workspace_root.join("USER.md");
+    let marker = "ALAN_SMOKE_PERSONA_MEMORY_MARKER";
+
+    let first_mock = MockLlmProvider::new().with_responses(vec![
+        GenerationResponse {
+            content: String::new(),
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: vec![ToolCall {
+                id: Some("call_store_memory".to_string()),
+                name: "write_file".to_string(),
+                arguments: serde_json::json!({
+                    "path": persona_user_path.to_string_lossy(),
+                    "content": format!("# USER\n- Favorite smoke marker: {marker}\n"),
+                }),
+            }],
+            usage: Some(TokenUsage {
+                prompt_tokens: 20,
+                cached_prompt_tokens: None,
+                completion_tokens: 5,
+                total_tokens: 25,
+                reasoning_tokens: None,
+            }),
+            finish_reason: None,
+            provider_response_id: None,
+            provider_response_status: None,
+            warnings: Vec::new(),
+        },
+        GenerationResponse {
+            content: "Stored marker.".to_string(),
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: Some(TokenUsage {
+                prompt_tokens: 20,
+                cached_prompt_tokens: None,
+                completion_tokens: 5,
+                total_tokens: 25,
+                reasoning_tokens: None,
+            }),
+            finish_reason: None,
+            provider_response_id: None,
+            provider_response_status: None,
+            warnings: Vec::new(),
+        },
+    ]);
+
+    let first_llm_client = LlmClient::new(first_mock);
+    let mut first_config = WorkspaceRuntimeConfig::default();
+    first_config.workspace_root_dir = Some(workspace_root.clone());
+    first_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    first_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    first_config.agent_config.runtime_config.governance = alan_protocol::GovernanceConfig {
+        profile: alan_protocol::GovernanceProfile::Autonomous,
+        policy_path: None,
+    };
+    let first_tools = alan_tools::create_tool_registry_with_core_tools(workspace_root.clone());
+
+    let mut first_controller =
+        spawn_with_llm_client_and_tools(first_config, first_llm_client, first_tools)
+            .expect("spawn first runtime");
+    first_controller
+        .wait_until_ready()
+        .await
+        .expect("first runtime ready");
+
+    let rx = first_controller.handle.event_sender.subscribe();
+    first_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(
+                "Remember a stable smoke marker across sessions.",
+            )],
+            context: None,
+        }))
+        .await
+        .expect("send first submission");
+
+    let first_events = collect_events_until_turn_complete(rx, Duration::from_secs(15)).await;
+    assert!(
+        first_events
+            .iter()
+            .any(|event| matches!(event, Event::TurnCompleted { .. })),
+        "first turn should complete"
+    );
+    first_controller
+        .shutdown()
+        .await
+        .expect("shutdown first runtime");
+
+    let persisted_user = fs::read_to_string(&persona_user_path).expect("read persisted USER.md");
+    assert!(
+        persisted_user.contains(marker),
+        "expected persona USER.md to contain stored marker"
+    );
+    assert!(
+        !workspace_duplicate_user_path.exists(),
+        "workspace root USER.md duplicate should not be created"
+    );
+
+    let second_mock = MockLlmProvider::new().with_response(GenerationResponse {
+        content: "Loaded marker.".to_string(),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: Vec::new(),
+        tool_calls: Vec::new(),
+        usage: Some(TokenUsage {
+            prompt_tokens: 10,
+            cached_prompt_tokens: None,
+            completion_tokens: 3,
+            total_tokens: 13,
+            reasoning_tokens: None,
+        }),
+        finish_reason: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        warnings: Vec::new(),
+    });
+    let second_llm_client = LlmClient::new(second_mock.clone());
+    let mut second_config = WorkspaceRuntimeConfig::default();
+    second_config.workspace_root_dir = Some(workspace_root.clone());
+    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+
+    let mut second_controller =
+        spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");
+    second_controller
+        .wait_until_ready()
+        .await
+        .expect("second runtime ready");
+
+    let rx = second_controller.handle.event_sender.subscribe();
+    second_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text("What stable memory do you have?")],
+            context: None,
+        }))
+        .await
+        .expect("send second submission");
+
+    let second_events = collect_events_until_turn_complete(rx, Duration::from_secs(10)).await;
+    assert!(
+        second_events
+            .iter()
+            .any(|event| matches!(event, Event::TurnCompleted { .. })),
+        "second turn should complete"
+    );
+    second_controller
+        .shutdown()
+        .await
+        .expect("shutdown second runtime");
+
+    let recorded_requests = second_mock.recorded_requests();
+    let system_prompt = recorded_requests
+        .last()
+        .and_then(|request| request.system_prompt.as_deref())
+        .expect("expected recorded system prompt");
+    assert!(
+        system_prompt.contains(marker),
+        "expected persisted persona marker to be reinjected into the next session prompt"
+    );
+    assert!(
+        system_prompt.contains(&format!(
+            "Write updates to: {}",
+            persona_user_path.display()
+        )),
+        "expected system prompt to show the exact writable USER.md target"
+    );
 }

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -434,10 +434,12 @@ async fn smoke_cross_session_persona_memory_is_reinjected() {
     ]);
 
     let first_llm_client = LlmClient::new(first_mock);
-    let mut first_config = WorkspaceRuntimeConfig::default();
-    first_config.workspace_root_dir = Some(workspace_root.clone());
-    first_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
-    first_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    let mut first_config = WorkspaceRuntimeConfig {
+        workspace_root_dir: Some(workspace_root.clone()),
+        workspace_alan_dir: Some(workspace_alan_dir.clone()),
+        agent_home_paths: Some(AlanHomePaths::from_home_dir(temp_home.path())),
+        ..WorkspaceRuntimeConfig::default()
+    };
     first_config.agent_config.runtime_config.governance = alan_protocol::GovernanceConfig {
         profile: alan_protocol::GovernanceProfile::Autonomous,
         policy_path: None,
@@ -506,10 +508,12 @@ async fn smoke_cross_session_persona_memory_is_reinjected() {
         warnings: Vec::new(),
     });
     let second_llm_client = LlmClient::new(second_mock.clone());
-    let mut second_config = WorkspaceRuntimeConfig::default();
-    second_config.workspace_root_dir = Some(workspace_root.clone());
-    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
-    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    let second_config = WorkspaceRuntimeConfig {
+        workspace_root_dir: Some(workspace_root.clone()),
+        workspace_alan_dir: Some(workspace_alan_dir.clone()),
+        agent_home_paths: Some(AlanHomePaths::from_home_dir(temp_home.path())),
+        ..WorkspaceRuntimeConfig::default()
+    };
 
     let mut second_controller =
         spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1032,7 +1032,7 @@ pub mod mock {
     /// let response = mock.generate(GenerationRequest::new()).await.unwrap();
     /// assert_eq!(response.content, "Hello!");
     /// ```
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct MockLlmProvider {
         responses: Arc<std::sync::Mutex<Vec<GenerationResponse>>>,
         recorded_requests: Arc<std::sync::Mutex<Vec<GenerationRequest>>>,
@@ -1125,26 +1125,89 @@ pub mod mock {
 
         async fn generate_stream(
             &mut self,
-            _request: GenerationRequest,
+            request: GenerationRequest,
         ) -> Result<mpsc::Receiver<StreamChunk>> {
+            self.recorded_requests
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(request);
+
+            let mut responses = self.responses.lock().unwrap_or_else(|e| e.into_inner());
+            let response = if responses.is_empty() {
+                self.default_response.clone()
+            } else {
+                responses.remove(0)
+            };
+
             let (tx, rx) = mpsc::channel(10);
 
-            // Send the default response as a single chunk
-            let content = self.default_response.content.clone();
+            let content = response.content.clone();
+            let tool_calls = response.tool_calls.clone();
+            let usage = response.usage;
+            let provider_response_id = response.provider_response_id.clone();
+            let provider_response_status = response.provider_response_status.clone();
             tokio::spawn(async move {
+                if !content.is_empty() {
+                    let _ = tx
+                        .send(StreamChunk {
+                            text: Some(content),
+                            thinking: None,
+                            thinking_signature: None,
+                            redacted_thinking: None,
+                            usage: None,
+                            provider_response_id: None,
+                            provider_response_status: None,
+                            sequence_number: None,
+                            tool_call_delta: None,
+                            is_finished: false,
+                            finish_reason: None,
+                        })
+                        .await;
+                }
+
+                for (index, tool_call) in tool_calls.iter().enumerate() {
+                    let arguments =
+                        serde_json::to_string(&tool_call.arguments).unwrap_or_else(|_| "{}".into());
+                    let _ = tx
+                        .send(StreamChunk {
+                            text: None,
+                            thinking: None,
+                            thinking_signature: None,
+                            redacted_thinking: None,
+                            usage: None,
+                            provider_response_id: None,
+                            provider_response_status: None,
+                            sequence_number: None,
+                            tool_call_delta: Some(ToolCallDelta {
+                                index,
+                                id: tool_call.id.clone(),
+                                name: Some(tool_call.name.clone()),
+                                arguments_delta: Some(arguments.clone()),
+                                arguments: Some(arguments),
+                            }),
+                            is_finished: false,
+                            finish_reason: None,
+                        })
+                        .await;
+                }
+
                 let _ = tx
                     .send(StreamChunk {
-                        text: Some(content),
+                        text: None,
                         thinking: None,
                         thinking_signature: None,
                         redacted_thinking: None,
-                        usage: None,
-                        provider_response_id: None,
-                        provider_response_status: None,
+                        usage,
+                        provider_response_id,
+                        provider_response_status,
                         sequence_number: None,
                         tool_call_delta: None,
                         is_finished: true,
-                        finish_reason: Some("stop".to_string()),
+                        finish_reason: Some(if tool_calls.is_empty() {
+                            "stop".to_string()
+                        } else {
+                            "tool_calls".to_string()
+                        }),
                     })
                     .await;
             });

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1547,9 +1547,12 @@ mod tests {
             LlmProvider::generate_stream(&mut mock, GenerationRequest::new())
                 .await
                 .unwrap();
-        let chunk: StreamChunk = rx.recv().await.unwrap();
+        let first_chunk: StreamChunk = rx.recv().await.unwrap();
+        let final_chunk: StreamChunk = rx.recv().await.unwrap();
 
-        assert_eq!(chunk.text, Some("Streamed".to_string()));
-        assert!(chunk.is_finished);
+        assert_eq!(first_chunk.text, Some("Streamed".to_string()));
+        assert!(!first_chunk.is_finished);
+        assert!(final_chunk.is_finished);
+        assert_eq!(final_chunk.finish_reason.as_deref(), Some("stop"));
     }
 }

--- a/crates/runtime/prompts/persona/USER.md
+++ b/crates/runtime/prompts/persona/USER.md
@@ -1,14 +1,17 @@
 # USER
 
-Record stable user preferences, identity details, and long-lived context here.
+Record only stable, user-confirmed preferences, identity details, and long-lived context here.
 
 Update this file when the user explicitly asks you to remember stable information across
 sessions, especially identity and communication preferences.
+
+Do not store inferred traits, speculative summaries, one-off requests, or transient current focus
+here. Put evolving project state in durable memory notes instead.
 
 ## Suggested Fields
 
 - Preferred name
 - Timezone
 - Communication style preferences
-- Ongoing projects and priorities
-- Constraints (security, compliance, deadlines)
+- Stable constraints (security, compliance, deadlines, access needs)
+- Explicit long-lived preferences the user asked you to remember

--- a/crates/runtime/prompts/system.md
+++ b/crates/runtime/prompts/system.md
@@ -15,6 +15,7 @@ You are Alan, an AI agent running inside the Alan runtime.
 - Use tools when they provide meaningful evidence for the answer.
 - Ask concise clarifying questions only when required inputs are missing.
 - If the user explicitly asks you to remember stable information across sessions, persist it to the appropriate workspace memory or user-context file with tools instead of only acknowledging it in text.
+- Only persist user-confirmed stable information. Do not write inferred traits, speculative summaries, or transient session focus into long-lived memory files.
 
 ## Communication Style
 

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -46,6 +46,8 @@ memory/
 
 Do not assume the current workspace always has a visible `.alan/` prefix in relative paths.
 Resolve the active memory location from the runtime/workspace context when possible.
+Treat `USER.md` as stable, user-confirmed identity/preference memory only. Put evolving work
+state in `MEMORY.md` or the dated daily notes instead.
 
 ## Session Start Protocol
 
@@ -58,9 +60,10 @@ When starting a new session (especially if resuming prior work):
 
 2. **Check recent daily notes**:
    ```
-   bash ls -lt {active_memory_dir}/*.md | head -5
+   bash ls -lt {active_memory_dir}
    ```
-   Then read the most recent daily note for context.
+   Then inspect the most recent entries from the output and read the latest daily note for
+   context.
 
 3. **Check git history** for recent changes:
    ```
@@ -79,6 +82,8 @@ Before ending a session or when wrapping up significant work:
 1. **Update stable user context**:
    - If the user explicitly asks you to remember stable identity or preference details across
      sessions, update `USER.md`.
+   - Do not write guessed personality traits, inferred preferences, or temporary current focus to
+     `USER.md`.
 
 2. **Update MEMORY.md** with any new key information:
    - New decisions made
@@ -147,3 +152,4 @@ Brief description of the project, its goals, and current state.
 4. **Be concise**: Memory should be scannable, not verbose
 5. **Don't duplicate git**: Don't repeat what's already in git history
 6. **Respect privacy**: Don't store sensitive information (API keys, passwords)
+7. **Keep `USER.md` narrow**: Store only stable, user-confirmed identity/preferences there

--- a/crates/runtime/src/llm.rs
+++ b/crates/runtime/src/llm.rs
@@ -599,9 +599,12 @@ mod tests {
             .await
             .unwrap();
 
-        let chunk = rx.recv().await.unwrap();
-        assert_eq!(chunk.text, Some("Streamed content".to_string()));
-        assert!(chunk.is_finished);
+        let first_chunk = rx.recv().await.unwrap();
+        let final_chunk = rx.recv().await.unwrap();
+        assert_eq!(first_chunk.text, Some("Streamed content".to_string()));
+        assert!(!first_chunk.is_finished);
+        assert!(final_chunk.is_finished);
+        assert_eq!(final_chunk.finish_reason.as_deref(), Some("stop"));
     }
 
     #[test]

--- a/crates/runtime/src/prompts/workspace.rs
+++ b/crates/runtime/src/prompts/workspace.rs
@@ -147,22 +147,33 @@ pub(crate) fn render_workspace_persona_context_from_dirs(workspace_dirs: &[PathB
     if files.is_empty() || files.iter().all(|file| file.missing) {
         return String::new();
     }
-    let workspace_label = workspace_dirs
+    let writable_persona_dir = workspace_dirs
         .last()
         .map(|dir| dir.display().to_string())
         .unwrap_or_else(|| "<unknown>".to_string());
 
     let mut prompt = String::new();
     prompt.push_str("## Workspace Persona Context\n");
-    prompt.push_str(&format!("Workspace: {workspace_label}\n"));
+    prompt.push_str(&format!(
+        "Writable Persona Directory: {writable_persona_dir}\n"
+    ));
     prompt.push_str(
-        "The following workspace files are already injected into this prompt and define the persona, role, and operating style.\n",
+        "The following workspace persona files are already injected into this prompt and define the persona, role, and operating style.\n",
     );
     prompt.push_str(
         "Do not re-read them with tools by default; only open or edit the on-disk files when you need to verify or persist changes.\n",
     );
     prompt.push_str(
         "When the user explicitly asks you to remember stable information across sessions, update the relevant user-context or memory files with tools instead of only acknowledging it in text.\n",
+    );
+    prompt.push_str(
+        "Paths below are exact on-disk targets. Always edit the exact `Write updates to:` path shown for a file.\n",
+    );
+    prompt.push_str(
+        "Do not create cwd-relative or sibling duplicates such as `./USER.md` based on guesswork.\n",
+    );
+    prompt.push_str(
+        "Only persist user-confirmed stable information. Do not store guesses, inferred traits, or transient session focus in `USER.md`.\n",
     );
 
     for file in files {
@@ -179,12 +190,10 @@ pub(crate) fn render_workspace_persona_context_from_dirs(workspace_dirs: &[PathB
             continue;
         }
         prompt.push_str(&format!("Resolved from: {}\n", file.path.display()));
-        if file.write_path != file.path {
-            prompt.push_str(&format!(
-                "Write updates to: {}\n",
-                file.write_path.display()
-            ));
-        }
+        prompt.push_str(&format!(
+            "Write updates to: {}\n",
+            file.write_path.display()
+        ));
         let content = file.content.unwrap_or_default();
         let trimmed = trim_workspace_content(&content, file.name, WORKSPACE_PERSONA_MAX_CHARS);
         if trimmed.is_empty() {
@@ -359,6 +368,8 @@ mod tests {
         assert!(prompt.contains("already injected into this prompt"));
         assert!(prompt.contains("Do not re-read them with tools by default"));
         assert!(prompt.contains("remember stable information across sessions"));
+        assert!(prompt.contains("Write updates to:"));
+        assert!(prompt.contains("Do not create cwd-relative or sibling duplicates"));
         assert!(prompt.contains("Resolved from:"));
     }
 
@@ -415,5 +426,18 @@ mod tests {
             )),
             "expected write target to be rendered"
         );
+    }
+
+    #[test]
+    fn test_render_workspace_persona_context_always_shows_write_target_even_without_overlay() {
+        let temp_dir = TempDir::new().unwrap();
+        ensure_workspace_bootstrap_files_at(temp_dir.path()).unwrap();
+
+        let prompt = render_workspace_persona_context(temp_dir.path());
+
+        assert!(prompt.contains(&format!(
+            "Write updates to: {}",
+            temp_dir.path().join(DEFAULT_USER_FILENAME).display()
+        )));
     }
 }

--- a/crates/runtime/src/rollout.rs
+++ b/crates/runtime/src/rollout.rs
@@ -386,7 +386,7 @@ pub struct EventRecord {
 
 /// Commands for the background writer task
 enum RolloutCmd {
-    Record(RolloutItem),
+    Record(Box<RolloutItem>),
     PersistBatch {
         items: Vec<RolloutItem>,
         ack: oneshot::Sender<Result<()>>,
@@ -563,7 +563,7 @@ impl RolloutRecorder {
 
     /// Record an item
     pub fn record_nowait(&self, item: RolloutItem) -> Result<()> {
-        if self.tx.send(RolloutCmd::Record(item)).is_err() {
+        if self.tx.send(RolloutCmd::Record(Box::new(item))).is_err() {
             warn!("Rollout channel closed, cannot record item");
             return Err(anyhow!("Rollout channel closed, cannot record item"));
         }

--- a/crates/runtime/src/rollout.rs
+++ b/crates/runtime/src/rollout.rs
@@ -7,12 +7,18 @@ use alan_protocol::{
 use anyhow::{Result, anyhow};
 use chrono::Datelike;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
+
+const DURABLE_PAYLOAD_MAX_STRING_CHARS: usize = 512;
+const DURABLE_PAYLOAD_MAX_ARRAY_ITEMS: usize = 32;
+const DURABLE_PAYLOAD_MAX_OBJECT_FIELDS: usize = 64;
+const DURABLE_PREVIEW_MAX_CHARS: usize = 160;
 
 /// Types of items recorded in the rollout
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,10 +146,196 @@ pub struct ToolCallRecord {
     pub name: String,
     pub arguments: serde_json::Value,
     pub result: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction: Option<ToolPayloadRedactionSummary>,
     pub success: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit: Option<alan_protocol::ToolDecisionAudit>,
     pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ToolPayloadRedactionSummary {
+    #[serde(default)]
+    pub redacted_fields: usize,
+    #[serde(default)]
+    pub truncated_values: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DurableToolPayload {
+    pub payload: Value,
+    pub digest: String,
+    pub preview: Option<String>,
+    pub redaction: Option<ToolPayloadRedactionSummary>,
+}
+
+pub fn build_durable_tool_payload(payload: &Value) -> DurableToolPayload {
+    let mut summary = ToolPayloadRedactionSummary::default();
+    let durable_payload = sanitize_payload_for_rollout(payload, &mut summary);
+    let digest = sha256_hex(&canonicalize_json(&durable_payload).to_string());
+    let preview = payload_preview(&durable_payload);
+    let redaction =
+        (summary.redacted_fields > 0 || summary.truncated_values > 0).then_some(summary);
+
+    DurableToolPayload {
+        payload: durable_payload,
+        digest,
+        preview,
+        redaction,
+    }
+}
+
+fn canonicalize_json(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut sorted = Map::new();
+            for key in keys {
+                if let Some(entry) = map.get(key) {
+                    sorted.insert(key.clone(), canonicalize_json(entry));
+                }
+            }
+            Value::Object(sorted)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonicalize_json).collect()),
+        _ => value.clone(),
+    }
+}
+
+fn sha256_hex(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn normalize_sensitive_key(key: &str) -> String {
+    key.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(|ch| ch.to_lowercase())
+        .collect()
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = normalize_sensitive_key(key);
+    matches!(
+        normalized.as_str(),
+        "authorization"
+            | "proxyauthorization"
+            | "cookie"
+            | "setcookie"
+            | "apikey"
+            | "xapikey"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "bearertoken"
+            | "clientsecret"
+            | "secret"
+    ) || normalized.contains("apikey")
+}
+
+fn truncate_string_for_rollout(text: &str, summary: &mut ToolPayloadRedactionSummary) -> String {
+    let mut chars = text.chars();
+    let preview: String = chars
+        .by_ref()
+        .take(DURABLE_PAYLOAD_MAX_STRING_CHARS)
+        .collect();
+    if chars.next().is_none() {
+        return text.to_string();
+    }
+
+    summary.truncated_values += 1;
+    format!("{preview}...[truncated]")
+}
+
+fn sanitize_payload_for_rollout(
+    payload: &Value,
+    summary: &mut ToolPayloadRedactionSummary,
+) -> Value {
+    match payload {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+
+            let omitted = keys.len().saturating_sub(DURABLE_PAYLOAD_MAX_OBJECT_FIELDS);
+            let mut sanitized = Map::new();
+            for key in keys.into_iter().take(DURABLE_PAYLOAD_MAX_OBJECT_FIELDS) {
+                let value = map.get(key).expect("key from map iteration must exist");
+                if is_sensitive_key(key) {
+                    summary.redacted_fields += 1;
+                    sanitized.insert(key.clone(), Value::String("[REDACTED]".to_string()));
+                } else {
+                    sanitized.insert(key.clone(), sanitize_payload_for_rollout(value, summary));
+                }
+            }
+
+            if omitted > 0 {
+                summary.truncated_values += omitted;
+                sanitized.insert(
+                    "_truncated".to_string(),
+                    Value::String(format!("{omitted} additional field(s) omitted")),
+                );
+            }
+
+            Value::Object(sanitized)
+        }
+        Value::Array(items) => {
+            let omitted = items.len().saturating_sub(DURABLE_PAYLOAD_MAX_ARRAY_ITEMS);
+            let mut sanitized: Vec<Value> = items
+                .iter()
+                .take(DURABLE_PAYLOAD_MAX_ARRAY_ITEMS)
+                .map(|item| sanitize_payload_for_rollout(item, summary))
+                .collect();
+
+            if omitted > 0 {
+                summary.truncated_values += omitted;
+                sanitized.push(serde_json::json!({
+                    "_truncated": format!("{omitted} additional item(s) omitted")
+                }));
+            }
+
+            Value::Array(sanitized)
+        }
+        Value::String(text) => Value::String(truncate_string_for_rollout(text, summary)),
+        _ => payload.clone(),
+    }
+}
+
+fn payload_preview(value: &Value) -> Option<String> {
+    let mut preview = match value {
+        Value::Null => return None,
+        Value::String(text) => text.trim().to_string(),
+        Value::Object(map) => {
+            if let Some(error) = map.get("error").and_then(Value::as_str) {
+                format!("error: {}", error.trim())
+            } else if let Some(status) = map.get("status").and_then(Value::as_str) {
+                status.trim().to_string()
+            } else {
+                value.to_string()
+            }
+        }
+        _ => value.to_string(),
+    };
+
+    if preview.is_empty() {
+        return None;
+    }
+
+    if preview.chars().count() > DURABLE_PREVIEW_MAX_CHARS {
+        preview = preview
+            .chars()
+            .take(DURABLE_PREVIEW_MAX_CHARS)
+            .collect::<String>();
+        preview.push_str("...");
+    }
+
+    Some(preview)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -612,10 +804,15 @@ impl RolloutRecorder {
         success: bool,
         audit: Option<alan_protocol::ToolDecisionAudit>,
     ) -> Result<()> {
+        let durable_arguments = build_durable_tool_payload(&arguments);
+        let durable_result = build_durable_tool_payload(&result);
         let item = RolloutItem::ToolCall(ToolCallRecord {
             name: name.to_string(),
-            arguments,
-            result,
+            arguments: durable_arguments.payload,
+            result: durable_result.payload,
+            result_digest: Some(durable_result.digest),
+            result_preview: durable_result.preview,
+            redaction: durable_result.redaction,
             success,
             audit,
             timestamp: chrono::Utc::now().to_rfc3339(),
@@ -645,10 +842,15 @@ impl RolloutRecorder {
         success: bool,
         audit: Option<alan_protocol::ToolDecisionAudit>,
     ) -> Result<()> {
+        let durable_arguments = build_durable_tool_payload(&arguments);
+        let durable_result = build_durable_tool_payload(&result);
         let item = RolloutItem::ToolCall(ToolCallRecord {
             name: name.to_string(),
-            arguments,
-            result,
+            arguments: durable_arguments.payload,
+            result: durable_result.payload,
+            result_digest: Some(durable_result.digest),
+            result_preview: durable_result.preview,
+            redaction: durable_result.redaction,
             success,
             audit,
             timestamp: chrono::Utc::now().to_rfc3339(),
@@ -1449,6 +1651,12 @@ this is not valid json
             name: "web_search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             result: serde_json::json!({"found": 5}),
+            result_digest: Some("digest-1".to_string()),
+            result_preview: Some("found".to_string()),
+            redaction: Some(ToolPayloadRedactionSummary {
+                redacted_fields: 1,
+                truncated_values: 0,
+            }),
             success: true,
             audit: None,
             timestamp: "2026-01-29T14:31:02Z".to_string(),
@@ -1461,6 +1669,66 @@ this is not valid json
         let deserialized: ToolCallRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.name, "web_search");
         assert!(deserialized.success);
+        assert_eq!(deserialized.result_digest.as_deref(), Some("digest-1"));
+        assert_eq!(deserialized.result_preview.as_deref(), Some("found"));
+        assert_eq!(
+            deserialized.redaction,
+            Some(ToolPayloadRedactionSummary {
+                redacted_fields: 1,
+                truncated_values: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_durable_tool_payload_redacts_sensitive_headers() {
+        let durable = build_durable_tool_payload(&serde_json::json!({
+            "status": 200,
+            "headers": {
+                "set-cookie": "session=secret",
+                "authorization": "Bearer top-secret",
+                "content-type": "application/json"
+            }
+        }));
+
+        assert_eq!(
+            durable.payload["headers"]["set-cookie"],
+            serde_json::json!("[REDACTED]")
+        );
+        assert_eq!(
+            durable.payload["headers"]["authorization"],
+            serde_json::json!("[REDACTED]")
+        );
+        assert_eq!(
+            durable.payload["headers"]["content-type"],
+            serde_json::json!("application/json")
+        );
+        assert_eq!(
+            durable.redaction,
+            Some(ToolPayloadRedactionSummary {
+                redacted_fields: 2,
+                truncated_values: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_build_durable_tool_payload_truncates_large_strings() {
+        let durable = build_durable_tool_payload(&serde_json::json!({
+            "body": "x".repeat(2000)
+        }));
+
+        let body = durable.payload["body"]
+            .as_str()
+            .expect("body should stay a string");
+        assert!(body.contains("...[truncated]"));
+        assert_eq!(
+            durable.redaction,
+            Some(ToolPayloadRedactionSummary {
+                redacted_fields: 0,
+                truncated_values: 1,
+            })
+        );
     }
 
     #[test]
@@ -1488,6 +1756,56 @@ this is not valid json
         let deserialized: EffectRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.effect_id, "ef-1");
         assert_eq!(deserialized.status, EffectStatus::Applied);
+    }
+
+    #[tokio::test]
+    async fn test_record_tool_call_redacts_sensitive_values_before_persisting() {
+        let temp_dir = TempDir::new().unwrap();
+        let recorder =
+            RolloutRecorder::new_in_dir("test-tool-redaction", "gemini-2.0-flash", temp_dir.path())
+                .await
+                .unwrap();
+
+        recorder
+            .record_tool_call_with_audit(
+                "web_fetch",
+                serde_json::json!({
+                    "headers": {
+                        "authorization": "Bearer top-secret"
+                    }
+                }),
+                serde_json::json!({
+                    "headers": {
+                        "set-cookie": "session=super-secret"
+                    }
+                }),
+                true,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let items = RolloutRecorder::load_history(recorder.path())
+            .await
+            .unwrap();
+        let tool_call = items.into_iter().find_map(|item| match item {
+            RolloutItem::ToolCall(record) => Some(record),
+            _ => None,
+        });
+
+        let record = tool_call.expect("tool call should be persisted");
+        assert_eq!(
+            record.arguments["headers"]["authorization"],
+            serde_json::json!("[REDACTED]")
+        );
+        assert_eq!(
+            record.result["headers"]["set-cookie"],
+            serde_json::json!("[REDACTED]")
+        );
+        assert!(
+            record.result_digest.is_some(),
+            "durable tool call should persist a result digest"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -668,14 +668,10 @@ where
         && matches!(existing.status, crate::rollout::EffectStatus::Applied)
     {
         let dedupe_reason = "Matching applied side effect found; skipped physical execution";
-        let replay_payload = existing
-            .result_payload
-            .clone()
-            .or_else(|| {
-                state
-                    .session
-                    .tool_payload_by_call_id(&existing.tool_call_id)
-            })
+        let replay_payload = state
+            .session
+            .tool_payload_by_call_id(&existing.tool_call_id)
+            .or_else(|| existing.result_payload.clone())
             .unwrap_or_else(|| {
                 json!({
                     "status": "dedupe_hit",
@@ -2037,33 +2033,49 @@ mod tests {
             counter: Arc::clone(&counter),
         });
         let mut state = create_test_state_with_session_and_tools(session, tools);
+        let arguments = json!({
+            "command": "curl https://example.com",
+            "headers": {
+                "authorization": "Bearer secret-token"
+            }
+        });
+        let identity =
+            build_effect_identity(&state.session, "bash", &arguments, EffectCategory::Network);
 
-        let _ = execute_single_tool_call(
-            &mut state,
-            "call-net-1",
-            "bash",
-            json!({"command": "curl https://example.com"}),
-        )
-        .await;
-        let _ = execute_single_tool_call(
-            &mut state,
-            "call-net-2",
-            "bash",
-            json!({"command": "curl https://example.com"}),
-        )
-        .await;
+        let _ = execute_single_tool_call(&mut state, "call-net-1", "bash", arguments.clone()).await;
+        let _ = execute_single_tool_call(&mut state, "call-net-2", "bash", arguments).await;
 
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+        let replayed_payload = state
+            .session
+            .tool_payload_by_call_id("call-net-2")
+            .expect("replayed tool payload should exist");
         assert_eq!(
-            state
-                .session
-                .tool_payload_by_call_id("call-net-2")
-                .expect("replayed tool payload should exist"),
+            replayed_payload,
             state
                 .session
                 .tool_payload_by_call_id("call-net-1")
                 .expect("original tool payload should exist"),
             "dedupe replay should preserve original network-tool payload"
+        );
+        assert_eq!(
+            replayed_payload["payload"]["headers"]["authorization"],
+            json!("Bearer secret-token"),
+            "dedupe replay should preserve the original live payload instead of the durable one"
+        );
+        let effect = state
+            .session
+            .effect_by_idempotency_key(&identity.idempotency_key)
+            .expect("effect record should exist");
+        assert_eq!(
+            effect
+                .result_payload
+                .as_ref()
+                .and_then(|payload| payload.get("payload"))
+                .and_then(|payload| payload.get("headers"))
+                .and_then(|headers| headers.get("authorization")),
+            Some(&json!("[REDACTED]")),
+            "durable effect payloads should stay redacted for persistence"
         );
     }
 

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -723,10 +723,11 @@ where
             }),
         );
         let now = chrono::Utc::now().to_rfc3339();
+        let durable_replay_payload = crate::rollout::build_durable_tool_payload(&replay_payload);
         let replay_digest = existing
             .result_digest
             .clone()
-            .unwrap_or_else(|| sha256_hex(&canonicalize_json(&replay_payload).to_string()));
+            .unwrap_or_else(|| durable_replay_payload.digest.clone());
         state.session.record_effect(crate::rollout::EffectRecord {
             effect_id: format!("ef-{}", uuid::Uuid::new_v4()),
             run_id: state.session.id.clone(),
@@ -735,7 +736,7 @@ where
             effect_type: identity.category.as_str().to_string(),
             request_fingerprint: identity.request_fingerprint.clone(),
             result_digest: Some(replay_digest),
-            result_payload: Some(replay_payload),
+            result_payload: Some(durable_replay_payload.payload),
             status: crate::rollout::EffectStatus::Applied,
             applied_at: existing.applied_at.clone().or(Some(now.clone())),
             reason: Some(dedupe_reason.to_string()),
@@ -798,7 +799,8 @@ where
             "status": "effect_checkpoint_persist_failed"
         });
         if let (Some(identity), Some(effect_start)) = (&effect_identity, &effect_start) {
-            let digest = sha256_hex(&canonicalize_json(&flush_error_payload).to_string());
+            let durable_flush_error_payload =
+                crate::rollout::build_durable_tool_payload(&flush_error_payload);
             state.session.record_effect(crate::rollout::EffectRecord {
                 effect_id: effect_start.effect_id.clone(),
                 run_id: effect_start.run_id.clone(),
@@ -806,8 +808,8 @@ where
                 idempotency_key: identity.idempotency_key.clone(),
                 effect_type: identity.category.as_str().to_string(),
                 request_fingerprint: identity.request_fingerprint.clone(),
-                result_digest: Some(digest),
-                result_payload: Some(flush_error_payload.clone()),
+                result_digest: Some(durable_flush_error_payload.digest),
+                result_payload: Some(durable_flush_error_payload.payload),
                 status: crate::rollout::EffectStatus::Failed,
                 applied_at: None,
                 reason: Some(flush_error.clone()),
@@ -857,7 +859,7 @@ where
     match tool_result {
         Ok(value) => {
             if let (Some(identity), Some(effect_start)) = (&effect_identity, &effect_start) {
-                let digest = sha256_hex(&canonicalize_json(&value).to_string());
+                let durable_value = crate::rollout::build_durable_tool_payload(&value);
                 state.session.record_effect(crate::rollout::EffectRecord {
                     effect_id: effect_start.effect_id.clone(),
                     run_id: effect_start.run_id.clone(),
@@ -865,8 +867,8 @@ where
                     idempotency_key: identity.idempotency_key.clone(),
                     effect_type: identity.category.as_str().to_string(),
                     request_fingerprint: identity.request_fingerprint.clone(),
-                    result_digest: Some(digest),
-                    result_payload: Some(value.clone()),
+                    result_digest: Some(durable_value.digest),
+                    result_payload: Some(durable_value.payload),
                     status: crate::rollout::EffectStatus::Applied,
                     applied_at: Some(chrono::Utc::now().to_rfc3339()),
                     reason: None,
@@ -905,7 +907,8 @@ where
         Err(err) => {
             let error_payload = json!({"error": err.to_string()});
             if let (Some(identity), Some(effect_start)) = (&effect_identity, &effect_start) {
-                let digest = sha256_hex(&canonicalize_json(&error_payload).to_string());
+                let durable_error_payload =
+                    crate::rollout::build_durable_tool_payload(&error_payload);
                 state.session.record_effect(crate::rollout::EffectRecord {
                     effect_id: effect_start.effect_id.clone(),
                     run_id: effect_start.run_id.clone(),
@@ -913,8 +916,8 @@ where
                     idempotency_key: identity.idempotency_key.clone(),
                     effect_type: identity.category.as_str().to_string(),
                     request_fingerprint: identity.request_fingerprint.clone(),
-                    result_digest: Some(digest),
-                    result_payload: Some(error_payload.clone()),
+                    result_digest: Some(durable_error_payload.digest),
+                    result_payload: Some(durable_error_payload.payload),
                     status: crate::rollout::EffectStatus::Failed,
                     applied_at: None,
                     reason: Some(err.to_string()),
@@ -2061,6 +2064,53 @@ mod tests {
                 .tool_payload_by_call_id("call-net-1")
                 .expect("original tool payload should exist"),
             "dedupe replay should preserve original network-tool payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_effect_record_uses_durable_payload_while_tape_keeps_live_payload() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut session = Session::new();
+        session.add_user_message("call api with auth");
+        let mut tools = ToolRegistry::new();
+        tools.register(CountingEffectTool {
+            name: "bash",
+            capability: ToolCapability::Network,
+            counter: Arc::clone(&counter),
+        });
+        let mut state = create_test_state_with_session_and_tools(session, tools);
+        let arguments = json!({
+            "command": "curl https://example.com",
+            "headers": {
+                "authorization": "Bearer secret-token"
+            }
+        });
+        let identity =
+            build_effect_identity(&state.session, "bash", &arguments, EffectCategory::Network);
+
+        let _ = execute_single_tool_call(&mut state, "call-net-secret", "bash", arguments).await;
+
+        let effect = state
+            .session
+            .effect_by_idempotency_key(&identity.idempotency_key)
+            .expect("effect record should exist");
+        assert_eq!(
+            effect
+                .result_payload
+                .as_ref()
+                .and_then(|payload| payload.get("payload"))
+                .and_then(|payload| payload.get("headers"))
+                .and_then(|headers| headers.get("authorization")),
+            Some(&json!("[REDACTED]"))
+        );
+
+        let live_payload = state
+            .session
+            .tool_payload_by_call_id("call-net-secret")
+            .expect("live tool payload should exist on tape");
+        assert_eq!(
+            live_payload["payload"]["headers"]["authorization"],
+            json!("Bearer secret-token")
         );
     }
 

--- a/crates/runtime/src/runtime/tool_policy.rs
+++ b/crates/runtime/src/runtime/tool_policy.rs
@@ -24,6 +24,20 @@ pub(super) fn evaluate_tool_policy(
     capability: Option<alan_protocol::ToolCapability>,
 ) -> ToolPolicyDecision {
     let sandbox_backend = crate::tools::Sandbox::backend_name_static();
+    if let Some(reason) = bash_shape_preflight_reason(tool_name, arguments) {
+        return ToolPolicyDecision::Forbidden {
+            reason: reason.clone(),
+            audit: alan_protocol::ToolDecisionAudit {
+                policy_source: "sandbox_preflight".to_string(),
+                rule_id: None,
+                action: "deny".to_string(),
+                reason: Some(reason),
+                capability: capability_label(capability).to_string(),
+                sandbox_backend: sandbox_backend.to_string(),
+            },
+        };
+    }
+
     let policy_decision = policy_engine.evaluate(crate::policy::PolicyContext {
         tool_name,
         arguments,
@@ -88,6 +102,17 @@ pub(super) fn evaluate_tool_policy(
     }
 }
 
+fn bash_shape_preflight_reason(tool_name: &str, arguments: &serde_json::Value) -> Option<String> {
+    if tool_name != "bash" {
+        return None;
+    }
+
+    let command = arguments
+        .get("command")
+        .and_then(serde_json::Value::as_str)?;
+    crate::tools::Sandbox::bash_preflight_reason(command)
+}
+
 pub(super) fn capability_label(capability: Option<alan_protocol::ToolCapability>) -> &'static str {
     match capability {
         Some(alan_protocol::ToolCapability::Read) => "read",
@@ -145,6 +170,33 @@ mod tests {
                 assert_eq!(audit.capability, "network");
             }
             other => panic!("expected allow, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_bash_shape_preflight_blocks_unsupported_wrapper_before_policy_allow() {
+        let policy =
+            crate::policy::PolicyEngine::for_profile(crate::policy::PolicyProfile::Autonomous);
+        let result = evaluate_tool_policy(
+            &policy,
+            &alan_protocol::GovernanceConfig {
+                profile: alan_protocol::GovernanceProfile::Autonomous,
+                policy_path: None,
+            },
+            "bash",
+            &json!({"command":"bash -lc 'rg TODO src'"}),
+            Some(alan_protocol::ToolCapability::Write),
+        );
+        match result {
+            ToolPolicyDecision::Forbidden { reason, audit } => {
+                assert!(
+                    reason.contains("rejects nested command evaluators")
+                        || reason.contains("rejects shell wrappers")
+                );
+                assert_eq!(audit.policy_source, "sandbox_preflight");
+                assert_eq!(audit.action, "deny");
+            }
+            other => panic!("expected preflight denial, got {:?}", other),
         }
     }
 

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -17,7 +17,7 @@ use crate::approval::{
 };
 use crate::rollout::{
     CompactedItem, ContextItemRecord, EffectRecord, EventRecord, ReferenceContextSnapshotRecord,
-    RolloutItem, RolloutRecorder,
+    RolloutItem, RolloutRecorder, build_durable_tool_payload,
 };
 use crate::tape::{ContextItem, ContextItemsDelta, Tape};
 
@@ -1042,18 +1042,25 @@ impl Session {
         _name: &str,
         payload: serde_json::Value,
     ) {
-        // Keep full payload on tape (source of truth).
-        // If the tool returns explicit content parts, preserve them natively.
-        // Any provider/context truncation happens at projection boundaries.
+        // Keep the live payload on tape (source of truth for the active runtime),
+        // but persist a durable redacted/truncated view to rollout.
         let message = Message::tool_multi(vec![crate::tape::ToolResponse {
             id: tool_call_id.to_string(),
-            content: Self::tool_payload_to_content_parts(payload),
+            content: Self::tool_payload_to_content_parts(payload.clone()),
         }]);
         self.tape.push(message.clone());
 
+        let durable_message = {
+            let durable_payload = build_durable_tool_payload(&payload);
+            Message::tool_multi(vec![crate::tape::ToolResponse {
+                id: tool_call_id.to_string(),
+                content: Self::tool_payload_to_content_parts(durable_payload.payload),
+            }])
+        };
+
         // Record to persistence if available (enqueue to recorder writer queue)
         if let Some(recorder) = self.recorder.as_ref()
-            && let Err(err) = recorder.record_tape_message_nowait(&message)
+            && let Err(err) = recorder.record_tape_message_nowait(&durable_message)
         {
             error!(error = %err, "Failed to record tool message");
         }
@@ -3981,7 +3988,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_tool_message_persists_tool_payload_with_tool_call_id() {
+    fn test_add_tool_message_persists_redacted_tool_payload_with_tool_call_id() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             use tokio::time::{Duration, Instant, sleep};
@@ -3995,7 +4002,13 @@ mod tests {
             session.add_tool_message(
                 "call_789",
                 "web_search",
-                serde_json::json!({"ok": true, "source": "test"}),
+                serde_json::json!({
+                    "ok": true,
+                    "headers": {
+                        "set-cookie": "session=secret-cookie",
+                        "content-type": "application/json"
+                    }
+                }),
             );
 
             let rollout_path = session.rollout_path().unwrap().clone();
@@ -4005,7 +4018,8 @@ mod tests {
                 if let Ok(content) = tokio::fs::read_to_string(&rollout_path).await
                     && content.contains("\"role\":\"tool\"")
                     && content.contains("\"tool_name\":\"call_789\"")
-                    && content.contains("{\\\"ok\\\":true,\\\"source\\\":\\\"test\\\"}")
+                    && content.contains("\\\"set-cookie\\\":\\\"[REDACTED]\\\"")
+                    && !content.contains("secret-cookie")
                 {
                     found = true;
                     break;

--- a/crates/runtime/src/tools/sandbox.rs
+++ b/crates/runtime/src/tools/sandbox.rs
@@ -50,6 +50,14 @@ impl Sandbox {
         SANDBOX_BACKEND_WORKSPACE_PATH_GUARD
     }
 
+    /// Return a stable rejection reason when a bash command shape is incompatible
+    /// with the workspace path guard backend.
+    pub fn bash_preflight_reason(cmd: &str) -> Option<String> {
+        validate_bash_command_shape(cmd)
+            .err()
+            .map(|err| err.to_string())
+    }
+
     /// Check if a path is within the workspace
     pub fn is_in_workspace(&self, path: &Path) -> bool {
         // Try to get absolute path
@@ -283,48 +291,108 @@ impl Sandbox {
     }
 
     fn validate_direct_command_shapes(&self, commands: &[Vec<String>]) -> Result<()> {
-        for words in commands {
-            let Some(command_index) = words.iter().position(|word| !is_env_assignment(word)) else {
-                continue;
-            };
-
-            let command_word = words[command_index].as_str();
-            if is_shell_control_prefix(command_word) {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects shell control flow like {} because workspace_path_guard only supports direct commands with statically checkable paths",
-                    self.backend_name(),
-                    command_word
-                ));
-            }
-
-            let command = command_basename(command_word);
-            if is_unsupported_shell_wrapper(command) {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects shell wrappers like {} because workspace_path_guard only supports direct commands with statically checkable paths",
-                    self.backend_name(),
-                    command
-                ));
-            }
-        }
-
-        Ok(())
+        validate_direct_command_shapes(commands, self.backend_name())
     }
 
     fn validate_shell_features(&self, cmd: &str) -> Result<()> {
-        let normalized = normalize_shell_line_continuations(cmd);
-        let comment_free = strip_shell_comments(&normalized);
-        if contains_shell_expansion(&comment_free)
-            || contains_shell_brace_expansion(&comment_free)
-            || contains_shell_globbing(&comment_free)
-        {
+        validate_shell_features(cmd, self.backend_name())
+    }
+
+    fn validate_nested_command_evaluators(&self, commands: &[Vec<String>]) -> Result<()> {
+        validate_nested_command_evaluators(commands, self.backend_name())
+    }
+
+    fn ensure_path_not_protected(&self, path: &Path, action: &str) -> Result<()> {
+        if let Some(component) = self.protected_subpath_component(path) {
             return Err(anyhow!(
-                "Sandbox backend {} rejects shell variable, command, brace, or glob expansion because path references cannot be validated safely",
-                self.backend_name()
+                "Sandbox backend {} blocks {} under protected subpath {}: {}",
+                self.backend_name(),
+                action,
+                component,
+                path.display()
             ));
         }
         Ok(())
     }
 
+    fn ensure_path_not_multiply_linked(&self, path: &Path, action: &str) -> Result<()> {
+        if existing_regular_file_has_multiple_links(path)? {
+            return Err(anyhow!(
+                "Sandbox backend {} blocks {} via multiply-linked file because hardlink aliases cannot be validated safely: {}",
+                self.backend_name(),
+                action,
+                path.display()
+            ));
+        }
+        Ok(())
+    }
+
+    fn protected_subpath_component(&self, path: &Path) -> Option<&'static str> {
+        let canonical_workspace = self
+            .canonicalize(&self.workspace_root)
+            .unwrap_or_else(|_| lexically_normalize_path(&self.workspace_root));
+        let resolved_path = self.resolved_path_with_existing_parents(path);
+        let relative = resolved_path.strip_prefix(&canonical_workspace).ok()?;
+        if is_allowed_protected_relative_path(relative) {
+            return None;
+        }
+        relative.components().find_map(|component| match component {
+            Component::Normal(name) => {
+                let candidate = name.to_str()?;
+                PROTECTED_SUBPATHS
+                    .iter()
+                    .copied()
+                    .find(|protected| *protected == candidate)
+            }
+            _ => None,
+        })
+    }
+
+    fn normalized_path(&self, path: &Path) -> PathBuf {
+        let absolute_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace_root.join(path)
+        };
+        if absolute_path.exists() {
+            self.canonicalize(&absolute_path)
+                .unwrap_or_else(|_| lexically_normalize_path(&absolute_path))
+        } else {
+            lexically_normalize_path(&absolute_path)
+        }
+    }
+
+    fn resolved_path_with_existing_parents(&self, path: &Path) -> PathBuf {
+        let absolute_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.workspace_root.join(path)
+        };
+        if absolute_path.exists() {
+            return self.normalized_path(&absolute_path);
+        }
+
+        let mut current = absolute_path.as_path();
+        let mut suffix = Vec::<OsString>::new();
+        while !current.exists() {
+            let Some(name) = current.file_name() else {
+                return lexically_normalize_path(&absolute_path);
+            };
+            suffix.push(name.to_os_string());
+            let Some(parent) = current.parent() else {
+                return lexically_normalize_path(&absolute_path);
+            };
+            current = parent;
+        }
+
+        let mut resolved = self
+            .canonicalize(current)
+            .unwrap_or_else(|_| lexically_normalize_path(current));
+        for component in suffix.iter().rev() {
+            resolved.push(component);
+        }
+        resolved
+    }
     fn validate_command_path_candidate(&self, token: &str, cwd: &Path) -> Result<()> {
         if token.is_empty() || token.starts_with('-') {
             return Ok(());
@@ -393,144 +461,130 @@ impl Sandbox {
         self.ensure_path_not_multiply_linked(&candidate, "process path reference")?;
         Ok(())
     }
+}
 
-    fn validate_nested_command_evaluators(&self, commands: &[Vec<String>]) -> Result<()> {
-        for words in commands {
-            let Some(view) = nested_evaluator_view(words) else {
-                continue;
-            };
-            if let Some(display) = view.opaque_wrapper_display.as_deref() {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects nested command evaluators like {} because inner paths cannot be validated safely",
-                    self.backend_name(),
-                    display
-                ));
-            }
-            if is_shell_eval_builtin(view.command) {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects nested command evaluators like {} because inner paths cannot be validated safely",
-                    self.backend_name(),
-                    view.display
-                ));
-            }
-            if let Some(dispatcher) =
-                opaque_command_dispatcher_display(&view.display, view.command, view.args)
-            {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects opaque command dispatchers like {} because child command paths cannot be validated safely",
-                    self.backend_name(),
-                    dispatcher
-                ));
-            }
-            if let Some(flag) = leading_eval_flag(view.command, view.args) {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects nested command evaluators like {} {} because inner paths cannot be validated safely",
-                    self.backend_name(),
-                    view.display,
-                    flag
-                ));
-            }
-            if let Some(interpreter) =
-                opaque_script_interpreter_display(&view.display, view.command, view.args)
-            {
-                return Err(anyhow!(
-                    "Sandbox backend {} rejects opaque script interpreters like {} because script bodies cannot be validated safely",
-                    self.backend_name(),
-                    interpreter
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    fn ensure_path_not_protected(&self, path: &Path, action: &str) -> Result<()> {
-        if let Some(component) = self.protected_subpath_component(path) {
+fn validate_nested_command_evaluators(commands: &[Vec<String>], backend_name: &str) -> Result<()> {
+    for words in commands {
+        let Some(view) = nested_evaluator_view(words) else {
+            continue;
+        };
+        if let Some(display) = view.opaque_wrapper_display.as_deref() {
             return Err(anyhow!(
-                "Sandbox backend {} blocks {} under protected subpath {}: {}",
-                self.backend_name(),
-                action,
-                component,
-                path.display()
+                "Sandbox backend {} rejects nested command evaluators like {} because inner paths cannot be validated safely",
+                backend_name,
+                display
             ));
         }
-        Ok(())
-    }
-
-    fn ensure_path_not_multiply_linked(&self, path: &Path, action: &str) -> Result<()> {
-        if existing_regular_file_has_multiple_links(path)? {
+        if is_shell_eval_builtin(view.command) {
             return Err(anyhow!(
-                "Sandbox backend {} blocks {} via multiply-linked file because hardlink aliases cannot be validated safely: {}",
-                self.backend_name(),
-                action,
-                path.display()
+                "Sandbox backend {} rejects nested command evaluators like {} because inner paths cannot be validated safely",
+                backend_name,
+                view.display
             ));
         }
-        Ok(())
+        if let Some(dispatcher) =
+            opaque_command_dispatcher_display(&view.display, view.command, view.args)
+        {
+            return Err(anyhow!(
+                "Sandbox backend {} rejects opaque command dispatchers like {} because child command paths cannot be validated safely",
+                backend_name,
+                dispatcher
+            ));
+        }
+        if let Some(flag) = leading_eval_flag(view.command, view.args) {
+            return Err(anyhow!(
+                "Sandbox backend {} rejects nested command evaluators like {} {} because inner paths cannot be validated safely",
+                backend_name,
+                view.display,
+                flag
+            ));
+        }
+        if let Some(interpreter) =
+            opaque_script_interpreter_display(&view.display, view.command, view.args)
+        {
+            return Err(anyhow!(
+                "Sandbox backend {} rejects opaque script interpreters like {} because script bodies cannot be validated safely",
+                backend_name,
+                interpreter
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_bash_command_shape(cmd: &str) -> Result<()> {
+    let normalized = normalize_shell_line_continuations(cmd);
+    let trimmed = normalized.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("Command cannot be empty"));
     }
 
-    fn protected_subpath_component(&self, path: &Path) -> Option<&'static str> {
-        let canonical_workspace = self
-            .canonicalize(&self.workspace_root)
-            .unwrap_or_else(|_| lexically_normalize_path(&self.workspace_root));
-        let resolved_path = self.resolved_path_with_existing_parents(path);
-        let relative = resolved_path.strip_prefix(&canonical_workspace).ok()?;
-        relative.components().find_map(|component| match component {
-            Component::Normal(name) => {
-                let candidate = name.to_str()?;
-                PROTECTED_SUBPATHS
-                    .iter()
-                    .copied()
-                    .find(|protected| *protected == candidate)
-            }
+    let commands = shell_commands(trimmed)?;
+    validate_direct_command_shapes(&commands, Sandbox::backend_name_static())?;
+    validate_nested_command_evaluators(&commands, Sandbox::backend_name_static())?;
+    validate_shell_features(trimmed, Sandbox::backend_name_static())?;
+
+    Ok(())
+}
+
+fn validate_direct_command_shapes(commands: &[Vec<String>], backend_name: &str) -> Result<()> {
+    for words in commands {
+        let Some(command_index) = words.iter().position(|word| !is_env_assignment(word)) else {
+            continue;
+        };
+
+        let command_word = words[command_index].as_str();
+        if is_shell_control_prefix(command_word) {
+            return Err(anyhow!(
+                "Sandbox backend {} rejects shell control flow like {} because workspace_path_guard only supports direct commands with statically checkable paths",
+                backend_name,
+                command_word
+            ));
+        }
+
+        let command = command_basename(command_word);
+        if is_unsupported_shell_wrapper(command) {
+            return Err(anyhow!(
+                "Sandbox backend {} rejects shell wrappers like {} because workspace_path_guard only supports direct commands with statically checkable paths",
+                backend_name,
+                command
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_shell_features(cmd: &str, backend_name: &str) -> Result<()> {
+    let normalized = normalize_shell_line_continuations(cmd);
+    let comment_free = strip_shell_comments(&normalized);
+    if contains_shell_expansion(&comment_free)
+        || contains_shell_brace_expansion(&comment_free)
+        || contains_shell_globbing(&comment_free)
+    {
+        return Err(anyhow!(
+            "Sandbox backend {} rejects shell variable, command, brace, or glob expansion because path references cannot be validated safely",
+            backend_name
+        ));
+    }
+    Ok(())
+}
+
+fn is_allowed_protected_relative_path(relative: &Path) -> bool {
+    let components: Vec<&str> = relative
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => name.to_str(),
             _ => None,
         })
-    }
+        .collect();
 
-    fn normalized_path(&self, path: &Path) -> PathBuf {
-        let absolute_path = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            self.workspace_root.join(path)
-        };
-        if absolute_path.exists() {
-            self.canonicalize(&absolute_path)
-                .unwrap_or_else(|_| lexically_normalize_path(&absolute_path))
-        } else {
-            lexically_normalize_path(&absolute_path)
-        }
-    }
-
-    fn resolved_path_with_existing_parents(&self, path: &Path) -> PathBuf {
-        let absolute_path = if path.is_absolute() {
-            path.to_path_buf()
-        } else {
-            self.workspace_root.join(path)
-        };
-        if absolute_path.exists() {
-            return self.normalized_path(&absolute_path);
-        }
-
-        let mut current = absolute_path.as_path();
-        let mut suffix = Vec::<OsString>::new();
-        while !current.exists() {
-            let Some(name) = current.file_name() else {
-                return lexically_normalize_path(&absolute_path);
-            };
-            suffix.push(name.to_os_string());
-            let Some(parent) = current.parent() else {
-                return lexically_normalize_path(&absolute_path);
-            };
-            current = parent;
-        }
-
-        let mut resolved = self
-            .canonicalize(current)
-            .unwrap_or_else(|_| lexically_normalize_path(current));
-        for component in suffix.iter().rev() {
-            resolved.push(component);
-        }
-        resolved
-    }
+    matches!(
+        components.as_slice(),
+        [".alan", "memory", ..]
+            | [".alan", "agent", "persona", ..]
+            | [".alan", "agents", _, "persona", ..]
+    )
 }
 
 fn looks_like_path_token(token: &str) -> bool {
@@ -2352,6 +2406,57 @@ mod tests {
 
         let result = sandbox.read_string(&protected).await;
         assert_eq!(result.unwrap(), "rules: []\n");
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_allows_write_to_workspace_persona_subpath() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        let persona_file = temp.path().join(".alan/agent/persona/USER.md");
+
+        sandbox
+            .write(&persona_file, b"# USER\n- Preferred name: Test\n")
+            .await
+            .unwrap();
+
+        let written = tokio::fs::read_to_string(&persona_file).await.unwrap();
+        assert!(written.contains("Preferred name"));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_allows_write_to_workspace_memory_subpath() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        let memory_file = temp.path().join(".alan/memory/MEMORY.md");
+
+        sandbox.write(&memory_file, b"# Memory\n").await.unwrap();
+
+        let written = tokio::fs::read_to_string(&memory_file).await.unwrap();
+        assert_eq!(written, "# Memory\n");
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_exec_allows_direct_command_for_workspace_memory_subpath() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        let memory_dir = temp.path().join(".alan/memory");
+        tokio::fs::create_dir_all(&memory_dir).await.unwrap();
+        tokio::fs::write(memory_dir.join("MEMORY.md"), "# Memory\n")
+            .await
+            .unwrap();
+
+        let result = sandbox
+            .exec_with_timeout_and_capability(
+                "ls .alan/memory",
+                temp.path(),
+                None,
+                Some(alan_protocol::ToolCapability::Read),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("MEMORY.md"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/tools/sandbox.rs
+++ b/crates/runtime/src/tools/sandbox.rs
@@ -331,8 +331,12 @@ impl Sandbox {
         let canonical_workspace = self
             .canonicalize(&self.workspace_root)
             .unwrap_or_else(|_| lexically_normalize_path(&self.workspace_root));
+        let normalized_workspace = lexically_normalize_path(&self.workspace_root);
         let resolved_path = self.resolved_path_with_existing_parents(path);
-        let relative = resolved_path.strip_prefix(&canonical_workspace).ok()?;
+        let relative = resolved_path
+            .strip_prefix(&canonical_workspace)
+            .or_else(|_| resolved_path.strip_prefix(&normalized_workspace))
+            .ok()?;
         if is_allowed_protected_relative_path(relative) {
             return None;
         }
@@ -571,13 +575,16 @@ fn validate_shell_features(cmd: &str, backend_name: &str) -> Result<()> {
 }
 
 fn is_allowed_protected_relative_path(relative: &Path) -> bool {
-    let components: Vec<&str> = relative
-        .components()
-        .filter_map(|component| match component {
-            Component::Normal(name) => name.to_str(),
-            _ => None,
-        })
-        .collect();
+    let mut components = Vec::new();
+    for component in relative.components() {
+        let Component::Normal(name) = component else {
+            return false;
+        };
+        let Some(name) = name.to_str() else {
+            return false;
+        };
+        components.push(name);
+    }
 
     matches!(
         components.as_slice(),
@@ -2436,6 +2443,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sandbox_blocks_write_with_parent_dir_bypass_into_protected_subpath() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        tokio::fs::create_dir_all(temp.path().join(".alan/agent"))
+            .await
+            .unwrap();
+
+        let bypass_path = temp.path().join(".alan/agent/persona/../policy.yaml");
+        let result = sandbox.write(&bypass_path, b"rules: []\n").await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("protected subpath .alan")
+        );
+    }
+
+    #[tokio::test]
     async fn test_sandbox_exec_allows_direct_command_for_workspace_memory_subpath() {
         let temp = TempDir::new().unwrap();
         let sandbox = Sandbox::new(temp.path().to_path_buf());
@@ -2457,6 +2484,32 @@ mod tests {
 
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.contains("MEMORY.md"));
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_exec_blocks_parent_dir_bypass_into_protected_subpath() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        tokio::fs::create_dir_all(temp.path().join(".alan/agent"))
+            .await
+            .unwrap();
+
+        let result = sandbox
+            .exec_with_timeout_and_capability(
+                "touch .alan/agent/persona/../policy.yaml",
+                temp.path(),
+                None,
+                Some(alan_protocol::ToolCapability::Write),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("protected subpath .alan")
+        );
     }
 
     #[tokio::test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,6 +226,9 @@ represents one conversation or task, limited by the LLM's context window.
 - **Bounded** — constrained by the context window; when full, start a new session
 - **Archivable** — completed sessions are saved as rollouts for replay or forking
 - **One active session per workspace** at any time; others are paused or archived
+- **Split live vs durable tool payloads** — the active tape may hold full tool
+  results for current-turn reasoning, while persisted rollout records store a
+  redacted/truncated durable projection
 
 ---
 
@@ -235,6 +238,12 @@ Alan uses policy-as-code as the only decision layer for tool governance.
 
 1. **Policy gate (`PolicyEngine`)**: per-call decision `allow | deny | escalate` based on tool name, capability, and command patterns.
 2. **Execution backend**: the current `workspace_path_guard` backend is a best-effort execution guard for workspace paths and shell shape checks, not a strict OS sandbox. Daemon session APIs surface this as `execution_backend`.
+
+Response guardrails sit after generation but before assistant text emission.
+When runtime already knows a draft is contradictory to session capabilities
+(for example, claiming that current/external data cannot be checked while a
+network-capable tool is available), it may regenerate once before emitting any
+user-visible assistant text.
 
 `escalate` always maps to `Event::Yield` and waits for `Op::Resume`. There is no `approval_policy` downgrade branch.
 

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -123,9 +123,43 @@ When policy returns `escalate`, runtime emits `Event::Yield` and waits for `Op::
 Current contract: [governance_current_contract.md](./governance_current_contract.md).  
 Target V2 design and policy file format: [HITE Governance](./spec/hite_governance.md).
 
+### Verification-First Response Guardrails
+
+Runtime prompt guidance now pushes the model to probe before claiming that
+tools or current/external data are unavailable. That prompt nudge is only the
+first layer. Alan also applies a runtime response guardrail before assistant
+text is emitted:
+
+- if a draft claims tools are unavailable while tools are registered, runtime
+  retries once with a correction instruction
+- if a draft claims current/external data access is unavailable while a
+  network-capable tool exists, runtime retries once before any user-visible
+  text is emitted
+- drafts that already contain tool calls bypass this retry path so the tool
+  orchestration loop remains the source of truth
+
+The accepted-output rule is therefore: user-visible assistant text should be
+the post-guardrail draft, not the first contradictory draft.
+
 ### Steering During Tool Execution
 
 `Op::Input` is treated as steering input. During a tool batch, runtime checks in-band steering after each tool call. If steering exists, remaining calls are marked as skipped and the steering message is injected before the next LLM generation.
+
+### Durable Tool Payloads
+
+Alan distinguishes between:
+
+- **live tool payloads on tape**: full in-session tool results used for the
+  current runtime's reasoning and replay inside the same process
+- **durable rollout payloads**: redacted/truncated projections written to
+  rollout `tool_call`, `message`, and `effect` records
+
+Durable payload persistence now redacts common secret-bearing fields such as
+`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, and common API
+key / token-shaped fields before writing rollout history. Long string bodies
+and oversized collections are also truncated. Effect records keep digests over
+the durable payload so replay/dedupe stays auditable without durably storing
+every raw byte.
 
 ### Filesystem Sandbox
 


### PR DESCRIPTION
## Summary
- redact durable rollout payloads before persistence and document the live-vs-durable payload split
- unblock `.alan` memory and persona writes, align bash preflight with sandbox enforcement, and mark daemon tasks/runs terminal on ordinary `TurnCompleted`
- extend smoke/live runtime coverage with cross-session memory checks and fix `MockLlmProvider::generate_stream()` so queued tool responses are honored
- refine the Mac shell sidebar/startup flow with a fresh-boot startup mode, keyboard space switching, and updated materials/shadows

## Why
- persisted memory flows were failing because the runtime sandbox treated key `.alan` state paths as protected writes
- some bash invocations could pass policy evaluation and still fail later in sandbox execution because unsupported wrapper shapes were not rejected early enough
- normal turn completion was not always closing task/run state cleanly, which left lifecycle bookkeeping inconsistent
- the shell UI changes make startup behavior more predictable and space navigation faster to operate

## Testing
- `cargo fmt --all`
- `cargo test -p alan-runtime --lib -- --nocapture`
- `cargo test -p alan-runtime test_bash_shape_preflight_blocks_unsupported_wrapper_before_policy_allow -- --nocapture`
- `cargo test -p alan --test smoke_test -- --nocapture`
- `cargo test -p alan spawn_event_bridge_marks_ -- --nocapture`
- `cargo test -p alan transition_run_status_sets_terminal_end_timestamp -- --nocapture`
- `cargo test -p alan --test live_runtime_smoke_test -- --ignored --nocapture`
- `ALAN_LIVE_PROVIDER_TESTS=1 ALAN_LIVE_CHATGPT_AUTH_STORAGE_PATH=/Users/morris/.alan/auth.json cargo test -p alan --test live_runtime_smoke_test live_chatgpt_runtime_cross_session_memory_smoke -- --ignored --exact --nocapture`

## Context
- Part 3 of #262. Base branch is PR2.
