### PR TITLE
[codex] Refresh session handoff and daily memory surfaces

### DIFF
--- a/crates/alan/tests/compaction_integration_test.rs
+++ b/crates/alan/tests/compaction_integration_test.rs
@@ -195,19 +195,6 @@ fn empty_memory_flush_json_response() -> String {
     .to_string()
 }
 
-fn dated_memory_note_paths(memory_dir: &FsPath) -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = std::fs::read_dir(memory_dir.join("daily"))
-        .unwrap()
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let path = entry.path();
-            (path.extension().and_then(|ext| ext.to_str()) == Some("md")).then_some(path)
-        })
-        .collect();
-    paths.sort();
-    paths
-}
-
 fn absolute_memory_note_path(memory_dir: &FsPath, attempt: &MemoryFlushAttemptSnapshot) -> PathBuf {
     let output_path = attempt
         .output_path
@@ -509,13 +496,13 @@ impl CompactionHarness {
             tokio::select! {
                 result = self.runtime_events_rx.recv() => {
                     match result {
-                        Ok(envelope) => match envelope.event {
-                            Event::Warning { message } => warnings.push(message),
-                            Event::CompactionObserved { attempt } => {
-                                if envelope.submission_id.as_deref() == Some(submission_id) {
-                                    assert_eq!(attempt.submission_id.as_deref(), Some(submission_id));
-                                    return (attempt, warnings);
-                                }
+                        Ok(envelope) => match (envelope.submission_id.as_deref(), envelope.event) {
+                            (_, Event::Warning { message }) => warnings.push(message),
+                            (Some(event_submission_id), Event::CompactionObserved { attempt })
+                                if event_submission_id == submission_id =>
+                            {
+                                assert_eq!(attempt.submission_id.as_deref(), Some(submission_id));
+                                return (attempt, warnings);
                             }
                             _ => {}
                         },
@@ -647,11 +634,6 @@ impl CompactionHarness {
 
         surfaces
     }
-
-    fn dated_memory_note_paths(&self) -> Vec<PathBuf> {
-        dated_memory_note_paths(&self.memory_dir)
-    }
-
     async fn shutdown(self) {
         let _ = self.controller.shutdown().await;
         self.bridge_task.abort();
@@ -963,11 +945,11 @@ async fn compaction_auto_pre_turn_soft_flush_skip_surfaces_match() {
     );
     assert!(flush_attempt.warning_message.is_none());
     assert!(flush_attempt.error_message.is_none());
+    assert!(flush_attempt.output_path.is_none());
     assert_eq!(
         compaction_attempt.memory_flush_attempt_id.as_deref(),
         Some(flush_attempt.attempt_id.as_str())
     );
-    assert!(harness.dated_memory_note_paths().is_empty());
 
     harness
         .collect_auto_compaction_surfaces(compaction_attempt, Some(flush_attempt))
@@ -1022,11 +1004,11 @@ async fn compaction_auto_pre_turn_soft_flush_failure_surfaces_match() {
             .iter()
             .any(|warning| warning.contains("Silent memory flush failed before compaction"))
     );
+    assert!(flush_attempt.output_path.is_none());
     assert_eq!(
         compaction_attempt.memory_flush_attempt_id.as_deref(),
         Some(flush_attempt.attempt_id.as_str())
     );
-    assert!(harness.dated_memory_note_paths().is_empty());
 
     harness
         .collect_auto_compaction_surfaces(compaction_attempt, Some(flush_attempt))
@@ -1073,7 +1055,6 @@ async fn compaction_auto_pre_turn_hard_skips_memory_flush_surfaces_match() {
         Some(CompactionPressureLevel::Hard)
     );
     assert!(outcome.compaction_attempt.memory_flush_attempt_id.is_none());
-    assert!(harness.dated_memory_note_paths().is_empty());
 
     harness
         .collect_auto_compaction_surfaces(&outcome.compaction_attempt, None)

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -177,7 +177,7 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn => {
-                        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
                             state,
                             "approved-tool-replay-ended-turn",
                         )
@@ -243,7 +243,7 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn => {
-                        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
                             state,
                             "approved-tool-replay-ended-turn",
                         )

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -177,6 +177,11 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn => {
+                        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                            state,
+                            "approved-tool-replay-ended-turn",
+                        )
+                        .await;
                         state.turn_state.set_turn_activity(TurnActivityState::Idle);
                     }
                 },
@@ -238,6 +243,11 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn => {
+                        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                            state,
+                            "approved-tool-replay-ended-turn",
+                        )
+                        .await;
                         state.turn_state.set_turn_activity(TurnActivityState::Idle);
                     }
                 },

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -176,12 +176,14 @@ where
                             .turn_state
                             .set_turn_activity(TurnActivityState::Paused);
                     }
-                    ToolBatchOrchestratorOutcome::EndTurn => {
-                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-                            state,
-                            "approved-tool-replay-ended-turn",
-                        )
-                        .await;
+                    ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
+                        if !surfaces_refreshed {
+                            super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
+                                state,
+                                "approved-tool-replay-ended-turn",
+                            )
+                            .await;
+                        }
                         state.turn_state.set_turn_activity(TurnActivityState::Idle);
                     }
                 },
@@ -242,12 +244,14 @@ where
                             .turn_state
                             .set_turn_activity(TurnActivityState::Paused);
                     }
-                    ToolBatchOrchestratorOutcome::EndTurn => {
-                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-                            state,
-                            "approved-tool-replay-ended-turn",
-                        )
-                        .await;
+                    ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
+                        if !surfaces_refreshed {
+                            super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
+                                state,
+                                "approved-tool-replay-ended-turn",
+                            )
+                            .await;
+                        }
                         state.turn_state.set_turn_activity(TurnActivityState::Idle);
                     }
                 },

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -81,7 +81,7 @@ fn render_memory_surfaces(
     now: DateTime<Utc>,
 ) -> RenderedMemorySurfaces {
     let current_goal = derive_current_goal(session, turn_state);
-    let latest_assistant_state = derive_latest_assistant_state(session);
+    let latest_assistant_state = derive_latest_assistant_state(session, turn_state);
     let active_plan_items = render_plan_items(turn_state, &["in_progress", "pending"]);
     let completed_plan_items = render_plan_items(turn_state, &["completed"]);
     let recent_messages = render_recent_messages(session);
@@ -135,17 +135,26 @@ fn derive_current_goal(session: &Session, turn_state: &TurnState) -> String {
         .unwrap_or_else(|| "No current goal recorded.".to_string())
 }
 
-fn derive_latest_assistant_state(session: &Session) -> String {
-    session
-        .tape
-        .messages()
+fn derive_latest_assistant_state(session: &Session, turn_state: &TurnState) -> String {
+    let messages = turn_state
+        .active_turn_message_start()
+        .and_then(|start| session.tape.messages().get(start..))
+        .unwrap_or_else(|| session.tape.messages());
+
+    messages
         .iter()
         .rev()
         .find(|message| message.is_assistant())
         .map(Message::non_thinking_text_content)
         .map(|text| truncate_chars(text.trim(), MAX_INLINE_TEXT_CHARS))
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "No assistant response recorded yet.".to_string())
+        .unwrap_or_else(|| {
+            if turn_state.active_turn_message_start().is_some() {
+                "This turn completed without a new assistant response.".to_string()
+            } else {
+                "No assistant response recorded yet.".to_string()
+            }
+        })
 }
 
 fn render_plan_items(turn_state: &TurnState, statuses: &[&str]) -> String {
@@ -381,6 +390,32 @@ mod tests {
                 .session_summary
                 .contains("[completed] Write the scaffolding")
         );
+    }
+
+    #[test]
+    fn render_memory_surfaces_scopes_latest_assistant_state_to_active_turn() {
+        let mut session = Session::new();
+        session.id = "sess-123".to_string();
+        session.add_user_message("Earlier task");
+        session.add_assistant_message("Earlier assistant response.", None);
+
+        let mut turn_state = TurnState::default();
+        turn_state.begin_turn(session.tape.messages().len());
+        session.add_user_message("Current tool-only turn");
+
+        let now = DateTime::parse_from_rfc3339("2026-04-15T15:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let rendered = render_memory_surfaces(&session, &turn_state, now);
+
+        assert!(
+            rendered
+                .handoff
+                .contains("This turn completed without a new assistant response.")
+        );
+        assert!(rendered.handoff.contains(
+            "## What Just Happened\n- This turn completed without a new assistant response."
+        ));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -64,6 +64,17 @@ pub(crate) async fn refresh_turn_memory_surfaces_best_effort(
     }
 }
 
+pub(crate) async fn refresh_active_turn_memory_surfaces_best_effort(
+    state: &RuntimeLoopState,
+    context: &'static str,
+) {
+    if state.turn_state.active_turn_message_start().is_none() {
+        return;
+    }
+
+    refresh_turn_memory_surfaces_best_effort(state, context).await;
+}
+
 fn render_memory_surfaces(
     session: &Session,
     turn_state: &TurnState,

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Datelike, Utc};
 use tokio::io::AsyncWriteExt;
+use tracing::warn;
 
 use crate::session::Session;
 use crate::tape::Message;
@@ -52,6 +53,15 @@ pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Re
     append_text_file(&daily_note_path(memory_dir, now), &rendered.daily_entry).await?;
 
     Ok(())
+}
+
+pub(crate) async fn refresh_turn_memory_surfaces_best_effort(
+    state: &RuntimeLoopState,
+    context: &'static str,
+) {
+    if let Err(err) = refresh_turn_memory_surfaces(state).await {
+        warn!(error = %err, context, "Failed to refresh memory surfaces");
+    }
 }
 
 fn render_memory_surfaces(

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -1,0 +1,420 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Datelike, Utc};
+use tokio::io::AsyncWriteExt;
+
+use crate::session::Session;
+use crate::tape::Message;
+
+use super::agent_loop::RuntimeLoopState;
+use super::turn_state::TurnState;
+
+const MAX_INLINE_TEXT_CHARS: usize = 280;
+const MAX_RECENT_MESSAGE_ITEMS: usize = 6;
+const MAX_PLAN_ITEMS_PER_SECTION: usize = 6;
+const MAX_COMPACTION_SUMMARY_CHARS: usize = 1_000;
+
+#[derive(Debug, Clone)]
+struct RenderedMemorySurfaces {
+    working_memory: String,
+    handoff: String,
+    session_summary: String,
+    daily_entry: String,
+}
+
+pub(crate) async fn refresh_turn_memory_surfaces(state: &RuntimeLoopState) -> Result<()> {
+    if !state.core_config.memory.enabled {
+        return Ok(());
+    }
+
+    let Some(memory_dir) = state.core_config.memory.workspace_dir.as_deref() else {
+        return Ok(());
+    };
+
+    crate::prompts::ensure_workspace_memory_layout_at(memory_dir)
+        .with_context(|| format!("failed to ensure memory layout at {}", memory_dir.display()))?;
+
+    let now = Utc::now();
+    let rendered = render_memory_surfaces(&state.session, &state.turn_state, now);
+
+    write_text_file(
+        &working_memory_path(memory_dir, &state.session.id),
+        &rendered.working_memory,
+    )
+    .await?;
+    write_text_file(&latest_handoff_path(memory_dir), &rendered.handoff).await?;
+    write_text_file(
+        &session_summary_path(memory_dir, &state.session.id, now),
+        &rendered.session_summary,
+    )
+    .await?;
+    append_text_file(&daily_note_path(memory_dir, now), &rendered.daily_entry).await?;
+
+    Ok(())
+}
+
+fn render_memory_surfaces(
+    session: &Session,
+    turn_state: &TurnState,
+    now: DateTime<Utc>,
+) -> RenderedMemorySurfaces {
+    let current_goal = derive_current_goal(session, turn_state);
+    let latest_assistant_state = derive_latest_assistant_state(session);
+    let active_plan_items = render_plan_items(turn_state, &["in_progress", "pending"]);
+    let completed_plan_items = render_plan_items(turn_state, &["completed"]);
+    let recent_messages = render_recent_messages(session);
+    let compaction_summary = render_compaction_summary(session);
+    let latest_memory_flush = render_latest_memory_flush(session);
+    let session_id = &session.id;
+    let updated_at = now.to_rfc3339();
+
+    let working_memory = format!(
+        "# Working Memory\n\nsession_id: {session_id}\nupdated_at: {updated_at}\n\n## Current Goal\n{current_goal}\n\n## Active Subgoals\n{active_plan_items}\n\n## Confirmed Constraints\n{compaction_summary}\n\n## Pending Verification\n{active_plan_items}\n\n## Open Loops\n{active_plan_items}\n\n## Recent Findings\n- Latest assistant state: {latest_assistant_state}\n{recent_messages}\n\n## Active Recall\n{latest_memory_flush}\n"
+    );
+
+    let handoff = format!(
+        "# Latest Handoff\n\nupdated_at: {updated_at}\nsession_id: {session_id}\n\n## Current Goal\n{current_goal}\n\n## What Just Happened\n- {latest_assistant_state}\n\n## Next Steps\n{active_plan_items}\n\n## Recent Context\n{compaction_summary}\n{recent_messages}\n"
+    );
+
+    let session_summary = format!(
+        "# Session Summary\n\nsession_id: {session_id}\nupdated_at: {updated_at}\n\n## Current Goal\n{current_goal}\n\n## Latest Assistant State\n- {latest_assistant_state}\n\n## Active Plan\n{active_plan_items}\n\n## Completed Plan Items\n{completed_plan_items}\n\n## Prior Compaction Summary\n{compaction_summary}\n\n## Recent Conversation Highlights\n{recent_messages}\n\n## Latest Memory Flush\n{latest_memory_flush}\n"
+    );
+
+    let daily_entry = format!(
+        "## {updated_at}\n\nsession_id: {session_id}\n\n### Current Goal\n{current_goal}\n\n### Latest Assistant State\n- {latest_assistant_state}\n\n### Next Steps\n{active_plan_items}\n\n### Latest Memory Flush\n{latest_memory_flush}\n\n"
+    );
+
+    RenderedMemorySurfaces {
+        working_memory,
+        handoff,
+        session_summary,
+        daily_entry,
+    }
+}
+
+fn derive_current_goal(session: &Session, turn_state: &TurnState) -> String {
+    turn_state
+        .plan_snapshot()
+        .and_then(|snapshot| snapshot.explanation.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            session
+                .tape
+                .messages()
+                .iter()
+                .rev()
+                .find(|message| message.is_user())
+                .map(Message::text_content)
+                .map(|text| truncate_chars(text.trim(), MAX_INLINE_TEXT_CHARS))
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or_else(|| "No current goal recorded.".to_string())
+}
+
+fn derive_latest_assistant_state(session: &Session) -> String {
+    session
+        .tape
+        .messages()
+        .iter()
+        .rev()
+        .find(|message| message.is_assistant())
+        .map(Message::non_thinking_text_content)
+        .map(|text| truncate_chars(text.trim(), MAX_INLINE_TEXT_CHARS))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "No assistant response recorded yet.".to_string())
+}
+
+fn render_plan_items(turn_state: &TurnState, statuses: &[&str]) -> String {
+    let Some(snapshot) = turn_state.plan_snapshot() else {
+        return "- None recorded.\n".to_string();
+    };
+
+    let items: Vec<String> = snapshot
+        .items
+        .iter()
+        .filter(|item| {
+            let status = match &item.status {
+                alan_protocol::PlanItemStatus::Pending => "pending",
+                alan_protocol::PlanItemStatus::InProgress => "in_progress",
+                alan_protocol::PlanItemStatus::Completed => "completed",
+            };
+            statuses.contains(&status)
+        })
+        .take(MAX_PLAN_ITEMS_PER_SECTION)
+        .map(|item| {
+            format!(
+                "- [{}] {}",
+                format_plan_status(&item.status),
+                item.content.trim()
+            )
+        })
+        .collect();
+
+    if items.is_empty() {
+        "- None recorded.\n".to_string()
+    } else {
+        format!("{}\n", items.join("\n"))
+    }
+}
+
+fn format_plan_status(status: &alan_protocol::PlanItemStatus) -> &'static str {
+    match status {
+        alan_protocol::PlanItemStatus::Pending => "pending",
+        alan_protocol::PlanItemStatus::InProgress => "in_progress",
+        alan_protocol::PlanItemStatus::Completed => "completed",
+    }
+}
+
+fn render_recent_messages(session: &Session) -> String {
+    let items: Vec<String> = session
+        .tape
+        .messages()
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { .. } => Some(("user", message.text_content())),
+            Message::Assistant { .. } => Some(("assistant", message.non_thinking_text_content())),
+            Message::Tool { .. } => Some(("tool", message.text_content())),
+            Message::System { .. } | Message::Context { .. } => None,
+        })
+        .filter_map(|(role, text)| {
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| {
+                format!(
+                    "- {}: {}",
+                    role,
+                    truncate_chars(trimmed, MAX_INLINE_TEXT_CHARS)
+                )
+            })
+        })
+        .rev()
+        .take(MAX_RECENT_MESSAGE_ITEMS)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
+    if items.is_empty() {
+        "- No recent conversation highlights recorded.\n".to_string()
+    } else {
+        format!("{}\n", items.join("\n"))
+    }
+}
+
+fn render_compaction_summary(session: &Session) -> String {
+    session
+        .tape
+        .summary()
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty())
+        .map(|summary| truncate_chars(summary, MAX_COMPACTION_SUMMARY_CHARS))
+        .unwrap_or_else(|| "No compaction summary recorded.".to_string())
+}
+
+fn render_latest_memory_flush(session: &Session) -> String {
+    session
+        .latest_memory_flush_attempt()
+        .map(|attempt| {
+            let output_path = attempt
+                .output_path
+                .as_deref()
+                .unwrap_or("<no-output-path-recorded>");
+            format!(
+                "- {} flush at {} -> {}",
+                format!("{:?}", attempt.result).to_lowercase(),
+                attempt.timestamp,
+                output_path
+            )
+        })
+        .unwrap_or_else(|| "- No memory flush attempt recorded.\n".to_string())
+}
+
+fn working_memory_path(memory_dir: &Path, session_id: &str) -> PathBuf {
+    memory_dir.join("working").join(format!("{session_id}.md"))
+}
+
+fn latest_handoff_path(memory_dir: &Path) -> PathBuf {
+    memory_dir.join("handoffs").join("LATEST.md")
+}
+
+fn session_summary_path(memory_dir: &Path, session_id: &str, now: DateTime<Utc>) -> PathBuf {
+    memory_dir.join("sessions").join(format!(
+        "{:04}/{:02}/{:02}/{}.md",
+        now.year(),
+        now.month(),
+        now.day(),
+        session_id
+    ))
+}
+
+fn daily_note_path(memory_dir: &Path, now: DateTime<Utc>) -> PathBuf {
+    memory_dir.join("daily").join(format!(
+        "{:04}-{:02}-{:02}.md",
+        now.year(),
+        now.month(),
+        now.day()
+    ))
+}
+
+async fn write_text_file(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
+    }
+    tokio::fs::write(path, content)
+        .await
+        .with_context(|| format!("failed to write memory surface {}", path.display()))?;
+    Ok(())
+}
+
+async fn append_text_file(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open memory surface {}", path.display()))?;
+    file.write_all(content.as_bytes())
+        .await
+        .with_context(|| format!("failed to append memory surface {}", path.display()))?;
+    Ok(())
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let text = text.trim();
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::turn_state::TurnState;
+    use crate::session::Session;
+
+    #[test]
+    fn render_memory_surfaces_follow_pure_text_layout_and_content() {
+        let mut session = Session::new();
+        session.id = "sess-123".to_string();
+        session.add_user_message("Finish the pure-text memory slice.");
+        session.add_assistant_message("Added scaffolding and prompt bootstrap.", None);
+
+        let mut turn_state = TurnState::default();
+        turn_state.set_plan_snapshot(
+            Some("Finish the pure-text memory slice.".to_string()),
+            vec![
+                alan_protocol::PlanItem {
+                    id: "p1".to_string(),
+                    content: "Write the scaffolding".to_string(),
+                    status: alan_protocol::PlanItemStatus::Completed,
+                },
+                alan_protocol::PlanItem {
+                    id: "p2".to_string(),
+                    content: "Refresh the handoff".to_string(),
+                    status: alan_protocol::PlanItemStatus::InProgress,
+                },
+            ],
+        );
+
+        let now = DateTime::parse_from_rfc3339("2026-04-15T15:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let rendered = render_memory_surfaces(&session, &turn_state, now);
+
+        assert!(rendered.working_memory.contains("# Working Memory"));
+        assert!(rendered.handoff.contains("# Latest Handoff"));
+        assert!(rendered.session_summary.contains("# Session Summary"));
+        assert!(
+            rendered
+                .daily_entry
+                .contains("## 2026-04-15T15:30:00+00:00")
+        );
+        assert!(
+            rendered
+                .session_summary
+                .contains("Finish the pure-text memory slice.")
+        );
+        assert!(
+            rendered
+                .session_summary
+                .contains("[in_progress] Refresh the handoff")
+        );
+        assert!(
+            rendered
+                .session_summary
+                .contains("[completed] Write the scaffolding")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_turn_memory_surfaces_writes_expected_files() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-write".to_string();
+        session.add_user_message("Keep the latest handoff fresh.");
+        session.add_assistant_message("Wrote the memory surfaces.", None);
+
+        let mut turn_state = TurnState::default();
+        turn_state.set_plan_snapshot(
+            Some("Keep the latest handoff fresh.".to_string()),
+            vec![alan_protocol::PlanItem {
+                id: "p1".to_string(),
+                content: "Verify the memory files".to_string(),
+                status: alan_protocol::PlanItemStatus::Pending,
+            }],
+        );
+
+        let state = RuntimeLoopState {
+            workspace_id: "test-workspace".to_string(),
+            session,
+            current_submission_id: None,
+            llm_client: crate::llm::LlmClient::new(alan_llm::MockLlmProvider::new()),
+            core_config: {
+                let mut config = crate::Config::default();
+                config.memory.workspace_dir = Some(memory_dir.clone());
+                config
+            },
+            runtime_config: super::super::RuntimeConfig::default(),
+            workspace_persona_dirs: Vec::new(),
+            tools: crate::tools::ToolRegistry::new(),
+            prompt_cache: super::super::prompt_cache::PromptAssemblyCache::new(Vec::new()),
+            turn_state,
+        };
+
+        refresh_turn_memory_surfaces(&state).await.unwrap();
+
+        assert!(working_memory_path(&memory_dir, "sess-write").exists());
+        assert!(latest_handoff_path(&memory_dir).exists());
+        assert!(
+            std::fs::read_dir(memory_dir.join("daily"))
+                .unwrap()
+                .next()
+                .is_some()
+        );
+        let session_summary_glob = memory_dir.join("sessions");
+        assert!(session_summary_glob.exists());
+        let handoff = tokio::fs::read_to_string(latest_handoff_path(&memory_dir))
+            .await
+            .unwrap();
+        assert!(handoff.contains("Keep the latest handoff fresh."));
+    }
+}

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -8,6 +8,7 @@ mod compaction;
 mod engine;
 mod loop_guard;
 mod memory_flush;
+mod memory_surfaces;
 mod prompt_cache;
 mod response_guardrails;
 mod submission_handlers;

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -58,7 +58,7 @@ pub(super) enum ToolOrchestratorOutcome {
 pub(super) enum ToolBatchOrchestratorOutcome {
     ContinueTurnLoop { refresh_context: bool },
     PauseTurn,
-    EndTurn,
+    EndTurn { surfaces_refreshed: bool },
 }
 
 fn dynamic_tool_resume_form(
@@ -1009,7 +1009,9 @@ where
                 return Ok(ToolBatchOrchestratorOutcome::PauseTurn);
             }
             ToolOrchestratorOutcome::EndTurn => {
-                return Ok(ToolBatchOrchestratorOutcome::EndTurn);
+                return Ok(ToolBatchOrchestratorOutcome::EndTurn {
+                    surfaces_refreshed: false,
+                });
             }
         }
     }
@@ -1025,11 +1027,18 @@ where
             is_final: true,
         })
         .await;
+        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
+            state,
+            "tool-loop-guard-ended-turn",
+        )
+        .await;
         emit(Event::TurnCompleted {
             summary: Some("Tool loop stopped by loop guard".to_string()),
         })
         .await;
-        return Ok(ToolBatchOrchestratorOutcome::EndTurn);
+        return Ok(ToolBatchOrchestratorOutcome::EndTurn {
+            surfaces_refreshed: true,
+        });
     }
 
     Ok(ToolBatchOrchestratorOutcome::ContinueTurnLoop { refresh_context })
@@ -1871,7 +1880,7 @@ mod tests {
         assert!(result.is_ok());
         // Invalid virtual tool should end turn
         match result.unwrap() {
-            ToolBatchOrchestratorOutcome::EndTurn => {
+            ToolBatchOrchestratorOutcome::EndTurn { .. } => {
                 // Check Error event was emitted
                 let has_error = events.iter().any(|e| matches!(e, Event::Error { .. }));
                 assert!(has_error, "Expected Error event for invalid virtual tool");
@@ -2492,7 +2501,7 @@ mod tests {
         assert!(result.is_ok());
         // After max loops, should end turn
         match result.unwrap() {
-            ToolBatchOrchestratorOutcome::EndTurn => {
+            ToolBatchOrchestratorOutcome::EndTurn { .. } => {
                 // Expected
             }
             _ => {

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1533,6 +1533,9 @@ where
                         .clear_responses_continuation("continuation_unavailable");
                 }
             }
+            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
+                warn!(error = %err, "Failed to refresh memory surfaces after fallback turn");
+            }
             emit(Event::TextDelta {
                 chunk: fallback_text.to_string(),
                 is_final: true,
@@ -1546,12 +1549,21 @@ where
         }
 
         if response_may_be_incomplete {
+            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
+                warn!(
+                    error = %err,
+                    "Failed to refresh memory surfaces after interrupted stream"
+                );
+            }
             emit_task_completed_success(
                 emit,
                 "Task completed with interrupted stream; response may be incomplete.",
             )
             .await;
         } else {
+            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
+                warn!(error = %err, "Failed to refresh memory surfaces after completed turn");
+            }
             emit_task_completed_success(emit, "Task completed").await;
         }
         return Ok(TurnExecutionOutcome::Finished);

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1499,6 +1499,11 @@ where
                 }
                 ToolBatchOrchestratorOutcome::PauseTurn => return Ok(TurnExecutionOutcome::Paused),
                 ToolBatchOrchestratorOutcome::EndTurn => {
+                    super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                        state,
+                        "turn-ended-after-tool-batch",
+                    )
+                    .await;
                     return Ok(TurnExecutionOutcome::Finished);
                 }
             }
@@ -1533,9 +1538,11 @@ where
                         .clear_responses_continuation("continuation_unavailable");
                 }
             }
-            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
-                warn!(error = %err, "Failed to refresh memory surfaces after fallback turn");
-            }
+            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                state,
+                "fallback-turn-completed",
+            )
+            .await;
             emit(Event::TextDelta {
                 chunk: fallback_text.to_string(),
                 is_final: true,
@@ -1549,21 +1556,22 @@ where
         }
 
         if response_may_be_incomplete {
-            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
-                warn!(
-                    error = %err,
-                    "Failed to refresh memory surfaces after interrupted stream"
-                );
-            }
+            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                state,
+                "interrupted-stream-completed",
+            )
+            .await;
             emit_task_completed_success(
                 emit,
                 "Task completed with interrupted stream; response may be incomplete.",
             )
             .await;
         } else {
-            if let Err(err) = super::memory_surfaces::refresh_turn_memory_surfaces(state).await {
-                warn!(error = %err, "Failed to refresh memory surfaces after completed turn");
-            }
+            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                state,
+                "turn-completed",
+            )
+            .await;
             emit_task_completed_success(emit, "Task completed").await;
         }
         return Ok(TurnExecutionOutcome::Finished);
@@ -4222,6 +4230,54 @@ description: {description}
             )
         });
         assert!(has_confirmation, "Expected Yield Confirmation event");
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_refreshes_memory_surfaces_when_tool_batch_ends_turn() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut state = create_test_state_with_provider(ToolCallMockProvider::new(
+            vec![ToolCall {
+                id: Some("call_1".to_string()),
+                name: "request_confirmation".to_string(),
+                arguments: json!({}),
+            }],
+            "",
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+
+        let cancel = CancellationToken::new();
+        let mut events = vec![];
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text("Test input")]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::Error { message, .. } if message == "Invalid confirmation request."
+        )));
+        assert!(memory_dir.join("handoffs").join("LATEST.md").exists());
+        assert!(memory_dir.join("sessions").exists());
+        assert!(
+            std::fs::read_dir(memory_dir.join("daily"))
+                .unwrap()
+                .next()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1498,12 +1498,14 @@ where
                     }
                 }
                 ToolBatchOrchestratorOutcome::PauseTurn => return Ok(TurnExecutionOutcome::Paused),
-                ToolBatchOrchestratorOutcome::EndTurn => {
-                    super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-                        state,
-                        "turn-ended-after-tool-batch",
-                    )
-                    .await;
+                ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
+                    if !surfaces_refreshed {
+                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
+                            state,
+                            "turn-ended-after-tool-batch",
+                        )
+                        .await;
+                    }
                     return Ok(TurnExecutionOutcome::Finished);
                 }
             }
@@ -4367,6 +4369,91 @@ description: {description}
         assert!(!memory_dir.join("handoffs").join("LATEST.md").exists());
         assert!(!memory_dir.join("sessions").exists());
         assert!(!memory_dir.join("daily").exists());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::field_reassign_with_default)]
+    async fn test_run_turn_tool_loop_guard_refreshes_memory_surfaces_before_completion_event() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        let generate_calls = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceMockProvider::new(
+            vec![
+                GenerationResponse {
+                    content: String::new(),
+                    thinking: None,
+                    thinking_signature: None,
+                    redacted_thinking: Vec::new(),
+                    tool_calls: vec![ToolCall {
+                        id: Some("call-1".to_string()),
+                        name: "update_plan".to_string(),
+                        arguments: json!({
+                            "explanation": "Loop 1",
+                            "items": [{"id": "1", "content": "Step 1", "status": "in_progress"}]
+                        }),
+                    }],
+                    usage: None,
+                    finish_reason: None,
+                    warnings: Vec::new(),
+                    provider_response_id: None,
+                    provider_response_status: None,
+                },
+                GenerationResponse {
+                    content: String::new(),
+                    thinking: None,
+                    thinking_signature: None,
+                    redacted_thinking: Vec::new(),
+                    tool_calls: vec![ToolCall {
+                        id: Some("call-2".to_string()),
+                        name: "update_plan".to_string(),
+                        arguments: json!({
+                            "explanation": "Loop 2",
+                            "items": [{"id": "2", "content": "Step 2", "status": "in_progress"}]
+                        }),
+                    }],
+                    usage: None,
+                    finish_reason: None,
+                    warnings: Vec::new(),
+                    provider_response_id: None,
+                    provider_response_status: None,
+                },
+            ],
+            Arc::clone(&generate_calls),
+        );
+        let mut state = create_test_state_with_provider(provider);
+        state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+        state.runtime_config.max_tool_loops = 2;
+
+        let cancel = CancellationToken::new();
+        let mut saw_handoff_before_completion = false;
+        let mut emit = |event: Event| {
+            if matches!(
+                event,
+                Event::TurnCompleted {
+                    summary: Some(ref summary)
+                } if summary == "Tool loop stopped by loop guard"
+            ) {
+                saw_handoff_before_completion = memory_dir.join("handoffs/LATEST.md").exists();
+            }
+            async {}
+        };
+
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text(
+                "Run until the loop guard stops you.",
+            )]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+        assert_eq!(generate_calls.load(Ordering::SeqCst), 2);
+        assert!(saw_handoff_before_completion);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1499,7 +1499,7 @@ where
                 }
                 ToolBatchOrchestratorOutcome::PauseTurn => return Ok(TurnExecutionOutcome::Paused),
                 ToolBatchOrchestratorOutcome::EndTurn => {
-                    super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                    super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
                         state,
                         "turn-ended-after-tool-batch",
                     )
@@ -1628,6 +1628,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::turn_state::TurnActivityState;
     use crate::{
         config::Config,
         llm::LlmClient,
@@ -4246,6 +4247,9 @@ description: {description}
             "",
         ));
         state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+        state
+            .turn_state
+            .set_turn_activity(TurnActivityState::Running);
 
         let cancel = CancellationToken::new();
         let mut events = vec![];
@@ -4278,6 +4282,91 @@ description: {description}
                 .next()
                 .is_some()
         );
+    }
+
+    struct SlowTool {
+        delay: tokio::time::Duration,
+    }
+
+    impl Tool for SlowTool {
+        fn name(&self) -> &str {
+            "slow_tool"
+        }
+
+        fn description(&self) -> &str {
+            "Slow tool used to test cancellation."
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({
+                "type": "object",
+                "properties": {}
+            })
+        }
+
+        fn execute(&self, _arguments: serde_json::Value, _ctx: &ToolContext) -> ToolResult {
+            let delay = self.delay;
+            Box::pin(async move {
+                tokio::time::sleep(delay).await;
+                Ok(json!({ "ok": true }))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_cancelled_tool_batch_does_not_refresh_memory_surfaces() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut state = create_test_state_with_provider(ToolCallMockProvider::new(
+            vec![ToolCall {
+                id: Some("call_1".to_string()),
+                name: "slow_tool".to_string(),
+                arguments: json!({}),
+            }],
+            "",
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+        state
+            .turn_state
+            .set_turn_activity(TurnActivityState::Running);
+        state.tools.register(SlowTool {
+            delay: tokio::time::Duration::from_millis(50),
+        });
+
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            cancel_for_task.cancel();
+        });
+
+        let mut events = vec![];
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text("Test input")]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            Event::TurnCompleted { summary: Some(summary) }
+                if summary == "Task cancelled by user"
+        )));
+        assert!(!memory_dir.join("handoffs").join("LATEST.md").exists());
+        assert!(!memory_dir.join("sessions").exists());
+        assert!(!memory_dir.join("daily").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Implement pure-text memory V2 slice 2 from #267.

This PR adds the first runtime-owned episodic write path:
- refreshes `memory/handoffs/LATEST.md` after completed turns
- writes deterministic session summaries under `memory/sessions/YYYY/MM/DD/<session-id>.md`
- writes runtime-owned working-memory files under `memory/working/<session-id>.md`
- appends turn-level chronology to `memory/daily/YYYY-MM-DD.md`
- migrates automatic memory-flush output onto the `daily/` surface

## Why
Slice 1 made the read path deterministic. This slice makes the write path useful: Alan now leaves behind inspectable cross-session artifacts instead of relying only on raw rollout logs and ad hoc daily notes in the memory root.

## Validation
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/alan-memory-pr2-tests cargo test -p alan-runtime refresh_turn_memory_surfaces_writes_expected_files --lib`
- `CARGO_TARGET_DIR=/tmp/alan-memory-pr2-tests cargo test -p alan-runtime snapshot_output_path_prefers_workspace_relative_memory_path --lib`
- `CARGO_TARGET_DIR=/tmp/alan-memory-pr2-tests cargo test -p alan --test compaction_integration_test compaction_auto_pre_turn_soft_flush_success_surfaces_match -- --exact`
- `CARGO_TARGET_DIR=/tmp/alan-memory-pr2-tests cargo test -p alan reconnect_snapshot_retains_memory_flush_attempt_after_replay_eviction --lib`

## Stack
- Base PR: #270
- Next planned PR: deterministic recall bundle routing (#268)
