### PR TITLE
[codex] Add deterministic pure-text runtime recall bundle

### DIFF
--- a/crates/alan/tests/compaction_integration_test.rs
+++ b/crates/alan/tests/compaction_integration_test.rs
@@ -713,9 +713,10 @@ fn failure_only_history_seed(session: &mut Session) {
     session.add_user_message("tail marker survives failure");
 }
 
-fn soft_threshold_context_window_tokens() -> u32 {
+fn soft_threshold_context_window_tokens(pending_turn_text: &str) -> u32 {
     let mut session = Session::new();
     seed_soft_threshold_history(&mut session);
+    session.add_user_message(pending_turn_text);
     ((session.tape.estimated_prompt_tokens() as f64) / 0.75).ceil() as u32
 }
 
@@ -725,14 +726,17 @@ fn hard_threshold_context_window_tokens() -> u32 {
     ((session.tape.estimated_prompt_tokens() as f64) / 0.95).ceil() as u32
 }
 
-fn configure_auto_pre_turn_soft_threshold(config: &mut WorkspaceRuntimeConfig) {
+fn configure_auto_pre_turn_soft_threshold(
+    config: &mut WorkspaceRuntimeConfig,
+    pending_turn_text: &str,
+) {
     config
         .agent_config
         .runtime_config
         .compaction_trigger_messages = 100;
     config.agent_config.runtime_config.compaction_keep_last = 1;
     config.agent_config.runtime_config.context_window_tokens =
-        soft_threshold_context_window_tokens();
+        soft_threshold_context_window_tokens(pending_turn_text);
     config.agent_config.runtime_config.compaction_trigger_ratio = 0.85;
     config
         .agent_config
@@ -822,6 +826,7 @@ async fn compaction_manual_success_surfaces_match() {
 
 #[tokio::test]
 async fn compaction_auto_pre_turn_soft_flush_success_surfaces_match() {
+    let pending_turn_text = "Proceed with the compaction follow-up work.";
     let session_id = format!("sess-soft-flush-success-{}", uuid::Uuid::new_v4());
     let temp = TempDir::new().unwrap();
     let (_, _, sessions_dir) = prepare_workspace(&temp);
@@ -845,13 +850,11 @@ async fn compaction_auto_pre_turn_soft_flush_success_surfaces_match() {
                 "Final response after automatic compaction.",
             ),
         ],
-        configure_auto_pre_turn_soft_threshold,
+        |config| configure_auto_pre_turn_soft_threshold(config, pending_turn_text),
     )
     .await;
 
-    let submission_id = harness
-        .request_turn("Continue the compaction follow-up work.")
-        .await;
+    let submission_id = harness.request_turn(pending_turn_text).await;
     let outcome = harness
         .wait_for_turn_completion_with_auto_compaction(&submission_id)
         .await;
@@ -900,6 +903,7 @@ async fn compaction_auto_pre_turn_soft_flush_success_surfaces_match() {
 
 #[tokio::test]
 async fn compaction_auto_pre_turn_soft_flush_skip_surfaces_match() {
+    let pending_turn_text = "Proceed after noop memory flush.";
     let session_id = format!("sess-soft-flush-skip-{}", uuid::Uuid::new_v4());
     let temp = TempDir::new().unwrap();
     let (_, _, sessions_dir) = prepare_workspace(&temp);
@@ -923,13 +927,11 @@ async fn compaction_auto_pre_turn_soft_flush_skip_surfaces_match() {
                 "Final response after noop memory flush.",
             ),
         ],
-        configure_auto_pre_turn_soft_threshold,
+        |config| configure_auto_pre_turn_soft_threshold(config, pending_turn_text),
     )
     .await;
 
-    let submission_id = harness
-        .request_turn("Continue after noop memory flush.")
-        .await;
+    let submission_id = harness.request_turn(pending_turn_text).await;
     let outcome = harness
         .wait_for_turn_completion_with_auto_compaction(&submission_id)
         .await;
@@ -960,6 +962,7 @@ async fn compaction_auto_pre_turn_soft_flush_skip_surfaces_match() {
 
 #[tokio::test]
 async fn compaction_auto_pre_turn_soft_flush_failure_surfaces_match() {
+    let pending_turn_text = "Proceed after memory flush failure.";
     let session_id = format!("sess-soft-flush-failure-{}", uuid::Uuid::new_v4());
     let temp = TempDir::new().unwrap();
     let (_, _, sessions_dir) = prepare_workspace(&temp);
@@ -983,13 +986,11 @@ async fn compaction_auto_pre_turn_soft_flush_failure_surfaces_match() {
                 "Final response after failed memory flush.",
             ),
         ],
-        configure_auto_pre_turn_soft_threshold,
+        |config| configure_auto_pre_turn_soft_threshold(config, pending_turn_text),
     )
     .await;
 
-    let submission_id = harness
-        .request_turn("Continue after memory flush failure.")
-        .await;
+    let submission_id = harness.request_turn(pending_turn_text).await;
     let outcome = harness
         .wait_for_turn_completion_with_auto_compaction(&submission_id)
         .await;
@@ -1019,6 +1020,7 @@ async fn compaction_auto_pre_turn_soft_flush_failure_surfaces_match() {
 
 #[tokio::test]
 async fn compaction_auto_pre_turn_hard_skips_memory_flush_surfaces_match() {
+    let pending_turn_text = "Proceed after hard-threshold compaction.";
     let session_id = format!("sess-hard-no-flush-{}", uuid::Uuid::new_v4());
     let temp = TempDir::new().unwrap();
     let (_, _, sessions_dir) = prepare_workspace(&temp);
@@ -1042,9 +1044,7 @@ async fn compaction_auto_pre_turn_hard_skips_memory_flush_surfaces_match() {
     )
     .await;
 
-    let submission_id = harness
-        .request_turn("Continue after hard-threshold compaction.")
-        .await;
+    let submission_id = harness.request_turn(pending_turn_text).await;
     let outcome = harness
         .wait_for_turn_completion_with_auto_compaction(&submission_id)
         .await;

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -562,3 +562,96 @@ async fn smoke_cross_session_persona_memory_is_reinjected() {
         "expected system prompt to show the exact writable USER.md target"
     );
 }
+
+#[tokio::test]
+async fn smoke_cross_session_runtime_memory_recall_bundle_is_reinjected() {
+    let temp_home = TempDir::new().expect("temp home");
+    let temp_workspace = TempDir::new().expect("temp workspace");
+    let workspace_root = temp_workspace.path().join("workspace");
+    let workspace_alan_dir = workspace_root.join(".alan");
+    let memory_dir = workspace_alan_dir.join("memory");
+    fs::create_dir_all(&workspace_alan_dir).expect("create workspace .alan");
+    alan_runtime::prompts::ensure_workspace_memory_layout_at(&memory_dir)
+        .expect("initialize workspace memory layout");
+
+    let marker = "ALAN_SMOKE_RUNTIME_MEMORY_RECALL";
+    fs::write(
+        memory_dir.join("USER.md"),
+        format!("# User Memory\n- Favorite runtime recall marker: {marker}\n"),
+    )
+    .expect("write memory USER.md");
+
+    let second_mock = MockLlmProvider::new().with_response(GenerationResponse {
+        content: marker.to_string(),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: Vec::new(),
+        tool_calls: Vec::new(),
+        usage: Some(TokenUsage {
+            prompt_tokens: 10,
+            cached_prompt_tokens: None,
+            completion_tokens: 3,
+            total_tokens: 13,
+            reasoning_tokens: None,
+        }),
+        finish_reason: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        warnings: Vec::new(),
+    });
+    let second_llm_client = LlmClient::new(second_mock.clone());
+    let mut second_config = WorkspaceRuntimeConfig::default();
+    second_config.workspace_root_dir = Some(workspace_root.clone());
+    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+
+    let mut second_controller =
+        spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");
+    second_controller
+        .wait_until_ready()
+        .await
+        .expect("second runtime ready");
+
+    let rx = second_controller.handle.event_sender.subscribe();
+    second_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(
+                "What is my favorite runtime recall marker?",
+            )],
+            context: None,
+        }))
+        .await
+        .expect("send second submission");
+
+    let second_events = collect_events_until_turn_complete(rx, Duration::from_secs(10)).await;
+    assert!(
+        second_events
+            .iter()
+            .any(|event| matches!(event, Event::TurnCompleted { .. })),
+        "second turn should complete"
+    );
+    second_controller
+        .shutdown()
+        .await
+        .expect("shutdown second runtime");
+
+    let recorded_requests = second_mock.recorded_requests();
+    let system_prompt = recorded_requests
+        .last()
+        .and_then(|request| request.system_prompt.as_deref())
+        .expect("expected recorded system prompt");
+    assert!(
+        system_prompt.contains("## Runtime Recall Bundle"),
+        "expected runtime recall bundle to be appended for identity recall questions"
+    );
+    assert!(
+        system_prompt.contains(".alan/memory/USER.md"),
+        "expected runtime recall bundle to cite USER.md"
+    );
+    assert!(
+        system_prompt.contains(marker),
+        "expected runtime recall bundle to include the stored marker"
+    );
+}

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -600,10 +600,12 @@ async fn smoke_cross_session_runtime_memory_recall_bundle_is_reinjected() {
         warnings: Vec::new(),
     });
     let second_llm_client = LlmClient::new(second_mock.clone());
-    let mut second_config = WorkspaceRuntimeConfig::default();
-    second_config.workspace_root_dir = Some(workspace_root.clone());
-    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
-    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    let second_config = WorkspaceRuntimeConfig {
+        workspace_root_dir: Some(workspace_root.clone()),
+        workspace_alan_dir: Some(workspace_alan_dir.clone()),
+        agent_home_paths: Some(AlanHomePaths::from_home_dir(temp_home.path())),
+        ..WorkspaceRuntimeConfig::default()
+    };
 
     let mut second_controller =
         spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");

--- a/crates/runtime/src/runtime/compaction.rs
+++ b/crates/runtime/src/runtime/compaction.rs
@@ -18,6 +18,7 @@ pub(crate) struct CompactionRequest {
     trigger: CompactionTrigger,
     reason: CompactionReason,
     focus: Option<String>,
+    additional_prompt_tokens: usize,
 }
 
 impl CompactionRequest {
@@ -27,6 +28,7 @@ impl CompactionRequest {
             trigger: CompactionTrigger::Manual,
             reason: CompactionReason::ExplicitRequest,
             focus: normalize_compaction_focus(focus),
+            additional_prompt_tokens: 0,
         }
     }
 
@@ -36,6 +38,7 @@ impl CompactionRequest {
             trigger: CompactionTrigger::Auto,
             reason: CompactionReason::WindowPressure,
             focus: None,
+            additional_prompt_tokens: 0,
         }
     }
 
@@ -45,7 +48,13 @@ impl CompactionRequest {
             trigger: CompactionTrigger::Auto,
             reason: CompactionReason::ContinuationPressure,
             focus: None,
+            additional_prompt_tokens: 0,
         }
+    }
+
+    pub(crate) fn with_additional_prompt_tokens(mut self, additional_prompt_tokens: usize) -> Self {
+        self.additional_prompt_tokens = additional_prompt_tokens;
+        self
     }
 
     pub(crate) fn mode(&self) -> CompactionMode {
@@ -62,6 +71,10 @@ impl CompactionRequest {
 
     pub(crate) fn focus(&self) -> Option<&str> {
         self.focus.as_deref()
+    }
+
+    pub(crate) fn additional_prompt_tokens(&self) -> usize {
+        self.additional_prompt_tokens
     }
 
     pub(crate) fn metadata(&self) -> CompactionRequestMetadata {
@@ -945,7 +958,11 @@ where
 {
     let keep_last = state.runtime_config.compaction_keep_last;
     let message_count = state.session.tape.len();
-    let estimated_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = state
+        .session
+        .tape
+        .estimated_prompt_tokens()
+        .saturating_add(request.additional_prompt_tokens());
     let pressure = evaluate_compaction_pressure(
         &state.runtime_config,
         request,
@@ -1157,7 +1174,11 @@ where
     let attempt_id = uuid::Uuid::new_v4().to_string();
     apply_tape_compaction(state, &summary, keep_last, retention_start);
     state.session.clear_responses_continuation("compaction");
-    let output_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+    let output_prompt_tokens = state
+        .session
+        .tape
+        .estimated_prompt_tokens()
+        .saturating_add(request.additional_prompt_tokens());
     let output_messages = state.session.tape.len();
     let timestamp = chrono::Utc::now().to_rfc3339();
     let duration_ms = duration_ms_since(started_at);

--- a/crates/runtime/src/runtime/memory_recall.rs
+++ b/crates/runtime/src/runtime/memory_recall.rs
@@ -228,8 +228,13 @@ fn collect_markdown_files_recursive_inner(
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
-    for entry in entries.filter_map(Result::ok) {
-        let path = entry.path();
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect();
+    paths.sort();
+    paths.reverse();
+    for path in paths {
         if path.is_dir() {
             collect_markdown_files_recursive_inner(&path, collected, max_files);
         } else if path.is_file()
@@ -357,5 +362,30 @@ mod tests {
 
         assert!(bundle.contains(".alan/memory/topics/memory-router.md"));
         assert!(bundle.contains("lexical recall"));
+    }
+
+    #[test]
+    fn collect_markdown_files_recursive_prioritizes_newest_paths_under_cap() {
+        let temp = TempDir::new().unwrap();
+        let sessions_dir = temp.path().join(".alan/memory/sessions");
+        fs::create_dir_all(sessions_dir.join("2026/04/15")).unwrap();
+        fs::create_dir_all(sessions_dir.join("2026/04/16")).unwrap();
+        fs::write(
+            sessions_dir.join("2026/04/15/session-older.md"),
+            "# Session Summary\nolder\n",
+        )
+        .unwrap();
+        fs::write(
+            sessions_dir.join("2026/04/16/session-newer.md"),
+            "# Session Summary\nnewer\n",
+        )
+        .unwrap();
+
+        let collected = collect_markdown_files_recursive(&sessions_dir, 1);
+
+        assert_eq!(
+            collected,
+            vec![sessions_dir.join("2026/04/16/session-newer.md")]
+        );
     }
 }

--- a/crates/runtime/src/runtime/memory_recall.rs
+++ b/crates/runtime/src/runtime/memory_recall.rs
@@ -22,6 +22,7 @@ pub(crate) fn build_turn_recall_bundle(
     if !memory_dir.exists() {
         return None;
     }
+    let canonical_memory_root = fs::canonicalize(memory_dir).ok()?;
 
     let query = user_input
         .map(parts_to_text)
@@ -64,18 +65,27 @@ pub(crate) fn build_turn_recall_bundle(
         scored_candidates.extend(score_candidate_files(
             collect_markdown_files_recursive(
                 &memory_dir.join("sessions"),
+                &canonical_memory_root,
                 MAX_CANDIDATE_SCAN_FILES,
             ),
             &query_tokens,
         ));
         scored_candidates.extend(score_candidate_files(
-            collect_markdown_files(&memory_dir.join("daily"), MAX_CANDIDATE_SCAN_FILES),
+            collect_markdown_files(
+                &memory_dir.join("daily"),
+                &canonical_memory_root,
+                MAX_CANDIDATE_SCAN_FILES,
+            ),
             &query_tokens,
         ));
     }
     if workspace_query || !query_tokens.is_empty() {
         scored_candidates.extend(score_candidate_files(
-            collect_markdown_files(&memory_dir.join("topics"), MAX_CANDIDATE_SCAN_FILES),
+            collect_markdown_files(
+                &memory_dir.join("topics"),
+                &canonical_memory_root,
+                MAX_CANDIDATE_SCAN_FILES,
+            ),
             &query_tokens,
         ));
     }
@@ -98,6 +108,7 @@ pub(crate) fn build_turn_recall_bundle(
     let sections: Vec<String> = selected_paths
         .into_iter()
         .filter(|path| seen.insert(path.clone()))
+        .filter(|path| path_is_safe_recall_file(path, &canonical_memory_root))
         .filter_map(|path| {
             let content = fs::read_to_string(&path).ok()?;
             let trimmed = content.trim();
@@ -124,6 +135,22 @@ pub(crate) fn build_turn_recall_bundle(
 Selected turn-relevant pure-text memory based on the current user request. Treat this as runtime-routed recall, not raw speculative search.\n\n{}",
         sections.join("\n")
     ))
+}
+
+fn path_is_within_canonical_root(path: &Path, canonical_memory_root: &Path) -> bool {
+    fs::canonicalize(path)
+        .ok()
+        .is_some_and(|canonical_path| canonical_path.starts_with(canonical_memory_root))
+}
+
+fn path_is_safe_recall_file(path: &Path, canonical_memory_root: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_file())
+        && path_is_within_canonical_root(path, canonical_memory_root)
+        && path
+            .extension()
+            .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
 }
 
 fn is_identity_query(query: &str) -> bool {
@@ -189,17 +216,25 @@ fn tokenize_query(query: &str) -> Vec<String> {
         .collect()
 }
 
-fn collect_markdown_files(dir: &Path, max_files: usize) -> Vec<PathBuf> {
+fn collect_markdown_files(
+    dir: &Path,
+    canonical_memory_root: &Path,
+    max_files: usize,
+) -> Vec<PathBuf> {
+    if !path_is_within_canonical_root(dir, canonical_memory_root) {
+        return Vec::new();
+    }
     let mut files: Vec<PathBuf> = fs::read_dir(dir)
         .ok()
         .into_iter()
         .flat_map(|entries| entries.filter_map(Result::ok))
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.is_file()
-                && path
-                    .extension()
-                    .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
+        .filter_map(|entry| {
+            let file_type = entry.file_type().ok()?;
+            if file_type.is_symlink() || !file_type.is_file() {
+                return None;
+            }
+            let path = entry.path();
+            path_is_safe_recall_file(&path, canonical_memory_root).then_some(path)
         })
         .collect();
     files.sort();
@@ -208,9 +243,13 @@ fn collect_markdown_files(dir: &Path, max_files: usize) -> Vec<PathBuf> {
     files
 }
 
-fn collect_markdown_files_recursive(dir: &Path, max_files: usize) -> Vec<PathBuf> {
+fn collect_markdown_files_recursive(
+    dir: &Path,
+    canonical_memory_root: &Path,
+    max_files: usize,
+) -> Vec<PathBuf> {
     let mut collected = Vec::new();
-    collect_markdown_files_recursive_inner(dir, &mut collected, max_files);
+    collect_markdown_files_recursive_inner(dir, canonical_memory_root, &mut collected, max_files);
     collected.sort();
     collected.reverse();
     collected.truncate(max_files);
@@ -219,10 +258,14 @@ fn collect_markdown_files_recursive(dir: &Path, max_files: usize) -> Vec<PathBuf
 
 fn collect_markdown_files_recursive_inner(
     dir: &Path,
+    canonical_memory_root: &Path,
     collected: &mut Vec<PathBuf>,
     max_files: usize,
 ) {
     if collected.len() >= max_files {
+        return;
+    }
+    if !path_is_within_canonical_root(dir, canonical_memory_root) {
         return;
     }
     let Ok(entries) = fs::read_dir(dir) else {
@@ -235,13 +278,21 @@ fn collect_markdown_files_recursive_inner(
     paths.sort();
     paths.reverse();
     for path in paths {
-        if path.is_dir() {
-            collect_markdown_files_recursive_inner(&path, collected, max_files);
-        } else if path.is_file()
-            && path
-                .extension()
-                .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
-        {
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_markdown_files_recursive_inner(
+                &path,
+                canonical_memory_root,
+                collected,
+                max_files,
+            );
+        } else if file_type.is_file() && path_is_safe_recall_file(&path, canonical_memory_root) {
             collected.push(path);
             if collected.len() >= max_files {
                 return;
@@ -381,11 +432,83 @@ mod tests {
         )
         .unwrap();
 
-        let collected = collect_markdown_files_recursive(&sessions_dir, 1);
+        let canonical_memory_root = fs::canonicalize(temp.path().join(".alan/memory")).unwrap();
+        let collected = collect_markdown_files_recursive(&sessions_dir, &canonical_memory_root, 1);
 
         assert_eq!(
             collected,
             vec![sessions_dir.join("2026/04/16/session-newer.md")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn continuity_query_skips_symlinked_session_directories() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        fs::write(
+            memory_dir.join("handoffs/LATEST.md"),
+            "# Latest Handoff\nWe were refining the recall router.\n",
+        )
+        .unwrap();
+        fs::create_dir_all(memory_dir.join("sessions/2026/04")).unwrap();
+
+        let external_dir = temp.path().join("external-sessions");
+        fs::create_dir_all(&external_dir).unwrap();
+        fs::write(
+            external_dir.join("session-leak.md"),
+            "# Session Summary\nZebraRecallLeak\n",
+        )
+        .unwrap();
+        symlink(&external_dir, memory_dir.join("sessions/2026/04/link-out")).unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text(
+                "What were we doing in the previous session about ZebraRecallLeak?",
+            )]),
+        )
+        .expect("expected recall bundle");
+
+        assert!(!bundle.contains("ZebraRecallLeak"));
+        assert!(!bundle.contains("session-leak.md"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn continuity_query_skips_handoff_paths_outside_memory_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let external_handoffs = temp.path().join("external-handoffs");
+        fs::create_dir_all(&external_handoffs).unwrap();
+        fs::write(
+            external_handoffs.join("LATEST.md"),
+            "# Latest Handoff\nZebraHandoffLeak\n",
+        )
+        .unwrap();
+
+        fs::remove_dir_all(memory_dir.join("handoffs")).unwrap();
+        symlink(&external_handoffs, memory_dir.join("handoffs")).unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text(
+                "What were we doing in the previous session about ZebraHandoffLeak?",
+            )]),
+        );
+
+        assert!(
+            bundle.is_none()
+                || bundle
+                    .as_deref()
+                    .is_some_and(|bundle| !bundle.contains("ZebraHandoffLeak"))
         );
     }
 }

--- a/crates/runtime/src/runtime/memory_recall.rs
+++ b/crates/runtime/src/runtime/memory_recall.rs
@@ -61,23 +61,24 @@ pub(crate) fn build_turn_recall_bundle(
     }
 
     let mut scored_candidates = Vec::new();
+    let mut fallback_recent_paths = Vec::new();
     if continuity_query || recent_query {
-        scored_candidates.extend(score_candidate_files(
-            collect_markdown_files_recursive(
-                &memory_dir.join("sessions"),
-                &canonical_memory_root,
-                MAX_CANDIDATE_SCAN_FILES,
-            ),
-            &query_tokens,
-        ));
-        scored_candidates.extend(score_candidate_files(
-            collect_markdown_files(
-                &memory_dir.join("daily"),
-                &canonical_memory_root,
-                MAX_CANDIDATE_SCAN_FILES,
-            ),
-            &query_tokens,
-        ));
+        let session_paths = collect_markdown_files_recursive(
+            &memory_dir.join("sessions"),
+            &canonical_memory_root,
+            MAX_CANDIDATE_SCAN_FILES,
+        );
+        let daily_paths = collect_markdown_files(
+            &memory_dir.join("daily"),
+            &canonical_memory_root,
+            MAX_CANDIDATE_SCAN_FILES,
+        );
+        if recent_query {
+            fallback_recent_paths.extend(session_paths.iter().cloned());
+            fallback_recent_paths.extend(daily_paths.iter().cloned());
+        }
+        scored_candidates.extend(score_candidate_files(session_paths, &query_tokens));
+        scored_candidates.extend(score_candidate_files(daily_paths, &query_tokens));
     }
     if workspace_query || !query_tokens.is_empty() {
         scored_candidates.extend(score_candidate_files(
@@ -96,13 +97,32 @@ pub(crate) fn build_turn_recall_bundle(
             .cmp(&left.score)
             .then_with(|| right.path.cmp(&left.path))
     });
+    let mut selected_candidate_paths = Vec::new();
+    let mut seen_candidate_paths = BTreeSet::new();
     for candidate in scored_candidates
         .into_iter()
         .filter(|candidate| candidate.score > 0)
-        .take(MAX_RECALL_FILES)
     {
-        selected_paths.push(candidate.path);
+        if selected_candidate_paths.len() >= MAX_RECALL_FILES {
+            break;
+        }
+        if seen_candidate_paths.insert(candidate.path.clone()) {
+            selected_candidate_paths.push(candidate.path);
+        }
     }
+    if recent_query && selected_candidate_paths.len() < MAX_RECALL_FILES {
+        fallback_recent_paths.sort();
+        fallback_recent_paths.reverse();
+        for path in fallback_recent_paths {
+            if selected_candidate_paths.len() >= MAX_RECALL_FILES {
+                break;
+            }
+            if seen_candidate_paths.insert(path.clone()) {
+                selected_candidate_paths.push(path);
+            }
+        }
+    }
+    selected_paths.extend(selected_candidate_paths);
 
     let mut seen = BTreeSet::new();
     let sections: Vec<String> = selected_paths
@@ -413,6 +433,35 @@ mod tests {
 
         assert!(bundle.contains(".alan/memory/topics/memory-router.md"));
         assert!(bundle.contains("lexical recall"));
+    }
+
+    #[test]
+    fn recent_query_falls_back_to_latest_recent_files_without_token_overlap() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        fs::create_dir_all(memory_dir.join("sessions/2026/04/16")).unwrap();
+        fs::write(
+            memory_dir.join("daily/2026-04-16.md"),
+            "## 2026-04-16\nALAN_RECENT_RECALL\n",
+        )
+        .unwrap();
+        fs::write(
+            memory_dir.join("sessions/2026/04/16/session-1.md"),
+            "# Session Summary\nALAN_RECENT_RECALL\n",
+        )
+        .unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text("What did we do yesterday?")]),
+        )
+        .expect("expected recall bundle");
+
+        assert!(bundle.contains("## Runtime Recall Bundle"));
+        assert!(bundle.contains(".alan/memory/daily/2026-04-16.md"));
+        assert!(bundle.contains(".alan/memory/sessions/2026/04/16/session-1.md"));
+        assert!(bundle.contains("ALAN_RECENT_RECALL"));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/memory_recall.rs
+++ b/crates/runtime/src/runtime/memory_recall.rs
@@ -1,0 +1,361 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::tape::{ContentPart, parts_to_text};
+
+const MAX_FILE_RECALL_CHARS: usize = 1_200;
+const MAX_RECALL_FILES: usize = 4;
+const MAX_CANDIDATE_SCAN_FILES: usize = 64;
+
+#[derive(Debug, Clone)]
+struct RecallCandidate {
+    path: PathBuf,
+    score: usize,
+}
+
+pub(crate) fn build_turn_recall_bundle(
+    memory_dir: Option<&Path>,
+    user_input: Option<&[ContentPart]>,
+) -> Option<String> {
+    let memory_dir = memory_dir?;
+    if !memory_dir.exists() {
+        return None;
+    }
+
+    let query = user_input
+        .map(parts_to_text)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if query.is_empty() {
+        return None;
+    }
+
+    let query_lower = query.to_lowercase();
+    let query_tokens = tokenize_query(&query_lower);
+    let identity_query = is_identity_query(&query_lower);
+    let continuity_query = is_continuity_query(&query_lower);
+    let workspace_query = is_workspace_query(&query_lower);
+    let recent_query = is_recent_query(&query_lower);
+
+    if !identity_query
+        && !continuity_query
+        && !workspace_query
+        && !recent_query
+        && query_tokens.is_empty()
+    {
+        return None;
+    }
+
+    let mut selected_paths = Vec::new();
+    if identity_query {
+        selected_paths.push(memory_dir.join("USER.md"));
+    }
+    if workspace_query {
+        selected_paths.push(memory_dir.join("MEMORY.md"));
+    }
+    if continuity_query {
+        selected_paths.push(memory_dir.join("handoffs").join("LATEST.md"));
+    }
+
+    let mut scored_candidates = Vec::new();
+    if continuity_query || recent_query {
+        scored_candidates.extend(score_candidate_files(
+            collect_markdown_files_recursive(
+                &memory_dir.join("sessions"),
+                MAX_CANDIDATE_SCAN_FILES,
+            ),
+            &query_tokens,
+        ));
+        scored_candidates.extend(score_candidate_files(
+            collect_markdown_files(&memory_dir.join("daily"), MAX_CANDIDATE_SCAN_FILES),
+            &query_tokens,
+        ));
+    }
+    if workspace_query || !query_tokens.is_empty() {
+        scored_candidates.extend(score_candidate_files(
+            collect_markdown_files(&memory_dir.join("topics"), MAX_CANDIDATE_SCAN_FILES),
+            &query_tokens,
+        ));
+    }
+
+    scored_candidates.sort_by(|left, right| {
+        right
+            .score
+            .cmp(&left.score)
+            .then_with(|| right.path.cmp(&left.path))
+    });
+    for candidate in scored_candidates
+        .into_iter()
+        .filter(|candidate| candidate.score > 0)
+        .take(MAX_RECALL_FILES)
+    {
+        selected_paths.push(candidate.path);
+    }
+
+    let mut seen = BTreeSet::new();
+    let sections: Vec<String> = selected_paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .filter_map(|path| {
+            let content = fs::read_to_string(&path).ok()?;
+            let trimmed = content.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let relative_path = path
+                .strip_prefix(memory_dir)
+                .map(|value| format!(".alan/memory/{}", value.display()))
+                .unwrap_or_else(|_| path.display().to_string());
+            Some(format!(
+                "### {relative_path}\n{}\n",
+                truncate_chars(trimmed, MAX_FILE_RECALL_CHARS)
+            ))
+        })
+        .collect();
+
+    if sections.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "## Runtime Recall Bundle\n\
+Selected turn-relevant pure-text memory based on the current user request. Treat this as runtime-routed recall, not raw speculative search.\n\n{}",
+        sections.join("\n")
+    ))
+}
+
+fn is_identity_query(query: &str) -> bool {
+    [
+        "who am i",
+        "my name",
+        "my preference",
+        "my preferences",
+        "favorite",
+        "prefer",
+    ]
+    .iter()
+    .any(|needle| query.contains(needle))
+}
+
+fn is_continuity_query(query: &str) -> bool {
+    [
+        "continue",
+        "resume",
+        "last time",
+        "previous session",
+        "earlier",
+        "before",
+        "where did we leave off",
+        "what were we doing",
+    ]
+    .iter()
+    .any(|needle| query.contains(needle))
+}
+
+fn is_workspace_query(query: &str) -> bool {
+    [
+        "architecture",
+        "decision",
+        "constraint",
+        "project context",
+        "why did we",
+        "workspace",
+    ]
+    .iter()
+    .any(|needle| query.contains(needle))
+}
+
+fn is_recent_query(query: &str) -> bool {
+    ["today", "yesterday", "recent", "latest", "just now"]
+        .iter()
+        .any(|needle| query.contains(needle))
+}
+
+fn tokenize_query(query: &str) -> Vec<String> {
+    const STOP_WORDS: &[&str] = &[
+        "about", "after", "again", "been", "from", "have", "into", "just", "that", "the", "their",
+        "them", "then", "they", "this", "what", "when", "where", "which", "while", "with", "would",
+        "your", "were",
+    ];
+
+    query
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(str::trim)
+        .filter(|token| token.len() >= 3)
+        .filter(|token| !STOP_WORDS.contains(token))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn collect_markdown_files(dir: &Path, max_files: usize) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
+        })
+        .collect();
+    files.sort();
+    files.reverse();
+    files.truncate(max_files);
+    files
+}
+
+fn collect_markdown_files_recursive(dir: &Path, max_files: usize) -> Vec<PathBuf> {
+    let mut collected = Vec::new();
+    collect_markdown_files_recursive_inner(dir, &mut collected, max_files);
+    collected.sort();
+    collected.reverse();
+    collected.truncate(max_files);
+    collected
+}
+
+fn collect_markdown_files_recursive_inner(
+    dir: &Path,
+    collected: &mut Vec<PathBuf>,
+    max_files: usize,
+) {
+    if collected.len() >= max_files {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown_files_recursive_inner(&path, collected, max_files);
+        } else if path.is_file()
+            && path
+                .extension()
+                .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
+        {
+            collected.push(path);
+            if collected.len() >= max_files {
+                return;
+            }
+        }
+    }
+}
+
+fn score_candidate_files(paths: Vec<PathBuf>, query_tokens: &[String]) -> Vec<RecallCandidate> {
+    paths
+        .into_iter()
+        .filter_map(|path| {
+            let content = fs::read_to_string(&path).ok()?;
+            let score = lexical_overlap_score(&path, &content, query_tokens);
+            Some(RecallCandidate { path, score })
+        })
+        .collect()
+}
+
+fn lexical_overlap_score(path: &Path, content: &str, query_tokens: &[String]) -> usize {
+    if query_tokens.is_empty() {
+        return 0;
+    }
+    let path_text = path.to_string_lossy().to_lowercase();
+    let content_text = content.to_lowercase();
+    query_tokens
+        .iter()
+        .filter(|token| path_text.contains(token.as_str()) || content_text.contains(token.as_str()))
+        .count()
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn identity_query_prefers_user_memory() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        fs::write(
+            memory_dir.join("USER.md"),
+            "# User Memory\nName: Morris Liu\n",
+        )
+        .unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text("Who am I?")]),
+        )
+        .expect("expected recall bundle");
+
+        assert!(bundle.contains(".alan/memory/USER.md"));
+        assert!(bundle.contains("Morris Liu"));
+    }
+
+    #[test]
+    fn continuity_query_picks_handoff_and_session_summary() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        fs::write(
+            memory_dir.join("handoffs/LATEST.md"),
+            "# Latest Handoff\nWe were refining the recall router.\n",
+        )
+        .unwrap();
+        fs::create_dir_all(memory_dir.join("sessions/2026/04/15")).unwrap();
+        fs::write(
+            memory_dir.join("sessions/2026/04/15/sess-1.md"),
+            "# Session Summary\nRecall router work in progress.\n",
+        )
+        .unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text(
+                "What were we doing in the previous session?",
+            )]),
+        )
+        .expect("expected recall bundle");
+
+        assert!(bundle.contains(".alan/memory/handoffs/LATEST.md"));
+        assert!(bundle.contains(".alan/memory/sessions/2026/04/15/sess-1.md"));
+    }
+
+    #[test]
+    fn workspace_query_can_pick_relevant_topic_page() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        fs::write(
+            memory_dir.join("topics/memory-router.md"),
+            "# Memory Router\nArchitecture decision: use lexical recall over pure-text files.\n",
+        )
+        .unwrap();
+
+        let bundle = build_turn_recall_bundle(
+            Some(&memory_dir),
+            Some(&[crate::tape::ContentPart::text(
+                "What is the architecture decision for the memory router?",
+            )]),
+        )
+        .expect("expected recall bundle");
+
+        assert!(bundle.contains(".alan/memory/topics/memory-router.md"));
+        assert!(bundle.contains("lexical recall"));
+    }
+}

--- a/crates/runtime/src/runtime/memory_recall.rs
+++ b/crates/runtime/src/runtime/memory_recall.rs
@@ -61,7 +61,8 @@ pub(crate) fn build_turn_recall_bundle(
     }
 
     let mut scored_candidates = Vec::new();
-    let mut fallback_recent_paths = Vec::new();
+    let mut fallback_recent_session_paths = Vec::new();
+    let mut fallback_recent_daily_paths = Vec::new();
     if continuity_query || recent_query {
         let session_paths = collect_markdown_files_recursive(
             &memory_dir.join("sessions"),
@@ -74,13 +75,15 @@ pub(crate) fn build_turn_recall_bundle(
             MAX_CANDIDATE_SCAN_FILES,
         );
         if recent_query {
-            fallback_recent_paths.extend(session_paths.iter().cloned());
-            fallback_recent_paths.extend(daily_paths.iter().cloned());
+            fallback_recent_session_paths.extend(session_paths.iter().cloned());
+            fallback_recent_daily_paths.extend(daily_paths.iter().cloned());
         }
         scored_candidates.extend(score_candidate_files(session_paths, &query_tokens));
         scored_candidates.extend(score_candidate_files(daily_paths, &query_tokens));
     }
-    if workspace_query || !query_tokens.is_empty() {
+    let should_score_topics = workspace_query
+        || (!identity_query && !continuity_query && !recent_query && !query_tokens.is_empty());
+    if should_score_topics {
         scored_candidates.extend(score_candidate_files(
             collect_markdown_files(
                 &memory_dir.join("topics"),
@@ -111,9 +114,10 @@ pub(crate) fn build_turn_recall_bundle(
         }
     }
     if recent_query && selected_candidate_paths.len() < MAX_RECALL_FILES {
-        fallback_recent_paths.sort();
-        fallback_recent_paths.reverse();
-        for path in fallback_recent_paths {
+        for path in interleave_recent_fallback_paths(
+            &fallback_recent_daily_paths,
+            &fallback_recent_session_paths,
+        ) {
             if selected_candidate_paths.len() >= MAX_RECALL_FILES {
                 break;
             }
@@ -171,6 +175,23 @@ fn path_is_safe_recall_file(path: &Path, canonical_memory_root: &Path) -> bool {
         && path
             .extension()
             .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
+}
+
+fn interleave_recent_fallback_paths(
+    daily_paths: &[PathBuf],
+    session_paths: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut interleaved = Vec::with_capacity(daily_paths.len() + session_paths.len());
+    let max_len = daily_paths.len().max(session_paths.len());
+    for index in 0..max_len {
+        if let Some(path) = daily_paths.get(index) {
+            interleaved.push(path.clone());
+        }
+        if let Some(path) = session_paths.get(index) {
+            interleaved.push(path.clone());
+        }
+    }
+    interleaved
 }
 
 fn is_identity_query(query: &str) -> bool {
@@ -441,16 +462,25 @@ mod tests {
         let memory_dir = temp.path().join(".alan/memory");
         crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
         fs::create_dir_all(memory_dir.join("sessions/2026/04/16")).unwrap();
+        for index in 1..=4 {
+            fs::write(
+                memory_dir.join(format!("topics/recent-match-{index}.md")),
+                format!("# Topic Note\nwe did document topic match {index}\n"),
+            )
+            .unwrap();
+        }
         fs::write(
             memory_dir.join("daily/2026-04-16.md"),
             "## 2026-04-16\nALAN_RECENT_RECALL\n",
         )
         .unwrap();
-        fs::write(
-            memory_dir.join("sessions/2026/04/16/session-1.md"),
-            "# Session Summary\nALAN_RECENT_RECALL\n",
-        )
-        .unwrap();
+        for index in 1..=4 {
+            fs::write(
+                memory_dir.join(format!("sessions/2026/04/16/session-{index}.md")),
+                format!("# Session Summary\nALAN_RECENT_RECALL_{index}\n"),
+            )
+            .unwrap();
+        }
 
         let bundle = build_turn_recall_bundle(
             Some(&memory_dir),
@@ -460,8 +490,9 @@ mod tests {
 
         assert!(bundle.contains("## Runtime Recall Bundle"));
         assert!(bundle.contains(".alan/memory/daily/2026-04-16.md"));
-        assert!(bundle.contains(".alan/memory/sessions/2026/04/16/session-1.md"));
-        assert!(bundle.contains("ALAN_RECENT_RECALL"));
+        assert!(bundle.contains(".alan/memory/sessions/2026/04/16/session-4.md"));
+        assert!(bundle.contains("ALAN_RECENT_RECALL_4"));
+        assert!(!bundle.contains(".alan/memory/topics/recent-match-4.md"));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -8,6 +8,7 @@ mod compaction;
 mod engine;
 mod loop_guard;
 mod memory_flush;
+mod memory_recall;
 mod memory_surfaces;
 mod prompt_cache;
 mod response_guardrails;

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -4730,6 +4730,55 @@ runtime:
     }
 
     #[tokio::test]
+    async fn test_run_turn_includes_runtime_recall_bundle_for_recent_query_fallback() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        std::fs::create_dir_all(memory_dir.join("sessions/2026/04/16")).unwrap();
+        std::fs::write(
+            memory_dir.join("daily/2026-04-16.md"),
+            "## 2026-04-16\nALAN_RECENT_RECALL\n",
+        )
+        .unwrap();
+        std::fs::write(
+            memory_dir.join("sessions/2026/04/16/session-1.md"),
+            "# Session Summary\nALAN_RECENT_RECALL\n",
+        )
+        .unwrap();
+
+        let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
+            Vec::new(),
+            "ALAN_RECENT_RECALL",
+            seen_system_prompts.clone(),
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+        state.prompt_cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text("What did we do yesterday?")]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        let system_prompts = seen_system_prompts.lock().unwrap();
+        let request_prompt = system_prompts.last().expect("expected system prompt");
+        assert!(request_prompt.contains("## Runtime Recall Bundle"));
+        assert!(request_prompt.contains(".alan/memory/daily/2026-04-16.md"));
+        assert!(request_prompt.contains(".alan/memory/sessions/2026/04/16/session-1.md"));
+        assert!(request_prompt.contains("ALAN_RECENT_RECALL"));
+    }
+
+    #[tokio::test]
     async fn test_run_turn_omits_runtime_recall_bundle_when_memory_disabled() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -65,6 +65,34 @@ fn append_system_instruction(request: &mut crate::llm::GenerationRequest, instru
     }
 }
 
+fn estimate_runtime_system_instruction_tokens(instruction: &str) -> usize {
+    crate::tape::estimate_text_tokens(instruction).saturating_add(1)
+}
+
+fn estimate_request_prompt_overhead_tokens(
+    turn_recall_bundle: Option<&str>,
+    pending_guardrail_instruction: Option<&str>,
+) -> usize {
+    turn_recall_bundle
+        .into_iter()
+        .chain(pending_guardrail_instruction)
+        .map(estimate_runtime_system_instruction_tokens)
+        .sum()
+}
+
+fn estimate_pending_turn_prompt_tokens(
+    pending_user_input: Option<&[crate::tape::ContentPart]>,
+    turn_recall_bundle: Option<&str>,
+) -> usize {
+    pending_user_input
+        .map(crate::tape::estimate_user_message_tokens)
+        .unwrap_or(0)
+        .saturating_add(estimate_request_prompt_overhead_tokens(
+            turn_recall_bundle,
+            None,
+        ))
+}
+
 fn inject_stream_recovery_instruction(
     request: &mut crate::llm::GenerationRequest,
     visible_text_so_far: &str,
@@ -732,8 +760,22 @@ where
         emit(Event::TurnStarted {}).await;
     }
 
+    let user_input_for_skills = user_input.clone();
+    let turn_recall_bundle = if state.core_config.memory.enabled {
+        super::memory_recall::build_turn_recall_bundle(
+            state.core_config.memory.workspace_dir.as_deref(),
+            user_input_for_skills.as_deref(),
+        )
+    } else {
+        None
+    };
+
     if !should_skip_auto_compaction_for_responses_continuation(state) {
-        let compaction_request = CompactionRequest::automatic_pre_turn();
+        let compaction_request = CompactionRequest::automatic_pre_turn()
+            .with_additional_prompt_tokens(estimate_pending_turn_prompt_tokens(
+                user_input_for_skills.as_deref(),
+                turn_recall_bundle.as_deref(),
+            ));
         match tokio::time::timeout(
             tokio::time::Duration::from_secs(COMPACTION_TIMEOUT_SECS),
             maybe_compact_context_with_cancel(state, emit, &compaction_request, cancel),
@@ -753,7 +795,6 @@ where
         return Ok(TurnExecutionOutcome::Finished);
     }
 
-    let user_input_for_skills = user_input.clone();
     if matches!(turn_kind, TurnRunKind::NewTurn) {
         state
             .turn_state
@@ -787,14 +828,6 @@ where
         .set_active_skills(prompt_build.active_skills.clone());
     let _domain_prompt = prompt_build.domain_prompt;
     let system_prompt = prompt_build.system_prompt;
-    let turn_recall_bundle = if state.core_config.memory.enabled {
-        super::memory_recall::build_turn_recall_bundle(
-            state.core_config.memory.workspace_dir.as_deref(),
-            user_input_for_skills.as_deref(),
-        )
-    } else {
-        None
-    };
 
     let tools = turn_tool_definitions(state);
 
@@ -829,7 +862,13 @@ where
         }
 
         let prompt_view = state.session.tape.prompt_view();
-        let estimated_prompt_tokens = prompt_view.estimated_tokens;
+        let estimated_prompt_tokens =
+            prompt_view
+                .estimated_tokens
+                .saturating_add(estimate_request_prompt_overhead_tokens(
+                    turn_recall_bundle.as_deref(),
+                    pending_guardrail_instruction.as_deref(),
+                ));
         let context_revision = prompt_view.reference_context.revision;
         let messages = prompt_view.messages;
         let raw_tape_messages = state.session.tape.messages().to_vec();
@@ -1425,6 +1464,19 @@ where
                 })
                 .await;
                 pending_guardrail_instruction = Some(instruction);
+                maybe_compact_mid_turn_if_needed(
+                    state,
+                    emit,
+                    cancel,
+                    estimate_request_prompt_overhead_tokens(
+                        turn_recall_bundle.as_deref(),
+                        pending_guardrail_instruction.as_deref(),
+                    ),
+                )
+                .await?;
+                if check_turn_cancelled(state, emit, cancel).await? {
+                    return Ok(TurnExecutionOutcome::Finished);
+                }
                 continue;
             }
         }
@@ -1503,7 +1555,16 @@ where
                 .await?
             {
                 ToolBatchOrchestratorOutcome::ContinueTurnLoop { .. } => {
-                    maybe_compact_mid_turn_if_needed(state, emit, cancel).await?;
+                    maybe_compact_mid_turn_if_needed(
+                        state,
+                        emit,
+                        cancel,
+                        estimate_request_prompt_overhead_tokens(
+                            turn_recall_bundle.as_deref(),
+                            pending_guardrail_instruction.as_deref(),
+                        ),
+                    )
+                    .await?;
                     if check_turn_cancelled(state, emit, cancel).await? {
                         return Ok(TurnExecutionOutcome::Finished);
                     }
@@ -1595,6 +1656,7 @@ async fn maybe_compact_mid_turn_if_needed<E, F>(
     state: &mut RuntimeLoopState,
     emit: &mut E,
     cancel: &CancellationToken,
+    additional_prompt_tokens: usize,
 ) -> Result<()>
 where
     E: FnMut(Event) -> F,
@@ -1604,7 +1666,11 @@ where
         return Ok(());
     }
 
-    let estimated_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+    let estimated_prompt_tokens = state
+        .session
+        .tape
+        .estimated_prompt_tokens()
+        .saturating_add(additional_prompt_tokens);
     let context_window_tokens = state.runtime_config.context_window_tokens as usize;
     if !state
         .turn_state
@@ -1613,7 +1679,8 @@ where
         return Ok(());
     }
 
-    let compaction_request = CompactionRequest::automatic_mid_turn();
+    let compaction_request = CompactionRequest::automatic_mid_turn()
+        .with_additional_prompt_tokens(additional_prompt_tokens);
     match tokio::time::timeout(
         tokio::time::Duration::from_secs(COMPACTION_TIMEOUT_SECS),
         maybe_compact_context_with_cancel(state, emit, &compaction_request, cancel),
@@ -4789,6 +4856,79 @@ runtime:
     }
 
     #[tokio::test]
+    async fn test_run_turn_pre_turn_compaction_accounts_for_runtime_recall_budget() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        std::fs::write(
+            memory_dir.join("USER.md"),
+            format!(
+                "# User Memory\n- Favorite runtime marker: {}\n",
+                "ALAN_PRETURN_RECALL ".repeat(80)
+            ),
+        )
+        .unwrap();
+
+        let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
+            Vec::new(),
+            "COMPACTED_FOR_RECALL",
+            seen_system_prompts.clone(),
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+        state.prompt_cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+        state.runtime_config.compaction_keep_last = 2;
+        state.runtime_config.compaction_trigger_messages = usize::MAX;
+        state.runtime_config.compaction_soft_trigger_ratio = 1.0;
+        state.runtime_config.compaction_hard_trigger_ratio = 1.0;
+        state.runtime_config.compaction_trigger_ratio = 1.0;
+        for idx in 0..3 {
+            state
+                .session
+                .add_user_message(&format!("Earlier user context {idx} {}", "u".repeat(220)));
+            state.session.add_assistant_message(
+                &format!("Earlier assistant context {idx} {}", "a".repeat(220)),
+                None,
+            );
+        }
+
+        let user_input = vec![ContentPart::text("What is my favorite runtime marker?")];
+        let turn_recall_bundle = crate::runtime::memory_recall::build_turn_recall_bundle(
+            Some(memory_dir.as_path()),
+            Some(&user_input),
+        );
+        let pending_prompt_tokens =
+            estimate_pending_turn_prompt_tokens(Some(&user_input), turn_recall_bundle.as_deref());
+        assert!(pending_prompt_tokens > 0);
+
+        let base_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+        state.runtime_config.context_window_tokens =
+            (base_prompt_tokens + pending_prompt_tokens - 1) as u32;
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(user_input),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(state.session.tape.summary(), Some("COMPACTED_FOR_RECALL"));
+
+        let system_prompts = seen_system_prompts.lock().unwrap();
+        assert_eq!(system_prompts.len(), 2);
+        let request_prompt = system_prompts.last().expect("expected final system prompt");
+        assert!(request_prompt.contains("## Runtime Recall Bundle"));
+        assert!(request_prompt.contains("ALAN_PRETURN_RECALL"));
+    }
+
+    #[tokio::test]
     async fn test_run_turn_omits_runtime_recall_bundle_when_memory_disabled() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
@@ -4830,6 +4970,58 @@ runtime:
         let request_prompt = system_prompts.last().expect("expected system prompt");
         assert!(!request_prompt.contains("## Runtime Recall Bundle"));
         assert!(!request_prompt.contains("ALAN_DISABLED_RECALL"));
+    }
+
+    #[tokio::test]
+    async fn test_maybe_compact_mid_turn_accounts_for_runtime_prompt_overhead() {
+        let mut state = create_test_state_with_provider(ContentMockProvider::new(
+            "MID_TURN_COMPACTION_SUMMARY",
+        ));
+        state.runtime_config.compaction_keep_last = 2;
+        state.runtime_config.compaction_trigger_messages = usize::MAX;
+        state.runtime_config.compaction_soft_trigger_ratio = 1.0;
+        state.runtime_config.compaction_hard_trigger_ratio = 1.0;
+        state.runtime_config.compaction_trigger_ratio = 1.0;
+        for idx in 0..3 {
+            state
+                .session
+                .add_user_message(&format!("Mid-turn user context {idx} {}", "u".repeat(220)));
+            state.session.add_assistant_message(
+                &format!("Mid-turn assistant context {idx} {}", "a".repeat(220)),
+                None,
+            );
+        }
+
+        let pending_guardrail_instruction = format!(
+            "Retry with a corrected answer and preserve tool intent.\n{}",
+            "guardrail-overhead ".repeat(80)
+        );
+        let additional_prompt_tokens = estimate_request_prompt_overhead_tokens(
+            None,
+            Some(pending_guardrail_instruction.as_str()),
+        );
+        assert!(additional_prompt_tokens > 0);
+
+        let base_prompt_tokens = state.session.tape.estimated_prompt_tokens();
+        state.runtime_config.context_window_tokens =
+            (base_prompt_tokens + additional_prompt_tokens - 1) as u32;
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = maybe_compact_mid_turn_if_needed(
+            &mut state,
+            &mut emit,
+            &cancel,
+            additional_prompt_tokens,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(
+            state.session.tape.summary(),
+            Some("MID_TURN_COMPACTION_SUMMARY")
+        );
+        assert_eq!(state.turn_state.compactions_this_turn(), 1);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -787,10 +787,14 @@ where
         .set_active_skills(prompt_build.active_skills.clone());
     let _domain_prompt = prompt_build.domain_prompt;
     let system_prompt = prompt_build.system_prompt;
-    let turn_recall_bundle = super::memory_recall::build_turn_recall_bundle(
-        state.core_config.memory.workspace_dir.as_deref(),
-        user_input_for_skills.as_deref(),
-    );
+    let turn_recall_bundle = if state.core_config.memory.enabled {
+        super::memory_recall::build_turn_recall_bundle(
+            state.core_config.memory.workspace_dir.as_deref(),
+            user_input_for_skills.as_deref(),
+        )
+    } else {
+        None
+    };
 
     let tools = turn_tool_definitions(state);
 
@@ -4723,6 +4727,50 @@ runtime:
         assert!(request_prompt.contains(".alan/memory/handoffs/LATEST.md"));
         assert!(request_prompt.contains(".alan/memory/sessions/2026/04/15/session-1.md"));
         assert!(request_prompt.contains("ALAN_CONTINUITY_RECALL"));
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_omits_runtime_recall_bundle_when_memory_disabled() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        std::fs::write(
+            memory_dir.join("USER.md"),
+            "# User Memory\n- Favorite runtime marker: ALAN_DISABLED_RECALL\n",
+        )
+        .unwrap();
+
+        let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
+            Vec::new(),
+            "ok",
+            seen_system_prompts.clone(),
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+        state.core_config.memory.enabled = false;
+        state.prompt_cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text(
+                "What is my favorite runtime marker?",
+            )]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        let system_prompts = seen_system_prompts.lock().unwrap();
+        let request_prompt = system_prompts.last().expect("expected system prompt");
+        assert!(!request_prompt.contains("## Runtime Recall Bundle"));
+        assert!(!request_prompt.contains("ALAN_DISABLED_RECALL"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -787,6 +787,10 @@ where
         .set_active_skills(prompt_build.active_skills.clone());
     let _domain_prompt = prompt_build.domain_prompt;
     let system_prompt = prompt_build.system_prompt;
+    let turn_recall_bundle = super::memory_recall::build_turn_recall_bundle(
+        state.core_config.memory.workspace_dir.as_deref(),
+        user_input_for_skills.as_deref(),
+    );
 
     let tools = turn_tool_definitions(state);
 
@@ -872,6 +876,9 @@ where
             Some(state.runtime_config.temperature),
             Some(state.runtime_config.max_tokens as i32),
         );
+        if let Some(recall_bundle) = turn_recall_bundle.as_deref() {
+            append_system_instruction(&mut request, recall_bundle);
+        }
         if let Some(instruction) = pending_guardrail_instruction.as_deref() {
             append_system_instruction(&mut request, instruction);
         }
@@ -4621,6 +4628,101 @@ runtime:
         fn provider_name(&self) -> &'static str {
             "recording_tool_call_mock"
         }
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_includes_runtime_recall_bundle_for_identity_query() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        std::fs::write(
+            memory_dir.join("USER.md"),
+            "# User Memory\n- Favorite runtime marker: ALAN_IDENTITY_RECALL\n",
+        )
+        .unwrap();
+
+        let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
+            Vec::new(),
+            "ALAN_IDENTITY_RECALL",
+            seen_system_prompts.clone(),
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+        state.prompt_cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text(
+                "What is my favorite runtime marker?",
+            )]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        let system_prompts = seen_system_prompts.lock().unwrap();
+        let request_prompt = system_prompts.last().expect("expected system prompt");
+        assert!(request_prompt.contains("## Runtime Recall Bundle"));
+        assert!(request_prompt.contains(".alan/memory/USER.md"));
+        assert!(request_prompt.contains("ALAN_IDENTITY_RECALL"));
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_includes_runtime_recall_bundle_for_continuity_query() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        let memory_dir = workspace_root.join(".alan/memory");
+        crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        std::fs::write(
+            memory_dir.join("handoffs/LATEST.md"),
+            "# Latest Handoff\n- Continuity marker: ALAN_CONTINUITY_RECALL\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(memory_dir.join("sessions/2026/04/15")).unwrap();
+        std::fs::write(
+            memory_dir.join("sessions/2026/04/15/session-1.md"),
+            "# Session Summary\n- Continuity marker: ALAN_CONTINUITY_RECALL\n",
+        )
+        .unwrap();
+
+        let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
+            Vec::new(),
+            "ALAN_CONTINUITY_RECALL",
+            seen_system_prompts.clone(),
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+        state.prompt_cache = prompt_cache_for_workspace_root(&workspace_root, Vec::new());
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text(
+                "What were we doing in the previous session?",
+            )]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        let system_prompts = seen_system_prompts.lock().unwrap();
+        let request_prompt = system_prompts.last().expect("expected system prompt");
+        assert!(request_prompt.contains("## Runtime Recall Bundle"));
+        assert!(request_prompt.contains(".alan/memory/handoffs/LATEST.md"));
+        assert!(request_prompt.contains(".alan/memory/sessions/2026/04/15/session-1.md"));
+        assert!(request_prompt.contains("ALAN_CONTINUITY_RECALL"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -4736,21 +4736,30 @@ runtime:
         let memory_dir = workspace_root.join(".alan/memory");
         crate::prompts::ensure_workspace_memory_layout_at(&memory_dir).unwrap();
         std::fs::create_dir_all(memory_dir.join("sessions/2026/04/16")).unwrap();
+        for index in 1..=4 {
+            std::fs::write(
+                memory_dir.join(format!("topics/recent-match-{index}.md")),
+                format!("# Topic Note\nwe did document topic match {index}\n"),
+            )
+            .unwrap();
+        }
         std::fs::write(
             memory_dir.join("daily/2026-04-16.md"),
             "## 2026-04-16\nALAN_RECENT_RECALL\n",
         )
         .unwrap();
-        std::fs::write(
-            memory_dir.join("sessions/2026/04/16/session-1.md"),
-            "# Session Summary\nALAN_RECENT_RECALL\n",
-        )
-        .unwrap();
+        for index in 1..=4 {
+            std::fs::write(
+                memory_dir.join(format!("sessions/2026/04/16/session-{index}.md")),
+                format!("# Session Summary\nALAN_RECENT_RECALL_{index}\n"),
+            )
+            .unwrap();
+        }
 
         let seen_system_prompts = Arc::new(std::sync::Mutex::new(Vec::new()));
         let mut state = create_test_state_with_provider(RecordingToolCallProvider::new(
             Vec::new(),
-            "ALAN_RECENT_RECALL",
+            "ALAN_RECENT_RECALL_4",
             seen_system_prompts.clone(),
         ));
         state.core_config.memory.workspace_dir = Some(memory_dir);
@@ -4774,8 +4783,9 @@ runtime:
         let request_prompt = system_prompts.last().expect("expected system prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains(".alan/memory/daily/2026-04-16.md"));
-        assert!(request_prompt.contains(".alan/memory/sessions/2026/04/16/session-1.md"));
-        assert!(request_prompt.contains("ALAN_RECENT_RECALL"));
+        assert!(request_prompt.contains(".alan/memory/sessions/2026/04/16/session-4.md"));
+        assert!(request_prompt.contains("ALAN_RECENT_RECALL_4"));
+        assert!(!request_prompt.contains(".alan/memory/topics/recent-match-4.md"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/tape.rs
+++ b/crates/runtime/src/tape.rs
@@ -879,7 +879,15 @@ fn estimate_json_tokens(value: &serde_json::Value) -> usize {
     estimate_text_tokens(&value.to_string())
 }
 
-fn estimate_text_tokens(text: &str) -> usize {
+pub(crate) fn estimate_user_message_tokens(parts: &[ContentPart]) -> usize {
+    parts
+        .iter()
+        .map(estimate_content_part_tokens)
+        .sum::<usize>()
+        + 6
+}
+
+pub(crate) fn estimate_text_tokens(text: &str) -> usize {
     let chars = text.chars().count();
     chars.div_ceil(4)
 }


### PR DESCRIPTION
## Summary
- add a deterministic pure-text runtime recall router that classifies identity, continuity, workspace, and recent-work queries
- inject a bounded source-labeled recall bundle into each turn prompt before generation so Alan can answer from memory without spending tool calls first
- add runtime and smoke coverage for cross-session recall from \.alan/memory surfaces

## Testing
- cargo fmt --all
- git diff --check
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-a cargo test -p alan-runtime identity_query_prefers_user_memory --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-b cargo test -p alan-runtime continuity_query_picks_handoff_and_session_summary --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-c cargo test -p alan-runtime test_run_turn_includes_runtime_recall_bundle_for_identity_query --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-d cargo test -p alan --test smoke_test smoke_cross_session_runtime_memory_recall_bundle_is_reinjected -- --exact
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-e cargo test -p alan-runtime test_run_turn_includes_runtime_recall_bundle_for_continuity_query --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr3-f cargo test -p alan-runtime workspace_query_can_pick_relevant_topic_page --lib

Closes #268