### PR TITLE
[codex] Add pure-text inbox promotion and continuity smoke coverage

### DIFF
--- a/crates/alan/tests/agent_root_overlay_integration_test.rs
+++ b/crates/alan/tests/agent_root_overlay_integration_test.rs
@@ -341,12 +341,48 @@ fn assert_overlay_request(request: &GenerationRequest) {
     assert_eq!(request.thinking_budget_tokens, Some(1024));
 }
 
-fn assert_overlay_requests(requests: &[GenerationRequest]) {
+fn is_memory_promotion_request(request: &GenerationRequest) -> bool {
+    request.system_prompt.as_deref() == Some(alan_runtime::prompts::MEMORY_PROMOTION_PROMPT)
+}
+
+fn overlay_requests(requests: &[GenerationRequest]) -> Vec<&GenerationRequest> {
+    let unexpected_requests: Vec<&GenerationRequest> = requests
+        .iter()
+        .filter(|request| !is_memory_promotion_request(request))
+        .filter(|request| {
+            !request
+                .system_prompt
+                .as_deref()
+                .is_some_and(|prompt| prompt.contains("workspace named soul"))
+        })
+        .collect();
     assert!(
-        !requests.is_empty(),
-        "expected at least one recorded LLM request"
+        unexpected_requests.is_empty(),
+        "unexpected internal requests recorded during overlay test: {unexpected_requests:?}"
     );
-    requests.iter().for_each(assert_overlay_request);
+
+    requests
+        .iter()
+        .filter(|request| {
+            request
+                .system_prompt
+                .as_deref()
+                .is_some_and(|prompt| prompt.contains("workspace named soul"))
+        })
+        .collect()
+}
+
+fn assert_overlay_requests(requests: &[GenerationRequest]) -> Vec<&GenerationRequest> {
+    let overlay_requests = overlay_requests(requests);
+    assert!(
+        !overlay_requests.is_empty(),
+        "expected at least one recorded overlay LLM request"
+    );
+    overlay_requests
+        .iter()
+        .copied()
+        .for_each(assert_overlay_request);
+    overlay_requests
 }
 
 fn assert_request_messages_include_history(
@@ -399,11 +435,6 @@ async fn named_agent_overlay_applies_highest_precedence_across_runtime_surfaces(
     )
     .await;
 
-    assert!(
-        requests.len() >= 2,
-        "expected a follow-up LLM request after the tool loop, saw {} request(s)",
-        requests.len()
-    );
     assert_overlay_requests(&requests);
 
     let policy_audit = events.iter().find_map(|event| match event {
@@ -459,9 +490,12 @@ async fn named_agent_overlay_survives_resume_and_fork_runtime_restarts() {
         "please use $overlay-skill after resume",
     )
     .await;
-    assert_overlay_requests(&resumed_requests);
+    let resumed_overlay_requests = assert_overlay_requests(&resumed_requests);
     assert_request_messages_include_history(
-        &resumed_requests[0],
+        resumed_overlay_requests
+            .last()
+            .copied()
+            .expect("expected resumed overlay request"),
         &[
             (
                 MessageRole::User,
@@ -484,9 +518,12 @@ async fn named_agent_overlay_survives_resume_and_fork_runtime_restarts() {
         "please use $overlay-skill after fork",
     )
     .await;
-    assert_overlay_requests(&forked_requests);
+    let forked_overlay_requests = assert_overlay_requests(&forked_requests);
     assert_request_messages_include_history(
-        &forked_requests[0],
+        forked_overlay_requests
+            .last()
+            .copied()
+            .expect("expected forked overlay request"),
         &[
             (
                 MessageRole::User,

--- a/crates/alan/tests/live_runtime_smoke_test.rs
+++ b/crates/alan/tests/live_runtime_smoke_test.rs
@@ -388,3 +388,165 @@ async fn live_chatgpt_runtime_cross_session_memory_smoke() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[ignore = "live runtime continuity smoke; requires ALAN_LIVE_PROVIDER_TESTS=1 and managed ChatGPT auth"]
+async fn live_chatgpt_runtime_cross_session_continuity_smoke() -> Result<()> {
+    if !live_enabled() {
+        eprintln!(
+            "[live-runtime-smoke] skipping chatgpt continuity: set {LIVE_ENABLE_ENV}=1 to enable"
+        );
+        return Ok(());
+    }
+
+    let Some(auth_storage_path) = non_empty_env(CHATGPT_AUTH_STORAGE_PATH_ENV) else {
+        eprintln!(
+            "[live-runtime-smoke] skipping chatgpt continuity: {CHATGPT_AUTH_STORAGE_PATH_ENV} is unset"
+        );
+        return Ok(());
+    };
+
+    let temp_home = TempDir::new().context("create temp home")?;
+    let temp_workspace = TempDir::new().context("create temp workspace root")?;
+    let workspace_root = temp_workspace.path().join("workspace");
+    let workspace_alan_dir = workspace_root.join(".alan");
+    std::fs::create_dir_all(&workspace_alan_dir).context("create workspace .alan dir")?;
+
+    let base_url = non_empty_env(CHATGPT_BASE_URL_ENV);
+    let model = non_empty_env(CHATGPT_MODEL_ENV).unwrap_or_else(|| "gpt-5.3-codex".to_string());
+    let continuity_marker = "continuity:ALAN_LIVE_RUNTIME_HANDOFF_MARKER";
+
+    let mut core_config = Config::for_chatgpt(base_url.as_deref(), Some(&model));
+    if let Some(account_id) = non_empty_env(CHATGPT_ACCOUNT_ID_ENV) {
+        core_config.chatgpt_account_id = Some(account_id);
+    }
+
+    let mut first_runtime_config = WorkspaceRuntimeConfig::from(core_config.clone());
+    first_runtime_config.workspace_root_dir = Some(workspace_root.clone());
+    first_runtime_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    first_runtime_config.default_cwd_override = Some(workspace_root.clone());
+    first_runtime_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    first_runtime_config.chatgpt_auth_storage_path = Some(PathBuf::from(auth_storage_path.clone()));
+
+    let mut first_tools = ToolRegistry::new();
+    if let Some(cwd) = first_runtime_config.default_cwd_override.clone() {
+        first_tools.set_default_cwd(cwd);
+    }
+
+    let mut first_controller = spawn_with_tool_registry(first_runtime_config, first_tools)
+        .context("spawn first continuity runtime")?;
+    first_controller
+        .wait_until_ready()
+        .await
+        .context("first continuity runtime should become ready")?;
+
+    let rx = first_controller.handle.event_sender.subscribe();
+    first_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(format!(
+                "Reply with exactly {continuity_marker}. Do not use tools, markdown, or punctuation."
+            ))],
+            context: None,
+        }))
+        .await
+        .context("submit live continuity seed turn")?;
+
+    let first_turn = collect_events_until_terminal(rx, TURN_TIMEOUT).await;
+    print_event_summary(
+        "live_chatgpt_runtime_cross_session_continuity_smoke (seed)",
+        &first_turn,
+    );
+    first_controller
+        .shutdown()
+        .await
+        .context("shutdown first continuity runtime")?;
+
+    ensure!(
+        first_turn.errors.is_empty(),
+        "live continuity seed turn emitted unexpected errors: {:?}",
+        first_turn.errors
+    );
+    ensure!(
+        first_turn.saw_turn_completed,
+        "live continuity seed turn did not reach TurnCompleted; warnings={:?}, text={:?}",
+        first_turn.warnings,
+        first_turn.text
+    );
+    ensure!(
+        first_turn.text.contains(continuity_marker),
+        "live continuity seed turn did not contain marker `{continuity_marker}`: {:?}",
+        first_turn.text
+    );
+
+    let handoff_path = workspace_alan_dir.join("memory/handoffs/LATEST.md");
+    let latest_handoff = std::fs::read_to_string(&handoff_path)
+        .with_context(|| format!("read {}", handoff_path.display()))?;
+    ensure!(
+        latest_handoff.contains(continuity_marker),
+        "latest handoff did not preserve continuity marker: {:?}",
+        latest_handoff
+    );
+
+    let mut second_runtime_config = WorkspaceRuntimeConfig::from(core_config);
+    second_runtime_config.workspace_root_dir = Some(workspace_root.clone());
+    second_runtime_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    second_runtime_config.default_cwd_override = Some(workspace_root);
+    second_runtime_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    second_runtime_config.chatgpt_auth_storage_path = Some(PathBuf::from(auth_storage_path));
+
+    let mut second_tools = ToolRegistry::new();
+    if let Some(cwd) = second_runtime_config.default_cwd_override.clone() {
+        second_tools.set_default_cwd(cwd);
+    }
+
+    let mut second_controller = spawn_with_tool_registry(second_runtime_config, second_tools)
+        .context("spawn second continuity runtime")?;
+    second_controller
+        .wait_until_ready()
+        .await
+        .context("second continuity runtime should become ready")?;
+
+    let rx = second_controller.handle.event_sender.subscribe();
+    second_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(
+                "What was the last continuity marker from the previous session? Reply with exactly the saved marker and nothing else.",
+            )],
+            context: None,
+        }))
+        .await
+        .context("submit live continuity recall turn")?;
+
+    let second_turn = collect_events_until_terminal(rx, TURN_TIMEOUT).await;
+    print_event_summary(
+        "live_chatgpt_runtime_cross_session_continuity_smoke (recall)",
+        &second_turn,
+    );
+    second_controller
+        .shutdown()
+        .await
+        .context("shutdown second continuity runtime")?;
+
+    ensure!(
+        second_turn.errors.is_empty(),
+        "live continuity recall turn emitted unexpected errors: {:?}",
+        second_turn.errors
+    );
+    ensure!(
+        second_turn.saw_turn_completed,
+        "live continuity recall turn did not reach TurnCompleted; warnings={:?}, text={:?}",
+        second_turn.warnings,
+        second_turn.text
+    );
+    ensure!(
+        second_turn.text.contains(continuity_marker),
+        "live continuity recall text did not contain expected marker `{continuity_marker}`: {:?}",
+        second_turn.text
+    );
+
+    Ok(())
+}

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -686,10 +686,12 @@ async fn smoke_cross_session_handoff_continuity_is_recalled() {
         warnings: Vec::new(),
     });
     let first_llm_client = LlmClient::new(first_mock);
-    let mut first_config = WorkspaceRuntimeConfig::default();
-    first_config.workspace_root_dir = Some(workspace_root.clone());
-    first_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
-    first_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    let first_config = WorkspaceRuntimeConfig {
+        workspace_root_dir: Some(workspace_root.clone()),
+        workspace_alan_dir: Some(workspace_alan_dir.clone()),
+        agent_home_paths: Some(AlanHomePaths::from_home_dir(temp_home.path())),
+        ..WorkspaceRuntimeConfig::default()
+    };
 
     let mut first_controller =
         spawn_with_llm_client(first_config, first_llm_client).expect("spawn first runtime");
@@ -749,10 +751,12 @@ async fn smoke_cross_session_handoff_continuity_is_recalled() {
         warnings: Vec::new(),
     });
     let second_llm_client = LlmClient::new(second_mock.clone());
-    let mut second_config = WorkspaceRuntimeConfig::default();
-    second_config.workspace_root_dir = Some(workspace_root.clone());
-    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
-    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+    let second_config = WorkspaceRuntimeConfig {
+        workspace_root_dir: Some(workspace_root.clone()),
+        workspace_alan_dir: Some(workspace_alan_dir.clone()),
+        agent_home_paths: Some(AlanHomePaths::from_home_dir(temp_home.path())),
+        ..WorkspaceRuntimeConfig::default()
+    };
 
     let mut second_controller =
         spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -792,9 +792,10 @@ async fn smoke_cross_session_handoff_continuity_is_recalled() {
 
     let recorded_requests = second_mock.recorded_requests();
     let system_prompt = recorded_requests
-        .last()
-        .and_then(|request| request.system_prompt.as_deref())
-        .expect("expected recorded system prompt");
+        .iter()
+        .filter_map(|request| request.system_prompt.as_deref())
+        .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+        .expect("expected recorded runtime recall prompt");
     assert!(system_prompt.contains("## Runtime Recall Bundle"));
     assert!(system_prompt.contains(".alan/memory/handoffs/LATEST.md"));
     assert!(system_prompt.contains(continuity_marker));

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -547,9 +547,16 @@ async fn smoke_cross_session_persona_memory_is_reinjected() {
 
     let recorded_requests = second_mock.recorded_requests();
     let system_prompt = recorded_requests
-        .last()
-        .and_then(|request| request.system_prompt.as_deref())
-        .expect("expected recorded system prompt");
+        .iter()
+        .filter_map(|request| request.system_prompt.as_deref())
+        .find(|prompt| prompt.contains(marker))
+        .or_else(|| {
+            recorded_requests
+                .iter()
+                .filter_map(|request| request.system_prompt.as_deref())
+                .find(|prompt| prompt.contains("Write updates to:"))
+        })
+        .expect("expected recorded system prompt containing persisted persona memory");
     assert!(
         system_prompt.contains(marker),
         "expected persisted persona marker to be reinjected into the next session prompt"
@@ -641,9 +648,10 @@ async fn smoke_cross_session_runtime_memory_recall_bundle_is_reinjected() {
 
     let recorded_requests = second_mock.recorded_requests();
     let system_prompt = recorded_requests
-        .last()
-        .and_then(|request| request.system_prompt.as_deref())
-        .expect("expected recorded system prompt");
+        .iter()
+        .filter_map(|request| request.system_prompt.as_deref())
+        .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+        .expect("expected recorded runtime recall prompt");
     assert!(
         system_prompt.contains("## Runtime Recall Bundle"),
         "expected runtime recall bundle to be appended for identity recall questions"

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -657,3 +657,141 @@ async fn smoke_cross_session_runtime_memory_recall_bundle_is_reinjected() {
         "expected runtime recall bundle to include the stored marker"
     );
 }
+
+#[tokio::test]
+async fn smoke_cross_session_handoff_continuity_is_recalled() {
+    let temp_home = TempDir::new().expect("temp home");
+    let temp_workspace = TempDir::new().expect("temp workspace");
+    let workspace_root = temp_workspace.path().join("workspace");
+    let workspace_alan_dir = workspace_root.join(".alan");
+    fs::create_dir_all(&workspace_alan_dir).expect("create workspace .alan");
+    let continuity_marker = "continuity:ALAN_SMOKE_HANDOFF_MARKER";
+
+    let first_mock = MockLlmProvider::new().with_response(GenerationResponse {
+        content: continuity_marker.to_string(),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: Vec::new(),
+        tool_calls: Vec::new(),
+        usage: Some(TokenUsage {
+            prompt_tokens: 10,
+            cached_prompt_tokens: None,
+            completion_tokens: 3,
+            total_tokens: 13,
+            reasoning_tokens: None,
+        }),
+        finish_reason: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        warnings: Vec::new(),
+    });
+    let first_llm_client = LlmClient::new(first_mock);
+    let mut first_config = WorkspaceRuntimeConfig::default();
+    first_config.workspace_root_dir = Some(workspace_root.clone());
+    first_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    first_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+
+    let mut first_controller =
+        spawn_with_llm_client(first_config, first_llm_client).expect("spawn first runtime");
+    first_controller
+        .wait_until_ready()
+        .await
+        .expect("first runtime ready");
+
+    let rx = first_controller.handle.event_sender.subscribe();
+    first_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(format!(
+                "Reply with exactly {continuity_marker} so it becomes the latest handoff marker."
+            ))],
+            context: None,
+        }))
+        .await
+        .expect("send first submission");
+
+    let first_events = collect_events_until_turn_complete(rx, Duration::from_secs(10)).await;
+    assert!(
+        first_events
+            .iter()
+            .any(|event| matches!(event, Event::TurnCompleted { .. })),
+        "first turn should complete"
+    );
+    first_controller
+        .shutdown()
+        .await
+        .expect("shutdown first runtime");
+
+    let latest_handoff =
+        fs::read_to_string(workspace_alan_dir.join("memory/handoffs/LATEST.md")).unwrap();
+    assert!(
+        latest_handoff.contains(continuity_marker),
+        "expected latest handoff to preserve the continuity marker"
+    );
+
+    let second_mock = MockLlmProvider::new().with_response(GenerationResponse {
+        content: continuity_marker.to_string(),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: Vec::new(),
+        tool_calls: Vec::new(),
+        usage: Some(TokenUsage {
+            prompt_tokens: 10,
+            cached_prompt_tokens: None,
+            completion_tokens: 3,
+            total_tokens: 13,
+            reasoning_tokens: None,
+        }),
+        finish_reason: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        warnings: Vec::new(),
+    });
+    let second_llm_client = LlmClient::new(second_mock.clone());
+    let mut second_config = WorkspaceRuntimeConfig::default();
+    second_config.workspace_root_dir = Some(workspace_root.clone());
+    second_config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+    second_config.agent_home_paths = Some(AlanHomePaths::from_home_dir(temp_home.path()));
+
+    let mut second_controller =
+        spawn_with_llm_client(second_config, second_llm_client).expect("spawn second runtime");
+    second_controller
+        .wait_until_ready()
+        .await
+        .expect("second runtime ready");
+
+    let rx = second_controller.handle.event_sender.subscribe();
+    second_controller
+        .handle
+        .submission_tx
+        .send(Submission::new(Op::Turn {
+            parts: vec![ContentPart::text(
+                "What were we doing in the previous session? Reply with exactly the saved continuity marker.",
+            )],
+            context: None,
+        }))
+        .await
+        .expect("send second submission");
+
+    let second_events = collect_events_until_turn_complete(rx, Duration::from_secs(10)).await;
+    assert!(
+        second_events
+            .iter()
+            .any(|event| matches!(event, Event::TurnCompleted { .. })),
+        "second turn should complete"
+    );
+    second_controller
+        .shutdown()
+        .await
+        .expect("shutdown second runtime");
+
+    let recorded_requests = second_mock.recorded_requests();
+    let system_prompt = recorded_requests
+        .last()
+        .and_then(|request| request.system_prompt.as_deref())
+        .expect("expected recorded system prompt");
+    assert!(system_prompt.contains("## Runtime Recall Bundle"));
+    assert!(system_prompt.contains(".alan/memory/handoffs/LATEST.md"));
+    assert!(system_prompt.contains(continuity_marker));
+}

--- a/crates/runtime/prompts/memory_promotion.md
+++ b/crates/runtime/prompts/memory_promotion.md
@@ -1,0 +1,36 @@
+You are performing a TURN-END MEMORY WRITE PLAN.
+
+Decide which facts from the provided active-turn user messages should be written
+into durable memory.
+
+Return JSON only. Do not include markdown fences or any prose outside the JSON.
+
+Use this exact schema:
+
+{
+  "writes": [
+    {
+      "kind": "user_identity | user_preference | workspace_fact | workflow_rule",
+      "target": "USER.md | MEMORY.md",
+      "confidence": "high | medium | low",
+      "disposition": "promote_now | stage_inbox",
+      "observation": "final concise memory line",
+      "evidence": ["supporting user statement"],
+      "promotion_rationale": "why this belongs in durable memory"
+    }
+  ]
+}
+
+Rules:
+- Only use evidence from the provided active-turn user messages.
+- Prefer `promote_now` only for direct user-stated stable identity, preference,
+  durable constraint, durable workflow rule, or an explicit request to remember
+  something long-term.
+- Use `stage_inbox` when the information is useful but not fully confirmed.
+- Ignore questions, hypotheticals, quoted examples, requests to verify, and
+  transient planning chatter.
+- Preserve exact names, abbreviations, punctuation, and version numbers when
+  they matter.
+- Keep `observation` concise, factual, and auditable.
+- Do not invent facts or infer more than the text supports.
+- Return `{"writes":[]}` when nothing should be stored.

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -133,6 +133,9 @@ Automatic runtime note:
    - runtime writes/refreshes `handoffs/LATEST.md`
    - runtime writes a curated session summary under `sessions/`
    - automatic memory flush may stage candidate memory under `inbox/`
+   - automatic turn-end memory promotion runs a model-mediated write-planning
+     pass over the active-turn user messages and either promotes confirmed facts
+     or stages inbox entries
 
 5. **Ensure clean state**: Code should compile, tests should pass, no half-done work.
 
@@ -175,3 +178,6 @@ Brief description of the project, its goals, and current state.
    into `topics/<slug>.md` and keep only the summary/index link in `MEMORY.md`
 9. **Use inbox-style staging when unsure**: Useful but not fully confirmed information belongs in
    candidate memory or daily/session notes before promotion into stable memory
+10. **Apply the same confirmation discipline everywhere**: Whether memory is being updated
+    manually through this skill or automatically by runtime, semantic judgment should come from the
+    model, while runtime keeps control of validation, provenance, and file writes

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -64,11 +64,14 @@ depending on durability and confirmation level.
 When starting a new session (especially if resuming prior work):
 
 1. **Prefer runtime bootstrap context first**.
-   The target design is for runtime to inject a bootstrap bundle built from:
+   Runtime injects a bootstrap bundle built from:
    - `USER.md`
    - `MEMORY.md`
    - `handoffs/LATEST.md`
    - the newest daily note
+
+   Runtime may also inject a smaller turn-time recall bundle for identity,
+   continuity, workspace, or recent-work questions.
 
 2. **Do not re-read all memory files by default** if the needed context is already present in the
    prompt.
@@ -126,10 +129,10 @@ Automatic runtime note:
   maintaining the long-lived index.
 
 4. **Let runtime own the session-handoff surfaces**.
-   Target direction:
+   Current runtime behavior:
    - runtime writes/refreshes `handoffs/LATEST.md`
    - runtime writes a curated session summary under `sessions/`
-   - runtime may stage candidate memory under `inbox/`
+   - automatic memory flush may stage candidate memory under `inbox/`
 
 5. **Ensure clean state**: Code should compile, tests should pass, no half-done work.
 

--- a/crates/runtime/src/prompts/mod.rs
+++ b/crates/runtime/src/prompts/mod.rs
@@ -49,3 +49,6 @@ Be concise, structured, and focused on helping the next LLM seamlessly continue 
 
 /// Memory-flush prompt for persisting durable context before automatic compaction.
 pub const MEMORY_FLUSH_PROMPT: &str = include_str!("../../prompts/memory_flush.md");
+
+/// Memory-promotion prompt for model-assisted turn-end durable write planning.
+pub const MEMORY_PROMOTION_PROMPT: &str = include_str!("../../prompts/memory_promotion.md");

--- a/crates/runtime/src/prompts/mod.rs
+++ b/crates/runtime/src/prompts/mod.rs
@@ -13,7 +13,10 @@ pub use assembler::{build_agent_system_prompt, build_agent_system_prompt_for_wor
 pub use loader::PromptLoader;
 pub use memory::{MEMORY_DAILY_DIRNAME, ensure_workspace_memory_layout_at};
 #[allow(unused_imports)]
-pub(crate) use memory::{render_workspace_memory_context, workspace_memory_tracked_paths};
+pub(crate) use memory::{
+    MEMORY_INBOX_DIRNAME, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME, WORKSPACE_MEMORY_FILENAME,
+    render_workspace_memory_context, workspace_memory_tracked_paths,
+};
 pub use workspace::ensure_workspace_bootstrap_files_at;
 #[allow(unused_imports)]
 pub(crate) use workspace::{

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -34,6 +34,11 @@ pub struct NormalizedToolCall {
     pub arguments: serde_json::Value,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum DeferredRuntimeAction {
+    TurnMemoryPromotion(super::memory_promotion::TurnMemoryPromotionJob),
+}
+
 /// Agent state for the execution loop
 pub struct RuntimeLoopState {
     pub workspace_id: String,
@@ -281,17 +286,43 @@ async fn finalize_replayed_tool_end_turn_best_effort(
             )
             .await;
         }
-
-        if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(state).await {
-            warn!(
-                error = %err,
-                context = promotion_context,
-                "Failed to capture confirmed turn memory after replayed tool end turn"
-            );
+        if let Some(job) =
+            super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
+        {
+            state
+                .turn_state
+                .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
         }
     }
 
     state.turn_state.set_turn_activity(TurnActivityState::Idle);
+}
+
+pub(super) async fn run_deferred_runtime_action_with_cancel(
+    state: &mut RuntimeLoopState,
+    action: DeferredRuntimeAction,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    match action {
+        DeferredRuntimeAction::TurnMemoryPromotion(job) => {
+            if let Err(err) = super::memory_promotion::run_turn_memory_promotion_job_with_cancel(
+                &mut state.llm_client,
+                &job,
+                cancel,
+            )
+            .await
+                && !cancel.is_cancelled()
+            {
+                warn!(
+                    error = %err,
+                    context = job.warning_context,
+                    "Failed to capture confirmed turn memory"
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Generate LLM response with retry logic
@@ -535,6 +566,18 @@ mod tests {
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
             turn_state,
         }
+    }
+
+    async fn run_deferred_runtime_actions(state: &mut RuntimeLoopState) -> usize {
+        let cancel = CancellationToken::new();
+        let actions = state.turn_state.drain_deferred_runtime_actions();
+        let count = actions.len();
+        for action in actions {
+            run_deferred_runtime_action_with_cancel(state, action, &cancel)
+                .await
+                .expect("run deferred runtime action");
+        }
+        count
     }
 
     // Test provider that returns errors
@@ -1115,6 +1158,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+        assert_eq!(run_deferred_runtime_actions(&mut state).await, 1);
 
         let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
         assert!(user_memory.contains("Name: Morris"));
@@ -1167,6 +1211,7 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+        assert_eq!(run_deferred_runtime_actions(&mut state).await, 1);
 
         let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
         assert!(user_memory.contains("Name: Morris"));

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -282,14 +282,7 @@ async fn finalize_replayed_tool_end_turn_best_effort(
             .await;
         }
 
-        if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
-            state.core_config.memory.enabled,
-            state.core_config.memory.workspace_dir.as_deref(),
-            &state.session,
-            state.turn_state.active_turn_message_start(),
-        )
-        .await
-        {
+        if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(state).await {
             warn!(
                 error = %err,
                 context = promotion_context,
@@ -403,6 +396,50 @@ mod tests {
     use tempfile::TempDir;
     use tokio_util::sync::CancellationToken;
 
+    fn maybe_memory_promotion_response(request: &GenerationRequest) -> Option<GenerationResponse> {
+        let system_prompt = request.system_prompt.as_deref()?;
+        if system_prompt != crate::prompts::MEMORY_PROMOTION_PROMPT {
+            return None;
+        }
+
+        let joined_user_text = request
+            .messages
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let content = if joined_user_text.contains("My name is Morris.") {
+            serde_json::json!({
+                "writes": [{
+                    "kind": "user_identity",
+                    "target": "USER.md",
+                    "confidence": "high",
+                    "disposition": "promote_now",
+                    "observation": "Name: Morris",
+                    "evidence": ["My name is Morris."],
+                    "promotion_rationale": "Direct user-stated stable identity detail."
+                }]
+            })
+            .to_string()
+        } else {
+            serde_json::json!({ "writes": [] }).to_string()
+        };
+
+        Some(GenerationResponse {
+            content,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: None,
+            finish_reason: None,
+            warnings: Vec::new(),
+            provider_response_id: None,
+            provider_response_status: None,
+        })
+    }
+
     struct DelayedMockProvider {
         delay: tokio::time::Duration,
         response_text: String,
@@ -421,9 +458,12 @@ mod tests {
     impl LlmProvider for DelayedMockProvider {
         async fn generate(
             &mut self,
-            _request: GenerationRequest,
+            request: GenerationRequest,
         ) -> anyhow::Result<GenerationResponse> {
             tokio::time::sleep(self.delay).await;
+            if let Some(response) = maybe_memory_promotion_response(&request) {
+                return Ok(response);
+            }
             Ok(GenerationResponse {
                 content: self.response_text.clone(),
                 thinking: None,

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -5,6 +5,7 @@
 use alan_protocol::{Event, Submission};
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use crate::{
     config::Config, llm::LlmClient, retry, runtime::RuntimeConfig, session::Session,
@@ -177,14 +178,14 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
-                        if !surfaces_refreshed {
-                            super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-                                state,
-                                "approved-tool-replay-ended-turn",
-                            )
-                            .await;
-                        }
-                        state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                        finalize_replayed_tool_end_turn_best_effort(
+                            state,
+                            cancel,
+                            surfaces_refreshed,
+                            "approved-tool-replay-ended-turn",
+                            "after approved tool replay call",
+                        )
+                        .await;
                     }
                 },
                 Err(err) => {
@@ -245,14 +246,14 @@ where
                             .set_turn_activity(TurnActivityState::Paused);
                     }
                     ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
-                        if !surfaces_refreshed {
-                            super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
-                                state,
-                                "approved-tool-replay-ended-turn",
-                            )
-                            .await;
-                        }
-                        state.turn_state.set_turn_activity(TurnActivityState::Idle);
+                        finalize_replayed_tool_end_turn_best_effort(
+                            state,
+                            cancel,
+                            surfaces_refreshed,
+                            "approved-tool-replay-ended-turn",
+                            "after approved tool replay batch",
+                        )
+                        .await;
                     }
                 },
                 Err(err) => {
@@ -263,6 +264,41 @@ where
             Ok(())
         }
     }
+}
+
+async fn finalize_replayed_tool_end_turn_best_effort(
+    state: &mut RuntimeLoopState,
+    cancel: &CancellationToken,
+    surfaces_refreshed: bool,
+    surfaces_context: &'static str,
+    promotion_context: &'static str,
+) {
+    if !cancel.is_cancelled() {
+        if !surfaces_refreshed {
+            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+                state,
+                surfaces_context,
+            )
+            .await;
+        }
+
+        if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+            state.core_config.memory.enabled,
+            state.core_config.memory.workspace_dir.as_deref(),
+            &state.session,
+            state.turn_state.active_turn_message_start(),
+        )
+        .await
+        {
+            warn!(
+                error = %err,
+                context = promotion_context,
+                "Failed to capture confirmed turn memory after replayed tool end turn"
+            );
+        }
+    }
+
+    state.turn_state.set_turn_activity(TurnActivityState::Idle);
 }
 
 /// Generate LLM response with retry logic
@@ -349,7 +385,7 @@ mod tests {
     };
     use super::*;
 
-    use crate::approval::PendingConfirmation;
+    use crate::approval::{PendingConfirmation, TOOL_ESCALATION_CHECKPOINT_TYPE};
     use crate::config::Config;
     use crate::llm::{
         GenerationRequest, GenerationResponse, LlmClient, LlmProvider, StreamChunk, ToolCall,
@@ -431,6 +467,33 @@ mod tests {
 
         fn provider_name(&self) -> &'static str {
             "mock"
+        }
+    }
+
+    fn create_replay_memory_test_state(
+        memory_dir: std::path::PathBuf,
+        turn_state: TurnState,
+        session: Session,
+    ) -> RuntimeLoopState {
+        RuntimeLoopState {
+            workspace_id: "test-workspace".to_string(),
+            session,
+            current_submission_id: None,
+            llm_client: LlmClient::new(DelayedMockProvider::new(
+                tokio::time::Duration::from_millis(0),
+                "",
+            )),
+            tools: ToolRegistry::new(),
+            core_config: {
+                let mut config = Config::default();
+                config.memory.workspace_dir = Some(memory_dir);
+                config.memory.enabled = true;
+                config
+            },
+            runtime_config: super::RuntimeConfig::default(),
+            workspace_persona_dirs: Vec::new(),
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
+            turn_state,
         }
     }
 
@@ -965,6 +1028,108 @@ mod tests {
             }
             _ => panic!("Expected TurnCompleted event"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_call_ends_turn() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let checkpoint_id = "tool_escalation_call-1";
+        let mut session = Session::new();
+        session.id = "sess-replay-call".to_string();
+        session.add_user_message("My name is Morris.");
+
+        let mut turn_state = TurnState::default();
+        turn_state.begin_turn(0);
+        turn_state.set_confirmation(PendingConfirmation {
+            checkpoint_id: checkpoint_id.to_string(),
+            checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
+            summary: "Replay tool call".to_string(),
+            details: json!({
+                "replay_tool_call": {
+                    "call_id": "call-1",
+                    "tool_name": "request_confirmation",
+                    "arguments": {}
+                }
+            }),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        });
+
+        let mut state = create_replay_memory_test_state(memory_dir.clone(), turn_state, session);
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let result = handle_submission_with_cancel(
+            &mut state,
+            Submission::new(alan_protocol::Op::Resume {
+                request_id: checkpoint_id.to_string(),
+                content: vec![alan_protocol::ContentPart::structured(
+                    json!({"choice": "approve"}),
+                )],
+            }),
+            &mut emit,
+            &cancel,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+
+        let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
+        assert!(user_memory.contains("Name: Morris"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_submission_promotes_direct_user_fact_when_replayed_tool_batch_ends_turn() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let checkpoint_id = "tool_escalation_batch-1";
+        let mut session = Session::new();
+        session.id = "sess-replay-batch".to_string();
+        session.add_user_message("My name is Morris.");
+
+        let mut turn_state = TurnState::default();
+        turn_state.begin_turn(0);
+        turn_state.set_confirmation(PendingConfirmation {
+            checkpoint_id: checkpoint_id.to_string(),
+            checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
+            summary: "Replay tool batch".to_string(),
+            details: json!({}),
+            options: vec!["approve".to_string(), "reject".to_string()],
+        });
+        turn_state.set_tool_replay_batch(
+            checkpoint_id,
+            vec![NormalizedToolCall {
+                id: "call-1".to_string(),
+                name: "request_confirmation".to_string(),
+                arguments: json!({}),
+            }],
+        );
+
+        let mut state = create_replay_memory_test_state(memory_dir.clone(), turn_state, session);
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+
+        let result = handle_submission_with_cancel(
+            &mut state,
+            Submission::new(alan_protocol::Op::Resume {
+                request_id: checkpoint_id.to_string(),
+                content: vec![alan_protocol::ContentPart::structured(
+                    json!({"choice": "approve"}),
+                )],
+            }),
+            &mut emit,
+            &cancel,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(state.turn_state.turn_activity(), TurnActivityState::Idle);
+
+        let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
+        assert!(user_memory.contains("Name: Morris"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/agent_loop.rs
+++ b/crates/runtime/src/runtime/agent_loop.rs
@@ -39,6 +39,12 @@ pub(crate) enum DeferredRuntimeAction {
     TurnMemoryPromotion(super::memory_promotion::TurnMemoryPromotionJob),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeferredRuntimeActionExit {
+    Completed,
+    Cancelled,
+}
+
 /// Agent state for the execution loop
 pub struct RuntimeLoopState {
     pub workspace_id: String,
@@ -302,27 +308,29 @@ pub(super) async fn run_deferred_runtime_action_with_cancel(
     state: &mut RuntimeLoopState,
     action: DeferredRuntimeAction,
     cancel: &CancellationToken,
-) -> Result<()> {
+) -> DeferredRuntimeActionExit {
     match action {
         DeferredRuntimeAction::TurnMemoryPromotion(job) => {
-            if let Err(err) = super::memory_promotion::run_turn_memory_promotion_job_with_cancel(
+            match super::memory_promotion::run_turn_memory_promotion_job_with_cancel(
                 &mut state.llm_client,
                 &job,
                 cancel,
             )
             .await
-                && !cancel.is_cancelled()
             {
-                warn!(
-                    error = %err,
-                    context = job.warning_context,
-                    "Failed to capture confirmed turn memory"
-                );
+                Ok(()) => DeferredRuntimeActionExit::Completed,
+                Err(_) if cancel.is_cancelled() => DeferredRuntimeActionExit::Cancelled,
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        context = job.warning_context,
+                        "Failed to capture confirmed turn memory"
+                    );
+                    DeferredRuntimeActionExit::Completed
+                }
             }
         }
     }
-
-    Ok(())
 }
 
 /// Generate LLM response with retry logic
@@ -573,9 +581,11 @@ mod tests {
         let actions = state.turn_state.drain_deferred_runtime_actions();
         let count = actions.len();
         for action in actions {
-            run_deferred_runtime_action_with_cancel(state, action, &cancel)
-                .await
-                .expect("run deferred runtime action");
+            assert_eq!(
+                run_deferred_runtime_action_with_cancel(state, action, &cancel).await,
+                DeferredRuntimeActionExit::Completed,
+                "run deferred runtime action"
+            );
         }
         count
     }

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -37,12 +37,12 @@ async fn requeue_leftover_inband_submissions(
     let broker_drained = broker.drain().await;
     let turn_drained = turn_state.drain_buffered_inband_submissions();
     let count = broker_drained.len() + turn_drained.len();
-    queued_submissions.extend(turn_drained.into_iter().map(QueuedRuntimeItem::Submission));
-    queued_submissions.extend(
-        broker_drained
-            .into_iter()
-            .map(QueuedRuntimeItem::Submission),
-    );
+    for submission in turn_drained {
+        push_submission_ahead_of_deferred(queued_submissions, submission);
+    }
+    for submission in broker_drained {
+        push_submission_ahead_of_deferred(queued_submissions, submission);
+    }
     count
 }
 
@@ -51,6 +51,17 @@ async fn requeue_leftover_inband_submissions(
 enum QueuedRuntimeItem {
     Submission(Submission),
     Deferred(super::agent_loop::DeferredRuntimeAction),
+}
+
+fn push_submission_ahead_of_deferred(
+    outer_queue: &mut VecDeque<QueuedRuntimeItem>,
+    submission: Submission,
+) {
+    let insertion_index = outer_queue
+        .iter()
+        .position(|item| matches!(item, QueuedRuntimeItem::Deferred(_)))
+        .unwrap_or(outer_queue.len());
+    outer_queue.insert(insertion_index, QueuedRuntimeItem::Submission(submission));
 }
 
 #[derive(Default)]
@@ -67,8 +78,7 @@ impl RuntimeSubmissionQueues {
     }
 
     fn push_outer_submission(&mut self, submission: Submission) {
-        self.outer_queue
-            .push_back(QueuedRuntimeItem::Submission(submission));
+        push_submission_ahead_of_deferred(&mut self.outer_queue, submission);
     }
 
     fn push_outer_deferred(&mut self, action: super::agent_loop::DeferredRuntimeAction) {
@@ -1286,6 +1296,7 @@ pub fn spawn_with_llm_client_and_tools(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::{agent_loop::DeferredRuntimeAction, memory_promotion};
     use alan_llm::MockLlmProvider;
     use alan_protocol::Op;
     use std::path::Path;
@@ -1293,6 +1304,112 @@ mod tests {
 
     fn write_agent_overlay(path: &Path, body: &str) {
         std::fs::write(path, body).unwrap();
+    }
+
+    fn make_deferred_action_for_test() -> DeferredRuntimeAction {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut session = Session::new();
+        session.id = "sess-deferred-queue".to_string();
+        session.add_user_message("My name is Morris.");
+
+        let mut turn_state = TurnState::default();
+        turn_state.begin_turn(0);
+
+        let mut core_config = crate::Config::default();
+        core_config.memory.enabled = true;
+        core_config.memory.workspace_dir = Some(memory_dir);
+        let runtime_config = RuntimeConfig::from(&core_config);
+
+        let state = RuntimeLoopState {
+            workspace_id: "workspace-queue-test".to_string(),
+            session,
+            current_submission_id: None,
+            llm_client: LlmClient::new(MockLlmProvider::new()),
+            core_config,
+            runtime_config,
+            workspace_persona_dirs: Vec::new(),
+            tools: crate::tools::ToolRegistry::new(),
+            prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
+            turn_state,
+        };
+
+        memory_promotion::build_turn_memory_promotion_job(&state, "queue ordering test")
+            .map(DeferredRuntimeAction::TurnMemoryPromotion)
+            .expect("build deferred memory promotion job")
+    }
+
+    fn queue_item_kinds(queue: &VecDeque<QueuedRuntimeItem>) -> Vec<&'static str> {
+        queue
+            .iter()
+            .map(|item| match item {
+                QueuedRuntimeItem::Submission(_) => "submission",
+                QueuedRuntimeItem::Deferred(_) => "deferred",
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_push_outer_submission_inserts_before_existing_deferred_actions() {
+        let mut queues = RuntimeSubmissionQueues::default();
+
+        let first_submission = Submission::new(Op::Interrupt);
+        let second_submission = Submission::new(Op::CompactWithOptions { focus: None });
+        let first_submission_id = first_submission.id.clone();
+        let second_submission_id = second_submission.id.clone();
+
+        queues.push_outer_submission(first_submission);
+        queues.push_outer_deferred(make_deferred_action_for_test());
+        queues.push_outer_deferred(make_deferred_action_for_test());
+        queues.push_outer_submission(second_submission);
+
+        assert_eq!(
+            queue_item_kinds(&queues.outer_queue),
+            vec!["submission", "submission", "deferred", "deferred"]
+        );
+
+        let queued_submission_ids = queues
+            .outer_queue
+            .iter()
+            .filter_map(|item| match item {
+                QueuedRuntimeItem::Submission(submission) => Some(submission.id.clone()),
+                QueuedRuntimeItem::Deferred(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            queued_submission_ids,
+            vec![first_submission_id, second_submission_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_requeue_active_turn_leftovers_inserts_before_existing_deferred_actions() {
+        let mut queues = RuntimeSubmissionQueues::default();
+        queues.push_outer_deferred(make_deferred_action_for_test());
+
+        let mut turn_state = TurnState::default();
+        let buffered_submission = Submission::new(Op::Input {
+            parts: vec![alan_protocol::ContentPart::text("follow up")],
+            mode: alan_protocol::InputMode::FollowUp,
+        });
+        let buffered_submission_id = buffered_submission.id.clone();
+        turn_state.push_buffered_inband_submission(buffered_submission);
+
+        let requeued = queues.requeue_active_turn_leftovers(&mut turn_state).await;
+
+        assert_eq!(requeued, 1);
+        assert_eq!(
+            queue_item_kinds(&queues.outer_queue),
+            vec!["submission", "deferred"]
+        );
+
+        match queues.outer_queue.front() {
+            Some(QueuedRuntimeItem::Submission(submission)) => {
+                assert_eq!(submission.id, buffered_submission_id);
+            }
+            _ => panic!("expected buffered submission at queue front"),
+        }
     }
 
     #[test]

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -1,6 +1,7 @@
 //! Agent Runtime - Core execution engine.
 
 use super::agent_loop::handle_submission_with_cancel;
+use super::agent_loop::run_deferred_runtime_action_with_cancel;
 use super::turn_driver::{
     TurnInputBroker, drive_turn_submission_with_cancel, is_turn_inband_submission,
     should_drive_turn_submission,
@@ -31,33 +32,48 @@ fn derived_soft_trigger_ratio(hard_trigger_ratio: f32) -> f32 {
 async fn requeue_leftover_inband_submissions(
     broker: &TurnInputBroker,
     turn_state: &mut TurnState,
-    queued_submissions: &mut VecDeque<Submission>,
+    queued_submissions: &mut VecDeque<QueuedRuntimeItem>,
 ) -> usize {
     let broker_drained = broker.drain().await;
     let turn_drained = turn_state.drain_buffered_inband_submissions();
     let count = broker_drained.len() + turn_drained.len();
-    queued_submissions.extend(turn_drained);
-    queued_submissions.extend(broker_drained);
+    queued_submissions.extend(turn_drained.into_iter().map(QueuedRuntimeItem::Submission));
+    queued_submissions.extend(
+        broker_drained
+            .into_iter()
+            .map(QueuedRuntimeItem::Submission),
+    );
     count
 }
 
 /// 1. The `outer_queue` - cross-turn queue for submissions that are not in the active turn.
 /// 2. The `active_turn_broker` - channel for in-turn submissions during active turn execution.
+enum QueuedRuntimeItem {
+    Submission(Submission),
+    Deferred(super::agent_loop::DeferredRuntimeAction),
+}
+
 #[derive(Default)]
 struct RuntimeSubmissionQueues {
     /// Cross-turn queue for submissions.
-    outer_queue: VecDeque<Submission>,
+    outer_queue: VecDeque<QueuedRuntimeItem>,
     /// The broker that queues in-turn submissions.
     active_turn_broker: TurnInputBroker,
 }
 
 impl RuntimeSubmissionQueues {
-    fn pop_outer(&mut self) -> Option<Submission> {
+    fn pop_outer(&mut self) -> Option<QueuedRuntimeItem> {
         self.outer_queue.pop_front()
     }
 
-    fn push_outer(&mut self, submission: Submission) {
-        self.outer_queue.push_back(submission);
+    fn push_outer_submission(&mut self, submission: Submission) {
+        self.outer_queue
+            .push_back(QueuedRuntimeItem::Submission(submission));
+    }
+
+    fn push_outer_deferred(&mut self, action: super::agent_loop::DeferredRuntimeAction) {
+        self.outer_queue
+            .push_back(QueuedRuntimeItem::Deferred(action));
     }
 
     async fn requeue_active_turn_leftovers(&mut self, turn_state: &mut TurnState) -> usize {
@@ -1052,13 +1068,13 @@ pub fn spawn_with_llm_client_and_tools(
                 break;
             }
 
-            let submission = if let Some(submission) = queues.pop_outer() {
-                Some(submission)
+            let queued_item = if let Some(queued_item) = queues.pop_outer() {
+                Some(queued_item)
             } else if submissions_closed {
                 None
             } else {
                 tokio::select! {
-                    submission = sub_rx.recv() => submission,
+                    submission = sub_rx.recv() => submission.map(QueuedRuntimeItem::Submission),
                     _ = shutdown_rx.recv() => {
                         shutdown_requested = true;
                         None
@@ -1066,117 +1082,170 @@ pub fn spawn_with_llm_client_and_tools(
                 }
             };
 
-            let Some(submission) = submission else {
+            let Some(queued_item) = queued_item else {
                 if shutdown_requested || submissions_closed {
                     break;
                 }
                 continue;
             };
 
-            debug!(?submission.id, "Received submission");
-            let drive_as_turn_submission = should_drive_turn_submission(&submission.op);
-            let submission_event_ctx = SubmissionEventContext::default();
-            submission_event_ctx.set_submission_id(submission.id.clone());
-            state.current_submission_id = Some(submission.id.clone());
+            match queued_item {
+                QueuedRuntimeItem::Submission(submission) => {
+                    debug!(?submission.id, "Received submission");
+                    let drive_as_turn_submission = should_drive_turn_submission(&submission.op);
+                    let submission_event_ctx = SubmissionEventContext::default();
+                    submission_event_ctx.set_submission_id(submission.id.clone());
+                    state.current_submission_id = Some(submission.id.clone());
 
-            // Fast path: no cancellation token needed unless we may run a long turn.
-            let cancel = CancellationToken::new();
-
-            // Create emitter closure
-            let event_tx_clone = evt_tx.clone();
-            let submission_event_ctx_for_emit = submission_event_ctx.clone();
-            let mut emit = |event: Event| {
-                let tx = event_tx_clone.clone();
-                let submission_id = submission_event_ctx_for_emit.get_submission_id();
-                async move {
-                    let _ = tx
-                        .send(RuntimeEventEnvelope {
-                            submission_id,
-                            event,
-                        })
-                        .await;
-                }
-            };
-
-            // Allow interrupt/shutdown to be handled while the current submission is running.
-            let broker_for_submission = queues.active_turn_broker.clone();
-            let submission_event_ctx_for_turn = submission_event_ctx.clone();
-            let mut set_active_submission_id = |submission_id: &str| {
-                submission_event_ctx_for_turn.set_submission_id(submission_id.to_string());
-            };
-            let mut submission_fut: std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<()>> + Send + '_>,
-            > = if drive_as_turn_submission {
-                Box::pin(drive_turn_submission_with_cancel(
-                    &mut state,
-                    submission,
-                    &broker_for_submission,
-                    &mut emit,
-                    &mut set_active_submission_id,
-                    &cancel,
-                ))
-            } else {
-                Box::pin(handle_submission_with_cancel(
-                    &mut state, submission, &mut emit, &cancel,
-                ))
-            };
-
-            loop {
-                tokio::select! {
-                    result = &mut submission_fut => {
-                        drop(submission_fut);
-                        if drive_as_turn_submission {
-                            let _ = queues
-                                .requeue_active_turn_leftovers(&mut state.turn_state)
-                                .await;
-                        }
-                        if let Err(e) = result {
-                            let error_msg = format!("Error handling submission: {}", e);
-                            error!(error = %error_msg);
-                            let _ = evt_tx
+                    let cancel = CancellationToken::new();
+                    let event_tx_clone = evt_tx.clone();
+                    let submission_event_ctx_for_emit = submission_event_ctx.clone();
+                    let mut emit = |event: Event| {
+                        let tx = event_tx_clone.clone();
+                        let submission_id = submission_event_ctx_for_emit.get_submission_id();
+                        async move {
+                            let _ = tx
                                 .send(RuntimeEventEnvelope {
-                                    submission_id: submission_event_ctx.get_submission_id(),
-                                    event: Event::Error {
-                                        message: error_msg,
-                                        recoverable: true,
-                                    },
+                                    submission_id,
+                                    event,
                                 })
                                 .await;
                         }
-                        state.current_submission_id = None;
-                        break;
-                    }
-                    incoming = sub_rx.recv(), if !submissions_closed => {
-                        match incoming {
-                            Some(incoming) => {
-                                if matches!(incoming.op, alan_protocol::Op::Interrupt) {
-                                    cancel.cancel();
-                                } else if drive_as_turn_submission
-                                    && is_turn_inband_submission(&incoming.op)
-                                {
-                                    if !queues.active_turn_broker.push(incoming.clone()).await {
-                                        queues.push_outer(incoming);
+                    };
+
+                    let broker_for_submission = queues.active_turn_broker.clone();
+                    let submission_event_ctx_for_turn = submission_event_ctx.clone();
+                    let mut set_active_submission_id = |submission_id: &str| {
+                        submission_event_ctx_for_turn.set_submission_id(submission_id.to_string());
+                    };
+                    let mut submission_fut: std::pin::Pin<
+                        Box<dyn std::future::Future<Output = Result<()>> + Send + '_>,
+                    > = if drive_as_turn_submission {
+                        Box::pin(drive_turn_submission_with_cancel(
+                            &mut state,
+                            submission,
+                            &broker_for_submission,
+                            &mut emit,
+                            &mut set_active_submission_id,
+                            &cancel,
+                        ))
+                    } else {
+                        Box::pin(handle_submission_with_cancel(
+                            &mut state, submission, &mut emit, &cancel,
+                        ))
+                    };
+
+                    loop {
+                        tokio::select! {
+                            result = &mut submission_fut => {
+                                drop(submission_fut);
+                                if drive_as_turn_submission {
+                                    let _ = queues
+                                        .requeue_active_turn_leftovers(&mut state.turn_state)
+                                        .await;
+                                }
+                                if let Err(e) = result {
+                                    let error_msg = format!("Error handling submission: {}", e);
+                                    error!(error = %error_msg);
+                                    let _ = evt_tx
+                                        .send(RuntimeEventEnvelope {
+                                            submission_id: submission_event_ctx.get_submission_id(),
+                                            event: Event::Error {
+                                                message: error_msg,
+                                                recoverable: true,
+                                            },
+                                        })
+                                        .await;
+                                }
+                                queues.outer_queue.extend(
+                                    state
+                                        .turn_state
+                                        .drain_deferred_runtime_actions()
+                                        .into_iter()
+                                        .map(QueuedRuntimeItem::Deferred),
+                                );
+                                state.current_submission_id = None;
+                                break;
+                            }
+                            incoming = sub_rx.recv(), if !submissions_closed => {
+                                match incoming {
+                                    Some(incoming) => {
+                                        if matches!(incoming.op, alan_protocol::Op::Interrupt) {
+                                            cancel.cancel();
+                                        } else if drive_as_turn_submission
+                                            && is_turn_inband_submission(&incoming.op)
+                                        {
+                                            if !queues.active_turn_broker.push(incoming.clone()).await {
+                                                queues.push_outer_submission(incoming);
+                                            }
+                                        } else {
+                                            queues.push_outer_submission(incoming);
+                                        }
                                     }
-                                } else {
-                                    queues.push_outer(incoming);
+                                    None => {
+                                        submissions_closed = true;
+                                        cancel.cancel();
+                                    }
                                 }
                             }
-                            None => {
-                                submissions_closed = true;
+                            _ = shutdown_rx.recv() => {
+                                shutdown_requested = true;
                                 cancel.cancel();
                             }
                         }
-                    }
-                    _ = shutdown_rx.recv() => {
-                        shutdown_requested = true;
-                        cancel.cancel();
+
+                        if shutdown_requested {
+                            continue;
+                        }
                     }
                 }
+                QueuedRuntimeItem::Deferred(action) => {
+                    let action_for_requeue = action.clone();
+                    let mut requeue_action = false;
+                    let cancel = CancellationToken::new();
+                    let mut action_fut = Box::pin(run_deferred_runtime_action_with_cancel(
+                        &mut state, action, &cancel,
+                    ));
 
-                if shutdown_requested {
-                    // Wait for the current submission to unwind after cancellation
-                    // before breaking the runtime loop.
-                    continue;
+                    loop {
+                        tokio::select! {
+                            result = &mut action_fut => {
+                                drop(action_fut);
+                                if let Err(err) = result {
+                                    error!(error = %err, "Error handling deferred runtime action");
+                                }
+                                if requeue_action {
+                                    queues.push_outer_deferred(action_for_requeue);
+                                }
+                                break;
+                            }
+                            incoming = sub_rx.recv(), if !submissions_closed => {
+                                match incoming {
+                                    Some(incoming) => {
+                                        if matches!(incoming.op, alan_protocol::Op::Interrupt) {
+                                            cancel.cancel();
+                                        } else {
+                                            requeue_action = true;
+                                            cancel.cancel();
+                                            queues.push_outer_submission(incoming);
+                                        }
+                                    }
+                                    None => {
+                                        submissions_closed = true;
+                                        cancel.cancel();
+                                    }
+                                }
+                            }
+                            _ = shutdown_rx.recv() => {
+                                shutdown_requested = true;
+                                cancel.cancel();
+                            }
+                        }
+
+                        if shutdown_requested {
+                            continue;
+                        }
+                    }
                 }
             }
 

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -77,6 +77,14 @@ impl RuntimeSubmissionQueues {
         self.outer_queue.pop_front()
     }
 
+    fn pop_outer_deferred(&mut self) -> Option<QueuedRuntimeItem> {
+        let deferred_index = self
+            .outer_queue
+            .iter()
+            .position(|item| matches!(item, QueuedRuntimeItem::Deferred(_)))?;
+        self.outer_queue.remove(deferred_index)
+    }
+
     fn push_outer_submission(&mut self, submission: Submission) {
         push_submission_ahead_of_deferred(&mut self.outer_queue, submission);
     }
@@ -1069,16 +1077,10 @@ pub fn spawn_with_llm_client_and_tools(
 
         let mut queues = RuntimeSubmissionQueues::default();
 
-        'runtime: loop {
-            if shutdown_requested {
-                info!(
-                    session_fingerprint = %session_log_fingerprint(&state.session.id),
-                    "Shutdown signal received, stopping runtime"
-                );
-                break;
-            }
-
-            let queued_item = if let Some(queued_item) = queues.pop_outer() {
+        loop {
+            let queued_item = if shutdown_requested {
+                queues.pop_outer_deferred()
+            } else if let Some(queued_item) = queues.pop_outer() {
                 Some(queued_item)
             } else if submissions_closed {
                 None
@@ -1087,6 +1089,7 @@ pub fn spawn_with_llm_client_and_tools(
                     submission = sub_rx.recv() => submission.map(QueuedRuntimeItem::Submission),
                     _ = shutdown_rx.recv() => {
                         shutdown_requested = true;
+                        submissions_closed = true;
                         None
                     }
                 }
@@ -1094,6 +1097,12 @@ pub fn spawn_with_llm_client_and_tools(
 
             let Some(queued_item) = queued_item else {
                 if shutdown_requested || submissions_closed {
+                    if shutdown_requested {
+                        info!(
+                            session_fingerprint = %session_log_fingerprint(&state.session.id),
+                            "Shutdown signal received, stopping runtime"
+                        );
+                    }
                     break;
                 }
                 continue;
@@ -1200,6 +1209,7 @@ pub fn spawn_with_llm_client_and_tools(
                             }
                             _ = shutdown_rx.recv() => {
                                 shutdown_requested = true;
+                                submissions_closed = true;
                                 cancel.cancel();
                             }
                         }
@@ -1242,25 +1252,16 @@ pub fn spawn_with_llm_client_and_tools(
                                     }
                                     None => {
                                         submissions_closed = true;
-                                        cancel.cancel();
                                     }
                                 }
                             }
                             _ = shutdown_rx.recv() => {
                                 shutdown_requested = true;
-                                cancel.cancel();
+                                submissions_closed = true;
                             }
-                        }
-
-                        if shutdown_requested {
-                            continue;
                         }
                     }
                 }
-            }
-
-            if shutdown_requested {
-                break 'runtime;
             }
         }
 
@@ -1297,9 +1298,15 @@ pub fn spawn_with_llm_client_and_tools(
 mod tests {
     use super::*;
     use crate::runtime::{agent_loop::DeferredRuntimeAction, memory_promotion};
-    use alan_llm::MockLlmProvider;
+    use alan_llm::{
+        GenerationRequest, GenerationResponse, LlmProvider, MockLlmProvider, StreamChunk,
+        TokenUsage,
+    };
     use alan_protocol::Op;
+    use anyhow::anyhow;
+    use async_trait::async_trait;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
     fn write_agent_overlay(path: &Path, body: &str) {
@@ -1348,6 +1355,92 @@ mod tests {
                 QueuedRuntimeItem::Deferred(_) => "deferred",
             })
             .collect()
+    }
+
+    fn mock_generation_response(content: impl Into<String>) -> GenerationResponse {
+        GenerationResponse {
+            content: content.into(),
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: Some(TokenUsage {
+                prompt_tokens: 10,
+                cached_prompt_tokens: None,
+                completion_tokens: 5,
+                total_tokens: 15,
+                reasoning_tokens: None,
+            }),
+            finish_reason: None,
+            provider_response_id: None,
+            provider_response_status: None,
+            warnings: Vec::new(),
+        }
+    }
+
+    struct ShutdownDrainMemoryPromotionProvider {
+        call_count: Arc<Mutex<usize>>,
+        deferred_delay: Duration,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ShutdownDrainMemoryPromotionProvider {
+        async fn generate(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<GenerationResponse> {
+            let current_call = {
+                let mut guard = self.call_count.lock().unwrap();
+                let current = *guard;
+                *guard += 1;
+                current
+            };
+
+            match current_call {
+                0 => Ok(mock_generation_response("Noted.")),
+                1 => {
+                    tokio::time::sleep(self.deferred_delay).await;
+                    Ok(mock_generation_response(
+                        serde_json::json!({
+                            "writes": [
+                                {
+                                    "kind": "user_identity",
+                                    "target": "USER.md",
+                                    "confidence": "high",
+                                    "disposition": "promote_now",
+                                    "observation": "Name: Morris",
+                                    "evidence": ["My name is Morris."],
+                                    "promotion_rationale": "Direct user-stated stable identity detail."
+                                }
+                            ]
+                        })
+                        .to_string(),
+                    ))
+                }
+                _ => Ok(mock_generation_response(
+                    serde_json::json!({ "writes": [] }).to_string(),
+                )),
+            }
+        }
+
+        async fn chat(&mut self, _system: Option<&str>, _user: &str) -> anyhow::Result<String> {
+            Err(anyhow!(
+                "ShutdownDrainMemoryPromotionProvider does not implement chat"
+            ))
+        }
+
+        async fn generate_stream(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+            Err(anyhow!(
+                "ShutdownDrainMemoryPromotionProvider does not implement generate_stream"
+            ))
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "shutdown_drain_memory_promotion"
+        }
     }
 
     #[test]
@@ -1410,6 +1503,66 @@ mod tests {
             }
             _ => panic!("expected buffered submission at queue front"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_runtime_shutdown_drains_deferred_memory_promotion_actions() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut core_config = crate::Config::default();
+        core_config.memory.enabled = true;
+        core_config.memory.workspace_dir = Some(memory_dir.clone());
+        core_config.streaming_mode = crate::config::StreamingMode::Off;
+
+        let mut agent_config = crate::AgentConfig::from(core_config);
+        agent_config.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
+
+        let config = WorkspaceRuntimeConfig {
+            agent_config,
+            ..WorkspaceRuntimeConfig::default()
+        };
+        let llm_client = LlmClient::new(ShutdownDrainMemoryPromotionProvider {
+            call_count: Arc::new(Mutex::new(0)),
+            deferred_delay: Duration::from_millis(100),
+        });
+
+        let mut controller = spawn_with_llm_client(config, llm_client).unwrap();
+        controller.wait_until_ready().await.unwrap();
+
+        let mut event_rx = controller.handle.event_sender.subscribe();
+        let submission = Submission::new(Op::Turn {
+            parts: vec![alan_protocol::ContentPart::text("My name is Morris.")],
+            context: None,
+        });
+        controller
+            .handle
+            .submission_tx
+            .send(submission.clone())
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let envelope = event_rx.recv().await.unwrap();
+                if envelope.submission_id.as_deref() != Some(submission.id.as_str()) {
+                    continue;
+                }
+                if matches!(envelope.event, Event::TurnCompleted { .. }) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("wait for turn completion");
+
+        controller.shutdown().await.unwrap();
+
+        let user_memory =
+            tokio::fs::read_to_string(memory_dir.join(crate::prompts::MEMORY_USER_FILENAME))
+                .await
+                .unwrap();
+        assert!(user_memory.contains("Name: Morris"));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -1,7 +1,9 @@
 //! Agent Runtime - Core execution engine.
 
-use super::agent_loop::handle_submission_with_cancel;
-use super::agent_loop::run_deferred_runtime_action_with_cancel;
+use super::agent_loop::{
+    DeferredRuntimeActionExit, handle_submission_with_cancel,
+    run_deferred_runtime_action_with_cancel,
+};
 use super::turn_driver::{
     TurnInputBroker, drive_turn_submission_with_cancel, is_turn_inband_submission,
     should_drive_turn_submission,
@@ -62,6 +64,13 @@ fn push_submission_ahead_of_deferred(
         .position(|item| matches!(item, QueuedRuntimeItem::Deferred(_)))
         .unwrap_or(outer_queue.len());
     outer_queue.insert(insertion_index, QueuedRuntimeItem::Submission(submission));
+}
+
+fn should_requeue_deferred_action(
+    requeue_requested: bool,
+    exit: DeferredRuntimeActionExit,
+) -> bool {
+    requeue_requested && matches!(exit, DeferredRuntimeActionExit::Cancelled)
 }
 
 #[derive(Default)]
@@ -1221,7 +1230,7 @@ pub fn spawn_with_llm_client_and_tools(
                 }
                 QueuedRuntimeItem::Deferred(action) => {
                     let action_for_requeue = action.clone();
-                    let mut requeue_action = false;
+                    let mut requeue_if_cancelled = false;
                     let cancel = CancellationToken::new();
                     let mut action_fut = Box::pin(run_deferred_runtime_action_with_cancel(
                         &mut state, action, &cancel,
@@ -1229,12 +1238,9 @@ pub fn spawn_with_llm_client_and_tools(
 
                     loop {
                         tokio::select! {
-                            result = &mut action_fut => {
+                            exit = &mut action_fut => {
                                 drop(action_fut);
-                                if let Err(err) = result {
-                                    error!(error = %err, "Error handling deferred runtime action");
-                                }
-                                if requeue_action {
+                                if should_requeue_deferred_action(requeue_if_cancelled, exit) {
                                     queues.push_outer_deferred(action_for_requeue);
                                 }
                                 break;
@@ -1245,7 +1251,7 @@ pub fn spawn_with_llm_client_and_tools(
                                         if matches!(incoming.op, alan_protocol::Op::Interrupt) {
                                             cancel.cancel();
                                         } else {
-                                            requeue_action = true;
+                                            requeue_if_cancelled = true;
                                             cancel.cancel();
                                             queues.push_outer_submission(incoming);
                                         }
@@ -1355,6 +1361,22 @@ mod tests {
                 QueuedRuntimeItem::Deferred(_) => "deferred",
             })
             .collect()
+    }
+
+    #[test]
+    fn test_should_requeue_deferred_action_only_after_cancelled_exit() {
+        assert!(should_requeue_deferred_action(
+            true,
+            DeferredRuntimeActionExit::Cancelled
+        ));
+        assert!(!should_requeue_deferred_action(
+            true,
+            DeferredRuntimeActionExit::Completed
+        ));
+        assert!(!should_requeue_deferred_action(
+            false,
+            DeferredRuntimeActionExit::Cancelled
+        ));
     }
 
     fn mock_generation_response(content: impl Into<String>) -> GenerationResponse {

--- a/crates/runtime/src/runtime/memory_flush.rs
+++ b/crates/runtime/src/runtime/memory_flush.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 
 use super::agent_loop::RuntimeLoopState;
-use crate::prompts::MEMORY_DAILY_DIRNAME;
 use super::memory_promotion::{InboxEntryDraft, stage_inbox_entry};
+use crate::prompts::MEMORY_DAILY_DIRNAME;
 
 const MEMORY_FLUSH_MAX_SECTION_ITEMS: usize = 6;
 const MEMORY_FLUSH_MAX_ITEM_CHARS: usize = 240;

--- a/crates/runtime/src/runtime/memory_flush.rs
+++ b/crates/runtime/src/runtime/memory_flush.rs
@@ -11,11 +11,12 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     llm::{Message, MessageRole, build_generation_request},
-    prompts,
+    prompts::{self, WORKSPACE_MEMORY_FILENAME},
 };
 
 use super::agent_loop::RuntimeLoopState;
 use crate::prompts::MEMORY_DAILY_DIRNAME;
+use super::memory_promotion::{InboxEntryDraft, stage_inbox_entry};
 
 const MEMORY_FLUSH_MAX_SECTION_ITEMS: usize = 6;
 const MEMORY_FLUSH_MAX_ITEM_CHARS: usize = 240;
@@ -182,18 +183,31 @@ pub(crate) async fn perform_memory_flush_attempt(
         &timestamp,
     );
     match append_memory_entry(&note_path, &entry).await {
-        Ok(()) => MemoryFlushAttemptSnapshot {
-            attempt_id,
-            compaction_mode,
-            pressure_level,
-            result: MemoryFlushResult::Success,
-            skip_reason: None,
-            source_messages,
-            output_path: Some(snapshot_output_path(&memory_dir, &note_path)),
-            warning_message: None,
-            error_message: None,
-            timestamp,
-        },
+        Ok(()) => {
+            if let Some(inbox_draft) =
+                build_memory_flush_inbox_draft(&state.session.id, &attempt_id, &flush_content)
+                && let Err(err) = stage_inbox_entry(&memory_dir, inbox_draft, now).await
+            {
+                tracing::warn!(
+                    error = %err,
+                    memory_dir = %memory_dir.display(),
+                    "failed to stage memory flush inbox entry"
+                );
+            }
+
+            MemoryFlushAttemptSnapshot {
+                attempt_id,
+                compaction_mode,
+                pressure_level,
+                result: MemoryFlushResult::Success,
+                skip_reason: None,
+                source_messages,
+                output_path: Some(snapshot_output_path(&memory_dir, &note_path)),
+                warning_message: None,
+                error_message: None,
+                timestamp,
+            }
+        }
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => skipped_attempt(
             attempt_id,
             compaction_mode,
@@ -406,6 +420,49 @@ fn render_memory_flush_entry(
     lines.join("\n")
 }
 
+fn build_memory_flush_inbox_draft(
+    session_id: &str,
+    attempt_id: &str,
+    content: &MemoryFlushContent,
+) -> Option<InboxEntryDraft> {
+    let observation = if !content.why.is_empty() {
+        content.why.clone()
+    } else {
+        content
+            .key_decisions
+            .first()
+            .or_else(|| content.constraints.first())
+            .or_else(|| content.next_steps.first())
+            .cloned()
+            .unwrap_or_default()
+    };
+    if observation.trim().is_empty() {
+        return None;
+    }
+
+    let mut evidence = Vec::new();
+    evidence.extend(content.key_decisions.iter().cloned());
+    evidence.extend(content.constraints.iter().cloned());
+    evidence.extend(content.next_steps.iter().cloned());
+    evidence.extend(content.important_refs.iter().cloned());
+
+    Some(InboxEntryDraft {
+        kind: "workspace_fact",
+        target: WORKSPACE_MEMORY_FILENAME.to_string(),
+        confidence: if content.key_decisions.is_empty() && content.constraints.is_empty() {
+            "low"
+        } else {
+            "medium"
+        },
+        observation,
+        evidence,
+        promotion_rationale: format!(
+            "Captured from automatic memory flush attempt `{attempt_id}` in session `{session_id}`. Review before promoting into stable memory."
+        ),
+        source_sessions: vec![session_id.to_string()],
+    })
+}
+
 fn push_section(lines: &mut Vec<String>, title: &str, items: &[String]) {
     if items.is_empty() {
         return;
@@ -560,6 +617,36 @@ mod tests {
         assert_eq!(
             snapshot_output_path(&memory_dir, &note_path),
             ".alan/memory/daily/2026-03-18.md"
+        );
+    }
+
+    #[test]
+    fn test_build_memory_flush_inbox_draft_targets_memory_md() {
+        let draft = build_memory_flush_inbox_draft(
+            "sess-123",
+            "flush-456",
+            &MemoryFlushContent {
+                why: "Preserve the current rollout constraints.".to_string(),
+                key_decisions: vec!["Keep the lexical recall path.".to_string()],
+                constraints: vec!["Do not introduce vector search.".to_string()],
+                next_steps: vec!["Land the next slice.".to_string()],
+                important_refs: vec!["docs/spec/pure_text_memory_contract.md".to_string()],
+            },
+        )
+        .expect("expected inbox draft");
+
+        assert_eq!(draft.kind, "workspace_fact");
+        assert_eq!(draft.target, WORKSPACE_MEMORY_FILENAME);
+        assert_eq!(draft.confidence, "medium");
+        assert!(
+            draft
+                .observation
+                .contains("Preserve the current rollout constraints.")
+        );
+        assert!(
+            draft
+                .promotion_rationale
+                .contains("automatic memory flush attempt `flush-456`")
         );
     }
 }

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Datelike, Utc};
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 
 use crate::llm::{
     GenerationRequest, LlmClient, Message as LlmMessage, MessageRole, build_generation_request,
@@ -15,6 +16,7 @@ use crate::prompts::{
     MEMORY_INBOX_DIRNAME, MEMORY_PROMOTION_PROMPT, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME,
     WORKSPACE_MEMORY_FILENAME, ensure_workspace_memory_layout_at,
 };
+#[cfg(test)]
 use crate::session::Session;
 use crate::tape::Message;
 
@@ -245,19 +247,90 @@ pub(crate) async fn promote_inbox_entry(
     })
 }
 
-pub(crate) async fn capture_confirmed_turn_memory(state: &mut RuntimeLoopState) -> Result<()> {
-    capture_confirmed_turn_memory_for_session(
-        state.core_config.memory.enabled,
-        state.core_config.memory.workspace_dir.as_deref(),
-        &mut state.llm_client,
-        state.runtime_config.llm_request_timeout_secs,
-        &state.session,
+#[derive(Debug, Clone)]
+pub(crate) struct TurnMemoryPromotionJob {
+    memory_dir: PathBuf,
+    session_id: String,
+    active_turn_user_messages: Vec<String>,
+    llm_request_timeout_secs: u64,
+    pub(crate) warning_context: &'static str,
+}
+
+pub(crate) fn build_turn_memory_promotion_job(
+    state: &RuntimeLoopState,
+    warning_context: &'static str,
+) -> Option<TurnMemoryPromotionJob> {
+    if !state.core_config.memory.enabled {
+        return None;
+    }
+
+    let memory_dir = state.core_config.memory.workspace_dir.clone()?;
+    let active_turn_user_messages = active_turn_user_messages(
+        state.session.tape.messages(),
         state.turn_state.active_turn_message_start(),
+    );
+    if active_turn_user_messages.is_empty() {
+        return None;
+    }
+
+    Some(TurnMemoryPromotionJob {
+        memory_dir,
+        session_id: state.session.id.clone(),
+        active_turn_user_messages,
+        llm_request_timeout_secs: state.runtime_config.llm_request_timeout_secs,
+        warning_context,
+    })
+}
+
+pub(crate) async fn run_turn_memory_promotion_job_with_cancel(
+    llm_client: &mut LlmClient,
+    job: &TurnMemoryPromotionJob,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    capture_confirmed_turn_memory_for_session(
+        llm_client,
+        job.llm_request_timeout_secs,
+        &job.memory_dir,
+        &job.session_id,
+        &job.active_turn_user_messages,
+        cancel,
     )
     .await
 }
 
 async fn capture_confirmed_turn_memory_for_session(
+    llm_client: &mut LlmClient,
+    llm_request_timeout_secs: u64,
+    memory_dir: &Path,
+    session_id: &str,
+    active_turn_user_messages: &[String],
+    cancel: &CancellationToken,
+) -> Result<()> {
+    let candidates = generate_memory_promotion_candidates(
+        llm_client,
+        llm_request_timeout_secs,
+        session_id,
+        active_turn_user_messages,
+        cancel,
+    )
+    .await?;
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    let now = Utc::now();
+    for candidate in candidates {
+        let inbox_path = stage_inbox_entry(memory_dir, candidate.draft, now).await?;
+        if candidate.disposition == PromotionDisposition::PromoteNow {
+            promote_inbox_entry(memory_dir, &inbox_path, now).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+async fn capture_confirmed_turn_memory_for_test(
     memory_enabled: bool,
     memory_dir: Option<&Path>,
     llm_client: &mut LlmClient,
@@ -273,11 +346,19 @@ async fn capture_confirmed_turn_memory_for_session(
         return Ok(());
     };
 
+    let active_turn_user_messages =
+        active_turn_user_messages(session.tape.messages(), active_turn_start);
+    if active_turn_user_messages.is_empty() {
+        return Ok(());
+    }
+
+    let cancel = CancellationToken::new();
     let candidates = generate_memory_promotion_candidates(
         llm_client,
         llm_request_timeout_secs,
-        session,
-        active_turn_start,
+        &session.id,
+        &active_turn_user_messages,
+        &cancel,
     )
     .await?;
     if candidates.is_empty() {
@@ -504,17 +585,10 @@ fn dedup_strings(values: Vec<String>) -> Vec<String> {
 async fn generate_memory_promotion_candidates(
     llm_client: &mut LlmClient,
     llm_request_timeout_secs: u64,
-    session: &Session,
-    active_turn_start: Option<usize>,
+    session_id: &str,
+    active_turn_user_messages: &[String],
+    cancel: &CancellationToken,
 ) -> Result<Vec<MemoryPromotionCandidate>> {
-    let active_turn_user_messages =
-        active_turn_messages(session.tape.messages(), active_turn_start)
-            .iter()
-            .filter(|message| message.is_user())
-            .map(Message::text_content)
-            .filter(|text| !text.trim().is_empty())
-            .collect::<Vec<_>>();
-
     if active_turn_user_messages.is_empty() {
         return Ok(Vec::new());
     }
@@ -522,16 +596,29 @@ async fn generate_memory_promotion_candidates(
     let response = generate_memory_promotion_response(
         llm_client,
         llm_request_timeout_secs,
-        build_memory_promotion_request(active_turn_user_messages),
+        build_memory_promotion_request(active_turn_user_messages.to_vec()),
+        cancel,
     )
     .await?;
 
-    parse_memory_promotion_candidates(&response.content, &session.id)
+    parse_memory_promotion_candidates(&response.content, session_id)
 }
 
 fn active_turn_messages(messages: &[Message], active_turn_start: Option<usize>) -> &[Message] {
     let turn_start = active_turn_start.unwrap_or(0).min(messages.len());
     &messages[turn_start..]
+}
+
+fn active_turn_user_messages(
+    messages: &[Message],
+    active_turn_start: Option<usize>,
+) -> Vec<String> {
+    active_turn_messages(messages, active_turn_start)
+        .iter()
+        .filter(|message| message.is_user())
+        .map(Message::text_content)
+        .filter(|text| !text.trim().is_empty())
+        .collect()
 }
 
 fn build_memory_promotion_request(active_turn_user_messages: Vec<String>) -> GenerationRequest {
@@ -561,21 +648,24 @@ async fn generate_memory_promotion_response(
     llm_client: &mut LlmClient,
     llm_request_timeout_secs: u64,
     request: GenerationRequest,
+    cancel: &CancellationToken,
 ) -> Result<crate::llm::GenerationResponse> {
     if llm_request_timeout_secs == 0 {
-        return llm_client
-            .generate(request)
-            .await
-            .context("generate turn-end memory promotion plan");
+        return tokio::select! {
+            _ = cancel.cancelled() => Err(anyhow!("LLM request cancelled")),
+            result = llm_client.generate(request) => result.context("generate turn-end memory promotion plan"),
+        };
     }
 
-    tokio::time::timeout(
-        Duration::from_secs(llm_request_timeout_secs),
-        llm_client.generate(request),
-    )
-    .await
-    .context("turn-end memory promotion plan timed out")?
-    .context("generate turn-end memory promotion plan")
+    tokio::select! {
+        _ = cancel.cancelled() => Err(anyhow!("LLM request cancelled")),
+        result = tokio::time::timeout(
+            Duration::from_secs(llm_request_timeout_secs),
+            llm_client.generate(request),
+        ) => result
+            .context("turn-end memory promotion plan timed out")?
+            .context("generate turn-end memory promotion plan"),
+    }
 }
 
 fn parse_memory_promotion_candidates(
@@ -816,7 +906,11 @@ async fn write_text_file(path: &Path, content: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alan_llm::{GenerationResponse, MockLlmProvider, TokenUsage};
+    use alan_llm::{
+        GenerationRequest, GenerationResponse, LlmProvider, MockLlmProvider, StreamChunk,
+        TokenUsage,
+    };
+    use async_trait::async_trait;
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -967,7 +1061,7 @@ mod tests {
         ));
         let mut llm_client = LlmClient::new(provider);
 
-        capture_confirmed_turn_memory_for_session(
+        capture_confirmed_turn_memory_for_test(
             true,
             Some(&memory_dir),
             &mut llm_client,
@@ -1000,7 +1094,7 @@ mod tests {
         let provider = MockLlmProvider::new();
         let mut llm_client = LlmClient::new(provider.clone());
 
-        capture_confirmed_turn_memory_for_session(
+        capture_confirmed_turn_memory_for_test(
             false,
             Some(&memory_dir),
             &mut llm_client,
@@ -1144,7 +1238,7 @@ Direct user-stated stable identity detail.
         ));
         let mut llm_client = LlmClient::new(provider);
 
-        capture_confirmed_turn_memory_for_session(
+        capture_confirmed_turn_memory_for_test(
             true,
             Some(&memory_dir),
             &mut llm_client,
@@ -1185,11 +1279,15 @@ Direct user-stated stable identity detail.
         ));
         let mut llm_client = LlmClient::new(provider.clone());
 
+        let active_turn_user_messages =
+            active_turn_user_messages(session.tape.messages(), Some(active_turn_start));
+        let cancel = CancellationToken::new();
         let drafts = generate_memory_promotion_candidates(
             &mut llm_client,
             30,
-            &session,
-            Some(active_turn_start),
+            &session.id,
+            &active_turn_user_messages,
+            &cancel,
         )
         .await
         .unwrap();
@@ -1202,6 +1300,76 @@ Direct user-stated stable identity detail.
         assert_eq!(
             requests[0].messages[0].content,
             "Please continue with the previous task."
+        );
+    }
+
+    struct DelayedMemoryPromotionProvider {
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl LlmProvider for DelayedMemoryPromotionProvider {
+        async fn generate(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<GenerationResponse> {
+            tokio::time::sleep(self.delay).await;
+            Ok(mock_generation_response(
+                serde_json::json!({ "writes": [] }).to_string(),
+            ))
+        }
+
+        async fn chat(&mut self, _system: Option<&str>, _user: &str) -> anyhow::Result<String> {
+            Err(anyhow!(
+                "DelayedMemoryPromotionProvider does not implement chat"
+            ))
+        }
+
+        async fn generate_stream(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+            Err(anyhow!(
+                "DelayedMemoryPromotionProvider does not implement generate_stream"
+            ))
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "delayed_memory_promotion"
+        }
+    }
+
+    #[tokio::test]
+    async fn run_turn_memory_promotion_job_timeout_zero_can_be_cancelled() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut llm_client = LlmClient::new(DelayedMemoryPromotionProvider {
+            delay: Duration::from_secs(10),
+        });
+        let job = TurnMemoryPromotionJob {
+            memory_dir: memory_dir.clone(),
+            session_id: "sess-cancelled".to_string(),
+            active_turn_user_messages: vec!["My name is Morris.".to_string()],
+            llm_request_timeout_secs: 0,
+            warning_context: "test cancellation",
+        };
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel_for_task.cancel();
+        });
+
+        let result =
+            run_turn_memory_promotion_job_with_cancel(&mut llm_client, &job, &cancel).await;
+        let _ = task.await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+        assert!(
+            collect_markdown_files_recursively(&memory_dir.join(MEMORY_INBOX_DIRNAME)).is_empty()
         );
     }
 

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -1,0 +1,803 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::{DateTime, Datelike, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+use crate::prompts::{
+    MEMORY_INBOX_DIRNAME, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME, WORKSPACE_MEMORY_FILENAME,
+    ensure_workspace_memory_layout_at,
+};
+use crate::session::Session;
+use crate::tape::Message;
+
+const DEFAULT_PROMOTED_FACTS_HEADER: &str = "## Promoted Facts";
+const DEFAULT_TOPIC_SUMMARY: &str = "Promoted from inbox entries.";
+const DEFAULT_EVIDENCE_ITEM: &str = "No evidence recorded.";
+
+#[derive(Debug, Clone)]
+pub(crate) struct InboxEntryDraft {
+    pub kind: &'static str,
+    pub target: String,
+    pub confidence: &'static str,
+    pub observation: String,
+    pub evidence: Vec<String>,
+    pub promotion_rationale: String,
+    pub source_sessions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PromotionOutcome {
+    pub inbox_path: PathBuf,
+    pub target_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct InboxEntryFrontmatter {
+    id: String,
+    kind: String,
+    status: String,
+    target: String,
+    confidence: String,
+    created_at: String,
+    updated_at: String,
+    source_sessions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InboxEntryDocument {
+    frontmatter: InboxEntryFrontmatter,
+    observation: String,
+    evidence: Vec<String>,
+    promotion_rationale: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct TopicPageFrontmatter {
+    title: String,
+    aliases: Vec<String>,
+    tags: Vec<String>,
+    entities: Vec<String>,
+    updated_at: String,
+    source_sessions: Vec<String>,
+}
+
+pub(crate) async fn stage_inbox_entry(
+    memory_dir: &Path,
+    draft: InboxEntryDraft,
+    now: DateTime<Utc>,
+) -> Result<PathBuf> {
+    ensure_workspace_memory_layout_at(memory_dir).with_context(|| {
+        format!(
+            "failed to ensure workspace memory layout before staging inbox entry at {}",
+            memory_dir.display()
+        )
+    })?;
+
+    let id = format!("inbox-{}", uuid::Uuid::new_v4().simple());
+    let path = inbox_entry_path(memory_dir, now, &id);
+    let document = InboxEntryDocument {
+        frontmatter: InboxEntryFrontmatter {
+            id,
+            kind: draft.kind.to_string(),
+            status: "observed".to_string(),
+            target: draft.target,
+            confidence: draft.confidence.to_string(),
+            created_at: now.to_rfc3339(),
+            updated_at: now.to_rfc3339(),
+            source_sessions: dedup_strings(draft.source_sessions),
+        },
+        observation: draft.observation.trim().to_string(),
+        evidence: normalize_items(draft.evidence),
+        promotion_rationale: draft.promotion_rationale.trim().to_string(),
+    };
+
+    write_text_file(&path, &render_inbox_entry(&document)).await?;
+    Ok(path)
+}
+
+pub(crate) async fn promote_inbox_entry(
+    memory_dir: &Path,
+    inbox_path: &Path,
+    now: DateTime<Utc>,
+) -> Result<PromotionOutcome> {
+    ensure_workspace_memory_layout_at(memory_dir).with_context(|| {
+        format!(
+            "failed to ensure workspace memory layout before promoting inbox entry at {}",
+            memory_dir.display()
+        )
+    })?;
+
+    let raw = tokio::fs::read_to_string(inbox_path)
+        .await
+        .with_context(|| format!("read inbox entry {}", inbox_path.display()))?;
+    let mut document = parse_inbox_entry(&raw)
+        .with_context(|| format!("parse inbox entry {}", inbox_path.display()))?;
+    let target_path = resolve_target_path(memory_dir, &document.frontmatter.target)?;
+    let promoted_from = format_relative_memory_path(memory_dir, inbox_path);
+    let promoted_stamp = now.format("%F").to_string();
+    let promoted_line = format!(
+        "- [{}] {} (promoted from {})",
+        promoted_stamp,
+        document.observation.trim(),
+        promoted_from
+    );
+
+    match document.frontmatter.target.as_str() {
+        MEMORY_USER_FILENAME | WORKSPACE_MEMORY_FILENAME => {
+            let existing = read_text_file_or_default(&target_path).await?;
+            if !existing.contains(document.observation.trim()) {
+                let updated = append_markdown_section_item(
+                    &existing,
+                    DEFAULT_PROMOTED_FACTS_HEADER,
+                    &promoted_line,
+                );
+                write_text_file(&target_path, &updated).await?;
+            }
+        }
+        target if is_topic_target(target) => {
+            let existing = read_text_file_or_default(&target_path).await?;
+            let title = slug_to_title(topic_slug_from_target(target)?);
+            let mut topic = ensure_topic_page_frontmatter(
+                &existing,
+                &title,
+                now,
+                &document.frontmatter.source_sessions,
+            )?;
+            if !topic.contains(document.observation.trim()) {
+                topic = append_markdown_section_item(&topic, "## Stable Facts", &promoted_line);
+                for evidence in document
+                    .evidence
+                    .iter()
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    topic = append_markdown_section_item(
+                        &topic,
+                        "## References",
+                        &format!("- {evidence}"),
+                    );
+                }
+                topic = append_markdown_section_item(
+                    &topic,
+                    "## References",
+                    &format!("- Source inbox entry: {promoted_from}"),
+                );
+            }
+            write_text_file(&target_path, &topic).await?;
+
+            let memory_path = memory_dir.join(WORKSPACE_MEMORY_FILENAME);
+            let memory_content = read_text_file_or_default(&memory_path).await?;
+            let topic_index_line = format!(
+                "- {} -> topics/{}.md",
+                topic_slug_from_target(target)?,
+                topic_slug_from_target(target)?
+            );
+            let updated_memory =
+                append_markdown_section_item(&memory_content, "## Topic Index", &topic_index_line);
+            write_text_file(&memory_path, &updated_memory).await?;
+        }
+        other => bail!("unsupported inbox promotion target: {other}"),
+    }
+
+    document.frontmatter.status = "confirmed".to_string();
+    document.frontmatter.updated_at = now.to_rfc3339();
+    write_text_file(inbox_path, &render_inbox_entry(&document)).await?;
+
+    Ok(PromotionOutcome {
+        inbox_path: inbox_path.to_path_buf(),
+        target_path,
+    })
+}
+
+pub(crate) async fn capture_confirmed_turn_memory(
+    memory_dir: Option<&Path>,
+    session: &Session,
+) -> Result<()> {
+    let Some(memory_dir) = memory_dir else {
+        return Ok(());
+    };
+
+    let drafts = derive_confirmed_memory_drafts(session);
+    if drafts.is_empty() {
+        return Ok(());
+    }
+
+    let now = Utc::now();
+    for draft in drafts {
+        let inbox_path = stage_inbox_entry(memory_dir, draft, now).await?;
+        promote_inbox_entry(memory_dir, &inbox_path, now).await?;
+    }
+
+    Ok(())
+}
+
+fn parse_inbox_entry(content: &str) -> Result<InboxEntryDocument> {
+    let (frontmatter, body) = split_frontmatter(content)?;
+    let frontmatter: InboxEntryFrontmatter =
+        serde_yaml::from_str(frontmatter).context("parse inbox frontmatter")?;
+
+    let observation = extract_markdown_section(body, "## Observation")
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+    let evidence = extract_markdown_section(body, "## Evidence")
+        .map(parse_markdown_list)
+        .unwrap_or_default();
+    let promotion_rationale = extract_markdown_section(body, "## Promotion Rationale")
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string();
+
+    Ok(InboxEntryDocument {
+        frontmatter,
+        observation,
+        evidence,
+        promotion_rationale,
+    })
+}
+
+fn render_inbox_entry(document: &InboxEntryDocument) -> String {
+    let frontmatter = render_yaml_without_leading_delimiter(&document.frontmatter)
+        .expect("serialize inbox frontmatter");
+    let evidence = if document.evidence.is_empty() {
+        format!("- {DEFAULT_EVIDENCE_ITEM}")
+    } else {
+        document
+            .evidence
+            .iter()
+            .map(|item| format!("- {item}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        "---\n{frontmatter}---\n\n## Observation\n{}\n\n## Evidence\n{}\n\n## Promotion Rationale\n{}\n",
+        document.observation.trim(),
+        evidence,
+        document.promotion_rationale.trim()
+    )
+}
+
+fn resolve_target_path(memory_dir: &Path, target: &str) -> Result<PathBuf> {
+    match target {
+        MEMORY_USER_FILENAME => Ok(memory_dir.join(MEMORY_USER_FILENAME)),
+        WORKSPACE_MEMORY_FILENAME => Ok(memory_dir.join(WORKSPACE_MEMORY_FILENAME)),
+        _ if is_topic_target(target) => Ok(memory_dir.join(target)),
+        _ => bail!("unsupported inbox target path: {target}"),
+    }
+}
+
+fn ensure_topic_page_frontmatter(
+    content: &str,
+    title: &str,
+    now: DateTime<Utc>,
+    source_sessions: &[String],
+) -> Result<String> {
+    let existing_body = if content.trim().is_empty() {
+        default_topic_body(title)
+    } else if let Ok((_, body)) = split_frontmatter(content) {
+        body.trim().to_string()
+    } else {
+        content.trim().to_string()
+    };
+
+    let frontmatter = if let Ok((yaml, _)) = split_frontmatter(content) {
+        let mut parsed: TopicPageFrontmatter =
+            serde_yaml::from_str(yaml).context("parse topic page frontmatter")?;
+        parsed.updated_at = now.to_rfc3339();
+        parsed.source_sessions = merge_source_sessions(parsed.source_sessions, source_sessions);
+        parsed
+    } else {
+        TopicPageFrontmatter {
+            title: title.to_string(),
+            aliases: Vec::new(),
+            tags: Vec::new(),
+            entities: Vec::new(),
+            updated_at: now.to_rfc3339(),
+            source_sessions: dedup_strings(source_sessions.to_vec()),
+        }
+    };
+
+    let frontmatter = render_yaml_without_leading_delimiter(&frontmatter)
+        .context("serialize topic page frontmatter")?;
+    Ok(format!(
+        "---\n{frontmatter}---\n\n{}\n",
+        existing_body.trim()
+    ))
+}
+
+fn default_topic_body(title: &str) -> String {
+    format!(
+        "# {title}\n\n## Summary\n{DEFAULT_TOPIC_SUMMARY}\n\n## Stable Facts\n\n## Key Decisions\n\n## Open Questions\n\n## References\n"
+    )
+}
+
+fn append_markdown_section_item(content: &str, heading: &str, item: &str) -> String {
+    if item.trim().is_empty() || content.contains(item) {
+        return ensure_trailing_newline(content);
+    }
+
+    let normalized = ensure_trailing_newline(content);
+    if let Some(start) = normalized.find(heading) {
+        let search_start = start + heading.len();
+        let section_tail = &normalized[search_start..];
+        let next_section_offset = section_tail
+            .find("\n## ")
+            .map(|offset| search_start + offset);
+        let insertion_at = next_section_offset.unwrap_or(normalized.len());
+        let mut updated = String::with_capacity(normalized.len() + item.len() + 4);
+        updated.push_str(&normalized[..insertion_at]);
+        if !updated.ends_with("\n\n") {
+            if !updated.ends_with('\n') {
+                updated.push('\n');
+            }
+            updated.push('\n');
+        }
+        updated.push_str(item.trim());
+        updated.push('\n');
+        if insertion_at < normalized.len() && !normalized[insertion_at..].starts_with('\n') {
+            updated.push('\n');
+        }
+        updated.push_str(&normalized[insertion_at..]);
+        return updated;
+    }
+
+    let mut updated = normalized.trim_end().to_string();
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(heading);
+    updated.push_str("\n\n");
+    updated.push_str(item.trim());
+    updated.push('\n');
+    updated
+}
+
+fn extract_markdown_section<'a>(content: &'a str, heading: &str) -> Option<&'a str> {
+    let start = content.find(heading)?;
+    let body_start = start + heading.len();
+    let section_tail = &content[body_start..];
+    let next_section_offset = section_tail.find("\n## ").unwrap_or(section_tail.len());
+    Some(section_tail[..next_section_offset].trim())
+}
+
+fn split_frontmatter(content: &str) -> Result<(&str, &str)> {
+    let trimmed = content.trim_start();
+    let remainder = trimmed
+        .strip_prefix("---\n")
+        .ok_or_else(|| anyhow!("missing frontmatter delimiter"))?;
+    let (frontmatter, body) = remainder
+        .split_once("\n---\n")
+        .ok_or_else(|| anyhow!("missing closing frontmatter delimiter"))?;
+    Ok((frontmatter, body))
+}
+
+fn render_yaml_without_leading_delimiter<T: Serialize>(value: &T) -> Result<String> {
+    let rendered = serde_yaml::to_string(value).context("render yaml")?;
+    Ok(rendered
+        .strip_prefix("---\n")
+        .unwrap_or(rendered.as_str())
+        .to_string())
+}
+
+fn parse_markdown_list(section: &str) -> Vec<String> {
+    section
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("- "))
+        .map(|line| line.trim_start_matches("- ").trim().to_string())
+        .filter(|line| !line.is_empty() && line != DEFAULT_EVIDENCE_ITEM)
+        .collect()
+}
+
+fn normalize_items(items: Vec<String>) -> Vec<String> {
+    dedup_strings(
+        items
+            .into_iter()
+            .map(|item| item.trim().to_string())
+            .filter(|item| !item.is_empty())
+            .collect(),
+    )
+}
+
+fn merge_source_sessions(mut existing: Vec<String>, additional: &[String]) -> Vec<String> {
+    existing.extend(additional.iter().cloned());
+    dedup_strings(existing)
+}
+
+fn dedup_strings(values: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.clone()))
+        .collect()
+}
+
+fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
+    let Some(user_text) = session
+        .tape
+        .messages()
+        .iter()
+        .rev()
+        .find(|message| message.is_user())
+        .map(Message::text_content)
+    else {
+        return Vec::new();
+    };
+
+    let normalized = normalize_whitespace(&user_text);
+    let lowered = normalized.to_lowercase();
+    let mut drafts = Vec::new();
+
+    if let Some(name) = extract_fact_after_prefix(&normalized, &lowered, &["my name is "]) {
+        drafts.push(InboxEntryDraft {
+            kind: "user_identity",
+            target: MEMORY_USER_FILENAME.to_string(),
+            confidence: "high",
+            observation: format!("Name: {name}"),
+            evidence: vec![normalized.clone()],
+            promotion_rationale: "Direct user-stated stable identity detail.".to_string(),
+            source_sessions: vec![session.id.clone()],
+        });
+    }
+
+    if let Some(preference) =
+        extract_fact_after_prefix(&normalized, &lowered, &["i prefer ", "my preferred "])
+    {
+        drafts.push(InboxEntryDraft {
+            kind: "user_preference",
+            target: MEMORY_USER_FILENAME.to_string(),
+            confidence: "high",
+            observation: format!("Preference: {preference}"),
+            evidence: vec![normalized.clone()],
+            promotion_rationale: "Direct user-stated stable preference.".to_string(),
+            source_sessions: vec![session.id.clone()],
+        });
+    }
+
+    if let Some(favorite) = extract_favorite_fact(&normalized, &lowered) {
+        drafts.push(InboxEntryDraft {
+            kind: "user_preference",
+            target: MEMORY_USER_FILENAME.to_string(),
+            confidence: "high",
+            observation: favorite,
+            evidence: vec![normalized.clone()],
+            promotion_rationale: "Direct user-stated favorite/preference detail.".to_string(),
+            source_sessions: vec![session.id.clone()],
+        });
+    }
+
+    if let Some(constraint) = extract_fact_after_prefix(
+        &normalized,
+        &lowered,
+        &[
+            "remember this constraint: ",
+            "remember the constraint: ",
+            "the constraint is ",
+        ],
+    ) {
+        drafts.push(InboxEntryDraft {
+            kind: "workspace_fact",
+            target: WORKSPACE_MEMORY_FILENAME.to_string(),
+            confidence: "high",
+            observation: format!("Constraint: {constraint}"),
+            evidence: vec![normalized.clone()],
+            promotion_rationale: "Direct user-stated durable workspace constraint.".to_string(),
+            source_sessions: vec![session.id.clone()],
+        });
+    }
+
+    if let Some(rule) = extract_fact_after_prefix(
+        &normalized,
+        &lowered,
+        &[
+            "remember this rule: ",
+            "remember the rule: ",
+            "the rule is ",
+            "workflow rule: ",
+        ],
+    ) {
+        drafts.push(InboxEntryDraft {
+            kind: "workflow_rule",
+            target: WORKSPACE_MEMORY_FILENAME.to_string(),
+            confidence: "high",
+            observation: format!("Workflow rule: {rule}"),
+            evidence: vec![normalized.clone()],
+            promotion_rationale: "Direct user-stated durable workflow rule.".to_string(),
+            source_sessions: vec![session.id.clone()],
+        });
+    }
+
+    drafts
+}
+
+fn extract_fact_after_prefix(original: &str, lowered: &str, prefixes: &[&str]) -> Option<String> {
+    prefixes.iter().find_map(|prefix| {
+        lowered.find(prefix).and_then(|start| {
+            let start = start + prefix.len();
+            let extracted = extract_until_sentence_boundary(&original[start..]);
+            (!extracted.is_empty()).then_some(extracted)
+        })
+    })
+}
+
+fn extract_favorite_fact(original: &str, lowered: &str) -> Option<String> {
+    let favorite_start = lowered.find("my favorite ")?;
+    let original_tail = &original[favorite_start + "my favorite ".len()..];
+    let lowered_tail = &lowered[favorite_start + "my favorite ".len()..];
+    let is_pos = lowered_tail.find(" is ")?;
+    let subject = extract_until_sentence_boundary(&original_tail[..is_pos]);
+    let value = extract_until_sentence_boundary(&original_tail[is_pos + " is ".len()..]);
+    if subject.is_empty() || value.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "Favorite {}: {}",
+        subject.trim_end_matches('s'),
+        value
+    ))
+}
+
+fn extract_until_sentence_boundary(text: &str) -> String {
+    let trimmed = text.trim();
+    let boundary = trimmed.find(['.', '\n', '!', '?']).unwrap_or(trimmed.len());
+    trimmed[..boundary]
+        .trim()
+        .trim_matches('`')
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim_end_matches(',')
+        .to_string()
+}
+
+fn normalize_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn is_topic_target(target: &str) -> bool {
+    target.starts_with(&format!("{MEMORY_TOPICS_DIRNAME}/")) && target.ends_with(".md")
+}
+
+fn topic_slug_from_target(target: &str) -> Result<&str> {
+    target
+        .strip_prefix(&format!("{MEMORY_TOPICS_DIRNAME}/"))
+        .and_then(|value| value.strip_suffix(".md"))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("invalid topic target: {target}"))
+}
+
+fn slug_to_title(slug: &str) -> String {
+    slug.split('-')
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => {
+                    format!("{}{}", first.to_ascii_uppercase(), chars.as_str())
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn inbox_entry_path(memory_dir: &Path, now: DateTime<Utc>, id: &str) -> PathBuf {
+    memory_dir.join(MEMORY_INBOX_DIRNAME).join(format!(
+        "{:04}/{:02}/{:02}/{}.md",
+        now.year(),
+        now.month(),
+        now.day(),
+        id
+    ))
+}
+
+fn format_relative_memory_path(memory_dir: &Path, path: &Path) -> String {
+    path.strip_prefix(memory_dir)
+        .map(|relative| format!(".alan/memory/{}", relative.display()))
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+fn ensure_trailing_newline(content: &str) -> String {
+    let mut normalized = content.trim_end().to_string();
+    if !normalized.is_empty() {
+        normalized.push('\n');
+    }
+    normalized
+}
+
+async fn read_text_file_or_default(path: &Path) -> Result<String> {
+    match tokio::fs::read_to_string(path).await {
+        Ok(content) => Ok(content),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(err) => Err(err).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+async fn write_text_file(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("create directory {}", parent.display()))?;
+    }
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .with_context(|| format!("create {}", path.display()))?;
+    file.write_all(content.as_bytes())
+        .await
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn stage_inbox_entry_writes_expected_observed_entry() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let inbox_path = stage_inbox_entry(
+            &memory_dir,
+            InboxEntryDraft {
+                kind: "workspace_fact",
+                target: WORKSPACE_MEMORY_FILENAME.to_string(),
+                confidence: "medium",
+                observation: "The recall router should stay lexical-only.".to_string(),
+                evidence: vec!["Observed in session summary.".to_string()],
+                promotion_rationale: "Useful, but not yet confirmed as stable memory.".to_string(),
+                source_sessions: vec!["sess-123".to_string()],
+            },
+            now,
+        )
+        .await
+        .unwrap();
+
+        let stored = tokio::fs::read_to_string(&inbox_path).await.unwrap();
+        assert!(stored.contains("status: observed"));
+        assert!(stored.contains("target: MEMORY.md"));
+        assert!(stored.contains("## Observation"));
+        assert!(stored.contains("lexical-only"));
+    }
+
+    #[tokio::test]
+    async fn promote_inbox_entry_updates_memory_file_and_marks_confirmed() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let inbox_path = stage_inbox_entry(
+            &memory_dir,
+            InboxEntryDraft {
+                kind: "workspace_fact",
+                target: WORKSPACE_MEMORY_FILENAME.to_string(),
+                confidence: "high",
+                observation: "Keep memory recall lexical and file-backed.".to_string(),
+                evidence: vec!["Repeated in design notes.".to_string()],
+                promotion_rationale: "Confirmed by the user.".to_string(),
+                source_sessions: vec!["sess-456".to_string()],
+            },
+            now,
+        )
+        .await
+        .unwrap();
+
+        let outcome = promote_inbox_entry(&memory_dir, &inbox_path, now)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.target_path,
+            memory_dir.join(WORKSPACE_MEMORY_FILENAME)
+        );
+        let memory_file = tokio::fs::read_to_string(memory_dir.join(WORKSPACE_MEMORY_FILENAME))
+            .await
+            .unwrap();
+        assert!(memory_file.contains("## Promoted Facts"));
+        assert!(memory_file.contains("lexical and file-backed"));
+
+        let updated_inbox = tokio::fs::read_to_string(inbox_path).await.unwrap();
+        assert!(updated_inbox.contains("status: confirmed"));
+    }
+
+    #[tokio::test]
+    async fn promote_topic_entry_creates_topic_page_and_memory_index() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let inbox_path = stage_inbox_entry(
+            &memory_dir,
+            InboxEntryDraft {
+                kind: "topic_fact",
+                target: "topics/memory-router.md".to_string(),
+                confidence: "medium",
+                observation: "Topic pages are the overflow surface for recurring memory facts."
+                    .to_string(),
+                evidence: vec!["Repeated across multiple sessions.".to_string()],
+                promotion_rationale: "Recurring enough to deserve a topic page.".to_string(),
+                source_sessions: vec!["sess-789".to_string()],
+            },
+            now,
+        )
+        .await
+        .unwrap();
+
+        let outcome = promote_inbox_entry(&memory_dir, &inbox_path, now)
+            .await
+            .unwrap();
+
+        let topic_path = memory_dir.join("topics/memory-router.md");
+        assert_eq!(outcome.target_path, topic_path);
+
+        let topic_page = tokio::fs::read_to_string(memory_dir.join("topics/memory-router.md"))
+            .await
+            .unwrap();
+        assert!(topic_page.contains("title: Memory Router"));
+        assert!(topic_page.contains("## Stable Facts"));
+        assert!(topic_page.contains("overflow surface"));
+
+        let memory_file = tokio::fs::read_to_string(memory_dir.join(WORKSPACE_MEMORY_FILENAME))
+            .await
+            .unwrap();
+        assert!(memory_file.contains("## Topic Index"));
+        assert!(memory_file.contains("memory-router -> topics/memory-router.md"));
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_promotes_explicit_user_fact() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-confirm".to_string();
+        session.add_user_message("My favorite editor is Helix.");
+
+        capture_confirmed_turn_memory(Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert!(user_memory.contains("Favorite editor: Helix"));
+
+        let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
+        let inbox_entries = collect_markdown_files_recursively(&inbox_root);
+        assert!(!inbox_entries.is_empty());
+    }
+
+    fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {
+        let mut collected = Vec::new();
+        collect_markdown_files_recursively_inner(dir, &mut collected);
+        collected
+    }
+
+    fn collect_markdown_files_recursively_inner(dir: &Path, collected: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_markdown_files_recursively_inner(&path, collected);
+            } else if path
+                .extension()
+                .is_some_and(|extension| extension == std::ffi::OsStr::new("md"))
+            {
+                collected.push(path);
+            }
+        }
+    }
+}

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -137,7 +137,7 @@ pub(crate) async fn stage_inbox_entry(
             updated_at: now.to_rfc3339(),
             source_sessions: dedup_strings(draft.source_sessions),
         },
-        observation: draft.observation.trim().to_string(),
+        observation: normalize_inline_text(&draft.observation),
         evidence: normalize_items(draft.evidence),
         promotion_rationale: draft.promotion_rationale.trim().to_string(),
     };
@@ -166,17 +166,23 @@ pub(crate) async fn promote_inbox_entry(
     let target_path = resolve_target_path(memory_dir, &document.frontmatter.target)?;
     let promoted_from = format_relative_memory_path(memory_dir, inbox_path);
     let promoted_stamp = now.format("%F").to_string();
+    let promoted_observation = normalize_inline_text(&document.observation);
+    if promoted_observation.is_empty() {
+        bail!(
+            "inbox entry observation was empty after normalization: {}",
+            inbox_path.display()
+        );
+    }
+    document.observation = promoted_observation.clone();
     let promoted_line = format!(
         "- [{}] {} (promoted from {})",
-        promoted_stamp,
-        document.observation.trim(),
-        promoted_from
+        promoted_stamp, promoted_observation, promoted_from
     );
 
     match document.frontmatter.target.as_str() {
         MEMORY_USER_FILENAME | WORKSPACE_MEMORY_FILENAME => {
             let existing = read_text_file_or_default(&target_path).await?;
-            if !contains_promoted_observation(&existing, document.observation.trim()) {
+            if !contains_promoted_observation(&existing, &document.observation) {
                 let updated = append_markdown_section_item(
                     &existing,
                     DEFAULT_PROMOTED_FACTS_HEADER,
@@ -194,7 +200,7 @@ pub(crate) async fn promote_inbox_entry(
                 now,
                 &document.frontmatter.source_sessions,
             )?;
-            if !contains_promoted_observation(&topic, document.observation.trim()) {
+            if !contains_promoted_observation(&topic, &document.observation) {
                 topic = append_markdown_section_item(&topic, "## Stable Facts", &promoted_line);
                 for evidence in document
                     .evidence
@@ -472,10 +478,14 @@ fn normalize_items(items: Vec<String>) -> Vec<String> {
     dedup_strings(
         items
             .into_iter()
-            .map(|item| item.trim().to_string())
+            .map(|item| normalize_inline_text(&item))
             .filter(|item| !item.is_empty())
             .collect(),
     )
+}
+
+fn normalize_inline_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn merge_source_sessions(mut existing: Vec<String>, additional: &[String]) -> Vec<String> {
@@ -602,11 +612,9 @@ fn normalize_memory_promotion_candidate(
     let kind = normalize_memory_kind(&raw.kind)?;
     let target = canonical_target_for_kind(kind);
     let confidence = normalize_memory_confidence(&raw.confidence)?;
-    let observation = truncate_with_suffix(
-        raw.observation.trim(),
-        MEMORY_PROMOTION_MAX_OBSERVATION_CHARS,
-        "...",
-    );
+    let observation = normalize_inline_text(&raw.observation);
+    let observation =
+        truncate_with_suffix(&observation, MEMORY_PROMOTION_MAX_OBSERVATION_CHARS, "...");
     if observation.is_empty() {
         return None;
     }
@@ -701,7 +709,7 @@ fn contains_promoted_observation(content: &str, observation: &str) -> bool {
 fn promoted_observation_from_line(line: &str) -> Option<&str> {
     let line = line.trim();
     let (_, remainder) = line.strip_prefix("- [")?.split_once("] ")?;
-    let (observation, _) = remainder.split_once(" (promoted from ")?;
+    let (observation, _) = remainder.rsplit_once(" (promoted from ")?;
     Some(observation.trim())
 }
 
@@ -1057,6 +1065,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn promote_inbox_entry_sanitizes_multiline_observation_before_writing() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let inbox_path = memory_dir.join("inbox/2026/04/15/inbox-multiline.md");
+        tokio::fs::create_dir_all(inbox_path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(
+            &inbox_path,
+            r#"---
+id: inbox-multiline
+kind: user_identity
+status: observed
+target: USER.md
+confidence: high
+created_at: 2026-04-15T10:30:00Z
+updated_at: 2026-04-15T10:30:00Z
+source_sessions:
+  - sess-multiline
+---
+
+## Observation
+Name: Bob
+Preferred editor: Vim
+
+## Evidence
+- My name is Bob.
+
+## Promotion Rationale
+Direct user-stated stable identity detail.
+"#,
+        )
+        .await
+        .unwrap();
+
+        promote_inbox_entry(&memory_dir, &inbox_path, now)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert!(user_memory.contains("Name: Bob Preferred editor: Vim"));
+
+        let confirmed_inbox = tokio::fs::read_to_string(&inbox_path).await.unwrap();
+        assert!(confirmed_inbox.contains("## Observation\nName: Bob Preferred editor: Vim\n"));
+    }
+
+    #[tokio::test]
     async fn capture_confirmed_turn_memory_stages_medium_confidence_rule_without_promotion() {
         let temp = TempDir::new().unwrap();
         let memory_dir = temp.path().join(".alan/memory");
@@ -1174,6 +1235,38 @@ mod tests {
     }
 
     #[test]
+    fn parse_memory_promotion_candidates_normalizes_multiline_inline_fields() {
+        let candidates = parse_memory_promotion_candidates(
+            &serde_json::json!({
+                "writes": [
+                    {
+                        "kind": "user_identity",
+                        "target": "USER.md",
+                        "confidence": "high",
+                        "disposition": "promote_now",
+                        "observation": "Name: Bob\nPreferred editor: Vim",
+                        "evidence": ["My name is Bob.\nI prefer Vim."],
+                        "promotion_rationale": "Direct user-stated stable identity detail."
+                    }
+                ]
+            })
+            .to_string(),
+            "sess-inline-normalize",
+        )
+        .unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].draft.observation,
+            "Name: Bob Preferred editor: Vim"
+        );
+        assert_eq!(
+            candidates[0].draft.evidence,
+            vec!["My name is Bob. I prefer Vim."]
+        );
+    }
+
+    #[test]
     fn parse_memory_promotion_candidates_rejects_kind_target_mismatch() {
         let candidates = parse_memory_promotion_candidates(
             &serde_json::json!({
@@ -1195,6 +1288,15 @@ mod tests {
         .unwrap();
 
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn promoted_observation_from_line_uses_last_promoted_from_suffix() {
+        let line = "- [2026-04-15] Workflow rule: keep literal (promoted from docs) text intact (promoted from .alan/memory/inbox/2026/04/15/inbox-rule.md)";
+        assert_eq!(
+            promoted_observation_from_line(line),
+            Some("Workflow rule: keep literal (promoted from docs) text intact")
+        );
     }
 
     fn mock_generation_response(content: String) -> GenerationResponse {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -515,10 +515,12 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
 }
 
 fn extract_fact_after_prefix(original: &str, prefixes: &[&str]) -> Option<String> {
-    prefixes.iter().find_map(|prefix| {
-        strip_prefix_case_insensitive_after_match(original, prefix).and_then(|tail| {
-            let extracted = extract_until_sentence_boundary(tail);
-            (!extracted.is_empty()).then_some(extracted)
+    declarative_statement_candidates(original).find_map(|statement| {
+        prefixes.iter().find_map(|prefix| {
+            strip_prefix_case_insensitive(statement, prefix).and_then(|tail| {
+                let extracted = extract_until_sentence_boundary(tail);
+                (!extracted.is_empty()).then_some(extracted)
+            })
         })
     })
 }
@@ -535,12 +537,30 @@ fn strip_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a 
     Some(&text[offset..])
 }
 
-fn char_boundary_indices(text: &str) -> impl Iterator<Item = usize> + '_ {
-    std::iter::once(0).chain(text.char_indices().skip(1).map(|(idx, _)| idx))
+fn declarative_statement_candidates(text: &str) -> impl Iterator<Item = &str> {
+    let mut statements = Vec::new();
+    let mut start = 0usize;
+
+    for (idx, ch) in text.char_indices() {
+        if matches!(ch, '.' | '!' | '?' | '\n') {
+            let statement = text[start..idx].trim();
+            if !statement.is_empty() && ch != '?' {
+                statements.push(statement);
+            }
+            start = idx + ch.len_utf8();
+        }
+    }
+
+    let tail = text[start..].trim();
+    if !tail.is_empty() {
+        statements.push(tail);
+    }
+
+    statements.into_iter()
 }
 
-fn strip_prefix_case_insensitive_after_match<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
-    char_boundary_indices(text).find_map(|idx| strip_prefix_case_insensitive(&text[idx..], prefix))
+fn char_boundary_indices(text: &str) -> impl Iterator<Item = usize> + '_ {
+    std::iter::once(0).chain(text.char_indices().skip(1).map(|(idx, _)| idx))
 }
 
 fn split_once_case_insensitive<'a>(text: &'a str, delimiter: &str) -> Option<(&'a str, &'a str)> {
@@ -550,18 +570,15 @@ fn split_once_case_insensitive<'a>(text: &'a str, delimiter: &str) -> Option<(&'
 }
 
 fn extract_favorite_fact(original: &str) -> Option<String> {
-    let original_tail = strip_prefix_case_insensitive_after_match(original, "my favorite ")?;
+    let original_tail = declarative_statement_candidates(original)
+        .find_map(|statement| strip_prefix_case_insensitive(statement, "my favorite "))?;
     let (subject_raw, value_raw) = split_once_case_insensitive(original_tail, " is ")?;
     let subject = extract_until_sentence_boundary(subject_raw);
     let value = extract_until_sentence_boundary(value_raw);
     if subject.is_empty() || value.is_empty() {
         return None;
     }
-    Some(format!(
-        "Favorite {}: {}",
-        subject.trim_end_matches('s'),
-        value
-    ))
+    Some(format!("Favorite {}: {}", subject, value))
 }
 
 fn extract_until_sentence_boundary(text: &str) -> String {
@@ -828,14 +845,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capture_confirmed_turn_memory_handles_unicode_before_ascii_prefixes() {
+    async fn capture_confirmed_turn_memory_handles_unicode_in_later_favorite_statement() {
         let temp = TempDir::new().unwrap();
         let memory_dir = temp.path().join(".alan/memory");
         ensure_workspace_memory_layout_at(&memory_dir).unwrap();
 
         let mut session = Session::new();
         session.id = "sess-unicode".to_string();
-        session.add_user_message("İ my favorite editor is Éda.");
+        session.add_user_message("Intro sentence. My favorite editor is Éda.");
 
         capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
             .await
@@ -848,14 +865,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capture_confirmed_turn_memory_handles_unicode_before_name_prefix() {
+    async fn capture_confirmed_turn_memory_handles_unicode_in_later_name_statement() {
         let temp = TempDir::new().unwrap();
         let memory_dir = temp.path().join(".alan/memory");
         ensure_workspace_memory_layout_at(&memory_dir).unwrap();
 
         let mut session = Session::new();
         session.id = "sess-unicode-name".to_string();
-        session.add_user_message("İ my name is Éda.");
+        session.add_user_message("Intro sentence. My name is Éda.");
 
         capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
             .await
@@ -865,6 +882,51 @@ mod tests {
             .await
             .unwrap();
         assert!(user_memory.contains("Name: Éda"));
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_skips_question_formulations() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-question".to_string();
+        session.add_user_message("Can you confirm if my name is Bob?");
+
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert_eq!(user_memory, "# User Memory\n");
+
+        let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
+        let inbox_entries = collect_markdown_files_recursively(&inbox_root);
+        assert!(inbox_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_preserves_favorite_subject_nouns() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-class".to_string();
+        session.add_user_message("My favorite class is math.");
+
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert!(user_memory.contains("Favorite class: math"));
+        assert!(!user_memory.contains("Favorite cla: math"));
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -319,9 +319,12 @@ async fn capture_confirmed_turn_memory_for_session(
     }
 
     let now = Utc::now();
+    ensure_memory_promotion_not_cancelled(cancel)?;
     for candidate in candidates {
+        ensure_memory_promotion_not_cancelled(cancel)?;
         let inbox_path = stage_inbox_entry(memory_dir, candidate.draft, now).await?;
         if candidate.disposition == PromotionDisposition::PromoteNow {
+            ensure_memory_promotion_not_cancelled(cancel)?;
             promote_inbox_entry(memory_dir, &inbox_path, now).await?;
         }
     }
@@ -602,6 +605,14 @@ async fn generate_memory_promotion_candidates(
     .await?;
 
     parse_memory_promotion_candidates(&response.content, session_id)
+}
+
+fn ensure_memory_promotion_not_cancelled(cancel: &CancellationToken) -> Result<()> {
+    if cancel.is_cancelled() {
+        bail!("LLM request cancelled");
+    }
+
+    Ok(())
 }
 
 fn active_turn_messages(messages: &[Message], active_turn_start: Option<usize>) -> &[Message] {
@@ -1307,6 +1318,10 @@ Direct user-stated stable identity detail.
         delay: Duration,
     }
 
+    struct CancelOnGenerateMemoryPromotionProvider {
+        cancel: CancellationToken,
+    }
+
     #[async_trait]
     impl LlmProvider for DelayedMemoryPromotionProvider {
         async fn generate(
@@ -1339,6 +1354,51 @@ Direct user-stated stable identity detail.
         }
     }
 
+    #[async_trait]
+    impl LlmProvider for CancelOnGenerateMemoryPromotionProvider {
+        async fn generate(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<GenerationResponse> {
+            self.cancel.cancel();
+            Ok(mock_generation_response(
+                serde_json::json!({
+                    "writes": [
+                        {
+                            "kind": "user_identity",
+                            "target": "USER.md",
+                            "confidence": "high",
+                            "disposition": "promote_now",
+                            "observation": "Name: Morris",
+                            "evidence": ["My name is Morris."],
+                            "promotion_rationale": "Direct user-stated stable identity detail."
+                        }
+                    ]
+                })
+                .to_string(),
+            ))
+        }
+
+        async fn chat(&mut self, _system: Option<&str>, _user: &str) -> anyhow::Result<String> {
+            Err(anyhow!(
+                "CancelOnGenerateMemoryPromotionProvider does not implement chat"
+            ))
+        }
+
+        async fn generate_stream(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+            Err(anyhow!(
+                "CancelOnGenerateMemoryPromotionProvider does not implement generate_stream"
+            ))
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "cancel_on_generate_memory_promotion"
+        }
+    }
+
     #[tokio::test]
     async fn run_turn_memory_promotion_job_timeout_zero_can_be_cancelled() {
         let temp = TempDir::new().unwrap();
@@ -1368,6 +1428,40 @@ Direct user-stated stable identity detail.
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("cancelled"));
+        assert!(
+            collect_markdown_files_recursively(&memory_dir.join(MEMORY_INBOX_DIRNAME)).is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_stops_before_writes_when_cancelled_after_generation() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let cancel = CancellationToken::new();
+        let mut llm_client = LlmClient::new(CancelOnGenerateMemoryPromotionProvider {
+            cancel: cancel.clone(),
+        });
+        let active_turn_user_messages = vec!["My name is Morris.".to_string()];
+
+        let result = capture_confirmed_turn_memory_for_session(
+            &mut llm_client,
+            30,
+            &memory_dir,
+            "sess-cancel-after-generation",
+            &active_turn_user_messages,
+            &cancel,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert_eq!(user_memory, "# User Memory\n");
         assert!(
             collect_markdown_files_recursively(&memory_dir.join(MEMORY_INBOX_DIRNAME)).is_empty()
         );

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -1,22 +1,39 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Datelike, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::llm::{
+    GenerationRequest, LlmClient, Message as LlmMessage, MessageRole, build_generation_request,
+};
 use crate::prompts::{
-    MEMORY_INBOX_DIRNAME, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME, WORKSPACE_MEMORY_FILENAME,
-    ensure_workspace_memory_layout_at,
+    MEMORY_INBOX_DIRNAME, MEMORY_PROMOTION_PROMPT, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME,
+    WORKSPACE_MEMORY_FILENAME, ensure_workspace_memory_layout_at,
 };
 use crate::session::Session;
 use crate::tape::Message;
 
+use super::agent_loop::RuntimeLoopState;
+
 const DEFAULT_PROMOTED_FACTS_HEADER: &str = "## Promoted Facts";
 const DEFAULT_TOPIC_SUMMARY: &str = "Promoted from inbox entries.";
 const DEFAULT_EVIDENCE_ITEM: &str = "No evidence recorded.";
+const MEMORY_PROMOTION_MAX_TOKENS: i32 = 768;
+const MEMORY_PROMOTION_MAX_WRITES: usize = 6;
+const MEMORY_PROMOTION_MAX_OBSERVATION_CHARS: usize = 240;
+const MEMORY_PROMOTION_MAX_RATIONALE_CHARS: usize = 320;
+const MEMORY_PROMOTION_MAX_EVIDENCE_ITEMS: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromotionDisposition {
+    PromoteNow,
+    StageInbox,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct InboxEntryDraft {
@@ -63,6 +80,36 @@ struct TopicPageFrontmatter {
     entities: Vec<String>,
     updated_at: String,
     source_sessions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MemoryPromotionModelOutput {
+    #[serde(default)]
+    writes: Vec<MemoryPromotionModelWrite>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MemoryPromotionModelWrite {
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    target: String,
+    #[serde(default)]
+    confidence: String,
+    #[serde(default)]
+    disposition: String,
+    #[serde(default)]
+    observation: String,
+    #[serde(default)]
+    evidence: Vec<String>,
+    #[serde(default)]
+    promotion_rationale: String,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryPromotionCandidate {
+    disposition: PromotionDisposition,
+    draft: InboxEntryDraft,
 }
 
 pub(crate) async fn stage_inbox_entry(
@@ -192,9 +239,23 @@ pub(crate) async fn promote_inbox_entry(
     })
 }
 
-pub(crate) async fn capture_confirmed_turn_memory(
+pub(crate) async fn capture_confirmed_turn_memory(state: &mut RuntimeLoopState) -> Result<()> {
+    capture_confirmed_turn_memory_for_session(
+        state.core_config.memory.enabled,
+        state.core_config.memory.workspace_dir.as_deref(),
+        &mut state.llm_client,
+        state.runtime_config.llm_request_timeout_secs,
+        &state.session,
+        state.turn_state.active_turn_message_start(),
+    )
+    .await
+}
+
+async fn capture_confirmed_turn_memory_for_session(
     memory_enabled: bool,
     memory_dir: Option<&Path>,
+    llm_client: &mut LlmClient,
+    llm_request_timeout_secs: u64,
     session: &Session,
     active_turn_start: Option<usize>,
 ) -> Result<()> {
@@ -206,15 +267,23 @@ pub(crate) async fn capture_confirmed_turn_memory(
         return Ok(());
     };
 
-    let drafts = derive_confirmed_memory_drafts(session, active_turn_start);
-    if drafts.is_empty() {
+    let candidates = generate_memory_promotion_candidates(
+        llm_client,
+        llm_request_timeout_secs,
+        session,
+        active_turn_start,
+    )
+    .await?;
+    if candidates.is_empty() {
         return Ok(());
     }
 
     let now = Utc::now();
-    for draft in drafts {
-        let inbox_path = stage_inbox_entry(memory_dir, draft, now).await?;
-        promote_inbox_entry(memory_dir, &inbox_path, now).await?;
+    for candidate in candidates {
+        let inbox_path = stage_inbox_entry(memory_dir, candidate.draft, now).await?;
+        if candidate.disposition == PromotionDisposition::PromoteNow {
+            promote_inbox_entry(memory_dir, &inbox_path, now).await?;
+        }
     }
 
     Ok(())
@@ -422,120 +491,199 @@ fn dedup_strings(values: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn derive_confirmed_memory_drafts(
+async fn generate_memory_promotion_candidates(
+    llm_client: &mut LlmClient,
+    llm_request_timeout_secs: u64,
     session: &Session,
     active_turn_start: Option<usize>,
-) -> Vec<InboxEntryDraft> {
-    let messages = active_turn_messages(session.tape.messages(), active_turn_start);
-    let mut drafts = Vec::new();
-    let mut seen_observations = HashSet::new();
+) -> Result<Vec<MemoryPromotionCandidate>> {
+    let active_turn_user_messages =
+        active_turn_messages(session.tape.messages(), active_turn_start)
+            .iter()
+            .filter(|message| message.is_user())
+            .map(Message::text_content)
+            .filter(|text| !text.trim().is_empty())
+            .collect::<Vec<_>>();
 
-    for normalized in messages
-        .iter()
-        .filter(|message| message.is_user())
-        .map(Message::text_content)
-        .map(|text| normalize_message_for_fact_parsing(&text))
-        .filter(|text| !text.is_empty())
-    {
-        if let Some(name) = extract_fact_after_prefix(&normalized, &["my name is "]) {
-            let observation = format!("Name: {name}");
-            if seen_observations.insert(observation.clone()) {
-                drafts.push(InboxEntryDraft {
-                    kind: "user_identity",
-                    target: MEMORY_USER_FILENAME.to_string(),
-                    confidence: "high",
-                    observation,
-                    evidence: vec![normalized.clone()],
-                    promotion_rationale: "Direct user-stated stable identity detail.".to_string(),
-                    source_sessions: vec![session.id.clone()],
-                });
-            }
-        }
-
-        if let Some(preference) =
-            extract_fact_after_prefix(&normalized, &["i prefer ", "my preferred "])
-        {
-            let observation = format!("Preference: {preference}");
-            if seen_observations.insert(observation.clone()) {
-                drafts.push(InboxEntryDraft {
-                    kind: "user_preference",
-                    target: MEMORY_USER_FILENAME.to_string(),
-                    confidence: "high",
-                    observation,
-                    evidence: vec![normalized.clone()],
-                    promotion_rationale: "Direct user-stated stable preference.".to_string(),
-                    source_sessions: vec![session.id.clone()],
-                });
-            }
-        }
-
-        if let Some(favorite) = extract_favorite_fact(&normalized)
-            && seen_observations.insert(favorite.clone())
-        {
-            drafts.push(InboxEntryDraft {
-                kind: "user_preference",
-                target: MEMORY_USER_FILENAME.to_string(),
-                confidence: "high",
-                observation: favorite,
-                evidence: vec![normalized.clone()],
-                promotion_rationale: "Direct user-stated favorite/preference detail.".to_string(),
-                source_sessions: vec![session.id.clone()],
-            });
-        }
-
-        if let Some(constraint) = extract_fact_after_prefix(
-            &normalized,
-            &[
-                "remember this constraint: ",
-                "remember the constraint: ",
-                "the constraint is ",
-            ],
-        ) {
-            let observation = format!("Constraint: {constraint}");
-            if seen_observations.insert(observation.clone()) {
-                drafts.push(InboxEntryDraft {
-                    kind: "workspace_fact",
-                    target: WORKSPACE_MEMORY_FILENAME.to_string(),
-                    confidence: "high",
-                    observation,
-                    evidence: vec![normalized.clone()],
-                    promotion_rationale: "Direct user-stated durable workspace constraint."
-                        .to_string(),
-                    source_sessions: vec![session.id.clone()],
-                });
-            }
-        }
-
-        if let Some(rule) = extract_fact_after_prefix(
-            &normalized,
-            &[
-                "remember this rule: ",
-                "remember the rule: ",
-                "the rule is ",
-                "workflow rule: ",
-            ],
-        ) {
-            let observation = format!("Workflow rule: {rule}");
-            if seen_observations.insert(observation.clone()) {
-                drafts.push(InboxEntryDraft {
-                    kind: "workflow_rule",
-                    target: WORKSPACE_MEMORY_FILENAME.to_string(),
-                    confidence: "high",
-                    observation,
-                    evidence: vec![normalized.clone()],
-                    promotion_rationale: "Direct user-stated durable workflow rule.".to_string(),
-                    source_sessions: vec![session.id.clone()],
-                });
-            }
-        }
+    if active_turn_user_messages.is_empty() {
+        return Ok(Vec::new());
     }
 
-    drafts
+    let response = generate_memory_promotion_response(
+        llm_client,
+        llm_request_timeout_secs,
+        build_memory_promotion_request(active_turn_user_messages),
+    )
+    .await?;
+
+    parse_memory_promotion_candidates(&response.content, &session.id)
 }
 
 fn active_turn_messages(messages: &[Message], active_turn_start: Option<usize>) -> &[Message] {
     let turn_start = active_turn_start.unwrap_or(0).min(messages.len());
     &messages[turn_start..]
+}
+
+fn build_memory_promotion_request(active_turn_user_messages: Vec<String>) -> GenerationRequest {
+    let messages = active_turn_user_messages
+        .into_iter()
+        .map(|content| LlmMessage {
+            role: MessageRole::User,
+            content,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            tool_calls: None,
+            tool_call_id: None,
+        })
+        .collect();
+
+    build_generation_request(
+        Some(MEMORY_PROMOTION_PROMPT.to_string()),
+        messages,
+        Vec::new(),
+        Some(0.1),
+        Some(MEMORY_PROMOTION_MAX_TOKENS),
+    )
+}
+
+async fn generate_memory_promotion_response(
+    llm_client: &mut LlmClient,
+    llm_request_timeout_secs: u64,
+    request: GenerationRequest,
+) -> Result<crate::llm::GenerationResponse> {
+    if llm_request_timeout_secs == 0 {
+        return llm_client
+            .generate(request)
+            .await
+            .context("generate turn-end memory promotion plan");
+    }
+
+    tokio::time::timeout(
+        Duration::from_secs(llm_request_timeout_secs),
+        llm_client.generate(request),
+    )
+    .await
+    .context("turn-end memory promotion plan timed out")?
+    .context("generate turn-end memory promotion plan")
+}
+
+fn parse_memory_promotion_candidates(
+    raw: &str,
+    session_id: &str,
+) -> Result<Vec<MemoryPromotionCandidate>> {
+    let json = extract_json_object(raw).ok_or_else(|| {
+        anyhow!("turn-end memory promotion response did not contain a JSON object")
+    })?;
+    let parsed: MemoryPromotionModelOutput = serde_json::from_str(json)
+        .context("failed to parse turn-end memory promotion response as JSON")?;
+
+    Ok(normalize_memory_promotion_candidates(parsed, session_id))
+}
+
+fn normalize_memory_promotion_candidates(
+    raw: MemoryPromotionModelOutput,
+    session_id: &str,
+) -> Vec<MemoryPromotionCandidate> {
+    let mut seen_observations = HashSet::new();
+
+    raw.writes
+        .into_iter()
+        .filter_map(|write| normalize_memory_promotion_candidate(write, session_id))
+        .filter(|candidate| seen_observations.insert(candidate.draft.observation.clone()))
+        .take(MEMORY_PROMOTION_MAX_WRITES)
+        .collect()
+}
+
+fn normalize_memory_promotion_candidate(
+    raw: MemoryPromotionModelWrite,
+    session_id: &str,
+) -> Option<MemoryPromotionCandidate> {
+    let kind = normalize_memory_kind(&raw.kind)?;
+    let target = canonical_target_for_kind(kind);
+    let confidence = normalize_memory_confidence(&raw.confidence)?;
+    let observation = truncate_with_suffix(
+        raw.observation.trim(),
+        MEMORY_PROMOTION_MAX_OBSERVATION_CHARS,
+        "...",
+    );
+    if observation.is_empty() {
+        return None;
+    }
+
+    let evidence = normalize_items(raw.evidence)
+        .into_iter()
+        .take(MEMORY_PROMOTION_MAX_EVIDENCE_ITEMS)
+        .collect::<Vec<_>>();
+    if evidence.is_empty() {
+        return None;
+    }
+
+    let promotion_rationale = truncate_with_suffix(
+        raw.promotion_rationale.trim(),
+        MEMORY_PROMOTION_MAX_RATIONALE_CHARS,
+        "...",
+    );
+    if promotion_rationale.is_empty() {
+        return None;
+    }
+
+    let disposition = normalize_promotion_disposition(&raw.disposition, confidence);
+    let target_matches_kind = raw.target.trim().eq_ignore_ascii_case(target);
+    if !raw.target.trim().is_empty() && !target_matches_kind {
+        return None;
+    }
+
+    Some(MemoryPromotionCandidate {
+        disposition,
+        draft: InboxEntryDraft {
+            kind,
+            target: target.to_string(),
+            confidence,
+            observation,
+            evidence,
+            promotion_rationale,
+            source_sessions: vec![session_id.to_string()],
+        },
+    })
+}
+
+fn normalize_memory_kind(kind: &str) -> Option<&'static str> {
+    match kind.trim() {
+        "user_identity" => Some("user_identity"),
+        "user_preference" => Some("user_preference"),
+        "workspace_fact" => Some("workspace_fact"),
+        "workflow_rule" => Some("workflow_rule"),
+        _ => None,
+    }
+}
+
+fn canonical_target_for_kind(kind: &str) -> &'static str {
+    match kind {
+        "user_identity" | "user_preference" => MEMORY_USER_FILENAME,
+        "workspace_fact" | "workflow_rule" => WORKSPACE_MEMORY_FILENAME,
+        _ => WORKSPACE_MEMORY_FILENAME,
+    }
+}
+
+fn normalize_memory_confidence(confidence: &str) -> Option<&'static str> {
+    match confidence.trim() {
+        "high" => Some("high"),
+        "medium" => Some("medium"),
+        "low" => Some("low"),
+        _ => None,
+    }
+}
+
+fn normalize_promotion_disposition(
+    disposition: &str,
+    confidence: &'static str,
+) -> PromotionDisposition {
+    match disposition.trim() {
+        "promote_now" if confidence == "high" => PromotionDisposition::PromoteNow,
+        "promote_now" | "stage_inbox" => PromotionDisposition::StageInbox,
+        _ => PromotionDisposition::StageInbox,
+    }
 }
 
 fn contains_promoted_observation(content: &str, observation: &str) -> bool {
@@ -557,161 +705,11 @@ fn promoted_observation_from_line(line: &str) -> Option<&str> {
     Some(observation.trim())
 }
 
-fn extract_fact_after_prefix(original: &str, prefixes: &[&str]) -> Option<String> {
-    declarative_statement_candidates(original).find_map(|statement| {
-        prefixes.iter().find_map(|prefix| {
-            strip_prefix_case_insensitive(statement, prefix).and_then(|tail| {
-                let extracted = extract_until_sentence_boundary(tail);
-                (!extracted.is_empty()).then_some(extracted)
-            })
-        })
-    })
-}
-
-fn strip_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
-    let mut offset = 0usize;
-    for prefix_char in prefix.chars() {
-        let next = text[offset..].chars().next()?;
-        if !next.to_lowercase().eq(std::iter::once(prefix_char)) {
-            return None;
-        }
-        offset += next.len_utf8();
-    }
-    Some(&text[offset..])
-}
-
-fn declarative_statement_candidates(text: &str) -> impl Iterator<Item = &str> {
-    let mut statements = Vec::new();
-    let mut start = 0usize;
-
-    for (idx, ch) in text.char_indices() {
-        if is_sentence_terminator(text, idx, ch) {
-            let statement = text[start..idx].trim();
-            if !statement.is_empty() && ch != '?' {
-                statements.push(statement);
-            }
-            start = idx + ch.len_utf8();
-        }
-    }
-
-    let tail = text[start..].trim();
-    if !tail.is_empty() {
-        statements.push(tail);
-    }
-
-    statements.into_iter()
-}
-
-fn char_boundary_indices(text: &str) -> impl Iterator<Item = usize> + '_ {
-    std::iter::once(0).chain(text.char_indices().skip(1).map(|(idx, _)| idx))
-}
-
-fn split_once_case_insensitive<'a>(text: &'a str, delimiter: &str) -> Option<(&'a str, &'a str)> {
-    char_boundary_indices(text).find_map(|idx| {
-        strip_prefix_case_insensitive(&text[idx..], delimiter).map(|tail| (&text[..idx], tail))
-    })
-}
-
-fn extract_favorite_fact(original: &str) -> Option<String> {
-    let original_tail = declarative_statement_candidates(original)
-        .find_map(|statement| strip_prefix_case_insensitive(statement, "my favorite "))?;
-    let (subject_raw, value_raw) = split_once_case_insensitive(original_tail, " is ")?;
-    let subject = extract_until_sentence_boundary(subject_raw);
-    let value = extract_until_sentence_boundary(value_raw);
-    if subject.is_empty() || value.is_empty() {
-        return None;
-    }
-    Some(format!("Favorite {}: {}", subject, value))
-}
-
-fn extract_until_sentence_boundary(text: &str) -> String {
-    let trimmed = text.trim();
-    let boundary = char_boundary_indices(trimmed)
-        .find(|&idx| {
-            let tail = &trimmed[idx..];
-            tail.starts_with(['\n', '!', '?', ';'])
-                || (tail.starts_with('.') && !is_initialism_period(trimmed, idx))
-                || has_clause_boundary_delimiter(tail)
-        })
-        .unwrap_or(trimmed.len());
-    trimmed[..boundary]
-        .trim()
-        .trim_matches('`')
-        .trim_matches('"')
-        .trim_matches('\'')
-        .trim_end_matches(',')
-        .to_string()
-}
-
-fn normalize_whitespace(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn normalize_message_for_fact_parsing(text: &str) -> String {
-    text.lines()
-        .map(normalize_whitespace)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn is_sentence_terminator(text: &str, idx: usize, ch: char) -> bool {
-    matches!(ch, '\n' | '!' | '?') || (ch == '.' && !is_initialism_period(text, idx))
-}
-
-fn has_clause_boundary_delimiter(text: &str) -> bool {
-    [
-        ", and i ",
-        ", and my ",
-        ", but i ",
-        ", but my ",
-        ", and remember ",
-        ", but remember ",
-        ", so i ",
-        ", so my ",
-        ", who ",
-        ", which ",
-        ", that ",
-        ", where ",
-        ", because ",
-        ", since ",
-        ", while ",
-        ", when ",
-        ", if ",
-        ", unless ",
-        ", although ",
-        ", though ",
-        " and i ",
-        " and my ",
-        " but i ",
-        " but my ",
-        " and remember ",
-        " but remember ",
-        " so i ",
-        " so my ",
-    ]
-    .iter()
-    .any(|delimiter| strip_prefix_case_insensitive(text, delimiter).is_some())
-}
-
-fn is_initialism_period(text: &str, idx: usize) -> bool {
-    let next_idx = idx + '.'.len_utf8();
-    alphabetic_run_length_before(text, idx) == 1 && alphabetic_run_length_after(text, next_idx) == 1
-}
-
-fn alphabetic_run_length_before(text: &str, idx: usize) -> usize {
-    text[..idx]
-        .chars()
-        .rev()
-        .take_while(|ch| ch.is_alphabetic())
-        .count()
-}
-
-fn alphabetic_run_length_after(text: &str, idx: usize) -> usize {
-    text[idx..]
-        .chars()
-        .take_while(|ch| ch.is_alphabetic())
-        .count()
+fn extract_json_object(raw: &str) -> Option<&str> {
+    let trimmed = raw.trim();
+    let start = trimmed.find('{')?;
+    let end = trimmed.rfind('}')?;
+    (start <= end).then_some(&trimmed[start..=end])
 }
 
 fn is_topic_target(target: &str) -> bool {
@@ -758,6 +756,27 @@ fn format_relative_memory_path(memory_dir: &Path, path: &Path) -> String {
         .unwrap_or_else(|_| path.display().to_string())
 }
 
+fn truncate_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let suffix_chars = suffix.chars().count();
+    if suffix_chars >= max_chars {
+        return suffix.chars().take(max_chars).collect();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(suffix_chars))
+        .collect::<String>();
+    truncated.push_str(suffix);
+    truncated
+}
+
 fn ensure_trailing_newline(content: &str) -> String {
     let mut normalized = content.trim_end().to_string();
     if !normalized.is_empty() {
@@ -789,6 +808,7 @@ async fn write_text_file(path: &Path, content: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alan_llm::{GenerationResponse, MockLlmProvider, TokenUsage};
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -913,23 +933,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capture_confirmed_turn_memory_promotes_explicit_user_fact() {
+    async fn capture_confirmed_turn_memory_promotes_model_selected_user_fact() {
         let temp = TempDir::new().unwrap();
         let memory_dir = temp.path().join(".alan/memory");
         ensure_workspace_memory_layout_at(&memory_dir).unwrap();
 
         let mut session = Session::new();
         session.id = "sess-confirm".to_string();
-        session.add_user_message("My favorite editor is Helix.");
+        session.add_user_message("My name is Dr. Bob.");
+        let provider = MockLlmProvider::new().with_response(mock_generation_response(
+            serde_json::json!({
+                "writes": [
+                    {
+                        "kind": "user_identity",
+                        "target": "USER.md",
+                        "confidence": "high",
+                        "disposition": "promote_now",
+                        "observation": "Name: Dr. Bob",
+                        "evidence": ["My name is Dr. Bob."],
+                        "promotion_rationale": "Direct user-stated stable identity detail."
+                    }
+                ]
+            })
+            .to_string(),
+        ));
+        let mut llm_client = LlmClient::new(provider);
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session, Some(0))
-            .await
-            .unwrap();
+        capture_confirmed_turn_memory_for_session(
+            true,
+            Some(&memory_dir),
+            &mut llm_client,
+            30,
+            &session,
+            Some(0),
+        )
+        .await
+        .unwrap();
 
         let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
             .await
             .unwrap();
-        assert!(user_memory.contains("Favorite editor: Helix"));
+        assert!(user_memory.contains("Name: Dr. Bob"));
 
         let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
         let inbox_entries = collect_markdown_files_recursively(&inbox_root);
@@ -945,10 +989,19 @@ mod tests {
         let mut session = Session::new();
         session.id = "sess-disabled".to_string();
         session.add_user_message("My name is Morris.");
+        let provider = MockLlmProvider::new();
+        let mut llm_client = LlmClient::new(provider.clone());
 
-        capture_confirmed_turn_memory(false, Some(&memory_dir), &session, Some(0))
-            .await
-            .unwrap();
+        capture_confirmed_turn_memory_for_session(
+            false,
+            Some(&memory_dir),
+            &mut llm_client,
+            30,
+            &session,
+            Some(0),
+        )
+        .await
+        .unwrap();
 
         let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
             .await
@@ -958,49 +1011,7 @@ mod tests {
         let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
         let inbox_entries = collect_markdown_files_recursively(&inbox_root);
         assert!(inbox_entries.is_empty());
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_handles_unicode_in_later_favorite_statement() {
-        let mut session = Session::new();
-        session.id = "sess-unicode".to_string();
-        session.add_user_message("Intro sentence. My favorite editor is Éda.");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Favorite editor: Éda");
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_handles_unicode_in_later_name_statement() {
-        let mut session = Session::new();
-        session.id = "sess-unicode-name".to_string();
-        session.add_user_message("Intro sentence. My name is Éda.");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Name: Éda");
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_skips_question_formulations() {
-        let mut session = Session::new();
-        session.id = "sess-question".to_string();
-        session.add_user_message("Can you confirm if my name is Bob?");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert!(drafts.is_empty());
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_preserves_favorite_subject_nouns() {
-        let mut session = Session::new();
-        session.id = "sess-class".to_string();
-        session.add_user_message("My favorite class is math.");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Favorite class: math");
+        assert!(provider.recorded_requests().is_empty());
     }
 
     #[tokio::test]
@@ -1045,8 +1056,61 @@ mod tests {
         assert_eq!(promoted_observations, vec!["Name: Bobby", "Name: Bob"]);
     }
 
-    #[test]
-    fn derive_confirmed_memory_drafts_only_uses_active_turn_user_messages() {
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_stages_medium_confidence_rule_without_promotion() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-rule".to_string();
+        session.add_user_message("The rule is use Python 3.12.");
+        let provider = MockLlmProvider::new().with_response(mock_generation_response(
+            serde_json::json!({
+                "writes": [
+                    {
+                        "kind": "workflow_rule",
+                        "target": "MEMORY.md",
+                        "confidence": "medium",
+                        "disposition": "stage_inbox",
+                        "observation": "Workflow rule: use Python 3.12",
+                        "evidence": ["The rule is use Python 3.12."],
+                        "promotion_rationale": "Potentially durable workflow rule, but wait for confirmation."
+                    }
+                ]
+            })
+            .to_string(),
+        ));
+        let mut llm_client = LlmClient::new(provider);
+
+        capture_confirmed_turn_memory_for_session(
+            true,
+            Some(&memory_dir),
+            &mut llm_client,
+            30,
+            &session,
+            Some(0),
+        )
+        .await
+        .unwrap();
+
+        let workspace_memory =
+            tokio::fs::read_to_string(memory_dir.join(WORKSPACE_MEMORY_FILENAME))
+                .await
+                .unwrap();
+        assert_eq!(workspace_memory, "# Memory\n");
+
+        let inbox_entries =
+            collect_markdown_files_recursively(&memory_dir.join(MEMORY_INBOX_DIRNAME));
+        assert_eq!(inbox_entries.len(), 1);
+
+        let stored = tokio::fs::read_to_string(&inbox_entries[0]).await.unwrap();
+        assert!(stored.contains("status: observed"));
+        assert!(stored.contains("Workflow rule: use Python 3.12"));
+    }
+
+    #[tokio::test]
+    async fn generate_memory_promotion_candidates_only_uses_active_turn_user_messages() {
         let mut session = Session::new();
         session.id = "sess-active-turn".to_string();
         session.add_user_message("My name is Bob.");
@@ -1055,68 +1119,103 @@ mod tests {
         let active_turn_start = session.tape.messages().len();
 
         session.add_user_message("Please continue with the previous task.");
+        let provider = MockLlmProvider::new().with_response(mock_generation_response(
+            serde_json::json!({ "writes": [] }).to_string(),
+        ));
+        let mut llm_client = LlmClient::new(provider.clone());
 
-        let drafts = derive_confirmed_memory_drafts(&session, Some(active_turn_start));
+        let drafts = generate_memory_promotion_candidates(
+            &mut llm_client,
+            30,
+            &session,
+            Some(active_turn_start),
+        )
+        .await
+        .unwrap();
+
         assert!(drafts.is_empty());
+
+        let requests = provider.recorded_requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].messages.len(), 1);
+        assert_eq!(
+            requests[0].messages[0].content,
+            "Please continue with the previous task."
+        );
     }
 
     #[test]
-    fn derive_confirmed_memory_drafts_stops_name_extraction_at_clause_boundary() {
-        let mut session = Session::new();
-        session.id = "sess-clause-boundary".to_string();
-        session.add_user_message("My name is Bob and I prefer Vim.");
+    fn parse_memory_promotion_candidates_downgrades_non_high_promote_now_to_stage_inbox() {
+        let candidates = parse_memory_promotion_candidates(
+            &serde_json::json!({
+                "writes": [
+                    {
+                        "kind": "workflow_rule",
+                        "target": "MEMORY.md",
+                        "confidence": "medium",
+                        "disposition": "promote_now",
+                        "observation": "Workflow rule: use Python 3.12",
+                        "evidence": ["The rule is use Python 3.12."],
+                        "promotion_rationale": "Potentially durable rule."
+                    }
+                ]
+            })
+            .to_string(),
+            "sess-parse",
+        )
+        .unwrap();
 
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Name: Bob");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].disposition, PromotionDisposition::StageInbox);
+        assert_eq!(
+            candidates[0].draft.observation,
+            "Workflow rule: use Python 3.12"
+        );
     }
 
     #[test]
-    fn derive_confirmed_memory_drafts_stops_name_extraction_at_comma_clause_boundary() {
-        let mut session = Session::new();
-        session.id = "sess-comma-clause-boundary".to_string();
-        session.add_user_message("My name is Bob, and I prefer Vim.");
+    fn parse_memory_promotion_candidates_rejects_kind_target_mismatch() {
+        let candidates = parse_memory_promotion_candidates(
+            &serde_json::json!({
+                "writes": [
+                    {
+                        "kind": "user_identity",
+                        "target": "MEMORY.md",
+                        "confidence": "high",
+                        "disposition": "promote_now",
+                        "observation": "Name: Dr. Bob",
+                        "evidence": ["My name is Dr. Bob."],
+                        "promotion_rationale": "Direct user-stated stable identity detail."
+                    }
+                ]
+            })
+            .to_string(),
+            "sess-mismatch",
+        )
+        .unwrap();
 
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Name: Bob");
+        assert!(candidates.is_empty());
     }
 
-    #[test]
-    fn derive_confirmed_memory_drafts_preserves_multiline_fact_boundaries() {
-        let mut session = Session::new();
-        session.id = "sess-multiline".to_string();
-        session.add_user_message("My name is Bob\nI prefer Vim");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        let observations = drafts
-            .iter()
-            .map(|draft| draft.observation.as_str())
-            .collect::<Vec<_>>();
-
-        assert_eq!(observations, vec!["Name: Bob", "Preference: Vim"]);
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_preserves_commas_inside_name_values() {
-        let mut session = Session::new();
-        session.id = "sess-name-suffix".to_string();
-        session.add_user_message("My name is Bob, Jr.");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Name: Bob, Jr");
-    }
-
-    #[test]
-    fn derive_confirmed_memory_drafts_preserves_initialisms_inside_favorite_values() {
-        let mut session = Session::new();
-        session.id = "sess-initialism-city".to_string();
-        session.add_user_message("My favorite city is Washington, D.C.");
-
-        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
-        assert_eq!(drafts.len(), 1);
-        assert_eq!(drafts[0].observation, "Favorite city: Washington, D.C");
+    fn mock_generation_response(content: String) -> GenerationResponse {
+        GenerationResponse {
+            content,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: Some(TokenUsage {
+                prompt_tokens: 10,
+                cached_prompt_tokens: None,
+                completion_tokens: 5,
+                total_tokens: 15,
+                reasoning_tokens: None,
+            }),
+            finish_reason: None,
+            provider_response_id: None,
+            provider_response_status: None,
+            warnings: Vec::new(),
+        }
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -846,89 +846,47 @@ mod tests {
         assert!(inbox_entries.is_empty());
     }
 
-    #[tokio::test]
-    async fn capture_confirmed_turn_memory_handles_unicode_in_later_favorite_statement() {
-        let temp = TempDir::new().unwrap();
-        let memory_dir = temp.path().join(".alan/memory");
-        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
-
+    #[test]
+    fn derive_confirmed_memory_drafts_handles_unicode_in_later_favorite_statement() {
         let mut session = Session::new();
         session.id = "sess-unicode".to_string();
         session.add_user_message("Intro sentence. My favorite editor is Éda.");
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
-            .await
-            .unwrap();
-
-        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
-            .await
-            .unwrap();
-        assert!(user_memory.contains("Favorite editor: Éda"));
+        let drafts = derive_confirmed_memory_drafts(&session);
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Favorite editor: Éda");
     }
 
-    #[tokio::test]
-    async fn capture_confirmed_turn_memory_handles_unicode_in_later_name_statement() {
-        let temp = TempDir::new().unwrap();
-        let memory_dir = temp.path().join(".alan/memory");
-        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
-
+    #[test]
+    fn derive_confirmed_memory_drafts_handles_unicode_in_later_name_statement() {
         let mut session = Session::new();
         session.id = "sess-unicode-name".to_string();
         session.add_user_message("Intro sentence. My name is Éda.");
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
-            .await
-            .unwrap();
-
-        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
-            .await
-            .unwrap();
-        assert!(user_memory.contains("Name: Éda"));
+        let drafts = derive_confirmed_memory_drafts(&session);
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Name: Éda");
     }
 
-    #[tokio::test]
-    async fn capture_confirmed_turn_memory_skips_question_formulations() {
-        let temp = TempDir::new().unwrap();
-        let memory_dir = temp.path().join(".alan/memory");
-        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
-
+    #[test]
+    fn derive_confirmed_memory_drafts_skips_question_formulations() {
         let mut session = Session::new();
         session.id = "sess-question".to_string();
         session.add_user_message("Can you confirm if my name is Bob?");
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
-            .await
-            .unwrap();
-
-        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
-            .await
-            .unwrap();
-        assert_eq!(user_memory, "# User Memory\n");
-
-        let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
-        let inbox_entries = collect_markdown_files_recursively(&inbox_root);
-        assert!(inbox_entries.is_empty());
+        let drafts = derive_confirmed_memory_drafts(&session);
+        assert!(drafts.is_empty());
     }
 
-    #[tokio::test]
-    async fn capture_confirmed_turn_memory_preserves_favorite_subject_nouns() {
-        let temp = TempDir::new().unwrap();
-        let memory_dir = temp.path().join(".alan/memory");
-        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
-
+    #[test]
+    fn derive_confirmed_memory_drafts_preserves_favorite_subject_nouns() {
         let mut session = Session::new();
         session.id = "sess-class".to_string();
         session.add_user_message("My favorite class is math.");
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
-            .await
-            .unwrap();
-
-        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
-            .await
-            .unwrap();
-        assert!(user_memory.contains("Favorite class: math"));
-        assert!(!user_memory.contains("Favorite cla: math"));
+        let drafts = derive_confirmed_memory_drafts(&session);
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Favorite class: math");
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -191,9 +191,14 @@ pub(crate) async fn promote_inbox_entry(
 }
 
 pub(crate) async fn capture_confirmed_turn_memory(
+    memory_enabled: bool,
     memory_dir: Option<&Path>,
     session: &Session,
 ) -> Result<()> {
+    if !memory_enabled {
+        return Ok(());
+    }
+
     let Some(memory_dir) = memory_dir else {
         return Ok(());
     };
@@ -427,10 +432,9 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
     };
 
     let normalized = normalize_whitespace(&user_text);
-    let lowered = normalized.to_lowercase();
     let mut drafts = Vec::new();
 
-    if let Some(name) = extract_fact_after_prefix(&normalized, &lowered, &["my name is "]) {
+    if let Some(name) = extract_fact_after_prefix(&normalized, &["my name is "]) {
         drafts.push(InboxEntryDraft {
             kind: "user_identity",
             target: MEMORY_USER_FILENAME.to_string(),
@@ -443,7 +447,7 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
     }
 
     if let Some(preference) =
-        extract_fact_after_prefix(&normalized, &lowered, &["i prefer ", "my preferred "])
+        extract_fact_after_prefix(&normalized, &["i prefer ", "my preferred "])
     {
         drafts.push(InboxEntryDraft {
             kind: "user_preference",
@@ -456,7 +460,7 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
         });
     }
 
-    if let Some(favorite) = extract_favorite_fact(&normalized, &lowered) {
+    if let Some(favorite) = extract_favorite_fact(&normalized) {
         drafts.push(InboxEntryDraft {
             kind: "user_preference",
             target: MEMORY_USER_FILENAME.to_string(),
@@ -470,7 +474,6 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
 
     if let Some(constraint) = extract_fact_after_prefix(
         &normalized,
-        &lowered,
         &[
             "remember this constraint: ",
             "remember the constraint: ",
@@ -490,7 +493,6 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
 
     if let Some(rule) = extract_fact_after_prefix(
         &normalized,
-        &lowered,
         &[
             "remember this rule: ",
             "remember the rule: ",
@@ -512,23 +514,46 @@ fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
     drafts
 }
 
-fn extract_fact_after_prefix(original: &str, lowered: &str, prefixes: &[&str]) -> Option<String> {
+fn extract_fact_after_prefix(original: &str, prefixes: &[&str]) -> Option<String> {
     prefixes.iter().find_map(|prefix| {
-        lowered.find(prefix).and_then(|start| {
-            let start = start + prefix.len();
-            let extracted = extract_until_sentence_boundary(&original[start..]);
+        strip_prefix_case_insensitive_after_match(original, prefix).and_then(|tail| {
+            let extracted = extract_until_sentence_boundary(tail);
             (!extracted.is_empty()).then_some(extracted)
         })
     })
 }
 
-fn extract_favorite_fact(original: &str, lowered: &str) -> Option<String> {
-    let favorite_start = lowered.find("my favorite ")?;
-    let original_tail = &original[favorite_start + "my favorite ".len()..];
-    let lowered_tail = &lowered[favorite_start + "my favorite ".len()..];
-    let is_pos = lowered_tail.find(" is ")?;
-    let subject = extract_until_sentence_boundary(&original_tail[..is_pos]);
-    let value = extract_until_sentence_boundary(&original_tail[is_pos + " is ".len()..]);
+fn strip_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    let mut offset = 0usize;
+    for prefix_char in prefix.chars() {
+        let next = text[offset..].chars().next()?;
+        if !next.to_lowercase().eq(std::iter::once(prefix_char)) {
+            return None;
+        }
+        offset += next.len_utf8();
+    }
+    Some(&text[offset..])
+}
+
+fn char_boundary_indices(text: &str) -> impl Iterator<Item = usize> + '_ {
+    std::iter::once(0).chain(text.char_indices().skip(1).map(|(idx, _)| idx))
+}
+
+fn strip_prefix_case_insensitive_after_match<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    char_boundary_indices(text).find_map(|idx| strip_prefix_case_insensitive(&text[idx..], prefix))
+}
+
+fn split_once_case_insensitive<'a>(text: &'a str, delimiter: &str) -> Option<(&'a str, &'a str)> {
+    char_boundary_indices(text).find_map(|idx| {
+        strip_prefix_case_insensitive(&text[idx..], delimiter).map(|tail| (&text[..idx], tail))
+    })
+}
+
+fn extract_favorite_fact(original: &str) -> Option<String> {
+    let original_tail = strip_prefix_case_insensitive_after_match(original, "my favorite ")?;
+    let (subject_raw, value_raw) = split_once_case_insensitive(original_tail, " is ")?;
+    let subject = extract_until_sentence_boundary(subject_raw);
+    let value = extract_until_sentence_boundary(value_raw);
     if subject.is_empty() || value.is_empty() {
         return None;
     }
@@ -764,7 +789,7 @@ mod tests {
         session.id = "sess-confirm".to_string();
         session.add_user_message("My favorite editor is Helix.");
 
-        capture_confirmed_turn_memory(Some(&memory_dir), &session)
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
             .await
             .unwrap();
 
@@ -776,6 +801,70 @@ mod tests {
         let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
         let inbox_entries = collect_markdown_files_recursively(&inbox_root);
         assert!(!inbox_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_is_noop_when_memory_disabled() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-disabled".to_string();
+        session.add_user_message("My name is Morris.");
+
+        capture_confirmed_turn_memory(false, Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert_eq!(user_memory, "# User Memory\n");
+
+        let inbox_root = memory_dir.join(MEMORY_INBOX_DIRNAME);
+        let inbox_entries = collect_markdown_files_recursively(&inbox_root);
+        assert!(inbox_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_handles_unicode_before_ascii_prefixes() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-unicode".to_string();
+        session.add_user_message("İ my favorite editor is Éda.");
+
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert!(user_memory.contains("Favorite editor: Éda"));
+    }
+
+    #[tokio::test]
+    async fn capture_confirmed_turn_memory_handles_unicode_before_name_prefix() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+
+        let mut session = Session::new();
+        session.id = "sess-unicode-name".to_string();
+        session.add_user_message("İ my name is Éda.");
+
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        assert!(user_memory.contains("Name: Éda"));
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     time::Duration,
 };
 
@@ -430,7 +430,9 @@ fn resolve_target_path(memory_dir: &Path, target: &str) -> Result<PathBuf> {
     match target {
         MEMORY_USER_FILENAME => Ok(memory_dir.join(MEMORY_USER_FILENAME)),
         WORKSPACE_MEMORY_FILENAME => Ok(memory_dir.join(WORKSPACE_MEMORY_FILENAME)),
-        _ if is_topic_target(target) => Ok(memory_dir.join(target)),
+        _ if is_topic_target(target) => Ok(memory_dir
+            .join(MEMORY_TOPICS_DIRNAME)
+            .join(format!("{}.md", topic_slug_from_target(target)?))),
         _ => bail!("unsupported inbox target path: {target}"),
     }
 }
@@ -822,14 +824,29 @@ fn extract_json_object(raw: &str) -> Option<&str> {
 }
 
 fn is_topic_target(target: &str) -> bool {
-    target.starts_with(&format!("{MEMORY_TOPICS_DIRNAME}/")) && target.ends_with(".md")
+    topic_slug_from_target(target).is_ok()
 }
 
 fn topic_slug_from_target(target: &str) -> Result<&str> {
-    target
-        .strip_prefix(&format!("{MEMORY_TOPICS_DIRNAME}/"))
+    let mut components = Path::new(target).components();
+    let Some(Component::Normal(dirname)) = components.next() else {
+        bail!("invalid topic target: {target}");
+    };
+    if dirname != std::ffi::OsStr::new(MEMORY_TOPICS_DIRNAME) {
+        bail!("invalid topic target: {target}");
+    }
+
+    let Some(Component::Normal(filename)) = components.next() else {
+        bail!("invalid topic target: {target}");
+    };
+    if components.next().is_some() {
+        bail!("invalid topic target: {target}");
+    }
+
+    filename
+        .to_str()
         .and_then(|value| value.strip_suffix(".md"))
-        .filter(|value| !value.trim().is_empty())
+        .filter(|value| !value.trim().is_empty() && *value != "." && *value != "..")
         .ok_or_else(|| anyhow!("invalid topic target: {target}"))
 }
 
@@ -1043,6 +1060,37 @@ mod tests {
             .unwrap();
         assert!(memory_file.contains("## Topic Index"));
         assert!(memory_file.contains("memory-router -> topics/memory-router.md"));
+    }
+
+    #[tokio::test]
+    async fn promote_inbox_entry_rejects_topic_target_path_traversal() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let inbox_path = stage_inbox_entry(
+            &memory_dir,
+            InboxEntryDraft {
+                kind: "topic_fact",
+                target: "topics/../../outside.md".to_string(),
+                confidence: "medium",
+                observation: "Traversal should never be accepted.".to_string(),
+                evidence: vec!["Imported inbox entry.".to_string()],
+                promotion_rationale: "Regression coverage for target validation.".to_string(),
+                source_sessions: vec!["sess-traversal".to_string()],
+            },
+            now,
+        )
+        .await
+        .unwrap();
+
+        let err = promote_inbox_entry(&memory_dir, &inbox_path, now)
+            .await
+            .expect_err("traversal target should be rejected");
+        assert!(err.to_string().contains("unsupported inbox target path"));
+        assert!(!temp.path().join("outside.md").exists());
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -702,8 +702,9 @@ mod tests {
         .unwrap();
 
         let stored = tokio::fs::read_to_string(&inbox_path).await.unwrap();
-        assert!(stored.contains("status: observed"));
-        assert!(stored.contains("target: MEMORY.md"));
+        let parsed = parse_inbox_entry(&stored).unwrap();
+        assert_eq!(parsed.frontmatter.status, "observed");
+        assert_eq!(parsed.frontmatter.target, WORKSPACE_MEMORY_FILENAME);
         assert!(stored.contains("## Observation"));
         assert!(stored.contains("lexical-only"));
     }
@@ -747,7 +748,8 @@ mod tests {
         assert!(memory_file.contains("lexical and file-backed"));
 
         let updated_inbox = tokio::fs::read_to_string(inbox_path).await.unwrap();
-        assert!(updated_inbox.contains("status: confirmed"));
+        let parsed = parse_inbox_entry(&updated_inbox).unwrap();
+        assert_eq!(parsed.frontmatter.status, "confirmed");
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -434,7 +434,7 @@ fn derive_confirmed_memory_drafts(
         .iter()
         .filter(|message| message.is_user())
         .map(Message::text_content)
-        .map(|text| normalize_whitespace(&text))
+        .map(|text| normalize_message_for_fact_parsing(&text))
         .filter(|text| !text.is_empty())
     {
         if let Some(name) = extract_fact_after_prefix(&normalized, &["my name is "]) {
@@ -655,6 +655,14 @@ fn extract_until_sentence_boundary(text: &str) -> String {
 
 fn normalize_whitespace(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn normalize_message_for_fact_parsing(text: &str) -> String {
+    text.lines()
+        .map(normalize_whitespace)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn is_topic_target(target: &str) -> bool {
@@ -1012,6 +1020,21 @@ mod tests {
         let drafts = derive_confirmed_memory_drafts(&session, Some(0));
         assert_eq!(drafts.len(), 1);
         assert_eq!(drafts[0].observation, "Name: Bob");
+    }
+
+    #[test]
+    fn derive_confirmed_memory_drafts_preserves_multiline_fact_boundaries() {
+        let mut session = Session::new();
+        session.id = "sess-multiline".to_string();
+        session.add_user_message("My name is Bob\nI prefer Vim");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
+        let observations = drafts
+            .iter()
+            .map(|draft| draft.observation.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(observations, vec!["Name: Bob", "Preference: Vim"]);
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -585,7 +585,7 @@ fn declarative_statement_candidates(text: &str) -> impl Iterator<Item = &str> {
     let mut start = 0usize;
 
     for (idx, ch) in text.char_indices() {
-        if matches!(ch, '.' | '!' | '?' | '\n') {
+        if is_sentence_terminator(text, idx, ch) {
             let statement = text[start..idx].trim();
             if !statement.is_empty() && ch != '?' {
                 statements.push(statement);
@@ -629,19 +629,9 @@ fn extract_until_sentence_boundary(text: &str) -> String {
     let boundary = char_boundary_indices(trimmed)
         .find(|&idx| {
             let tail = &trimmed[idx..];
-            tail.starts_with(['.', '\n', '!', '?', ',', ';'])
-                || [
-                    " and i ",
-                    " and my ",
-                    " but i ",
-                    " but my ",
-                    " and remember ",
-                    " but remember ",
-                    " so i ",
-                    " so my ",
-                ]
-                .iter()
-                .any(|delimiter| strip_prefix_case_insensitive(tail, delimiter).is_some())
+            tail.starts_with(['\n', '!', '?', ';'])
+                || (tail.starts_with('.') && !is_initialism_period(trimmed, idx))
+                || has_clause_boundary_delimiter(tail)
         })
         .unwrap_or(trimmed.len());
     trimmed[..boundary]
@@ -663,6 +653,65 @@ fn normalize_message_for_fact_parsing(text: &str) -> String {
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn is_sentence_terminator(text: &str, idx: usize, ch: char) -> bool {
+    matches!(ch, '\n' | '!' | '?') || (ch == '.' && !is_initialism_period(text, idx))
+}
+
+fn has_clause_boundary_delimiter(text: &str) -> bool {
+    [
+        ", and i ",
+        ", and my ",
+        ", but i ",
+        ", but my ",
+        ", and remember ",
+        ", but remember ",
+        ", so i ",
+        ", so my ",
+        ", who ",
+        ", which ",
+        ", that ",
+        ", where ",
+        ", because ",
+        ", since ",
+        ", while ",
+        ", when ",
+        ", if ",
+        ", unless ",
+        ", although ",
+        ", though ",
+        " and i ",
+        " and my ",
+        " but i ",
+        " but my ",
+        " and remember ",
+        " but remember ",
+        " so i ",
+        " so my ",
+    ]
+    .iter()
+    .any(|delimiter| strip_prefix_case_insensitive(text, delimiter).is_some())
+}
+
+fn is_initialism_period(text: &str, idx: usize) -> bool {
+    let next_idx = idx + '.'.len_utf8();
+    alphabetic_run_length_before(text, idx) == 1 && alphabetic_run_length_after(text, next_idx) == 1
+}
+
+fn alphabetic_run_length_before(text: &str, idx: usize) -> usize {
+    text[..idx]
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_alphabetic())
+        .count()
+}
+
+fn alphabetic_run_length_after(text: &str, idx: usize) -> usize {
+    text[idx..]
+        .chars()
+        .take_while(|ch| ch.is_alphabetic())
+        .count()
 }
 
 fn is_topic_target(target: &str) -> bool {
@@ -1023,6 +1072,17 @@ mod tests {
     }
 
     #[test]
+    fn derive_confirmed_memory_drafts_stops_name_extraction_at_comma_clause_boundary() {
+        let mut session = Session::new();
+        session.id = "sess-comma-clause-boundary".to_string();
+        session.add_user_message("My name is Bob, and I prefer Vim.");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Name: Bob");
+    }
+
+    #[test]
     fn derive_confirmed_memory_drafts_preserves_multiline_fact_boundaries() {
         let mut session = Session::new();
         session.id = "sess-multiline".to_string();
@@ -1035,6 +1095,28 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(observations, vec!["Name: Bob", "Preference: Vim"]);
+    }
+
+    #[test]
+    fn derive_confirmed_memory_drafts_preserves_commas_inside_name_values() {
+        let mut session = Session::new();
+        session.id = "sess-name-suffix".to_string();
+        session.add_user_message("My name is Bob, Jr.");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Name: Bob, Jr");
+    }
+
+    #[test]
+    fn derive_confirmed_memory_drafts_preserves_initialisms_inside_favorite_values() {
+        let mut session = Session::new();
+        session.id = "sess-initialism-city".to_string();
+        session.add_user_message("My favorite city is Washington, D.C.");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Favorite city: Washington, D.C");
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/memory_promotion.rs
+++ b/crates/runtime/src/runtime/memory_promotion.rs
@@ -1,9 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Datelike, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 
 use crate::prompts::{
     MEMORY_INBOX_DIRNAME, MEMORY_TOPICS_DIRNAME, MEMORY_USER_FILENAME, WORKSPACE_MEMORY_FILENAME,
@@ -127,7 +129,7 @@ pub(crate) async fn promote_inbox_entry(
     match document.frontmatter.target.as_str() {
         MEMORY_USER_FILENAME | WORKSPACE_MEMORY_FILENAME => {
             let existing = read_text_file_or_default(&target_path).await?;
-            if !existing.contains(document.observation.trim()) {
+            if !contains_promoted_observation(&existing, document.observation.trim()) {
                 let updated = append_markdown_section_item(
                     &existing,
                     DEFAULT_PROMOTED_FACTS_HEADER,
@@ -145,7 +147,7 @@ pub(crate) async fn promote_inbox_entry(
                 now,
                 &document.frontmatter.source_sessions,
             )?;
-            if !topic.contains(document.observation.trim()) {
+            if !contains_promoted_observation(&topic, document.observation.trim()) {
                 topic = append_markdown_section_item(&topic, "## Stable Facts", &promoted_line);
                 for evidence in document
                     .evidence
@@ -194,6 +196,7 @@ pub(crate) async fn capture_confirmed_turn_memory(
     memory_enabled: bool,
     memory_dir: Option<&Path>,
     session: &Session,
+    active_turn_start: Option<usize>,
 ) -> Result<()> {
     if !memory_enabled {
         return Ok(());
@@ -203,7 +206,7 @@ pub(crate) async fn capture_confirmed_turn_memory(
         return Ok(());
     };
 
-    let drafts = derive_confirmed_memory_drafts(session);
+    let drafts = derive_confirmed_memory_drafts(session, active_turn_start);
     if drafts.is_empty() {
         return Ok(());
     }
@@ -419,99 +422,139 @@ fn dedup_strings(values: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn derive_confirmed_memory_drafts(session: &Session) -> Vec<InboxEntryDraft> {
-    let Some(user_text) = session
-        .tape
-        .messages()
-        .iter()
-        .rev()
-        .find(|message| message.is_user())
-        .map(Message::text_content)
-    else {
-        return Vec::new();
-    };
-
-    let normalized = normalize_whitespace(&user_text);
+fn derive_confirmed_memory_drafts(
+    session: &Session,
+    active_turn_start: Option<usize>,
+) -> Vec<InboxEntryDraft> {
+    let messages = active_turn_messages(session.tape.messages(), active_turn_start);
     let mut drafts = Vec::new();
+    let mut seen_observations = HashSet::new();
 
-    if let Some(name) = extract_fact_after_prefix(&normalized, &["my name is "]) {
-        drafts.push(InboxEntryDraft {
-            kind: "user_identity",
-            target: MEMORY_USER_FILENAME.to_string(),
-            confidence: "high",
-            observation: format!("Name: {name}"),
-            evidence: vec![normalized.clone()],
-            promotion_rationale: "Direct user-stated stable identity detail.".to_string(),
-            source_sessions: vec![session.id.clone()],
-        });
-    }
-
-    if let Some(preference) =
-        extract_fact_after_prefix(&normalized, &["i prefer ", "my preferred "])
+    for normalized in messages
+        .iter()
+        .filter(|message| message.is_user())
+        .map(Message::text_content)
+        .map(|text| normalize_whitespace(&text))
+        .filter(|text| !text.is_empty())
     {
-        drafts.push(InboxEntryDraft {
-            kind: "user_preference",
-            target: MEMORY_USER_FILENAME.to_string(),
-            confidence: "high",
-            observation: format!("Preference: {preference}"),
-            evidence: vec![normalized.clone()],
-            promotion_rationale: "Direct user-stated stable preference.".to_string(),
-            source_sessions: vec![session.id.clone()],
-        });
-    }
+        if let Some(name) = extract_fact_after_prefix(&normalized, &["my name is "]) {
+            let observation = format!("Name: {name}");
+            if seen_observations.insert(observation.clone()) {
+                drafts.push(InboxEntryDraft {
+                    kind: "user_identity",
+                    target: MEMORY_USER_FILENAME.to_string(),
+                    confidence: "high",
+                    observation,
+                    evidence: vec![normalized.clone()],
+                    promotion_rationale: "Direct user-stated stable identity detail.".to_string(),
+                    source_sessions: vec![session.id.clone()],
+                });
+            }
+        }
 
-    if let Some(favorite) = extract_favorite_fact(&normalized) {
-        drafts.push(InboxEntryDraft {
-            kind: "user_preference",
-            target: MEMORY_USER_FILENAME.to_string(),
-            confidence: "high",
-            observation: favorite,
-            evidence: vec![normalized.clone()],
-            promotion_rationale: "Direct user-stated favorite/preference detail.".to_string(),
-            source_sessions: vec![session.id.clone()],
-        });
-    }
+        if let Some(preference) =
+            extract_fact_after_prefix(&normalized, &["i prefer ", "my preferred "])
+        {
+            let observation = format!("Preference: {preference}");
+            if seen_observations.insert(observation.clone()) {
+                drafts.push(InboxEntryDraft {
+                    kind: "user_preference",
+                    target: MEMORY_USER_FILENAME.to_string(),
+                    confidence: "high",
+                    observation,
+                    evidence: vec![normalized.clone()],
+                    promotion_rationale: "Direct user-stated stable preference.".to_string(),
+                    source_sessions: vec![session.id.clone()],
+                });
+            }
+        }
 
-    if let Some(constraint) = extract_fact_after_prefix(
-        &normalized,
-        &[
-            "remember this constraint: ",
-            "remember the constraint: ",
-            "the constraint is ",
-        ],
-    ) {
-        drafts.push(InboxEntryDraft {
-            kind: "workspace_fact",
-            target: WORKSPACE_MEMORY_FILENAME.to_string(),
-            confidence: "high",
-            observation: format!("Constraint: {constraint}"),
-            evidence: vec![normalized.clone()],
-            promotion_rationale: "Direct user-stated durable workspace constraint.".to_string(),
-            source_sessions: vec![session.id.clone()],
-        });
-    }
+        if let Some(favorite) = extract_favorite_fact(&normalized)
+            && seen_observations.insert(favorite.clone())
+        {
+            drafts.push(InboxEntryDraft {
+                kind: "user_preference",
+                target: MEMORY_USER_FILENAME.to_string(),
+                confidence: "high",
+                observation: favorite,
+                evidence: vec![normalized.clone()],
+                promotion_rationale: "Direct user-stated favorite/preference detail.".to_string(),
+                source_sessions: vec![session.id.clone()],
+            });
+        }
 
-    if let Some(rule) = extract_fact_after_prefix(
-        &normalized,
-        &[
-            "remember this rule: ",
-            "remember the rule: ",
-            "the rule is ",
-            "workflow rule: ",
-        ],
-    ) {
-        drafts.push(InboxEntryDraft {
-            kind: "workflow_rule",
-            target: WORKSPACE_MEMORY_FILENAME.to_string(),
-            confidence: "high",
-            observation: format!("Workflow rule: {rule}"),
-            evidence: vec![normalized.clone()],
-            promotion_rationale: "Direct user-stated durable workflow rule.".to_string(),
-            source_sessions: vec![session.id.clone()],
-        });
+        if let Some(constraint) = extract_fact_after_prefix(
+            &normalized,
+            &[
+                "remember this constraint: ",
+                "remember the constraint: ",
+                "the constraint is ",
+            ],
+        ) {
+            let observation = format!("Constraint: {constraint}");
+            if seen_observations.insert(observation.clone()) {
+                drafts.push(InboxEntryDraft {
+                    kind: "workspace_fact",
+                    target: WORKSPACE_MEMORY_FILENAME.to_string(),
+                    confidence: "high",
+                    observation,
+                    evidence: vec![normalized.clone()],
+                    promotion_rationale: "Direct user-stated durable workspace constraint."
+                        .to_string(),
+                    source_sessions: vec![session.id.clone()],
+                });
+            }
+        }
+
+        if let Some(rule) = extract_fact_after_prefix(
+            &normalized,
+            &[
+                "remember this rule: ",
+                "remember the rule: ",
+                "the rule is ",
+                "workflow rule: ",
+            ],
+        ) {
+            let observation = format!("Workflow rule: {rule}");
+            if seen_observations.insert(observation.clone()) {
+                drafts.push(InboxEntryDraft {
+                    kind: "workflow_rule",
+                    target: WORKSPACE_MEMORY_FILENAME.to_string(),
+                    confidence: "high",
+                    observation,
+                    evidence: vec![normalized.clone()],
+                    promotion_rationale: "Direct user-stated durable workflow rule.".to_string(),
+                    source_sessions: vec![session.id.clone()],
+                });
+            }
+        }
     }
 
     drafts
+}
+
+fn active_turn_messages(messages: &[Message], active_turn_start: Option<usize>) -> &[Message] {
+    let turn_start = active_turn_start.unwrap_or(0).min(messages.len());
+    &messages[turn_start..]
+}
+
+fn contains_promoted_observation(content: &str, observation: &str) -> bool {
+    let observation = observation.trim();
+    if observation.is_empty() {
+        return false;
+    }
+
+    content
+        .lines()
+        .filter_map(promoted_observation_from_line)
+        .any(|existing| existing == observation)
+}
+
+fn promoted_observation_from_line(line: &str) -> Option<&str> {
+    let line = line.trim();
+    let (_, remainder) = line.strip_prefix("- [")?.split_once("] ")?;
+    let (observation, _) = remainder.split_once(" (promoted from ")?;
+    Some(observation.trim())
 }
 
 fn extract_fact_after_prefix(original: &str, prefixes: &[&str]) -> Option<String> {
@@ -583,7 +626,24 @@ fn extract_favorite_fact(original: &str) -> Option<String> {
 
 fn extract_until_sentence_boundary(text: &str) -> String {
     let trimmed = text.trim();
-    let boundary = trimmed.find(['.', '\n', '!', '?']).unwrap_or(trimmed.len());
+    let boundary = char_boundary_indices(trimmed)
+        .find(|&idx| {
+            let tail = &trimmed[idx..];
+            tail.starts_with(['.', '\n', '!', '?', ',', ';'])
+                || [
+                    " and i ",
+                    " and my ",
+                    " but i ",
+                    " but my ",
+                    " and remember ",
+                    " but remember ",
+                    " so i ",
+                    " so my ",
+                ]
+                .iter()
+                .any(|delimiter| strip_prefix_case_insensitive(tail, delimiter).is_some())
+        })
+        .unwrap_or(trimmed.len());
     trimmed[..boundary]
         .trim()
         .trim_matches('`')
@@ -663,10 +723,7 @@ async fn write_text_file(path: &Path, content: &str) -> Result<()> {
             .await
             .with_context(|| format!("create directory {}", parent.display()))?;
     }
-    let mut file = tokio::fs::File::create(path)
-        .await
-        .with_context(|| format!("create {}", path.display()))?;
-    file.write_all(content.as_bytes())
+    tokio::fs::write(path, content)
         .await
         .with_context(|| format!("write {}", path.display()))?;
     Ok(())
@@ -808,7 +865,7 @@ mod tests {
         session.id = "sess-confirm".to_string();
         session.add_user_message("My favorite editor is Helix.");
 
-        capture_confirmed_turn_memory(true, Some(&memory_dir), &session)
+        capture_confirmed_turn_memory(true, Some(&memory_dir), &session, Some(0))
             .await
             .unwrap();
 
@@ -832,7 +889,7 @@ mod tests {
         session.id = "sess-disabled".to_string();
         session.add_user_message("My name is Morris.");
 
-        capture_confirmed_turn_memory(false, Some(&memory_dir), &session)
+        capture_confirmed_turn_memory(false, Some(&memory_dir), &session, Some(0))
             .await
             .unwrap();
 
@@ -852,7 +909,7 @@ mod tests {
         session.id = "sess-unicode".to_string();
         session.add_user_message("Intro sentence. My favorite editor is Éda.");
 
-        let drafts = derive_confirmed_memory_drafts(&session);
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
         assert_eq!(drafts.len(), 1);
         assert_eq!(drafts[0].observation, "Favorite editor: Éda");
     }
@@ -863,7 +920,7 @@ mod tests {
         session.id = "sess-unicode-name".to_string();
         session.add_user_message("Intro sentence. My name is Éda.");
 
-        let drafts = derive_confirmed_memory_drafts(&session);
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
         assert_eq!(drafts.len(), 1);
         assert_eq!(drafts[0].observation, "Name: Éda");
     }
@@ -874,7 +931,7 @@ mod tests {
         session.id = "sess-question".to_string();
         session.add_user_message("Can you confirm if my name is Bob?");
 
-        let drafts = derive_confirmed_memory_drafts(&session);
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
         assert!(drafts.is_empty());
     }
 
@@ -884,9 +941,77 @@ mod tests {
         session.id = "sess-class".to_string();
         session.add_user_message("My favorite class is math.");
 
-        let drafts = derive_confirmed_memory_drafts(&session);
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
         assert_eq!(drafts.len(), 1);
         assert_eq!(drafts[0].observation, "Favorite class: math");
+    }
+
+    #[tokio::test]
+    async fn promote_inbox_entry_treats_similar_facts_as_distinct_observations() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+        ensure_workspace_memory_layout_at(&memory_dir).unwrap();
+        let existing_memory = "# User Memory\n\n## Promoted Facts\n\n- [2026-04-14] Name: Bobby (promoted from .alan/memory/inbox/2026/04/14/inbox-old.md)\n";
+        tokio::fs::write(memory_dir.join(MEMORY_USER_FILENAME), existing_memory)
+            .await
+            .unwrap();
+        let now = DateTime::parse_from_rfc3339("2026-04-15T10:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let inbox_path = stage_inbox_entry(
+            &memory_dir,
+            InboxEntryDraft {
+                kind: "user_identity",
+                target: MEMORY_USER_FILENAME.to_string(),
+                confidence: "high",
+                observation: "Name: Bob".to_string(),
+                evidence: vec!["My name is Bob.".to_string()],
+                promotion_rationale: "Direct user-stated stable identity detail.".to_string(),
+                source_sessions: vec!["sess-bob".to_string()],
+            },
+            now,
+        )
+        .await
+        .unwrap();
+
+        promote_inbox_entry(&memory_dir, &inbox_path, now)
+            .await
+            .unwrap();
+
+        let user_memory = tokio::fs::read_to_string(memory_dir.join(MEMORY_USER_FILENAME))
+            .await
+            .unwrap();
+        let promoted_observations = user_memory
+            .lines()
+            .filter_map(promoted_observation_from_line)
+            .collect::<Vec<_>>();
+        assert_eq!(promoted_observations, vec!["Name: Bobby", "Name: Bob"]);
+    }
+
+    #[test]
+    fn derive_confirmed_memory_drafts_only_uses_active_turn_user_messages() {
+        let mut session = Session::new();
+        session.id = "sess-active-turn".to_string();
+        session.add_user_message("My name is Bob.");
+        session.add_assistant_message("Noted.", None);
+
+        let active_turn_start = session.tape.messages().len();
+
+        session.add_user_message("Please continue with the previous task.");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(active_turn_start));
+        assert!(drafts.is_empty());
+    }
+
+    #[test]
+    fn derive_confirmed_memory_drafts_stops_name_extraction_at_clause_boundary() {
+        let mut session = Session::new();
+        session.id = "sess-clause-boundary".to_string();
+        session.add_user_message("My name is Bob and I prefer Vim.");
+
+        let drafts = derive_confirmed_memory_drafts(&session, Some(0));
+        assert_eq!(drafts.len(), 1);
+        assert_eq!(drafts[0].observation, "Name: Bob");
     }
 
     fn collect_markdown_files_recursively(dir: &Path) -> Vec<PathBuf> {

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -8,6 +8,7 @@ mod compaction;
 mod engine;
 mod loop_guard;
 mod memory_flush;
+mod memory_promotion;
 mod memory_recall;
 mod memory_surfaces;
 mod prompt_cache;

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -2320,11 +2320,14 @@ mod tests {
         let actions = state.turn_state.drain_deferred_runtime_actions();
         let count = actions.len();
         for action in actions {
-            super::super::agent_loop::run_deferred_runtime_action_with_cancel(
-                state, action, &cancel,
-            )
-            .await
-            .expect("run deferred runtime action");
+            assert_eq!(
+                super::super::agent_loop::run_deferred_runtime_action_with_cancel(
+                    state, action, &cancel,
+                )
+                .await,
+                super::super::agent_loop::DeferredRuntimeActionExit::Completed,
+                "run deferred runtime action"
+            );
         }
         count
     }

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -94,7 +94,7 @@ fn estimate_pending_turn_prompt_tokens(
 }
 
 async fn finalize_turn_memory_best_effort(
-    state: &RuntimeLoopState,
+    state: &mut RuntimeLoopState,
     surfaces_refreshed: bool,
     surfaces_context: &'static str,
     promotion_context: &'static str,
@@ -104,14 +104,7 @@ async fn finalize_turn_memory_best_effort(
             .await;
     }
 
-    if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
-        state.core_config.memory.enabled,
-        state.core_config.memory.workspace_dir.as_deref(),
-        &state.session,
-        state.turn_state.active_turn_message_start(),
-    )
-    .await
-    {
+    if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(state).await {
         warn!(error = %err, context = promotion_context, "Failed to capture confirmed turn memory");
     }
 }
@@ -1760,6 +1753,50 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
 
+    fn maybe_memory_promotion_response(request: &GenerationRequest) -> Option<GenerationResponse> {
+        let system_prompt = request.system_prompt.as_deref()?;
+        if system_prompt != crate::prompts::MEMORY_PROMOTION_PROMPT {
+            return None;
+        }
+
+        let joined_user_text = request
+            .messages
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let content = if joined_user_text.contains("My name is Morris.") {
+            serde_json::json!({
+                "writes": [{
+                    "kind": "user_identity",
+                    "target": "USER.md",
+                    "confidence": "high",
+                    "disposition": "promote_now",
+                    "observation": "Name: Morris",
+                    "evidence": ["My name is Morris."],
+                    "promotion_rationale": "Direct user-stated stable identity detail."
+                }]
+            })
+            .to_string()
+        } else {
+            serde_json::json!({ "writes": [] }).to_string()
+        };
+
+        Some(GenerationResponse {
+            content,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: None,
+            finish_reason: None,
+            warnings: Vec::new(),
+            provider_response_id: None,
+            provider_response_status: None,
+        })
+    }
+
     // Mock provider that returns content without tool calls
     struct ContentMockProvider {
         content: String,
@@ -1784,8 +1821,11 @@ mod tests {
     impl LlmProvider for ContentMockProvider {
         async fn generate(
             &mut self,
-            _request: GenerationRequest,
+            request: GenerationRequest,
         ) -> anyhow::Result<GenerationResponse> {
+            if let Some(response) = maybe_memory_promotion_response(&request) {
+                return Ok(response);
+            }
             Ok(GenerationResponse {
                 content: self.content.clone(),
                 thinking: self.thinking.clone(),
@@ -1851,8 +1891,11 @@ mod tests {
     impl LlmProvider for ToolCallMockProvider {
         async fn generate(
             &mut self,
-            _request: GenerationRequest,
+            request: GenerationRequest,
         ) -> anyhow::Result<GenerationResponse> {
+            if let Some(response) = maybe_memory_promotion_response(&request) {
+                return Ok(response);
+            }
             Ok(GenerationResponse {
                 content: self.content.clone(),
                 thinking: None,
@@ -2081,9 +2124,12 @@ mod tests {
     impl LlmProvider for SequenceMockProvider {
         async fn generate(
             &mut self,
-            _request: GenerationRequest,
+            request: GenerationRequest,
         ) -> anyhow::Result<GenerationResponse> {
             self.generate_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(response) = maybe_memory_promotion_response(&request) {
+                return Ok(response);
+            }
             self.responses
                 .pop_front()
                 .ok_or_else(|| anyhow::anyhow!("No more scripted responses"))
@@ -4599,7 +4645,7 @@ description: {description}
 
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
-        assert_eq!(generate_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(generate_calls.load(Ordering::SeqCst), 3);
         assert!(saw_handoff_before_completion);
     }
 
@@ -4723,6 +4769,9 @@ runtime:
             request: GenerationRequest,
         ) -> anyhow::Result<GenerationResponse> {
             self.record_system_prompt(&request);
+            if let Some(response) = maybe_memory_promotion_response(&request) {
+                return Ok(response);
+            }
             Ok(GenerationResponse {
                 content: self.content.clone(),
                 thinking: None,
@@ -4808,7 +4857,10 @@ runtime:
         assert!(result.is_ok());
 
         let system_prompts = seen_system_prompts.lock().unwrap();
-        let request_prompt = system_prompts.last().expect("expected system prompt");
+        let request_prompt = system_prompts
+            .iter()
+            .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+            .expect("expected runtime recall bundle prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains(".alan/memory/USER.md"));
         assert!(request_prompt.contains("ALAN_IDENTITY_RECALL"));
@@ -4858,7 +4910,10 @@ runtime:
         assert!(result.is_ok());
 
         let system_prompts = seen_system_prompts.lock().unwrap();
-        let request_prompt = system_prompts.last().expect("expected system prompt");
+        let request_prompt = system_prompts
+            .iter()
+            .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+            .expect("expected runtime recall bundle prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains(".alan/memory/handoffs/LATEST.md"));
         assert!(request_prompt.contains(".alan/memory/sessions/2026/04/15/session-1.md"));
@@ -4916,7 +4971,10 @@ runtime:
         assert!(result.is_ok());
 
         let system_prompts = seen_system_prompts.lock().unwrap();
-        let request_prompt = system_prompts.last().expect("expected system prompt");
+        let request_prompt = system_prompts
+            .iter()
+            .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+            .expect("expected runtime recall bundle prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains(".alan/memory/daily/2026-04-16.md"));
         assert!(request_prompt.contains(".alan/memory/sessions/2026/04/16/session-4.md"));
@@ -4991,8 +5049,11 @@ runtime:
         assert_eq!(state.session.tape.summary(), Some("COMPACTED_FOR_RECALL"));
 
         let system_prompts = seen_system_prompts.lock().unwrap();
-        assert_eq!(system_prompts.len(), 2);
-        let request_prompt = system_prompts.last().expect("expected final system prompt");
+        assert_eq!(system_prompts.len(), 3);
+        let request_prompt = system_prompts
+            .iter()
+            .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
+            .expect("expected runtime recall bundle prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains("ALAN_PRETURN_RECALL"));
     }

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::llm::{build_generation_request, project_tool_response_for_prompt};
 
-use super::agent_loop::{RuntimeLoopState, generate_with_retry_with_cancel};
+use super::agent_loop::{DeferredRuntimeAction, RuntimeLoopState, generate_with_retry_with_cancel};
 use super::compaction::{CompactionRequest, maybe_compact_context_with_cancel};
 use super::response_guardrails::{
     AssistantDraft, GuardrailDecision, ResponseGuardrailContext, ResponseGuardrails,
@@ -104,8 +104,12 @@ async fn finalize_turn_memory_best_effort(
             .await;
     }
 
-    if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(state).await {
-        warn!(error = %err, context = promotion_context, "Failed to capture confirmed turn memory");
+    if let Some(job) =
+        super::memory_promotion::build_turn_memory_promotion_job(state, promotion_context)
+    {
+        state
+            .turn_state
+            .push_deferred_runtime_action(DeferredRuntimeAction::TurnMemoryPromotion(job));
     }
 }
 
@@ -1872,6 +1876,51 @@ mod tests {
         }
     }
 
+    struct FailOnMemoryPromotionProvider {
+        content: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FailOnMemoryPromotionProvider {
+        async fn generate(
+            &mut self,
+            request: GenerationRequest,
+        ) -> anyhow::Result<GenerationResponse> {
+            if maybe_memory_promotion_response(&request).is_some() {
+                panic!("turn execution should not synchronously call memory promotion");
+            }
+
+            Ok(GenerationResponse {
+                content: self.content.clone(),
+                thinking: None,
+                thinking_signature: None,
+                redacted_thinking: Vec::new(),
+                tool_calls: Vec::new(),
+                usage: None,
+                finish_reason: None,
+                warnings: Vec::new(),
+                provider_response_id: None,
+                provider_response_status: None,
+            })
+        }
+
+        async fn chat(&mut self, _system: Option<&str>, _user: &str) -> anyhow::Result<String> {
+            Ok(self.content.clone())
+        }
+
+        async fn generate_stream(
+            &mut self,
+            _request: GenerationRequest,
+        ) -> anyhow::Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(rx)
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "fail_on_memory_promotion"
+        }
+    }
+
     // Mock provider that returns tool calls
     struct ToolCallMockProvider {
         tool_calls: Vec<ToolCall>,
@@ -2264,6 +2313,20 @@ mod tests {
             prompt_cache: crate::runtime::prompt_cache::PromptAssemblyCache::new(Vec::new()),
             turn_state: TurnState::default(),
         }
+    }
+
+    async fn run_deferred_runtime_actions(state: &mut RuntimeLoopState) -> usize {
+        let cancel = CancellationToken::new();
+        let actions = state.turn_state.drain_deferred_runtime_actions();
+        let count = actions.len();
+        for action in actions {
+            super::super::agent_loop::run_deferred_runtime_action_with_cancel(
+                state, action, &cancel,
+            )
+            .await
+            .expect("run deferred runtime action");
+        }
+        count
     }
 
     fn prompt_cache_for_workspace_root(
@@ -4474,9 +4537,51 @@ description: {description}
 
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+        let user_memory_before =
+            std::fs::read_to_string(memory_dir.join("USER.md")).unwrap_or_else(|_| String::new());
+        assert!(!user_memory_before.contains("Name: Morris"));
+        assert_eq!(run_deferred_runtime_actions(&mut state).await, 1);
 
         let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
         assert!(user_memory.contains("Name: Morris"));
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_defers_memory_promotion_until_after_completion() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut state = create_test_state_with_provider(FailOnMemoryPromotionProvider {
+            content: "Done.".to_string(),
+        });
+        state.core_config.memory.workspace_dir = Some(memory_dir);
+        state.core_config.memory.enabled = true;
+
+        let cancel = CancellationToken::new();
+        let mut events = Vec::new();
+        let mut emit = |event: Event| {
+            events.push(event);
+            async {}
+        };
+
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text("My name is Morris.")]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, Event::TurnCompleted { .. }))
+        );
+        assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
     }
 
     struct SlowTool {
@@ -4645,7 +4750,8 @@ description: {description}
 
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
-        assert_eq!(generate_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(generate_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
         assert!(saw_handoff_before_completion);
     }
 
@@ -5049,13 +5155,14 @@ runtime:
         assert_eq!(state.session.tape.summary(), Some("COMPACTED_FOR_RECALL"));
 
         let system_prompts = seen_system_prompts.lock().unwrap();
-        assert_eq!(system_prompts.len(), 3);
+        assert_eq!(system_prompts.len(), 2);
         let request_prompt = system_prompts
             .iter()
             .find(|prompt| prompt.contains("## Runtime Recall Bundle"))
             .expect("expected runtime recall bundle prompt");
         assert!(request_prompt.contains("## Runtime Recall Bundle"));
         assert!(request_prompt.contains("ALAN_PRETURN_RECALL"));
+        assert_eq!(state.turn_state.drain_deferred_runtime_actions().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1618,6 +1618,7 @@ where
             )
             .await;
             if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
             )
@@ -1644,6 +1645,7 @@ where
             )
             .await;
             if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
             )
@@ -1666,6 +1668,7 @@ where
             )
             .await;
             if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
             )

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1621,6 +1621,7 @@ where
                 state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
+                state.turn_state.active_turn_message_start(),
             )
             .await
             {
@@ -1648,6 +1649,7 @@ where
                 state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
+                state.turn_state.active_turn_message_start(),
             )
             .await
             {
@@ -1671,6 +1673,7 @@ where
                 state.core_config.memory.enabled,
                 state.core_config.memory.workspace_dir.as_deref(),
                 &state.session,
+                state.turn_state.active_turn_message_start(),
             )
             .await
             {

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1617,6 +1617,14 @@ where
                 "fallback-turn-completed",
             )
             .await;
+            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.workspace_dir.as_deref(),
+                &state.session,
+            )
+            .await
+            {
+                warn!(error = %err, "Failed to capture confirmed turn memory after fallback turn");
+            }
             emit(Event::TextDelta {
                 chunk: fallback_text.to_string(),
                 is_final: true,
@@ -1635,6 +1643,17 @@ where
                 "interrupted-stream-completed",
             )
             .await;
+            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.workspace_dir.as_deref(),
+                &state.session,
+            )
+            .await
+            {
+                warn!(
+                    error = %err,
+                    "Failed to capture confirmed turn memory after interrupted stream"
+                );
+            }
             emit_task_completed_success(
                 emit,
                 "Task completed with interrupted stream; response may be incomplete.",
@@ -1646,6 +1665,14 @@ where
                 "turn-completed",
             )
             .await;
+            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+                state.core_config.memory.workspace_dir.as_deref(),
+                &state.session,
+            )
+            .await
+            {
+                warn!(error = %err, "Failed to capture confirmed turn memory after completed turn");
+            }
             emit_task_completed_success(emit, "Task completed").await;
         }
         return Ok(TurnExecutionOutcome::Finished);

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -93,6 +93,29 @@ fn estimate_pending_turn_prompt_tokens(
         ))
 }
 
+async fn finalize_turn_memory_best_effort(
+    state: &RuntimeLoopState,
+    surfaces_refreshed: bool,
+    surfaces_context: &'static str,
+    promotion_context: &'static str,
+) {
+    if !surfaces_refreshed {
+        super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(state, surfaces_context)
+            .await;
+    }
+
+    if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
+        state.core_config.memory.enabled,
+        state.core_config.memory.workspace_dir.as_deref(),
+        &state.session,
+        state.turn_state.active_turn_message_start(),
+    )
+    .await
+    {
+        warn!(error = %err, context = promotion_context, "Failed to capture confirmed turn memory");
+    }
+}
+
 fn inject_stream_recovery_instruction(
     request: &mut crate::llm::GenerationRequest,
     visible_text_so_far: &str,
@@ -1571,10 +1594,12 @@ where
                 }
                 ToolBatchOrchestratorOutcome::PauseTurn => return Ok(TurnExecutionOutcome::Paused),
                 ToolBatchOrchestratorOutcome::EndTurn { surfaces_refreshed } => {
-                    if !surfaces_refreshed {
-                        super::memory_surfaces::refresh_active_turn_memory_surfaces_best_effort(
+                    if !cancel.is_cancelled() {
+                        finalize_turn_memory_best_effort(
                             state,
+                            surfaces_refreshed,
                             "turn-ended-after-tool-batch",
+                            "after tool-driven end turn",
                         )
                         .await;
                     }
@@ -1612,21 +1637,13 @@ where
                         .clear_responses_continuation("continuation_unavailable");
                 }
             }
-            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+            finalize_turn_memory_best_effort(
                 state,
+                false,
                 "fallback-turn-completed",
+                "after fallback turn",
             )
             .await;
-            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
-                state.core_config.memory.enabled,
-                state.core_config.memory.workspace_dir.as_deref(),
-                &state.session,
-                state.turn_state.active_turn_message_start(),
-            )
-            .await
-            {
-                warn!(error = %err, "Failed to capture confirmed turn memory after fallback turn");
-            }
             emit(Event::TextDelta {
                 chunk: fallback_text.to_string(),
                 is_final: true,
@@ -1640,45 +1657,26 @@ where
         }
 
         if response_may_be_incomplete {
-            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+            finalize_turn_memory_best_effort(
                 state,
+                false,
                 "interrupted-stream-completed",
+                "after interrupted stream",
             )
             .await;
-            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
-                state.core_config.memory.enabled,
-                state.core_config.memory.workspace_dir.as_deref(),
-                &state.session,
-                state.turn_state.active_turn_message_start(),
-            )
-            .await
-            {
-                warn!(
-                    error = %err,
-                    "Failed to capture confirmed turn memory after interrupted stream"
-                );
-            }
             emit_task_completed_success(
                 emit,
                 "Task completed with interrupted stream; response may be incomplete.",
             )
             .await;
         } else {
-            super::memory_surfaces::refresh_turn_memory_surfaces_best_effort(
+            finalize_turn_memory_best_effort(
                 state,
+                false,
                 "turn-completed",
+                "after completed turn",
             )
             .await;
-            if let Err(err) = super::memory_promotion::capture_confirmed_turn_memory(
-                state.core_config.memory.enabled,
-                state.core_config.memory.workspace_dir.as_deref(),
-                &state.session,
-                state.turn_state.active_turn_message_start(),
-            )
-            .await
-            {
-                warn!(error = %err, "Failed to capture confirmed turn memory after completed turn");
-            }
             emit_task_completed_success(emit, "Task completed").await;
         }
         return Ok(TurnExecutionOutcome::Finished);
@@ -4395,6 +4393,44 @@ description: {description}
                 .next()
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn test_run_turn_promotes_direct_user_fact_when_tool_batch_ends_turn() {
+        let temp = TempDir::new().unwrap();
+        let memory_dir = temp.path().join(".alan/memory");
+
+        let mut state = create_test_state_with_provider(ToolCallMockProvider::new(
+            vec![ToolCall {
+                id: Some("call_1".to_string()),
+                name: "request_confirmation".to_string(),
+                arguments: json!({}),
+            }],
+            "",
+        ));
+        state.core_config.memory.workspace_dir = Some(memory_dir.clone());
+        state.core_config.memory.enabled = true;
+        state
+            .turn_state
+            .set_turn_activity(TurnActivityState::Running);
+
+        let cancel = CancellationToken::new();
+        let mut emit = |_event: Event| async {};
+        let result = run_turn_with_cancel(
+            &mut state,
+            TurnRunKind::NewTurn,
+            Some(vec![ContentPart::text("My name is Morris.")]),
+            &mut emit,
+            &cancel,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), TurnExecutionOutcome::Finished));
+
+        let user_memory = std::fs::read_to_string(memory_dir.join("USER.md")).unwrap();
+        assert!(user_memory.contains("Name: Morris"));
     }
 
     struct SlowTool {

--- a/crates/runtime/src/runtime/turn_state.rs
+++ b/crates/runtime/src/runtime/turn_state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
-use super::agent_loop::NormalizedToolCall;
+use super::agent_loop::{DeferredRuntimeAction, NormalizedToolCall};
 use crate::approval::{PendingConfirmation, PendingDynamicToolCall, PendingStructuredInputRequest};
 use crate::skills::ActiveSkillEnvelope;
 use crate::tape::ContentPart;
@@ -62,6 +62,8 @@ pub(crate) struct TurnState {
     active_skills: Vec<ActiveSkillEnvelope>,
     /// Latest explicit plan/progress state published during the current session.
     plan_snapshot: Option<PlanSnapshot>,
+    /// Best-effort follow-up work queued after a turn completes.
+    deferred_runtime_actions: VecDeque<DeferredRuntimeAction>,
 }
 
 impl TurnState {
@@ -186,6 +188,14 @@ impl TurnState {
 
     pub(crate) fn plan_snapshot(&self) -> Option<&PlanSnapshot> {
         self.plan_snapshot.as_ref()
+    }
+
+    pub(crate) fn push_deferred_runtime_action(&mut self, action: DeferredRuntimeAction) {
+        self.deferred_runtime_actions.push_back(action);
+    }
+
+    pub(crate) fn drain_deferred_runtime_actions(&mut self) -> VecDeque<DeferredRuntimeAction> {
+        std::mem::take(&mut self.deferred_runtime_actions)
     }
 
     pub(crate) fn can_auto_mid_turn_compact(

--- a/docs/live_runtime_smoke.md
+++ b/docs/live_runtime_smoke.md
@@ -7,7 +7,7 @@
 This smoke layer validates Alan's real runtime turn path against a live
 provider. It exists to catch bugs that the provider-only harness cannot see,
 such as runtime-default request fields leaking into provider-specific request
-shaping.
+shaping, or regressions in runtime-owned memory surfaces.
 
 Unlike the provider harness, this layer drives:
 
@@ -57,7 +57,10 @@ The current managed `chatgpt` runtime smoke asserts that:
 1. a runtime configured from live ChatGPT auth can start successfully;
 2. a submitted user turn reaches `TurnCompleted`;
 3. the turn emits assistant text containing the requested token;
-4. the runtime does not emit a provider error during the turn.
+4. stable cross-session preference memory can be persisted and recalled;
+5. recent-work continuity survives restart through runtime-owned handoff
+   surfaces;
+6. the runtime does not emit a provider error during the turn.
 
 This specifically covers the real runtime path that previously leaked the
 default `temperature=0.3` field into the managed ChatGPT Responses request.

--- a/docs/spec/memory_architecture.md
+++ b/docs/spec/memory_architecture.md
@@ -36,7 +36,9 @@ Implemented in the current tree:
    directory's `memory/` folder.
 3. Automatic pre-compaction memory flush writes durable context to a daily note
    surface before soft-threshold compaction.
-4. Latest memory-flush attempt state is recoverable via replay, thread reads,
+4. Automatic confirmed-turn memory promotion uses a model-mediated structured
+   write plan instead of a brittle phrase parser.
+5. Latest memory-flush attempt state is recoverable via replay, thread reads,
    reconnect snapshots, and rollout fallback.
 
 Still incomplete or target-only:
@@ -147,6 +149,8 @@ Important distinctions:
 1. not every useful observation should go directly into stable memory,
 2. not every past session detail belongs in `MEMORY.md`,
 3. working memory must never masquerade as long-term memory.
+4. automatic promotion should be model-mediated and schema-validated, with
+   runtime retaining sole authority over durable writes.
 
 ## Relationship to Compaction
 

--- a/docs/spec/pure_text_memory_contract.md
+++ b/docs/spec/pure_text_memory_contract.md
@@ -69,6 +69,9 @@ are not the same thing as curated memory.
   fully promoted into stable memory.
 - **Promotion**: moving a candidate or repeated observation into `USER.md`,
   `MEMORY.md`, or a topic page.
+- **Write plan**: a structured, model-produced proposal describing which
+  active-turn facts should be promoted immediately versus staged as inbox
+  entries.
 
 ## Memory Layers
 
@@ -510,10 +513,36 @@ Rules:
 
 ## Runtime Write Path
 
+### Model-Mediated Write Planning
+
+Automatic turn-end promotion should not depend on an ever-growing Rust
+heuristic parser for phrases like "my name is ..." or "the rule is ...".
+
+Instead, runtime should run a bounded, model-mediated write-planning pass over
+the active-turn user messages and require structured output.
+
+Contract:
+
+1. runtime chooses when to invoke the pass and which source messages are in
+   scope,
+2. the model returns a bounded JSON write plan with `kind`, canonical target,
+   confidence, disposition (`promote_now` or `stage_inbox`), observation,
+   evidence, and promotion rationale,
+3. runtime validates and canonicalizes that output before any file write,
+4. runtime, not the model, remains the only component allowed to mutate memory
+   files,
+5. invalid, mismatched, or over-broad candidates must be dropped rather than
+   written,
+6. low-confidence or ambiguous candidates must fall back to inbox staging.
+
+This is the automatic-runtime counterpart to the memory skill's confirmation
+discipline: the model performs semantic judgment, while runtime owns trigger
+timing, validation, provenance, and durable writes.
+
 ### Confirmed Writes
 
-Runtime may promote information directly into stable memory when one of the
-following is true:
+Runtime may execute a direct stable write only when the validated write plan
+marks an item `promote_now` and one of the following is true:
 
 1. the user explicitly says to remember it,
 2. the user directly states the fact as stable identity/preference/constraint,
@@ -522,8 +551,9 @@ following is true:
 
 ### Observed Captures
 
-When information seems useful but is not yet strong enough for stable memory,
-runtime should record it as an inbox entry or daily note instead of dropping it.
+When the validated write plan says information is useful but not yet strong
+enough for stable memory, runtime should record it as an inbox entry or daily
+note instead of dropping it.
 
 Observed captures are appropriate for:
 
@@ -572,6 +602,17 @@ The existing pre-compaction memory flush remains valid, but its role changes:
 4. it may create or enrich inbox entries when the output is durable but not yet
    confirmed.
 
+Both automatic memory flush and automatic confirmed-turn promotion are
+model-mediated extraction paths. They differ in landing zone and policy, not in
+who owns durable writes:
+
+1. memory flush primarily targets daily-note preservation and candidate inbox
+   staging,
+2. confirmed-turn promotion targets stable-memory writes only after runtime
+   validates a write plan,
+3. neither path should rely on bespoke punctuation heuristics as the source of
+   truth for semantic memory decisions.
+
 Compaction and memory are related but separate:
 
 1. compaction protects the current session from context overflow,
@@ -606,3 +647,5 @@ Compaction and memory are related but separate:
 5. Cross-session continuity works without any required vector database or
    SQLite service.
 6. The system remains debuggable with ordinary file inspection and `rg`.
+7. Automatic promotion correctness does not depend on brittle string-splitting
+   heuristics for abbreviations, version numbers, or clause punctuation.

--- a/docs/testing_strategy.md
+++ b/docs/testing_strategy.md
@@ -115,6 +115,8 @@ Current scope:
 - managed `chatgpt` runtime startup,
 - real turn submission,
 - event-stream completion to `turn_completed`,
+- cross-session stable-memory persistence and recall,
+- cross-session handoff continuity after restart,
 - text output and no-provider-error assertions.
 
 Operational model:


### PR DESCRIPTION
## Summary
- add a pure-text inbox/promotion helper that stages observed memory, promotes explicit confirmed facts, and keeps topic-page overflow auditable
- stage candidate memory from automatic memory flushes and capture a narrow set of direct user-stated stable facts at turn completion
- extend mock and live runtime smoke coverage for cross-session handoff continuity, and update memory/live-smoke docs to match the new behavior

## Testing
- cargo fmt --all
- git diff --check
- CARGO_TARGET_DIR=/tmp/alan-memory-pr4-rt cargo test -p alan-runtime memory_promotion --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr4-rt cargo test -p alan-runtime test_build_memory_flush_inbox_draft_targets_memory_md --lib
- CARGO_TARGET_DIR=/tmp/alan-memory-pr4-alan cargo test -p alan --test smoke_test smoke_cross_session_handoff_continuity_is_recalled -- --exact
- CARGO_TARGET_DIR=/tmp/alan-memory-pr4-alan cargo test -p alan --test live_runtime_smoke_test live_chatgpt_runtime_cross_session_continuity_smoke -- --ignored --exact --nocapture

Closes #266