### PR TITLE
Improve TUI reconnect replay errors

### DIFF
--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -138,6 +138,83 @@ describe("AlanClient replay", () => {
     expect(errors[0]).toContain("Event replay gap detected");
   });
 
+  test("rewrites replay 404 into an active-session recovery hint", async () => {
+    const client = new AlanClient({
+      url: "ws://example.com",
+      autoManageDaemon: false,
+    });
+
+    (client as any).lastEventId = eventId(42);
+    (client as any).connectionVersion = 3;
+
+    installMockFetch(async (input): Promise<Response> => {
+      const requestUrl =
+        typeof input === "string"
+          ? new URL(input)
+          : input instanceof URL
+            ? input
+            : new URL(input.url);
+      if (requestUrl.pathname.endsWith("/events/read")) {
+        return new Response(
+          JSON.stringify({ error: "Session replay buffer not found" }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (requestUrl.pathname.endsWith("/read")) {
+        return jsonResponse({
+          session_id: "sess-test",
+          workspace_id: "/tmp/ws",
+          active: true,
+          resolved_model: "gpt-5.4",
+          governance: { profile: "autonomous" },
+          streaming_mode: "auto",
+          partial_stream_recovery_mode: "continue_once",
+          messages: [],
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${requestUrl.toString()}`);
+    });
+
+    await expect(
+      (client as any).replayMissedEvents("sess-test", 3),
+    ).rejects.toThrow(
+      "Session sess-test is still registered, but its replay stream is unavailable.",
+    );
+  });
+
+  test("rewrites replay 404 into a missing-session lifecycle hint", async () => {
+    const client = new AlanClient({
+      url: "ws://example.com",
+      autoManageDaemon: false,
+    });
+
+    (client as any).lastEventId = eventId(99);
+    (client as any).connectionVersion = 5;
+
+    installMockFetch(async (input): Promise<Response> => {
+      const requestUrl =
+        typeof input === "string"
+          ? new URL(input)
+          : input instanceof URL
+            ? input
+            : new URL(input.url);
+      return new Response(JSON.stringify({ error: "Not Found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await expect(
+      (client as any).replayMissedEvents("sess-test", 5),
+    ).rejects.toThrow(
+      "Session sess-test is no longer active on the daemon.",
+    );
+  });
+
   test("captures and restores replay state snapshots", () => {
     const client = new AlanClient({
       url: "ws://example.com",

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -52,6 +52,12 @@ interface ErrorResponse {
   message?: string;
 }
 
+type ReplayUnavailableState =
+  | "active"
+  | "archived"
+  | "missing"
+  | "unknown";
+
 export interface ReplayStateSnapshot {
   sessionId: string;
   lastEventId: string | null;
@@ -254,9 +260,7 @@ export class AlanClient {
         `${this.baseUrl}/api/v1/sessions/${sessionId}/events/read?${params.toString()}`,
       );
       if (!response.ok) {
-        throw new Error(
-          `Failed to replay missed events: ${response.statusText}`,
-        );
+        throw await this.buildReplayReadError(sessionId, response);
       }
       const page = (await response.json()) as ReadEventsResponse;
       if (!Array.isArray(page.events)) {
@@ -312,6 +316,54 @@ export class AlanClient {
         return;
       }
       afterEventId = pageLastEventId;
+    }
+  }
+
+  private async buildReplayReadError(
+    sessionId: string,
+    response: Response,
+  ): Promise<Error> {
+    const errorMsg = await this.readErrorMessage(response);
+    if (response.status !== 404) {
+      return new Error(`Failed to replay missed events: ${errorMsg}`);
+    }
+
+    const availability = await this.probeReplayUnavailableState(sessionId);
+    switch (availability) {
+      case "active":
+        return new Error(
+          `Session ${sessionId} is still registered, but its replay stream is unavailable. Retry reconnect or reopen the session.`,
+        );
+      case "archived":
+        return new Error(
+          `Session ${sessionId} is archived and no longer has a live replay stream. Open its saved transcript or fork a new session.`,
+        );
+      case "missing":
+        return new Error(
+          `Session ${sessionId} is no longer active on the daemon. It may have expired, been deleted, or been lost after daemon restart.`,
+        );
+      default:
+        return new Error(
+          `Failed to replay missed events: ${errorMsg}. Session availability could not be confirmed.`,
+        );
+    }
+  }
+
+  private async probeReplayUnavailableState(
+    sessionId: string,
+  ): Promise<ReplayUnavailableState> {
+    try {
+      const session = await this.getSession(sessionId);
+      return session.active === false ? "archived" : "active";
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes("404") ||
+        message.toLowerCase().includes("not found")
+      ) {
+        return "missing";
+      }
+      return "unknown";
     }
   }
 
@@ -381,7 +433,9 @@ export class AlanClient {
     );
 
     if (!response.ok) {
-      throw new Error(`Failed to get session: ${response.statusText}`);
+      throw new Error(
+        `Failed to get session: ${await this.readErrorMessage(response)}`,
+      );
     }
 
     return (await response.json()) as SessionReadResponse;
@@ -855,6 +909,7 @@ export class AlanClient {
     return new Promise((resolve, reject) => {
       let ready = false;
       let settled = false;
+      let initializationFailure: Error | null = null;
       const queuedEnvelopes: EventEnvelope[] = [];
       const resolveOnce = () => {
         if (settled) return;
@@ -877,6 +932,7 @@ export class AlanClient {
               await this.replayMissedEvents(sessionId, version);
             } catch (error) {
               const replayError = error as Error;
+              initializationFailure = replayError;
               this.emit("error", replayError);
               rejectOnce(replayError);
               if (version === this.connectionVersion) {
@@ -915,10 +971,13 @@ export class AlanClient {
 
         this.ws.on("close", () => {
           if (version !== this.connectionVersion) return;
-          this.emit("disconnected");
+          if (ready) {
+            this.emit("disconnected");
+          }
           if (!ready) {
             rejectOnce(
-              new Error("WebSocket closed before initialization completed"),
+              initializationFailure ??
+                new Error("WebSocket closed before initialization completed"),
             );
           }
           this.attemptReconnect(version);

--- a/docs/maintainer/session_reconnect_fix_checklist.md
+++ b/docs/maintainer/session_reconnect_fix_checklist.md
@@ -1,0 +1,23 @@
+# Session Reconnect Fix Checklist
+
+This checklist tracks the fixes identified from sessions `04cc2106` and
+`1d5d6824`.
+
+## Stack 1: TUI reconnect error handling
+
+- [x] Reclassify replay `404 Not Found` as a session lifecycle problem instead of a raw transport error.
+- [x] Stop surfacing misleading `Disconnected from agent` when reconnect fails before initialization completes.
+- [x] Add TUI client tests covering replay `404` for active and missing sessions.
+
+## Stack 2: Archived session read-only fallback
+
+- [ ] Let daemon `read_session` fall back to rollout-only archived sessions when no active session entry exists.
+- [ ] Let daemon `history` fall back to rollout-only archived sessions when no active session entry exists.
+- [ ] Return `active: false` for archived/read-only session reads.
+- [ ] Add route tests covering archived session read/history fallback.
+
+## Stack 3: 04cc quality fixes
+
+- [ ] Preserve whitespace-only streaming text deltas so spaces and newlines are not dropped from assistant output.
+- [ ] Add regression tests for whitespace-preserving streamed text assembly.
+- [ ] Make bash tool guidance explicit about avoiding opaque interpreter wrappers that sandbox preflight will reject.


### PR DESCRIPTION
## Summary
- reclassify replay 404s as session lifecycle failures instead of raw transport errors
- stop emitting a misleading disconnected event when reconnect dies before initialization completes
- add client tests for active-session and missing-session replay 404s

## Verification
- bun test src/client.test.ts
- bun run typecheck

## Checklist
- [x] Reclassify replay 404 as a session lifecycle problem
- [x] Stop surfacing misleading disconnected status during failed reconnect init
- [x] Add TUI client regression coverage
