### PR TITLE
Preserve streamed whitespace and clarify bash guidance

### DIFF
--- a/crates/llm/src/chatgpt_responses.rs
+++ b/crates/llm/src/chatgpt_responses.rs
@@ -268,11 +268,7 @@ impl ChatgptResponsesClient {
 
         match event_type {
             "response.output_text.delta" | "response.refusal.delta" => {
-                if let Some(text) = event
-                    .get("delta")
-                    .and_then(serde_json::Value::as_str)
-                    .filter(|value| is_non_empty(value))
-                {
+                if let Some(text) = responses_stream_text_delta(&event) {
                     *emitted_payload = true;
                     if tx
                         .send(StreamChunk {
@@ -969,6 +965,14 @@ fn responses_stream_tool_name(
         .map(ToString::to_string)
 }
 
+// Streamed text can arrive as standalone spaces/newlines that preserve formatting.
+fn responses_stream_text_delta(event: &serde_json::Value) -> Option<&str> {
+    event
+        .get("delta")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
 fn is_non_empty(value: &str) -> bool {
     !value.trim().is_empty()
 }
@@ -1639,6 +1643,39 @@ mod tests {
         assert!(terminal.is_finished);
         assert_eq!(terminal.finish_reason.as_deref(), Some("stop"));
         assert_eq!(terminal.usage.map(|usage| usage.total_tokens), Some(3));
+    }
+
+    #[tokio::test]
+    async fn handle_stream_event_preserves_whitespace_only_output_text_delta() {
+        let client = ChatgptResponsesClient::with_params(
+            "https://chatgpt.com/backend-api/codex",
+            "gpt-5.3-codex",
+            HashMap::new(),
+            Some("acct_123".to_string()),
+            None,
+        )
+        .expect("client");
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamChunk>(4);
+        let mut latest_usage = None;
+        let mut emitted_payload = false;
+        let mut saw_tool_calls = false;
+
+        let action = client
+            .handle_stream_event(
+                &tx,
+                r#"{"type":"response.output_text.delta","delta":" ","sequence_number":0}"#,
+                &mut latest_usage,
+                &mut emitted_payload,
+                &mut saw_tool_calls,
+            )
+            .await
+            .expect("event");
+
+        assert_eq!(action, StreamEventAction::Continue);
+        assert!(emitted_payload);
+        let chunk = rx.recv().await.expect("text chunk");
+        assert_eq!(chunk.text.as_deref(), Some(" "));
+        assert!(!chunk.is_finished);
     }
 
     #[tokio::test]

--- a/crates/llm/src/openai_chat_completions.rs
+++ b/crates/llm/src/openai_chat_completions.rs
@@ -858,11 +858,7 @@ impl OpenAiChatCompletionsClient {
 
                 match event_type {
                     "response.output_text.delta" | "response.refusal.delta" => {
-                        if let Some(text) = event
-                            .get("delta")
-                            .and_then(serde_json::Value::as_str)
-                            .filter(|value| is_non_empty(value))
-                        {
+                        if let Some(text) = responses_stream_text_delta(&event) {
                             emitted_payload = true;
                             if tx
                                 .send(StreamChunk {
@@ -2054,6 +2050,14 @@ pub(crate) fn is_non_empty(value: &str) -> bool {
     !value.trim().is_empty()
 }
 
+// Streamed text can arrive as standalone spaces/newlines that preserve formatting.
+fn responses_stream_text_delta(event: &serde_json::Value) -> Option<&str> {
+    event
+        .get("delta")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
 fn extract_reasoning_text_from_value(value: &serde_json::Value) -> Option<String> {
     match value {
         serde_json::Value::String(text) if is_non_empty(text) => Some(text.clone()),
@@ -2724,6 +2728,21 @@ mod tests {
         assert_eq!(response.model, "gpt-4");
         assert_eq!(response.choices.len(), 1);
         assert_eq!(response.usage.as_ref().unwrap().total_tokens, 30);
+    }
+
+    #[test]
+    fn test_responses_stream_text_delta_preserves_whitespace_only_chunks() {
+        let event = serde_json::json!({
+            "type": "response.output_text.delta",
+            "delta": " ",
+        });
+        assert_eq!(responses_stream_text_delta(&event), Some(" "));
+
+        let empty_event = serde_json::json!({
+            "type": "response.output_text.delta",
+            "delta": "",
+        });
+        assert_eq!(responses_stream_text_delta(&empty_event), None);
     }
 
     #[test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1606,7 +1606,7 @@ impl Tool for BashTool {
     }
 
     fn description(&self) -> &str {
-        "Execute shell commands in the workspace, subject to policy and execution-backend constraints."
+        "Execute shell commands in the workspace, subject to policy and execution-backend constraints. Prefer direct commands like rg, sed, git status, or curl. Avoid opaque interpreter wrappers like python -, python -c, bash -c, or sh -c unless they are genuinely required, because sandbox preflight may classify or reject them conservatively."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1616,7 +1616,7 @@ impl Tool for BashTool {
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "Shell command to execute"
+                    "description": "Shell command to execute. Prefer direct commands instead of wrappers like python -, python -c, bash -c, or sh -c."
                 },
                 "timeout": {
                     "type": "integer",
@@ -2981,6 +2981,15 @@ mod tests {
             alan_protocol::ToolCapability::Network
         );
         assert_eq!(tool.timeout_secs(), 300);
+    }
+
+    #[test]
+    fn test_bash_tool_description_warns_about_eval_wrappers() {
+        let tool = BashTool::new(PathBuf::from("/tmp"));
+        let description = tool.description();
+        assert!(description.contains("python -c"));
+        assert!(description.contains("bash -c"));
+        assert!(description.contains("Prefer direct commands"));
     }
 
     #[test]

--- a/docs/maintainer/session_reconnect_fix_checklist.md
+++ b/docs/maintainer/session_reconnect_fix_checklist.md
@@ -18,6 +18,6 @@ This checklist tracks the fixes identified from sessions `04cc2106` and
 
 ## Stack 3: 04cc quality fixes
 
-- [ ] Preserve whitespace-only streaming text deltas so spaces and newlines are not dropped from assistant output.
-- [ ] Add regression tests for whitespace-preserving streamed text assembly.
-- [ ] Make bash tool guidance explicit about avoiding opaque interpreter wrappers that sandbox preflight will reject.
+- [x] Preserve whitespace-only streaming text deltas so spaces and newlines are not dropped from assistant output.
+- [x] Add regression tests for whitespace-preserving streamed text assembly.
+- [x] Make bash tool guidance explicit about avoiding opaque interpreter wrappers that sandbox preflight will reject.


### PR DESCRIPTION
## Summary
- preserve whitespace-only streamed text deltas for managed and OpenAI Responses flows
- add regressions covering whitespace-only streamed chunks
- make bash tool guidance explicit about avoiding opaque eval wrappers

## Testing
- cargo test -p alan-llm handle_stream_event_preserves_whitespace_only_output_text_delta -- --nocapture
- cargo test -p alan-llm test_responses_stream_text_delta_preserves_whitespace_only_chunks -- --nocapture
- cargo test -p alan-tools test_bash_tool_description_warns_about_eval_wrappers -- --nocapture