### PR TITLE
docs: document archived inactive session semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,11 +224,19 @@ represents one conversation or task, limited by the LLM's context window.
 
 **Key properties:**
 - **Bounded** — constrained by the context window; when full, start a new session
-- **Archivable** — completed sessions are saved as rollouts for replay or forking
-- **One active session per workspace** at any time; others are paused or archived
+- **Archivable** — daemon may detach the runtime while retaining session
+  metadata and rollout bindings, so inactive sessions remain readable and
+  resumable for replay or forking
+- **One active runtime per workspace** at any time; daemon may still retain
+  multiple inactive archived session bindings
 - **Split live vs durable tool payloads** — the active tape may hold full tool
   results for current-turn reasoning, while persisted rollout records store a
   redacted/truncated durable projection
+
+The compatibility session APIs surface this distinction through `active`.
+`active=false` means the session still exists as retained daemon metadata, but
+no live runtime is currently attached. TTL cleanup archives sessions by flipping
+them into that inactive retained state; explicit delete is the destructive path.
 
 ---
 

--- a/docs/spec/app_server_protocol.md
+++ b/docs/spec/app_server_protocol.md
@@ -45,6 +45,9 @@ Implemented in the current tree:
    streaming HTTP events, and WebSocket streaming.
 5. Compaction and memory-flush attempt recovery are already exposed through
    replay buffers, session reads, and reconnect snapshots.
+6. Compatibility session reads already retain archived sessions with
+   `active=false`; TTL cleanup archives in place instead of hard-removing the
+   session record.
 
 Still target-only:
 
@@ -127,6 +130,7 @@ Current endpoints map to target semantics:
 12. `POST /sessions/{id}/compact` -> `thread/compact`
 13. `POST /sessions/{id}/schedule_at` -> scheduler extension
 14. `POST /sessions/{id}/sleep_until` -> scheduler extension
+15. `DELETE /sessions/{id}` -> compatibility hard delete
 
 Compatibility notes:
 
@@ -134,6 +138,19 @@ Compatibility notes:
 2. Legacy mode-less `Op::Input` defaults to `mode=steer`.
 3. `thread/rollback` is explicitly non-durable; compatibility responses surface `durability.durable=false` and an in-memory warning.
 4. `POST /sessions/{id}/compact` always maps to `Op::CompactWithOptions`; clients may omit the body or send `{ "focus": "..." }`.
+
+## Compatibility Session Lifecycle (Current Behavior)
+
+1. `GET /sessions`, `GET /sessions/{id}`, and `GET /sessions/{id}/read` expose
+   an `active` boolean that describes runtime liveness, not resource existence.
+2. `active=true` means the daemon currently has a live runtime attached for that
+   session.
+3. `active=false` means the daemon retained the session binding, rollout path,
+   and persisted history, but no live runtime is currently attached.
+4. TTL cleanup currently archives expired sessions in place by deactivating the
+   runtime while preserving the compatibility record for later reads or resume.
+5. Explicit `DELETE /sessions/{id}` is the destructive removal path and deletes
+   the compatibility record entirely.
 
 ## Input Modes (First-Class Semantics)
 

--- a/docs/spec/remote_control_architecture.md
+++ b/docs/spec/remote_control_architecture.md
@@ -216,6 +216,11 @@ Signal constraints:
 1. If cursor is valid: replay from `after_event_id`.
 2. If cursor evicted (`gap=true`): fetch session snapshot then continue streaming.
 3. Reconnect never triggers implicit turn re-execution.
+4. If compatibility session metadata reports `active=false`, clients should
+   treat the session as retained but currently inactive and fall back to
+   snapshot/read or explicit resume instead of assuming a live event stream.
+5. TTL cleanup may transition an idle session from live to inactive without
+   changing `session_id`; explicit delete remains the destructive removal path.
 
 ## Multi-Client Consistency
 


### PR DESCRIPTION
## Summary
- document compatibility-session active semantics in the app server protocol
- clarify that TTL cleanup archives sessions in place while DELETE /sessions/{id} is the destructive removal path
- note in architecture and remote-control docs that inactive sessions remain readable/resumable

## Context
Follow-up documentation update after #274, #275, and #276 merged. The implementation already retains archived sessions with active=false; this PR updates the written contract to match current behavior.

## Testing
- git diff --check
