### PR TITLE
Add explicit ToolCapability::Unknown support

### DIFF
--- a/crates/protocol/src/op.rs
+++ b/crates/protocol/src/op.rs
@@ -14,6 +14,7 @@ pub enum ToolCapability {
     Read,
     Write,
     Network,
+    Unknown,
 }
 
 /// Builtin governance profile for tool policy behavior.
@@ -372,6 +373,34 @@ mod tests {
             Op::RegisterDynamicTools { tools } => {
                 assert_eq!(tools.len(), 1);
                 assert_eq!(tools[0].capability, None);
+            }
+            _ => panic!("Expected RegisterDynamicTools"),
+        }
+    }
+
+    #[test]
+    fn test_register_dynamic_tools_round_trips_explicit_unknown_capability() {
+        let op = Op::RegisterDynamicTools {
+            tools: vec![DynamicToolSpec {
+                name: "lookup_ticket".to_string(),
+                description: "Lookup ticket".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"]
+                }),
+                capability: Some(ToolCapability::Unknown),
+            }],
+        };
+
+        let json = serde_json::to_string(&op).unwrap();
+        assert!(json.contains("\"unknown\""));
+
+        let parsed: Op = serde_json::from_str(&json).unwrap();
+        match parsed {
+            Op::RegisterDynamicTools { tools } => {
+                assert_eq!(tools.len(), 1);
+                assert_eq!(tools[0].capability, Some(ToolCapability::Unknown));
             }
             _ => panic!("Expected RegisterDynamicTools"),
         }

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -65,7 +65,7 @@ pub struct PolicyFile {
 pub struct PolicyContext<'a> {
     pub tool_name: &'a str,
     pub arguments: &'a serde_json::Value,
-    pub capability: Option<alan_protocol::ToolCapability>,
+    pub capability: alan_protocol::ToolCapability,
 }
 
 /// Evaluation output with lightweight audit metadata.
@@ -323,12 +323,12 @@ fn rule_matches(rule: &PolicyRule, ctx: &PolicyContext<'_>) -> bool {
     true
 }
 
-fn capability_label(capability: Option<alan_protocol::ToolCapability>) -> &'static str {
+fn capability_label(capability: alan_protocol::ToolCapability) -> &'static str {
     match capability {
-        Some(alan_protocol::ToolCapability::Read) => "read",
-        Some(alan_protocol::ToolCapability::Write) => "write",
-        Some(alan_protocol::ToolCapability::Network) => "network",
-        None => "unknown",
+        alan_protocol::ToolCapability::Read => "read",
+        alan_protocol::ToolCapability::Write => "write",
+        alan_protocol::ToolCapability::Network => "network",
+        alan_protocol::ToolCapability::Unknown => "unknown",
     }
 }
 
@@ -362,7 +362,7 @@ mod tests {
         let decision = engine.evaluate(PolicyContext {
             tool_name: "bash",
             arguments: &json!({"command":"curl https://example.com"}),
-            capability: Some(alan_protocol::ToolCapability::Network),
+            capability: alan_protocol::ToolCapability::Network,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-network"));
@@ -374,7 +374,7 @@ mod tests {
         let decision = engine.evaluate(PolicyContext {
             tool_name: "bash",
             arguments: &json!({"command":"curl https://example.com"}),
-            capability: Some(alan_protocol::ToolCapability::Network),
+            capability: alan_protocol::ToolCapability::Network,
         });
         assert_eq!(decision.action, PolicyAction::Allow);
     }
@@ -385,7 +385,7 @@ mod tests {
         let decision = engine.evaluate(PolicyContext {
             tool_name: "bash",
             arguments: &json!({"command":"rm -rf / --no-preserve-root"}),
-            capability: Some(alan_protocol::ToolCapability::Write),
+            capability: alan_protocol::ToolCapability::Write,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-rm-root"));
@@ -414,11 +414,23 @@ default_action: allow
         let decision = engine.evaluate(PolicyContext {
             tool_name: "read_file",
             arguments: &json!({}),
-            capability: Some(alan_protocol::ToolCapability::Read),
+            capability: alan_protocol::ToolCapability::Read,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-read-file"));
         assert_eq!(decision.source, "workspace_policy_file");
+    }
+
+    #[test]
+    fn autonomous_escalates_unknown_capability() {
+        let engine = PolicyEngine::for_profile(PolicyProfile::Autonomous);
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "bash",
+            arguments: &json!({"command":"python3 script.py"}),
+            capability: alan_protocol::ToolCapability::Unknown,
+        });
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-unknown"));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -287,19 +287,19 @@ pub(super) struct ToolOrchestratorInputs<'a> {
 
 fn classify_effect_category(
     tool_name: &str,
-    tool_capability: Option<ToolCapability>,
+    tool_capability: ToolCapability,
 ) -> Option<EffectCategory> {
     match tool_capability {
-        Some(ToolCapability::Read) => None,
-        Some(ToolCapability::Network) => Some(EffectCategory::Network),
-        Some(ToolCapability::Write) => {
+        ToolCapability::Read => None,
+        ToolCapability::Network => Some(EffectCategory::Network),
+        ToolCapability::Write => {
             if matches!(tool_name, "write_file" | "edit_file") {
                 Some(EffectCategory::File)
             } else {
                 Some(EffectCategory::Process)
             }
         }
-        None => {
+        ToolCapability::Unknown => {
             if tool_name == "bash" {
                 Some(EffectCategory::Process)
             } else {
@@ -425,7 +425,8 @@ where
                 .dynamic_tools
                 .get(&tool_call.name)
                 .and_then(|tool| tool.capability)
-        });
+        })
+        .unwrap_or(ToolCapability::Unknown);
     let policy_decision = evaluate_tool_policy(
         &state.runtime_config.policy_engine,
         &state.runtime_config.governance,

--- a/crates/runtime/src/runtime/tool_policy.rs
+++ b/crates/runtime/src/runtime/tool_policy.rs
@@ -21,7 +21,7 @@ pub(super) fn evaluate_tool_policy(
     governance: &alan_protocol::GovernanceConfig,
     tool_name: &str,
     arguments: &serde_json::Value,
-    capability: Option<alan_protocol::ToolCapability>,
+    capability: alan_protocol::ToolCapability,
 ) -> ToolPolicyDecision {
     let sandbox_backend = crate::tools::Sandbox::backend_name_static();
     if let Some(reason) = bash_shape_preflight_reason(tool_name, arguments) {
@@ -113,12 +113,12 @@ fn bash_shape_preflight_reason(tool_name: &str, arguments: &serde_json::Value) -
     crate::tools::Sandbox::bash_preflight_reason(command)
 }
 
-pub(super) fn capability_label(capability: Option<alan_protocol::ToolCapability>) -> &'static str {
+pub(super) fn capability_label(capability: alan_protocol::ToolCapability) -> &'static str {
     match capability {
-        Some(alan_protocol::ToolCapability::Read) => "read",
-        Some(alan_protocol::ToolCapability::Write) => "write",
-        Some(alan_protocol::ToolCapability::Network) => "network",
-        None => "unknown",
+        alan_protocol::ToolCapability::Read => "read",
+        alan_protocol::ToolCapability::Write => "write",
+        alan_protocol::ToolCapability::Network => "network",
+        alan_protocol::ToolCapability::Unknown => "unknown",
     }
 }
 
@@ -139,7 +139,7 @@ mod tests {
             },
             "dynamic_tool",
             &json!({"id":"123"}),
-            None,
+            alan_protocol::ToolCapability::Unknown,
         );
         match result {
             ToolPolicyDecision::Escalate { details, .. } => {
@@ -162,7 +162,7 @@ mod tests {
             },
             "bash",
             &json!({"query":"rust"}),
-            Some(alan_protocol::ToolCapability::Network),
+            alan_protocol::ToolCapability::Network,
         );
         match result {
             ToolPolicyDecision::Allow { audit } => {
@@ -185,7 +185,7 @@ mod tests {
             },
             "bash",
             &json!({"command":"bash -lc 'rg TODO src'"}),
-            Some(alan_protocol::ToolCapability::Write),
+            alan_protocol::ToolCapability::Unknown,
         );
         match result {
             ToolPolicyDecision::Forbidden { reason, audit } => {
@@ -212,7 +212,7 @@ mod tests {
             },
             "write_file",
             &json!({"path":"a.txt","content":"x"}),
-            Some(alan_protocol::ToolCapability::Write),
+            alan_protocol::ToolCapability::Write,
         );
         match result {
             ToolPolicyDecision::Escalate { audit, .. } => {

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -525,11 +525,18 @@ fn sed_in_place_flag(tokens: &[&str]) -> bool {
     tokens.iter().skip(1).copied().any(|token| {
         token == "-i"
             || token == "--in-place"
+            || short_option_cluster_contains_flag(token, 'i')
             || token
                 .strip_prefix("-i")
                 .is_some_and(|suffix| !suffix.is_empty())
             || token.starts_with("--in-place=")
     })
+}
+
+fn short_option_cluster_contains_flag(token: &str, flag: char) -> bool {
+    token.starts_with('-')
+        && !token.starts_with("--")
+        && token.chars().skip(1).any(|ch| ch == flag)
 }
 
 fn find_has_write_action(tokens: &[&str]) -> bool {
@@ -3357,6 +3364,18 @@ mod tests {
     #[test]
     fn test_classify_bash_command_sed_in_place_is_write() {
         let cap = classify_bash_command("sed -i 's/foo/bar/' src/lib.rs");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_sed_clustered_ei_is_write() {
+        let cap = classify_bash_command("sed -Ei 's/foo/bar/' src/lib.rs");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_sed_clustered_ni_is_write() {
+        let cap = classify_bash_command("sed -ni 's/foo/bar/' src/lib.rs");
         assert_eq!(cap, alan_protocol::ToolCapability::Write);
     }
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -280,6 +280,7 @@ fn classify_bash_command(command: &str) -> alan_protocol::ToolCapability {
         .replace(['\n', '\r', '|'], ";");
 
     let mut saw_write = false;
+    let mut saw_unknown = false;
     for fragment in flattened.split(';') {
         let capability = classify_bash_fragment(fragment.trim());
         if matches!(capability, alan_protocol::ToolCapability::Network) {
@@ -288,10 +289,15 @@ fn classify_bash_command(command: &str) -> alan_protocol::ToolCapability {
         if matches!(capability, alan_protocol::ToolCapability::Write) {
             saw_write = true;
         }
+        if matches!(capability, alan_protocol::ToolCapability::Unknown) {
+            saw_unknown = true;
+        }
     }
 
     if saw_write {
         alan_protocol::ToolCapability::Write
+    } else if saw_unknown {
+        alan_protocol::ToolCapability::Unknown
     } else {
         alan_protocol::ToolCapability::Read
     }
@@ -428,13 +434,13 @@ fn classify_bash_fragment(fragment: &str) -> alan_protocol::ToolCapability {
     let effective_tokens = effective_tokens.as_slice();
 
     if contains_unsupported_shell_form(&tokens) {
-        return alan_protocol::ToolCapability::Write;
+        return alan_protocol::ToolCapability::Unknown;
     }
     if is_network_command(fragment, effective_tokens) {
         return alan_protocol::ToolCapability::Network;
     }
     if contains_nested_eval_wrapper(&tokens) {
-        return alan_protocol::ToolCapability::Write;
+        return alan_protocol::ToolCapability::Unknown;
     }
     if is_write_command(fragment, effective_tokens) {
         return alan_protocol::ToolCapability::Write;
@@ -442,7 +448,7 @@ fn classify_bash_fragment(fragment: &str) -> alan_protocol::ToolCapability {
     if is_safe_read_command(effective_tokens) || is_wrapper_query_command(&tokens) {
         return alan_protocol::ToolCapability::Read;
     }
-    alan_protocol::ToolCapability::Write
+    alan_protocol::ToolCapability::Unknown
 }
 
 fn contains_unsupported_shell_form(tokens: &[&str]) -> bool {
@@ -495,6 +501,14 @@ fn is_write_command(fragment: &str, tokens: &[&str]) -> bool {
         return true;
     }
 
+    if head == "sed" && sed_in_place_flag(tokens) {
+        return true;
+    }
+
+    if head == "find" && find_has_write_action(tokens) {
+        return true;
+    }
+
     if head == "git" {
         if is_git_network_command(tokens) {
             return false;
@@ -505,6 +519,25 @@ fn is_write_command(fragment: &str, tokens: &[&str]) -> bool {
     }
 
     contains_output_redirection(fragment)
+}
+
+fn sed_in_place_flag(tokens: &[&str]) -> bool {
+    tokens.iter().skip(1).copied().any(|token| {
+        token == "-i"
+            || token == "--in-place"
+            || token
+                .strip_prefix("-i")
+                .is_some_and(|suffix| !suffix.is_empty())
+            || token.starts_with("--in-place=")
+    })
+}
+
+fn find_has_write_action(tokens: &[&str]) -> bool {
+    tokens
+        .iter()
+        .skip(1)
+        .copied()
+        .any(|token| matches!(token, "-exec" | "-execdir" | "-delete" | "-ok" | "-okdir"))
 }
 
 fn contains_nested_eval_wrapper(tokens: &[&str]) -> bool {
@@ -3029,72 +3062,72 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_bash_command_defaults_unknown_to_write() {
+    fn test_classify_bash_command_defaults_ambiguous_python_eval_to_unknown() {
         let cap = classify_bash_command("python -c \"print('hi')\"");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_python_script_file_as_write() {
+    fn test_classify_bash_command_treats_python_script_file_as_unknown() {
         let cap = classify_bash_command("python3 script.py");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_shell_script_file_as_write() {
+    fn test_classify_bash_command_treats_shell_script_file_as_unknown() {
         let cap = classify_bash_command("bash script.sh");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_awk_script_file_as_write() {
+    fn test_classify_bash_command_treats_awk_script_file_as_unknown() {
         let cap = classify_bash_command("awk -f script.awk input.txt");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_shell_eval_wrappers_as_write() {
+    fn test_classify_bash_command_treats_shell_eval_wrappers_as_unknown() {
         let cap = classify_bash_command("bash -lc \"rg TODO src\"");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_shell_eval_wrappers_with_leading_options_as_write() {
+    fn test_classify_bash_command_treats_shell_eval_wrappers_with_leading_options_as_unknown() {
         let cap = classify_bash_command("bash --noprofile -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_python_eval_wrappers_with_leading_options_as_write() {
+    fn test_classify_bash_command_treats_python_eval_wrappers_with_leading_options_as_unknown() {
         let cap = classify_bash_command("python3 -B -c 'print(\"hi\")'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_node_inline_long_eval_wrapper_as_write() {
+    fn test_classify_bash_command_treats_node_inline_long_eval_wrapper_as_unknown() {
         let cap =
             classify_bash_command("node --eval='require(\"fs\").writeFileSync(\"x\", \"y\")'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_shell_inline_long_command_wrapper_as_write() {
+    fn test_classify_bash_command_treats_shell_inline_long_command_wrapper_as_unknown() {
         let cap = classify_bash_command("sh --command='rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_eval_wrapper_with_line_continuation_as_write() {
+    fn test_classify_bash_command_treats_eval_wrapper_with_line_continuation_as_unknown() {
         let cap = classify_bash_command("s\\\nh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_node_print_eval_wrappers_as_write() {
+    fn test_classify_bash_command_treats_node_print_eval_wrappers_as_unknown() {
         let cap = classify_bash_command(
             "node --trace-warnings -p 'require(\"fs\").writeFileSync(\"x\", \"y\")'",
         );
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
@@ -3104,9 +3137,9 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_bash_command_treats_multiline_eval_wrapper_as_write() {
+    fn test_classify_bash_command_treats_multiline_eval_wrapper_as_unknown() {
         let cap = classify_bash_command("echo ok\nsh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
@@ -3116,87 +3149,87 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_bash_command_treats_env_shell_eval_wrappers_as_write() {
+    fn test_classify_bash_command_treats_env_shell_eval_wrappers_as_unknown() {
         let cap = classify_bash_command("env FOO=bar sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_bang_prefixed_shell_eval_as_write() {
+    fn test_classify_bash_command_treats_bang_prefixed_shell_eval_as_unknown() {
         let cap = classify_bash_command("! sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_then_prefixed_shell_eval_as_write() {
+    fn test_classify_bash_command_treats_then_prefixed_shell_eval_as_unknown() {
         let cap = classify_bash_command("if true; then sh -c 'rg TODO src'; fi");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_command_wrapper_shell_eval_as_write() {
+    fn test_classify_bash_command_treats_command_wrapper_shell_eval_as_unknown() {
         let cap = classify_bash_command("command -p sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_nice_wrapper_as_write() {
+    fn test_classify_bash_command_treats_nice_wrapper_as_unknown() {
         let cap = classify_bash_command("nice -n 5 sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_time_wrapper_as_write() {
+    fn test_classify_bash_command_treats_time_wrapper_as_unknown() {
         let cap = classify_bash_command("time sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_command_query_mode_as_write() {
+    fn test_classify_bash_command_treats_command_query_mode_as_unknown() {
         let cap = classify_bash_command("command -v sh -c");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_timeout_query_mode_as_write() {
+    fn test_classify_bash_command_treats_timeout_query_mode_as_unknown() {
         let cap = classify_bash_command("timeout --version");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_timeout_query_with_line_continuation_as_write() {
+    fn test_classify_bash_command_treats_timeout_query_with_line_continuation_as_unknown() {
         let cap = classify_bash_command("time\\\nout --ver\\\nsion");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_builtin_query_mode_as_write() {
+    fn test_classify_bash_command_treats_builtin_query_mode_as_unknown() {
         let cap = classify_bash_command("builtin -p eval");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_exec_wrapper_shell_eval_with_argv0_as_write() {
+    fn test_classify_bash_command_treats_exec_wrapper_shell_eval_with_argv0_as_unknown() {
         let cap = classify_bash_command("exec -a alan sh -c 'rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_stdbuf_wrapped_read_command_as_write() {
+    fn test_classify_bash_command_treats_stdbuf_wrapped_read_command_as_unknown() {
         let cap = classify_bash_command("stdbuf -oL rg TODO src");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_env_split_string_as_write() {
+    fn test_classify_bash_command_treats_env_split_string_as_unknown() {
         let cap = classify_bash_command("env -S 'sh -c rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
-    fn test_classify_bash_command_treats_clustered_env_split_string_as_write() {
+    fn test_classify_bash_command_treats_clustered_env_split_string_as_unknown() {
         let cap = classify_bash_command("env -iS 'sh -c rg TODO src'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]
@@ -3334,9 +3367,9 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_bash_command_find_name_defaults_to_write() {
+    fn test_classify_bash_command_find_name_defaults_to_unknown() {
         let cap = classify_bash_command("find . -name '*.rs'");
-        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
     }
 
     #[test]

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -52,7 +52,7 @@ pub trait Tool: Send + Sync {
     fn description(&self) -> &str;
     fn parameters_schema(&self) -> Value;            // JSON Schema
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult;
-    fn capability(&self, args: &Value) -> ToolCapability;  // read / write / network
+    fn capability(&self, args: &Value) -> ToolCapability;  // read / write / network / unknown
     fn timeout_secs(&self) -> usize;                 // tool default timeout (seconds)
 }
 ```


### PR DESCRIPTION
## Summary
- add an explicit `ToolCapability::Unknown` variant and round-trip coverage for dynamic tool registration
- normalize runtime policy/effect handling onto explicit `Unknown` semantics instead of relying on `None` as an implicit unknown capability
- teach the bash classifier to return `Unknown` for ambiguous wrapper/interpreter shapes while preserving explicit write detection for cases like `sed -i` and `find ... -exec`

Closes #278.

## Testing
- cargo test -p alan-tools --lib -- --nocapture
- cargo test -p alan-runtime test_conservative_unknown_capability_escalates -- --nocapture
- cargo test -p alan-runtime autonomous_escalates_unknown_capability -- --nocapture
- cargo test -p alan-runtime test_unknown_effect_status_escalates_without_execution -- --nocapture
- cargo test -p alan-runtime test_bash_shape_preflight_blocks_unsupported_wrapper_before_policy_allow -- --nocapture
- cargo test -p alan-protocol register_dynamic_tools -- --nocapture
