### PR TITLE
[VNext][Alan Coding][Repo Worker] Harden delivery contract and package validation

### DIFF
--- a/crates/runtime/skills/repo-coding/SKILL.md
+++ b/crates/runtime/skills/repo-coding/SKILL.md
@@ -43,6 +43,8 @@ The repo worker should:
 ## Package Resources
 
 - Read `references/package.md` for the package map and local validation entrypoints.
+- Read `references/delivery_contract.md` for the bounded repo-worker output shape.
+- Read `references/evaluator_boundary.md` before recommending evaluator support.
 - Use the package-local child launch target `repo-worker`.
 - Keep repo-local edits bounded; return control when the task expands beyond
   delegated scope.

--- a/crates/runtime/skills/repo-coding/agents/openai.yaml
+++ b/crates/runtime/skills/repo-coding/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Coding"
+  short_description: "Delegate bounded repo-scoped coding work"
+  default_prompt: "Use this package when Alan should hand off focused coding work to a repo-scoped child worker with a clear verification and delivery contract."

--- a/crates/runtime/skills/repo-coding/evals/evaluator_cases.json
+++ b/crates/runtime/skills/repo-coding/evals/evaluator_cases.json
@@ -19,6 +19,15 @@
       "expected_mode": "recommended"
     },
     {
+      "id": "single_verification_failure_with_targeted_checks",
+      "repeated_verification_failures": 1,
+      "deterministic_checks_available": true,
+      "ui_heavy_task": false,
+      "risky_refactor": "small",
+      "evaluator_used": false,
+      "expected_mode": "not_needed"
+    },
+    {
       "id": "missing_deterministic_checks",
       "repeated_verification_failures": 0,
       "deterministic_checks_available": false,

--- a/crates/runtime/skills/repo-coding/evals/evaluator_cases.json
+++ b/crates/runtime/skills/repo-coding/evals/evaluator_cases.json
@@ -1,0 +1,40 @@
+{
+  "cases": [
+    {
+      "id": "small_bugfix_with_targeted_checks",
+      "repeated_verification_failures": 0,
+      "deterministic_checks_available": true,
+      "ui_heavy_task": false,
+      "risky_refactor": "small",
+      "evaluator_used": false,
+      "expected_mode": "not_needed"
+    },
+    {
+      "id": "repeated_verification_failure",
+      "repeated_verification_failures": 2,
+      "deterministic_checks_available": true,
+      "ui_heavy_task": false,
+      "risky_refactor": "small",
+      "evaluator_used": false,
+      "expected_mode": "recommended"
+    },
+    {
+      "id": "missing_deterministic_checks",
+      "repeated_verification_failures": 0,
+      "deterministic_checks_available": false,
+      "ui_heavy_task": false,
+      "risky_refactor": "medium",
+      "evaluator_used": false,
+      "expected_mode": "recommended"
+    },
+    {
+      "id": "ui_heavy_run_with_evaluator",
+      "repeated_verification_failures": 1,
+      "deterministic_checks_available": true,
+      "ui_heavy_task": true,
+      "risky_refactor": "large",
+      "evaluator_used": true,
+      "expected_mode": "used"
+    }
+  ]
+}

--- a/crates/runtime/skills/repo-coding/references/delivery_contract.md
+++ b/crates/runtime/skills/repo-coding/references/delivery_contract.md
@@ -1,0 +1,36 @@
+# Repo-Worker Delivery Contract
+
+Repo-worker runs should end with a bounded delivery artifact that the parent
+steward can inspect without replaying the full child transcript.
+
+## Required fields
+
+The contract is expressed as JSON with these required fields:
+
+1. `status`: one of `completed`, `blocked`, or `failed`
+2. `summary`: concise explanation of what happened
+3. `changed_files`: array of repo-relative file paths
+4. `verification`: non-empty array of verification entries
+5. `residual_risks`: array of remaining risks or blockers
+6. `evaluator`: conditional evaluator decision and reason
+
+## Verification entry shape
+
+Each verification entry should include:
+
+1. `command`
+2. `scope`: `targeted` or `broader`
+3. `status`: `passed`, `failed`, or `not_run`
+4. `exit_code`
+5. `summary`
+
+## Evaluator field
+
+`evaluator` should record:
+
+1. `mode`: `not_needed`, `recommended`, or `used`
+2. `reason`: concise explanation tied to the task state
+
+This keeps the repo-worker output explicit about whether the run stayed inside
+the stable solo loop or crossed into a case where evaluator support should have
+been considered.

--- a/crates/runtime/skills/repo-coding/references/evaluator_boundary.md
+++ b/crates/runtime/skills/repo-coding/references/evaluator_boundary.md
@@ -1,0 +1,25 @@
+# Conditional Evaluator Boundary
+
+The repo worker should not default to always-on evaluator or critic loops.
+
+Planner remains load-bearing by default. Evaluator support is conditional.
+
+## Recommend evaluator when
+
+1. targeted verification fails repeatedly,
+2. deterministic checks are missing or too weak,
+3. the task is UI or browser heavy,
+4. the refactor is large or unusually risky.
+
+## Do not require evaluator when
+
+1. the task is a small repo-local change,
+2. deterministic targeted verification exists,
+3. the first verification pass succeeds,
+4. the residual risk is already bounded and explained clearly.
+
+## Reporting rule
+
+Even when evaluator support is not used, the repo worker should state that
+decision in the delivery contract through `evaluator.mode` and
+`evaluator.reason`.

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -11,9 +11,15 @@ is defined in `docs/spec/alan_coding_steward_contract.md`.
 1. `SKILL.md` as the parent-facing entry for repo-scoped coding delegation.
 2. `skill.yaml` declaring delegated execution through the package-local
    `repo-worker` child target.
-3. `agents/repo-worker/` with the child agent root, coding micro-skills, and
+3. `agents/openai.yaml` with package-level compatibility metadata for catalog
+   display and activation hints.
+4. `agents/repo-worker/` with the child agent root, coding micro-skills, and
    extension manifest examples.
-4. External smoke and harness entrypoints under `scripts/repo-worker/` and
+5. `references/delivery_contract.md` and `references/evaluator_boundary.md`
+   describing the bounded output contract and conditional evaluator boundary.
+6. `scripts/` with deterministic validators for delivery-contract shape and
+   evaluator-boundary cases.
+7. External smoke and harness entrypoints under `scripts/repo-worker/` and
    `scripts/harness/`.
 
 ## Quick validation

--- a/crates/runtime/skills/repo-coding/scripts/check_evaluator_boundaries.sh
+++ b/crates/runtime/skills/repo-coding/scripts/check_evaluator_boundaries.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/check_evaluator_boundaries.sh <evaluator-cases.json>
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to validate repo-worker evaluator boundaries." >&2
+    exit 1
+fi
+
+cases_path="$1"
+if [[ ! -f "$cases_path" ]]; then
+    echo "Missing evaluator cases: $cases_path" >&2
+    exit 1
+fi
+
+mismatches="$(
+    jq -rc '
+      def decide_mode:
+        if .evaluator_used then
+          "used"
+        elif (.repeated_verification_failures > 0)
+          or (.deterministic_checks_available | not)
+          or .ui_heavy_task
+          or (.risky_refactor == "large")
+        then
+          "recommended"
+        else
+          "not_needed"
+        end;
+
+      .cases[]
+      | {id, expected_mode, actual_mode: decide_mode}
+      | select(.expected_mode != .actual_mode)
+    ' "$cases_path"
+)"
+
+if [[ -n "$mismatches" ]]; then
+    echo "Repo-worker evaluator-boundary mismatches:" >&2
+    printf '%s\n' "$mismatches" >&2
+    exit 1
+fi
+
+case_count="$(jq -r '.cases | length' "$cases_path")"
+echo "Repo-worker evaluator boundaries validated for ${case_count} cases."

--- a/crates/runtime/skills/repo-coding/scripts/check_evaluator_boundaries.sh
+++ b/crates/runtime/skills/repo-coding/scripts/check_evaluator_boundaries.sh
@@ -29,7 +29,7 @@ mismatches="$(
       def decide_mode:
         if .evaluator_used then
           "used"
-        elif (.repeated_verification_failures > 0)
+        elif (.repeated_verification_failures > 1)
           or (.deterministic_checks_available | not)
           or .ui_heavy_task
           or (.risky_refactor == "large")

--- a/crates/runtime/skills/repo-coding/scripts/validate_delivery_contract.sh
+++ b/crates/runtime/skills/repo-coding/scripts/validate_delivery_contract.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/validate_delivery_contract.sh <delivery-contract.json>
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to validate the repo-worker delivery contract." >&2
+    exit 1
+fi
+
+contract_path="$1"
+if [[ ! -f "$contract_path" ]]; then
+    echo "Missing delivery contract: $contract_path" >&2
+    exit 1
+fi
+
+jq -e '
+  def one_of($value; $choices):
+    $choices | index($value) != null;
+
+  (.status | type == "string") and
+  (.status as $status | one_of($status; ["completed", "blocked", "failed"])) and
+  (.summary | type == "string" and length > 0) and
+  (.changed_files | type == "array" and all(.[]; type == "string")) and
+  (.verification | type == "array" and length > 0) and
+  all(
+    .verification[];
+    (.command | type == "string" and length > 0) and
+    (.scope | type == "string") and
+    (.scope as $scope | one_of($scope; ["targeted", "broader"])) and
+    (.status | type == "string") and
+    (.status as $status | one_of($status; ["passed", "failed", "not_run"])) and
+    (.exit_code | type == "number") and
+    (.summary | type == "string" and length > 0)
+  ) and
+  (.residual_risks | type == "array" and all(.[]; type == "string")) and
+  (.evaluator | type == "object") and
+  (.evaluator.mode | type == "string") and
+  (.evaluator.mode as $mode | one_of($mode; ["not_needed", "recommended", "used"])) and
+  (.evaluator.reason | type == "string" and length > 0)
+' "$contract_path" >/dev/null
+
+echo "Repo-worker delivery contract is valid: $contract_path"

--- a/crates/runtime/src/skills/capability_view.rs
+++ b/crates/runtime/src/skills/capability_view.rs
@@ -257,6 +257,60 @@ mod tests {
     }
 
     #[test]
+    fn builtin_repo_coding_package_exposes_repo_worker_resources() {
+        let view = ResolvedCapabilityView::from_package_dirs(Vec::new());
+        let package = view
+            .packages
+            .iter()
+            .find(|package| package.id == "builtin:alan-repo-coding")
+            .unwrap();
+
+        let root_dir = package.root_dir.as_ref().unwrap();
+        assert!(root_dir.join("SKILL.md").is_file());
+        assert!(root_dir.join("agents/openai.yaml").is_file());
+        assert!(root_dir.join("references/delivery_contract.md").is_file());
+        assert!(root_dir.join("references/evaluator_boundary.md").is_file());
+        assert!(
+            root_dir
+                .join("scripts/validate_delivery_contract.sh")
+                .is_file()
+        );
+        assert!(
+            root_dir
+                .join("scripts/check_evaluator_boundaries.sh")
+                .is_file()
+        );
+        assert!(root_dir.join("evals/evaluator_cases.json").is_file());
+
+        assert_eq!(
+            package.exports.child_agents[0].handle,
+            alan_protocol::SpawnTarget::PackageChildAgent {
+                package_id: "builtin:alan-repo-coding".to_string(),
+                export_name: "repo-worker".to_string(),
+            }
+        );
+        assert_eq!(package.exports.child_agents[0].name, "repo-worker");
+        assert_eq!(
+            package
+                .exports
+                .resources
+                .scripts_dir
+                .as_deref()
+                .map(std::path::Path::is_dir),
+            Some(true)
+        );
+        assert_eq!(
+            package
+                .exports
+                .resources
+                .references_dir
+                .as_deref()
+                .map(std::path::Path::is_dir),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn resolved_capability_view_discovers_single_skill_packages_from_overlay_dirs() {
         let temp = TempDir::new().unwrap();
         let skills_dir = temp.path().join("skills");

--- a/crates/runtime/src/skills/registry.rs
+++ b/crates/runtime/src/skills/registry.rs
@@ -1037,6 +1037,56 @@ interface:
     }
 
     #[test]
+    fn load_capability_view_loads_builtin_repo_coding_compatibility_metadata() {
+        let capability_view = ResolvedCapabilityView::from_package_dirs(Vec::new());
+        let registry = SkillsRegistry::load_capability_view(&capability_view, &[]).unwrap();
+        let skill = registry.get(&"repo-coding".to_string()).unwrap();
+
+        assert_eq!(
+            skill.package_id.as_deref(),
+            Some("builtin:alan-repo-coding")
+        );
+        assert!(skill.enabled);
+        assert!(skill.allow_implicit_invocation);
+        assert_eq!(skill.display_name(), "Repo Coding");
+        assert_eq!(
+            skill.effective_short_description(),
+            Some("Launch a repo-scoped coding worker")
+        );
+        assert_eq!(
+            skill
+                .compatible_metadata
+                .interface
+                .short_description
+                .as_deref(),
+            Some("Delegate bounded repo-scoped coding work")
+        );
+        assert_eq!(
+            skill
+                .compatible_metadata
+                .interface
+                .default_prompt
+                .as_deref(),
+            Some(
+                "Use this package when Alan should hand off focused coding work to a repo-scoped child worker with a clear verification and delivery contract."
+            )
+        );
+        assert_eq!(
+            skill.execution,
+            ResolvedSkillExecution::Delegate {
+                target: "repo-worker".to_string(),
+                source: SkillExecutionResolutionSource::ExplicitMetadata,
+            }
+        );
+        assert!(
+            skill
+                .resource_root
+                .as_deref()
+                .is_some_and(|path| path.join("references/delivery_contract.md").is_file())
+        );
+    }
+
+    #[test]
     fn load_capability_view_invalid_sidecar_is_non_fatal() {
         let temp = TempDir::new().unwrap();
         let repo_skills = temp.path().join("skills");

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -220,7 +220,7 @@ Start with an automatically executable batch (each must include input script, as
    - Assertions: promotion only if thresholds pass (success rate, cost, boundary violations).
 8. `repo_worker/minimum_loop`
    - Goal: validate the first-party repo-worker package executes task -> plan -> edit -> verify -> deliver.
-   - Assertions: package completeness, loop artifacts, verification success.
+   - Assertions: package completeness, loop artifacts, verification success, and delivery-contract validity.
 9. `repo_worker/input_modes_stability`
    - Goal: validate `steer/follow_up/next_turn` semantics in repo-worker paths.
    - Assertions: queue behavior, turn-driving semantics, and buffering boundaries.

--- a/docs/harness/scenarios/repo_worker/minimum_loop.json
+++ b/docs/harness/scenarios/repo_worker/minimum_loop.json
@@ -7,11 +7,13 @@
   "assertions": [
     "repo-worker package layout is complete",
     "minimum repo-worker loop artifacts are emitted",
-    "verification command exits zero"
+    "verification command exits zero",
+    "delivery contract and evaluator boundary validations pass"
   ],
   "kpi_tags": [
     "repo_worker_loop",
     "package_shape",
-    "verification"
+    "verification",
+    "delivery_contract"
   ]
 }

--- a/scripts/repo-worker/run_smoke.sh
+++ b/scripts/repo-worker/run_smoke.sh
@@ -166,8 +166,8 @@ verification_status="passed"
 verification_summary="Targeted cargo test passed after patching add()."
 if [[ $verify_exit -ne 0 ]]; then
     delivery_status="failed"
-    evaluator_mode="recommended"
-    evaluator_reason="Targeted verification failed, so evaluator support should be considered before retrying broader checks."
+    evaluator_mode="not_needed"
+    evaluator_reason="Targeted verification failed once, but evaluator support is only recommended after repeated failures or when scope/risk increases."
     residual_risks_json='["Targeted verification failed; inspect verify.log before expanding scope."]'
     verification_status="failed"
     verification_summary="Targeted cargo test failed after the patch; broader checks were intentionally skipped."

--- a/scripts/repo-worker/run_smoke.sh
+++ b/scripts/repo-worker/run_smoke.sh
@@ -45,8 +45,14 @@ trace_file="$artifact_root/loop_trace.log"
 required_files=(
     "SKILL.md"
     "skill.yaml"
+    "agents/openai.yaml"
     "references/package.md"
+    "references/delivery_contract.md"
+    "references/evaluator_boundary.md"
     "evals/README.md"
+    "evals/evaluator_cases.json"
+    "scripts/validate_delivery_contract.sh"
+    "scripts/check_evaluator_boundaries.sh"
     "agents/repo-worker/agent.toml"
     "agents/repo-worker/persona/ROLE.md"
     "agents/repo-worker/policy.yaml"
@@ -152,29 +158,101 @@ if [[ -n "$change_line" ]]; then
     edit_applied=true
 fi
 
+delivery_status="completed"
+evaluator_mode="not_needed"
+evaluator_reason="A targeted deterministic check passed on a small repo-local bug fix, so evaluator support was not needed."
+residual_risks_json='[]'
+verification_status="passed"
+verification_summary="Targeted cargo test passed after patching add()."
+if [[ $verify_exit -ne 0 ]]; then
+    delivery_status="failed"
+    evaluator_mode="recommended"
+    evaluator_reason="Targeted verification failed, so evaluator support should be considered before retrying broader checks."
+    residual_risks_json='["Targeted verification failed; inspect verify.log before expanding scope."]'
+    verification_status="failed"
+    verification_summary="Targeted cargo test failed after the patch; broader checks were intentionally skipped."
+fi
+
+cat >"$artifact_root/delivery_contract.json" <<JSON
+{
+  "status": "$delivery_status",
+  "summary": "Fixed add() to return addition instead of subtraction.",
+  "changed_files": [
+    "src/lib.rs"
+  ],
+  "verification": [
+    {
+      "command": "cargo test --quiet",
+      "scope": "targeted",
+      "status": "$verification_status",
+      "exit_code": $verify_exit,
+      "summary": "$verification_summary"
+    }
+  ],
+  "residual_risks": $residual_risks_json,
+  "evaluator": {
+    "mode": "$evaluator_mode",
+    "reason": "$evaluator_reason"
+  }
+}
+JSON
+
+set +e
+"$package_root/scripts/validate_delivery_contract.sh" \
+    "$artifact_root/delivery_contract.json" \
+    >"$artifact_root/delivery_contract.log" 2>&1
+delivery_contract_exit=$?
+"$package_root/scripts/check_evaluator_boundaries.sh" \
+    "$package_root/evals/evaluator_cases.json" \
+    >"$artifact_root/evaluator_boundary.log" 2>&1
+evaluator_boundary_exit=$?
+set -e
+
+delivery_contract_valid=false
+if [[ $delivery_contract_exit -eq 0 ]]; then
+    delivery_contract_valid=true
+fi
+
+evaluator_boundaries_valid=false
+if [[ $evaluator_boundary_exit -eq 0 ]]; then
+    evaluator_boundaries_valid=true
+fi
+
+smoke_passed=false
+if [[ "$verified" == "true" && "$delivery_contract_valid" == "true" && "$evaluator_boundaries_valid" == "true" ]]; then
+    smoke_passed=true
+fi
+
 cat >"$artifact_root/delivery_summary.md" <<SUMMARY
 # Repo Worker Smoke Summary
 
+- status: $delivery_status
 - mode: $mode
 - edit_applied: $edit_applied
 - edit_line: ${change_line:-unknown}
 - verify_exit: $verify_exit
 - verified: $verified
+- evaluator_mode: $evaluator_mode
+- delivery_contract_valid: $delivery_contract_valid
+- evaluator_boundaries_valid: $evaluator_boundaries_valid
 SUMMARY
 
 cat >"$artifact_root/assertion_report.json" <<ASSERT
-{"scenario":"repo_worker/minimum_loop_smoke","passed":$verified,"assertions":[{"name":"package_present","passed":true},{"name":"edit_applied","passed":$edit_applied},{"name":"verify_command_exit_zero","passed":$verified}]}
+{"scenario":"repo_worker/minimum_loop_smoke","passed":$smoke_passed,"assertions":[{"name":"package_present","passed":true},{"name":"edit_applied","passed":$edit_applied},{"name":"verify_command_exit_zero","passed":$verified},{"name":"delivery_contract_valid","passed":$delivery_contract_valid},{"name":"evaluator_boundaries_valid","passed":$evaluator_boundaries_valid}]}
 ASSERT
 
 cat >"$artifact_root/summary.json" <<REPORT
-{"mode":"$mode","verify_exit":$verify_exit,"verified":$verified,"artifact_root":"target/repo-worker/smoke/latest"}
+{"mode":"$mode","status":"$delivery_status","verify_exit":$verify_exit,"verified":$verified,"delivery_contract_valid":$delivery_contract_valid,"evaluator_boundaries_valid":$evaluator_boundaries_valid,"passed":$smoke_passed,"artifact_root":"target/repo-worker/smoke/latest"}
 REPORT
 
 echo "Repo worker smoke summary:"
 echo "  mode: $mode"
 echo "  verify_exit: $verify_exit"
+echo "  delivery_contract_valid: $delivery_contract_valid"
+echo "  evaluator_boundaries_valid: $evaluator_boundaries_valid"
+echo "  passed: $smoke_passed"
 echo "  artifacts: $artifact_root"
 
-if [[ $verify_exit -ne 0 ]]; then
+if [[ $verify_exit -ne 0 || $delivery_contract_exit -ne 0 || $evaluator_boundary_exit -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary
- add package-level compatibility metadata for `repo-coding` and test the builtin prompt/catalog surface
- define deterministic repo-worker delivery-contract and evaluator-boundary references, fixtures, and validation scripts
- harden `scripts/repo-worker/run_smoke.sh` and repo-worker harness commands so the blocking subset validates the new contract and avoids whole-package test binary scans

## Testing
- cargo fmt --all
- cargo test -p alan-runtime skills::capability_view::tests::builtin_repo_coding_package_exposes_repo_worker_resources -- --exact
- cargo test -p alan-runtime skills::registry::tests::load_capability_view_loads_builtin_repo_coding_compatibility_metadata -- --exact
- bash scripts/repo-worker/run_smoke.sh --mode ci
- bash scripts/harness/run_repo_worker_suite.sh --ci-blocking

## Stack
- base: #286
- continues #283