### PR TITLE
[VNext][Alan Coding][Governance] Add workspace-aware coding boundaries

### DIFF
--- a/crates/runtime/skills/repo-coding/agents/repo-worker/policy.yaml
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/policy.yaml
@@ -1,8 +1,97 @@
 rules:
+  - id: deny-rm-root
+    tool: bash
+    match_command: "rm -rf /"
+    action: deny
+    reason: dangerous destructive command
+
+  - id: deny-filesystem-wipe
+    tool: bash
+    match_command: "mkfs"
+    action: deny
+    reason: dangerous filesystem operation
+
+  - id: escalate-unknown
+    tool: "*"
+    capability: unknown
+    action: escalate
+    reason: unknown capability requires escalation in the repo worker
+
+  - id: escalate-network
+    tool: "*"
+    capability: network
+    action: escalate
+    reason: network access is an owner boundary for repo-worker execution
+
   - id: escalate-publish
     tool: bash
     match_command: "git push"
     action: escalate
     reason: owner boundary for publish actions
+
+  - id: escalate-force-push
+    tool: bash
+    match_command: "git push --force"
+    action: escalate
+    reason: force push requires escalation
+
+  - id: escalate-cargo-publish
+    tool: bash
+    match_command: "cargo publish"
+    action: escalate
+    reason: package publish requires escalation
+
+  - id: escalate-npm-publish
+    tool: bash
+    match_command: "npm publish"
+    action: escalate
+    reason: package publish requires escalation
+
+  - id: escalate-shared-deploy
+    tool: bash
+    match_command: "kubectl apply"
+    action: escalate
+    reason: shared deploy actions require escalation
+
+  - id: escalate-terraform-apply
+    tool: bash
+    match_command: "terraform apply"
+    action: escalate
+    reason: infrastructure apply requires escalation
+
+  - id: escalate-workflow-edits
+    tool: "*"
+    capability: write
+    match_path_prefix: ".github/workflows/"
+    action: escalate
+    reason: workflow edits cross a shared automation boundary
+
+  - id: escalate-deploy-path-edits
+    tool: "*"
+    capability: write
+    match_path_prefix: "deploy/"
+    action: escalate
+    reason: deploy path edits require escalation
+
+  - id: escalate-infra-path-edits
+    tool: "*"
+    capability: write
+    match_path_prefix: "infra/"
+    action: escalate
+    reason: infrastructure path edits require escalation
+
+  - id: escalate-credential-reads
+    tool: "*"
+    capability: read
+    match_path_prefix: ".env"
+    action: escalate
+    reason: credential reads require escalation
+
+  - id: escalate-credential-writes
+    tool: "*"
+    capability: write
+    match_path_prefix: ".env"
+    action: escalate
+    reason: credential writes require escalation
 
 default_action: allow

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -69,6 +69,7 @@ pub struct PolicyContext<'a> {
     pub tool_name: &'a str,
     pub arguments: &'a serde_json::Value,
     pub capability: alan_protocol::ToolCapability,
+    pub cwd: Option<&'a Path>,
 }
 
 /// Evaluation output with lightweight audit metadata.
@@ -331,7 +332,7 @@ fn rule_matches(rule: &PolicyRule, ctx: &PolicyContext<'_>) -> bool {
     }
 
     if let Some(path_prefix) = rule.match_path_prefix.as_deref()
-        && !arguments_match_path_prefix(ctx.arguments, path_prefix)
+        && !arguments_match_path_prefix(ctx.arguments, path_prefix, ctx.cwd)
     {
         return false;
     }
@@ -339,24 +340,56 @@ fn rule_matches(rule: &PolicyRule, ctx: &PolicyContext<'_>) -> bool {
     true
 }
 
-fn arguments_match_path_prefix(arguments: &serde_json::Value, path_prefix: &str) -> bool {
+fn arguments_match_path_prefix(
+    arguments: &serde_json::Value,
+    path_prefix: &str,
+    current_cwd: Option<&Path>,
+) -> bool {
     let normalized_prefix = normalize_path_match_value(path_prefix);
 
-    collect_path_candidates(arguments)
+    collect_path_candidates(arguments, current_cwd)
         .into_iter()
-        .map(normalize_path_match_value)
         .any(|candidate| candidate.matches_prefix(&normalized_prefix))
 }
 
-fn collect_path_candidates(arguments: &serde_json::Value) -> Vec<&str> {
+fn collect_path_candidates(
+    arguments: &serde_json::Value,
+    current_cwd: Option<&Path>,
+) -> Vec<NormalizedPathMatchValue> {
     const PATH_KEYS: &[&str] = &["path", "paths", "directory", "cwd", "workspace_root"];
+    const BASE_PATH_KEYS: &[&str] = &["directory", "cwd", "workspace_root"];
 
     let Some(object) = arguments.as_object() else {
         return Vec::new();
     };
 
+    let raw_candidates = collect_path_values(object, PATH_KEYS);
+    let mut candidates: Vec<_> = raw_candidates
+        .iter()
+        .copied()
+        .map(normalize_path_match_value)
+        .collect();
+    let base_candidates = collect_base_path_candidates(object, current_cwd, BASE_PATH_KEYS);
+
+    for raw_candidate in raw_candidates {
+        let normalized_candidate = normalize_path_match_value(raw_candidate);
+        if normalized_candidate.is_absolute {
+            continue;
+        }
+        for base_candidate in &base_candidates {
+            candidates.push(normalized_candidate.resolved_against(base_candidate));
+        }
+    }
+
+    candidates
+}
+
+fn collect_path_values<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Vec<&'a str> {
     let mut candidates = Vec::new();
-    for key in PATH_KEYS {
+    for key in keys {
         let Some(value) = object.get(*key) else {
             continue;
         };
@@ -371,6 +404,21 @@ fn collect_path_candidates(arguments: &serde_json::Value) -> Vec<&str> {
         }
     }
 
+    candidates
+}
+
+fn collect_base_path_candidates(
+    object: &serde_json::Map<String, serde_json::Value>,
+    current_cwd: Option<&Path>,
+    keys: &[&str],
+) -> Vec<NormalizedPathMatchValue> {
+    let mut candidates: Vec<_> = collect_path_values(object, keys)
+        .into_iter()
+        .map(normalize_path_match_value)
+        .collect();
+    if let Some(cwd) = current_cwd {
+        candidates.push(normalize_path_match_value(&cwd.to_string_lossy()));
+    }
     candidates
 }
 
@@ -430,6 +478,20 @@ impl NormalizedPathMatchValue {
         (0..self.segments.len())
             .map(|index| self.segments[index..].join("/"))
             .collect()
+    }
+
+    fn resolved_against(&self, base: &Self) -> Self {
+        if self.is_absolute {
+            return self.clone();
+        }
+
+        let mut combined = if base.is_absolute {
+            PathBuf::from(base.render_absolute())
+        } else {
+            PathBuf::from(base.render_relative())
+        };
+        combined.push(self.render_relative());
+        normalize_path_match_value(&combined.to_string_lossy())
     }
 }
 
@@ -521,6 +583,7 @@ mod tests {
             tool_name: "bash",
             arguments: &json!({"command":"curl https://example.com"}),
             capability: alan_protocol::ToolCapability::Network,
+            cwd: None,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-network"));
@@ -533,6 +596,7 @@ mod tests {
             tool_name: "bash",
             arguments: &json!({"command":"curl https://example.com"}),
             capability: alan_protocol::ToolCapability::Network,
+            cwd: None,
         });
         assert_eq!(decision.action, PolicyAction::Allow);
     }
@@ -544,6 +608,7 @@ mod tests {
             tool_name: "bash",
             arguments: &json!({"command":"rm -rf / --no-preserve-root"}),
             capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-rm-root"));
@@ -573,6 +638,7 @@ default_action: allow
             tool_name: "read_file",
             arguments: &json!({}),
             capability: alan_protocol::ToolCapability::Read,
+            cwd: None,
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-read-file"));
@@ -599,6 +665,7 @@ default_action: allow
             tool_name: "write_file",
             arguments: &json!({"path":"./.github/workflows/release.yml","content":"name: release"}),
             capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
         });
 
         assert_eq!(decision.action, PolicyAction::Escalate);
@@ -625,6 +692,7 @@ default_action: allow
             tool_name: "edit_file",
             arguments: &json!({"paths":["src/lib.rs","deploy/prod.yaml"]}),
             capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
         });
 
         assert_eq!(decision.action, PolicyAction::Escalate);
@@ -654,6 +722,7 @@ default_action: allow
                 "content":"name: release"
             }),
             capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
         });
 
         assert_eq!(decision.action, PolicyAction::Escalate);
@@ -680,6 +749,34 @@ default_action: allow
             tool_name: "edit_file",
             arguments: &json!({"path":"tmp/../deploy/prod.yaml"}),
             capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-deploy"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_parent_traversal_against_current_cwd() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-deploy".to_string()),
+                tool: Some("*".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some("deploy/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("deploy config updates require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "edit_file",
+            arguments: &json!({"path":"../deploy/prod.yaml"}),
+            capability: alan_protocol::ToolCapability::Write,
+            cwd: Some(Path::new("/workspace/repo/src")),
         });
 
         assert_eq!(decision.action, PolicyAction::Escalate);
@@ -712,6 +809,7 @@ default_action: allow
             tool_name: "read_file",
             arguments: &json!({"path":".env.production"}),
             capability: alan_protocol::ToolCapability::Read,
+            cwd: None,
         });
 
         assert_eq!(decision.action, PolicyAction::Escalate);
@@ -726,6 +824,7 @@ default_action: allow
             tool_name: "bash",
             arguments: &json!({"command":"python3 script.py"}),
             capability: alan_protocol::ToolCapability::Unknown,
+            cwd: None,
         });
         assert_eq!(decision.action, PolicyAction::Escalate);
         assert_eq!(decision.rule_id.as_deref(), Some("review-unknown"));

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -345,7 +345,7 @@ fn arguments_match_path_prefix(arguments: &serde_json::Value, path_prefix: &str)
     collect_path_candidates(arguments)
         .into_iter()
         .map(normalize_path_match_value)
-        .any(|candidate| candidate.starts_with(&normalized_prefix))
+        .any(|candidate| candidate.matches_prefix(&normalized_prefix))
 }
 
 fn collect_path_candidates(arguments: &serde_json::Value) -> Vec<&str> {
@@ -374,12 +374,111 @@ fn collect_path_candidates(arguments: &serde_json::Value) -> Vec<&str> {
     candidates
 }
 
-fn normalize_path_match_value(value: &str) -> String {
-    let mut normalized = value.trim();
-    while let Some(stripped) = normalized.strip_prefix("./") {
-        normalized = stripped;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedPathMatchValue {
+    is_absolute: bool,
+    has_trailing_separator: bool,
+    segments: Vec<String>,
+}
+
+impl NormalizedPathMatchValue {
+    fn matches_prefix(&self, prefix: &Self) -> bool {
+        let normalized_prefix = prefix.render_relative();
+        if normalized_prefix.is_empty() {
+            return false;
+        }
+
+        if prefix.is_absolute {
+            return self.is_absolute
+                && path_prefix_matches(
+                    &self.render_absolute(),
+                    &prefix.render_absolute(),
+                    prefix.has_trailing_separator,
+                );
+        }
+
+        if self.is_absolute {
+            return self.relative_tails().into_iter().any(|candidate| {
+                path_prefix_matches(
+                    &candidate,
+                    &normalized_prefix,
+                    prefix.has_trailing_separator,
+                )
+            });
+        }
+
+        path_prefix_matches(
+            &self.render_relative(),
+            &normalized_prefix,
+            prefix.has_trailing_separator,
+        )
     }
-    normalized.to_string()
+
+    fn render_absolute(&self) -> String {
+        if self.segments.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", self.render_relative())
+        }
+    }
+
+    fn render_relative(&self) -> String {
+        self.segments.join("/")
+    }
+
+    fn relative_tails(&self) -> Vec<String> {
+        (0..self.segments.len())
+            .map(|index| self.segments[index..].join("/"))
+            .collect()
+    }
+}
+
+fn normalize_path_match_value(value: &str) -> NormalizedPathMatchValue {
+    let normalized_separators = value.trim().replace('\\', "/");
+    let has_trailing_separator = normalized_separators.ends_with('/');
+    let path = Path::new(normalized_separators.as_str());
+    let mut is_absolute = path.is_absolute();
+    let mut segments = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                is_absolute = true;
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(segments.last().map(String::as_str), Some(segment) if segment != "..") {
+                    segments.pop();
+                } else if !is_absolute {
+                    segments.push("..".to_string());
+                }
+            }
+            Component::Normal(segment) => {
+                segments.push(segment.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    NormalizedPathMatchValue {
+        is_absolute,
+        has_trailing_separator,
+        segments,
+    }
+}
+
+fn path_prefix_matches(candidate: &str, prefix: &str, require_component_boundary: bool) -> bool {
+    if prefix.is_empty() {
+        return false;
+    }
+
+    if require_component_boundary {
+        candidate == prefix
+            || candidate
+                .strip_prefix(prefix)
+                .is_some_and(|remaining| remaining.starts_with('/'))
+    } else {
+        candidate.starts_with(prefix)
+    }
 }
 
 fn capability_label(capability: alan_protocol::ToolCapability) -> &'static str {
@@ -525,6 +624,61 @@ default_action: allow
         let decision = engine.evaluate(PolicyContext {
             tool_name: "edit_file",
             arguments: &json!({"paths":["src/lib.rs","deploy/prod.yaml"]}),
+            capability: alan_protocol::ToolCapability::Write,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-deploy"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_absolute_write_path() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-workflows".to_string()),
+                tool: Some("write_file".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some(".github/workflows/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("workflow edits require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "write_file",
+            arguments: &json!({
+                "path":"/workspace/repo/.github/workflows/release.yml",
+                "content":"name: release"
+            }),
+            capability: alan_protocol::ToolCapability::Write,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-workflows"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_parent_traversal_path() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-deploy".to_string()),
+                tool: Some("*".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some("deploy/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("deploy config updates require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "edit_file",
+            arguments: &json!({"path":"tmp/../deploy/prod.yaml"}),
             capability: alan_protocol::ToolCapability::Write,
         });
 

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -45,6 +45,9 @@ pub struct PolicyRule {
     /// For bash: case-insensitive substring match against command.
     #[serde(default)]
     pub match_command: Option<String>,
+    /// For file-oriented tools: normalized prefix match against common path arguments.
+    #[serde(default)]
+    pub match_path_prefix: Option<String>,
     /// Rule action.
     pub action: PolicyAction,
     /// Optional human-readable reason.
@@ -95,6 +98,7 @@ impl PolicyEngine {
                         tool: Some("*".to_string()),
                         capability: Some("network".to_string()),
                         match_command: None,
+                        match_path_prefix: None,
                         action: PolicyAction::Deny,
                         reason: Some(
                             "network access is denied by conservative profile".to_string(),
@@ -105,6 +109,7 @@ impl PolicyEngine {
                         tool: Some("*".to_string()),
                         capability: Some("write".to_string()),
                         match_command: None,
+                        match_path_prefix: None,
                         action: PolicyAction::Escalate,
                         reason: Some("write operations require escalation".to_string()),
                     },
@@ -113,6 +118,7 @@ impl PolicyEngine {
                         tool: Some("*".to_string()),
                         capability: Some("unknown".to_string()),
                         match_command: None,
+                        match_path_prefix: None,
                         action: PolicyAction::Escalate,
                         reason: Some("unknown capability requires escalation".to_string()),
                     },
@@ -127,6 +133,7 @@ impl PolicyEngine {
                         tool: Some("bash".to_string()),
                         capability: None,
                         match_command: Some("rm -rf /".to_string()),
+                        match_path_prefix: None,
                         action: PolicyAction::Deny,
                         reason: Some("dangerous destructive command".to_string()),
                     },
@@ -135,6 +142,7 @@ impl PolicyEngine {
                         tool: Some("bash".to_string()),
                         capability: None,
                         match_command: Some("mkfs".to_string()),
+                        match_path_prefix: None,
                         action: PolicyAction::Deny,
                         reason: Some("dangerous filesystem operation".to_string()),
                     },
@@ -143,6 +151,7 @@ impl PolicyEngine {
                         tool: Some("bash".to_string()),
                         capability: None,
                         match_command: Some("git push --force".to_string()),
+                        match_path_prefix: None,
                         action: PolicyAction::Escalate,
                         reason: Some("force push requires escalation".to_string()),
                     },
@@ -151,6 +160,7 @@ impl PolicyEngine {
                         tool: Some("*".to_string()),
                         capability: Some("unknown".to_string()),
                         match_command: None,
+                        match_path_prefix: None,
                         action: PolicyAction::Escalate,
                         reason: Some("unknown capability requires escalation".to_string()),
                     },
@@ -320,7 +330,56 @@ fn rule_matches(rule: &PolicyRule, ctx: &PolicyContext<'_>) -> bool {
         }
     }
 
+    if let Some(path_prefix) = rule.match_path_prefix.as_deref()
+        && !arguments_match_path_prefix(ctx.arguments, path_prefix)
+    {
+        return false;
+    }
+
     true
+}
+
+fn arguments_match_path_prefix(arguments: &serde_json::Value, path_prefix: &str) -> bool {
+    let normalized_prefix = normalize_path_match_value(path_prefix);
+
+    collect_path_candidates(arguments)
+        .into_iter()
+        .map(normalize_path_match_value)
+        .any(|candidate| candidate.starts_with(&normalized_prefix))
+}
+
+fn collect_path_candidates(arguments: &serde_json::Value) -> Vec<&str> {
+    const PATH_KEYS: &[&str] = &["path", "paths", "directory", "cwd", "workspace_root"];
+
+    let Some(object) = arguments.as_object() else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    for key in PATH_KEYS {
+        let Some(value) = object.get(*key) else {
+            continue;
+        };
+        match value {
+            serde_json::Value::String(path) => candidates.push(path.as_str()),
+            serde_json::Value::Array(paths) => {
+                for path in paths.iter().filter_map(serde_json::Value::as_str) {
+                    candidates.push(path);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    candidates
+}
+
+fn normalize_path_match_value(value: &str) -> String {
+    let mut normalized = value.trim();
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped;
+    }
+    normalized.to_string()
 }
 
 fn capability_label(capability: alan_protocol::ToolCapability) -> &'static str {
@@ -418,6 +477,91 @@ default_action: allow
         });
         assert_eq!(decision.action, PolicyAction::Deny);
         assert_eq!(decision.rule_id.as_deref(), Some("deny-read-file"));
+        assert_eq!(decision.source, "workspace_policy_file");
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_write_path() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-workflows".to_string()),
+                tool: Some("write_file".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some(".github/workflows/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("workflow edits require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "write_file",
+            arguments: &json!({"path":"./.github/workflows/release.yml","content":"name: release"}),
+            capability: alan_protocol::ToolCapability::Write,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-workflows"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_paths_array() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-deploy".to_string()),
+                tool: Some("*".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some("deploy/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("deploy config updates require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "edit_file",
+            arguments: &json!({"paths":["src/lib.rs","deploy/prod.yaml"]}),
+            capability: alan_protocol::ToolCapability::Write,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-deploy"));
+    }
+
+    #[test]
+    fn load_workspace_policy_file_supports_match_path_prefix() {
+        let tmp = TempDir::new().unwrap();
+        let policy_dir = tmp.path().join("workspace-alan");
+        std::fs::create_dir_all(&policy_dir).unwrap();
+        std::fs::write(
+            policy_dir.join("policy.yaml"),
+            r#"
+rules:
+  - id: review-credentials
+    tool: read_file
+    capability: read
+    match_path_prefix: ".env"
+    action: escalate
+    reason: credential reads require escalation
+default_action: allow
+"#,
+        )
+        .unwrap();
+
+        let engine =
+            PolicyEngine::load_or_profile(Some(policy_dir.as_path()), PolicyProfile::Autonomous);
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "read_file",
+            arguments: &json!({"path":".env.production"}),
+            capability: alan_protocol::ToolCapability::Read,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-credentials"));
         assert_eq!(decision.source, "workspace_policy_file");
     }
 

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -533,14 +533,21 @@ fn path_prefix_matches(candidate: &str, prefix: &str, require_component_boundary
         return false;
     }
 
+    let candidate = normalize_path_match_case(candidate);
+    let prefix = normalize_path_match_case(prefix);
+
     if require_component_boundary {
         candidate == prefix
             || candidate
-                .strip_prefix(prefix)
+                .strip_prefix(prefix.as_str())
                 .is_some_and(|remaining| remaining.starts_with('/'))
     } else {
-        candidate.starts_with(prefix)
+        candidate.starts_with(prefix.as_str())
     }
+}
+
+fn normalize_path_match_case(value: &str) -> String {
+    value.to_lowercase()
 }
 
 fn capability_label(capability: alan_protocol::ToolCapability) -> &'static str {
@@ -781,6 +788,33 @@ default_action: allow
 
         assert_eq!(decision.action, PolicyAction::Escalate);
         assert_eq!(decision.rule_id.as_deref(), Some("review-deploy"));
+    }
+
+    #[test]
+    fn policy_rule_match_path_prefix_matches_case_variants() {
+        let engine = PolicyEngine {
+            rules: vec![PolicyRule {
+                id: Some("review-workflows".to_string()),
+                tool: Some("write_file".to_string()),
+                capability: Some("write".to_string()),
+                match_command: None,
+                match_path_prefix: Some(".github/workflows/".to_string()),
+                action: PolicyAction::Escalate,
+                reason: Some("workflow edits require escalation".to_string()),
+            }],
+            default_action: PolicyAction::Allow,
+            source: "test",
+        };
+
+        let decision = engine.evaluate(PolicyContext {
+            tool_name: "write_file",
+            arguments: &json!({"path":".GitHub/Workflows/release.yml","content":"name: release"}),
+            capability: alan_protocol::ToolCapability::Write,
+            cwd: None,
+        });
+
+        assert_eq!(decision.action, PolicyAction::Escalate);
+        assert_eq!(decision.rule_id.as_deref(), Some("review-workflows"));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -459,6 +459,7 @@ where
                 .and_then(|tool| tool.capability)
         })
         .unwrap_or(ToolCapability::Unknown);
+    let current_tool_cwd = state.tools.default_cwd();
     let policy_decision = maybe_allow_approved_tool_escalation_replay(
         evaluate_tool_policy(
             &state.runtime_config.policy_engine,
@@ -466,6 +467,7 @@ where
             &tool_call.name,
             &tool_arguments,
             tool_capability,
+            current_tool_cwd.as_deref(),
         ),
         allow_approved_tool_escalation_execution,
     );

--- a/crates/runtime/src/runtime/tool_policy.rs
+++ b/crates/runtime/src/runtime/tool_policy.rs
@@ -22,6 +22,7 @@ pub(super) fn evaluate_tool_policy(
     tool_name: &str,
     arguments: &serde_json::Value,
     capability: alan_protocol::ToolCapability,
+    current_cwd: Option<&std::path::Path>,
 ) -> ToolPolicyDecision {
     let sandbox_backend = crate::tools::Sandbox::backend_name_static();
     if let Some(reason) = bash_shape_preflight_reason(tool_name, arguments) {
@@ -42,6 +43,7 @@ pub(super) fn evaluate_tool_policy(
         tool_name,
         arguments,
         capability,
+        cwd: current_cwd,
     });
     let capability_kind = capability_label(capability).to_string();
     let policy_source = policy_decision.source.to_string();
@@ -126,6 +128,8 @@ pub(super) fn capability_label(capability: alan_protocol::ToolCapability) -> &'s
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     #[test]
     fn test_conservative_unknown_capability_escalates() {
@@ -140,6 +144,7 @@ mod tests {
             "dynamic_tool",
             &json!({"id":"123"}),
             alan_protocol::ToolCapability::Unknown,
+            None,
         );
         match result {
             ToolPolicyDecision::Escalate { details, .. } => {
@@ -163,6 +168,7 @@ mod tests {
             "bash",
             &json!({"query":"rust"}),
             alan_protocol::ToolCapability::Network,
+            None,
         );
         match result {
             ToolPolicyDecision::Allow { audit } => {
@@ -186,6 +192,7 @@ mod tests {
             "bash",
             &json!({"command":"bash -lc 'rg TODO src'"}),
             alan_protocol::ToolCapability::Unknown,
+            None,
         );
         match result {
             ToolPolicyDecision::Forbidden { reason, audit } => {
@@ -213,11 +220,55 @@ mod tests {
             "write_file",
             &json!({"path":"a.txt","content":"x"}),
             alan_protocol::ToolCapability::Write,
+            None,
         );
         match result {
             ToolPolicyDecision::Escalate { audit, .. } => {
                 assert_eq!(audit.action, "escalate");
                 assert_eq!(audit.capability, "write");
+            }
+            other => panic!("expected escalation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_tool_policy_uses_current_cwd_for_relative_path_prefix_matching() {
+        let tmp = TempDir::new().unwrap();
+        let policy_dir = tmp.path().join("workspace-alan");
+        std::fs::create_dir_all(&policy_dir).unwrap();
+        std::fs::write(
+            policy_dir.join("policy.yaml"),
+            r#"
+rules:
+  - id: review-deploy
+    tool: "*"
+    capability: write
+    match_path_prefix: "deploy/"
+    action: escalate
+    reason: deploy config updates require escalation
+default_action: allow
+"#,
+        )
+        .unwrap();
+        let policy = crate::policy::PolicyEngine::load_or_profile(
+            Some(policy_dir.as_path()),
+            crate::policy::PolicyProfile::Autonomous,
+        );
+        let result = evaluate_tool_policy(
+            &policy,
+            &alan_protocol::GovernanceConfig {
+                profile: alan_protocol::GovernanceProfile::Autonomous,
+                policy_path: None,
+            },
+            "write_file",
+            &json!({"path":"../deploy/prod.yaml","content":"version = 2"}),
+            alan_protocol::ToolCapability::Write,
+            Some(Path::new("/workspace/repo/src")),
+        );
+        match result {
+            ToolPolicyDecision::Escalate { audit, .. } => {
+                assert_eq!(audit.action, "escalate");
+                assert_eq!(audit.rule_id.as_deref(), Some("review-deploy"));
             }
             other => panic!("expected escalation, got {:?}", other),
         }

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -110,6 +110,8 @@ relative policy prefixes still match absolute tool paths on component
 boundaries.
 When the runtime has a current tool `cwd`, relative path arguments are also
 evaluated against that base so parent-traversal paths do not bypass policy.
+Alan also case-folds path-prefix comparisons conservatively so case variants do
+not bypass policy on case-insensitive hosts.
 
 This is useful for coding-governance boundaries on sensitive paths such as
 workflow, deploy, infrastructure, or credential files. It does not make bash

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -94,6 +94,23 @@ Current daemon session APIs report this host-side guard as
 `execution_backend: "workspace_path_guard"` so clients can present the active
 execution backend honestly without implying strict containment.
 
+### 5. Current Policy Matchers Include Path Prefix Rules
+
+Alan's current `policy.yaml` matcher surface includes:
+
+1. `tool`
+2. `capability`
+3. `match_command`
+4. `match_path_prefix`
+
+`match_path_prefix` currently applies to common file-oriented arguments such as
+`path`, `paths`, `directory`, `cwd`, and `workspace_root`.
+
+This is useful for coding-governance boundaries on sensitive paths such as
+workflow, deploy, infrastructure, or credential files. It does not make bash
+commands fully path-aware; shell payloads still rely on `match_command` plus
+the execution backend's own path/shaping logic.
+
 ## Alignment Rules
 
 - README and current-user docs must describe the semantics in this document.

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -105,6 +105,9 @@ Alan's current `policy.yaml` matcher surface includes:
 
 `match_path_prefix` currently applies to common file-oriented arguments such as
 `path`, `paths`, `directory`, `cwd`, and `workspace_root`.
+Before matching, Alan lexically normalizes `.` / `..` segments and lets
+relative policy prefixes still match absolute tool paths on component
+boundaries.
 
 This is useful for coding-governance boundaries on sensitive paths such as
 workflow, deploy, infrastructure, or credential files. It does not make bash

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -108,6 +108,8 @@ Alan's current `policy.yaml` matcher surface includes:
 Before matching, Alan lexically normalizes `.` / `..` segments and lets
 relative policy prefixes still match absolute tool paths on component
 boundaries.
+When the runtime has a current tool `cwd`, relative path arguments are also
+evaluated against that base so parent-traversal paths do not bypass policy.
 
 This is useful for coding-governance boundaries on sensitive paths such as
 workflow, deploy, infrastructure, or credential files. It does not make bash

--- a/docs/harness/scenarios/repo_worker/governance_boundary.json
+++ b/docs/harness/scenarios/repo_worker/governance_boundary.json
@@ -1,13 +1,14 @@
 {
   "id": "repo_worker/governance_boundary",
   "category": "repo_worker",
-  "description": "Validate repo-worker governance catches both unknown side-effect status and sensitive path boundaries.",
+  "description": "Validate repo-worker governance catches unknown side-effect status plus normalized sensitive path boundaries.",
   "blocking": false,
-  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
+  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_absolute_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_path -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
   "assertions": [
     "unknown side-effect status does not auto-execute",
     "confirmation yield is emitted for manual handoff",
     "sensitive path edits can be escalated through policy path-prefix rules",
+    "absolute and traversed paths still honor policy path-prefix rules",
     "workspace policy files can express coding-specific path boundaries"
   ],
   "kpi_tags": [

--- a/docs/harness/scenarios/repo_worker/governance_boundary.json
+++ b/docs/harness/scenarios/repo_worker/governance_boundary.json
@@ -1,14 +1,15 @@
 {
   "id": "repo_worker/governance_boundary",
   "category": "repo_worker",
-  "description": "Validate repo-worker governance catches unknown side-effect status plus normalized sensitive path boundaries.",
+  "description": "Validate repo-worker governance catches unknown side-effect status plus normalized cwd-aware sensitive path boundaries.",
   "blocking": false,
-  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_absolute_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_path -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
+  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib runtime::tool_policy::tests::test_tool_policy_uses_current_cwd_for_relative_path_prefix_matching -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_absolute_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_against_current_cwd -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
   "assertions": [
     "unknown side-effect status does not auto-execute",
     "confirmation yield is emitted for manual handoff",
     "sensitive path edits can be escalated through policy path-prefix rules",
     "absolute and traversed paths still honor policy path-prefix rules",
+    "relative parent traversal also honors path-prefix rules after resolving against the current tool cwd",
     "workspace policy files can express coding-specific path boundaries"
   ],
   "kpi_tags": [

--- a/docs/harness/scenarios/repo_worker/governance_boundary.json
+++ b/docs/harness/scenarios/repo_worker/governance_boundary.json
@@ -1,17 +1,19 @@
 {
   "id": "repo_worker/governance_boundary",
   "category": "repo_worker",
-  "description": "Validate unknown side-effect status in repo-worker flow requires governance-safe handoff.",
+  "description": "Validate repo-worker governance catches both unknown side-effect status and sensitive path boundaries.",
   "blocking": false,
-  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact",
+  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
   "assertions": [
     "unknown side-effect status does not auto-execute",
     "confirmation yield is emitted for manual handoff",
-    "recovery flow does not bypass governance"
+    "sensitive path edits can be escalated through policy path-prefix rules",
+    "workspace policy files can express coding-specific path boundaries"
   ],
   "kpi_tags": [
     "governance",
     "boundary",
-    "manual_handoff"
+    "manual_handoff",
+    "path_boundary"
   ]
 }

--- a/docs/harness/scenarios/repo_worker/governance_boundary.json
+++ b/docs/harness/scenarios/repo_worker/governance_boundary.json
@@ -1,15 +1,16 @@
 {
   "id": "repo_worker/governance_boundary",
   "category": "repo_worker",
-  "description": "Validate repo-worker governance catches unknown side-effect status plus normalized cwd-aware sensitive path boundaries.",
+  "description": "Validate repo-worker governance catches unknown side-effect status plus normalized cwd-aware and case-folded sensitive path boundaries.",
   "blocking": false,
-  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib runtime::tool_policy::tests::test_tool_policy_uses_current_cwd_for_relative_path_prefix_matching -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_absolute_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_against_current_cwd -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
+  "command": "cargo test -p alan-runtime --lib runtime::tool_orchestrator::tests::test_unknown_effect_status_escalates_without_execution -- --exact && cargo test -p alan-runtime --lib runtime::tool_policy::tests::test_tool_policy_uses_current_cwd_for_relative_path_prefix_matching -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_absolute_write_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_path -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_parent_traversal_against_current_cwd -- --exact && cargo test -p alan-runtime --lib policy::tests::policy_rule_match_path_prefix_matches_case_variants -- --exact && cargo test -p alan-runtime --lib policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact",
   "assertions": [
     "unknown side-effect status does not auto-execute",
     "confirmation yield is emitted for manual handoff",
     "sensitive path edits can be escalated through policy path-prefix rules",
     "absolute and traversed paths still honor policy path-prefix rules",
     "relative parent traversal also honors path-prefix rules after resolving against the current tool cwd",
+    "case variants still honor path-prefix rules on case-insensitive hosts and conservative matches on case-sensitive hosts",
     "workspace policy files can express coding-specific path boundaries"
   ],
   "kpi_tags": [

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -92,6 +92,8 @@ steps, it is probably a plan rather than a spec.
 
 - [hite_governance.md](./hite_governance.md): target HITE governance model
   and authorization semantics.
+- [alan_coding_governance_contract.md](./alan_coding_governance_contract.md):
+  workspace-aware steward and repo-worker coding governance.
 - [governance_boundaries.md](./governance_boundaries.md): HITE boundary and
   exception-plane contract.
 - [skill_system_contract.md](./skill_system_contract.md): authoritative

--- a/docs/spec/alan_coding_governance_contract.md
+++ b/docs/spec/alan_coding_governance_contract.md
@@ -79,6 +79,8 @@ relative policy prefixes still match absolute tool paths on component
 boundaries.
 When the runtime has a current tool `cwd`, relative path arguments are also
 evaluated against that base so parent-traversal paths do not bypass policy.
+Alan also case-folds path-prefix comparisons conservatively so case variants do
+not bypass policy on case-insensitive hosts.
 
 This does not make bash fully path-aware. For shell commands, `match_command`
 remains the current mechanism.

--- a/docs/spec/alan_coding_governance_contract.md
+++ b/docs/spec/alan_coding_governance_contract.md
@@ -1,0 +1,131 @@
+# Alan Coding Governance Contract
+
+> Status: partially implemented target contract for workspace-aware coding
+> governance across the steward and repo-worker line.
+
+## Goal
+
+Define how Alan's coding governance should distinguish:
+
+1. the home-root steward's discovery and routing actions,
+2. the repo worker's bounded repo-local coding loop,
+3. owner-boundary actions that must escalate or deny.
+
+This document is coding-specific. It complements the general HITE governance
+docs rather than replacing them.
+
+## Non-Goals
+
+This contract does not:
+
+1. redefine the general HITE model,
+2. promise a strict containment backend,
+3. define the external benchmark ladder,
+4. replace the repo-worker package contract.
+
+## Governance Split
+
+### Parent Steward Fast Path
+
+The parent steward fast path should cover:
+
+1. workspace discovery and comparison,
+2. safe read-heavy repo selection,
+3. planning and routing decisions,
+4. spawn preparation and bounded result integration.
+
+The parent steward should not silently mutate multiple repos or publish
+externally under a generic "coding task" interpretation.
+
+### Repo-Worker Fast Path
+
+The child repo-worker fast path should cover:
+
+1. repo-local reads and searches,
+2. repo-local edits inside the bound workspace,
+3. targeted deterministic verification,
+4. bounded delivery summaries and residual-risk reporting.
+
+The child worker fast path ends when the task attempts to cross trust,
+workspace, credential, or publish boundaries.
+
+## Owner-Boundary Classes For Coding
+
+Coding governance should escalate or deny at least these classes:
+
+1. cross-workspace mutation beyond the delegated repo scope,
+2. network or external publishing actions,
+3. credential exploration or modification,
+4. shared deploy or infrastructure changes,
+5. destructive or ambiguous high-blast-radius actions,
+6. unknown-capability tools whose real blast radius is unclear.
+
+## Current Implementation Hooks
+
+Today Alan can express part of this boundary through `policy.yaml` plus the
+runtime policy engine.
+
+Current matcher surface:
+
+1. `tool`
+2. `capability`
+3. `match_command`
+4. `match_path_prefix`
+
+`match_path_prefix` is currently evaluated against common file-oriented
+arguments such as `path`, `paths`, `directory`, `cwd`, and `workspace_root`.
+
+This does not make bash fully path-aware. For shell commands, `match_command`
+remains the current mechanism.
+
+## Repo-Worker Child Policy Guidance
+
+The first-party repo worker should keep these defaults explicit in its child
+policy:
+
+1. unknown capability -> escalate,
+2. network capability -> escalate,
+3. publish commands -> escalate,
+4. deploy and infrastructure commands -> escalate,
+5. credential reads or writes -> escalate,
+6. dangerous destructive commands -> deny.
+
+Path-sensitive escalation is appropriate for files such as:
+
+1. `.github/workflows/`
+2. `deploy/`
+3. `infra/`
+4. `.env*`
+
+## Known Gaps
+
+The current implementation still has important limits:
+
+1. bash payloads are not fully path-classified,
+2. cross-workspace intent is still inferred mainly from launch shape and path
+   guard rather than a dedicated policy dimension,
+3. trust-boundary metadata such as `owner_boundary` or `blast_radius` is not
+   yet modeled as first-class policy fields,
+4. the current backend remains `workspace_path_guard`, which is best-effort
+   rather than strict containment.
+
+## Relationship To Other Contracts
+
+1. `alan_coding_steward_contract.md` defines the product split between steward
+   and repo worker.
+2. `hite_governance.md` defines the broader target governance model.
+3. `governance_boundaries.md` defines generic HITE boundary classes.
+4. `governance_current_contract.md` remains the source of truth for current
+   shipped behavior.
+
+## Acceptance Criteria
+
+This contract is satisfied when:
+
+1. steward fast-path actions are described separately from repo-worker fast-path actions,
+2. coding owner-boundary classes are explicit,
+3. current policy matcher support and its limits are documented honestly,
+4. the first-party repo-worker policy uses explicit rules for publish,
+   credential, deploy, and unknown-capability boundaries,
+5. tests and/or harness coverage exist for at least one path-sensitive coding
+   governance rule.

--- a/docs/spec/alan_coding_governance_contract.md
+++ b/docs/spec/alan_coding_governance_contract.md
@@ -77,6 +77,8 @@ arguments such as `path`, `paths`, `directory`, `cwd`, and `workspace_root`.
 Before matching, Alan lexically normalizes `.` / `..` segments and lets
 relative policy prefixes still match absolute tool paths on component
 boundaries.
+When the runtime has a current tool `cwd`, relative path arguments are also
+evaluated against that base so parent-traversal paths do not bypass policy.
 
 This does not make bash fully path-aware. For shell commands, `match_command`
 remains the current mechanism.

--- a/docs/spec/alan_coding_governance_contract.md
+++ b/docs/spec/alan_coding_governance_contract.md
@@ -74,6 +74,9 @@ Current matcher surface:
 
 `match_path_prefix` is currently evaluated against common file-oriented
 arguments such as `path`, `paths`, `directory`, `cwd`, and `workspace_root`.
+Before matching, Alan lexically normalizes `.` / `..` segments and lets
+relative policy prefixes still match absolute tool paths on component
+boundaries.
 
 This does not make bash fully path-aware. For shell commands, `match_command`
 remains the current mechanism.

--- a/docs/spec/alan_coding_steward_contract.md
+++ b/docs/spec/alan_coding_steward_contract.md
@@ -323,8 +323,9 @@ This contract intentionally stops at the product boundary.
 
 Adjacent tracks:
 
-1. coding governance belongs primarily to `hite_governance.md`,
-   `governance_boundaries.md`, and the follow-on coding-governance issue,
+1. coding governance belongs primarily to `alan_coding_governance_contract.md`,
+   `hite_governance.md`, `governance_boundaries.md`, and the follow-on
+   coding-governance issue,
 2. steward and repo-worker evaluation belong to harness and benchmark work
    tracked separately.
 


### PR DESCRIPTION
## Summary
- extend `PolicyRule` with path-prefix matching for file-oriented coding boundaries
- tighten the first-party repo-worker child policy around unknown/network/publish/deploy/credential actions
- add a dedicated coding-governance spec and governance harness coverage for path-sensitive rules

## Testing
- cargo fmt --all
- cargo test -p alan-runtime policy::tests::policy_rule_match_path_prefix_matches_write_path -- --exact
- cargo test -p alan-runtime policy::tests::load_workspace_policy_file_supports_match_path_prefix -- --exact
- bash scripts/harness/run_repo_worker_suite.sh

## Stack
- base: #287
- continues #284