### PR TITLE
[VNext][Alan Coding][Bench] Add Lite-first full-steward SWE-bench adapter

### DIFF
--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -19,3 +19,51 @@ Cross-package harness scenarios remain under:
 
 - `docs/harness/scenarios/repo_worker/`
 - `docs/harness/scenarios/coding_steward/`
+
+## Lite-First Full-Steward Bring-Up
+
+`run_swebench_full_steward_case.sh` is the M1 external benchmark entrypoint
+for this package.
+
+It does not bypass Alan's orchestration layer. Instead it:
+
+1. starts a real root/steward session,
+2. submits one benchmark problem to that steward,
+3. requires repo-local coding work to run through child repo-worker launch,
+4. reads rollout/session artifacts after completion,
+5. exports:
+   - `model.patch`
+   - `prediction.json`
+   - `predictions.jsonl`
+   - `run.json`
+   - `assertion_report.json`
+   - `kpi.json`
+
+Use the template case file as a starting point:
+
+- `evals/files/swebench_lite_case.template.json`
+
+The case file should point at:
+
+1. one prepared `SWE-bench Lite` workspace checkout,
+2. one problem-statement text file for that instance.
+
+Run one full-steward case locally with:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh \
+  crates/runtime/skills/repo-coding/evals/files/swebench_lite_case.template.json
+```
+
+This is intentionally operator-run and non-CI-blocking.
+
+Recommended rollout order:
+
+1. one Lite case,
+2. a curated Lite subset,
+3. full Lite,
+4. curated Pro subsets.
+
+Official harness scoring still happens outside this package. The local runner
+produces `predictions.jsonl` so operators can hand results to the official
+SWE-bench evaluation flow after Alan finishes the steward-led run.

--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -22,8 +22,8 @@ Cross-package harness scenarios remain under:
 
 ## Lite-First Full-Steward Bring-Up
 
-`run_swebench_full_steward_case.sh` is the M1 external benchmark entrypoint
-for this package.
+`run_swebench_full_steward_case.sh` is the M1 single-case external benchmark
+entrypoint for this package.
 
 It does not bypass Alan's orchestration layer. Instead it:
 
@@ -64,6 +64,30 @@ Recommended rollout order:
 3. full Lite,
 4. curated Pro subsets.
 
-Official harness scoring still happens outside this package. The local runner
-produces `predictions.jsonl` so operators can hand results to the official
-SWE-bench evaluation flow after Alan finishes the steward-led run.
+For the M2 curated-subset step, use:
+
+- `evals/files/swebench_lite_subset.template.json`
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
+  crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
+```
+
+That suite runner aggregates per-case artifacts into one suite directory and
+generates:
+
+1. `predictions.jsonl`
+2. `case_results.jsonl`
+3. `run.json`
+4. `benchmark.json`
+5. `kpi.json`
+6. `score_with_official_harness.sh`
+
+Official harness scoring still happens outside Alan's runtime loop, but the
+package now provides a thin wrapper so operators do not need to remember the
+raw Python module entrypoint:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh \
+  target/benchmarks/swebench_lite/suites/swebench_lite_curated/predictions.jsonl
+```

--- a/crates/runtime/skills/repo-coding/evals/files/swebench_lite_case.template.json
+++ b/crates/runtime/skills/repo-coding/evals/files/swebench_lite_case.template.json
@@ -1,0 +1,7 @@
+{
+  "instance_id": "replace-with-swebench-lite-instance-id",
+  "dataset": "SWE-bench Lite",
+  "workspace_dir": "/absolute/path/to/prepared/swebench-lite/workspace",
+  "problem_statement_file": "/absolute/path/to/problem_statement.txt",
+  "timeout_secs": 1800
+}

--- a/crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
+++ b/crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
@@ -1,0 +1,9 @@
+{
+  "suite": "swebench_lite_curated",
+  "dataset": "SWE-bench Lite",
+  "dataset_name": "princeton-nlp/SWE-bench_Lite",
+  "max_workers": 8,
+  "cases": [
+    "swebench_lite_case.template.json"
+  ]
+}

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -51,3 +51,18 @@ That runner should:
 2. require repo-local work to happen through delegated child launch,
 3. export `model.patch` plus single-case prediction artifacts,
 4. emit Alan-native orchestration metadata alongside the benchmark patch.
+
+The next bring-up step is a curated subset aggregator:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
+  crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
+```
+
+That suite runner should:
+
+1. execute each Lite case through the same steward entrypoint,
+2. aggregate suite-level `predictions.jsonl`,
+3. emit `run.json`, `benchmark.json`, `kpi.json`, and `case_results.jsonl`,
+4. generate `score_with_official_harness.sh` by delegating to the package-local
+   `score_swebench_predictions.sh` wrapper.

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -29,3 +29,25 @@ is defined in `docs/spec/alan_coding_steward_contract.md`.
 2. `bash scripts/harness/run_repo_worker_suite.sh --ci-blocking`
 3. `bash scripts/harness/run_coding_steward_suite.sh --ci-blocking`
 4. `cargo run -p alan -- skills eval crates/runtime/skills/repo-coding --output-dir target/skills-eval/repo-coding/latest`
+
+## External Benchmark Bring-Up
+
+The Lite-first full-steward external benchmark path starts with a single
+operator-run case:
+
+1. prepare one clean `SWE-bench Lite` workspace checkout,
+2. prepare the benchmark problem statement text,
+3. fill in `evals/files/swebench_lite_case.template.json`,
+4. run:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh \
+  crates/runtime/skills/repo-coding/evals/files/swebench_lite_case.template.json
+```
+
+That runner should:
+
+1. use the steward runtime as the benchmark entrypoint,
+2. require repo-local work to happen through delegated child launch,
+3. export `model.patch` plus single-case prediction artifacts,
+4. emit Alan-native orchestration metadata alongside the benchmark patch.

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -401,7 +401,7 @@ if [[ "$passed" == true ]]; then
     pass_rate_percent="100.00"
 fi
 
-prediction_json="$(jq -n \
+prediction_json="$(jq -cn \
     --arg instance_id "$instance_id" \
     --arg model_name_or_path "$resolved_model" \
     --rawfile model_patch "$patch_file" \

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh <case-json> [--output-dir <dir>] [--agent <name>] [--keep-session]
+
+Case JSON fields:
+  instance_id               Required benchmark instance identifier.
+  workspace_dir             Required absolute or case-relative path to a clean prepared git workspace.
+  problem_statement         Inline problem statement text (optional if problem_statement_file is set).
+  problem_statement_file    Absolute or case-relative path to a text file with the benchmark problem statement.
+  timeout_secs              Optional turn timeout for the steward run (default: 1800).
+  dataset                   Optional dataset label (default: SWE-bench Lite).
+  agent_name                Optional agent override.
+
+The runner starts Alan's root/steward entrypoint against the prepared workspace,
+submits one benchmark task, waits for the turn to complete, verifies that
+repo-local work happened through delegated child launch(es), and exports:
+
+  - model.patch
+  - prediction.json / predictions.jsonl
+  - run.json
+  - assertion_report.json
+  - kpi.json
+
+This is the M1 single-case bring-up path for the Lite-first full-steward
+benchmark adapter. It assumes the benchmark workspace is already prepared
+according to the external dataset/operator flow.
+USAGE
+}
+
+require_command() {
+    local command_name="$1"
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        echo "Missing required command: $command_name" >&2
+        exit 1
+    fi
+}
+
+resolve_path() {
+    local raw_path="$1"
+    local base_dir="$2"
+    if [[ "$raw_path" == /* ]]; then
+        printf '%s\n' "$raw_path"
+    else
+        printf '%s\n' "$base_dir/$raw_path"
+    fi
+}
+
+case_json=""
+output_dir=""
+cli_agent_name=""
+keep_session=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            output_dir="$2"
+            shift 2
+            ;;
+        --agent)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            cli_agent_name="$2"
+            shift 2
+            ;;
+        --keep-session)
+            keep_session=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            usage
+            exit 2
+            ;;
+        *)
+            if [[ -n "$case_json" ]]; then
+                usage
+                exit 2
+            fi
+            case_json="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$case_json" ]]; then
+    usage
+    exit 2
+fi
+
+require_command jq
+require_command curl
+require_command git
+require_command cargo
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_root="$(cd "$script_dir/.." && pwd)"
+repo_root="$(cd "$package_root/../../../.." && pwd)"
+case_json="$(cd "$(dirname "$case_json")" && pwd)/$(basename "$case_json")"
+case_dir="$(dirname "$case_json")"
+
+if [[ ! -f "$case_json" ]]; then
+    echo "Case file not found: $case_json" >&2
+    exit 1
+fi
+
+instance_id="$(jq -r '.instance_id // empty' "$case_json")"
+dataset_label="$(jq -r '.dataset // "SWE-bench Lite"' "$case_json")"
+workspace_raw="$(jq -r '.workspace_dir // empty' "$case_json")"
+problem_statement_inline="$(jq -r '.problem_statement // empty' "$case_json")"
+problem_statement_file_raw="$(jq -r '.problem_statement_file // empty' "$case_json")"
+timeout_secs="$(jq -r '.timeout_secs // 1800' "$case_json")"
+case_agent_name="$(jq -r '.agent_name // empty' "$case_json")"
+
+if [[ -z "$instance_id" || -z "$workspace_raw" ]]; then
+    echo "Case file must define non-empty instance_id and workspace_dir." >&2
+    exit 1
+fi
+
+workspace_dir="$(resolve_path "$workspace_raw" "$case_dir")"
+if [[ ! -d "$workspace_dir" ]]; then
+    echo "Workspace directory not found: $workspace_dir" >&2
+    exit 1
+fi
+
+if [[ -n "$problem_statement_file_raw" ]]; then
+    problem_statement_file="$(resolve_path "$problem_statement_file_raw" "$case_dir")"
+    if [[ ! -f "$problem_statement_file" ]]; then
+        echo "Problem statement file not found: $problem_statement_file" >&2
+        exit 1
+    fi
+    problem_statement="$(cat "$problem_statement_file")"
+elif [[ -n "$problem_statement_inline" ]]; then
+    problem_statement="$problem_statement_inline"
+    problem_statement_file=""
+else
+    echo "Case file must define problem_statement or problem_statement_file." >&2
+    exit 1
+fi
+
+if ! git -C "$workspace_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Workspace must be a git work tree: $workspace_dir" >&2
+    exit 1
+fi
+
+workspace_dir="$(git -C "$workspace_dir" rev-parse --show-toplevel)"
+workspace_alan_dir="$workspace_dir/.alan"
+if [[ -n "$(git -C "$workspace_dir" status --short --untracked-files=all)" ]]; then
+    echo "Workspace must be clean before running the benchmark case: $workspace_dir" >&2
+    exit 1
+fi
+
+if [[ -z "$output_dir" ]]; then
+    output_dir="$repo_root/target/benchmarks/swebench_lite/latest/$instance_id"
+fi
+mkdir -p "$output_dir"
+
+events_file="$output_dir/events.jsonl"
+assistant_output_file="$output_dir/assistant_output.txt"
+prompt_file="$output_dir/task_prompt.md"
+create_response_file="$output_dir/create_session.json"
+submit_response_file="$output_dir/submit_response.json"
+read_response_file="$output_dir/read_session.json"
+status_file="$output_dir/git_status.txt"
+patch_file="$output_dir/model.patch"
+prediction_file="$output_dir/prediction.json"
+predictions_jsonl="$output_dir/predictions.jsonl"
+rollout_copy_file="$output_dir/parent_rollout.jsonl"
+assertion_file="$output_dir/assertion_report.json"
+run_file="$output_dir/run.json"
+kpi_file="$output_dir/kpi.json"
+
+: >"$events_file"
+: >"$assistant_output_file"
+
+effective_agent_name="$cli_agent_name"
+if [[ -z "$effective_agent_name" ]]; then
+    effective_agent_name="$case_agent_name"
+fi
+
+base_url="${ALAN_AGENTD_URL:-http://127.0.0.1:8090}"
+session_id=""
+daemon_started=false
+delete_session_on_exit=true
+
+cleanup() {
+    if [[ "$delete_session_on_exit" == true && -n "$session_id" ]]; then
+        curl -fsS -X DELETE "$base_url/api/v1/sessions/$session_id" >/dev/null 2>&1 || true
+    fi
+    if [[ "$daemon_started" == true ]]; then
+        (cd "$repo_root" && cargo run -p alan -- daemon stop >/dev/null 2>&1) || true
+    fi
+}
+trap cleanup EXIT
+
+if ! curl -fsS "$base_url/health" >/dev/null 2>&1; then
+    (cd "$repo_root" && cargo run -p alan -- daemon start >/dev/null)
+    daemon_started=true
+fi
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+start_epoch="$(date +%s)"
+
+cat >"$prompt_file" <<EOF
+You are Alan's root coding steward running a $dataset_label benchmark case.
+
+Hard requirements:
+1. Treat this run as full steward mode.
+2. Use \$repo-coding to delegate repo-local coding work to a fresh repo worker child runtime.
+3. Do not perform repo-local file edits or repo-local verification in the parent steward runtime.
+4. Keep the final response concise: what changed, what was verified, and residual risk.
+
+Benchmark metadata:
+- instance_id: $instance_id
+- dataset: $dataset_label
+- bound_workspace_root: $workspace_dir
+
+The benchmark harness has already bound the target repository as the active
+workspace for this run. You still must route repo-local coding execution
+through child launch rather than editing inline in the parent runtime.
+
+Problem statement:
+$problem_statement
+EOF
+
+create_body="$(jq -n \
+    --arg workspace_dir "$workspace_dir" \
+    --arg agent_name "$effective_agent_name" \
+    '{
+        workspace_dir: $workspace_dir,
+        governance: { profile: "autonomous" }
+    }
+    + (if $agent_name == "" then {} else { agent_name: $agent_name } end)')"
+
+curl -fsS \
+    -H 'Content-Type: application/json' \
+    -d "$create_body" \
+    "$base_url/api/v1/sessions" \
+    >"$create_response_file"
+
+session_id="$(jq -r '.session_id // empty' "$create_response_file")"
+if [[ -z "$session_id" ]]; then
+    echo "Failed to create session." >&2
+    exit 1
+fi
+
+submit_body="$(jq -n --rawfile prompt "$prompt_file" '{
+    op: {
+        type: "turn",
+        parts: [
+            {
+                type: "text",
+                text: $prompt
+            }
+        ]
+    }
+}')"
+
+curl -fsS \
+    -H 'Content-Type: application/json' \
+    -d "$submit_body" \
+    "$base_url/api/v1/sessions/$session_id/submit" \
+    >"$submit_response_file"
+
+event_cursor=""
+turn_completed=false
+yielded=false
+timed_out=false
+error_messages_file="$output_dir/error_messages.txt"
+warning_messages_file="$output_dir/warning_messages.txt"
+: >"$error_messages_file"
+: >"$warning_messages_file"
+
+while true; do
+    now_epoch="$(date +%s)"
+    if (( now_epoch - start_epoch >= timeout_secs )); then
+        timed_out=true
+        break
+    fi
+
+    read_url="$base_url/api/v1/sessions/$session_id/events/read?limit=200"
+    if [[ -n "$event_cursor" ]]; then
+        read_url="$read_url&after_event_id=$event_cursor"
+    fi
+
+    response="$(curl -fsS "$read_url")"
+    latest_event_id="$(printf '%s' "$response" | jq -r '.latest_event_id // empty')"
+    if [[ -n "$latest_event_id" ]]; then
+        event_cursor="$latest_event_id"
+    fi
+
+    while IFS= read -r event_json; do
+        if [[ -z "$event_json" ]]; then
+            continue
+        fi
+        printf '%s\n' "$event_json" >>"$events_file"
+        event_type="$(printf '%s' "$event_json" | jq -r '.type')"
+        case "$event_type" in
+            text_delta)
+                printf '%s' "$(printf '%s' "$event_json" | jq -r '.chunk')" >>"$assistant_output_file"
+                ;;
+            warning)
+                printf '%s\n' "$(printf '%s' "$event_json" | jq -r '.message')" >>"$warning_messages_file"
+                ;;
+            error)
+                printf '%s\n' "$(printf '%s' "$event_json" | jq -r '.message')" >>"$error_messages_file"
+                ;;
+            yield)
+                yielded=true
+                ;;
+            turn_completed)
+                turn_completed=true
+                ;;
+        esac
+    done < <(printf '%s' "$response" | jq -c '.events[]')
+
+    if [[ "$turn_completed" == true || "$yielded" == true ]]; then
+        break
+    fi
+
+    sleep 1
+done
+
+curl -fsS "$base_url/api/v1/sessions/$session_id/read" >"$read_response_file"
+resolved_model="$(jq -r '.resolved_model // "unknown"' "$read_response_file")"
+rollout_path="$(jq -r '.rollout_path // empty' "$read_response_file")"
+
+if [[ -z "$rollout_path" || ! -f "$rollout_path" ]]; then
+    echo "Failed to resolve a durable rollout path for session $session_id." >&2
+    exit 1
+fi
+
+cp "$rollout_path" "$rollout_copy_file"
+
+spawn_count="$(jq -s '[.[] | select(.type == "tool_call" and .name == "invoke_delegated_skill")] | length' "$rollout_copy_file")"
+parent_inline_write_count="$(jq -s '[.[] | select(.type == "tool_call" and .name != "invoke_delegated_skill") | select((.audit.capability // "") == "write")] | length' "$rollout_copy_file")"
+parent_inline_write_names="$(jq -s '[.[] | select(.type == "tool_call" and .name != "invoke_delegated_skill") | select((.audit.capability // "") == "write") | .name] | unique' "$rollout_copy_file")"
+child_runs_json="$(jq -s '[.[] | select(.type == "tool_call" and .name == "invoke_delegated_skill") | .result.child_run? | select(. != null)]' "$rollout_copy_file")"
+completed_child_count="$(printf '%s' "$child_runs_json" | jq '[.[] | select(.terminal_status == "completed")] | length')"
+
+printf '%s\n' "$child_runs_json" | jq -c '.[]' | while IFS= read -r child_run; do
+    child_rollout="$(printf '%s' "$child_run" | jq -r '.rollout_path // empty')"
+    child_session="$(printf '%s' "$child_run" | jq -r '.session_id // "child"')"
+    if [[ -n "$child_rollout" && -f "$child_rollout" ]]; then
+        cp "$child_rollout" "$output_dir/${child_session}.jsonl"
+    fi
+done
+
+if [[ "$keep_session" != true ]]; then
+    curl -fsS -X DELETE "$base_url/api/v1/sessions/$session_id" >/dev/null 2>&1 || true
+    delete_session_on_exit=false
+    rm -rf "$workspace_alan_dir"
+fi
+
+git -C "$workspace_dir" add -N -A -- . ':(glob,exclude).alan/**' >/dev/null 2>&1 || true
+git -C "$workspace_dir" status --short --untracked-files=all -- . ':(glob,exclude).alan/**' >"$status_file"
+git -C "$workspace_dir" diff --binary --no-ext-diff HEAD -- . ':(glob,exclude).alan/**' >"$patch_file"
+patch_bytes="$(wc -c <"$patch_file" | tr -d ' ')"
+
+run_status="completed"
+passed=true
+if [[ "$timed_out" == true ]]; then
+    run_status="timed_out"
+    passed=false
+elif [[ "$yielded" == true ]]; then
+    run_status="yielded"
+    passed=false
+elif [[ "$turn_completed" != true ]]; then
+    run_status="missing_turn_completed"
+    passed=false
+elif (( spawn_count == 0 )); then
+    run_status="missing_child_launch"
+    passed=false
+elif (( completed_child_count == 0 )); then
+    run_status="child_not_completed"
+    passed=false
+elif (( parent_inline_write_count > 0 )); then
+    run_status="parent_inline_write_detected"
+    passed=false
+elif (( patch_bytes == 0 )); then
+    run_status="empty_patch"
+    passed=false
+fi
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+duration_secs="$(( $(date +%s) - start_epoch ))"
+pass_rate_percent="0.00"
+if [[ "$passed" == true ]]; then
+    pass_rate_percent="100.00"
+fi
+
+prediction_json="$(jq -n \
+    --arg instance_id "$instance_id" \
+    --arg model_name_or_path "$resolved_model" \
+    --rawfile model_patch "$patch_file" \
+    '{
+        instance_id: $instance_id,
+        model_name_or_path: $model_name_or_path,
+        model_patch: $model_patch
+    }')"
+
+printf '%s\n' "$prediction_json" >"$prediction_file"
+printf '%s\n' "$prediction_json" >"$predictions_jsonl"
+
+jq -n \
+    --arg instance_id "$instance_id" \
+    --arg run_status "$run_status" \
+    --argjson timed_out "$timed_out" \
+    --argjson yielded "$yielded" \
+    --argjson turn_completed "$turn_completed" \
+    --argjson spawn_count "$spawn_count" \
+    --argjson completed_child_count "$completed_child_count" \
+    --argjson parent_inline_write_count "$parent_inline_write_count" \
+    --argjson patch_nonempty "$([[ "$patch_bytes" -gt 0 ]] && echo true || echo false)" \
+    --argjson passed "$passed" \
+    --argjson parent_inline_write_names "$parent_inline_write_names" \
+    '{
+        instance_id: $instance_id,
+        run_status: $run_status,
+        passed: $passed,
+        assertions: [
+            {
+                name: "turn_completed",
+                passed: $turn_completed
+            },
+            {
+                name: "delegated_child_launch_observed",
+                passed: ($spawn_count > 0),
+                detail: ("spawn_count=" + ($spawn_count | tostring))
+            },
+            {
+                name: "completed_child_run_observed",
+                passed: ($completed_child_count > 0),
+                detail: ("completed_child_count=" + ($completed_child_count | tostring))
+            },
+            {
+                name: "parent_did_not_edit_inline",
+                passed: ($parent_inline_write_count == 0),
+                detail: ("parent_inline_write_names=" + ($parent_inline_write_names | tostring))
+            },
+            {
+                name: "nonempty_model_patch",
+                passed: $patch_nonempty
+            },
+            {
+                name: "no_yield_or_timeout",
+                passed: ((not $timed_out) and (not $yielded))
+            }
+        ]
+    }' >"$assertion_file"
+
+jq -n \
+    --arg instance_id "$instance_id" \
+    --arg dataset "$dataset_label" \
+    --arg case_json "$case_json" \
+    --arg workspace_dir "$workspace_dir" \
+    --arg started_at "$started_at" \
+    --arg finished_at "$finished_at" \
+    --arg session_id "$session_id" \
+    --arg rollout_path "$rollout_path" \
+    --arg resolved_model "$resolved_model" \
+    --arg prompt_file "$prompt_file" \
+    --arg assistant_output_file "$assistant_output_file" \
+    --arg create_response_file "$create_response_file" \
+    --arg submit_response_file "$submit_response_file" \
+    --arg prediction_file "$prediction_file" \
+    --arg predictions_jsonl "$predictions_jsonl" \
+    --arg patch_file "$patch_file" \
+    --arg status_file "$status_file" \
+    --arg read_response_file "$read_response_file" \
+    --arg events_file "$events_file" \
+    --arg error_messages_file "$error_messages_file" \
+    --arg warning_messages_file "$warning_messages_file" \
+    --arg problem_statement_file "$problem_statement_file" \
+    --argjson duration_secs "$duration_secs" \
+    --argjson spawn_count "$spawn_count" \
+    --argjson completed_child_count "$completed_child_count" \
+    --argjson parent_inline_write_count "$parent_inline_write_count" \
+    --argjson patch_bytes "$patch_bytes" \
+    --argjson timed_out "$timed_out" \
+    --argjson yielded "$yielded" \
+    --argjson turn_completed "$turn_completed" \
+    --argjson passed "$passed" \
+    --argjson child_runs "$child_runs_json" \
+    --argjson parent_inline_write_names "$parent_inline_write_names" \
+    '{
+        instance_id: $instance_id,
+        dataset: $dataset,
+        mode: "full_steward_single_case",
+        case_json: $case_json,
+        started_at: $started_at,
+        finished_at: $finished_at,
+        duration_secs: $duration_secs,
+        session_id: $session_id,
+        rollout_path: $rollout_path,
+        resolved_model: $resolved_model,
+        workspace_dir: $workspace_dir,
+        problem_statement_file: (if $problem_statement_file == "" then null else $problem_statement_file end),
+        prompt_file: $prompt_file,
+        assistant_output_file: $assistant_output_file,
+        create_response_file: $create_response_file,
+        submit_response_file: $submit_response_file,
+        prediction_file: $prediction_file,
+        predictions_jsonl: $predictions_jsonl,
+        patch_file: $patch_file,
+        status_file: $status_file,
+        read_response_file: $read_response_file,
+        events_file: $events_file,
+        error_messages_file: $error_messages_file,
+        warning_messages_file: $warning_messages_file,
+        spawn_count: $spawn_count,
+        completed_child_count: $completed_child_count,
+        parent_inline_write_count: $parent_inline_write_count,
+        parent_inline_write_names: $parent_inline_write_names,
+        patch_bytes: $patch_bytes,
+        timed_out: $timed_out,
+        yielded: $yielded,
+        turn_completed: $turn_completed,
+        passed: $passed,
+        child_runs: $child_runs
+    }' >"$run_file"
+
+jq -n \
+    --arg suite "swebench_full_steward" \
+    --arg mode "single_case" \
+    --argjson total 1 \
+    --argjson passed_count "$([[ "$passed" == true ]] && echo 1 || echo 0)" \
+    --argjson failed_count "$([[ "$passed" == true ]] && echo 0 || echo 1)" \
+    --argjson skipped 0 \
+    --argjson duration_secs "$duration_secs" \
+    --argjson executed_scenarios "[\"$instance_id\"]" \
+    --argjson kpi_tag_counts '{"external_benchmark":1,"swebench_lite":1,"full_steward":1,"single_case":1}' \
+    --argjson pass_rate_percent "$pass_rate_percent" \
+    '{
+        suite: $suite,
+        mode: $mode,
+        total: $total,
+        passed: $passed_count,
+        failed: $failed_count,
+        skipped: $skipped,
+        pass_rate_percent: $pass_rate_percent,
+        duration_secs: $duration_secs,
+        executed_scenarios: $executed_scenarios,
+        kpi_tag_counts: $kpi_tag_counts
+    }' >"$kpi_file"
+
+if [[ "$keep_session" == true ]]; then
+    delete_session_on_exit=false
+fi
+
+echo "Full-steward SWE-bench case summary:"
+echo "  instance_id: $instance_id"
+echo "  dataset: $dataset_label"
+echo "  run_status: $run_status"
+echo "  session_id: $session_id"
+echo "  resolved_model: $resolved_model"
+echo "  spawn_count: $spawn_count"
+echo "  parent_inline_write_count: $parent_inline_write_count"
+echo "  patch_bytes: $patch_bytes"
+echo "  artifacts: $output_dir"
+
+if [[ "$passed" != true ]]; then
+    exit 1
+fi

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh <suite-json> [--output-dir <dir>] [--agent <name>] [--keep-session]
+
+Suite JSON fields:
+  suite           Optional suite name (default: swebench_lite_curated).
+  dataset         Optional human label (default: SWE-bench Lite).
+  dataset_name    Optional official harness dataset name (default: princeton-nlp/SWE-bench_Lite).
+  max_workers     Optional official harness worker count hint (default: 8).
+  agent_name      Optional agent override for all cases in the suite.
+  cases           Required array of case-json paths, absolute or relative to the suite file.
+
+This runner calls `run_swebench_full_steward_case.sh` for each case, aggregates
+single-case outputs into one suite directory, writes a unified
+`predictions.jsonl`, and generates `score_with_official_harness.sh`.
+USAGE
+}
+
+resolve_path() {
+    local raw_path="$1"
+    local base_dir="$2"
+    if [[ "$raw_path" == /* ]]; then
+        printf '%s\n' "$raw_path"
+    else
+        printf '%s\n' "$base_dir/$raw_path"
+    fi
+}
+
+suite_json=""
+output_dir=""
+cli_agent_name=""
+keep_session=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            output_dir="$2"
+            shift 2
+            ;;
+        --agent)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            cli_agent_name="$2"
+            shift 2
+            ;;
+        --keep-session)
+            keep_session=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            usage
+            exit 2
+            ;;
+        *)
+            if [[ -n "$suite_json" ]]; then
+                usage
+                exit 2
+            fi
+            suite_json="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$suite_json" ]]; then
+    usage
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Missing required command: jq" >&2
+    exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_root="$(cd "$script_dir/.." && pwd)"
+repo_root="$(cd "$package_root/../../../.." && pwd)"
+suite_json="$(cd "$(dirname "$suite_json")" && pwd)/$(basename "$suite_json")"
+suite_dirname="$(dirname "$suite_json")"
+
+if [[ ! -f "$suite_json" ]]; then
+    echo "Suite file not found: $suite_json" >&2
+    exit 1
+fi
+
+suite_name="$(jq -r '.suite // "swebench_lite_curated"' "$suite_json")"
+dataset_label="$(jq -r '.dataset // "SWE-bench Lite"' "$suite_json")"
+dataset_name="$(jq -r '.dataset_name // "princeton-nlp/SWE-bench_Lite"' "$suite_json")"
+max_workers="$(jq -r '.max_workers // 8' "$suite_json")"
+suite_agent_name="$(jq -r '.agent_name // empty' "$suite_json")"
+case_count="$(jq '.cases | length' "$suite_json")"
+
+if (( case_count == 0 )); then
+    echo "Suite file must define at least one case path in .cases." >&2
+    exit 1
+fi
+
+effective_agent_name="$cli_agent_name"
+if [[ -z "$effective_agent_name" ]]; then
+    effective_agent_name="$suite_agent_name"
+fi
+
+if [[ -z "$output_dir" ]]; then
+    output_dir="$repo_root/target/benchmarks/swebench_lite/suites/$suite_name"
+fi
+mkdir -p "$output_dir/cases"
+
+predictions_jsonl="$output_dir/predictions.jsonl"
+suite_run_file="$output_dir/run.json"
+suite_kpi_file="$output_dir/kpi.json"
+benchmark_file="$output_dir/benchmark.json"
+case_results_jsonl="$output_dir/case_results.jsonl"
+scoring_script="$output_dir/score_with_official_harness.sh"
+
+: >"$predictions_jsonl"
+: >"$case_results_jsonl"
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+start_epoch="$(date +%s)"
+total=0
+passed=0
+failed=0
+
+case_runner="${ALAN_SWEBENCH_CASE_RUNNER:-$script_dir/run_swebench_full_steward_case.sh}"
+score_runner="${ALAN_SWEBENCH_SCORE_RUNNER:-$script_dir/score_swebench_predictions.sh}"
+
+if [[ ! -f "$case_runner" ]]; then
+    echo "Case runner not found: $case_runner" >&2
+    exit 1
+fi
+
+if [[ ! -f "$score_runner" ]]; then
+    echo "Score runner not found: $score_runner" >&2
+    exit 1
+fi
+
+while IFS= read -r case_path_raw; do
+    if [[ -z "$case_path_raw" ]]; then
+        continue
+    fi
+    case_path="$(resolve_path "$case_path_raw" "$suite_dirname")"
+    if [[ ! -f "$case_path" ]]; then
+        echo "Missing suite case file: $case_path" >&2
+        exit 1
+    fi
+
+    instance_id="$(jq -r '.instance_id // empty' "$case_path")"
+    if [[ -z "$instance_id" ]]; then
+        echo "Case file is missing instance_id: $case_path" >&2
+        exit 1
+    fi
+
+    case_output_dir="$output_dir/cases/$instance_id"
+    mkdir -p "$case_output_dir"
+
+    case_cmd=(bash "$case_runner" "$case_path" --output-dir "$case_output_dir")
+    if [[ -n "$effective_agent_name" ]]; then
+        case_cmd+=(--agent "$effective_agent_name")
+    fi
+    if [[ "$keep_session" == true ]]; then
+        case_cmd+=(--keep-session)
+    fi
+
+    set +e
+    "${case_cmd[@]}" >"$case_output_dir/stdout.log" 2>&1
+    case_exit=$?
+    set -e
+
+    total=$((total + 1))
+    if [[ $case_exit -eq 0 ]]; then
+        passed=$((passed + 1))
+    else
+        failed=$((failed + 1))
+    fi
+
+    if [[ -f "$case_output_dir/prediction.json" ]]; then
+        cat "$case_output_dir/prediction.json" >>"$predictions_jsonl"
+        printf '\n' >>"$predictions_jsonl"
+    fi
+
+    if [[ -f "$case_output_dir/run.json" ]]; then
+        jq -cn \
+            --arg case_path "$case_path" \
+            --argjson exit_code "$case_exit" \
+            --slurpfile run "$case_output_dir/run.json" \
+            '{case_path:$case_path,exit_code:$exit_code,run:$run[0]}' \
+            >>"$case_results_jsonl"
+    else
+        jq -cn \
+            --arg case_path "$case_path" \
+            --arg instance_id "$instance_id" \
+            --argjson exit_code "$case_exit" \
+            '{case_path:$case_path,instance_id:$instance_id,exit_code:$exit_code,run:null}' \
+            >>"$case_results_jsonl"
+    fi
+done < <(jq -r '.cases[]' "$suite_json")
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+duration_secs="$(( $(date +%s) - start_epoch ))"
+pass_rate_percent="$(awk "BEGIN { printf \"%.2f\", ($passed / $total) * 100 }")"
+
+cat >"$scoring_script" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash "$score_runner" "$predictions_jsonl" \\
+  --dataset-name "$dataset_name" \\
+  --max-workers "$max_workers" \\
+  --run-id "${suite_name}_\$(date -u +%Y%m%dT%H%M%SZ)"
+EOF
+chmod +x "$scoring_script"
+
+jq -n \
+    --arg suite "$suite_name" \
+    --arg dataset "$dataset_label" \
+    --arg dataset_name "$dataset_name" \
+    --arg suite_json "$suite_json" \
+    --arg started_at "$started_at" \
+    --arg finished_at "$finished_at" \
+    --arg predictions_jsonl "$predictions_jsonl" \
+    --arg scoring_script "$scoring_script" \
+    --arg case_results_jsonl "$case_results_jsonl" \
+    --argjson max_workers "$max_workers" \
+    --argjson total "$total" \
+    --argjson passed "$passed" \
+    --argjson failed "$failed" \
+    --argjson duration_secs "$duration_secs" \
+    --argjson case_results "$(jq -s '.' "$case_results_jsonl")" \
+    '{
+        suite: $suite,
+        dataset: $dataset,
+        dataset_name: $dataset_name,
+        suite_json: $suite_json,
+        started_at: $started_at,
+        finished_at: $finished_at,
+        duration_secs: $duration_secs,
+        total: $total,
+        passed: $passed,
+        failed: $failed,
+        max_workers: $max_workers,
+        predictions_jsonl: $predictions_jsonl,
+        scoring_script: $scoring_script,
+        case_results_jsonl: $case_results_jsonl,
+        case_results: $case_results
+    }' >"$suite_run_file"
+
+jq -n \
+    --arg suite "$suite_name" \
+    --arg dataset "$dataset_label" \
+    --arg dataset_name "$dataset_name" \
+    --arg predictions_jsonl "$predictions_jsonl" \
+    --arg scoring_script "$scoring_script" \
+    --argjson total_cases "$total" \
+    --argjson passed_cases "$passed" \
+    --argjson failed_cases "$failed" \
+    --argjson pass_rate_percent "$pass_rate_percent" \
+    --argjson duration_secs "$duration_secs" \
+    '{
+        suite: $suite,
+        dataset: $dataset,
+        dataset_name: $dataset_name,
+        total_cases: $total_cases,
+        passed_cases: $passed_cases,
+        failed_cases: $failed_cases,
+        pass_rate_percent: $pass_rate_percent,
+        duration_secs: $duration_secs,
+        predictions_jsonl: $predictions_jsonl,
+        scoring_script: $scoring_script
+    }' >"$benchmark_file"
+
+jq -n \
+    --arg suite "swebench_full_steward" \
+    --arg mode "subset" \
+    --argjson total "$total" \
+    --argjson passed "$passed" \
+    --argjson failed "$failed" \
+    --argjson skipped 0 \
+    --argjson pass_rate_percent "$pass_rate_percent" \
+    --argjson duration_secs "$duration_secs" \
+    --argjson executed_scenarios "$(jq -s '[ .[] | (.run.instance_id // .instance_id // empty) | select(. != "") ]' "$case_results_jsonl")" \
+    --argjson kpi_tag_counts '{"external_benchmark":1,"swebench_lite":1,"full_steward":1,"subset":1}' \
+    '{
+        suite: $suite,
+        mode: $mode,
+        total: $total,
+        passed: $passed,
+        failed: $failed,
+        skipped: $skipped,
+        pass_rate_percent: $pass_rate_percent,
+        duration_secs: $duration_secs,
+        executed_scenarios: $executed_scenarios,
+        kpi_tag_counts: $kpi_tag_counts
+    }' >"$suite_kpi_file"
+
+echo "Full-steward SWE-bench subset summary:"
+echo "  suite: $suite_name"
+echo "  dataset: $dataset_label"
+echo "  dataset_name: $dataset_name"
+echo "  total: $total"
+echo "  passed: $passed"
+echo "  failed: $failed"
+echo "  predictions: $predictions_jsonl"
+echo "  scoring_script: $scoring_script"
+echo "  artifacts: $output_dir"
+
+if (( failed > 0 )); then
+    exit 1
+fi

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
@@ -188,8 +188,7 @@ while IFS= read -r case_path_raw; do
     fi
 
     if [[ -f "$case_output_dir/prediction.json" ]]; then
-        cat "$case_output_dir/prediction.json" >>"$predictions_jsonl"
-        printf '\n' >>"$predictions_jsonl"
+        jq -c . "$case_output_dir/prediction.json" >>"$predictions_jsonl"
     fi
 
     if [[ -f "$case_output_dir/run.json" ]]; then

--- a/crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh
+++ b/crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh <predictions-jsonl> [--dataset-name <name>] [--max-workers <n>] [--run-id <id>]
+
+Defaults:
+  dataset-name  princeton-nlp/SWE-bench_Lite
+  max-workers   8
+  run-id        swebench_eval_<timestamp>
+
+This is a thin wrapper around the official SWE-bench harness entrypoint:
+  python -m swebench.harness.run_evaluation
+USAGE
+}
+
+predictions_path=""
+dataset_name="princeton-nlp/SWE-bench_Lite"
+max_workers="8"
+run_id="swebench_eval_$(date -u +%Y%m%dT%H%M%SZ)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dataset-name)
+            dataset_name="$2"
+            shift 2
+            ;;
+        --max-workers)
+            max_workers="$2"
+            shift 2
+            ;;
+        --run-id)
+            run_id="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            usage
+            exit 2
+            ;;
+        *)
+            if [[ -n "$predictions_path" ]]; then
+                usage
+                exit 2
+            fi
+            predictions_path="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$predictions_path" ]]; then
+    usage
+    exit 2
+fi
+
+if [[ ! -f "$predictions_path" ]]; then
+    echo "Predictions file not found: $predictions_path" >&2
+    exit 1
+fi
+
+python_bin=""
+if command -v python >/dev/null 2>&1; then
+    python_bin="python"
+elif command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+else
+    echo "Missing required command: python or python3" >&2
+    exit 1
+fi
+
+"$python_bin" -m swebench.harness.run_evaluation \
+  --dataset_name "$dataset_name" \
+  --predictions_path "$predictions_path" \
+  --max_workers "$max_workers" \
+  --run_id "$run_id"

--- a/docs/spec/alan_coding_eval_contract.md
+++ b/docs/spec/alan_coding_eval_contract.md
@@ -77,6 +77,13 @@ The intended mapping is:
 3. external benchmark adapters transform outside task corpora into those
    operator-side eval surfaces.
 
+The recommended implementation order is Lite-first:
+
+1. single-case `SWE-bench Lite` bring-up through the steward entrypoint,
+2. curated Lite subset runs,
+3. full Lite runs,
+4. curated `SWE-bench Pro` expansion after the Lite path is stable.
+
 ## Current Executable Surfaces
 
 Today the minimum executable coding eval surface should include:
@@ -84,6 +91,11 @@ Today the minimum executable coding eval surface should include:
 1. `bash scripts/harness/run_coding_steward_suite.sh`
 2. `bash scripts/harness/run_repo_worker_suite.sh`
 3. `cargo run -p alan -- skills eval crates/runtime/skills/repo-coding`
+
+The first external benchmark bring-up path is operator-run rather than
+CI-blocking:
+
+4. `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh <case-json>`
 
 ## Shared KPI Contract
 

--- a/docs/spec/alan_coding_eval_contract.md
+++ b/docs/spec/alan_coding_eval_contract.md
@@ -96,6 +96,8 @@ The first external benchmark bring-up path is operator-run rather than
 CI-blocking:
 
 4. `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh <case-json>`
+5. `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh <suite-json>`
+6. `bash crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh <predictions-jsonl>`
 
 ## Shared KPI Contract
 
@@ -134,4 +136,6 @@ This contract is satisfied when:
 4. shared harness KPI output includes scenario lists and tag counts suitable
    for later aggregation,
 5. external benchmark work is framed as an adapter layer on top of local eval
-   surfaces rather than the only measure of coding quality.
+   surfaces rather than the only measure of coding quality,
+6. the Lite-first adapter includes both single-case bring-up and curated-subset
+   aggregation surfaces before any full-dataset expansion.


### PR DESCRIPTION
## Summary
- add the Lite-first single-case and curated-subset SWE-bench full-steward runners under the repo-coding package
- generate suite-level predictions, KPI artifacts, and an official-harness scoring entrypoint without bypassing Alan's steward -> repo-worker contract
- document the Lite-first benchmark ladder and scoring workflow in the package docs and eval contract

## Verification
- `bash -n crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh`
- `bash -n crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh`
- `bash -n crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh`
- `jq . crates/runtime/skills/repo-coding/evals/files/swebench_lite_case.template.json`
- `jq . crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json`
- `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh --help`
- `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh --help`
- `bash crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh --help`
- smoke-tested subset aggregation with a temporary fake case runner and verified `kpi.json`, `run.json`, `predictions.jsonl`, and `score_with_official_harness.sh` generation

Closes #291