### PR TITLE
[codex] Define tool locality and binding contract

### DIFF
--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -657,20 +657,22 @@ fn build_child_tool_registry(
             bound_workspace_root(parent).map(|root| lexically_normalize_path(&root));
 
         for tool_name in &selected_tool_names {
+            // Preserve explicit parent overrides; only consult factories when the
+            // existing tool cannot be rebound or safely shared into the child workspace.
             if let Some(tool) = parent.tools.get(&tool_name) {
                 if let Some(rebound_tool) = tool.rebind_workspace(workspace_root) {
                     rebound.register_boxed(rebound_tool);
-                } else if let Some(materialized_tool) = parent
-                    .tools
-                    .materialize_for_workspace(&tool_name, workspace_root)
-                {
-                    rebound.register_boxed(materialized_tool);
                 } else if tool.locality() != crate::tools::ToolLocality::WorkspaceLocal
                     || normalized_parent_workspace_root
                         .as_ref()
                         .is_some_and(|root| *root == normalized_requested_workspace_root)
                 {
                     rebound.register_shared(tool);
+                } else if let Some(materialized_tool) = parent
+                    .tools
+                    .materialize_for_workspace(&tool_name, workspace_root)
+                {
+                    rebound.register_boxed(materialized_tool);
                 } else {
                     continue;
                 }
@@ -1607,7 +1609,46 @@ Body
     }
 
     #[tokio::test]
-    async fn build_child_tool_registry_prefers_workspace_factory_before_sharing_parent_tool() {
+    async fn build_child_tool_registry_shares_existing_global_override_before_factory_fallback() {
+        let temp = TempDir::new().unwrap();
+        let parent_root = temp.path().join("repo");
+        let child_root = temp.path().join("other-repo");
+        std::fs::create_dir_all(&child_root).unwrap();
+        std::fs::write(child_root.join("target.txt"), "child workspace contents\n").unwrap();
+
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let mut parent = make_parent_state(&temp, requests, response);
+        let mut parent_tools = ToolRegistry::new();
+        parent_tools.set_default_cwd(parent_root);
+        parent_tools.register(NamedTestTool::new("workspace_read"));
+        parent_tools.register_workspace_factory("workspace_read", |workspace_root| {
+            Box::new(FactoryOnlyWorkspaceBoundTestTool::new(
+                "workspace_read",
+                workspace_root.to_path_buf(),
+            ))
+        });
+        parent.tools = parent_tools;
+
+        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+        spec.launch.workspace_root = Some(child_root);
+        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
+            allowed_tools: vec!["workspace_read".to_string()],
+        });
+
+        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
+        let result = child_tools
+            .execute("workspace_read", json!({ "path": "target.txt" }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["ok"], json!(true));
+        assert!(result.get("content").is_none());
+    }
+
+    #[tokio::test]
+    async fn build_child_tool_registry_falls_back_to_factory_for_unshareable_parent_tool() {
         let temp = TempDir::new().unwrap();
         let parent_root = temp.path().join("repo");
         let child_root = temp.path().join("other-repo");

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -665,7 +665,7 @@ fn build_child_tool_registry(
                     .materialize_for_workspace(&tool_name, workspace_root)
                 {
                     rebound.register_boxed(materialized_tool);
-                } else if !tool.is_workspace_local()
+                } else if tool.locality() != crate::tools::ToolLocality::WorkspaceLocal
                     || normalized_parent_workspace_root
                         .as_ref()
                         .is_some_and(|root| *root == normalized_requested_workspace_root)
@@ -1107,8 +1107,8 @@ mod tests {
             })
         }
 
-        fn is_workspace_local(&self) -> bool {
-            true
+        fn locality(&self) -> crate::tools::ToolLocality {
+            crate::tools::ToolLocality::WorkspaceLocal
         }
 
         fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -1178,8 +1178,8 @@ mod tests {
             })
         }
 
-        fn is_workspace_local(&self) -> bool {
-            true
+        fn locality(&self) -> crate::tools::ToolLocality {
+            crate::tools::ToolLocality::WorkspaceLocal
         }
     }
 

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -659,7 +659,7 @@ fn build_child_tool_registry(
         for tool_name in &selected_tool_names {
             // Preserve explicit parent overrides; only consult factories when the
             // existing tool cannot be rebound or safely shared into the child workspace.
-            if let Some(tool) = parent.tools.get(&tool_name) {
+            if let Some(tool) = parent.tools.get(tool_name) {
                 if let Some(rebound_tool) = tool.rebind_workspace(workspace_root) {
                     rebound.register_boxed(rebound_tool);
                 } else if tool.locality() != crate::tools::ToolLocality::WorkspaceLocal
@@ -670,7 +670,7 @@ fn build_child_tool_registry(
                     rebound.register_shared(tool);
                 } else if let Some(materialized_tool) = parent
                     .tools
-                    .materialize_for_workspace(&tool_name, workspace_root)
+                    .materialize_for_workspace(tool_name, workspace_root)
                 {
                     rebound.register_boxed(materialized_tool);
                 } else {
@@ -681,7 +681,7 @@ fn build_child_tool_registry(
 
             if let Some(materialized_tool) = parent
                 .tools
-                .materialize_for_workspace(&tool_name, workspace_root)
+                .materialize_for_workspace(tool_name, workspace_root)
             {
                 rebound.register_boxed(materialized_tool);
             }

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -461,9 +461,9 @@ where
         })
         .unwrap_or(ToolCapability::Unknown);
     let is_dynamic_tool = state.session.dynamic_tools.contains_key(&tool_call.name);
-    let is_workspace_local_tool = state.tools.is_workspace_local_tool(&tool_call.name);
+    let tool_locality = state.tools.tool_locality(&tool_call.name);
     if !is_dynamic_tool
-        && is_workspace_local_tool
+        && tool_locality == Some(crate::tools::ToolLocality::WorkspaceLocal)
         && (tool_call.name == "bash" || tool_capability != ToolCapability::Network)
         && let Some((routing_payload, routing_preview, routing_audit)) =
             workspace_routing_preflight(state, &tool_call.name, &tool_arguments, tool_capability)
@@ -1524,8 +1524,12 @@ mod tests {
             self.capability
         }
 
-        fn is_workspace_local(&self) -> bool {
-            self.workspace_local
+        fn locality(&self) -> crate::tools::ToolLocality {
+            if self.workspace_local {
+                crate::tools::ToolLocality::WorkspaceLocal
+            } else {
+                crate::tools::ToolLocality::Global
+            }
         }
     }
 

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -9,5 +9,5 @@ mod registry;
 mod sandbox;
 
 pub use context::ToolContext;
-pub use registry::{Tool, ToolRegistry, ToolResult};
+pub use registry::{Tool, ToolLocality, ToolRegistry, ToolResult};
 pub use sandbox::{ExecResult, Sandbox};

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -233,12 +233,18 @@ impl ToolRegistry {
             .filter(|(name, _)| allowed.contains(name.as_str()))
             .map(|(name, tool)| (name.clone(), Arc::clone(tool)))
             .collect();
+        let workspace_factories = self
+            .workspace_factories
+            .iter()
+            .filter(|(name, _)| allowed.contains(name.as_str()))
+            .map(|(name, factory)| (name.clone(), Arc::clone(factory)))
+            .collect();
 
         Self {
             tools,
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            workspace_factories: self.workspace_factories.clone(),
+            workspace_factories,
             default_cwd: self.default_cwd.clone(),
         }
     }
@@ -594,6 +600,27 @@ mod tests {
         assert!(registry.is_workspace_local_tool("workspace_local_tool"));
         assert!(!registry.is_workspace_local_tool("test_tool"));
         assert_eq!(registry.tool_locality("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_filtered_clone_with_config_prunes_workspace_factories_to_allowed_tools() {
+        let mut registry = ToolRegistry::new();
+        registry.register_workspace_factory("allowed_factory", |_| Box::new(WorkspaceLocalTool));
+        registry.register_workspace_factory("blocked_factory", |_| Box::new(WorkspaceLocalTool));
+
+        let filtered =
+            registry.filtered_clone_with_config(["allowed_factory"], Arc::new(Config::default()));
+
+        assert!(
+            filtered
+                .materialize_for_workspace("allowed_factory", Path::new("/workspace"))
+                .is_some()
+        );
+        assert!(
+            filtered
+                .materialize_for_workspace("blocked_factory", Path::new("/workspace"))
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -18,6 +18,15 @@ use crate::llm::ToolDefinition;
 pub type ToolResult = Pin<Box<dyn Future<Output = Result<Value>> + Send>>;
 type WorkspaceToolFactory = dyn Fn(&Path) -> Box<dyn Tool> + Send + Sync;
 
+/// Coarse locality class for tool execution and workspace-routing policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolLocality {
+    /// Tool semantics are not implicitly tied to the runtime's bound workspace.
+    Global,
+    /// Tool semantics are tied to the runtime's bound local workspace.
+    WorkspaceLocal,
+}
+
 /// A tool that can be executed by the agent
 pub trait Tool: Send + Sync {
     /// Get the tool's name
@@ -45,8 +54,8 @@ pub trait Tool: Send + Sync {
     /// Whether this tool operates on the runtime's bound local workspace.
     ///
     /// Workspace-routing preflight only applies to tools in this category.
-    fn is_workspace_local(&self) -> bool {
-        false
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::Global
     }
 
     /// Rebind the tool to a different workspace root for child-runtime launches.
@@ -169,9 +178,14 @@ impl ToolRegistry {
         self.get(name).map(|tool| tool.capability(arguments))
     }
 
+    /// Resolve a tool's locality classification.
+    pub fn tool_locality(&self, name: &str) -> Option<ToolLocality> {
+        self.get(name).map(|tool| tool.locality())
+    }
+
     /// Whether the named tool targets the runtime's bound local workspace.
     pub fn is_workspace_local_tool(&self, name: &str) -> bool {
-        self.get(name).is_some_and(|tool| tool.is_workspace_local())
+        self.tool_locality(name) == Some(ToolLocality::WorkspaceLocal)
     }
 
     /// Get all registered tool names
@@ -473,6 +487,30 @@ mod tests {
         }
     }
 
+    struct WorkspaceLocalTool;
+
+    impl Tool for WorkspaceLocalTool {
+        fn name(&self) -> &str {
+            "workspace_local_tool"
+        }
+
+        fn description(&self) -> &str {
+            "Workspace-local test tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        fn execute(&self, _arguments: Value, _ctx: &ToolContext) -> ToolResult {
+            Box::pin(async move { Ok(serde_json::json!({"ok": true})) })
+        }
+
+        fn locality(&self) -> ToolLocality {
+            ToolLocality::WorkspaceLocal
+        }
+    }
+
     fn test_ctx() -> ToolContext {
         ToolContext::new(
             PathBuf::from("/workspace"),
@@ -537,6 +575,25 @@ mod tests {
             Some(alan_protocol::ToolCapability::Network)
         );
         assert_eq!(registry.capability_for_tool("nonexistent", &args), None);
+    }
+
+    #[test]
+    fn test_tool_registry_locality_for_tool() {
+        let mut registry = ToolRegistry::new();
+        registry.register(TestTool);
+        registry.register(WorkspaceLocalTool);
+
+        assert_eq!(
+            registry.tool_locality("test_tool"),
+            Some(ToolLocality::Global)
+        );
+        assert_eq!(
+            registry.tool_locality("workspace_local_tool"),
+            Some(ToolLocality::WorkspaceLocal)
+        );
+        assert!(registry.is_workspace_local_tool("workspace_local_tool"));
+        assert!(!registry.is_workspace_local_tool("test_tool"));
+        assert_eq!(registry.tool_locality("nonexistent"), None);
     }
 
     #[test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -9,9 +9,7 @@
 //! - All: core + read-only exploration tools
 
 use alan_runtime::Config;
-use alan_runtime::tools::{
-    Sandbox, Tool, ToolContext, ToolLocality, ToolRegistry, ToolResult,
-};
+use alan_runtime::tools::{Sandbox, Tool, ToolContext, ToolLocality, ToolRegistry, ToolResult};
 use anyhow::{Result, anyhow};
 use regex::RegexBuilder;
 use serde_json::{Value, json};

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -9,7 +9,9 @@
 //! - All: core + read-only exploration tools
 
 use alan_runtime::Config;
-use alan_runtime::tools::{Sandbox, Tool, ToolContext, ToolRegistry, ToolResult};
+use alan_runtime::tools::{
+    Sandbox, Tool, ToolContext, ToolLocality, ToolRegistry, ToolResult,
+};
 use anyhow::{Result, anyhow};
 use regex::RegexBuilder;
 use serde_json::{Value, json};
@@ -113,8 +115,8 @@ impl Tool for ReadFileTool {
         alan_protocol::ToolCapability::Read
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -184,8 +186,8 @@ impl Tool for WriteFileTool {
         alan_protocol::ToolCapability::Write
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -271,8 +273,8 @@ impl Tool for EditFileTool {
         alan_protocol::ToolCapability::Write
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -1727,8 +1729,8 @@ impl Tool for BashTool {
         300 // Must be >= user-configurable timeout upper bound in schema
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -1825,8 +1827,8 @@ impl Tool for GrepTool {
         alan_protocol::ToolCapability::Read
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -1965,8 +1967,8 @@ impl Tool for GlobTool {
         alan_protocol::ToolCapability::Read
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
@@ -2060,8 +2062,8 @@ impl Tool for ListDirTool {
         alan_protocol::ToolCapability::Read
     }
 
-    fn is_workspace_local(&self) -> bool {
-        true
+    fn locality(&self) -> ToolLocality {
+        ToolLocality::WorkspaceLocal
     }
 
     fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -117,6 +117,12 @@ runtime itself, not `alan-tools`.
 
 All implementations live in [alan-tools/src/lib.rs](../crates/tools/src/lib.rs).
 
+Tool catalog identity is separate from runtime execution binding. Built-in
+definitions keep stable names/schema/locality across runtimes, while
+workspace-specific facts such as `workspace_root` and `cwd` belong to runtime
+binding/context. See
+[tool_catalog_binding_contract.md](./spec/tool_catalog_binding_contract.md).
+
 `bash` exposes a `timeout` argument in schema (1–300, default 60), and the tool-level default timeout is currently 300 seconds (`timeout_secs`).
 
 ### Tool Governance: HITE First, Execution Backend Second

--- a/docs/spec/tool_catalog_binding_contract.md
+++ b/docs/spec/tool_catalog_binding_contract.md
@@ -1,0 +1,147 @@
+# Tool Catalog And Binding Contract
+
+> Status: target runtime contract for tool identity, locality, execution
+> binding, and exposure.
+
+## Goals
+
+This document defines how Alan should model tools so workspace routing,
+child-runtime launches, and host/tool composition all follow one contract:
+
+1. tool identity is stable across runtimes,
+2. workspace binding is explicit runtime state rather than hidden tool state,
+3. tool visibility is chosen separately from execution binding,
+4. child runtimes derive their tool surface from the same catalog contract as
+   launch roots.
+
+## Non-Goals
+
+This contract does not:
+
+1. replace the capability-router/provider-routing design,
+2. redefine dynamic tool registration payloads,
+3. require all tools to support every locality,
+4. promise an OS-level sandbox beyond the current execution backend.
+
+## Stable Vocabulary
+
+- **Tool catalog**: the stable set of tool definitions available to a runtime or
+  host. A catalog entry defines `name`, `description`, parameter schema,
+  capability classification, timeout hint, and locality.
+- **Materialized tool instance**: the executable implementation object for one
+  catalog entry. Materialization may allocate runtime helpers, but must not
+  silently bind the instance to one workspace.
+- **Tool locality**: whether the tool's semantics are global to the runtime or
+  tied to the runtime's bound local workspace.
+- **Tool execution binding**: the explicit runtime-owned binding supplied at
+  execution time, including the current `cwd`, scratch area, and optional
+  `workspace_root`.
+- **Tool context**: the per-call execution object passed to tool
+  implementations, containing the execution binding plus shared config.
+- **Exposure profile**: the allowlisted subset of catalog entries visible to a
+  given runtime.
+
+## Core Rules
+
+### 1. Catalog Entries Are Workspace-Agnostic
+
+A tool catalog entry defines what the tool is, not where it executes.
+
+Catalog metadata such as name, schema, description, timeout, capability, and
+locality must stay stable across workspaces. Two runtimes bound to different
+workspaces should still describe the same built-in tool catalog entry with the
+same identity.
+
+### 2. Locality Is Explicit
+
+Every tool belongs to one of these coarse locality classes:
+
+1. `global`: the tool is not implicitly tied to the runtime's bound workspace,
+2. `workspace_local`: the tool acts on the runtime's currently bound local
+   workspace.
+
+Workspace-routing preflight only applies to `workspace_local` tools. A tool is
+not treated as workspace-local merely because its JSON arguments contain fields
+named `path`, `cwd`, `workspace_root`, or similar.
+
+### 3. Execution Binding Is Runtime State, Not Tool State
+
+Workspace roots, working directories, scratch directories, and similar
+execution-site facts belong to runtime binding/context, not to catalog
+identity.
+
+Built-in tool constructors must therefore be workspace-agnostic. A runtime may
+materialize the same built-in tool implementation once and execute it under
+many different bindings over time, as long as the execution binding is
+provided explicitly.
+
+### 4. Workspace-Local Tools Require Explicit Workspace Binding
+
+When executing a `workspace_local` tool, the runtime must provide an execution
+binding whose `workspace_root` is explicit.
+
+If both `workspace_root` and `cwd` are present:
+
+1. `cwd` must be nested inside `workspace_root`,
+2. path resolution must stay relative to the bound `cwd`,
+3. execution backends must enforce the bound `workspace_root` rather than any
+   hidden process-global default.
+
+Running a workspace-local tool without an explicit workspace binding is a
+runtime binding error, not a reason for the tool implementation to guess.
+
+### 5. Exposure Profile Is Separate From Binding
+
+Tool visibility answers "which tools may this runtime call", not "what
+workspace are those tools bound to".
+
+Changing a tool allowlist:
+
+1. may add or remove visible catalog entries,
+2. must not mutate execution binding,
+3. must not require distinct per-workspace catalog identities for built-ins.
+
+### 6. Child Runtimes Materialize From Catalog Plus Profile
+
+Child-runtime tool surfaces must be derived from:
+
+1. the shared tool catalog,
+2. the child runtime's exposure profile,
+3. the child runtime's own execution binding.
+
+They must not depend on inheriting parent tool instances that already carry
+workspace-specific state. Parent/child runtime differences are expressed
+through exposure profiles and execution bindings, not by redefining the built-in
+catalog per workspace.
+
+### 7. Persistence And Audit Must Match Resolved Binding
+
+When Alan persists delegated-launch requests, routing decisions, or audit
+records, the stored workspace-related fields must match the resolved execution
+binding that the child runtime will actually use.
+
+Alan must not persist unresolved relative workspace fields and then depend on
+process-local defaults at execution time.
+
+## Relationship To Other Contracts
+
+1. `kernel_contract.md` defines the one-workspace-per-instance invariant.
+2. `workspace_routing_contract.md` defines when target-local work must route to
+   a child runtime.
+3. `capability_router.md` defines provider routing above the tool layer.
+4. `governance_boundaries.md` defines policy and execution-backend boundaries.
+
+## Acceptance Criteria
+
+This contract is satisfied when:
+
+1. built-in tool constructors no longer require a workspace path just to define
+   the tool,
+2. workspace-routing preflight consults explicit tool locality instead of
+   argument-shape heuristics,
+3. workspace-local tool execution receives runtime-owned binding/context with
+   explicit `workspace_root`,
+4. child runtimes can expose built-in tools from catalog/profile selection
+   without inheriting parent-bound workspace state,
+5. persisted launch metadata reflects the same workspace binding the runtime
+   actually executes with.

--- a/docs/spec/workspace_routing_contract.md
+++ b/docs/spec/workspace_routing_contract.md
@@ -140,12 +140,14 @@ because they contain echoed mentions of the target path or task text.
 ## Relationship To Other Contracts
 
 1. `kernel_contract.md` defines the one-workspace-per-instance invariant.
-2. `alan_coding_steward_contract.md` defines the steward / repo-worker product
+2. `tool_catalog_binding_contract.md` defines tool locality, exposure, and
+   runtime execution binding semantics.
+3. `alan_coding_steward_contract.md` defines the steward / repo-worker product
    split for coding execution.
-3. `alan_coding_governance_contract.md` defines coding-specific fast paths and
+4. `alan_coding_governance_contract.md` defines coding-specific fast paths and
    owner-boundary classes.
-4. `governance_boundaries.md` defines the generic HITE boundary model.
-5. `governance_current_contract.md` remains the source of truth for shipped
+5. `governance_boundaries.md` defines the generic HITE boundary model.
+6. `governance_current_contract.md` remains the source of truth for shipped
    semantics until implementation catches up.
 
 ## Acceptance Criteria


### PR DESCRIPTION
## What changed
- add `docs/spec/tool_catalog_binding_contract.md` to separate tool catalog identity, locality, execution binding, and exposure profile
- link the new contract from the existing workspace-routing and tools docs
- replace the implicit `is_workspace_local` boolean with explicit `ToolLocality`
- route workspace preflight checks through the explicit locality classification

## Why
The current workspace-routing fix still relied on an underspecified tool model. This PR defines the contract first so the later implementation PRs can remove hidden workspace state without changing the intended behavior again.

## Validation
- `cargo test -p alan-runtime test_tool_registry_locality_for_tool`
- `cargo test -p alan-runtime test_static_host_tool_with_path_like_payload_bypasses_workspace_routing_preflight`
- `cargo test -p alan-runtime test_cross_workspace_bash_is_blocked_before_policy_escalation`
- `cargo test -p alan-tools test_create_tool_registry_with_core_tools`

## Stack
Base for the next PR: `codex/tool-binding-context`