### PR TITLE
[codex] Bind workspace-local tools via runtime context

### DIFF
--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -711,14 +711,19 @@ fn build_child_tool_registry(
         parent.tools.clone_with_config(child_config)
     };
 
+    let workspace_root = resolve_child_workspace_root(parent, spec);
     if let Some(cwd) = spec
         .launch
         .cwd
         .clone()
-        .or_else(|| spec.launch.workspace_root.clone())
+        .or_else(|| workspace_root.clone())
         .or_else(|| parent.tools.default_cwd())
     {
-        tools.set_default_cwd(cwd);
+        if let Some(workspace_root) = workspace_root {
+            tools.set_default_workspace_binding(workspace_root, cwd);
+        } else {
+            tools.set_default_cwd(cwd);
+        }
     }
     Ok(tools)
 }

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -959,9 +959,13 @@ pub fn spawn_with_llm_client_and_tools(
 
     let resolved_agent_definition = crate::ResolvedAgentDefinition::from_runtime_config(&config)?;
     if let Some(default_cwd) = config.default_cwd_override.as_ref() {
-        tools.set_default_cwd(default_cwd.clone());
+        if let Some(ws_root) = resolved_agent_definition.workspace_root_dir.as_ref() {
+            tools.set_default_workspace_binding(ws_root.clone(), default_cwd.clone());
+        } else {
+            tools.set_default_cwd(default_cwd.clone());
+        }
     } else if let Some(ws_root) = resolved_agent_definition.workspace_root_dir.as_ref() {
-        tools.set_default_cwd(ws_root.clone());
+        tools.set_default_workspace_root(ws_root.clone());
     }
 
     let mut agent_config = config.agent_config.clone();

--- a/crates/runtime/src/tools/context.rs
+++ b/crates/runtime/src/tools/context.rs
@@ -1,12 +1,48 @@
 //! Tool execution context for dependency injection.
 
+use super::sandbox::Sandbox;
 use crate::config::Config;
-use std::path::PathBuf;
+use anyhow::{Result, anyhow};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+/// Explicit runtime-owned binding for tool execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolExecutionBinding {
+    /// Bound workspace root for workspace-local tools.
+    pub workspace_root: Option<PathBuf>,
+    /// Working directory for relative path resolution and process execution.
+    pub cwd: PathBuf,
+    /// Scratch directory for temporary files.
+    pub scratch_dir: PathBuf,
+}
+
+impl ToolExecutionBinding {
+    /// Create a binding with an optional workspace root.
+    pub fn new(workspace_root: Option<PathBuf>, cwd: PathBuf, scratch_dir: PathBuf) -> Self {
+        Self {
+            workspace_root,
+            cwd,
+            scratch_dir,
+        }
+    }
+
+    /// Create a binding for tools that do not require a workspace root.
+    pub fn without_workspace(cwd: PathBuf, scratch_dir: PathBuf) -> Self {
+        Self::new(None, cwd, scratch_dir)
+    }
+
+    /// Create a binding for workspace-local tools.
+    pub fn with_workspace(workspace_root: PathBuf, cwd: PathBuf, scratch_dir: PathBuf) -> Self {
+        Self::new(Some(workspace_root), cwd, scratch_dir)
+    }
+}
 
 /// Context provided to tools during execution.
 /// Contains all dependencies needed by tools.
 pub struct ToolContext {
+    /// Bound workspace root for workspace-local tools.
+    pub workspace_root: Option<PathBuf>,
     /// Working directory for the tool
     pub cwd: PathBuf,
     /// Scratch directory for temporary files
@@ -16,17 +52,69 @@ pub struct ToolContext {
 }
 
 impl ToolContext {
-    /// Create a new tool context
+    /// Create a new workspace-local tool context where `cwd == workspace_root`.
     pub fn new(cwd: PathBuf, scratch_dir: PathBuf, config: Arc<Config>) -> Self {
+        Self::with_workspace(cwd.clone(), cwd, scratch_dir, config)
+    }
+
+    /// Create a new tool context without a workspace binding.
+    pub fn without_workspace(cwd: PathBuf, scratch_dir: PathBuf, config: Arc<Config>) -> Self {
+        Self::from_binding(
+            ToolExecutionBinding::without_workspace(cwd, scratch_dir),
+            config,
+        )
+    }
+
+    /// Create a new tool context for a workspace-local execution site.
+    pub fn with_workspace(
+        workspace_root: PathBuf,
+        cwd: PathBuf,
+        scratch_dir: PathBuf,
+        config: Arc<Config>,
+    ) -> Self {
+        Self::from_binding(
+            ToolExecutionBinding::with_workspace(workspace_root, cwd, scratch_dir),
+            config,
+        )
+    }
+
+    /// Create a tool context from an explicit execution binding.
+    pub fn from_binding(binding: ToolExecutionBinding, config: Arc<Config>) -> Self {
         Self {
-            cwd,
-            scratch_dir,
+            workspace_root: binding.workspace_root,
+            cwd: binding.cwd,
+            scratch_dir: binding.scratch_dir,
             config,
         }
     }
 
+    /// Return the current execution binding.
+    pub fn binding(&self) -> ToolExecutionBinding {
+        ToolExecutionBinding {
+            workspace_root: self.workspace_root.clone(),
+            cwd: self.cwd.clone(),
+            scratch_dir: self.scratch_dir.clone(),
+        }
+    }
+
+    /// Return the bound workspace root if present.
+    pub fn workspace_root(&self) -> Option<&Path> {
+        self.workspace_root.as_deref()
+    }
+
+    /// Require an explicit workspace root for workspace-local tools.
+    pub fn require_workspace_root(&self) -> Result<&Path> {
+        self.workspace_root()
+            .ok_or_else(|| anyhow!("Workspace-local tool requires explicit workspace binding"))
+    }
+
+    /// Create a sandbox bound to the current workspace root.
+    pub fn workspace_sandbox(&self) -> Result<Sandbox> {
+        Ok(Sandbox::new(self.require_workspace_root()?.to_path_buf()))
+    }
+
     /// Resolve a path relative to working directory
-    pub fn resolve_path(&self, path: impl AsRef<std::path::Path>) -> PathBuf {
+    pub fn resolve_path(&self, path: impl AsRef<Path>) -> PathBuf {
         if path.as_ref().is_absolute() {
             path.as_ref().to_path_buf()
         } else {
@@ -42,7 +130,8 @@ mod tests {
     #[test]
     fn test_tool_context_resolve_path() {
         let config = Arc::new(Config::default());
-        let ctx = ToolContext::new(
+        let ctx = ToolContext::with_workspace(
+            PathBuf::from("/workspace"),
             PathBuf::from("/workspace"),
             PathBuf::from("/tmp/scratch"),
             config,
@@ -58,6 +147,27 @@ mod tests {
         assert_eq!(
             ctx.resolve_path("/absolute/file.txt"),
             PathBuf::from("/absolute/file.txt")
+        );
+    }
+
+    #[test]
+    fn test_tool_context_exposes_workspace_binding() {
+        let config = Arc::new(Config::default());
+        let ctx = ToolContext::with_workspace(
+            PathBuf::from("/workspace"),
+            PathBuf::from("/workspace/src"),
+            PathBuf::from("/tmp/scratch"),
+            config,
+        );
+
+        assert_eq!(ctx.workspace_root(), Some(Path::new("/workspace")));
+        assert_eq!(
+            ctx.binding(),
+            ToolExecutionBinding::with_workspace(
+                PathBuf::from("/workspace"),
+                PathBuf::from("/workspace/src"),
+                PathBuf::from("/tmp/scratch")
+            )
         );
     }
 }

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -8,6 +8,6 @@ mod context;
 mod registry;
 mod sandbox;
 
-pub use context::ToolContext;
+pub use context::{ToolContext, ToolExecutionBinding};
 pub use registry::{Tool, ToolLocality, ToolRegistry, ToolResult};
 pub use sandbox::{ExecResult, Sandbox};

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -1,6 +1,6 @@
 //! Tool registry for managing and executing tools.
 
-use super::context::ToolContext;
+use super::context::{ToolContext, ToolExecutionBinding};
 use anyhow::Result;
 use jsonschema::{Draft, Validator};
 use serde_json::Value;
@@ -75,7 +75,7 @@ pub struct ToolRegistry {
     config: Arc<Config>,
     schema_cache: Arc<std::sync::Mutex<HashMap<String, Arc<Validator>>>>,
     workspace_factories: HashMap<String, Arc<WorkspaceToolFactory>>,
-    default_cwd: Option<std::path::PathBuf>,
+    default_binding: Option<ToolExecutionBinding>,
 }
 
 impl ToolRegistry {
@@ -91,18 +91,61 @@ impl ToolRegistry {
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             workspace_factories: HashMap::new(),
-            default_cwd: None,
+            default_binding: None,
         }
+    }
+
+    /// Set a default execution binding for `execute()` calls that don't provide context.
+    pub fn set_default_execution_binding(&mut self, binding: ToolExecutionBinding) {
+        self.default_binding = Some(binding);
+    }
+
+    /// Get the configured default execution binding, if any.
+    pub fn default_execution_binding(&self) -> Option<ToolExecutionBinding> {
+        self.default_binding.clone()
+    }
+
+    /// Set a default workspace binding using the provided workspace root and cwd.
+    pub fn set_default_workspace_binding(
+        &mut self,
+        workspace_root: std::path::PathBuf,
+        cwd: std::path::PathBuf,
+    ) {
+        let scratch_dir = default_scratch_dir_for_cwd(&cwd);
+        self.default_binding = Some(ToolExecutionBinding::with_workspace(
+            workspace_root,
+            cwd,
+            scratch_dir,
+        ));
+    }
+
+    /// Set a default workspace root using the workspace root as cwd.
+    pub fn set_default_workspace_root(&mut self, workspace_root: std::path::PathBuf) {
+        self.set_default_workspace_binding(workspace_root.clone(), workspace_root);
     }
 
     /// Set a default working directory for `execute()` calls that don't provide context.
     pub fn set_default_cwd(&mut self, cwd: std::path::PathBuf) {
-        self.default_cwd = Some(cwd);
+        let scratch_dir = default_scratch_dir_for_cwd(&cwd);
+        let workspace_root = self
+            .default_binding
+            .as_ref()
+            .and_then(|binding| binding.workspace_root.clone());
+        self.default_binding = Some(ToolExecutionBinding::new(workspace_root, cwd, scratch_dir));
     }
 
     /// Get the configured default working directory, if any.
     pub fn default_cwd(&self) -> Option<std::path::PathBuf> {
-        self.default_cwd.clone()
+        self.default_binding
+            .as_ref()
+            .map(|binding| binding.cwd.clone())
+    }
+
+    /// Get the configured default workspace root, if any.
+    pub fn default_workspace_root(&self) -> Option<std::path::PathBuf> {
+        self.default_binding
+            .as_ref()
+            .and_then(|binding| binding.workspace_root.clone())
     }
 
     /// Register a tool
@@ -204,7 +247,7 @@ impl ToolRegistry {
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             workspace_factories: self.workspace_factories.clone(),
-            default_cwd: self.default_cwd.clone(),
+            default_binding: self.default_binding.clone(),
         }
     }
 
@@ -245,7 +288,7 @@ impl ToolRegistry {
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             workspace_factories,
-            default_cwd: self.default_cwd.clone(),
+            default_binding: self.default_binding.clone(),
         }
     }
 
@@ -296,16 +339,12 @@ impl ToolRegistry {
     /// Execute a tool by name (backward compatible, uses default context)
     /// Note: This creates a default ToolContext. Prefer execute_with_context for production use.
     pub async fn execute(&self, name: &str, arguments: Value) -> Result<Value> {
-        // Create a default context - this is a simplification for backward compatibility
-        let cwd = self.default_cwd.clone().unwrap_or_else(|| {
-            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+        let binding = self.default_binding.clone().unwrap_or_else(|| {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let scratch_dir = default_scratch_dir_for_cwd(&cwd);
+            ToolExecutionBinding::without_workspace(cwd, scratch_dir)
         });
-        let scratch_dir = self
-            .default_cwd
-            .as_ref()
-            .map(|dir| default_scratch_dir_for_cwd(dir))
-            .unwrap_or_else(std::env::temp_dir);
-        let ctx = ToolContext::new(cwd, scratch_dir, self.config.clone());
+        let ctx = ToolContext::from_binding(binding, self.config.clone());
         self.execute_with_context(name, arguments, &ctx).await
     }
 
@@ -461,6 +500,36 @@ mod tests {
         fn execute(&self, _arguments: Value, ctx: &ToolContext) -> ToolResult {
             let scratch = ctx.scratch_dir.display().to_string();
             Box::pin(async move { Ok(serde_json::json!({"scratch": scratch})) })
+        }
+    }
+
+    struct BindingEchoTool;
+
+    impl Tool for BindingEchoTool {
+        fn name(&self) -> &str {
+            "binding_echo"
+        }
+
+        fn description(&self) -> &str {
+            "Return execution binding from tool context"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        fn execute(&self, _arguments: Value, ctx: &ToolContext) -> ToolResult {
+            let workspace_root = ctx
+                .workspace_root()
+                .map(|path| path.display().to_string())
+                .unwrap_or_default();
+            let cwd = ctx.cwd.display().to_string();
+            Box::pin(async move {
+                Ok(serde_json::json!({
+                    "workspace_root": workspace_root,
+                    "cwd": cwd,
+                }))
+            })
         }
     }
 
@@ -709,6 +778,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result["scratch"], "/tmp/alan-test-cwd/.alan/tmp");
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_execute_uses_default_workspace_binding() {
+        let mut registry = ToolRegistry::new();
+        registry.register(BindingEchoTool);
+        registry.set_default_workspace_root(PathBuf::from("/tmp/alan-test-workspace"));
+
+        let result = registry
+            .execute("binding_echo", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result["workspace_root"], "/tmp/alan-test-workspace");
+        assert_eq!(result["cwd"], "/tmp/alan-test-workspace");
+    }
+
+    #[tokio::test]
+    async fn test_tool_registry_set_default_cwd_preserves_workspace_root() {
+        let mut registry = ToolRegistry::new();
+        registry.register(BindingEchoTool);
+        registry.set_default_workspace_root(PathBuf::from("/tmp/alan-test-workspace"));
+        registry.set_default_cwd(PathBuf::from("/tmp/alan-test-workspace/src"));
+
+        let result = registry
+            .execute("binding_echo", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result["workspace_root"], "/tmp/alan-test-workspace");
+        assert_eq!(result["cwd"], "/tmp/alan-test-workspace/src");
     }
 
     #[tokio::test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -2309,11 +2309,7 @@ mod tests {
 
         let tool = ReadFileTool::new(workspace.clone());
         let config = Arc::new(Config::default());
-        let ctx = ToolContext::without_workspace(
-            workspace.clone(),
-            workspace.join("tmp"),
-            config,
-        );
+        let ctx = ToolContext::without_workspace(workspace.clone(), workspace.join("tmp"), config);
 
         let err = tool
             .execute(json!({"path": "test.txt"}), &ctx)

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -21,15 +21,11 @@ use std::path::Path;
 // ============================================================================
 
 /// read_file - Read a file's contents
-pub struct ReadFileTool {
-    sandbox: Sandbox,
-}
+pub struct ReadFileTool;
 
 impl ReadFileTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -67,7 +63,10 @@ impl Tool for ReadFileTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let path = ctx.resolve_path(args["path"].as_str().unwrap_or(""));
         let offset = args["offset"].as_u64().unwrap_or(1) as usize;
         let limit = args["limit"].as_u64().unwrap_or(1000) as usize;
@@ -127,15 +126,11 @@ impl Tool for ReadFileTool {
 // ============================================================================
 
 /// write_file - Write content to a file
-pub struct WriteFileTool {
-    sandbox: Sandbox,
-}
+pub struct WriteFileTool;
 
 impl WriteFileTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -166,7 +161,10 @@ impl Tool for WriteFileTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let path = ctx.resolve_path(args["path"].as_str().unwrap_or(""));
         let content = args["content"].as_str().unwrap_or("").to_string();
 
@@ -198,15 +196,11 @@ impl Tool for WriteFileTool {
 // ============================================================================
 
 /// edit_file - Edit a file using search/replace
-pub struct EditFileTool {
-    sandbox: Sandbox,
-}
+pub struct EditFileTool;
 
 impl EditFileTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -241,7 +235,10 @@ impl Tool for EditFileTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let path = ctx.resolve_path(args["path"].as_str().unwrap_or(""));
         let old_string = args["old_string"].as_str().unwrap_or("").to_string();
         let new_string = args["new_string"].as_str().unwrap_or("").to_string();
@@ -285,15 +282,11 @@ impl Tool for EditFileTool {
 // ============================================================================
 
 /// bash - Execute shell commands
-pub struct BashTool {
-    sandbox: Sandbox,
-}
+pub struct BashTool;
 
 impl BashTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -1693,7 +1686,10 @@ impl Tool for BashTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let cwd = ctx.cwd.clone();
         let command = args["command"].as_str().unwrap_or("").to_string();
         let capability = classify_bash_command(&command);
@@ -1741,15 +1737,11 @@ impl Tool for BashTool {
 // ============================================================================
 
 /// grep - Search file contents
-pub struct GrepTool {
-    sandbox: Sandbox,
-}
+pub struct GrepTool;
 
 impl GrepTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -1785,7 +1777,10 @@ impl Tool for GrepTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let path = ctx.resolve_path(args["path"].as_str().unwrap_or(""));
         let pattern = args["pattern"].as_str().unwrap_or("").to_string();
         let case_sensitive = args["case_sensitive"].as_bool().unwrap_or(false);
@@ -1882,15 +1877,11 @@ async fn search_directory(
 // ============================================================================
 
 /// glob - Find files matching patterns
-pub struct GlobTool {
-    sandbox: Sandbox,
-}
+pub struct GlobTool;
 
 impl GlobTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -1922,7 +1913,10 @@ impl Tool for GlobTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let base_path = if let Some(path) = args["path"].as_str() {
             ctx.resolve_path(path)
         } else {
@@ -1979,15 +1973,11 @@ impl Tool for GlobTool {
 // ============================================================================
 
 /// list_dir - List directory contents
-pub struct ListDirTool {
-    sandbox: Sandbox,
-}
+pub struct ListDirTool;
 
 impl ListDirTool {
-    pub fn new(workspace: std::path::PathBuf) -> Self {
-        Self {
-            sandbox: Sandbox::new(workspace),
-        }
+    pub fn new(_workspace: std::path::PathBuf) -> Self {
+        Self
     }
 }
 
@@ -2014,7 +2004,10 @@ impl Tool for ListDirTool {
     }
 
     fn execute(&self, args: Value, ctx: &ToolContext) -> ToolResult {
-        let sandbox = self.sandbox.clone();
+        let sandbox = match ctx.workspace_sandbox() {
+            Ok(sandbox) => sandbox,
+            Err(err) => return Box::pin(async move { Err(err) }),
+        };
         let path = if let Some(p) = args["path"].as_str() {
             ctx.resolve_path(p)
         } else {
@@ -2210,6 +2203,7 @@ pub fn create_tool_registry_with_core_tools_and_config(
 ) -> ToolRegistry {
     let mut registry = ToolRegistry::with_config(config);
     register_builtin_workspace_factories(&mut registry);
+    registry.set_default_workspace_root(workspace.clone());
 
     for tool in create_core_tools(workspace) {
         registry.register_boxed(tool);
@@ -2222,6 +2216,7 @@ pub fn create_tool_registry_with_core_tools_and_config(
 pub fn create_tool_registry_with_read_only_tools(workspace: std::path::PathBuf) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
     register_builtin_workspace_factories(&mut registry);
+    registry.set_default_workspace_root(workspace.clone());
 
     for tool in create_read_only_tools(workspace) {
         registry.register_boxed(tool);
@@ -2234,6 +2229,7 @@ pub fn create_tool_registry_with_read_only_tools(workspace: std::path::PathBuf) 
 pub fn create_tool_registry_with_all_tools(workspace: std::path::PathBuf) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
     register_builtin_workspace_factories(&mut registry);
+    registry.set_default_workspace_root(workspace.clone());
 
     for tool in create_all_tools(workspace) {
         registry.register_boxed(tool);
@@ -2301,6 +2297,33 @@ mod tests {
 
         assert_eq!(result["path"], json!(rebound_workspace.join("test.txt")));
         assert_eq!(result["content"], json!("rebound"));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_tool_requires_explicit_workspace_binding() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path().to_path_buf();
+        tokio::fs::write(workspace.join("test.txt"), "hello\n")
+            .await
+            .unwrap();
+
+        let tool = ReadFileTool::new(workspace.clone());
+        let config = Arc::new(Config::default());
+        let ctx = ToolContext::without_workspace(
+            workspace.clone(),
+            workspace.join("tmp"),
+            config,
+        );
+
+        let err = tool
+            .execute(json!({"path": "test.txt"}), &ctx)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Workspace-local tool requires explicit workspace binding")
+        );
     }
 
     #[tokio::test]
@@ -2656,7 +2679,12 @@ mod tests {
 
         let tool = BashTool::new(workspace.clone());
         let config = Arc::new(Config::default());
-        let ctx = ToolContext::new(workspace.join("subdir"), workspace.join("tmp"), config);
+        let ctx = ToolContext::with_workspace(
+            workspace.clone(),
+            workspace.join("subdir"),
+            workspace.join("tmp"),
+            config,
+        );
 
         let args = json!({"command": "pwd"});
         let result = tool.execute(args, &ctx).await.unwrap();


### PR DESCRIPTION
## What changed
- add explicit `ToolExecutionBinding` and extend `ToolContext` with bound `workspace_root`
- teach `ToolRegistry` to carry default workspace bindings instead of only `cwd`
- make builtin workspace-local tools read sandbox binding from runtime context instead of hidden tool fields
- preserve workspace roots when child runtimes and nested cwd bindings are derived

## Why
This is the mechanical split that makes tool execution binding runtime-owned state instead of tool-owned state. After this PR, builtin tools no longer need hidden workspace instances to execute correctly.

## Validation
- `cargo test -p alan-runtime test_tool_registry_execute_uses_default_workspace_binding`
- `cargo test -p alan-runtime test_tool_registry_set_default_cwd_preserves_workspace_root`
- `cargo test -p alan-runtime build_child_tool_registry_rebinds_workspace_sensitive_tools_for_requested_workspace`
- `cargo test -p alan-tools test_read_file_tool`
- `cargo test -p alan-tools test_bash_tool_working_directory`
- `cargo test -p alan-tools test_read_file_tool_requires_explicit_workspace_binding`
- `cargo test -p alan-tools test_create_tool_registry_with_core_tools`

## Stack
Base for the next PR: `codex/tool-catalog-materialization`