### PR TITLE
[codex] Materialize child tools from catalog profiles

### DIFF
--- a/crates/alan/src/daemon/runtime_manager.rs
+++ b/crates/alan/src/daemon/runtime_manager.rs
@@ -250,10 +250,13 @@ impl RuntimeManager {
             None
         };
 
-        let tools = alan_tools::create_tool_registry_with_core_tools_and_config(
-            workspace_root_path.clone(),
-            Arc::new(runtime_config.agent_config.core_config.clone()),
-        );
+        let mut tools = alan_runtime::tools::ToolRegistry::with_config(Arc::new(
+            runtime_config.agent_config.core_config.clone(),
+        ));
+        alan_tools::register_builtin_tool_catalog(&mut tools);
+        for tool in alan_tools::create_core_tools() {
+            tools.register_boxed(tool);
+        }
 
         // Start runtime.
         let mut controller = spawn_with_tool_registry(runtime_config, tools)?;

--- a/crates/alan/src/skill_catalog.rs
+++ b/crates/alan/src/skill_catalog.rs
@@ -4,8 +4,10 @@ use alan_runtime::skills::{
     build_skill_host_capabilities, skill_availability_issues, skill_remediation,
     validate_canonical_skill_id,
 };
-use alan_runtime::{AgentRootKind, Config, ResolvedAgentDefinition, WorkspaceRuntimeConfig};
-use alan_tools::create_tool_registry_with_core_tools_and_config;
+use alan_runtime::{
+    AgentRootKind, Config, ResolvedAgentDefinition, ToolRegistry, WorkspaceRuntimeConfig,
+};
+use alan_tools::{create_core_tools, register_builtin_tool_catalog};
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -129,16 +131,13 @@ pub fn resolve_skill_host_capabilities(
     if !resolved.config_overlay_paths.is_empty() {
         core_config = core_config.with_agent_root_overlays(&resolved.config_overlay_paths)?;
     }
-    let tools = resolved
-        .workspace_root_dir
-        .as_ref()
-        .map(|workspace_root| {
-            create_tool_registry_with_core_tools_and_config(
-                workspace_root.clone(),
-                Arc::new(core_config.clone()),
-            )
-        })
-        .unwrap_or_else(|| alan_runtime::ToolRegistry::with_config(Arc::new(core_config.clone())));
+    let mut tools = ToolRegistry::with_config(Arc::new(core_config));
+    if resolved.workspace_root_dir.is_some() {
+        register_builtin_tool_catalog(&mut tools);
+        for tool in create_core_tools() {
+            tools.register_boxed(tool);
+        }
+    }
     let delegated_supported = !resolved
         .roots
         .roots()

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -637,7 +637,7 @@ fn build_child_tool_registry(
         return Ok(ToolRegistry::with_config(child_config));
     }
 
-    let mut tools = if let Some(workspace_root) = spec.launch.workspace_root.as_deref() {
+    let mut tools = if spec.launch.workspace_root.is_some() {
         let mut rebound = ToolRegistry::with_config(Arc::clone(&child_config));
         let selected_tool_names = spec
             .runtime_overrides
@@ -652,61 +652,23 @@ fn build_child_tool_registry(
                     .map(str::to_string)
                     .collect()
             });
-        let normalized_requested_workspace_root = lexically_normalize_path(workspace_root);
-        let normalized_parent_workspace_root =
-            bound_workspace_root(parent).map(|root| lexically_normalize_path(&root));
-
-        for tool_name in &selected_tool_names {
-            // Preserve explicit parent overrides; only consult factories when the
-            // existing tool cannot be rebound or safely shared into the child workspace.
-            if let Some(tool) = parent.tools.get(tool_name) {
-                if let Some(rebound_tool) = tool.rebind_workspace(workspace_root) {
-                    rebound.register_boxed(rebound_tool);
-                } else if tool.locality() != crate::tools::ToolLocality::WorkspaceLocal
-                    || normalized_parent_workspace_root
-                        .as_ref()
-                        .is_some_and(|root| *root == normalized_requested_workspace_root)
-                {
-                    rebound.register_shared(tool);
-                } else if let Some(materialized_tool) = parent
-                    .tools
-                    .materialize_for_workspace(tool_name, workspace_root)
-                {
-                    rebound.register_boxed(materialized_tool);
-                } else {
-                    continue;
-                }
+        for tool_name in selected_tool_names {
+            if let Some(materialized_tool) = parent.tools.materialize(&tool_name) {
+                rebound.register_boxed(materialized_tool);
                 continue;
             }
 
-            if let Some(materialized_tool) = parent
-                .tools
-                .materialize_for_workspace(tool_name, workspace_root)
+            if let Some(tool) = parent.tools.get(&tool_name)
+                && tool.locality() == crate::tools::ToolLocality::Global
             {
-                rebound.register_boxed(materialized_tool);
+                rebound.register_shared(tool);
             }
-        }
-        let missing_tools = rebound.validate_required_tools(&selected_tool_names)?;
-        if !missing_tools.is_empty() {
-            bail!(
-                "Child-agent launch requested tools that cannot be bound for workspace '{}': {}",
-                workspace_root.display(),
-                missing_tools.join(", ")
-            );
         }
         rebound
     } else if let Some(tool_profile) = spec.runtime_overrides.tool_profile.as_ref() {
-        let filtered = parent
+        parent
             .tools
-            .filtered_clone_with_config(&tool_profile.allowed_tools, child_config);
-        let missing_tools = filtered.validate_required_tools(&tool_profile.allowed_tools)?;
-        if !missing_tools.is_empty() {
-            bail!(
-                "Child-agent launch requested unavailable tools: {}",
-                missing_tools.join(", ")
-            );
-        }
-        filtered
+            .catalog_filtered_clone_with_config(&tool_profile.allowed_tools, child_config)
     } else {
         parent.tools.clone_with_config(child_config)
     };
@@ -1117,77 +1079,6 @@ mod tests {
         fn locality(&self) -> crate::tools::ToolLocality {
             crate::tools::ToolLocality::WorkspaceLocal
         }
-
-        fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-            Some(Box::new(Self::new(
-                &self.name,
-                workspace_root.to_path_buf(),
-            )))
-        }
-    }
-
-    struct FactoryOnlyWorkspaceBoundTestTool {
-        name: String,
-        workspace_root: PathBuf,
-    }
-
-    impl FactoryOnlyWorkspaceBoundTestTool {
-        fn new(name: &str, workspace_root: PathBuf) -> Self {
-            Self {
-                name: name.to_string(),
-                workspace_root,
-            }
-        }
-    }
-
-    impl Tool for FactoryOnlyWorkspaceBoundTestTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-
-        fn description(&self) -> &str {
-            "workspace-bound factory-only test tool"
-        }
-
-        fn parameters_schema(&self) -> serde_json::Value {
-            json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {
-                    "path": {
-                        "type": "string"
-                    }
-                }
-            })
-        }
-
-        fn execute(
-            &self,
-            arguments: serde_json::Value,
-            ctx: &crate::tools::ToolContext,
-        ) -> crate::tools::ToolResult {
-            let workspace_root = self.workspace_root.clone();
-            let path = ctx.resolve_path(arguments["path"].as_str().unwrap_or(""));
-            Box::pin(async move {
-                if !path.starts_with(&workspace_root) {
-                    anyhow::bail!(
-                        "outside workspace: '{}' not within '{}'",
-                        path.display(),
-                        workspace_root.display()
-                    );
-                }
-
-                let content = tokio::fs::read_to_string(&path).await?;
-                Ok(json!({
-                    "path": path.to_string_lossy(),
-                    "content": content
-                }))
-            })
-        }
-
-        fn locality(&self) -> crate::tools::ToolLocality {
-            crate::tools::ToolLocality::WorkspaceLocal
-        }
     }
 
     fn make_parent_state(
@@ -1538,7 +1429,7 @@ Body
     }
 
     #[tokio::test]
-    async fn build_child_tool_registry_rebinds_workspace_sensitive_tools_for_requested_workspace() {
+    async fn build_child_tool_registry_skips_workspace_local_tools_without_catalog_factory() {
         let temp = TempDir::new().unwrap();
         let parent_root = temp.path().join("repo");
         let child_root = temp.path().join("other-repo");
@@ -1559,16 +1450,7 @@ Body
         spec.launch.cwd = Some(child_root.clone());
 
         let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
-        let result = child_tools
-            .execute("workspace_read", json!({ "path": "target.txt" }))
-            .await
-            .unwrap();
-
-        assert_eq!(result["content"], json!("child workspace contents\n"));
-        assert_eq!(
-            result["path"],
-            json!(child_root.join("target.txt").to_string_lossy().to_string())
-        );
+        assert!(child_tools.get("workspace_read").is_none());
     }
 
     #[tokio::test]
@@ -1584,10 +1466,11 @@ Body
         let mut parent = make_parent_state(&temp, requests, response);
         let mut parent_tools = ToolRegistry::new();
         parent_tools.set_default_cwd(parent_root);
-        parent_tools.register_workspace_factory("workspace_read", |workspace_root| {
+        let child_root_for_factory = child_root.clone();
+        parent_tools.register_tool_factory("workspace_read", move || {
             Box::new(WorkspaceBoundTestTool::new(
                 "workspace_read",
-                workspace_root.to_path_buf(),
+                child_root_for_factory.clone(),
             ))
         });
         parent.tools = parent_tools;
@@ -1611,127 +1494,6 @@ Body
             result["path"],
             json!(child_root.join("target.txt").to_string_lossy().to_string())
         );
-    }
-
-    #[tokio::test]
-    async fn build_child_tool_registry_shares_existing_global_override_before_factory_fallback() {
-        let temp = TempDir::new().unwrap();
-        let parent_root = temp.path().join("repo");
-        let child_root = temp.path().join("other-repo");
-        std::fs::create_dir_all(&child_root).unwrap();
-        std::fs::write(child_root.join("target.txt"), "child workspace contents\n").unwrap();
-
-        let requests = RecordedRequests::default();
-        let response = completed_response("Child finished cleanly.");
-        let mut parent = make_parent_state(&temp, requests, response);
-        let mut parent_tools = ToolRegistry::new();
-        parent_tools.set_default_cwd(parent_root);
-        parent_tools.register(NamedTestTool::new("workspace_read"));
-        parent_tools.register_workspace_factory("workspace_read", |workspace_root| {
-            Box::new(FactoryOnlyWorkspaceBoundTestTool::new(
-                "workspace_read",
-                workspace_root.to_path_buf(),
-            ))
-        });
-        parent.tools = parent_tools;
-
-        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
-        spec.handles = vec![SpawnHandle::Workspace];
-        spec.launch.workspace_root = Some(child_root);
-        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
-            allowed_tools: vec!["workspace_read".to_string()],
-        });
-
-        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
-        let result = child_tools
-            .execute("workspace_read", json!({ "path": "target.txt" }))
-            .await
-            .unwrap();
-
-        assert_eq!(result["ok"], json!(true));
-        assert!(result.get("content").is_none());
-    }
-
-    #[tokio::test]
-    async fn build_child_tool_registry_falls_back_to_factory_for_unshareable_parent_tool() {
-        let temp = TempDir::new().unwrap();
-        let parent_root = temp.path().join("repo");
-        let child_root = temp.path().join("other-repo");
-        std::fs::create_dir_all(&child_root).unwrap();
-        std::fs::write(child_root.join("target.txt"), "child workspace contents\n").unwrap();
-
-        let requests = RecordedRequests::default();
-        let response = completed_response("Child finished cleanly.");
-        let mut parent = make_parent_state(&temp, requests, response);
-        let mut parent_tools = ToolRegistry::new();
-        parent_tools.set_default_cwd(parent_root.clone());
-        parent_tools.register(FactoryOnlyWorkspaceBoundTestTool::new(
-            "workspace_read",
-            parent_root,
-        ));
-        parent_tools.register_workspace_factory("workspace_read", |workspace_root| {
-            Box::new(FactoryOnlyWorkspaceBoundTestTool::new(
-                "workspace_read",
-                workspace_root.to_path_buf(),
-            ))
-        });
-        parent.tools = parent_tools;
-
-        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
-        spec.handles = vec![SpawnHandle::Workspace];
-        spec.launch.workspace_root = Some(child_root.clone());
-        spec.launch.cwd = Some(child_root.clone());
-        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
-            allowed_tools: vec!["workspace_read".to_string()],
-        });
-
-        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
-        let result = child_tools
-            .execute("workspace_read", json!({ "path": "target.txt" }))
-            .await
-            .unwrap();
-
-        assert_eq!(result["content"], json!("child workspace contents\n"));
-        assert_eq!(
-            result["path"],
-            json!(child_root.join("target.txt").to_string_lossy().to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn build_child_tool_registry_rejects_unbindable_workspace_local_tools() {
-        let temp = TempDir::new().unwrap();
-        let parent_root = temp.path().join("repo");
-        let child_root = temp.path().join("other-repo");
-        std::fs::create_dir_all(&child_root).unwrap();
-
-        let requests = RecordedRequests::default();
-        let response = completed_response("Child finished cleanly.");
-        let mut parent = make_parent_state(&temp, requests, response);
-        let mut parent_tools = ToolRegistry::new();
-        parent_tools.set_default_cwd(parent_root.clone());
-        parent_tools.register(FactoryOnlyWorkspaceBoundTestTool::new(
-            "workspace_read",
-            parent_root,
-        ));
-        parent.tools = parent_tools;
-
-        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
-        spec.handles = vec![SpawnHandle::Workspace];
-        spec.launch.workspace_root = Some(child_root);
-        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
-            allowed_tools: vec!["workspace_read".to_string()],
-        });
-
-        let err = match build_child_tool_registry(&parent, &spec, &parent.core_config) {
-            Ok(_) => panic!("expected child tool registry build to fail"),
-            Err(err) => err,
-        };
-        assert!(
-            err.to_string()
-                .contains("requested tools that cannot be bound for workspace")
-        );
-        assert!(err.to_string().contains("workspace_read"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -664,11 +664,18 @@ fn build_child_tool_registry(
                 rebound.register_shared(tool);
             }
         }
+        validate_child_tool_profile_allowlist(
+            &rebound,
+            spec.runtime_overrides.tool_profile.as_ref(),
+            spec.launch.workspace_root.as_deref(),
+        )?;
         rebound
     } else if let Some(tool_profile) = spec.runtime_overrides.tool_profile.as_ref() {
-        parent
+        let filtered = parent
             .tools
-            .catalog_filtered_clone_with_config(&tool_profile.allowed_tools, child_config)
+            .catalog_filtered_clone_with_config(&tool_profile.allowed_tools, child_config);
+        validate_child_tool_profile_allowlist(&filtered, Some(tool_profile), None)?;
+        filtered
     } else {
         parent.tools.clone_with_config(child_config)
     };
@@ -688,6 +695,34 @@ fn build_child_tool_registry(
         }
     }
     Ok(tools)
+}
+
+fn validate_child_tool_profile_allowlist(
+    tools: &ToolRegistry,
+    tool_profile: Option<&alan_protocol::SpawnToolProfileOverride>,
+    workspace_root: Option<&Path>,
+) -> Result<()> {
+    let Some(tool_profile) = tool_profile else {
+        return Ok(());
+    };
+
+    let missing_tools = tools.validate_required_tools(&tool_profile.allowed_tools)?;
+    if missing_tools.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(workspace_root) = workspace_root {
+        bail!(
+            "Child-agent launch requested tools that cannot be bound for workspace '{}': {}",
+            workspace_root.display(),
+            missing_tools.join(", ")
+        );
+    }
+
+    bail!(
+        "Child-agent launch requested unavailable tools: {}",
+        missing_tools.join(", ")
+    );
 }
 
 fn resolve_child_workspace_root(parent: &RuntimeLoopState, spec: &SpawnSpec) -> Option<PathBuf> {
@@ -1454,6 +1489,40 @@ Body
     }
 
     #[tokio::test]
+    async fn build_child_tool_registry_rejects_missing_requested_workspace_tool_without_factory() {
+        let temp = TempDir::new().unwrap();
+        let parent_root = temp.path().join("repo");
+        let child_root = temp.path().join("other-repo");
+        std::fs::create_dir_all(&child_root).unwrap();
+
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let mut parent = make_parent_state(&temp, requests, response);
+        let mut parent_tools = ToolRegistry::new();
+        parent_tools.set_default_cwd(parent_root.clone());
+        parent_tools.register(WorkspaceBoundTestTool::new("workspace_read", parent_root));
+        parent.tools = parent_tools;
+
+        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+        spec.launch.workspace_root = Some(child_root.clone());
+        spec.launch.cwd = Some(child_root);
+        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
+            allowed_tools: vec!["workspace_read".to_string()],
+        });
+
+        let err = match build_child_tool_registry(&parent, &spec, &parent.core_config) {
+            Ok(_) => panic!("expected missing requested workspace tool to fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("requested tools that cannot be bound for workspace")
+        );
+        assert!(err.to_string().contains("workspace_read"));
+    }
+
+    #[tokio::test]
     async fn build_child_tool_registry_materializes_workspace_tools_from_parent_factories() {
         let temp = TempDir::new().unwrap();
         let parent_root = temp.path().join("repo");
@@ -1494,6 +1563,27 @@ Body
             result["path"],
             json!(child_root.join("target.txt").to_string_lossy().to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn build_child_tool_registry_rejects_unavailable_requested_tool_profile_entries() {
+        let temp = TempDir::new().unwrap();
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let parent = make_parent_state(&temp, requests, response);
+
+        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
+            allowed_tools: vec!["alpha".to_string(), "missing".to_string()],
+        });
+
+        let err = match build_child_tool_registry(&parent, &spec, &parent.core_config) {
+            Ok(_) => panic!("expected unavailable requested tool profile entry to fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("requested unavailable tools"));
+        assert!(err.to_string().contains("missing"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -637,7 +637,7 @@ fn build_child_tool_registry(
         return Ok(ToolRegistry::with_config(child_config));
     }
 
-    let mut tools = if spec.launch.workspace_root.is_some() {
+    let mut tools = if let Some(workspace_root) = spec.launch.workspace_root.as_deref() {
         let mut rebound = ToolRegistry::with_config(Arc::clone(&child_config));
         let selected_tool_names = spec
             .runtime_overrides
@@ -652,16 +652,23 @@ fn build_child_tool_registry(
                     .map(str::to_string)
                     .collect()
             });
+        let normalized_requested_workspace_root = lexically_normalize_path(workspace_root);
+        let normalized_parent_workspace_root =
+            bound_workspace_root(parent).map(|root| lexically_normalize_path(&root));
+
         for tool_name in selected_tool_names {
-            if let Some(materialized_tool) = parent.tools.materialize(&tool_name) {
-                rebound.register_boxed(materialized_tool);
+            if let Some(tool) = parent.tools.get(&tool_name)
+                && (tool.locality() == crate::tools::ToolLocality::Global
+                    || normalized_parent_workspace_root
+                        .as_ref()
+                        .is_some_and(|root| *root == normalized_requested_workspace_root))
+            {
+                rebound.register_shared(tool);
                 continue;
             }
 
-            if let Some(tool) = parent.tools.get(&tool_name)
-                && tool.locality() == crate::tools::ToolLocality::Global
-            {
-                rebound.register_shared(tool);
+            if let Some(materialized_tool) = parent.tools.materialize(&tool_name) {
+                rebound.register_boxed(materialized_tool);
             }
         }
         validate_child_tool_profile_allowlist(
@@ -1116,6 +1123,52 @@ mod tests {
         }
     }
 
+    struct MarkerTool {
+        name: String,
+        marker: String,
+        locality: crate::tools::ToolLocality,
+    }
+
+    impl MarkerTool {
+        fn new(name: &str, marker: &str, locality: crate::tools::ToolLocality) -> Self {
+            Self {
+                name: name.to_string(),
+                marker: marker.to_string(),
+                locality,
+            }
+        }
+    }
+
+    impl Tool for MarkerTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "marker test tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({
+                "type": "object",
+                "properties": {}
+            })
+        }
+
+        fn execute(
+            &self,
+            _arguments: serde_json::Value,
+            _ctx: &crate::tools::ToolContext,
+        ) -> crate::tools::ToolResult {
+            let marker = self.marker.clone();
+            Box::pin(async move { Ok(json!({ "marker": marker })) })
+        }
+
+        fn locality(&self) -> crate::tools::ToolLocality {
+            self.locality
+        }
+    }
+
     fn make_parent_state(
         temp: &TempDir,
         requests: RecordedRequests,
@@ -1563,6 +1616,91 @@ Body
             result["path"],
             json!(child_root.join("target.txt").to_string_lossy().to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn build_child_tool_registry_preserves_global_override_before_factory() {
+        let temp = TempDir::new().unwrap();
+        let parent_root = temp.path().join("repo");
+        let child_root = temp.path().join("other-repo");
+        std::fs::create_dir_all(&child_root).unwrap();
+
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let mut parent = make_parent_state(&temp, requests, response);
+        let mut parent_tools = ToolRegistry::new();
+        parent_tools.set_default_cwd(parent_root);
+        parent_tools.register(MarkerTool::new(
+            "override_tool",
+            "override",
+            crate::tools::ToolLocality::Global,
+        ));
+        parent_tools.register_tool_factory("override_tool", || {
+            Box::new(MarkerTool::new(
+                "override_tool",
+                "factory",
+                crate::tools::ToolLocality::Global,
+            ))
+        });
+        parent.tools = parent_tools;
+
+        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+        spec.launch.workspace_root = Some(child_root.clone());
+        spec.launch.cwd = Some(child_root);
+        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
+            allowed_tools: vec!["override_tool".to_string()],
+        });
+
+        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
+        let result = child_tools
+            .execute("override_tool", json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result["marker"], json!("override"));
+    }
+
+    #[tokio::test]
+    async fn build_child_tool_registry_preserves_same_workspace_local_override_before_factory() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("repo");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+
+        let requests = RecordedRequests::default();
+        let response = completed_response("Child finished cleanly.");
+        let mut parent = make_parent_state(&temp, requests, response);
+        let mut parent_tools = ToolRegistry::new();
+        parent_tools.set_default_workspace_root(workspace_root.clone());
+        parent_tools.register(MarkerTool::new(
+            "workspace_override",
+            "override",
+            crate::tools::ToolLocality::WorkspaceLocal,
+        ));
+        parent_tools.register_tool_factory("workspace_override", || {
+            Box::new(MarkerTool::new(
+                "workspace_override",
+                "factory",
+                crate::tools::ToolLocality::WorkspaceLocal,
+            ))
+        });
+        parent.tools = parent_tools;
+
+        let mut spec = launch_spec(temp.path().join("repo/.alan/agents/grader"));
+        spec.handles = vec![SpawnHandle::Workspace];
+        spec.launch.workspace_root = Some(workspace_root.clone());
+        spec.launch.cwd = Some(workspace_root);
+        spec.runtime_overrides.tool_profile = Some(alan_protocol::SpawnToolProfileOverride {
+            allowed_tools: vec!["workspace_override".to_string()],
+        });
+
+        let child_tools = build_child_tool_registry(&parent, &spec, &parent.core_config).unwrap();
+        let result = child_tools
+            .execute("workspace_override", json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result["marker"], json!("override"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -275,8 +275,8 @@ impl ToolRegistry {
         }
     }
 
-    /// Clone this registry by materializing tools from the catalog when
-    /// possible, falling back to sharing global tool instances.
+    /// Clone this registry by preserving already-registered tools first and
+    /// materializing missing names from the catalog when possible.
     ///
     /// Missing allowed names are omitted. Callers that need strict allowlist
     /// enforcement should validate the result with `validate_required_tools`.
@@ -303,15 +303,13 @@ impl ToolRegistry {
         };
 
         for name in allowed {
-            if let Some(materialized) = self.materialize(&name) {
-                cloned.register_boxed(materialized);
+            if let Some(tool) = self.get(&name) {
+                cloned.register_shared(tool);
                 continue;
             }
 
-            if let Some(tool) = self.get(&name)
-                && tool.locality() == ToolLocality::Global
-            {
-                cloned.register_shared(tool);
+            if let Some(materialized) = self.materialize(&name) {
+                cloned.register_boxed(materialized);
             }
         }
 
@@ -721,6 +719,61 @@ mod tests {
 
         assert!(filtered.materialize("allowed_factory").is_some());
         assert!(filtered.materialize("blocked_factory").is_none());
+    }
+
+    struct MarkerTool {
+        name: &'static str,
+        marker: &'static str,
+        locality: ToolLocality,
+    }
+
+    impl Tool for MarkerTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "marker tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        fn execute(&self, _arguments: Value, _ctx: &ToolContext) -> ToolResult {
+            let marker = self.marker;
+            Box::pin(async move { Ok(serde_json::json!({ "marker": marker })) })
+        }
+
+        fn locality(&self) -> ToolLocality {
+            self.locality
+        }
+    }
+
+    #[tokio::test]
+    async fn test_catalog_filtered_clone_with_config_preserves_registered_overrides() {
+        let mut registry = ToolRegistry::new();
+        registry.register(MarkerTool {
+            name: "override_tool",
+            marker: "override",
+            locality: ToolLocality::Global,
+        });
+        registry.register_tool_factory("override_tool", || {
+            Box::new(MarkerTool {
+                name: "override_tool",
+                marker: "factory",
+                locality: ToolLocality::Global,
+            })
+        });
+
+        let filtered = registry
+            .catalog_filtered_clone_with_config(["override_tool"], Arc::new(Config::default()));
+        let result = filtered
+            .execute("override_tool", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(result["marker"], serde_json::json!("override"));
     }
 
     #[test]

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -6,7 +6,6 @@ use jsonschema::{Draft, Validator};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::future::Future;
-use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use tracing::debug;
@@ -16,7 +15,7 @@ use crate::llm::ToolDefinition;
 
 /// Result type for tool execution
 pub type ToolResult = Pin<Box<dyn Future<Output = Result<Value>> + Send>>;
-type WorkspaceToolFactory = dyn Fn(&Path) -> Box<dyn Tool> + Send + Sync;
+type ToolFactory = dyn Fn() -> Box<dyn Tool> + Send + Sync;
 
 /// Coarse locality class for tool execution and workspace-routing policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,15 +56,6 @@ pub trait Tool: Send + Sync {
     fn locality(&self) -> ToolLocality {
         ToolLocality::Global
     }
-
-    /// Rebind the tool to a different workspace root for child-runtime launches.
-    ///
-    /// Tools that are workspace-relative can return a fresh instance here.
-    /// Tools without workspace-local state can use the default `None` and will
-    /// be shared into the child runtime as-is.
-    fn rebind_workspace(&self, _workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        None
-    }
 }
 
 /// Registry for managing tools
@@ -74,7 +64,7 @@ pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
     config: Arc<Config>,
     schema_cache: Arc<std::sync::Mutex<HashMap<String, Arc<Validator>>>>,
-    workspace_factories: HashMap<String, Arc<WorkspaceToolFactory>>,
+    tool_factories: HashMap<String, Arc<ToolFactory>>,
     default_binding: Option<ToolExecutionBinding>,
 }
 
@@ -90,7 +80,7 @@ impl ToolRegistry {
             tools: HashMap::new(),
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            workspace_factories: HashMap::new(),
+            tool_factories: HashMap::new(),
             default_binding: None,
         }
     }
@@ -181,13 +171,12 @@ impl ToolRegistry {
         self.tools.insert(name, tool);
     }
 
-    /// Register a workspace-bound tool factory that can materialize a fresh
-    /// tool instance for child-runtime launches.
-    pub fn register_workspace_factory<F>(&mut self, name: &str, factory: F)
+    /// Register a tool factory that can materialize a fresh catalog instance.
+    pub fn register_tool_factory<F>(&mut self, name: &str, factory: F)
     where
-        F: Fn(&Path) -> Box<dyn Tool> + Send + Sync + 'static,
+        F: Fn() -> Box<dyn Tool> + Send + Sync + 'static,
     {
-        self.workspace_factories
+        self.tool_factories
             .insert(name.to_string(), Arc::new(factory));
     }
 
@@ -196,15 +185,9 @@ impl ToolRegistry {
         self.tools.get(name).cloned()
     }
 
-    /// Materialize a fresh tool instance for a different workspace root.
-    pub fn materialize_for_workspace(
-        &self,
-        name: &str,
-        workspace_root: &Path,
-    ) -> Option<Box<dyn Tool>> {
-        self.workspace_factories
-            .get(name)
-            .map(|factory| factory(workspace_root))
+    /// Materialize a fresh tool instance from the catalog.
+    pub fn materialize(&self, name: &str) -> Option<Box<dyn Tool>> {
+        self.tool_factories.get(name).map(|factory| factory())
     }
 
     /// Check if a tool exists
@@ -246,7 +229,7 @@ impl ToolRegistry {
                 .collect(),
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            workspace_factories: self.workspace_factories.clone(),
+            tool_factories: self.tool_factories.clone(),
             default_binding: self.default_binding.clone(),
         }
     }
@@ -276,8 +259,8 @@ impl ToolRegistry {
             .filter(|(name, _)| allowed.contains(name.as_str()))
             .map(|(name, tool)| (name.clone(), Arc::clone(tool)))
             .collect();
-        let workspace_factories = self
-            .workspace_factories
+        let tool_factories = self
+            .tool_factories
             .iter()
             .filter(|(name, _)| allowed.contains(name.as_str()))
             .map(|(name, factory)| (name.clone(), Arc::clone(factory)))
@@ -287,9 +270,49 @@ impl ToolRegistry {
             tools,
             config,
             schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            workspace_factories,
+            tool_factories,
             default_binding: self.default_binding.clone(),
         }
+    }
+
+    /// Clone this registry by materializing tools from the catalog when
+    /// possible, falling back to sharing global tool instances.
+    pub fn catalog_filtered_clone_with_config<I, S>(&self, allowed: I, config: Arc<Config>) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let allowed = allowed
+            .into_iter()
+            .map(|name| name.as_ref().to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        let mut cloned = Self {
+            tools: HashMap::new(),
+            config,
+            schema_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            tool_factories: self
+                .tool_factories
+                .iter()
+                .filter(|(name, _)| allowed.contains(name.as_str()))
+                .map(|(name, factory)| (name.clone(), Arc::clone(factory)))
+                .collect(),
+            default_binding: self.default_binding.clone(),
+        };
+
+        for name in allowed {
+            if let Some(materialized) = self.materialize(&name) {
+                cloned.register_boxed(materialized);
+                continue;
+            }
+
+            if let Some(tool) = self.get(&name)
+                && tool.locality() == ToolLocality::Global
+            {
+                cloned.register_shared(tool);
+            }
+        }
+
+        cloned
     }
 
     /// Get tool definitions for LLM function calling
@@ -672,24 +695,29 @@ mod tests {
     }
 
     #[test]
-    fn test_filtered_clone_with_config_prunes_workspace_factories_to_allowed_tools() {
+    fn test_filtered_clone_with_config_prunes_tool_factories_to_allowed_tools() {
         let mut registry = ToolRegistry::new();
-        registry.register_workspace_factory("allowed_factory", |_| Box::new(WorkspaceLocalTool));
-        registry.register_workspace_factory("blocked_factory", |_| Box::new(WorkspaceLocalTool));
+        registry.register_tool_factory("allowed_factory", || Box::new(WorkspaceLocalTool));
+        registry.register_tool_factory("blocked_factory", || Box::new(WorkspaceLocalTool));
 
         let filtered =
             registry.filtered_clone_with_config(["allowed_factory"], Arc::new(Config::default()));
 
-        assert!(
-            filtered
-                .materialize_for_workspace("allowed_factory", Path::new("/workspace"))
-                .is_some()
-        );
-        assert!(
-            filtered
-                .materialize_for_workspace("blocked_factory", Path::new("/workspace"))
-                .is_none()
-        );
+        assert!(filtered.materialize("allowed_factory").is_some());
+        assert!(filtered.materialize("blocked_factory").is_none());
+    }
+
+    #[test]
+    fn test_catalog_filtered_clone_with_config_prunes_tool_factories_to_allowed_tools() {
+        let mut registry = ToolRegistry::new();
+        registry.register_tool_factory("allowed_factory", || Box::new(WorkspaceLocalTool));
+        registry.register_tool_factory("blocked_factory", || Box::new(WorkspaceLocalTool));
+
+        let filtered = registry
+            .catalog_filtered_clone_with_config(["allowed_factory"], Arc::new(Config::default()));
+
+        assert!(filtered.materialize("allowed_factory").is_some());
+        assert!(filtered.materialize("blocked_factory").is_none());
     }
 
     #[test]

--- a/crates/runtime/src/tools/registry.rs
+++ b/crates/runtime/src/tools/registry.rs
@@ -277,6 +277,9 @@ impl ToolRegistry {
 
     /// Clone this registry by materializing tools from the catalog when
     /// possible, falling back to sharing global tool instances.
+    ///
+    /// Missing allowed names are omitted. Callers that need strict allowlist
+    /// enforcement should validate the result with `validate_required_tools`.
     pub fn catalog_filtered_clone_with_config<I, S>(&self, allowed: I, config: Arc<Config>) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -8,7 +8,6 @@
 //! - Read-only exploration: read_file, grep, glob, list_dir
 //! - All: core + read-only exploration tools
 
-use alan_runtime::Config;
 use alan_runtime::tools::{Sandbox, Tool, ToolContext, ToolLocality, ToolRegistry, ToolResult};
 use anyhow::{Result, anyhow};
 use regex::RegexBuilder;
@@ -21,10 +20,11 @@ use std::path::Path;
 // ============================================================================
 
 /// read_file - Read a file's contents
+#[derive(Default)]
 pub struct ReadFileTool;
 
 impl ReadFileTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -115,10 +115,6 @@ impl Tool for ReadFileTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -126,10 +122,11 @@ impl Tool for ReadFileTool {
 // ============================================================================
 
 /// write_file - Write content to a file
+#[derive(Default)]
 pub struct WriteFileTool;
 
 impl WriteFileTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -185,10 +182,6 @@ impl Tool for WriteFileTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -196,10 +189,11 @@ impl Tool for WriteFileTool {
 // ============================================================================
 
 /// edit_file - Edit a file using search/replace
+#[derive(Default)]
 pub struct EditFileTool;
 
 impl EditFileTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -271,10 +265,6 @@ impl Tool for EditFileTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -282,10 +272,11 @@ impl Tool for EditFileTool {
 // ============================================================================
 
 /// bash - Execute shell commands
+#[derive(Default)]
 pub struct BashTool;
 
 impl BashTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -1726,10 +1717,6 @@ impl Tool for BashTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -1737,10 +1724,11 @@ impl Tool for BashTool {
 // ============================================================================
 
 /// grep - Search file contents
+#[derive(Default)]
 pub struct GrepTool;
 
 impl GrepTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -1823,10 +1811,6 @@ impl Tool for GrepTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 async fn search_directory(
@@ -1877,10 +1861,11 @@ async fn search_directory(
 // ============================================================================
 
 /// glob - Find files matching patterns
+#[derive(Default)]
 pub struct GlobTool;
 
 impl GlobTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -1962,10 +1947,6 @@ impl Tool for GlobTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -1973,10 +1954,11 @@ impl Tool for GlobTool {
 // ============================================================================
 
 /// list_dir - List directory contents
+#[derive(Default)]
 pub struct ListDirTool;
 
 impl ListDirTool {
-    pub fn new(_workspace: std::path::PathBuf) -> Self {
+    pub fn new() -> Self {
         Self
     }
 }
@@ -2056,10 +2038,6 @@ impl Tool for ListDirTool {
     fn locality(&self) -> ToolLocality {
         ToolLocality::WorkspaceLocal
     }
-
-    fn rebind_workspace(&self, workspace_root: &Path) -> Option<Box<dyn Tool>> {
-        Some(Box::new(Self::new(workspace_root.to_path_buf())))
-    }
 }
 
 // ============================================================================
@@ -2123,89 +2101,70 @@ fn is_binary_file(path: &Path) -> bool {
 // Factory
 // ============================================================================
 
-/// Create the default core toolset (4 tools) with the given workspace.
+/// Register built-in tool catalog factories.
+fn register_builtin_tool_factories(registry: &mut ToolRegistry) {
+    registry.register_tool_factory("read_file", || Box::new(ReadFileTool::new()));
+    registry.register_tool_factory("write_file", || Box::new(WriteFileTool::new()));
+    registry.register_tool_factory("edit_file", || Box::new(EditFileTool::new()));
+    registry.register_tool_factory("bash", || Box::new(BashTool::new()));
+    registry.register_tool_factory("grep", || Box::new(GrepTool::new()));
+    registry.register_tool_factory("glob", || Box::new(GlobTool::new()));
+    registry.register_tool_factory("list_dir", || Box::new(ListDirTool::new()));
+}
+
+/// Register the built-in tool catalog on an existing registry.
+pub fn register_builtin_tool_catalog(registry: &mut ToolRegistry) {
+    register_builtin_tool_factories(registry);
+}
+
+/// Create the default core toolset (4 tools).
 ///
 /// Core tools:
 /// - read_file
 /// - write_file
 /// - edit_file
 /// - bash
-fn register_builtin_workspace_factories(registry: &mut ToolRegistry) {
-    registry.register_workspace_factory("read_file", |workspace| {
-        Box::new(ReadFileTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("write_file", |workspace| {
-        Box::new(WriteFileTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("edit_file", |workspace| {
-        Box::new(EditFileTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("bash", |workspace| {
-        Box::new(BashTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("grep", |workspace| {
-        Box::new(GrepTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("glob", |workspace| {
-        Box::new(GlobTool::new(workspace.to_path_buf()))
-    });
-    registry.register_workspace_factory("list_dir", |workspace| {
-        Box::new(ListDirTool::new(workspace.to_path_buf()))
-    });
-}
-
-pub fn create_core_tools(workspace: std::path::PathBuf) -> Vec<Box<dyn Tool>> {
+pub fn create_core_tools() -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(ReadFileTool::new(workspace.clone())),
-        Box::new(WriteFileTool::new(workspace.clone())),
-        Box::new(EditFileTool::new(workspace.clone())),
-        Box::new(BashTool::new(workspace.clone())),
+        Box::new(ReadFileTool::new()),
+        Box::new(WriteFileTool::new()),
+        Box::new(EditFileTool::new()),
+        Box::new(BashTool::new()),
     ]
 }
 
-/// Create the read-only exploration toolset (4 tools) with the given workspace.
+/// Create the read-only exploration toolset (4 tools).
 ///
 /// Read-only tools:
 /// - read_file
 /// - grep
 /// - glob
 /// - list_dir
-pub fn create_read_only_tools(workspace: std::path::PathBuf) -> Vec<Box<dyn Tool>> {
+pub fn create_read_only_tools() -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(ReadFileTool::new(workspace.clone())),
-        Box::new(GrepTool::new(workspace.clone())),
-        Box::new(GlobTool::new(workspace.clone())),
-        Box::new(ListDirTool::new(workspace.clone())),
+        Box::new(ReadFileTool::new()),
+        Box::new(GrepTool::new()),
+        Box::new(GlobTool::new()),
+        Box::new(ListDirTool::new()),
     ]
 }
 
-/// Create all 7 built-in tools with the given workspace.
-pub fn create_all_tools(workspace: std::path::PathBuf) -> Vec<Box<dyn Tool>> {
-    let mut tools = create_core_tools(workspace.clone());
-    tools.push(Box::new(GrepTool::new(workspace.clone())));
-    tools.push(Box::new(GlobTool::new(workspace.clone())));
-    tools.push(Box::new(ListDirTool::new(workspace.clone())));
+/// Create all 7 built-in tools.
+pub fn create_all_tools() -> Vec<Box<dyn Tool>> {
+    let mut tools = create_core_tools();
+    tools.push(Box::new(GrepTool::new()));
+    tools.push(Box::new(GlobTool::new()));
+    tools.push(Box::new(ListDirTool::new()));
     tools
 }
 
 /// Create a ToolRegistry with the 4 core tools pre-registered.
 pub fn create_tool_registry_with_core_tools(workspace: std::path::PathBuf) -> ToolRegistry {
-    create_tool_registry_with_core_tools_and_config(
-        workspace,
-        std::sync::Arc::new(Config::default()),
-    )
-}
-
-/// Create a ToolRegistry with the 4 core tools and builtin workspace factories pre-registered.
-pub fn create_tool_registry_with_core_tools_and_config(
-    workspace: std::path::PathBuf,
-    config: std::sync::Arc<Config>,
-) -> ToolRegistry {
-    let mut registry = ToolRegistry::with_config(config);
-    register_builtin_workspace_factories(&mut registry);
+    let mut registry = ToolRegistry::new();
+    register_builtin_tool_catalog(&mut registry);
     registry.set_default_workspace_root(workspace.clone());
 
-    for tool in create_core_tools(workspace) {
+    for tool in create_core_tools() {
         registry.register_boxed(tool);
     }
 
@@ -2215,10 +2174,10 @@ pub fn create_tool_registry_with_core_tools_and_config(
 /// Create a ToolRegistry with the 4 read-only tools pre-registered.
 pub fn create_tool_registry_with_read_only_tools(workspace: std::path::PathBuf) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
-    register_builtin_workspace_factories(&mut registry);
+    register_builtin_tool_catalog(&mut registry);
     registry.set_default_workspace_root(workspace.clone());
 
-    for tool in create_read_only_tools(workspace) {
+    for tool in create_read_only_tools() {
         registry.register_boxed(tool);
     }
 
@@ -2228,10 +2187,10 @@ pub fn create_tool_registry_with_read_only_tools(workspace: std::path::PathBuf) 
 /// Create a ToolRegistry with all 7 built-in tools pre-registered.
 pub fn create_tool_registry_with_all_tools(workspace: std::path::PathBuf) -> ToolRegistry {
     let mut registry = ToolRegistry::new();
-    register_builtin_workspace_factories(&mut registry);
+    register_builtin_tool_catalog(&mut registry);
     registry.set_default_workspace_root(workspace.clone());
 
-    for tool in create_all_tools(workspace) {
+    for tool in create_all_tools() {
         registry.register_boxed(tool);
     }
 
@@ -2257,7 +2216,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2269,34 +2228,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_file_tool_rebinds_workspace_root() {
+    async fn test_read_file_tool_uses_workspace_binding_from_context() {
         let temp = TempDir::new().unwrap();
-        let original_workspace = temp.path().join("original");
-        let rebound_workspace = temp.path().join("rebound");
-        tokio::fs::create_dir_all(&original_workspace)
-            .await
-            .unwrap();
-        tokio::fs::create_dir_all(&rebound_workspace).await.unwrap();
-        tokio::fs::write(rebound_workspace.join("test.txt"), "rebound\n")
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(workspace.join("test.txt"), "bound\n")
             .await
             .unwrap();
 
-        let tool = ReadFileTool::new(original_workspace.clone());
-        let rebound_tool = tool
-            .rebind_workspace(&rebound_workspace)
-            .expect("read_file should support workspace rebinding");
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
-        let ctx = ToolContext::new(
-            rebound_workspace.clone(),
-            rebound_workspace.join("tmp"),
-            config,
-        );
+        let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
         let args = json!({"path": "test.txt"});
-        let result = rebound_tool.execute(args, &ctx).await.unwrap();
+        let result = tool.execute(args, &ctx).await.unwrap();
 
-        assert_eq!(result["path"], json!(rebound_workspace.join("test.txt")));
-        assert_eq!(result["content"], json!("rebound"));
+        assert_eq!(result["path"], json!(workspace.join("test.txt")));
+        assert_eq!(result["content"], json!("bound"));
     }
 
     #[tokio::test]
@@ -2307,7 +2255,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::without_workspace(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2334,7 +2282,7 @@ mod tests {
         .await
         .unwrap();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2358,7 +2306,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2374,7 +2322,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2395,7 +2343,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ReadFileTool::new(workspace.clone());
+        let tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2412,8 +2360,8 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let write_tool = WriteFileTool::new(workspace.clone());
-        let read_tool = ReadFileTool::new(workspace.clone());
+        let write_tool = WriteFileTool::new();
+        let read_tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2433,7 +2381,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = WriteFileTool::new(workspace.clone());
+        let tool = WriteFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2454,7 +2402,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = WriteFileTool::new(workspace.clone());
+        let tool = WriteFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2475,7 +2423,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = WriteFileTool::new(workspace.clone());
+        let tool = WriteFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2500,8 +2448,8 @@ mod tests {
             .await
             .unwrap();
 
-        let edit_tool = EditFileTool::new(workspace.clone());
-        let read_tool = ReadFileTool::new(workspace.clone());
+        let edit_tool = EditFileTool::new();
+        let read_tool = ReadFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2521,7 +2469,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = EditFileTool::new(workspace.clone());
+        let tool = EditFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2544,7 +2492,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = EditFileTool::new(workspace.clone());
+        let tool = EditFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2568,7 +2516,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = EditFileTool::new(workspace.clone());
+        let tool = EditFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2596,7 +2544,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = EditFileTool::new(workspace.clone());
+        let tool = EditFileTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2620,7 +2568,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = BashTool::new(workspace.clone());
+        let tool = BashTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2636,7 +2584,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = BashTool::new(workspace.clone());
+        let tool = BashTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2652,7 +2600,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = BashTool::new(workspace.clone());
+        let tool = BashTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2673,7 +2621,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = BashTool::new(workspace.clone());
+        let tool = BashTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::with_workspace(
             workspace.clone(),
@@ -2701,7 +2649,7 @@ mod tests {
         .await
         .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2720,7 +2668,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2739,7 +2687,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2766,7 +2714,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2785,7 +2733,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2801,7 +2749,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2827,7 +2775,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2857,7 +2805,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GrepTool::new(workspace.clone());
+        let tool = GrepTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2882,7 +2830,7 @@ mod tests {
         tokio::fs::write(workspace.join("b.rs"), "").await.unwrap();
         tokio::fs::write(workspace.join("c.txt"), "").await.unwrap();
 
-        let tool = GlobTool::new(workspace.clone());
+        let tool = GlobTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2911,7 +2859,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GlobTool::new(workspace.clone());
+        let tool = GlobTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2936,7 +2884,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = GlobTool::new(workspace.clone());
+        let tool = GlobTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2952,7 +2900,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = GlobTool::new(workspace.clone());
+        let tool = GlobTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2974,7 +2922,7 @@ mod tests {
             .unwrap();
         tokio::fs::create_dir(workspace.join("dir1")).await.unwrap();
 
-        let tool = ListDirTool::new(workspace.clone());
+        let tool = ListDirTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -2993,7 +2941,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ListDirTool::new(workspace.clone());
+        let tool = ListDirTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -3009,7 +2957,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = ListDirTool::new(workspace.clone());
+        let tool = ListDirTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -3035,7 +2983,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = ListDirTool::new(workspace.clone());
+        let tool = ListDirTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -3061,7 +3009,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().to_path_buf();
 
-        let tool = ListDirTool::new(workspace.clone());
+        let tool = ListDirTool::new();
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(workspace.clone(), workspace.join("tmp"), config);
 
@@ -3124,7 +3072,7 @@ mod tests {
     // Tool trait method tests
     #[test]
     fn test_read_file_tool_metadata() {
-        let tool = ReadFileTool::new(PathBuf::from("/tmp"));
+        let tool = ReadFileTool::new();
         assert_eq!(tool.name(), "read_file");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3134,7 +3082,7 @@ mod tests {
 
     #[test]
     fn test_write_file_tool_metadata() {
-        let tool = WriteFileTool::new(PathBuf::from("/tmp"));
+        let tool = WriteFileTool::new();
         assert_eq!(tool.name(), "write_file");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3144,7 +3092,7 @@ mod tests {
 
     #[test]
     fn test_edit_file_tool_metadata() {
-        let tool = EditFileTool::new(PathBuf::from("/tmp"));
+        let tool = EditFileTool::new();
         assert_eq!(tool.name(), "edit_file");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3154,7 +3102,7 @@ mod tests {
 
     #[test]
     fn test_bash_tool_metadata() {
-        let tool = BashTool::new(PathBuf::from("/tmp"));
+        let tool = BashTool::new();
         assert_eq!(tool.name(), "bash");
         assert_eq!(
             tool.capability(&json!({"command":"ls -la"})),
@@ -3173,7 +3121,7 @@ mod tests {
 
     #[test]
     fn test_bash_tool_description_warns_about_eval_wrappers() {
-        let tool = BashTool::new(PathBuf::from("/tmp"));
+        let tool = BashTool::new();
         let description = tool.description();
         assert!(description.contains("python -c"));
         assert!(description.contains("bash -c"));
@@ -3541,7 +3489,7 @@ mod tests {
 
     #[test]
     fn test_grep_tool_metadata() {
-        let tool = GrepTool::new(PathBuf::from("/tmp"));
+        let tool = GrepTool::new();
         assert_eq!(tool.name(), "grep");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3551,7 +3499,7 @@ mod tests {
 
     #[test]
     fn test_glob_tool_metadata() {
-        let tool = GlobTool::new(PathBuf::from("/tmp"));
+        let tool = GlobTool::new();
         assert_eq!(tool.name(), "glob");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3561,7 +3509,7 @@ mod tests {
 
     #[test]
     fn test_list_dir_tool_metadata() {
-        let tool = ListDirTool::new(PathBuf::from("/tmp"));
+        let tool = ListDirTool::new();
         assert_eq!(tool.name(), "list_dir");
         assert_eq!(
             tool.capability(&json!({})),
@@ -3571,16 +3519,14 @@ mod tests {
 
     #[test]
     fn test_parameter_schemas_are_valid() {
-        let workspace = PathBuf::from("/tmp");
-
         let tools: Vec<Box<dyn Tool>> = vec![
-            Box::new(ReadFileTool::new(workspace.clone())),
-            Box::new(WriteFileTool::new(workspace.clone())),
-            Box::new(EditFileTool::new(workspace.clone())),
-            Box::new(BashTool::new(workspace.clone())),
-            Box::new(GrepTool::new(workspace.clone())),
-            Box::new(GlobTool::new(workspace.clone())),
-            Box::new(ListDirTool::new(workspace.clone())),
+            Box::new(ReadFileTool::new()),
+            Box::new(WriteFileTool::new()),
+            Box::new(EditFileTool::new()),
+            Box::new(BashTool::new()),
+            Box::new(GrepTool::new()),
+            Box::new(GlobTool::new()),
+            Box::new(ListDirTool::new()),
         ];
 
         for tool in tools {
@@ -3601,7 +3547,7 @@ mod tests {
 
     #[test]
     fn test_create_core_tools() {
-        let tools = create_core_tools(PathBuf::from("/tmp"));
+        let tools = create_core_tools();
         assert_eq!(tools.len(), 4);
 
         let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name()).collect();
@@ -3613,7 +3559,7 @@ mod tests {
 
     #[test]
     fn test_create_read_only_tools() {
-        let tools = create_read_only_tools(PathBuf::from("/tmp"));
+        let tools = create_read_only_tools();
         assert_eq!(tools.len(), 4);
 
         let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name()).collect();
@@ -3625,7 +3571,7 @@ mod tests {
 
     #[test]
     fn test_create_all_tools() {
-        let tools = create_all_tools(PathBuf::from("/tmp"));
+        let tools = create_all_tools();
         assert_eq!(tools.len(), 7);
     }
 
@@ -3656,8 +3602,8 @@ mod tests {
         assert!(registry.get("grep").is_none());
 
         let grep_tool = registry
-            .materialize_for_workspace("grep", &child_workspace)
-            .expect("core registry should materialize grep for child workspaces");
+            .materialize("grep")
+            .expect("core registry should materialize grep from the catalog");
         let config = Arc::new(Config::default());
         let ctx = ToolContext::new(child_workspace.clone(), child_workspace.join("tmp"), config);
         let result = grep_tool


### PR DESCRIPTION
## What changed
- remove the remaining `rebind_workspace` stopgap from the tool contract
- turn registry-side child materialization into catalog-driven `register_tool_factory` / `materialize`
- require workspace-local child tools to come from catalog factories instead of inherited parent instances
- make builtin tool catalog registration explicit in daemon/runtime-manager and skill-catalog paths
- drop workspace arguments from builtin tool constructors and `create_*_tools` helpers

## Why
PR2 moved execution binding into runtime context, but child runtimes could still inherit parent tool instances through a workspace-specific fallback path. This PR removes that second path so child tool exposure now comes from catalog + profile only.

## Validation
- `cargo test -p alan-tools test_core_registry_materializes_missing_read_only_tool_for_child_workspace`
- `cargo test -p alan-runtime build_child_tool_registry_skips_workspace_local_tools_without_catalog_factory`
- `cargo test -p alan-runtime build_child_tool_registry_materializes_workspace_tools_from_parent_factories`
- `cargo test -p alan-tools test_create_core_tools`
- `cargo test -p alan --lib test_runtime_manager_new`

## Stack
Top of stack. Depends on `codex/tool-binding-context`.