### PR TITLE
[VNext][Alan Coding][Bench] Add SWE-bench Lite pilot materialization workflow

### DIFF
--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -39,6 +39,14 @@ It does not bypass Alan's orchestration layer. Instead it:
    - `assertion_report.json`
    - `kpi.json`
 
+The case-level `run.json` also records Alan-native orchestration metadata such
+as:
+
+1. `spawn_count`
+2. `escalation_count`
+3. `child_runs`
+4. `duration_secs`
+
 Use the template case file as a starting point:
 
 - `evals/files/swebench_lite_case.template.json`
@@ -67,10 +75,63 @@ Recommended rollout order:
 For the M2 curated-subset step, use:
 
 - `evals/files/swebench_lite_subset.template.json`
+- `evals/files/swebench_lite_pilot_v1.ids.txt`
+
+To materialize a real pilot subset from official Lite rows into Alan case/suite
+manifests, use:
+
+```bash
+python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py \
+  --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
+  --dataset-name princeton-nlp/SWE-bench_Lite \
+  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
+```
+
+If you do not want to install the optional `datasets` package, the same script
+also accepts one or more local dataset exports via repeated `--dataset-file`
+arguments. It supports:
+
+1. JSONL rows with `instance_id` and `problem_statement`
+2. JSON arrays of row objects
+3. Hugging Face datasets-server JSON responses with `rows[].row`
+
+The materializer writes:
+
+1. `cases/<instance_id>.json`
+2. `problem_statements/<instance_id>.txt`
+3. `suite.json`
+4. `materialization_report.json`
+
+For an official rows fallback without extra Python packages:
+
+```bash
+curl -L -o /tmp/swebench-lite.rows-0.json \
+  'https://datasets-server.huggingface.co/rows?dataset=princeton-nlp/SWE-bench_Lite&config=default&split=test&offset=0&length=100'
+curl -L -o /tmp/swebench-lite.rows-100.json \
+  'https://datasets-server.huggingface.co/rows?dataset=princeton-nlp/SWE-bench_Lite&config=default&split=test&offset=100&length=100'
+curl -L -o /tmp/swebench-lite.rows-200.json \
+  'https://datasets-server.huggingface.co/rows?dataset=princeton-nlp/SWE-bench_Lite&config=default&split=test&offset=200&length=100'
+
+python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py \
+  --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
+  --dataset-file /tmp/swebench-lite.rows-0.json \
+  --dataset-file /tmp/swebench-lite.rows-100.json \
+  --dataset-file /tmp/swebench-lite.rows-200.json \
+  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
+```
 
 ```bash
 bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
   crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
+```
+
+Or run the generated pilot suite directly:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
+  target/benchmarks/swebench_lite/manifests/pilot_v1/suite.json
 ```
 
 That suite runner aggregates per-case artifacts into one suite directory and
@@ -82,6 +143,9 @@ generates:
 4. `benchmark.json`
 5. `kpi.json`
 6. `score_with_official_harness.sh`
+
+Suite-level `run.json` and `benchmark.json` now also summarize
+`total_escalation_count` across all executed cases.
 
 Official harness scoring still happens outside Alan's runtime loop, but the
 package now provides a thin wrapper so operators do not need to remember the

--- a/crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt
+++ b/crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt
@@ -1,0 +1,13 @@
+# SWE-bench Lite pilot subset for the first Alan full-steward external baseline.
+# Selection bias: lighter operational footprint first, with repo diversity across
+# web/framework, HTTP, test runner, and docs-oriented Python projects.
+django__django-15789
+django__django-15790
+django__django-15814
+pallets__flask-4045
+pallets__flask-4992
+psf__requests-1963
+psf__requests-2148
+pytest-dev__pytest-11143
+pytest-dev__pytest-7168
+sphinx-doc__sphinx-10451

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -55,8 +55,14 @@ That runner should:
 The next bring-up step is a curated subset aggregator:
 
 ```bash
+python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py \
+  --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
+  --dataset-name princeton-nlp/SWE-bench_Lite \
+  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
+
 bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
-  crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
+  target/benchmarks/swebench_lite/manifests/pilot_v1/suite.json
 ```
 
 That suite runner should:
@@ -64,5 +70,7 @@ That suite runner should:
 1. execute each Lite case through the same steward entrypoint,
 2. aggregate suite-level `predictions.jsonl`,
 3. emit `run.json`, `benchmark.json`, `kpi.json`, and `case_results.jsonl`,
-4. generate `score_with_official_harness.sh` by delegating to the package-local
+4. surface orchestration counters such as `spawn_count` and `escalation_count`
+   inside the run artifacts,
+5. generate `score_with_official_harness.sh` by delegating to the package-local
    `score_swebench_predictions.sh` wrapper.

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
@@ -132,7 +132,12 @@ def load_rows_from_dataset_file(path: Path) -> list[dict]:
     if not raw:
         return []
     if raw[0] in "[{":
-        return load_rows_from_json_payload(json.loads(raw))
+        try:
+            return load_rows_from_json_payload(json.loads(raw))
+        except json.JSONDecodeError:
+            # Fall back to linewise parsing for JSONL exports that also begin
+            # with "{" on the first line.
+            pass
     rows: list[dict] = []
     for line in raw.splitlines():
         line = line.strip()

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize Alan full-steward SWE-bench Lite case manifests, problem "
+            "statement files, and a suite manifest from official dataset rows."
+        )
+    )
+    parser.add_argument(
+        "--instance-ids-file",
+        required=True,
+        help="Text file containing one SWE-bench instance_id per line.",
+    )
+    parser.add_argument(
+        "--dataset-file",
+        action="append",
+        default=[],
+        help=(
+            "Local JSON/JSONL dataset export. Can be repeated. Supports raw row "
+            "objects, datasets-server responses, or JSONL rows."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-name",
+        help=(
+            "Official Hugging Face dataset name. Requires the optional "
+            "`datasets` Python package when used."
+        ),
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        help="Dataset split to load when --dataset-name is used. Default: test.",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        help=(
+            "Directory containing one prepared workspace per instance_id, using "
+            "<workspace-root>/<instance_id>."
+        ),
+    )
+    parser.add_argument(
+        "--workspace-map-file",
+        help="Optional JSON file mapping instance_id to workspace_dir.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for generated cases/, problem_statements/, and suite.json.",
+    )
+    parser.add_argument(
+        "--suite-name",
+        default="swebench_lite_pilot_v1",
+        help="Suite name to write into suite.json. Default: swebench_lite_pilot_v1.",
+    )
+    parser.add_argument(
+        "--dataset-label",
+        default="SWE-bench Lite",
+        help="Human-readable dataset label for case manifests. Default: SWE-bench Lite.",
+    )
+    parser.add_argument(
+        "--scoring-dataset-name",
+        default="princeton-nlp/SWE-bench_Lite",
+        help=(
+            "Official harness dataset name written into suite.json. "
+            "Default: princeton-nlp/SWE-bench_Lite."
+        ),
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=4,
+        help="Official harness max_workers hint written into suite.json. Default: 4.",
+    )
+    parser.add_argument(
+        "--timeout-secs",
+        type=int,
+        default=1800,
+        help="timeout_secs written into each case manifest. Default: 1800.",
+    )
+    parser.add_argument(
+        "--allow-missing-workspaces",
+        action="store_true",
+        help="Allow generation even when a referenced workspace directory does not exist yet.",
+    )
+    return parser.parse_args()
+
+
+def read_instance_ids(path: Path) -> list[str]:
+    instance_ids: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        instance_ids.append(line)
+    if not instance_ids:
+        raise ValueError(f"No instance ids found in {path}")
+    return instance_ids
+
+
+def normalize_row(item: object) -> dict:
+    if not isinstance(item, dict):
+        raise ValueError(f"Unsupported dataset row payload: {type(item).__name__}")
+    if "row" in item and isinstance(item["row"], dict):
+        return item["row"]
+    return item
+
+
+def load_rows_from_json_payload(payload: object) -> list[dict]:
+    if isinstance(payload, dict):
+        if "rows" in payload and isinstance(payload["rows"], list):
+            return [normalize_row(item) for item in payload["rows"]]
+        if "instance_id" in payload:
+            return [normalize_row(payload)]
+        raise ValueError("Unsupported JSON object payload; expected rows[] or an instance row")
+    if isinstance(payload, list):
+        return [normalize_row(item) for item in payload]
+    raise ValueError("Unsupported JSON payload; expected an object or array")
+
+
+def load_rows_from_dataset_file(path: Path) -> list[dict]:
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    if raw[0] in "[{":
+        return load_rows_from_json_payload(json.loads(raw))
+    rows: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(normalize_row(json.loads(line)))
+    return rows
+
+
+def load_rows_from_hf_dataset(dataset_name: str, split: str) -> list[dict]:
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise SystemExit(
+            "The `datasets` package is required for --dataset-name. "
+            "Install it or pass one or more --dataset-file exports instead."
+        ) from exc
+
+    dataset = load_dataset(dataset_name, split=split)
+    return [dict(row) for row in dataset]
+
+
+def build_row_index(dataset_rows: Iterable[dict]) -> dict[str, dict]:
+    index: dict[str, dict] = {}
+    for row in dataset_rows:
+        instance_id = row.get("instance_id")
+        if not instance_id:
+            continue
+        if instance_id not in index:
+            index[instance_id] = row
+    return index
+
+
+def load_workspace_map(args: argparse.Namespace, instance_ids: Iterable[str]) -> tuple[dict[str, Path], list[str]]:
+    mapping: dict[str, Path] = {}
+    missing: list[str] = []
+
+    if args.workspace_map_file:
+        payload = json.loads(Path(args.workspace_map_file).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("--workspace-map-file must contain a JSON object")
+        for instance_id, raw_path in payload.items():
+            mapping[instance_id] = Path(str(raw_path)).expanduser().resolve()
+
+    if args.workspace_root:
+        root = Path(args.workspace_root).expanduser().resolve()
+        for instance_id in instance_ids:
+            mapping.setdefault(instance_id, root / instance_id)
+
+    if not mapping:
+        raise ValueError("Provide --workspace-root or --workspace-map-file")
+
+    for instance_id in instance_ids:
+        if instance_id not in mapping:
+            missing.append(instance_id)
+
+    return mapping, missing
+
+
+def main() -> int:
+    args = parse_args()
+    instance_ids_path = Path(args.instance_ids_file).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+
+    if not args.dataset_file and not args.dataset_name:
+        raise SystemExit("Provide at least one --dataset-file or --dataset-name.")
+
+    instance_ids = read_instance_ids(instance_ids_path)
+
+    dataset_rows: list[dict] = []
+    for dataset_file in args.dataset_file:
+        dataset_rows.extend(load_rows_from_dataset_file(Path(dataset_file).expanduser().resolve()))
+    if args.dataset_name:
+        dataset_rows.extend(load_rows_from_hf_dataset(args.dataset_name, args.split))
+
+    row_index = build_row_index(dataset_rows)
+    missing_rows = [instance_id for instance_id in instance_ids if instance_id not in row_index]
+    if missing_rows:
+        raise SystemExit(
+            "Missing instance rows in dataset input: " + ", ".join(sorted(missing_rows))
+        )
+
+    workspace_map, missing_workspace_mappings = load_workspace_map(args, instance_ids)
+    if missing_workspace_mappings:
+        raise SystemExit(
+            "Missing workspace mapping for instances: "
+            + ", ".join(sorted(missing_workspace_mappings))
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cases_dir = output_dir / "cases"
+    statements_dir = output_dir / "problem_statements"
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    statements_dir.mkdir(parents=True, exist_ok=True)
+
+    missing_workspace_dirs: list[str] = []
+    repo_counts: Counter[str] = Counter()
+    case_files: list[str] = []
+
+    for instance_id in instance_ids:
+        row = row_index[instance_id]
+        workspace_dir = workspace_map[instance_id]
+        if not workspace_dir.exists():
+            missing_workspace_dirs.append(instance_id)
+            if not args.allow_missing_workspaces:
+                raise SystemExit(
+                    f"Workspace directory does not exist for {instance_id}: {workspace_dir}"
+                )
+
+        repo = row.get("repo", "unknown")
+        repo_counts[repo] += 1
+
+        problem_statement_path = statements_dir / f"{instance_id}.txt"
+        problem_statement_path.write_text(
+            row["problem_statement"].rstrip() + "\n",
+            encoding="utf-8",
+        )
+
+        case_path = cases_dir / f"{instance_id}.json"
+        case_payload = {
+            "instance_id": instance_id,
+            "dataset": args.dataset_label,
+            "workspace_dir": str(workspace_dir),
+            "problem_statement_file": str(problem_statement_path),
+            "timeout_secs": args.timeout_secs,
+        }
+        case_path.write_text(
+            json.dumps(case_payload, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        case_files.append(str(case_path.relative_to(output_dir)))
+
+    suite_payload = {
+        "suite": args.suite_name,
+        "dataset": args.dataset_label,
+        "dataset_name": args.scoring_dataset_name,
+        "max_workers": args.max_workers,
+        "cases": case_files,
+    }
+    suite_path = output_dir / "suite.json"
+    suite_path.write_text(json.dumps(suite_payload, indent=2) + "\n", encoding="utf-8")
+
+    report_payload = {
+        "suite": args.suite_name,
+        "dataset_name": args.scoring_dataset_name,
+        "instance_ids_file": str(instance_ids_path),
+        "instance_count": len(instance_ids),
+        "repos": dict(sorted(repo_counts.items())),
+        "dataset_files": [str(Path(path).expanduser().resolve()) for path in args.dataset_file],
+        "dataset_source": args.dataset_name,
+        "workspace_root": (
+            str(Path(args.workspace_root).expanduser().resolve())
+            if args.workspace_root
+            else None
+        ),
+        "workspace_map_file": (
+            str(Path(args.workspace_map_file).expanduser().resolve())
+            if args.workspace_map_file
+            else None
+        ),
+        "allow_missing_workspaces": args.allow_missing_workspaces,
+        "missing_workspace_dirs": missing_workspace_dirs,
+        "suite_json": str(suite_path),
+    }
+    report_path = output_dir / "materialization_report.json"
+    report_path.write_text(json.dumps(report_payload, indent=2) + "\n", encoding="utf-8")
+
+    print(f"suite_json\t{suite_path}")
+    print(f"instance_count\t{len(instance_ids)}")
+    for repo, count in sorted(repo_counts.items()):
+        print(f"repo_count\t{repo}\t{count}")
+    if missing_workspace_dirs:
+        print(
+            "warning\tmissing_workspaces\t" + ",".join(sorted(missing_workspace_dirs)),
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -495,6 +495,9 @@ jq -n \
     --arg problem_statement_file "$problem_statement_file" \
     --argjson duration_secs "$duration_secs" \
     --argjson spawn_count "$spawn_count" \
+    --argjson parent_escalation_count "$parent_escalation_count" \
+    --argjson child_escalation_count "$child_escalation_count" \
+    --argjson escalation_count "$escalation_count" \
     --argjson completed_child_count "$completed_child_count" \
     --argjson parent_inline_write_count "$parent_inline_write_count" \
     --argjson patch_bytes "$patch_bytes" \

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -345,18 +345,24 @@ fi
 cp "$rollout_path" "$rollout_copy_file"
 
 spawn_count="$(jq -s '[.[] | select(.type == "tool_call" and .name == "invoke_delegated_skill")] | length' "$rollout_copy_file")"
+parent_escalation_count="$(jq -s '[.[] | select(.type == "tool_call") | select((.audit.action // "") == "escalate")] | length' "$rollout_copy_file")"
 parent_inline_write_count="$(jq -s '[.[] | select(.type == "tool_call" and .name != "invoke_delegated_skill") | select((.audit.capability // "") == "write")] | length' "$rollout_copy_file")"
 parent_inline_write_names="$(jq -s '[.[] | select(.type == "tool_call" and .name != "invoke_delegated_skill") | select((.audit.capability // "") == "write") | .name] | unique' "$rollout_copy_file")"
 child_runs_json="$(jq -s '[.[] | select(.type == "tool_call" and .name == "invoke_delegated_skill") | .result.child_run? | select(. != null)]' "$rollout_copy_file")"
 completed_child_count="$(printf '%s' "$child_runs_json" | jq '[.[] | select(.terminal_status == "completed")] | length')"
+child_escalation_count=0
 
-printf '%s\n' "$child_runs_json" | jq -c '.[]' | while IFS= read -r child_run; do
+while IFS= read -r child_run; do
     child_rollout="$(printf '%s' "$child_run" | jq -r '.rollout_path // empty')"
     child_session="$(printf '%s' "$child_run" | jq -r '.session_id // "child"')"
     if [[ -n "$child_rollout" && -f "$child_rollout" ]]; then
         cp "$child_rollout" "$output_dir/${child_session}.jsonl"
+        child_rollout_escalation_count="$(jq -s '[.[] | select(.type == "tool_call") | select((.audit.action // "") == "escalate")] | length' "$child_rollout")"
+        child_escalation_count=$((child_escalation_count + child_rollout_escalation_count))
     fi
-done
+done < <(printf '%s\n' "$child_runs_json" | jq -c '.[]')
+
+escalation_count=$((parent_escalation_count + child_escalation_count))
 
 if [[ "$keep_session" != true ]]; then
     curl -fsS -X DELETE "$base_url/api/v1/sessions/$session_id" >/dev/null 2>&1 || true
@@ -421,6 +427,9 @@ jq -n \
     --argjson yielded "$yielded" \
     --argjson turn_completed "$turn_completed" \
     --argjson spawn_count "$spawn_count" \
+    --argjson parent_escalation_count "$parent_escalation_count" \
+    --argjson child_escalation_count "$child_escalation_count" \
+    --argjson escalation_count "$escalation_count" \
     --argjson completed_child_count "$completed_child_count" \
     --argjson parent_inline_write_count "$parent_inline_write_count" \
     --argjson patch_nonempty "$([[ "$patch_bytes" -gt 0 ]] && echo true || echo false)" \
@@ -521,6 +530,9 @@ jq -n \
         error_messages_file: $error_messages_file,
         warning_messages_file: $warning_messages_file,
         spawn_count: $spawn_count,
+        parent_escalation_count: $parent_escalation_count,
+        child_escalation_count: $child_escalation_count,
+        escalation_count: $escalation_count,
         completed_child_count: $completed_child_count,
         parent_inline_write_count: $parent_inline_write_count,
         parent_inline_write_names: $parent_inline_write_names,
@@ -567,6 +579,7 @@ echo "  run_status: $run_status"
 echo "  session_id: $session_id"
 echo "  resolved_model: $resolved_model"
 echo "  spawn_count: $spawn_count"
+echo "  escalation_count: $escalation_count"
 echo "  parent_inline_write_count: $parent_inline_write_count"
 echo "  patch_bytes: $patch_bytes"
 echo "  artifacts: $output_dir"

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
@@ -211,6 +211,7 @@ done < <(jq -r '.cases[]' "$suite_json")
 finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 duration_secs="$(( $(date +%s) - start_epoch ))"
 pass_rate_percent="$(awk "BEGIN { printf \"%.2f\", ($passed / $total) * 100 }")"
+total_escalation_count="$(jq -s '[.[] | (.run.escalation_count // 0)] | add // 0' "$case_results_jsonl")"
 
 cat >"$scoring_script" <<EOF
 #!/usr/bin/env bash
@@ -237,6 +238,7 @@ jq -n \
     --argjson total "$total" \
     --argjson passed "$passed" \
     --argjson failed "$failed" \
+    --argjson total_escalation_count "$total_escalation_count" \
     --argjson duration_secs "$duration_secs" \
     --argjson case_results "$(jq -s '.' "$case_results_jsonl")" \
     '{
@@ -250,6 +252,7 @@ jq -n \
         total: $total,
         passed: $passed,
         failed: $failed,
+        total_escalation_count: $total_escalation_count,
         max_workers: $max_workers,
         predictions_jsonl: $predictions_jsonl,
         scoring_script: $scoring_script,
@@ -266,6 +269,7 @@ jq -n \
     --argjson total_cases "$total" \
     --argjson passed_cases "$passed" \
     --argjson failed_cases "$failed" \
+    --argjson total_escalation_count "$total_escalation_count" \
     --argjson pass_rate_percent "$pass_rate_percent" \
     --argjson duration_secs "$duration_secs" \
     '{
@@ -275,6 +279,7 @@ jq -n \
         total_cases: $total_cases,
         passed_cases: $passed_cases,
         failed_cases: $failed_cases,
+        total_escalation_count: $total_escalation_count,
         pass_rate_percent: $pass_rate_percent,
         duration_secs: $duration_secs,
         predictions_jsonl: $predictions_jsonl,
@@ -312,6 +317,7 @@ echo "  dataset_name: $dataset_name"
 echo "  total: $total"
 echo "  passed: $passed"
 echo "  failed: $failed"
+echo "  total_escalation_count: $total_escalation_count"
 echo "  predictions: $predictions_jsonl"
 echo "  scoring_script: $scoring_script"
 echo "  artifacts: $output_dir"


### PR DESCRIPTION
## Summary
- add a stdlib-only materializer that turns official SWE-bench Lite rows plus prepared workspaces into Alan case/suite manifests
- commit a first pilot subset ids file covering 10 Lite instances across django, flask, requests, pytest, and sphinx
- extend the full-steward benchmark artifacts with escalation counters and document both the `datasets` and official-rows fallback workflows

## Verification
- `bash -n crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh`
- `bash -n crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh`
- `python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py --help`
- mock materialization smoke with a local datasets-server-style JSON fixture and prepared workspace directories
- official Lite rows alignment check against `swebench_lite_pilot_v1.ids.txt` using the Hugging Face datasets-server responses for offsets 0/100/200

Related: #285
