### PR TITLE
[VNext][Alan Coding][Bench] Add SWE-bench Lite workspace preparation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,16 @@ target
 # Coverage artifacts
 lcov.info
 
+# Python local caches and coverage artifacts
+**/__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+
 # Local Ghostty developer artifacts for the Apple client.
 clients/apple/GhosttyKit.xcframework
 clients/apple/GhosttyKit.xcframework.bak-*/

--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -77,6 +77,30 @@ For the M2 curated-subset step, use:
 - `evals/files/swebench_lite_subset.template.json`
 - `evals/files/swebench_lite_pilot_v1.ids.txt`
 
+Before materializing the Alan suite, prepare one clean git workspace per
+instance id at the benchmark `base_commit`:
+
+```bash
+python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py \
+  --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
+  --dataset-name princeton-nlp/SWE-bench_Lite \
+  --workspace-root target/benchmarks/swebench_lite/workspaces/pilot_v1
+```
+
+That preparer:
+
+1. reads official Lite rows,
+2. mirrors each upstream repo once under `.repo-cache/`,
+3. materializes `<workspace-root>/<instance_id>` as a clean detached checkout at
+   `base_commit`,
+4. writes `workspace_map.json` and `preparation_report.json`.
+
+The workspace preparer intentionally stops at clean git checkout materialization.
+It does not install repo dependencies or reproduce the official SWE-bench Docker
+images. Alan's final resolved/unresolved scoring still comes from the official
+harness wrapper, while any richer host-native verification remains an
+operator-owned environment concern.
+
 To materialize a real pilot subset from official Lite rows into Alan case/suite
 manifests, use:
 
@@ -84,7 +108,7 @@ manifests, use:
 python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py \
   --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
   --dataset-name princeton-nlp/SWE-bench_Lite \
-  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --workspace-root target/benchmarks/swebench_lite/workspaces/pilot_v1 \
   --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
 ```
 
@@ -118,9 +142,16 @@ python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.p
   --dataset-file /tmp/swebench-lite.rows-0.json \
   --dataset-file /tmp/swebench-lite.rows-100.json \
   --dataset-file /tmp/swebench-lite.rows-200.json \
-  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --workspace-root target/benchmarks/swebench_lite/workspaces/pilot_v1 \
   --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
 ```
+
+The end-to-end pilot order is now:
+
+1. `prepare_swebench_lite_workspaces.py`
+2. `prepare_swebench_lite_subset.py`
+3. `run_swebench_full_steward_subset.sh`
+4. `score_swebench_predictions.sh`
 
 ```bash
 bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \

--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -95,6 +95,11 @@ That preparer:
    `base_commit`,
 4. writes `workspace_map.json` and `preparation_report.json`.
 
+Reruns are idempotent at the owned-output level: if a workspace directory is a
+stale or partial previous attempt, the preparer recreates it automatically. If
+you pass `--reuse-existing-workspaces`, already-clean matching workspaces are
+kept instead.
+
 The workspace preparer intentionally stops at clean git checkout materialization.
 It does not install repo dependencies or reproduce the official SWE-bench Docker
 images. Alan's final resolved/unresolved scoring still comes from the official

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -55,10 +55,15 @@ That runner should:
 The next bring-up step is a curated subset aggregator:
 
 ```bash
+python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py \
+  --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
+  --dataset-name princeton-nlp/SWE-bench_Lite \
+  --workspace-root target/benchmarks/swebench_lite/workspaces/pilot_v1
+
 python3 crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py \
   --instance-ids-file crates/runtime/skills/repo-coding/evals/files/swebench_lite_pilot_v1.ids.txt \
   --dataset-name princeton-nlp/SWE-bench_Lite \
-  --workspace-root /absolute/path/to/prepared/swebench-lite/workspaces \
+  --workspace-root target/benchmarks/swebench_lite/workspaces/pilot_v1 \
   --output-dir target/benchmarks/swebench_lite/manifests/pilot_v1
 
 bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
@@ -74,3 +79,8 @@ That suite runner should:
    inside the run artifacts,
 5. generate `score_with_official_harness.sh` by delegating to the package-local
    `score_swebench_predictions.sh` wrapper.
+
+The workspace preparation script intentionally materializes only clean git
+checkouts at each case's `base_commit`. Official resolved/unresolved scoring
+still happens through the Docker-backed SWE-bench harness, while host-native
+dependency provisioning remains operator-owned.

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -84,3 +84,7 @@ The workspace preparation script intentionally materializes only clean git
 checkouts at each case's `base_commit`. Official resolved/unresolved scoring
 still happens through the Docker-backed SWE-bench harness, while host-native
 dependency provisioning remains operator-owned.
+
+At the owned-output level, reruns are recoverable: stale or partial workspace
+directories are recreated automatically, while `--reuse-existing-workspaces`
+keeps already-clean matching checkouts in place.

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
@@ -7,6 +7,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable
 
+from swebench_lite_common import build_row_index, load_dataset_rows, read_instance_ids
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -93,84 +95,6 @@ def parse_args() -> argparse.Namespace:
         help="Allow generation even when a referenced workspace directory does not exist yet.",
     )
     return parser.parse_args()
-
-
-def read_instance_ids(path: Path) -> list[str]:
-    instance_ids: list[str] = []
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        instance_ids.append(line)
-    if not instance_ids:
-        raise ValueError(f"No instance ids found in {path}")
-    return instance_ids
-
-
-def normalize_row(item: object) -> dict:
-    if not isinstance(item, dict):
-        raise ValueError(f"Unsupported dataset row payload: {type(item).__name__}")
-    if "row" in item and isinstance(item["row"], dict):
-        return item["row"]
-    return item
-
-
-def load_rows_from_json_payload(payload: object) -> list[dict]:
-    if isinstance(payload, dict):
-        if "rows" in payload and isinstance(payload["rows"], list):
-            return [normalize_row(item) for item in payload["rows"]]
-        if "instance_id" in payload:
-            return [normalize_row(payload)]
-        raise ValueError("Unsupported JSON object payload; expected rows[] or an instance row")
-    if isinstance(payload, list):
-        return [normalize_row(item) for item in payload]
-    raise ValueError("Unsupported JSON payload; expected an object or array")
-
-
-def load_rows_from_dataset_file(path: Path) -> list[dict]:
-    raw = path.read_text(encoding="utf-8").strip()
-    if not raw:
-        return []
-    if raw[0] in "[{":
-        try:
-            return load_rows_from_json_payload(json.loads(raw))
-        except json.JSONDecodeError:
-            # Fall back to linewise parsing for JSONL exports that also begin
-            # with "{" on the first line.
-            pass
-    rows: list[dict] = []
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        rows.append(normalize_row(json.loads(line)))
-    return rows
-
-
-def load_rows_from_hf_dataset(dataset_name: str, split: str) -> list[dict]:
-    try:
-        from datasets import load_dataset
-    except ImportError as exc:
-        raise SystemExit(
-            "The `datasets` package is required for --dataset-name. "
-            "Install it or pass one or more --dataset-file exports instead."
-        ) from exc
-
-    dataset = load_dataset(dataset_name, split=split)
-    return [dict(row) for row in dataset]
-
-
-def build_row_index(dataset_rows: Iterable[dict]) -> dict[str, dict]:
-    index: dict[str, dict] = {}
-    for row in dataset_rows:
-        instance_id = row.get("instance_id")
-        if not instance_id:
-            continue
-        if instance_id not in index:
-            index[instance_id] = row
-    return index
-
-
 def load_workspace_map(args: argparse.Namespace, instance_ids: Iterable[str]) -> tuple[dict[str, Path], list[str]]:
     mapping: dict[str, Path] = {}
     missing: list[str] = []
@@ -207,11 +131,7 @@ def main() -> int:
 
     instance_ids = read_instance_ids(instance_ids_path)
 
-    dataset_rows: list[dict] = []
-    for dataset_file in args.dataset_file:
-        dataset_rows.extend(load_rows_from_dataset_file(Path(dataset_file).expanduser().resolve()))
-    if args.dataset_name:
-        dataset_rows.extend(load_rows_from_hf_dataset(args.dataset_name, args.split))
+    dataset_rows = load_dataset_rows(args.dataset_file, args.dataset_name, args.split)
 
     row_index = build_row_index(dataset_rows)
     missing_rows = [instance_id for instance_id in instance_ids if instance_id not in row_index]

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py
@@ -7,7 +7,12 @@ from collections import Counter
 from pathlib import Path
 from typing import Iterable
 
-from swebench_lite_common import build_row_index, load_dataset_rows, read_instance_ids
+from swebench_lite_common import (
+    build_row_index,
+    ensure_owned_child_path,
+    load_dataset_rows,
+    read_instance_ids,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -95,6 +100,23 @@ def parse_args() -> argparse.Namespace:
         help="Allow generation even when a referenced workspace directory does not exist yet.",
     )
     return parser.parse_args()
+
+
+def resolve_materialized_output_path(
+    instance_id: str,
+    output_root: Path,
+    suffix: str,
+    label: str,
+) -> Path:
+    output_path = output_root / f"{instance_id}{suffix}"
+    ensure_owned_child_path(
+        output_path,
+        output_root,
+        f"{label} for instance_id {instance_id!r}",
+    )
+    return output_path
+
+
 def load_workspace_map(args: argparse.Namespace, instance_ids: Iterable[str]) -> tuple[dict[str, Path], list[str]]:
     mapping: dict[str, Path] = {}
     missing: list[str] = []
@@ -109,7 +131,13 @@ def load_workspace_map(args: argparse.Namespace, instance_ids: Iterable[str]) ->
     if args.workspace_root:
         root = Path(args.workspace_root).expanduser().resolve()
         for instance_id in instance_ids:
-            mapping.setdefault(instance_id, root / instance_id)
+            if instance_id in mapping:
+                continue
+            mapping[instance_id] = ensure_owned_child_path(
+                root / instance_id,
+                root,
+                f"workspace directory for instance_id {instance_id!r}",
+            )
 
     if not mapping:
         raise ValueError("Provide --workspace-root or --workspace-map-file")
@@ -140,7 +168,10 @@ def main() -> int:
             "Missing instance rows in dataset input: " + ", ".join(sorted(missing_rows))
         )
 
-    workspace_map, missing_workspace_mappings = load_workspace_map(args, instance_ids)
+    try:
+        workspace_map, missing_workspace_mappings = load_workspace_map(args, instance_ids)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     if missing_workspace_mappings:
         raise SystemExit(
             "Missing workspace mapping for instances: "
@@ -170,13 +201,29 @@ def main() -> int:
         repo = row.get("repo", "unknown")
         repo_counts[repo] += 1
 
-        problem_statement_path = statements_dir / f"{instance_id}.txt"
+        try:
+            problem_statement_path = resolve_materialized_output_path(
+                instance_id,
+                statements_dir,
+                ".txt",
+                "problem statement path",
+            )
+            case_path = resolve_materialized_output_path(
+                instance_id,
+                cases_dir,
+                ".json",
+                "case manifest path",
+            )
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+
+        problem_statement_path.parent.mkdir(parents=True, exist_ok=True)
         problem_statement_path.write_text(
             row["problem_statement"].rstrip() + "\n",
             encoding="utf-8",
         )
 
-        case_path = cases_dir / f"{instance_id}.json"
+        case_path.parent.mkdir(parents=True, exist_ok=True)
         case_payload = {
             "instance_id": instance_id,
             "dataset": args.dataset_label,

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+from swebench_lite_common import (
+    build_row_index,
+    load_dataset_rows,
+    read_instance_ids,
+    slug_repo_name,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare clean SWE-bench Lite git workspaces at each case's base_commit "
+            "using official dataset rows."
+        )
+    )
+    parser.add_argument(
+        "--instance-ids-file",
+        required=True,
+        help="Text file containing one SWE-bench instance_id per line.",
+    )
+    parser.add_argument(
+        "--dataset-file",
+        action="append",
+        default=[],
+        help=(
+            "Local JSON/JSONL dataset export. Can be repeated. Supports raw row "
+            "objects, datasets-server responses, or JSONL rows."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-name",
+        help=(
+            "Official Hugging Face dataset name. Requires the optional "
+            "`datasets` Python package when used."
+        ),
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        help="Dataset split to load when --dataset-name is used. Default: test.",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        required=True,
+        help="Output directory using the layout <workspace-root>/<instance_id>.",
+    )
+    parser.add_argument(
+        "--repo-cache-root",
+        help=(
+            "Mirror cache directory used to avoid repeated remote clones. "
+            "Default: <workspace-root>/.repo-cache."
+        ),
+    )
+    parser.add_argument(
+        "--github-root",
+        default="https://github.com",
+        help="Repository host prefix. Default: https://github.com.",
+    )
+    parser.add_argument(
+        "--workspace-map-output",
+        help="Optional JSON output path for instance_id -> workspace_dir mappings.",
+    )
+    parser.add_argument(
+        "--skip-mirror-fetch",
+        action="store_true",
+        help="Reuse existing mirrors without fetching remote updates.",
+    )
+    parser.add_argument(
+        "--reuse-existing-workspaces",
+        action="store_true",
+        help=(
+            "Keep an existing workspace when it is already a clean git checkout "
+            "at the requested base_commit."
+        ),
+    )
+    return parser.parse_args()
+
+
+def run_git(args: list[str], cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def repo_clone_url(repo: str, github_root: str) -> str:
+    return f"{github_root.rstrip('/')}/{repo}.git"
+
+
+def ensure_repo_mirror(repo: str, mirror_path: Path, github_root: str, skip_fetch: bool) -> None:
+    clone_url = repo_clone_url(repo, github_root)
+    if mirror_path.exists():
+        if not mirror_path.is_dir():
+            raise ValueError(f"Mirror path exists but is not a directory: {mirror_path}")
+        if not skip_fetch:
+            run_git(["remote", "update", "--prune"], cwd=mirror_path)
+        return
+
+    mirror_path.parent.mkdir(parents=True, exist_ok=True)
+    run_git(["clone", "--mirror", clone_url, str(mirror_path)])
+
+
+def existing_workspace_matches(workspace_dir: Path, base_commit: str) -> bool:
+    if not workspace_dir.exists():
+        return False
+    if not workspace_dir.is_dir():
+        raise ValueError(f"Workspace path exists but is not a directory: {workspace_dir}")
+
+    try:
+        top_level = Path(run_git(["rev-parse", "--show-toplevel"], cwd=workspace_dir)).resolve()
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"Workspace is not a git repository: {workspace_dir}") from exc
+
+    if top_level != workspace_dir.resolve():
+        raise ValueError(
+            f"Workspace path must be the repository root: {workspace_dir} (resolved {top_level})"
+        )
+
+    head_commit = run_git(["rev-parse", "HEAD"], cwd=workspace_dir)
+    status = run_git(["status", "--short", "--untracked-files=all"], cwd=workspace_dir)
+    return head_commit == base_commit and status == ""
+
+
+def prepare_workspace(
+    workspace_dir: Path,
+    mirror_path: Path,
+    repo: str,
+    base_commit: str,
+    github_root: str,
+) -> None:
+    workspace_dir.parent.mkdir(parents=True, exist_ok=True)
+    run_git(["clone", str(mirror_path), str(workspace_dir)])
+    run_git(["remote", "set-url", "origin", repo_clone_url(repo, github_root)], cwd=workspace_dir)
+    run_git(["checkout", "--detach", base_commit], cwd=workspace_dir)
+    status = run_git(["status", "--short", "--untracked-files=all"], cwd=workspace_dir)
+    if status:
+        raise ValueError(f"Prepared workspace is not clean: {workspace_dir}")
+
+
+def main() -> int:
+    args = parse_args()
+    instance_ids_path = Path(args.instance_ids_file).expanduser().resolve()
+    workspace_root = Path(args.workspace_root).expanduser().resolve()
+    repo_cache_root = (
+        Path(args.repo_cache_root).expanduser().resolve()
+        if args.repo_cache_root
+        else workspace_root / ".repo-cache"
+    )
+    workspace_map_output = (
+        Path(args.workspace_map_output).expanduser().resolve()
+        if args.workspace_map_output
+        else workspace_root / "workspace_map.json"
+    )
+
+    if not args.dataset_file and not args.dataset_name:
+        raise SystemExit("Provide at least one --dataset-file or --dataset-name.")
+
+    instance_ids = read_instance_ids(instance_ids_path)
+    dataset_rows = load_dataset_rows(args.dataset_file, args.dataset_name, args.split)
+    row_index = build_row_index(dataset_rows)
+
+    missing_rows = [instance_id for instance_id in instance_ids if instance_id not in row_index]
+    if missing_rows:
+        raise SystemExit(
+            "Missing instance rows in dataset input: " + ", ".join(sorted(missing_rows))
+        )
+
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    repo_cache_root.mkdir(parents=True, exist_ok=True)
+
+    repo_counts: Counter[str] = Counter()
+    row_by_instance: dict[str, dict] = {}
+    for instance_id in instance_ids:
+        row = row_index[instance_id]
+        repo = str(row.get("repo", "")).strip()
+        base_commit = str(row.get("base_commit", "")).strip()
+        if not repo or not base_commit:
+            raise SystemExit(
+                f"Dataset row for {instance_id} must include non-empty repo and base_commit"
+            )
+        row_by_instance[instance_id] = row
+        repo_counts[repo] += 1
+
+    mirror_errors: dict[str, str] = {}
+    mirror_by_repo: dict[str, Path] = {}
+    for repo in sorted(repo_counts):
+        mirror_path = repo_cache_root / f"{slug_repo_name(repo)}.git"
+        mirror_by_repo[repo] = mirror_path
+        try:
+            ensure_repo_mirror(repo, mirror_path, args.github_root, args.skip_mirror_fetch)
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            mirror_errors[repo] = str(exc)
+
+    workspace_map: dict[str, str] = {}
+    prepared: list[dict[str, str]] = []
+    reused: list[dict[str, str]] = []
+    failures: list[dict[str, str]] = []
+
+    for instance_id in instance_ids:
+        row = row_by_instance[instance_id]
+        repo = str(row["repo"])
+        base_commit = str(row["base_commit"])
+        environment_setup_commit = str(row.get("environment_setup_commit", "")).strip()
+        workspace_dir = workspace_root / instance_id
+        workspace_map[instance_id] = str(workspace_dir)
+
+        if repo in mirror_errors:
+            failures.append(
+                {
+                    "instance_id": instance_id,
+                    "repo": repo,
+                    "workspace_dir": str(workspace_dir),
+                    "reason": f"mirror_error: {mirror_errors[repo]}",
+                }
+            )
+            continue
+
+        try:
+            if workspace_dir.exists():
+                if not args.reuse_existing_workspaces:
+                    raise ValueError(
+                        "workspace already exists; rerun with --reuse-existing-workspaces "
+                        "when it is already clean at the requested base_commit"
+                    )
+                if existing_workspace_matches(workspace_dir, base_commit):
+                    reused.append(
+                        {
+                            "instance_id": instance_id,
+                            "repo": repo,
+                            "base_commit": base_commit,
+                            "environment_setup_commit": environment_setup_commit,
+                            "workspace_dir": str(workspace_dir),
+                        }
+                    )
+                    continue
+                raise ValueError(
+                    f"existing workspace does not match clean base_commit {base_commit}"
+                )
+
+            prepare_workspace(
+                workspace_dir=workspace_dir,
+                mirror_path=mirror_by_repo[repo],
+                repo=repo,
+                base_commit=base_commit,
+                github_root=args.github_root,
+            )
+            prepared.append(
+                {
+                    "instance_id": instance_id,
+                    "repo": repo,
+                    "base_commit": base_commit,
+                    "environment_setup_commit": environment_setup_commit,
+                    "workspace_dir": str(workspace_dir),
+                }
+            )
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            failures.append(
+                {
+                    "instance_id": instance_id,
+                    "repo": repo,
+                    "base_commit": base_commit,
+                    "environment_setup_commit": environment_setup_commit,
+                    "workspace_dir": str(workspace_dir),
+                    "reason": str(exc),
+                }
+            )
+
+    workspace_map_output.parent.mkdir(parents=True, exist_ok=True)
+    workspace_map_output.write_text(
+        json.dumps(workspace_map, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    report_payload = {
+        "instance_ids_file": str(instance_ids_path),
+        "instance_count": len(instance_ids),
+        "dataset_files": [str(Path(path).expanduser().resolve()) for path in args.dataset_file],
+        "dataset_source": args.dataset_name,
+        "workspace_root": str(workspace_root),
+        "repo_cache_root": str(repo_cache_root),
+        "workspace_map_file": str(workspace_map_output),
+        "github_root": args.github_root,
+        "reuse_existing_workspaces": args.reuse_existing_workspaces,
+        "repos": dict(sorted(repo_counts.items())),
+        "prepared_count": len(prepared),
+        "reused_count": len(reused),
+        "failed_count": len(failures),
+        "prepared": prepared,
+        "reused": reused,
+        "failures": failures,
+    }
+    report_path = workspace_root / "preparation_report.json"
+    report_path.write_text(json.dumps(report_payload, indent=2) + "\n", encoding="utf-8")
+
+    print(f"workspace_root\t{workspace_root}")
+    print(f"workspace_map\t{workspace_map_output}")
+    print(f"report\t{report_path}")
+    print(f"prepared_count\t{len(prepared)}")
+    print(f"reused_count\t{len(reused)}")
+    print(f"failed_count\t{len(failures)}")
+    for repo, count in sorted(repo_counts.items()):
+        print(f"repo_count\t{repo}\t{count}")
+
+    if failures:
+        for failure in failures:
+            print(
+                "failure\t{instance_id}\t{reason}".format(**failure),
+                file=sys.stderr,
+            )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 from swebench_lite_common import (
     build_row_index,
+    ensure_owned_child_path,
     load_dataset_rows,
+    paths_overlap,
     read_instance_ids,
     slug_repo_name,
 )
@@ -108,20 +110,23 @@ def ensure_origin_url(repo_path: Path, origin_url: str) -> None:
         run_git(["remote", "add", "origin", origin_url], cwd=repo_path)
 
 
-def ensure_owned_child_path(path: Path, owner_root: Path, label: str) -> None:
-    resolved_path = path.resolve()
-    resolved_root = owner_root.resolve()
-    if resolved_path == resolved_root or not resolved_path.is_relative_to(resolved_root):
-        raise ValueError(f"{label} must stay under {resolved_root}: {resolved_path}")
-
-
-def resolve_owned_workspace_dir(instance_id: str, workspace_root: Path) -> Path:
+def resolve_owned_workspace_dir(
+    instance_id: str,
+    workspace_root: Path,
+    reserved_paths: list[tuple[str, Path]],
+) -> Path:
     workspace_dir = workspace_root / instance_id
     ensure_owned_child_path(
         workspace_dir,
         workspace_root,
         f"workspace directory for instance_id {instance_id!r}",
     )
+    for reserved_label, reserved_path in reserved_paths:
+        if paths_overlap(workspace_dir, reserved_path):
+            raise ValueError(
+                f"workspace directory for instance_id {instance_id!r} overlaps "
+                f"{reserved_label}: {reserved_path.resolve()}"
+            )
     return workspace_dir
 
 
@@ -236,6 +241,7 @@ def main() -> int:
         if args.workspace_map_output
         else workspace_root / "workspace_map.json"
     )
+    report_path = workspace_root / "preparation_report.json"
 
     if not args.dataset_file and not args.dataset_name:
         raise SystemExit("Provide at least one --dataset-file or --dataset-name.")
@@ -286,6 +292,11 @@ def main() -> int:
     reused: list[dict[str, str]] = []
     recreated: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
+    reserved_workspace_paths = [
+        ("repo cache root", repo_cache_root),
+        ("workspace map output", workspace_map_output),
+        ("preparation report", report_path),
+    ]
 
     for instance_id in instance_ids:
         row = row_by_instance[instance_id]
@@ -295,7 +306,11 @@ def main() -> int:
         workspace_dir_candidate = workspace_root / instance_id
 
         try:
-            workspace_dir = resolve_owned_workspace_dir(instance_id, workspace_root)
+            workspace_dir = resolve_owned_workspace_dir(
+                instance_id,
+                workspace_root,
+                reserved_workspace_paths,
+            )
         except ValueError as exc:
             failures.append(
                 {
@@ -426,7 +441,6 @@ def main() -> int:
         "recreated": recreated,
         "failures": failures,
     }
-    report_path = workspace_root / "preparation_report.json"
     report_path.write_text(json.dumps(report_payload, indent=2) + "\n", encoding="utf-8")
 
     print(f"workspace_root\t{workspace_root}")

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -115,6 +115,16 @@ def ensure_owned_child_path(path: Path, owner_root: Path, label: str) -> None:
         raise ValueError(f"{label} must stay under {resolved_root}: {resolved_path}")
 
 
+def resolve_owned_workspace_dir(instance_id: str, workspace_root: Path) -> Path:
+    workspace_dir = workspace_root / instance_id
+    ensure_owned_child_path(
+        workspace_dir,
+        workspace_root,
+        f"workspace directory for instance_id {instance_id!r}",
+    )
+    return workspace_dir
+
+
 def reset_owned_directory(path: Path, owner_root: Path, label: str) -> None:
     ensure_owned_child_path(path, owner_root, label)
     if path.is_symlink():
@@ -198,6 +208,20 @@ def prepare_workspace(
         raise ValueError(f"Prepared workspace is not clean: {workspace_dir}")
 
 
+def normalize_preparation_row(row: dict, instance_id: str) -> dict[str, str]:
+    repo = str(row.get("repo", "")).strip()
+    base_commit = str(row.get("base_commit", "")).strip()
+    if not repo or not base_commit:
+        raise ValueError(
+            f"Dataset row for {instance_id} must include non-empty repo and base_commit"
+        )
+    return {
+        "repo": repo,
+        "base_commit": base_commit,
+        "environment_setup_commit": str(row.get("environment_setup_commit", "")).strip(),
+    }
+
+
 def main() -> int:
     args = parse_args()
     instance_ids_path = Path(args.instance_ids_file).expanduser().resolve()
@@ -230,17 +254,14 @@ def main() -> int:
     repo_cache_root.mkdir(parents=True, exist_ok=True)
 
     repo_counts: Counter[str] = Counter()
-    row_by_instance: dict[str, dict] = {}
+    row_by_instance: dict[str, dict[str, str]] = {}
     for instance_id in instance_ids:
-        row = row_index[instance_id]
-        repo = str(row.get("repo", "")).strip()
-        base_commit = str(row.get("base_commit", "")).strip()
-        if not repo or not base_commit:
-            raise SystemExit(
-                f"Dataset row for {instance_id} must include non-empty repo and base_commit"
-            )
-        row_by_instance[instance_id] = row
-        repo_counts[repo] += 1
+        try:
+            normalized_row = normalize_preparation_row(row_index[instance_id], instance_id)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+        row_by_instance[instance_id] = normalized_row
+        repo_counts[normalized_row["repo"]] += 1
 
     mirror_errors: dict[str, str] = {}
     mirror_by_repo: dict[str, Path] = {}
@@ -268,11 +289,41 @@ def main() -> int:
 
     for instance_id in instance_ids:
         row = row_by_instance[instance_id]
-        repo = str(row["repo"])
-        base_commit = str(row["base_commit"])
-        environment_setup_commit = str(row.get("environment_setup_commit", "")).strip()
-        workspace_dir = workspace_root / instance_id
+        repo = row["repo"]
+        base_commit = row["base_commit"]
+        environment_setup_commit = row["environment_setup_commit"]
+        workspace_dir_candidate = workspace_root / instance_id
+
+        try:
+            workspace_dir = resolve_owned_workspace_dir(instance_id, workspace_root)
+        except ValueError as exc:
+            failures.append(
+                {
+                    "instance_id": instance_id,
+                    "repo": repo,
+                    "base_commit": base_commit,
+                    "environment_setup_commit": environment_setup_commit,
+                    "workspace_dir": str(workspace_dir_candidate),
+                    "reason": str(exc),
+                }
+            )
+            continue
+
         workspace_map[instance_id] = str(workspace_dir)
+
+        mirror_path = mirror_by_repo.get(repo)
+        if mirror_path is None:
+            failures.append(
+                {
+                    "instance_id": instance_id,
+                    "repo": repo,
+                    "base_commit": base_commit,
+                    "environment_setup_commit": environment_setup_commit,
+                    "workspace_dir": str(workspace_dir),
+                    "reason": f"missing mirror mapping for repo {repo!r}",
+                }
+            )
+            continue
 
         if repo in mirror_errors:
             failures.append(
@@ -322,7 +373,7 @@ def main() -> int:
 
             prepare_workspace(
                 workspace_dir=workspace_dir,
-                mirror_path=mirror_by_repo[repo],
+                mirror_path=mirror_path,
                 repo=repo,
                 base_commit=base_commit,
                 github_root=args.github_root,

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -101,6 +101,13 @@ def repo_clone_url(repo: str, github_root: str) -> str:
     return f"{github_root.rstrip('/')}/{repo}.git"
 
 
+def ensure_origin_url(repo_path: Path, origin_url: str) -> None:
+    try:
+        run_git(["remote", "set-url", "origin", origin_url], cwd=repo_path)
+    except subprocess.CalledProcessError:
+        run_git(["remote", "add", "origin", origin_url], cwd=repo_path)
+
+
 def ensure_owned_child_path(path: Path, owner_root: Path, label: str) -> None:
     resolved_path = path.resolve()
     resolved_root = owner_root.resolve()
@@ -142,6 +149,7 @@ def ensure_repo_mirror(
             reset_owned_directory(mirror_path, repo_cache_root, "mirror path")
             recreated = True
         else:
+            ensure_origin_url(mirror_path, clone_url)
             if not skip_fetch:
                 run_git(["remote", "update", "--prune"], cwd=mirror_path)
             return recreated
@@ -183,7 +191,7 @@ def prepare_workspace(
 ) -> None:
     workspace_dir.parent.mkdir(parents=True, exist_ok=True)
     run_git(["clone", str(mirror_path), str(workspace_dir)])
-    run_git(["remote", "set-url", "origin", repo_clone_url(repo, github_root)], cwd=workspace_dir)
+    ensure_origin_url(workspace_dir, repo_clone_url(repo, github_root))
     run_git(["checkout", "--detach", base_commit], cwd=workspace_dir)
     status = run_git(["status", "--short", "--untracked-files=all"], cwd=workspace_dir)
     if status:
@@ -282,6 +290,10 @@ def main() -> int:
                 if args.reuse_existing_workspaces:
                     try:
                         if existing_workspace_matches(workspace_dir, base_commit):
+                            ensure_origin_url(
+                                workspace_dir,
+                                repo_clone_url(repo, args.github_root),
+                            )
                             reused.append(
                                 {
                                     "instance_id": instance_id,

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -179,16 +179,16 @@ def existing_workspace_matches(workspace_dir: Path, base_commit: str) -> bool:
 
     try:
         top_level = Path(run_git(["rev-parse", "--show-toplevel"], cwd=workspace_dir)).resolve()
+        head_commit = run_git(["rev-parse", "HEAD"], cwd=workspace_dir)
+        status = run_git(["status", "--short", "--untracked-files=all"], cwd=workspace_dir)
     except subprocess.CalledProcessError as exc:
-        raise ValueError(f"Workspace is not a git repository: {workspace_dir}") from exc
+        raise ValueError(f"Workspace is not a reusable git checkout: {workspace_dir}") from exc
 
     if top_level != workspace_dir.resolve():
         raise ValueError(
             f"Workspace path must be the repository root: {workspace_dir} (resolved {top_level})"
         )
 
-    head_commit = run_git(["rev-parse", "HEAD"], cwd=workspace_dir)
-    status = run_git(["status", "--short", "--untracked-files=all"], cwd=workspace_dir)
     return head_commit == base_commit and status == ""
 
 

--- a/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
+++ b/crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 from collections import Counter
@@ -100,22 +101,61 @@ def repo_clone_url(repo: str, github_root: str) -> str:
     return f"{github_root.rstrip('/')}/{repo}.git"
 
 
-def ensure_repo_mirror(repo: str, mirror_path: Path, github_root: str, skip_fetch: bool) -> None:
-    clone_url = repo_clone_url(repo, github_root)
-    if mirror_path.exists():
-        if not mirror_path.is_dir():
-            raise ValueError(f"Mirror path exists but is not a directory: {mirror_path}")
-        if not skip_fetch:
-            run_git(["remote", "update", "--prune"], cwd=mirror_path)
+def ensure_owned_child_path(path: Path, owner_root: Path, label: str) -> None:
+    resolved_path = path.resolve()
+    resolved_root = owner_root.resolve()
+    if resolved_path == resolved_root or not resolved_path.is_relative_to(resolved_root):
+        raise ValueError(f"{label} must stay under {resolved_root}: {resolved_path}")
+
+
+def reset_owned_directory(path: Path, owner_root: Path, label: str) -> None:
+    ensure_owned_child_path(path, owner_root, label)
+    if path.is_symlink():
+        raise ValueError(f"{label} must not be a symlink: {path}")
+    if not path.exists():
         return
+    if not path.is_dir():
+        raise ValueError(f"{label} exists but is not a directory: {path}")
+    shutil.rmtree(path)
+
+
+def is_bare_git_repository(path: Path) -> bool:
+    try:
+        return run_git(["rev-parse", "--is-bare-repository"], cwd=path) == "true"
+    except subprocess.CalledProcessError:
+        return False
+
+
+def ensure_repo_mirror(
+    repo: str,
+    mirror_path: Path,
+    repo_cache_root: Path,
+    github_root: str,
+    skip_fetch: bool,
+) -> bool:
+    clone_url = repo_clone_url(repo, github_root)
+    recreated = False
+    if mirror_path.exists():
+        if mirror_path.is_symlink():
+            raise ValueError(f"mirror path must not be a symlink: {mirror_path}")
+        if not is_bare_git_repository(mirror_path):
+            reset_owned_directory(mirror_path, repo_cache_root, "mirror path")
+            recreated = True
+        else:
+            if not skip_fetch:
+                run_git(["remote", "update", "--prune"], cwd=mirror_path)
+            return recreated
 
     mirror_path.parent.mkdir(parents=True, exist_ok=True)
     run_git(["clone", "--mirror", clone_url, str(mirror_path)])
+    return recreated
 
 
 def existing_workspace_matches(workspace_dir: Path, base_commit: str) -> bool:
     if not workspace_dir.exists():
         return False
+    if workspace_dir.is_symlink():
+        raise ValueError(f"Workspace path must not be a symlink: {workspace_dir}")
     if not workspace_dir.is_dir():
         raise ValueError(f"Workspace path exists but is not a directory: {workspace_dir}")
 
@@ -196,17 +236,26 @@ def main() -> int:
 
     mirror_errors: dict[str, str] = {}
     mirror_by_repo: dict[str, Path] = {}
+    recreated_mirrors: list[str] = []
     for repo in sorted(repo_counts):
         mirror_path = repo_cache_root / f"{slug_repo_name(repo)}.git"
         mirror_by_repo[repo] = mirror_path
         try:
-            ensure_repo_mirror(repo, mirror_path, args.github_root, args.skip_mirror_fetch)
+            if ensure_repo_mirror(
+                repo,
+                mirror_path,
+                repo_cache_root,
+                args.github_root,
+                args.skip_mirror_fetch,
+            ):
+                recreated_mirrors.append(repo)
         except (subprocess.CalledProcessError, ValueError) as exc:
             mirror_errors[repo] = str(exc)
 
     workspace_map: dict[str, str] = {}
     prepared: list[dict[str, str]] = []
     reused: list[dict[str, str]] = []
+    recreated: list[dict[str, str]] = []
     failures: list[dict[str, str]] = []
 
     for instance_id in instance_ids:
@@ -230,24 +279,33 @@ def main() -> int:
 
         try:
             if workspace_dir.exists():
-                if not args.reuse_existing_workspaces:
-                    raise ValueError(
-                        "workspace already exists; rerun with --reuse-existing-workspaces "
-                        "when it is already clean at the requested base_commit"
-                    )
-                if existing_workspace_matches(workspace_dir, base_commit):
-                    reused.append(
-                        {
-                            "instance_id": instance_id,
-                            "repo": repo,
-                            "base_commit": base_commit,
-                            "environment_setup_commit": environment_setup_commit,
-                            "workspace_dir": str(workspace_dir),
-                        }
-                    )
-                    continue
-                raise ValueError(
-                    f"existing workspace does not match clean base_commit {base_commit}"
+                if args.reuse_existing_workspaces:
+                    try:
+                        if existing_workspace_matches(workspace_dir, base_commit):
+                            reused.append(
+                                {
+                                    "instance_id": instance_id,
+                                    "repo": repo,
+                                    "base_commit": base_commit,
+                                    "environment_setup_commit": environment_setup_commit,
+                                    "workspace_dir": str(workspace_dir),
+                                }
+                            )
+                            continue
+                    except ValueError:
+                        # Invalid or partial workspace directories are reset below
+                        # so operators can rerun preparation without manual cleanup.
+                        pass
+
+                reset_owned_directory(workspace_dir, workspace_root, "workspace directory")
+                recreated.append(
+                    {
+                        "instance_id": instance_id,
+                        "repo": repo,
+                        "base_commit": base_commit,
+                        "environment_setup_commit": environment_setup_commit,
+                        "workspace_dir": str(workspace_dir),
+                    }
                 )
 
             prepare_workspace(
@@ -294,12 +352,15 @@ def main() -> int:
         "workspace_map_file": str(workspace_map_output),
         "github_root": args.github_root,
         "reuse_existing_workspaces": args.reuse_existing_workspaces,
+        "recreated_mirrors": sorted(recreated_mirrors),
         "repos": dict(sorted(repo_counts.items())),
         "prepared_count": len(prepared),
         "reused_count": len(reused),
+        "recreated_count": len(recreated),
         "failed_count": len(failures),
         "prepared": prepared,
         "reused": reused,
+        "recreated": recreated,
         "failures": failures,
     }
     report_path = workspace_root / "preparation_report.json"
@@ -310,6 +371,7 @@ def main() -> int:
     print(f"report\t{report_path}")
     print(f"prepared_count\t{len(prepared)}")
     print(f"reused_count\t{len(reused)}")
+    print(f"recreated_count\t{len(recreated)}")
     print(f"failed_count\t{len(failures)}")
     for repo, count in sorted(repo_counts.items()):
         print(f"repo_count\t{repo}\t{count}")

--- a/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
+++ b/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+def read_instance_ids(path: Path) -> list[str]:
+    instance_ids: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        instance_ids.append(line)
+    if not instance_ids:
+        raise ValueError(f"No instance ids found in {path}")
+    return instance_ids
+
+
+def normalize_row(item: object) -> dict:
+    if not isinstance(item, dict):
+        raise ValueError(f"Unsupported dataset row payload: {type(item).__name__}")
+    if "row" in item and isinstance(item["row"], dict):
+        return item["row"]
+    return item
+
+
+def load_rows_from_json_payload(payload: object) -> list[dict]:
+    if isinstance(payload, dict):
+        if "rows" in payload and isinstance(payload["rows"], list):
+            return [normalize_row(item) for item in payload["rows"]]
+        if "instance_id" in payload:
+            return [normalize_row(payload)]
+        raise ValueError("Unsupported JSON object payload; expected rows[] or an instance row")
+    if isinstance(payload, list):
+        return [normalize_row(item) for item in payload]
+    raise ValueError("Unsupported JSON payload; expected an object or array")
+
+
+def load_rows_from_dataset_file(path: Path) -> list[dict]:
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    if raw[0] in "[{":
+        try:
+            return load_rows_from_json_payload(json.loads(raw))
+        except json.JSONDecodeError:
+            # Fall back to linewise parsing for JSONL exports that also begin
+            # with "{" on the first line.
+            pass
+    rows: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(normalize_row(json.loads(line)))
+    return rows
+
+
+def load_rows_from_hf_dataset(dataset_name: str, split: str) -> list[dict]:
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise SystemExit(
+            "The `datasets` package is required for --dataset-name. "
+            "Install it or pass one or more --dataset-file exports instead."
+        ) from exc
+
+    dataset = load_dataset(dataset_name, split=split)
+    return [dict(row) for row in dataset]
+
+
+def load_dataset_rows(
+    dataset_files: Iterable[str],
+    dataset_name: str | None,
+    split: str,
+) -> list[dict]:
+    dataset_rows: list[dict] = []
+    for dataset_file in dataset_files:
+        dataset_rows.extend(load_rows_from_dataset_file(Path(dataset_file).expanduser().resolve()))
+    if dataset_name:
+        dataset_rows.extend(load_rows_from_hf_dataset(dataset_name, split))
+    return dataset_rows
+
+
+def build_row_index(dataset_rows: Iterable[dict]) -> dict[str, dict]:
+    index: dict[str, dict] = {}
+    for row in dataset_rows:
+        instance_id = row.get("instance_id")
+        if not instance_id:
+            continue
+        if instance_id not in index:
+            index[instance_id] = row
+    return index
+
+
+def slug_repo_name(repo: str) -> str:
+    return repo.replace("/", "__")

--- a/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
+++ b/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
@@ -95,5 +95,23 @@ def build_row_index(dataset_rows: Iterable[dict]) -> dict[str, dict]:
     return index
 
 
+def ensure_owned_child_path(path: Path, owner_root: Path, label: str) -> Path:
+    resolved_path = path.resolve()
+    resolved_root = owner_root.resolve()
+    if resolved_path == resolved_root or not resolved_path.is_relative_to(resolved_root):
+        raise ValueError(f"{label} must stay under {resolved_root}: {resolved_path}")
+    return resolved_path
+
+
+def paths_overlap(path: Path, other: Path) -> bool:
+    resolved_path = path.resolve()
+    resolved_other = other.resolve()
+    return (
+        resolved_path == resolved_other
+        or resolved_path.is_relative_to(resolved_other)
+        or resolved_other.is_relative_to(resolved_path)
+    )
+
+
 def slug_repo_name(repo: str) -> str:
     return quote(repo, safe="")

--- a/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
+++ b/crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import quote
 
 
 def read_instance_ids(path: Path) -> list[str]:
@@ -95,4 +96,4 @@ def build_row_index(dataset_rows: Iterable[dict]) -> dict[str, dict]:
 
 
 def slug_repo_name(repo: str) -> str:
-    return repo.replace("/", "__")
+    return quote(repo, safe="")

--- a/docs/spec/alan_coding_eval_contract.md
+++ b/docs/spec/alan_coding_eval_contract.md
@@ -99,6 +99,12 @@ CI-blocking:
 5. `bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh <suite-json>`
 6. `bash crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh <predictions-jsonl>`
 
+For the Lite-first path, first-party scripts may also prepare clean benchmark
+git workspaces and materialize Alan suite manifests from official dataset rows.
+That workspace preparation step is separate from official Docker-backed
+SWE-bench scoring and does not by itself promise identical host-native runtime
+dependencies.
+
 ## Shared KPI Contract
 
 Harness KPI output should keep these shared fields:


### PR DESCRIPTION
## Summary
- add a stdlib-only SWE-bench Lite workspace preparation script that mirrors upstream repos and materializes clean `<workspace-root>/<instance_id>` checkouts at `base_commit`
- extract shared Lite dataset row loading into `swebench_lite_common.py` and reuse it from the existing subset materializer
- update repo-coding eval/docs/spec so the operator workflow is now workspace prep -> suite materialization -> steward subset run -> official scoring
- ignore Python cache artifacts such as `__pycache__` and `*.pyc` at the repo root

## Why
`#297` made it possible to materialize a real Lite pilot subset once prepared workspaces existed. This PR removes that remaining manual benchmark blocker by giving the repo a first-party way to prepare the expected per-instance git workspaces.

## Verification
- `python3 -m py_compile crates/runtime/skills/repo-coding/scripts/swebench_lite_common.py crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_subset.py crates/runtime/skills/repo-coding/scripts/prepare_swebench_lite_workspaces.py`
- local smoke test with a temporary bare git remote: prepare workspaces, rerun with `--reuse-existing-workspaces`, and materialize a suite successfully

Refs #285