### PR TITLE
[codex] Document Rust-first skill tooling preference

### DIFF
--- a/crates/runtime/skills/skill-creator/SKILL.md
+++ b/crates/runtime/skills/skill-creator/SKILL.md
@@ -61,8 +61,10 @@ shape and using explicit tooling.
 - Reuse `assets/templates/` when you need starter package content.
 - Use `alan skills init`, `alan skills validate`, and `alan skills eval` for
   the primary authoring flow.
-- Use `alan-skill-tools aggregate-benchmark` and
-  `alan-skill-tools generate-review` for review artifact regeneration.
+- Use the package-local compatibility wrappers under `scripts/` for review
+  artifact regeneration.
+- In an Alan source checkout, those wrappers map to the current Rust
+  implementation via `cargo run -p alan-skill-tools -- <subcommand> ...`.
 
 ## Rules
 
@@ -72,6 +74,9 @@ shape and using explicit tooling.
 3. Prefer Rust CLI/bin surfaces over shell, Python, or TypeScript helpers
    unless an external ecosystem or a tiny package-private step makes a script
    the better fit.
-4. Do not auto-load authoring or eval assets into the runtime prompt.
-5. Make `description` concrete enough that catalog-based selection stays
+4. If shared authoring or eval helpers move into Rust, prefer consolidating
+   them into existing packages such as `alan-tools` or the `alan` CLI rather
+   than introducing another standalone helper package.
+5. Do not auto-load authoring or eval assets into the runtime prompt.
+6. Make `description` concrete enough that catalog-based selection stays
    reliable.

--- a/crates/runtime/skills/skill-creator/SKILL.md
+++ b/crates/runtime/skills/skill-creator/SKILL.md
@@ -63,8 +63,6 @@ shape and using explicit tooling.
   the primary authoring flow.
 - Use the package-local compatibility wrappers under `scripts/` for review
   artifact regeneration.
-- In an Alan source checkout, those wrappers map to the current Rust
-  implementation via `cargo run -p alan-skill-tools -- <subcommand> ...`.
 
 ## Rules
 

--- a/crates/runtime/skills/skill-creator/SKILL.md
+++ b/crates/runtime/skills/skill-creator/SKILL.md
@@ -31,7 +31,8 @@ Package-local surfaces:
 
 - `SKILL.md`: portable selection contract and core workflow
 - `skill.yaml` / `package.yaml`: Alan-native runtime defaults
-- `scripts/`: deterministic helpers
+- `scripts/`: package-private deterministic helpers when a Rust CLI/bin is not
+  the better fit
 - `references/`: material to load only when needed
 - `assets/`: templates or output resources
 - `agents/`: child-agent roots and authoring metadata such as `openai.yaml`
@@ -46,7 +47,8 @@ shape and using explicit tooling.
 2. Pick a short package name in lowercase hyphen-case.
 3. Scaffold the package with `alan skills init`.
 4. Keep `SKILL.md` lean. Move detailed reference material into `references/`.
-5. Put repeated deterministic logic in `scripts/`.
+5. Prefer reusable Rust CLI/bin tooling first; keep only package-private or
+   ecosystem-bound helpers in `scripts/`.
 6. If the skill delegates, export a package-local child agent under `agents/`.
 7. Validate with `alan skills validate --path <package>`.
 8. Run explicit evaluation with `alan skills eval --path <package>`.
@@ -57,16 +59,19 @@ shape and using explicit tooling.
 - Read `references/openai_yaml.md` before editing `agents/openai.yaml`.
 - Read `references/schemas.md` for the structured eval manifest shape.
 - Reuse `assets/templates/` when you need starter package content.
-- Use `scripts/init_skill.py` and `scripts/quick_validate.py` for deterministic
-  helper flows.
-- Use `scripts/run_eval.py`, `scripts/aggregate_benchmark.py`, and
-  `scripts/generate_review.py` for explicit eval and review loops.
+- Use `alan skills init`, `alan skills validate`, and `alan skills eval` for
+  the primary authoring flow.
+- Use `alan-skill-tools aggregate-benchmark` and
+  `alan-skill-tools generate-review` for review artifact regeneration.
 
 ## Rules
 
 1. Prefer one package over sprawling nested abstractions.
 2. Keep runtime tools, package-local helpers, and shared authoring tooling
    separate.
-3. Do not auto-load authoring or eval assets into the runtime prompt.
-4. Make `description` concrete enough that catalog-based selection stays
+3. Prefer Rust CLI/bin surfaces over shell, Python, or TypeScript helpers
+   unless an external ecosystem or a tiny package-private step makes a script
+   the better fit.
+4. Do not auto-load authoring or eval assets into the runtime prompt.
+5. Make `description` concrete enough that catalog-based selection stays
    reliable.

--- a/docs/skill_authoring.md
+++ b/docs/skill_authoring.md
@@ -34,6 +34,19 @@ Alan separates three things:
 
 Shipping a script inside a skill package does not create a new runtime tool.
 
+## Tooling Preference
+
+For first-party skill authoring and evaluation flows:
+
+- prefer existing Rust CLI/bin surfaces such as `alan ...` and
+  `alan-skill-tools ...`
+- avoid introducing new shell, Python, or TypeScript scripts unless they are
+  genuinely required by an external ecosystem, a trivial package-private glue
+  step, or compatibility
+- prefer `evals/evals.json` over legacy eval hooks
+- when a helper becomes non-trivial or reusable across packages, promote it
+  into shared Rust tooling instead of adding another package-local script
+
 ## Commands
 
 Create a new package from a first-party template:
@@ -114,6 +127,10 @@ If no manifest is present, Alan falls back to legacy hooks:
 - `scripts/eval.sh`
 - `scripts/eval.py`
 
+These legacy hooks remain for compatibility. New first-party packages should
+prefer `evals/evals.json`, and should not add new Python eval hooks unless the
+underlying workflow is unavoidably Python-native.
+
 Legacy hooks run with the package root as the current working directory and
 export:
 
@@ -137,9 +154,12 @@ Alan keeps reusable authoring/eval helpers in `crates/skill-tools/`.
 
 Promotion path:
 
-- keep a helper in `scripts/` when it is private to one skill package
-- move it into shared tooling when multiple skill packages need the same stable
-  operator-side helper
+- first prefer an existing Rust CLI/bin surface such as `alan` or
+  `alan-skill-tools`
+- keep a helper in `scripts/` only when it is private to one skill package and
+  there is a clear reason not to make it a Rust CLI/bin
+- move a reusable or non-trivial helper into shared Rust tooling when multiple
+  skill packages need the same stable operator-side helper
 - promote it into a runtime tool only when models need a uniform host-level
   capability rather than an explicit authoring workflow
 
@@ -148,7 +168,9 @@ Promotion path:
 - Treat `description` as the selection contract. It should say what the skill
   does and when to use it.
 - Keep `SKILL.md` short and procedural.
-- Prefer deterministic scripts over repeatedly rewritten code.
+- Prefer deterministic tooling over repeatedly rewritten code. For first-party
+  helpers, default to Rust CLI/bin surfaces over shell, Python, or TypeScript
+  scripts.
 - Use `references/` for detailed schemas, examples, and background material.
 - Keep package clutter low. Do not add extra README/changelog/process-history
   files inside skill packages unless they are part of the skill itself.

--- a/docs/skill_authoring.md
+++ b/docs/skill_authoring.md
@@ -38,14 +38,18 @@ Shipping a script inside a skill package does not create a new runtime tool.
 
 For first-party skill authoring and evaluation flows:
 
-- prefer existing Rust CLI/bin surfaces such as `alan ...` and
-  `alan-skill-tools ...`
+- prefer existing Rust CLI/bin surfaces such as `alan ...`
 - avoid introducing new shell, Python, or TypeScript scripts unless they are
   genuinely required by an external ecosystem, a trivial package-private glue
   step, or compatibility
 - prefer `evals/evals.json` over legacy eval hooks
 - when a helper becomes non-trivial or reusable across packages, promote it
-  into shared Rust tooling instead of adding another package-local script
+  into shared Rust tooling inside existing surfaces such as `alan-tools` or the
+  `alan` CLI instead of adding another package-local script or a new standalone
+  helper package
+- when today’s implementation still sits behind package-local compatibility
+  wrappers, prefer those wrappers over assuming an extra helper binary is on
+  `PATH`
 
 ## Commands
 
@@ -147,19 +151,21 @@ Alan keeps reusable authoring/eval helpers in `crates/skill-tools/`.
 
 - `alan skills eval` uses the shared tooling library for manifest execution and
   artifact generation
-- the `alan-skill-tools` binary exposes reusable helper commands such as
-  `aggregate-benchmark` and `generate-review`
+- package-local compatibility wrappers may call the current Rust implementation
+  in `crates/skill-tools/`; in an Alan source checkout, the direct fallback is
+  `cargo run -p alan-skill-tools -- <subcommand> ...`
 - package-local scripts can call those helpers without turning them into
   runtime tools or `alan` top-level commands
 
 Promotion path:
 
-- first prefer an existing Rust CLI/bin surface such as `alan` or
-  `alan-skill-tools`
+- first prefer an existing Rust CLI/bin surface such as `alan`
 - keep a helper in `scripts/` only when it is private to one skill package and
   there is a clear reason not to make it a Rust CLI/bin
 - move a reusable or non-trivial helper into shared Rust tooling when multiple
-  skill packages need the same stable operator-side helper
+  skill packages need the same stable operator-side helper, and prefer
+  consolidating that work into existing packages such as `alan-tools` or the
+  `alan` CLI rather than proliferating standalone helper packages
 - promote it into a runtime tool only when models need a uniform host-level
   capability rather than an explicit authoring workflow
 

--- a/docs/skill_authoring.md
+++ b/docs/skill_authoring.md
@@ -48,8 +48,8 @@ For first-party skill authoring and evaluation flows:
   `alan` CLI instead of adding another package-local script or a new standalone
   helper package
 - when today’s implementation still sits behind package-local compatibility
-  wrappers, prefer those wrappers over assuming an extra helper binary is on
-  `PATH`
+  wrappers, prefer those wrappers over introducing or assuming an extra helper
+  binary
 
 ## Commands
 
@@ -147,13 +147,12 @@ non-fatal by default and becomes fatal with `--require-hook`.
 
 ## Shared Tooling
 
-Alan keeps reusable authoring/eval helpers in `crates/skill-tools/`.
+Alan keeps reusable authoring/eval logic separate from runtime tools.
 
 - `alan skills eval` uses the shared tooling library for manifest execution and
   artifact generation
-- package-local compatibility wrappers may call the current Rust implementation
-  in `crates/skill-tools/`; in an Alan source checkout, the direct fallback is
-  `cargo run -p alan-skill-tools -- <subcommand> ...`
+- package-local compatibility wrappers are the current executable surface for
+  package-private review and benchmark helper flows
 - package-local scripts can call those helpers without turning them into
   runtime tools or `alan` top-level commands
 

--- a/docs/spec/skill_system_contract.md
+++ b/docs/spec/skill_system_contract.md
@@ -34,7 +34,9 @@ Alan's skill system must optimize for six things at the same time:
 - **Host tool**: a runtime capability registered through Alan's tool system and
   exposed uniformly to the model.
 - **Package-local helper**: deterministic executable or support logic shipped
-  inside a skill package, usually under `scripts/`.
+  inside a skill package, usually under `scripts/`. This is a package-private
+  compatibility surface, not the preferred home for reusable first-party
+  tooling.
 - **Package-local launch target**: an Alan-native export under `agents/<name>/`
   that may be launched for delegated execution.
 - **Implicit invocation**: a skill is listed in the prompt catalog so the model
@@ -383,13 +385,20 @@ Rules:
    exposed uniformly to the model.
 2. Skill packages do **not** create new runtime tool definitions merely by
    shipping files in the package tree.
-3. Package-local deterministic helpers belong under `scripts/` and are invoked
-   through host tools such as `bash`, or through explicit first-party authoring
-   flows such as `alan skills eval`.
-4. If a skill depends on an external executable that is not shipped inside the
+3. New first-party authoring and evaluation tooling should prefer typed Rust
+   CLI surfaces or dedicated Rust binaries over shell, Python, or TypeScript
+   scripts whenever feasible.
+4. Package-local helpers are a compatibility and package-private escape hatch.
+   They remain appropriate for thin glue around external ecosystems, trivial
+   private helpers, or cases where the underlying toolchain is itself shell- or
+   Python-defined.
+5. Package-local deterministic helpers that remain script-based belong under
+   `scripts/` and are invoked through host tools such as `bash`, or through
+   explicit first-party authoring flows such as `alan skills eval`.
+6. If a skill depends on an external executable that is not shipped inside the
    package, authors should declare it through `capabilities.required_tools` or
    `compatibility.dependencies` with dependency kind `tool`.
-5. Reusable skill tooling may be shared across multiple skill packages, but it
+7. Reusable skill tooling may be shared across multiple skill packages, but it
    remains operator-side tooling unless Alan explicitly promotes it into the
    runtime tool surface.
 
@@ -406,7 +415,8 @@ Rules:
 1. `SKILL.md` should stay concise and procedural.
 2. Detailed schemas, examples, and domain reference material should move into
    `references/`.
-3. Deterministic scripts should live in `scripts/`.
+3. Package-private deterministic helpers that remain script-based should live
+   in `scripts/`.
 4. Templates and output resources should live in `assets/`.
 5. Relative resource paths resolve against the canonical package resource root.
 6. Authoring should keep references shallow.


### PR DESCRIPTION
## Summary

- document a Rust-first default for first-party skill authoring and evaluation tooling
- clarify that `scripts/` is a package-private compatibility surface, not the preferred home for reusable first-party tooling
- update the built-in `skill-creator` guidance to point authors at `alan` and `alan-skill-tools` instead of Python wrapper scripts

## Why

We want one clear default for first-party skill tooling: when shell, Python, or TypeScript is not necessary, prefer typed Rust CLI/bin surfaces.

This keeps authoring flows more consistent, reduces wrapper sprawl around existing Rust commands, and gives us a cleaner basis for follow-on cleanup work.

Related to #301.

## Validation

- `git diff --cached --check`
- No automated test suite run; docs-only changes
