### PR TITLE
[codex] Fix cargo audit rustls-webpki advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,9 +2020,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- update `rustls-webpki` in `Cargo.lock` from `0.103.12` to `0.103.13`
- clear the new `cargo audit` hard failure caused by `RUSTSEC-2026-0104`
- keep the change scoped to the lockfile so unrelated in-flight work does not get mixed into the fix

## Why

`cargo audit` started failing in CI after the newly published `RUSTSEC-2026-0104` advisory for `rustls-webpki 0.103.12`.

This branch applies the smallest viable remediation by updating the affected locked dependency to the patched release required by the advisory.

## Validation

- `cargo audit`
- `cargo check --workspace`

Note: `cargo audit` still reports the existing allowed `rand 0.9.2` warning (`RUSTSEC-2026-0097`), but the hard failure is resolved.
