### PR TITLE
[VNext][Alan Coding] Harden repo-worker delivery contract

### DIFF
--- a/crates/runtime/skills/repo-coding/SKILL.md
+++ b/crates/runtime/skills/repo-coding/SKILL.md
@@ -29,16 +29,42 @@ work.
    approval scope.
 4. Expect bounded result integration rather than inheriting the full child
    transcript into the parent tape.
+5. Do not ask the repo worker to end with prose. The child handoff is the
+   package delivery contract JSON even when the user-facing parent response
+   should be concise prose.
+
+## Working Principles
+
+1. Treat this package as Alan's general repo-local coding mode, not as a
+   benchmark adapter.
+2. Optimize reusable coding behavior such as understanding constraints, keeping
+   edits bounded, verifying honestly, and delivering clear residual risk.
+3. Use explicit continuity handles from the steward when they materially help,
+   including `plan`, `conversation_snapshot`, and optional `memory`.
+4. Treat repeated validation and error-handling patterns as repo-wide
+   invariants: inspect adjacent entrypoints and keep semantics consistent.
+5. Treat truncated search output as incomplete discovery; narrow the search or
+   read candidate files before deciding implementation scope.
+6. Do not tune repo-worker behavior to a specific repository, benchmark corpus,
+   or issue family.
 
 ## Repo-Worker Expectations
 
 The repo worker should:
 
 1. inspect local code and restate constraints,
-2. decompose the change into short verifiable steps,
-3. apply minimal edits,
-4. run targeted verification,
-5. return a concise delivery summary with residual risk.
+2. identify nearby behavior guards such as tests, invariants, and public
+   interfaces before editing,
+3. decompose the change into short verifiable steps,
+4. apply minimal edits that preserve unrelated behavior,
+5. keep shared validation, invariant, and error semantics consistent across
+   neighboring code paths,
+6. distinguish public/user-facing validation errors from internal assertions,
+7. prefer focused regression coverage over weakening existing tests,
+8. run targeted verification,
+9. describe verification outcomes honestly, including `mixed`,
+   `environment_blocked`, or `not_run` states when they occur,
+10. return a concise delivery summary with residual risk.
 
 ## Package Resources
 
@@ -46,5 +72,7 @@ The repo worker should:
 - Read `references/delivery_contract.md` for the bounded repo-worker output shape.
 - Read `references/evaluator_boundary.md` before recommending evaluator support.
 - Use the package-local child launch target `repo-worker`.
+- Preserve the repo-worker delivery contract in delegated task text; do not
+  override it with "return a concise summary" prose instructions.
 - Keep repo-local edits bounded; return control when the task expands beyond
   delegated scope.

--- a/crates/runtime/skills/repo-coding/SKILL.md
+++ b/crates/runtime/skills/repo-coding/SKILL.md
@@ -25,8 +25,8 @@ work.
 1. Treat the parent Alan runtime as the coding steward.
 2. Use this package when the task should move into a fresh repo worker bound to
    one repo or directory.
-3. Keep launch inputs explicit: delegated task, cwd, workspace boundary, and
-   approval scope.
+3. Keep launch inputs explicit: delegated task, cwd, workspace boundary, child
+   time budget, and approval scope.
 4. Expect bounded result integration rather than inheriting the full child
    transcript into the parent tape.
 5. Do not ask the repo worker to end with prose. The child handoff is the

--- a/crates/runtime/skills/repo-coding/agents/repo-worker/agent.toml
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/agent.toml
@@ -1,5 +1,3 @@
-openai_responses_model = "gpt-5.4"
-
 [[skill_overrides]]
 skill = "repo-coding"
 enabled = false

--- a/crates/runtime/skills/repo-coding/agents/repo-worker/persona/ROLE.md
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/persona/ROLE.md
@@ -5,3 +5,55 @@ You are the package-local `repo-worker` child agent.
 Your job is to execute bounded coding work inside the delegated repo or
 directory, keep edits minimal, verify what changed, and return a clear delivery
 summary without expanding scope silently.
+
+Rules:
+
+1. Treat the parent Alan runtime as the coding steward. You are a bounded
+   Alan child for repo-local execution, not a standalone patch bot.
+2. Optimize for general repo coding quality rather than benchmark-specific,
+   repository-specific, or issue-family-specific tricks.
+3. Treat nearby tests, public interfaces, and existing invariants as behavior
+   constraints. If the task statement conflicts with them, surface the
+   discrepancy instead of silently picking one side.
+4. Prefer the smallest change that solves the problem and add focused
+   regression coverage when that is the safest way to preserve behavior.
+5. For validation, invariant, or error-semantics changes, search for adjacent
+   entrypoints that enforce the same concept and keep exception types,
+   messages, and behavior consistent across those paths.
+   If the task says an error or behavior was "already added" for a related
+   concept, inspect that related path and decide whether it must change too;
+   do not only copy its message style.
+6. If search output is truncated, noisy, or includes path errors, rerun a
+   narrower search or read the candidate files directly before editing. Do not
+   make a semantic decision from incomplete search output.
+7. Treat public/user-input validation as runtime behavior, not a developer
+   assertion. Do not implement public validation with `assert`, because
+   assertions can be disabled and are only appropriate for internal invariants.
+   If nearby public validation still uses `assert`, consider whether the same
+   change should convert that path to an explicit runtime error too.
+8. Report verification honestly. Only claim a check passed when it actually
+   passed, and explicitly call out blocked, mixed, failed, or not-run states.
+9. Use any steward-provided continuity handles, including optional memory,
+   conservatively and only when they materially improve the delegated task.
+10. Produce the final handoff as one bounded JSON delivery artifact, without
+   Markdown fences. It must include these top-level keys:
+   `status`, `summary`, `changed_files`, `behavioral_guards`,
+   `verification`, `residual_risks`, and `evaluator`. Include
+   `test_change_reason` when tests changed. This overrides any delegated task
+   wording that asks for a prose summary.
+   - `verification` must include `overall_status`, `verification_attempted`,
+     `attempted_count`, `passed_count`, `failed_count`,
+     `environment_blocked_count`, `blocked_count`, `not_run_count`,
+     `all_passed`, and `entries`.
+   - `evaluator` must be an object with `mode` and `reason`, not a string.
+11. Keep shell usage workspace-safe: prefer one simple command per tool call,
+   avoid chaining with `&&`/`;`, avoid shell glob or brace expansion, and use
+   exact read/edit tools when you already know the target files.
+12. Before declaring verification blocked, check for repo-local execution
+   entrypoints such as `.venv/bin/python`, `venv/bin/python`, `python -m
+   pytest`, `tox`, or `nox`; if those are unavailable, stop retrying and
+   report `environment_blocked` instead of guessing.
+13. Do not trigger approval or dependency-bootstrap flows just to make
+    verification run. If validation would require environment sync, package
+    installation, `uv run`, `rye sync`, or similar setup work, report
+    `environment_blocked` rather than pausing for confirmation.

--- a/crates/runtime/skills/repo-coding/agents/repo-worker/skills/decompose/SKILL.md
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/skills/decompose/SKILL.md
@@ -8,6 +8,19 @@ metadata:
 
 # Instructions
 
-1. Restate objective, scope, and repo-local constraints before changing files.
-2. Produce a short actionable plan with explicit verification steps.
-3. Identify irreversible actions and route them through governance boundaries.
+1. Restate the objective, scope, repo-local constraints, and any explicit
+   continuity handles before changing files.
+2. Identify nearby tests, public interfaces, and invariants that act as
+   behavior constraints for the requested change.
+3. For validation or error-handling work, identify every adjacent entrypoint
+   that enforces the same invariant before planning edits; note the expected
+   exception type, message style, and compatibility impact.
+4. When the issue references an existing analogous validation, inspect that
+   implementation explicitly and decide whether its error type/message should
+   be aligned as part of the same invariant.
+5. If discovery output is truncated or noisy, plan a narrower follow-up read
+   before deciding scope.
+6. Produce a short actionable plan with explicit verification steps.
+7. If the task statement conflicts with current tests or observable behavior,
+   surface that discrepancy instead of silently normalizing it away.
+8. Identify irreversible actions and route them through governance boundaries.

--- a/crates/runtime/skills/repo-coding/agents/repo-worker/skills/deliver/SKILL.md
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/skills/deliver/SKILL.md
@@ -9,5 +9,14 @@ metadata:
 # Instructions
 
 1. Report changed files and behavior impact.
-2. List verification commands and outcomes.
-3. Call out remaining risks, follow-up work, and rollback considerations.
+2. List verification commands and outcomes, and only mark checks as passed when
+   they actually succeeded.
+3. Call out remaining risks, blocked environments, and follow-up work.
+4. Include rollback considerations and any steward-provided assumptions or
+   continuity handles that materially shaped the result.
+5. End with a single JSON object, without Markdown fencing, that satisfies
+   `references/delivery_contract.md` so the parent steward can ingest the
+   bounded delivery artifact directly.
+6. The final assistant message must be that JSON object and nothing else. Do
+   not prepend prose such as `Changed:` or append extra commentary outside the
+   JSON payload.

--- a/crates/runtime/skills/repo-coding/agents/repo-worker/skills/edit-verify/SKILL.md
+++ b/crates/runtime/skills/repo-coding/agents/repo-worker/skills/edit-verify/SKILL.md
@@ -8,6 +8,33 @@ metadata:
 
 # Instructions
 
-1. Apply the minimal edits needed for the current step.
-2. Run targeted checks first, then broader checks only when the task requires them.
-3. Record command output summaries and unresolved risks.
+1. Apply the minimal edits needed for the current step while preserving
+   unrelated behavior.
+2. Treat existing tests as constraints and do not weaken or rewrite them
+   without an explicit behavior-level reason.
+3. When changing validation, invariants, or error behavior, update all
+   neighboring code paths that implement the same rule so callers observe
+   consistent semantics.
+4. Replace assertion-based public input checks with explicit runtime errors
+   when the task is about user-facing validation semantics; keep assertions
+   only when they are intentionally internal invariants. Do not add new
+   public-input validation with `assert`.
+5. If a search or command result is truncated, rerun a narrower command or use
+   exact file reads before editing.
+6. Run targeted checks first, then broader checks only when the task requires
+   them.
+7. Add focused regression coverage when a missing behavior guard is the safest
+   way to lock in the fix.
+8. Record command-output summaries with explicit pass, mixed, blocked, failed,
+   or not-run outcomes and note unresolved risks.
+9. Keep shell commands simple and workspace-safe: avoid `&&`, shell globs, and
+   brace expansion; use separate tool calls when you need multiple reads or
+   checks.
+10. Prefer repo-local runners or interpreters when available, such as
+   `.venv/bin/python`, `venv/bin/python`, `python -m pytest`, `tox`, or
+   `nox`; if the environment is clearly unavailable, report
+   `environment_blocked` instead of continuing blind retries.
+11. Do not install dependencies, sync environments, or invoke approval-requiring
+   bootstrap commands solely to get verification running. If the available
+   environment cannot execute the targeted checks directly, stop and report
+   `environment_blocked`.

--- a/crates/runtime/skills/repo-coding/evals/README.md
+++ b/crates/runtime/skills/repo-coding/evals/README.md
@@ -2,12 +2,38 @@
 
 Package-local repo-coding eval fixtures and review assets live here.
 
+## Operating Principles
+
+Treat this directory as an evaluation and operator-run benchmark surface, not
+as the place where repo-worker behavior is defined.
+
+Rules:
+
+1. External benchmarks measure how well Alan's general coding behavior
+   transfers to outside corpora; they do not define repo-worker prompts or
+   justify dataset-specific shortcuts.
+2. Full steward mode means the root Alan runtime remains the owner of routing,
+   continuity, and delivery framing. The repo-worker child owns only bounded
+   repo-local execution.
+3. Findings from SWE-bench or similar ladders should be generalized back into
+   reusable contracts, prompts, tools, or harness checks rather than encoded
+   as benchmark-only heuristics.
+4. Alan-native `passed` fields in local run artifacts are orchestration and
+   delivery assertions. Official resolved/unresolved status still comes from
+   the external harness when that harness is run.
+5. Existing tests, nearby invariants, and public interfaces remain behavior
+   constraints. Benchmark patches that require weakening them should be treated
+   as suspect and reviewed explicitly.
+
 Current surfaces:
 
 1. `evals.json` as the manifest-first entrypoint for `alan skills eval`.
 2. `files/benchmark_cases.json` as deterministic steward-vs-legacy routing fixtures.
 3. `../scripts/run_benchmark_fixture.sh` and `../scripts/grade_benchmark_case.sh`
    as package-local benchmark helpers.
+4. `../scripts/check_delivery_contract_examples.sh` plus
+   `files/delivery_contract_*.json` as executable verification-honesty and
+   behavior-preserving delivery fixtures.
 
 Run the scaffold locally with:
 
@@ -36,8 +62,17 @@ It does not bypass Alan's orchestration layer. Instead it:
    - `prediction.json`
    - `predictions.jsonl`
    - `run.json`
+   - `verification_entries.json`
+   - `verification_summary.json`
    - `assertion_report.json`
    - `kpi.json`
+
+This runner exists to observe Alan's coding line in a realistic external task
+setting while preserving the product boundary:
+
+1. Alan stays the home-root coding steward,
+2. repo-local edits still flow through the delegated repo-worker child,
+3. benchmark runs remain an adapter layer on top of that general behavior.
 
 The case-level `run.json` also records Alan-native orchestration metadata such
 as:
@@ -46,6 +81,12 @@ as:
 2. `escalation_count`
 3. `child_runs`
 4. `duration_secs`
+5. `verification_summary`
+
+Case-level `run.json.passed` is intentionally an Alan-native orchestration
+result. It means the steward completed, delegated repo-local work through a
+child launch, and produced a non-empty patch. It is not the official
+SWE-bench resolved/unresolved outcome.
 
 Use the template case file as a starting point:
 
@@ -68,14 +109,19 @@ This is intentionally operator-run and non-CI-blocking.
 Recommended rollout order:
 
 1. one Lite case,
-2. a curated Lite subset,
-3. full Lite,
-4. curated Pro subsets.
+2. a 3-case Lite smoke subset,
+3. a curated Lite pilot subset,
+4. full Lite,
+5. curated Pro subsets.
 
 For the M2 curated-subset step, use:
 
 - `evals/files/swebench_lite_subset.template.json`
 - `evals/files/swebench_lite_pilot_v1.ids.txt`
+
+For the smoke-first gate before the larger pilot subset, use:
+
+- `evals/files/swebench_lite_smoke_v1.ids.txt`
 
 Before materializing the Alan suite, prepare one clean git workspace per
 instance id at the benchmark `base_commit`:
@@ -158,6 +204,9 @@ The end-to-end pilot order is now:
 3. `run_swebench_full_steward_subset.sh`
 4. `score_swebench_predictions.sh`
 
+For the smoke-first variant, replace `swebench_lite_pilot_v1.ids.txt` with
+`swebench_lite_smoke_v1.ids.txt` and keep the rest of the flow unchanged.
+
 ```bash
 bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
   crates/runtime/skills/repo-coding/evals/files/swebench_lite_subset.template.json
@@ -179,15 +228,59 @@ generates:
 4. `benchmark.json`
 5. `kpi.json`
 6. `score_with_official_harness.sh`
+7. `official_harness_run.json` when official scoring is invoked
+8. `official_harness_submitted_report.json` when official scoring is invoked
 
 Suite-level `run.json` and `benchmark.json` now also summarize
-`total_escalation_count` across all executed cases.
+`total_escalation_count` across all executed cases. When the suite is run with
+`--score-official`, they also embed the collected official harness manifest.
+Their `passed` / `failed` case counts are orchestration counts for the case
+runner; the official SWE-bench result remains the harness manifest.
+
+When `score_swebench_predictions.sh` is run later against an existing suite
+directory, it now also syncs the official result back into the suite-owned
+artifacts when they exist:
+
+1. `cases/<instance_id>/official_harness_instance_result.json`
+2. `case_results.jsonl`
+3. `run.json`
+4. `benchmark.json`
+5. `kpi.json`
+
+Use `official_harness_run.json` for the full raw wrapper manifest and
+`official_harness_submitted_report.json` for the compact subset-only summary.
 
 Official harness scoring still happens outside Alan's runtime loop, but the
 package now provides a thin wrapper so operators do not need to remember the
 raw Python module entrypoint:
 
 ```bash
+export ALAN_SWEBENCH_HARNESS_PYTHON_BIN=/absolute/path/to/harness/python
+
 bash crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh \
-  target/benchmarks/swebench_lite/suites/swebench_lite_curated/predictions.jsonl
+  target/benchmarks/swebench_lite/suites/swebench_lite_curated/predictions.jsonl \
+  --work-dir target/benchmarks/swebench_lite/suites/swebench_lite_curated \
+  --manifest-file target/benchmarks/swebench_lite/suites/swebench_lite_curated/official_harness_run.json
+```
+
+To check or set up that dedicated harness environment:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh
+
+bash crates/runtime/skills/repo-coding/scripts/setup_swebench_harness_env.sh
+export ALAN_SWEBENCH_HARNESS_PYTHON_BIN=/absolute/path/to/repo/target/benchmarks/swebench_harness/.venv/bin/python
+```
+
+The setup script installs the official harness into a dedicated virtualenv so
+the harness Python does not have to match the Python that Alan child runtimes
+use inside benchmark workspaces. It also installs `socksio` so the harness can
+run on hosts that expose Hugging Face access through a SOCKS proxy.
+
+To run the curated suite and trigger the official harness in one step:
+
+```bash
+bash crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh \
+  target/benchmarks/swebench_lite/manifests/pilot_v1/suite.json \
+  --score-official
 ```

--- a/crates/runtime/skills/repo-coding/evals/evals.json
+++ b/crates/runtime/skills/repo-coding/evals/evals.json
@@ -103,6 +103,15 @@
           "scripts/grade_benchmark_case.sh"
         ]
       }
+    },
+    {
+      "id": "delivery-contract-examples",
+      "type": "command",
+      "prompt": "Validate repo-worker delivery contract examples for verification honesty and behavior-preserving reporting.",
+      "command": [
+        "bash",
+        "scripts/check_delivery_contract_examples.sh"
+      ]
     }
   ]
 }

--- a/crates/runtime/skills/repo-coding/evals/files/delivery_contract_invalid_passed_with_failure_exit.json
+++ b/crates/runtime/skills/repo-coding/evals/files/delivery_contract_invalid_passed_with_failure_exit.json
@@ -1,0 +1,35 @@
+{
+  "status": "completed",
+  "summary": "Claims verification passed even though the cited command failed.",
+  "changed_files": [
+    "src/lib.rs"
+  ],
+  "behavioral_guards": [
+    "lib.rs behavior should stay stable."
+  ],
+  "verification": {
+    "overall_status": "passed",
+    "verification_attempted": true,
+    "attempted_count": 1,
+    "passed_count": 1,
+    "failed_count": 0,
+    "environment_blocked_count": 0,
+    "blocked_count": 0,
+    "not_run_count": 0,
+    "all_passed": true,
+    "entries": [
+      {
+        "command": "cargo test --quiet",
+        "scope": "targeted",
+        "status": "passed",
+        "exit_code": 1,
+        "summary": "This should fail validation because the exit code is non-zero."
+      }
+    ]
+  },
+  "residual_risks": [],
+  "evaluator": {
+    "mode": "not_needed",
+    "reason": "Placeholder."
+  }
+}

--- a/crates/runtime/skills/repo-coding/evals/files/delivery_contract_invalid_test_only_without_reason.json
+++ b/crates/runtime/skills/repo-coding/evals/files/delivery_contract_invalid_test_only_without_reason.json
@@ -1,0 +1,35 @@
+{
+  "status": "completed",
+  "summary": "Adjusted tests only without giving a behavior-level reason.",
+  "changed_files": [
+    "tests/test_service.py"
+  ],
+  "behavioral_guards": [
+    "The existing test should only be changed with an explicit contract-level reason."
+  ],
+  "verification": {
+    "overall_status": "passed",
+    "verification_attempted": true,
+    "attempted_count": 1,
+    "passed_count": 1,
+    "failed_count": 0,
+    "environment_blocked_count": 0,
+    "blocked_count": 0,
+    "not_run_count": 0,
+    "all_passed": true,
+    "entries": [
+      {
+        "command": "pytest tests/test_service.py -q",
+        "scope": "targeted",
+        "status": "passed",
+        "exit_code": 0,
+        "summary": "The modified test passed."
+      }
+    ]
+  },
+  "residual_risks": [],
+  "evaluator": {
+    "mode": "not_needed",
+    "reason": "Placeholder."
+  }
+}

--- a/crates/runtime/skills/repo-coding/evals/files/delivery_contract_valid_environment_blocked.json
+++ b/crates/runtime/skills/repo-coding/evals/files/delivery_contract_valid_environment_blocked.json
@@ -1,0 +1,38 @@
+{
+  "status": "blocked",
+  "summary": "Prepared the patch, but verification is blocked because pytest is unavailable in the host environment.",
+  "changed_files": [
+    "src/service.py"
+  ],
+  "behavioral_guards": [
+    "service.fetch() should preserve its public return shape.",
+    "The existing pytest suite remains the intended deterministic behavior guard."
+  ],
+  "verification": {
+    "overall_status": "environment_blocked",
+    "verification_attempted": true,
+    "attempted_count": 1,
+    "passed_count": 0,
+    "failed_count": 0,
+    "environment_blocked_count": 1,
+    "blocked_count": 0,
+    "not_run_count": 0,
+    "all_passed": false,
+    "entries": [
+      {
+        "command": "pytest tests/test_service.py -q",
+        "scope": "targeted",
+        "status": "environment_blocked",
+        "exit_code": 1,
+        "summary": "ModuleNotFoundError: No module named 'pytest'"
+      }
+    ]
+  },
+  "residual_risks": [
+    "Targeted verification could not run until pytest is installed in the workspace environment."
+  ],
+  "evaluator": {
+    "mode": "recommended",
+    "reason": "Deterministic checks are currently unavailable in the host environment, so evaluator support may help once verification is unblocked."
+  }
+}

--- a/crates/runtime/skills/repo-coding/evals/files/delivery_contract_valid_mixed.json
+++ b/crates/runtime/skills/repo-coding/evals/files/delivery_contract_valid_mixed.json
@@ -1,0 +1,47 @@
+{
+  "status": "completed",
+  "summary": "Fixed the parser bug with a targeted unit test and deferred the broader integration suite.",
+  "changed_files": [
+    "src/parser.rs",
+    "tests/parser_regression.rs"
+  ],
+  "behavioral_guards": [
+    "parse_config() should continue accepting the existing public input shape.",
+    "The parser regression test locks in the bugfix without broadening behavior."
+  ],
+  "test_change_reason": "The regression test captures the pre-existing parser contract that the product code fix now restores.",
+  "verification": {
+    "overall_status": "mixed",
+    "verification_attempted": true,
+    "attempted_count": 1,
+    "passed_count": 1,
+    "failed_count": 0,
+    "environment_blocked_count": 0,
+    "blocked_count": 0,
+    "not_run_count": 1,
+    "all_passed": true,
+    "entries": [
+      {
+        "command": "cargo test parser_regression --quiet",
+        "scope": "targeted",
+        "status": "passed",
+        "exit_code": 0,
+        "summary": "The focused parser regression test passed."
+      },
+      {
+        "command": "cargo test --quiet",
+        "scope": "broader",
+        "status": "not_run",
+        "exit_code": null,
+        "summary": "The broader suite was intentionally deferred after the targeted regression passed."
+      }
+    ]
+  },
+  "residual_risks": [
+    "The full crate test suite was not run in this bounded fix loop."
+  ],
+  "evaluator": {
+    "mode": "not_needed",
+    "reason": "A small repo-local fix had deterministic targeted coverage and did not require evaluator support."
+  }
+}

--- a/crates/runtime/skills/repo-coding/evals/files/swebench_lite_smoke_v1.ids.txt
+++ b/crates/runtime/skills/repo-coding/evals/files/swebench_lite_smoke_v1.ids.txt
@@ -1,0 +1,3 @@
+psf__requests-1963
+pallets__flask-4045
+pytest-dev__pytest-11143

--- a/crates/runtime/skills/repo-coding/references/delivery_contract.md
+++ b/crates/runtime/skills/repo-coding/references/delivery_contract.md
@@ -10,19 +10,56 @@ The contract is expressed as JSON with these required fields:
 1. `status`: one of `completed`, `blocked`, or `failed`
 2. `summary`: concise explanation of what happened
 3. `changed_files`: array of repo-relative file paths
-4. `verification`: non-empty array of verification entries
-5. `residual_risks`: array of remaining risks or blockers
-6. `evaluator`: conditional evaluator decision and reason
+4. `behavioral_guards`: non-empty array describing nearby tests, public
+   interfaces, or invariants treated as constraints
+5. `verification`: structured verification summary
+6. `residual_risks`: array of remaining risks or blockers
+7. `evaluator`: conditional evaluator decision and reason
+
+## Conditional fields
+
+1. `test_change_reason`: required when `changed_files` includes one or more
+   test files, because test-only or test-shaping changes need an explicit
+   behavior-level reason
 
 ## Verification entry shape
 
-Each verification entry should include:
+`verification.entries` should contain zero or more verification entries. Each
+entry should include:
 
 1. `command`
 2. `scope`: `targeted` or `broader`
-3. `status`: `passed`, `failed`, or `not_run`
-4. `exit_code`
+3. `status`: one of `passed`, `failed`, `blocked`, `environment_blocked`, or
+   `not_run`
+4. `exit_code`: integer exit code for attempted commands, or `null` when the
+   command was blocked or not run
 5. `summary`
+
+## Verification summary shape
+
+`verification` should also include:
+
+1. `overall_status`: one of `passed`, `failed`, `blocked`,
+   `environment_blocked`, `mixed`, or `not_attempted`
+2. `verification_attempted`: boolean
+3. `attempted_count`
+4. `passed_count`
+5. `failed_count`
+6. `environment_blocked_count`
+7. `blocked_count`
+8. `not_run_count`
+9. `all_passed`
+
+Reporting rules:
+
+1. `passed` means every attempted verification command succeeded.
+2. `blocked` means every attempted verification command was blocked by policy
+   or governance.
+3. `environment_blocked` means every attempted verification command failed for
+   host-environment reasons such as missing dependencies or executables.
+4. `mixed` means multiple attempted outcomes occurred, or some cited commands
+   were intentionally not run.
+5. `not_attempted` means no verification command actually ran.
 
 ## Evaluator field
 
@@ -33,4 +70,5 @@ Each verification entry should include:
 
 This keeps the repo-worker output explicit about whether the run stayed inside
 the stable solo loop or crossed into a case where evaluator support should have
-been considered.
+been considered, while making verification honesty and behavior-preserving
+changes machine-checkable.

--- a/crates/runtime/skills/repo-coding/references/package.md
+++ b/crates/runtime/skills/repo-coding/references/package.md
@@ -6,6 +6,23 @@ This first-party package productizes Alan's repo-scoped coding worker under
 It is not the full coding product boundary by itself. The steward/worker model
 is defined in `docs/spec/alan_coding_steward_contract.md`.
 
+## Package Principles
+
+This package should make Alan better at general repo-local coding work. It
+should not evolve into a SWE-bench adapter with product-specific behavior.
+
+Rules:
+
+1. The parent Alan runtime remains the coding steward; this package provides
+   the bounded repo-worker path inside that broader stewardship model.
+2. Any improvements motivated by benchmark findings should be reusable coding
+   improvements that help normal repository work as well.
+3. Explicit continuity handles handed down by the steward, including optional
+   memory, are for project continuity and task execution quality, not for
+   benchmark-only escape hatches.
+4. Verification claims and delivery summaries produced through this package
+   must remain evidence-backed and behavior-preserving.
+
 ## What this package contains
 
 1. `SKILL.md` as the parent-facing entry for repo-scoped coding delegation.
@@ -17,8 +34,9 @@ is defined in `docs/spec/alan_coding_steward_contract.md`.
    extension manifest examples.
 5. `references/delivery_contract.md` and `references/evaluator_boundary.md`
    describing the bounded output contract and conditional evaluator boundary.
-6. `evals/evals.json` plus `evals/files/benchmark_cases.json` for manifest-first
-   benchmark scaffolding.
+6. `evals/evals.json`, `evals/files/benchmark_cases.json`, and
+   `evals/files/delivery_contract_*.json` for manifest-first benchmark and
+   delivery-contract scaffolding.
 7. `scripts/` with deterministic validators and benchmark helpers.
 8. External smoke and harness entrypoints under `scripts/repo-worker/` and
    `scripts/harness/`.
@@ -51,6 +69,9 @@ That runner should:
 2. require repo-local work to happen through delegated child launch,
 3. export `model.patch` plus single-case prediction artifacts,
 4. emit Alan-native orchestration metadata alongside the benchmark patch.
+
+Those artifacts measure transfer quality for Alan's coding line. They should
+never become the source of benchmark-corpus-specific runtime rules.
 
 The next bring-up step is a curated subset aggregator:
 

--- a/crates/runtime/skills/repo-coding/scripts/check_delivery_contract_examples.sh
+++ b/crates/runtime/skills/repo-coding/scripts/check_delivery_contract_examples.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+package_root="$repo_root/crates/runtime/skills/repo-coding"
+validator="$package_root/scripts/validate_delivery_contract.sh"
+fixtures_root="$package_root/evals/files"
+
+valid_fixtures=(
+    "$fixtures_root/delivery_contract_valid_mixed.json"
+    "$fixtures_root/delivery_contract_valid_environment_blocked.json"
+)
+
+invalid_fixtures=(
+    "$fixtures_root/delivery_contract_invalid_passed_with_failure_exit.json"
+    "$fixtures_root/delivery_contract_invalid_test_only_without_reason.json"
+)
+
+for fixture in "${valid_fixtures[@]}"; do
+    bash "$validator" "$fixture" >/dev/null
+done
+
+for fixture in "${invalid_fixtures[@]}"; do
+    if bash "$validator" "$fixture" >/dev/null 2>&1; then
+        echo "Expected delivery contract validation to fail: $fixture" >&2
+        exit 1
+    fi
+done
+
+echo "Repo-worker delivery-contract examples validated."

--- a/crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh
+++ b/crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh [--python-bin <path>] [--json]
+
+Checks whether the local machine is ready to run the official SWE-bench
+harness. The check covers:
+
+  1. a usable Python interpreter,
+  2. the `swebench` Python module,
+  3. Docker CLI availability,
+  4. Docker daemon reachability.
+
+Environment:
+  ALAN_SWEBENCH_HARNESS_PYTHON_BIN
+      Optional default Python interpreter for the harness.
+USAGE
+}
+
+python_bin_override=""
+json_output=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --python-bin)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            python_bin_override="$2"
+            shift 2
+            ;;
+        --json)
+            json_output=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+pick_python_bin() {
+    if [[ -n "$python_bin_override" ]]; then
+        printf '%s\n' "$python_bin_override"
+    elif [[ -n "${ALAN_SWEBENCH_HARNESS_PYTHON_BIN:-}" ]]; then
+        printf '%s\n' "$ALAN_SWEBENCH_HARNESS_PYTHON_BIN"
+    elif command -v python >/dev/null 2>&1; then
+        printf '%s\n' "python"
+    elif command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' "python3"
+    else
+        printf '\n'
+    fi
+}
+
+python_bin="$(pick_python_bin)"
+python_available=false
+python_module_available=false
+docker_command_available=false
+docker_daemon_reachable=false
+python_executable=""
+python_version=""
+docker_bin=""
+docker_version=""
+socks_proxy_configured=false
+socksio_module_available=false
+socks_proxy_url=""
+
+declare -a missing_requirements=()
+
+if [[ -n "$python_bin" ]]; then
+    if python_executable="$("$python_bin" -c 'import sys; print(sys.executable)' 2>/dev/null)"; then
+        python_available=true
+        python_version="$("$python_bin" -c 'import sys; print(sys.version.splitlines()[0])' 2>/dev/null || true)"
+        if "$python_bin" -c 'import importlib.util, sys; sys.exit(0 if importlib.util.find_spec("swebench") else 1)' >/dev/null 2>&1; then
+            python_module_available=true
+        else
+            missing_requirements+=("swebench_python_module")
+        fi
+        if "$python_bin" -c 'import importlib.util, sys; sys.exit(0 if importlib.util.find_spec("socksio") else 1)' >/dev/null 2>&1; then
+            socksio_module_available=true
+        fi
+    else
+        missing_requirements+=("python_interpreter_unusable")
+    fi
+else
+    missing_requirements+=("python_interpreter_missing")
+fi
+
+for proxy_var_name in ALL_PROXY all_proxy HTTPS_PROXY https_proxy HTTP_PROXY http_proxy; do
+    proxy_value="${!proxy_var_name:-}"
+    if [[ -n "$proxy_value" && "$proxy_value" =~ ^[sS][oO][cC][kK][sS] ]]; then
+        socks_proxy_configured=true
+        socks_proxy_url="$proxy_value"
+        break
+    fi
+done
+
+if [[ "$socks_proxy_configured" == true && "$socksio_module_available" != true ]]; then
+    missing_requirements+=("socksio_python_module_for_proxy")
+fi
+
+if command -v docker >/dev/null 2>&1; then
+    docker_command_available=true
+    docker_bin="$(command -v docker)"
+    docker_version="$(docker --version 2>/dev/null || true)"
+    if docker info >/dev/null 2>&1; then
+        docker_daemon_reachable=true
+    else
+        missing_requirements+=("docker_daemon_unreachable")
+    fi
+else
+    missing_requirements+=("docker_cli_missing")
+fi
+
+ready=false
+if [[ "$python_available" == true && "$python_module_available" == true && "$docker_command_available" == true && "$docker_daemon_reachable" == true ]]; then
+    ready=true
+fi
+
+if [[ "$json_output" == true ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Missing required command for --json output: jq" >&2
+        exit 1
+    fi
+    missing_requirements_json='[]'
+    if (( ${#missing_requirements[@]} > 0 )); then
+        missing_requirements_json="$(printf '%s\n' "${missing_requirements[@]}" | jq -R . | jq -s .)"
+    fi
+    jq -n \
+        --arg requested_python_bin "$python_bin_override" \
+        --arg selected_python_bin "$python_bin" \
+        --arg python_executable "$python_executable" \
+        --arg python_version "$python_version" \
+        --arg docker_bin "$docker_bin" \
+        --arg docker_version "$docker_version" \
+        --arg socks_proxy_url "$socks_proxy_url" \
+        --argjson python_available "$python_available" \
+        --argjson swebench_module_available "$python_module_available" \
+        --argjson socks_proxy_configured "$socks_proxy_configured" \
+        --argjson socksio_module_available "$socksio_module_available" \
+        --argjson docker_command_available "$docker_command_available" \
+        --argjson docker_daemon_reachable "$docker_daemon_reachable" \
+        --argjson ready "$ready" \
+        --argjson missing_requirements "$missing_requirements_json" \
+        '{
+            ready: $ready,
+            requested_python_bin: (if $requested_python_bin == "" then null else $requested_python_bin end),
+            selected_python_bin: (if $selected_python_bin == "" then null else $selected_python_bin end),
+            python_executable: (if $python_executable == "" then null else $python_executable end),
+            python_version: (if $python_version == "" then null else $python_version end),
+            swebench_module_available: $swebench_module_available,
+            socks_proxy_configured: $socks_proxy_configured,
+            socks_proxy_url: (if $socks_proxy_url == "" then null else $socks_proxy_url end),
+            socksio_module_available: $socksio_module_available,
+            docker_command_available: $docker_command_available,
+            docker_daemon_reachable: $docker_daemon_reachable,
+            docker_bin: (if $docker_bin == "" then null else $docker_bin end),
+            docker_version: (if $docker_version == "" then null else $docker_version end),
+            missing_requirements: $missing_requirements
+        }'
+else
+    echo "SWE-bench harness preflight:"
+    echo "  ready: $ready"
+    echo "  selected_python_bin: ${python_bin:-<none>}"
+    echo "  python_executable: ${python_executable:-<none>}"
+    echo "  python_version: ${python_version:-<none>}"
+    echo "  swebench_module_available: $python_module_available"
+    echo "  socks_proxy_configured: $socks_proxy_configured"
+    echo "  socksio_module_available: $socksio_module_available"
+    echo "  docker_command_available: $docker_command_available"
+    echo "  docker_daemon_reachable: $docker_daemon_reachable"
+    if [[ -n "$socks_proxy_url" ]]; then
+        echo "  socks_proxy_url: $socks_proxy_url"
+    fi
+    if [[ -n "$docker_version" ]]; then
+        echo "  docker_version: $docker_version"
+    fi
+    if (( ${#missing_requirements[@]} > 0 )); then
+        echo "  missing_requirements:"
+        for requirement in "${missing_requirements[@]}"; do
+            echo "    - $requirement"
+        done
+    fi
+fi
+
+if [[ "$ready" != true ]]; then
+    exit 1
+fi

--- a/crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh
+++ b/crates/runtime/skills/repo-coding/scripts/check_swebench_harness_env.sh
@@ -53,10 +53,10 @@ pick_python_bin() {
         printf '%s\n' "$python_bin_override"
     elif [[ -n "${ALAN_SWEBENCH_HARNESS_PYTHON_BIN:-}" ]]; then
         printf '%s\n' "$ALAN_SWEBENCH_HARNESS_PYTHON_BIN"
-    elif command -v python >/dev/null 2>&1; then
-        printf '%s\n' "python"
     elif command -v python3 >/dev/null 2>&1; then
         printf '%s\n' "python3"
+    elif command -v python >/dev/null 2>&1; then
+        printf '%s\n' "python"
     else
         printf '\n'
     fi
@@ -123,7 +123,11 @@ else
 fi
 
 ready=false
-if [[ "$python_available" == true && "$python_module_available" == true && "$docker_command_available" == true && "$docker_daemon_reachable" == true ]]; then
+if [[ "$python_available" == true \
+    && "$python_module_available" == true \
+    && "$docker_command_available" == true \
+    && "$docker_daemon_reachable" == true \
+    && ${#missing_requirements[@]} -eq 0 ]]; then
     ready=true
 fi
 

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -113,11 +113,37 @@ fi
 require_command jq
 require_command curl
 require_command git
-require_command cargo
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 package_root="$(cd "$script_dir/.." && pwd)"
 repo_root="$(cd "$package_root/../../../.." && pwd)"
+configured_alan_bin="${ALAN_BIN:-}"
+use_prebuilt_alan=false
+alan_bin=""
+if [[ -n "$configured_alan_bin" ]]; then
+    if [[ ! -x "$configured_alan_bin" ]]; then
+        echo "Configured ALAN_BIN is not executable: $configured_alan_bin" >&2
+        exit 1
+    fi
+    alan_bin="$configured_alan_bin"
+    use_prebuilt_alan=true
+elif [[ -x "$repo_root/target/debug/alan" ]]; then
+    alan_bin="$repo_root/target/debug/alan"
+    use_prebuilt_alan=true
+else
+    require_command cargo
+fi
+
+run_alan_daemon() {
+    local daemon_subcommand="$1"
+    shift || true
+    if [[ "$use_prebuilt_alan" == true ]]; then
+        (cd "$repo_root" && env "$@" "$alan_bin" daemon "$daemon_subcommand")
+    else
+        (cd "$repo_root" && env "$@" cargo run -p alan -- daemon "$daemon_subcommand")
+    fi
+}
+
 case_json="$(cd "$(dirname "$case_json")" && pwd)/$(basename "$case_json")"
 case_dir="$(dirname "$case_json")"
 
@@ -219,7 +245,7 @@ cleanup() {
         curl -fsS -X DELETE "$base_url/api/v1/sessions/$session_id" >/dev/null 2>&1 || true
     fi
     if [[ "$daemon_started" == true ]]; then
-        (cd "$repo_root" && cargo run -p alan -- daemon stop >/dev/null 2>&1) || true
+        run_alan_daemon stop >/dev/null 2>&1 || true
     fi
 }
 trap cleanup EXIT
@@ -234,9 +260,9 @@ fi
 
 if ! curl -fsS "$base_url/health" >/dev/null 2>&1; then
     if [[ -n "$daemon_bind_address" ]]; then
-        (cd "$repo_root" && BIND_ADDRESS="$daemon_bind_address" cargo run -p alan -- daemon start >/dev/null)
+        run_alan_daemon start BIND_ADDRESS="$daemon_bind_address" >/dev/null
     else
-        (cd "$repo_root" && cargo run -p alan -- daemon start >/dev/null)
+        run_alan_daemon start >/dev/null
     fi
     daemon_started=true
 fi
@@ -434,7 +460,7 @@ if (( ${#child_rollout_files[@]} > 0 )); then
                 | .[0]
               ) // ($lines[0] // "");
         def environment_blocked($text):
-            ($text // "" | test("command not found|No module named 'pytest'|No module named pytest|ModuleNotFoundError: No module named 'pytest'|ModuleNotFoundError: No module named pytest|No module named 'nose'|No module named nose|ModuleNotFoundError: No module named 'nose'|ModuleNotFoundError: No module named nose|executable file not found"; "i"));
+            ($text // "" | test("command not found|No module named 'pytest'|No module named pytest|ModuleNotFoundError: No module named 'pytest'|ModuleNotFoundError: No module named pytest|No module named 'nose'|No module named nose|ModuleNotFoundError: No module named 'nose'|ModuleNotFoundError: No module named nose|executable file not found|Target Python binary .* not found"; "i"));
         [
             .[]
             | select(.type == "tool_call" and .name == "bash")

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_case.sh
@@ -39,6 +39,16 @@ require_command() {
     fi
 }
 
+pick_free_localhost_port() {
+    python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
 resolve_path() {
     local raw_path="$1"
     local base_dir="$2"
@@ -157,6 +167,12 @@ fi
 
 workspace_dir="$(git -C "$workspace_dir" rev-parse --show-toplevel)"
 workspace_alan_dir="$workspace_dir/.alan"
+repo_status_without_alan="$(git -C "$workspace_dir" status --short --untracked-files=all -- . ':(glob,exclude).alan/**')"
+if [[ -z "$repo_status_without_alan" && -d "$workspace_alan_dir" ]]; then
+    if ! git -C "$workspace_dir" ls-files --error-unmatch -- .alan '.alan/**' >/dev/null 2>&1; then
+        rm -rf "$workspace_alan_dir"
+    fi
+fi
 if [[ -n "$(git -C "$workspace_dir" status --short --untracked-files=all)" ]]; then
     echo "Workspace must be clean before running the benchmark case: $workspace_dir" >&2
     exit 1
@@ -181,6 +197,8 @@ rollout_copy_file="$output_dir/parent_rollout.jsonl"
 assertion_file="$output_dir/assertion_report.json"
 run_file="$output_dir/run.json"
 kpi_file="$output_dir/kpi.json"
+verification_entries_file="$output_dir/verification_entries.json"
+verification_summary_file="$output_dir/verification_summary.json"
 
 : >"$events_file"
 : >"$assistant_output_file"
@@ -190,7 +208,8 @@ if [[ -z "$effective_agent_name" ]]; then
     effective_agent_name="$case_agent_name"
 fi
 
-base_url="${ALAN_AGENTD_URL:-http://127.0.0.1:8090}"
+base_url="${ALAN_AGENTD_URL:-}"
+daemon_bind_address=""
 session_id=""
 daemon_started=false
 delete_session_on_exit=true
@@ -205,8 +224,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [[ -z "$base_url" ]]; then
+    require_command python3
+    daemon_port="$(pick_free_localhost_port)"
+    daemon_bind_address="127.0.0.1:$daemon_port"
+    base_url="http://$daemon_bind_address"
+    export ALAN_AGENTD_URL="$base_url"
+fi
+
 if ! curl -fsS "$base_url/health" >/dev/null 2>&1; then
-    (cd "$repo_root" && cargo run -p alan -- daemon start >/dev/null)
+    if [[ -n "$daemon_bind_address" ]]; then
+        (cd "$repo_root" && BIND_ADDRESS="$daemon_bind_address" cargo run -p alan -- daemon start >/dev/null)
+    else
+        (cd "$repo_root" && cargo run -p alan -- daemon start >/dev/null)
+    fi
     daemon_started=true
 fi
 
@@ -351,18 +382,144 @@ parent_inline_write_names="$(jq -s '[.[] | select(.type == "tool_call" and .name
 child_runs_json="$(jq -s '[.[] | select(.type == "tool_call" and .name == "invoke_delegated_skill") | .result.child_run? | select(. != null)]' "$rollout_copy_file")"
 completed_child_count="$(printf '%s' "$child_runs_json" | jq '[.[] | select(.terminal_status == "completed")] | length')"
 child_escalation_count=0
+child_rollout_files=()
 
 while IFS= read -r child_run; do
     child_rollout="$(printf '%s' "$child_run" | jq -r '.rollout_path // empty')"
     child_session="$(printf '%s' "$child_run" | jq -r '.session_id // "child"')"
     if [[ -n "$child_rollout" && -f "$child_rollout" ]]; then
-        cp "$child_rollout" "$output_dir/${child_session}.jsonl"
+        child_rollout_copy="$output_dir/${child_session}.jsonl"
+        cp "$child_rollout" "$child_rollout_copy"
+        child_rollout_files+=("$child_rollout_copy")
         child_rollout_escalation_count="$(jq -s '[.[] | select(.type == "tool_call") | select((.audit.action // "") == "escalate")] | length' "$child_rollout")"
         child_escalation_count=$((child_escalation_count + child_rollout_escalation_count))
     fi
 done < <(printf '%s\n' "$child_runs_json" | jq -c '.[]')
 
 escalation_count=$((parent_escalation_count + child_escalation_count))
+
+if (( ${#child_rollout_files[@]} > 0 )); then
+    jq -s '
+        def verification_command($cmd):
+            ($cmd | test("(^|[[:space:]])(pytest|py\\.test|nosetests|nosetests3)([[:space:]]|$)"))
+            or ($cmd | test("(^|[[:space:]])python(3)?([[:space:]]+[-[:alnum:]_./:=+]+)*[[:space:]]+-m[[:space:]]+(pytest|unittest)([[:space:]]|$)"))
+            or ($cmd | test("(^|[[:space:]])cargo[[:space:]]+(test|check|clippy)([[:space:]]|$)"))
+            or ($cmd | test("(^|[[:space:]])go[[:space:]]+test([[:space:]]|$)"))
+            or ($cmd | test("(^|[[:space:]])(npm|pnpm|yarn|bun)[[:space:]]+test([[:space:]]|$)"))
+            or ($cmd | test("(^|[[:space:]])(make|just)[[:space:]]+(test|check)([[:space:]]|$)"));
+        def verification_scope($cmd):
+            if ($cmd | test("(^|[[:space:]])(-k|::|--maxfail|test[^[:space:]]*|[^[:space:]]+\\.(py|rs|go|js|ts))([[:space:]]|$)")) then
+                "targeted"
+            else
+                "broader"
+            end;
+        def first_nonempty_line($text):
+            ($text // "" | split("\n") | map(select(length > 0)) | .[0] // "");
+        def first_meaningful_line($text):
+            ($text // "" | split("\n") | map(select(length > 0))) as $lines
+            | (
+                $lines
+                | map(select(test("command not found|No module named|ModuleNotFoundError|ImportError|AssertionError|FAILED|ERROR|ERR"; "i")))
+                | .[0]
+              ) // (
+                $lines
+                | map(
+                    select(
+                        (test("SyntaxWarning|DeprecationWarning|ResourceWarning"; "i") | not)
+                        and . != "\"\"\""
+                        and . != "E"
+                        and (test("^=+$") | not)
+                    )
+                )
+                | .[0]
+              ) // ($lines[0] // "");
+        def environment_blocked($text):
+            ($text // "" | test("command not found|No module named 'pytest'|No module named pytest|ModuleNotFoundError: No module named 'pytest'|ModuleNotFoundError: No module named pytest|No module named 'nose'|No module named nose|ModuleNotFoundError: No module named 'nose'|ModuleNotFoundError: No module named nose|executable file not found"; "i"));
+        [
+            .[]
+            | select(.type == "tool_call" and .name == "bash")
+            | . as $call
+            | ($call.arguments.command // "") as $cmd
+            | select(verification_command($cmd))
+            | ($call.result.stderr // $call.result.error // "") as $stderr
+            | ($call.result.stdout // "") as $stdout
+            | {
+                command: $cmd,
+                scope: verification_scope($cmd),
+                status: (
+                    if (($call.result.status // "") == "blocked_by_policy") then
+                        "blocked"
+                    elif (($call.result.exit_code // 1) == 0) then
+                        "passed"
+                    elif environment_blocked($stderr) then
+                        "environment_blocked"
+                    else
+                        "failed"
+                    end
+                ),
+                exit_code: ($call.result.exit_code // null),
+                summary: (
+                    first_meaningful_line($stderr) as $stderr_line
+                    | if $stderr_line != "" then
+                        $stderr_line
+                      else
+                        first_meaningful_line($stdout) as $stdout_line
+                        | if $stdout_line != "" then
+                            $stdout_line
+                          elif (($call.result.status // "") != "") then
+                            ($call.result.status // "")
+                          else
+                            "no output"
+                          end
+                      end
+                )
+            }
+        ]
+    ' "${child_rollout_files[@]}" >"$verification_entries_file"
+else
+    printf '[]\n' >"$verification_entries_file"
+fi
+
+jq -n \
+    --slurpfile entries "$verification_entries_file" \
+    '
+        ($entries[0] // []) as $entries
+        | ($entries | map(.status) | unique) as $status_kinds
+        | ($entries | map(select(.status == "passed")) | length) as $passed_count
+        | ($entries | map(select(.status == "failed")) | length) as $failed_count
+        | ($entries | map(select(.status == "environment_blocked")) | length) as $environment_blocked_count
+        | ($entries | map(select(.status == "blocked")) | length) as $blocked_count
+        | ($entries | map(select(.status == "not_run")) | length) as $not_run_count
+        | ($entries | length) as $attempted_count
+        | {
+            overall_status: (
+                if $attempted_count == 0 then
+                    "not_attempted"
+                elif (($status_kinds | length) > 1) then
+                    "mixed"
+                elif $passed_count == $attempted_count then
+                    "passed"
+                elif $failed_count == $attempted_count then
+                    "failed"
+                elif $environment_blocked_count == $attempted_count then
+                    "environment_blocked"
+                elif $blocked_count == $attempted_count then
+                    "blocked"
+                else
+                    "attempted"
+                end
+            ),
+            verification_attempted: ($attempted_count > 0),
+            attempted_count: $attempted_count,
+            passed_count: $passed_count,
+            failed_count: $failed_count,
+            environment_blocked_count: $environment_blocked_count,
+            blocked_count: $blocked_count,
+            not_run_count: $not_run_count,
+            all_passed: ($attempted_count > 0 and $passed_count == $attempted_count),
+            entries: $entries
+        }
+    ' >"$verification_summary_file"
 
 if [[ "$keep_session" != true ]]; then
     curl -fsS -X DELETE "$base_url/api/v1/sessions/$session_id" >/dev/null 2>&1 || true
@@ -465,7 +622,7 @@ jq -n \
             },
             {
                 name: "no_yield_or_timeout",
-                passed: ((not $timed_out) and (not $yielded))
+                passed: (($timed_out | not) and ($yielded | not))
             }
         ]
     }' >"$assertion_file"
@@ -484,6 +641,8 @@ jq -n \
     --arg assistant_output_file "$assistant_output_file" \
     --arg create_response_file "$create_response_file" \
     --arg submit_response_file "$submit_response_file" \
+    --arg assertion_file "$assertion_file" \
+    --arg kpi_file "$kpi_file" \
     --arg prediction_file "$prediction_file" \
     --arg predictions_jsonl "$predictions_jsonl" \
     --arg patch_file "$patch_file" \
@@ -492,6 +651,8 @@ jq -n \
     --arg events_file "$events_file" \
     --arg error_messages_file "$error_messages_file" \
     --arg warning_messages_file "$warning_messages_file" \
+    --arg verification_entries_file "$verification_entries_file" \
+    --arg verification_summary_file "$verification_summary_file" \
     --arg problem_statement_file "$problem_statement_file" \
     --argjson duration_secs "$duration_secs" \
     --argjson spawn_count "$spawn_count" \
@@ -504,9 +665,11 @@ jq -n \
     --argjson timed_out "$timed_out" \
     --argjson yielded "$yielded" \
     --argjson turn_completed "$turn_completed" \
+    --arg run_status "$run_status" \
     --argjson passed "$passed" \
     --argjson child_runs "$child_runs_json" \
     --argjson parent_inline_write_names "$parent_inline_write_names" \
+    --argjson verification_summary "$(jq -c . "$verification_summary_file")" \
     '{
         instance_id: $instance_id,
         dataset: $dataset,
@@ -517,6 +680,7 @@ jq -n \
         duration_secs: $duration_secs,
         session_id: $session_id,
         rollout_path: $rollout_path,
+        run_status: $run_status,
         resolved_model: $resolved_model,
         workspace_dir: $workspace_dir,
         problem_statement_file: (if $problem_statement_file == "" then null else $problem_statement_file end),
@@ -524,6 +688,8 @@ jq -n \
         assistant_output_file: $assistant_output_file,
         create_response_file: $create_response_file,
         submit_response_file: $submit_response_file,
+        assertion_file: $assertion_file,
+        kpi_file: $kpi_file,
         prediction_file: $prediction_file,
         predictions_jsonl: $predictions_jsonl,
         patch_file: $patch_file,
@@ -532,6 +698,8 @@ jq -n \
         events_file: $events_file,
         error_messages_file: $error_messages_file,
         warning_messages_file: $warning_messages_file,
+        verification_entries_file: $verification_entries_file,
+        verification_summary_file: $verification_summary_file,
         spawn_count: $spawn_count,
         parent_escalation_count: $parent_escalation_count,
         child_escalation_count: $child_escalation_count,
@@ -544,6 +712,10 @@ jq -n \
         yielded: $yielded,
         turn_completed: $turn_completed,
         passed: $passed,
+        orchestration_passed: $passed,
+        scoring_semantics: "passed reflects Alan-native orchestration assertions only; official resolved/unresolved status comes from the SWE-bench harness",
+        verification_status: $verification_summary.overall_status,
+        verification_summary: $verification_summary,
         child_runs: $child_runs
     }' >"$run_file"
 
@@ -584,6 +756,7 @@ echo "  resolved_model: $resolved_model"
 echo "  spawn_count: $spawn_count"
 echo "  escalation_count: $escalation_count"
 echo "  parent_inline_write_count: $parent_inline_write_count"
+echo "  verification_status: $(jq -r '.overall_status' "$verification_summary_file")"
 echo "  patch_bytes: $patch_bytes"
 echo "  artifacts: $output_dir"
 

--- a/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
+++ b/crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
     cat <<'USAGE'
 Usage:
-  crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh <suite-json> [--output-dir <dir>] [--agent <name>] [--keep-session]
+  crates/runtime/skills/repo-coding/scripts/run_swebench_full_steward_subset.sh <suite-json> [--output-dir <dir>] [--agent <name>] [--keep-session] [--score-official]
 
 Suite JSON fields:
   suite           Optional suite name (default: swebench_lite_curated).
@@ -16,7 +16,8 @@ Suite JSON fields:
 
 This runner calls `run_swebench_full_steward_case.sh` for each case, aggregates
 single-case outputs into one suite directory, writes a unified
-`predictions.jsonl`, and generates `score_with_official_harness.sh`.
+`predictions.jsonl`, generates `score_with_official_harness.sh`, and can
+optionally invoke the official SWE-bench harness immediately.
 USAGE
 }
 
@@ -34,6 +35,7 @@ suite_json=""
 output_dir=""
 cli_agent_name=""
 keep_session=false
+score_official=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -55,6 +57,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --keep-session)
             keep_session=true
+            shift
+            ;;
+        --score-official)
+            score_official=true
             shift
             ;;
         -h|--help)
@@ -125,6 +131,7 @@ suite_kpi_file="$output_dir/kpi.json"
 benchmark_file="$output_dir/benchmark.json"
 case_results_jsonl="$output_dir/case_results.jsonl"
 scoring_script="$output_dir/score_with_official_harness.sh"
+official_harness_manifest="$output_dir/official_harness_run.json"
 
 : >"$predictions_jsonl"
 : >"$case_results_jsonl"
@@ -134,6 +141,9 @@ start_epoch="$(date +%s)"
 total=0
 passed=0
 failed=0
+official_harness_requested=false
+official_harness_exit_code="null"
+official_harness_summary_json="null"
 
 case_runner="${ALAN_SWEBENCH_CASE_RUNNER:-$script_dir/run_swebench_full_steward_case.sh}"
 score_runner="${ALAN_SWEBENCH_SCORE_RUNNER:-$script_dir/score_swebench_predictions.sh}"
@@ -217,12 +227,68 @@ cat >"$scoring_script" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Optional:
+#   export ALAN_SWEBENCH_HARNESS_PYTHON_BIN=/absolute/path/to/harness/python
+#
 bash "$score_runner" "$predictions_jsonl" \\
   --dataset-name "$dataset_name" \\
   --max-workers "$max_workers" \\
-  --run-id "${suite_name}_\$(date -u +%Y%m%dT%H%M%SZ)"
+  --run-id "${suite_name}_\$(date -u +%Y%m%dT%H%M%SZ)" \\
+  --work-dir "$output_dir" \\
+  --manifest-file "$official_harness_manifest"
 EOF
 chmod +x "$scoring_script"
+
+if [[ "$score_official" == true ]]; then
+    official_harness_requested=true
+    set +e
+    bash "$score_runner" "$predictions_jsonl" \
+      --dataset-name "$dataset_name" \
+      --max-workers "$max_workers" \
+      --run-id "${suite_name}_$(date -u +%Y%m%dT%H%M%SZ)" \
+      --work-dir "$output_dir" \
+      --manifest-file "$official_harness_manifest"
+    official_harness_exit_code=$?
+    set -e
+    if [[ -f "$official_harness_manifest" ]]; then
+        official_harness_summary_json="$(jq -c . "$official_harness_manifest")"
+    fi
+fi
+
+if [[ "$official_harness_summary_json" != "null" ]]; then
+    official_instance_results_jsonl="$(printf '%s' "$official_harness_summary_json" | jq -r '.instance_results_jsonl // empty')"
+    if [[ -n "$official_instance_results_jsonl" && -f "$official_instance_results_jsonl" ]]; then
+        tmp_case_results_jsonl="$output_dir/case_results.with_official.tmp.jsonl"
+        : >"$tmp_case_results_jsonl"
+        while IFS= read -r case_record; do
+            if [[ -z "$case_record" ]]; then
+                continue
+            fi
+            case_instance_id="$(printf '%s' "$case_record" | jq -r '.run.instance_id // .instance_id // empty')"
+            official_result="$(jq -c --arg instance_id "$case_instance_id" 'select(.instance_id == $instance_id)' "$official_instance_results_jsonl" | head -n 1)"
+            if [[ -n "$official_result" ]]; then
+                case_official_result_file="$output_dir/cases/$case_instance_id/official_harness_instance_result.json"
+                printf '%s\n' "$official_result" >"$case_official_result_file"
+                jq -cn \
+                    --argjson record "$case_record" \
+                    --arg case_official_result_file "$case_official_result_file" \
+                    --argjson official "$official_result" \
+                    '$record + {
+                        official_harness_result_file: $case_official_result_file,
+                        official_harness_result: $official
+                    }' >>"$tmp_case_results_jsonl"
+            else
+                jq -cn \
+                    --argjson record "$case_record" \
+                    '$record + {
+                        official_harness_result_file: null,
+                        official_harness_result: null
+                    }' >>"$tmp_case_results_jsonl"
+            fi
+        done <"$case_results_jsonl"
+        mv "$tmp_case_results_jsonl" "$case_results_jsonl"
+    fi
+fi
 
 jq -n \
     --arg suite "$suite_name" \
@@ -233,6 +299,7 @@ jq -n \
     --arg finished_at "$finished_at" \
     --arg predictions_jsonl "$predictions_jsonl" \
     --arg scoring_script "$scoring_script" \
+    --arg official_harness_manifest "$official_harness_manifest" \
     --arg case_results_jsonl "$case_results_jsonl" \
     --argjson max_workers "$max_workers" \
     --argjson total "$total" \
@@ -241,6 +308,10 @@ jq -n \
     --argjson total_escalation_count "$total_escalation_count" \
     --argjson duration_secs "$duration_secs" \
     --argjson case_results "$(jq -s '.' "$case_results_jsonl")" \
+    --argjson official_harness_requested "$official_harness_requested" \
+    --argjson official_harness_exit_code "$official_harness_exit_code" \
+    --argjson official_harness "$official_harness_summary_json" \
+    --arg scoring_semantics "passed/failed counts reflect Alan-native orchestration case results; official resolved/unresolved status comes from the SWE-bench harness manifest when present" \
     '{
         suite: $suite,
         dataset: $dataset,
@@ -256,6 +327,11 @@ jq -n \
         max_workers: $max_workers,
         predictions_jsonl: $predictions_jsonl,
         scoring_script: $scoring_script,
+        official_harness_manifest: $official_harness_manifest,
+        official_harness_requested: $official_harness_requested,
+        official_harness_exit_code: $official_harness_exit_code,
+        official_harness: $official_harness,
+        scoring_semantics: $scoring_semantics,
         case_results_jsonl: $case_results_jsonl,
         case_results: $case_results
     }' >"$suite_run_file"
@@ -266,12 +342,17 @@ jq -n \
     --arg dataset_name "$dataset_name" \
     --arg predictions_jsonl "$predictions_jsonl" \
     --arg scoring_script "$scoring_script" \
+    --arg official_harness_manifest "$official_harness_manifest" \
     --argjson total_cases "$total" \
     --argjson passed_cases "$passed" \
     --argjson failed_cases "$failed" \
     --argjson total_escalation_count "$total_escalation_count" \
     --argjson pass_rate_percent "$pass_rate_percent" \
     --argjson duration_secs "$duration_secs" \
+    --argjson official_harness_requested "$official_harness_requested" \
+    --argjson official_harness_exit_code "$official_harness_exit_code" \
+    --argjson official_harness "$official_harness_summary_json" \
+    --arg scoring_semantics "passed/failed counts reflect Alan-native orchestration case results; official resolved/unresolved status comes from the SWE-bench harness manifest when present" \
     '{
         suite: $suite,
         dataset: $dataset,
@@ -283,7 +364,12 @@ jq -n \
         pass_rate_percent: $pass_rate_percent,
         duration_secs: $duration_secs,
         predictions_jsonl: $predictions_jsonl,
-        scoring_script: $scoring_script
+        scoring_script: $scoring_script,
+        official_harness_manifest: $official_harness_manifest,
+        official_harness_requested: $official_harness_requested,
+        official_harness_exit_code: $official_harness_exit_code,
+        official_harness: $official_harness,
+        scoring_semantics: $scoring_semantics
     }' >"$benchmark_file"
 
 jq -n \
@@ -318,10 +404,17 @@ echo "  total: $total"
 echo "  passed: $passed"
 echo "  failed: $failed"
 echo "  total_escalation_count: $total_escalation_count"
+if [[ "$official_harness_requested" == true ]]; then
+    echo "  official_harness_exit_code: $official_harness_exit_code"
+fi
 echo "  predictions: $predictions_jsonl"
 echo "  scoring_script: $scoring_script"
 echo "  artifacts: $output_dir"
 
 if (( failed > 0 )); then
+    exit 1
+fi
+
+if [[ "$official_harness_requested" == true && "$official_harness_exit_code" != "0" ]]; then
     exit 1
 fi

--- a/crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh
+++ b/crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh
@@ -4,15 +4,21 @@ set -euo pipefail
 usage() {
     cat <<'USAGE'
 Usage:
-  crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh <predictions-jsonl> [--dataset-name <name>] [--max-workers <n>] [--run-id <id>]
+  crates/runtime/skills/repo-coding/scripts/score_swebench_predictions.sh <predictions-jsonl> [--dataset-name <name>] [--max-workers <n>] [--run-id <id>] [--work-dir <dir>] [--manifest-file <path>] [--python-bin <path>]
 
 Defaults:
   dataset-name  princeton-nlp/SWE-bench_Lite
   max-workers   8
   run-id        swebench_eval_<timestamp>
+  work-dir      directory containing <predictions-jsonl>
+  manifest-file <work-dir>/official_harness_run.json
 
 This is a thin wrapper around the official SWE-bench harness entrypoint:
   python -m swebench.harness.run_evaluation
+
+Environment:
+  ALAN_SWEBENCH_HARNESS_PYTHON_BIN
+      Optional Python interpreter for the official harness.
 USAGE
 }
 
@@ -20,6 +26,9 @@ predictions_path=""
 dataset_name="princeton-nlp/SWE-bench_Lite"
 max_workers="8"
 run_id="swebench_eval_$(date -u +%Y%m%dT%H%M%SZ)"
+work_dir=""
+manifest_file=""
+python_bin_override=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -33,6 +42,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --run-id)
             run_id="$2"
+            shift 2
+            ;;
+        --work-dir)
+            work_dir="$2"
+            shift 2
+            ;;
+        --manifest-file)
+            manifest_file="$2"
+            shift 2
+            ;;
+        --python-bin)
+            python_bin_override="$2"
             shift 2
             ;;
         -h|--help)
@@ -59,23 +80,381 @@ if [[ -z "$predictions_path" ]]; then
     exit 2
 fi
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+preflight_script="$script_dir/check_swebench_harness_env.sh"
+
 if [[ ! -f "$predictions_path" ]]; then
     echo "Predictions file not found: $predictions_path" >&2
     exit 1
 fi
 
-python_bin=""
-if command -v python >/dev/null 2>&1; then
-    python_bin="python"
-elif command -v python3 >/dev/null 2>&1; then
-    python_bin="python3"
-else
-    echo "Missing required command: python or python3" >&2
-    exit 1
+predictions_path="$(cd "$(dirname "$predictions_path")" && pwd)/$(basename "$predictions_path")"
+if [[ -z "$work_dir" ]]; then
+    work_dir="$(dirname "$predictions_path")"
+fi
+mkdir -p "$work_dir"
+work_dir="$(cd "$work_dir" && pwd)"
+
+if [[ -z "$manifest_file" ]]; then
+    manifest_file="$work_dir/official_harness_run.json"
+fi
+mkdir -p "$(dirname "$manifest_file")"
+manifest_file="$(cd "$(dirname "$manifest_file")" && pwd)/$(basename "$manifest_file")"
+
+stdout_file="$work_dir/official_harness_stdout.log"
+stderr_file="$work_dir/official_harness_stderr.log"
+preflight_stderr_file="$work_dir/official_harness_preflight.stderr.log"
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+start_epoch="$(date +%s)"
+
+preflight_args=(--json)
+if [[ -n "$python_bin_override" ]]; then
+    preflight_args+=(--python-bin "$python_bin_override")
 fi
 
-"$python_bin" -m swebench.harness.run_evaluation \
-  --dataset_name "$dataset_name" \
-  --predictions_path "$predictions_path" \
-  --max_workers "$max_workers" \
-  --run_id "$run_id"
+preflight_status=0
+set +e
+preflight_json="$(bash "$preflight_script" "${preflight_args[@]}" 2>"$preflight_stderr_file")"
+preflight_status=$?
+set -e
+
+if [[ -z "$preflight_json" ]]; then
+    preflight_json='{"ready":false,"missing_requirements":["preflight_failed_without_json"]}'
+fi
+
+python_bin="$(printf '%s' "$preflight_json" | jq -r '.selected_python_bin // empty')"
+if [[ -z "$python_bin" ]]; then
+    python_bin="${python_bin_override:-${ALAN_SWEBENCH_HARNESS_PYTHON_BIN:-}}"
+fi
+
+exit_code=0
+if [[ "$preflight_status" -ne 0 ]]; then
+    printf 'Official SWE-bench harness preflight failed.\n' >"$stderr_file"
+    if [[ -s "$preflight_stderr_file" ]]; then
+        cat "$preflight_stderr_file" >>"$stderr_file"
+    fi
+    exit_code=1
+fi
+
+if [[ "$exit_code" -eq 0 ]]; then
+    set +e
+    (
+        cd "$work_dir"
+        "$python_bin" -m swebench.harness.run_evaluation \
+          --dataset_name "$dataset_name" \
+          --predictions_path "$predictions_path" \
+          --max_workers "$max_workers" \
+          --run_id "$run_id"
+    ) >"$stdout_file" 2>"$stderr_file"
+    exit_code=$?
+    set -e
+fi
+
+finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+duration_secs="$(( $(date +%s) - start_epoch ))"
+results_dir="$work_dir/evaluation_results/$run_id"
+results_json="$results_dir/results.json"
+instance_results_jsonl="$results_dir/instance_results.jsonl"
+logs_dir="$work_dir/logs"
+results_json_payload='null'
+report_json=""
+report_json_payload='null'
+instance_results_payload='[]'
+submitted_report_file="$work_dir/official_harness_submitted_report.json"
+submitted_report_payload='null'
+submitted_report_available=false
+instance_count=0
+resolved_count=0
+unresolved_count=0
+resolved_rate_percent="null"
+
+if [[ -f "$results_json" ]]; then
+    results_json_payload="$(jq -c . "$results_json")"
+fi
+
+report_json="$(find "$work_dir" -maxdepth 1 -type f -name "*.$run_id.json" | head -n 1)"
+if [[ -n "$report_json" && -f "$report_json" ]]; then
+    report_json_payload="$(jq -c . "$report_json")"
+fi
+
+if [[ ! -f "$instance_results_jsonl" && -n "$report_json" && -f "$report_json" ]]; then
+    synthesized_instance_results_jsonl="$work_dir/official_harness_instance_results.jsonl"
+    jq -c '
+        to_entries[]
+        | select(.value | type == "object")
+        | select(.value | has("resolved"))
+        | {
+            instance_id: .key,
+            resolved: (.value.resolved // false),
+            report: .value
+        }
+    ' "$report_json" >"$synthesized_instance_results_jsonl"
+    if [[ -s "$synthesized_instance_results_jsonl" ]]; then
+        instance_results_jsonl="$synthesized_instance_results_jsonl"
+    fi
+fi
+
+if [[ ! -f "$instance_results_jsonl" ]]; then
+    synthesized_instance_results_jsonl="$work_dir/official_harness_instance_results.jsonl"
+    : >"$synthesized_instance_results_jsonl"
+    while IFS= read -r instance_report_file; do
+        jq -c '
+            to_entries[]
+            | select(.value | type == "object")
+            | {
+                instance_id: .key,
+                resolved: (.value.resolved // false),
+                report: .value
+            }
+        ' "$instance_report_file" >>"$synthesized_instance_results_jsonl"
+    done < <(find "$logs_dir/run_evaluation/$run_id" -type f -name report.json 2>/dev/null | sort)
+    if [[ -s "$synthesized_instance_results_jsonl" ]]; then
+        instance_results_jsonl="$synthesized_instance_results_jsonl"
+    fi
+fi
+
+if [[ -f "$instance_results_jsonl" ]]; then
+    instance_results_payload="$(jq -s '.' "$instance_results_jsonl")"
+    instance_count="$(jq -s 'length' "$instance_results_jsonl")"
+    resolved_count="$(jq -s '[.[] | select(.resolved == true)] | length' "$instance_results_jsonl")"
+    unresolved_count=$((instance_count - resolved_count))
+    if (( instance_count > 0 )); then
+        resolved_rate_percent="$(awk "BEGIN { printf \"%.2f\", ($resolved_count / $instance_count) * 100 }")"
+    fi
+fi
+
+if [[ -f "$instance_results_jsonl" ]]; then
+    jq -n \
+        --arg report_json "$report_json" \
+        --argjson report "$report_json_payload" \
+        --argjson instance_results "$instance_results_payload" \
+        --argjson instance_count "$instance_count" \
+        --argjson resolved_count "$resolved_count" \
+        --argjson unresolved_count "$unresolved_count" \
+        '{
+            submitted_instances: ($report.submitted_instances // $instance_count),
+            completed_instances: ($report.completed_instances // $instance_count),
+            resolved_instances: ($report.resolved_instances // $resolved_count),
+            unresolved_instances: ($report.unresolved_instances // $unresolved_count),
+            empty_patch_instances: ($report.empty_patch_instances // 0),
+            error_instances: ($report.error_instances // 0),
+            submitted_ids: ($report.submitted_ids // ($instance_results | map(.instance_id))),
+            completed_ids: ($report.completed_ids // ($instance_results | map(.instance_id))),
+            resolved_ids: ($report.resolved_ids // ($instance_results | map(select(.resolved == true) | .instance_id))),
+            unresolved_ids: ($report.unresolved_ids // ($instance_results | map(select(.resolved != true) | .instance_id))),
+            error_ids: ($report.error_ids // []),
+            empty_patch_ids: ($report.empty_patch_ids // []),
+            missing_ids: (($report.submitted_ids // ($instance_results | map(.instance_id)))
+                - ($report.completed_ids // ($instance_results | map(.instance_id)))),
+            report_json: (if $report_json == "" then null else $report_json end)
+        }' >"$submitted_report_file"
+    submitted_report_payload="$(jq -c . "$submitted_report_file")"
+    submitted_report_available=true
+fi
+
+jq -n \
+    --arg dataset_name "$dataset_name" \
+    --arg predictions_path "$predictions_path" \
+    --arg run_id "$run_id" \
+    --arg work_dir "$work_dir" \
+    --arg started_at "$started_at" \
+    --arg finished_at "$finished_at" \
+    --arg stdout_file "$stdout_file" \
+    --arg stderr_file "$stderr_file" \
+    --arg results_dir "$results_dir" \
+    --arg results_json "$results_json" \
+    --arg instance_results_jsonl "$instance_results_jsonl" \
+    --arg report_json "$report_json" \
+    --arg submitted_report_file "$submitted_report_file" \
+    --arg logs_dir "$logs_dir" \
+    --arg preflight_stderr_file "$preflight_stderr_file" \
+    --argjson max_workers "$max_workers" \
+    --argjson duration_secs "$duration_secs" \
+    --argjson exit_code "$exit_code" \
+    --argjson preflight "$preflight_json" \
+    --argjson results_json_available "$([[ -f "$results_json" ]] && echo true || echo false)" \
+    --argjson instance_results_available "$([[ -f "$instance_results_jsonl" ]] && echo true || echo false)" \
+    --argjson report_json_available "$([[ -n "$report_json" && -f "$report_json" ]] && echo true || echo false)" \
+    --argjson submitted_report_available "$submitted_report_available" \
+    --argjson instance_count "$instance_count" \
+    --argjson resolved_count "$resolved_count" \
+    --argjson unresolved_count "$unresolved_count" \
+    --argjson results "$results_json_payload" \
+    --argjson report "$report_json_payload" \
+    --argjson submitted_report "$submitted_report_payload" \
+    '{
+        dataset_name: $dataset_name,
+        predictions_path: $predictions_path,
+        run_id: $run_id,
+        work_dir: $work_dir,
+        started_at: $started_at,
+        finished_at: $finished_at,
+        duration_secs: $duration_secs,
+        exit_code: $exit_code,
+        preflight: $preflight,
+        overall_status: (
+            if ($preflight.ready | not) then
+                "preflight_failed"
+            elif $exit_code != 0 then
+                "failed_to_run"
+            elif ($instance_results_available and $instance_count > 0 and $resolved_count == $instance_count) then
+                "all_resolved"
+            elif ($instance_results_available and $resolved_count > 0) then
+                "partially_resolved"
+            elif $instance_results_available then
+                "none_resolved"
+            else
+                "completed_without_instance_results"
+            end
+        ),
+        max_workers: $max_workers,
+        stdout_file: $stdout_file,
+        stderr_file: $stderr_file,
+        preflight_stderr_file: (if ($preflight.ready | not) and ($preflight_stderr_file != "") then $preflight_stderr_file else null end),
+        results_dir: $results_dir,
+        results_json: (if $results_json_available then $results_json else null end),
+        instance_results_jsonl: (if $instance_results_available then $instance_results_jsonl else null end),
+        report_json: (if $report_json_available then $report_json else null end),
+        submitted_report_json: (if $submitted_report_available then $submitted_report_file else null end),
+        logs_dir: $logs_dir,
+        results_json_available: $results_json_available,
+        instance_results_available: $instance_results_available,
+        report_json_available: $report_json_available,
+        submitted_report_available: $submitted_report_available,
+        instance_count: $instance_count,
+        resolved_count: $resolved_count,
+        unresolved_count: $unresolved_count,
+        results: (if $results_json_available then $results else null end),
+        report: (if $report_json_available then $report else null end),
+        submitted_report: (if $submitted_report_available then $submitted_report else null end)
+    }' >"$manifest_file"
+
+if [[ -f "$instance_results_jsonl" ]]; then
+    while IFS= read -r official_result; do
+        if [[ -z "$official_result" ]]; then
+            continue
+        fi
+        case_instance_id="$(printf '%s' "$official_result" | jq -r '.instance_id // empty')"
+        if [[ -z "$case_instance_id" ]]; then
+            continue
+        fi
+        case_official_result_dir="$work_dir/cases/$case_instance_id"
+        if [[ -d "$case_official_result_dir" ]]; then
+            printf '%s\n' "$official_result" >"$case_official_result_dir/official_harness_instance_result.json"
+        fi
+    done <"$instance_results_jsonl"
+fi
+
+case_results_jsonl="$work_dir/case_results.jsonl"
+if [[ -f "$case_results_jsonl" && -f "$instance_results_jsonl" ]]; then
+    tmp_case_results_jsonl="$work_dir/case_results.with_official.tmp.jsonl"
+    : >"$tmp_case_results_jsonl"
+    while IFS= read -r case_record; do
+        if [[ -z "$case_record" ]]; then
+            continue
+        fi
+        case_instance_id="$(printf '%s' "$case_record" | jq -r '.run.instance_id // .instance_id // empty')"
+        official_result="$(jq -c --arg instance_id "$case_instance_id" 'select(.instance_id == $instance_id)' "$instance_results_jsonl" | head -n 1)"
+        if [[ -n "$official_result" ]]; then
+            case_official_result_file="$work_dir/cases/$case_instance_id/official_harness_instance_result.json"
+            jq -cn \
+                --argjson record "$case_record" \
+                --arg case_official_result_file "$case_official_result_file" \
+                --argjson official "$official_result" \
+                '$record + {
+                    official_harness_result_file: $case_official_result_file,
+                    official_harness_result: $official
+                }' >>"$tmp_case_results_jsonl"
+        else
+            jq -cn \
+                --argjson record "$case_record" \
+                '$record + {
+                    official_harness_result_file: null,
+                    official_harness_result: null
+                }' >>"$tmp_case_results_jsonl"
+        fi
+    done <"$case_results_jsonl"
+    mv "$tmp_case_results_jsonl" "$case_results_jsonl"
+fi
+
+manifest_payload="$(jq -c . "$manifest_file")"
+suite_run_file="$work_dir/run.json"
+if [[ -f "$suite_run_file" ]]; then
+    tmp_suite_run_file="$work_dir/run.with_official.tmp.json"
+    jq \
+        --arg official_harness_manifest "$manifest_file" \
+        --arg case_results_jsonl "$case_results_jsonl" \
+        --argjson official_harness "$manifest_payload" \
+        --argjson official_harness_requested true \
+        --argjson official_harness_exit_code "$exit_code" \
+        --argjson case_results "$([[ -f "$case_results_jsonl" ]] && jq -s . "$case_results_jsonl" || printf 'null')" \
+        --argjson submitted_report "$submitted_report_payload" \
+        '. + {
+            official_harness_manifest: $official_harness_manifest,
+            official_harness_requested: $official_harness_requested,
+            official_harness_exit_code: $official_harness_exit_code,
+            official_harness: $official_harness,
+            official_harness_submitted_report_file: (if $submitted_report == null then null else ($official_harness.submitted_report_json // null) end),
+            official_harness_submitted_report: $submitted_report,
+            case_results_jsonl: (if $case_results == null then .case_results_jsonl else $case_results_jsonl end),
+            case_results: (if $case_results == null then .case_results else $case_results end)
+        }' "$suite_run_file" >"$tmp_suite_run_file"
+    mv "$tmp_suite_run_file" "$suite_run_file"
+fi
+
+suite_benchmark_file="$work_dir/benchmark.json"
+if [[ -f "$suite_benchmark_file" ]]; then
+    tmp_suite_benchmark_file="$work_dir/benchmark.with_official.tmp.json"
+    jq \
+        --arg official_harness_manifest "$manifest_file" \
+        --argjson official_harness "$manifest_payload" \
+        --argjson official_harness_requested true \
+        --argjson official_harness_exit_code "$exit_code" \
+        --argjson submitted_report "$submitted_report_payload" \
+        '. + {
+            official_harness_manifest: $official_harness_manifest,
+            official_harness_requested: $official_harness_requested,
+            official_harness_exit_code: $official_harness_exit_code,
+            official_harness: $official_harness,
+            official_harness_submitted_report_file: (if $submitted_report == null then null else ($official_harness.submitted_report_json // null) end),
+            official_harness_submitted_report: $submitted_report
+        }' "$suite_benchmark_file" >"$tmp_suite_benchmark_file"
+    mv "$tmp_suite_benchmark_file" "$suite_benchmark_file"
+fi
+
+suite_kpi_file="$work_dir/kpi.json"
+if [[ -f "$suite_kpi_file" ]]; then
+    tmp_suite_kpi_file="$work_dir/kpi.with_official.tmp.json"
+    jq \
+        --argjson official_harness_requested true \
+        --argjson official_harness_exit_code "$exit_code" \
+        --argjson official_harness "$manifest_payload" \
+        --argjson submitted_report "$submitted_report_payload" \
+        --argjson official_instance_count "$instance_count" \
+        --argjson official_resolved_count "$resolved_count" \
+        --argjson official_unresolved_count "$unresolved_count" \
+        --argjson official_resolved_rate_percent "$resolved_rate_percent" \
+        '. + {
+            official_harness_requested: $official_harness_requested,
+            official_harness_exit_code: $official_harness_exit_code,
+            official_harness_overall_status: $official_harness.overall_status,
+            official_instance_count: $official_instance_count,
+            official_resolved_count: $official_resolved_count,
+            official_unresolved_count: $official_unresolved_count,
+            official_resolved_rate_percent: $official_resolved_rate_percent,
+            official_resolved_ids: (if $submitted_report == null then [] else ($submitted_report.resolved_ids // []) end),
+            official_unresolved_ids: (if $submitted_report == null then [] else ($submitted_report.unresolved_ids // []) end)
+        }' "$suite_kpi_file" >"$tmp_suite_kpi_file"
+    mv "$tmp_suite_kpi_file" "$suite_kpi_file"
+fi
+
+if [[ -s "$stdout_file" ]]; then
+    cat "$stdout_file"
+fi
+if [[ -s "$stderr_file" ]]; then
+    cat "$stderr_file" >&2
+fi
+
+if [[ "$exit_code" -ne 0 ]]; then
+    exit "$exit_code"
+fi

--- a/crates/runtime/skills/repo-coding/scripts/setup_swebench_harness_env.sh
+++ b/crates/runtime/skills/repo-coding/scripts/setup_swebench_harness_env.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  crates/runtime/skills/repo-coding/scripts/setup_swebench_harness_env.sh [--venv-dir <dir>] [--python-bin <path>]
+
+Creates a dedicated virtualenv for the official SWE-bench harness and installs
+the `swebench` Python package into it.
+
+Defaults:
+  venv-dir   target/benchmarks/swebench_harness/.venv
+
+Environment:
+  ALAN_SWEBENCH_HARNESS_PYTHON_BIN
+      Optional default base interpreter.
+
+After setup, export:
+  ALAN_SWEBENCH_HARNESS_PYTHON_BIN=<venv-dir>/bin/python
+USAGE
+}
+
+venv_dir=""
+python_bin_override=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --venv-dir)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            venv_dir="$2"
+            shift 2
+            ;;
+        --python-bin)
+            if [[ -z "${2:-}" ]]; then
+                usage
+                exit 2
+            fi
+            python_bin_override="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+
+if [[ -z "$venv_dir" ]]; then
+    venv_dir="$repo_root/target/benchmarks/swebench_harness/.venv"
+fi
+
+pick_python_bin() {
+    if [[ -n "$python_bin_override" ]]; then
+        printf '%s\n' "$python_bin_override"
+    elif [[ -n "${ALAN_SWEBENCH_HARNESS_PYTHON_BIN:-}" ]]; then
+        printf '%s\n' "$ALAN_SWEBENCH_HARNESS_PYTHON_BIN"
+    elif command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' "python3"
+    elif command -v python >/dev/null 2>&1; then
+        printf '%s\n' "python"
+    else
+        printf '\n'
+    fi
+}
+
+base_python_bin="$(pick_python_bin)"
+if [[ -z "$base_python_bin" ]]; then
+    echo "Missing required command: python3 or python" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$venv_dir")"
+"$base_python_bin" -m venv "$venv_dir"
+
+harness_python="$venv_dir/bin/python"
+"$harness_python" -m pip install --upgrade pip setuptools wheel
+"$harness_python" -m pip install swebench socksio
+
+echo "SWE-bench harness environment ready:"
+echo "  venv_dir: $venv_dir"
+echo "  harness_python: $harness_python"
+echo "  export ALAN_SWEBENCH_HARNESS_PYTHON_BIN=$harness_python"
+
+bash "$script_dir/check_swebench_harness_env.sh" --python-bin "$harness_python"

--- a/crates/runtime/skills/repo-coding/scripts/validate_delivery_contract.sh
+++ b/crates/runtime/skills/repo-coding/scripts/validate_delivery_contract.sh
@@ -28,20 +28,94 @@ jq -e '
   def one_of($value; $choices):
     $choices | index($value) != null;
 
+  def is_test_path($path):
+    $path | test("(^|/)(tests?|specs?|__tests__)(/|$)|(^|/)[^/]+(_test|_spec)\\.[^/]+$|(^|/)[^/]+\\.(test|spec)\\.[^/]+$");
+
+  def attempted_entries($entries):
+    $entries | map(select(.status != "not_run"));
+
+  def expected_overall_status($entries):
+    attempted_entries($entries) as $attempted
+    | ($attempted | map(.status) | unique) as $attempted_statuses
+    | if ($entries | length) == 0 or ($attempted | length) == 0 then
+        "not_attempted"
+      elif ($entries | length) > ($attempted | length) then
+        "mixed"
+      elif ($attempted_statuses | length) > 1 then
+        "mixed"
+      elif ($attempted_statuses[0] // "") == "passed" then
+        "passed"
+      elif ($attempted_statuses[0] // "") == "failed" then
+        "failed"
+      elif ($attempted_statuses[0] // "") == "environment_blocked" then
+        "environment_blocked"
+      elif ($attempted_statuses[0] // "") == "blocked" then
+        "blocked"
+      else
+        "mixed"
+      end;
+
   (.status | type == "string") and
   (.status as $status | one_of($status; ["completed", "blocked", "failed"])) and
   (.summary | type == "string" and length > 0) and
   (.changed_files | type == "array" and all(.[]; type == "string")) and
-  (.verification | type == "array" and length > 0) and
+  (.behavioral_guards | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and
+  (
+    (.changed_files | any(.[]; is_test_path(.))) as $has_test_changes
+    | if $has_test_changes then
+        (.test_change_reason | type == "string" and length > 0)
+      else
+        ((has("test_change_reason") | not) or (.test_change_reason == null) or (.test_change_reason | type == "string"))
+      end
+  ) and
+  (.verification | type == "object") and
+  (.verification.entries | type == "array") and
   all(
-    .verification[];
+    .verification.entries[];
     (.command | type == "string" and length > 0) and
     (.scope | type == "string") and
     (.scope as $scope | one_of($scope; ["targeted", "broader"])) and
     (.status | type == "string") and
-    (.status as $status | one_of($status; ["passed", "failed", "not_run"])) and
-    (.exit_code | type == "number") and
+    (.status as $status | one_of($status; ["passed", "failed", "blocked", "environment_blocked", "not_run"])) and
+    (
+      if .status == "passed" then
+        (.exit_code | type == "number" and . == 0)
+      elif .status == "failed" or .status == "environment_blocked" then
+        (.exit_code | type == "number" and . != 0)
+      else
+        .exit_code == null
+      end
+    ) and
     (.summary | type == "string" and length > 0)
+  ) and
+  (.verification.overall_status | type == "string") and
+  (.verification.overall_status as $status | one_of($status; ["passed", "failed", "blocked", "environment_blocked", "mixed", "not_attempted"])) and
+  (.verification.verification_attempted | type == "boolean") and
+  (.verification.attempted_count | type == "number") and
+  (.verification.passed_count | type == "number") and
+  (.verification.failed_count | type == "number") and
+  (.verification.environment_blocked_count | type == "number") and
+  (.verification.blocked_count | type == "number") and
+  (.verification.not_run_count | type == "number") and
+  (.verification.all_passed | type == "boolean") and
+  (
+    (.verification.entries // []) as $entries
+    | attempted_entries($entries) as $attempted
+    | ($entries | map(select(.status == "passed")) | length) as $passed_count
+    | ($entries | map(select(.status == "failed")) | length) as $failed_count
+    | ($entries | map(select(.status == "environment_blocked")) | length) as $environment_blocked_count
+    | ($entries | map(select(.status == "blocked")) | length) as $blocked_count
+    | ($entries | map(select(.status == "not_run")) | length) as $not_run_count
+    | ($attempted | length) as $attempted_count
+    | .verification.attempted_count == $attempted_count
+    and .verification.passed_count == $passed_count
+    and .verification.failed_count == $failed_count
+    and .verification.environment_blocked_count == $environment_blocked_count
+    and .verification.blocked_count == $blocked_count
+    and .verification.not_run_count == $not_run_count
+    and .verification.verification_attempted == ($attempted_count > 0)
+    and .verification.all_passed == ($attempted_count > 0 and $passed_count == $attempted_count)
+    and .verification.overall_status == expected_overall_status($entries)
   ) and
   (.residual_risks | type == "array" and all(.[]; type == "string")) and
   (.evaluator | type == "object") and

--- a/crates/runtime/skills/skill-creator/agents/skill-creator/agent.toml
+++ b/crates/runtime/skills/skill-creator/agents/skill-creator/agent.toml
@@ -1,1 +1,0 @@
-openai_responses_model = "gpt-5.4"

--- a/crates/runtime/skills/workspace-inspect/agents/workspace-reader/agent.toml
+++ b/crates/runtime/skills/workspace-inspect/agents/workspace-reader/agent.toml
@@ -1,5 +1,3 @@
-openai_responses_model = "gpt-5.4"
-
 [[skill_overrides]]
 skill = "workspace-inspect"
 enabled = false

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -665,7 +665,9 @@ impl Config {
         let mut config: Self = merged
             .try_into()
             .context("failed to deserialize merged agent-root configuration")?;
-        if config.connection_profile.is_none() {
+        if config.connection_profile == self.connection_profile {
+            config.copy_internal_provider_config_from(self);
+        } else if config.connection_profile.is_none() {
             config.connection_profile = self.connection_profile.clone();
             config.copy_internal_provider_config_from(self);
         }
@@ -1761,6 +1763,21 @@ allow_implicit_invocation = false
     }
 
     #[test]
+    fn test_builtin_launch_root_agent_configs_parse_as_agent_overlays() {
+        let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let paths = [
+            crate_root.join("skills/repo-coding/agents/repo-worker/agent.toml"),
+            crate_root.join("skills/workspace-inspect/agents/workspace-reader/agent.toml"),
+            crate_root.join("skills/skill-creator/agents/skill-creator/agent.toml"),
+        ];
+
+        for path in paths {
+            Config::from_file(&path)
+                .unwrap_or_else(|err| panic!("failed to parse {}: {err:#}", path.display()));
+        }
+    }
+
+    #[test]
     fn test_config_file_path_prefers_alan_config_path_env() {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -2185,6 +2202,31 @@ supports_reasoning = true
         assert_eq!(overlaid.thinking_budget_tokens, Some(1024));
         assert_eq!(overlaid.effective_model_info().unwrap().slug, "custom-kimi");
         assert_eq!(overlaid.effective_context_window_tokens(), 654_321);
+    }
+
+    #[test]
+    fn test_with_agent_root_overlays_preserves_internal_provider_state_for_same_connection_profile()
+    {
+        let temp = TempDir::new().unwrap();
+        let overlay_path = temp.path().join("agent.toml");
+        std::fs::write(&overlay_path, "tool_repeat_limit = 9\n").unwrap();
+
+        let mut config = Config::default();
+        config.connection_profile = Some("openai-main".to_string());
+        config.llm_provider = LlmProvider::OpenAiResponses;
+        config.openai_responses_api_key = Some("sk-test".to_string());
+        config.openai_responses_model = "gpt-5.4".to_string();
+
+        let overlaid = config.with_agent_root_overlays(&[overlay_path]).unwrap();
+
+        assert_eq!(overlaid.connection_profile.as_deref(), Some("openai-main"));
+        assert_eq!(overlaid.llm_provider, LlmProvider::OpenAiResponses);
+        assert_eq!(
+            overlaid.openai_responses_api_key.as_deref(),
+            Some("sk-test")
+        );
+        assert_eq!(overlaid.openai_responses_model, "gpt-5.4");
+        assert_eq!(overlaid.tool_repeat_limit, 9);
     }
 
     #[test]

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -2211,11 +2211,13 @@ supports_reasoning = true
         let overlay_path = temp.path().join("agent.toml");
         std::fs::write(&overlay_path, "tool_repeat_limit = 9\n").unwrap();
 
-        let mut config = Config::default();
-        config.connection_profile = Some("openai-main".to_string());
-        config.llm_provider = LlmProvider::OpenAiResponses;
-        config.openai_responses_api_key = Some("sk-test".to_string());
-        config.openai_responses_model = "gpt-5.4".to_string();
+        let config = Config {
+            connection_profile: Some("openai-main".to_string()),
+            llm_provider: LlmProvider::OpenAiResponses,
+            openai_responses_api_key: Some("sk-test".to_string()),
+            openai_responses_model: "gpt-5.4".to_string(),
+            ..Default::default()
+        };
 
         let overlaid = config.with_agent_root_overlays(&[overlay_path]).unwrap();
 

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -45,6 +45,7 @@ pub(crate) struct ChildRuntimeResult {
     pub rollout_path: Option<PathBuf>,
     pub output_text: String,
     pub turn_summary: Option<String>,
+    pub structured_output: Option<serde_json::Value>,
     pub warnings: Vec<String>,
     pub error_message: Option<String>,
     pub pause: Option<ChildRuntimePause>,
@@ -54,6 +55,7 @@ pub(crate) struct ChildRuntimeResult {
 struct ObservedChildTerminalEvent {
     output_text: String,
     turn_summary: Option<String>,
+    structured_output: Option<serde_json::Value>,
     warnings: Vec<String>,
     error_message: Option<String>,
     pause: Option<ChildRuntimePause>,
@@ -395,13 +397,28 @@ impl ChildRuntimeController {
         let mut warnings = self.startup_metadata.warnings.clone();
         warnings.extend(observed.warnings);
         self.terminate_runtime().await;
+        let rollout_fallback_text = if observed.output_text.trim().is_empty() {
+            read_latest_assistant_text_from_rollout(self.startup_metadata.rollout_path.as_deref())
+                .await
+        } else {
+            None
+        };
+        let output_text = if observed.output_text.trim().is_empty() {
+            rollout_fallback_text.unwrap_or(observed.output_text)
+        } else {
+            observed.output_text
+        };
+        let structured_output = observed
+            .structured_output
+            .or_else(|| parse_child_structured_output(output_text.as_str()));
 
         Ok(ChildRuntimeResult {
             status: observed.status,
             session_id: self.startup_metadata.session_id.clone(),
             rollout_path: self.startup_metadata.rollout_path.clone(),
-            output_text: observed.output_text,
+            output_text,
             turn_summary: observed.turn_summary,
+            structured_output,
             warnings,
             error_message: observed.error_message,
             pause: observed.pause,
@@ -421,6 +438,7 @@ impl ChildRuntimeController {
             rollout_path: self.startup_metadata.rollout_path.clone(),
             output_text: String::new(),
             turn_summary: None,
+            structured_output: None,
             warnings: self.startup_metadata.warnings.clone(),
             error_message: None,
             pause: None,
@@ -512,9 +530,11 @@ impl ChildRuntimeController {
                         None
                     }
                     alan_protocol::Event::TurnCompleted { summary } => {
+                        let structured_output = parse_child_structured_output(output_text.as_str());
                         Some(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
                             turn_summary: summary,
+                            structured_output,
                             warnings: warnings.clone(),
                             error_message: None,
                             pause: None,
@@ -523,25 +543,33 @@ impl ChildRuntimeController {
                     }
                     alan_protocol::Event::Yield {
                         request_id, kind, ..
-                    } => Some(ObservedChildTerminalEvent {
-                        output_text: output_text.clone(),
-                        turn_summary: None,
-                        warnings: warnings.clone(),
-                        error_message: None,
-                        pause: Some(ChildRuntimePause { request_id, kind }),
-                        status: ChildRuntimeStatus::Paused,
-                    }),
+                    } => {
+                        let structured_output = parse_child_structured_output(output_text.as_str());
+                        Some(ObservedChildTerminalEvent {
+                            output_text: output_text.clone(),
+                            turn_summary: None,
+                            structured_output,
+                            warnings: warnings.clone(),
+                            error_message: None,
+                            pause: Some(ChildRuntimePause { request_id, kind }),
+                            status: ChildRuntimeStatus::Paused,
+                        })
+                    }
                     alan_protocol::Event::Error {
                         message,
                         recoverable,
-                    } if !recoverable => Some(ObservedChildTerminalEvent {
-                        output_text: output_text.clone(),
-                        turn_summary: None,
-                        warnings: warnings.clone(),
-                        error_message: Some(message),
-                        pause: None,
-                        status: ChildRuntimeStatus::Failed,
-                    }),
+                    } if !recoverable => {
+                        let structured_output = parse_child_structured_output(output_text.as_str());
+                        Some(ObservedChildTerminalEvent {
+                            output_text: output_text.clone(),
+                            turn_summary: None,
+                            structured_output,
+                            warnings: warnings.clone(),
+                            error_message: Some(message),
+                            pause: None,
+                            status: ChildRuntimeStatus::Failed,
+                        })
+                    }
                     alan_protocol::Event::Error { message, .. } => {
                         warnings.push(message);
                         None
@@ -557,6 +585,7 @@ impl ChildRuntimeController {
                 Some(ObservedChildTerminalEvent {
                     output_text: output_text.clone(),
                     turn_summary: None,
+                    structured_output: parse_child_structured_output(output_text.as_str()),
                     warnings: warnings.clone(),
                     error_message: Some(message),
                     pause: None,
@@ -566,6 +595,7 @@ impl ChildRuntimeController {
             Err(RecvError::Closed) => Some(ObservedChildTerminalEvent {
                 output_text: output_text.clone(),
                 turn_summary: None,
+                structured_output: parse_child_structured_output(output_text.as_str()),
                 warnings: warnings.clone(),
                 error_message: Some(
                     "Child-agent runtime stopped before producing a terminal event".to_string(),
@@ -592,12 +622,119 @@ impl ChildRuntimeController {
         ObservedChildTerminalEvent {
             output_text: String::new(),
             turn_summary: None,
+            structured_output: None,
             warnings: Vec::new(),
             error_message: Some("Child-agent turn timed out".to_string()),
             pause: None,
             status: ChildRuntimeStatus::TimedOut,
         }
     }
+}
+
+fn parse_child_structured_output(text: &str) -> Option<serde_json::Value> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    serde_json::from_str::<serde_json::Value>(trimmed)
+        .ok()
+        .or_else(|| parse_last_json_fenced_block(trimmed))
+}
+
+async fn read_latest_assistant_text_from_rollout(rollout_path: Option<&Path>) -> Option<String> {
+    let rollout_path = rollout_path?;
+    let contents = tokio::fs::read_to_string(rollout_path).await.ok()?;
+    extract_latest_assistant_text_from_rollout(contents.as_str())
+}
+
+fn extract_latest_assistant_text_from_rollout(contents: &str) -> Option<String> {
+    let mut last_text = None;
+
+    for line in contents.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        if object.get("type").and_then(serde_json::Value::as_str) != Some("message") {
+            continue;
+        }
+        if object.get("role").and_then(serde_json::Value::as_str) != Some("assistant") {
+            continue;
+        }
+
+        let direct_content = object
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .and_then(non_empty_trimmed);
+        if direct_content.is_some() {
+            last_text = direct_content;
+            continue;
+        }
+
+        let nested_parts = object
+            .get("message")
+            .and_then(|message| message.get("parts"))
+            .and_then(serde_json::Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|part| {
+                        if part.get("type").and_then(serde_json::Value::as_str) == Some("text") {
+                            part.get("text")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::trim)
+                                .filter(|text| !text.is_empty())
+                                .map(ToOwned::to_owned)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .filter(|parts| !parts.is_empty())
+            .map(|parts| parts.join("\n"));
+        if nested_parts.is_some() {
+            last_text = nested_parts;
+        }
+    }
+
+    last_text
+}
+
+fn non_empty_trimmed(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn parse_last_json_fenced_block(text: &str) -> Option<serde_json::Value> {
+    let mut remainder = text;
+    let mut last_match = None;
+
+    while let Some(start_idx) = remainder.find("```") {
+        let fence_remainder = &remainder[start_idx + 3..];
+        let Some(newline_idx) = fence_remainder.find('\n') else {
+            break;
+        };
+        let info_string = fence_remainder[..newline_idx].trim().to_ascii_lowercase();
+        let content_start = start_idx + 3 + newline_idx + 1;
+        let content_remainder = &remainder[content_start..];
+        let Some(end_idx) = content_remainder.find("```") else {
+            break;
+        };
+        if info_string.is_empty() || info_string == "json" {
+            last_match = Some(content_remainder[..end_idx].trim().to_string());
+        }
+        remainder = &content_remainder[end_idx + 3..];
+    }
+
+    last_match.and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
 }
 
 fn build_child_agent_config(parent: &RuntimeLoopState, spec: &SpawnSpec) -> AgentConfig {
@@ -2066,6 +2203,123 @@ thinking_budget_tokens = 1024
         let result = controller.join().await.unwrap();
         assert_eq!(result.status, ChildRuntimeStatus::Completed);
         assert_eq!(result.output_text, "final child output");
+        assert!(result.structured_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn child_runtime_join_extracts_structured_output_from_json_body() {
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let submission_id = "sub-json".to_string();
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::TextDelta {
+                chunk: "{\"status\":\"completed\",\"summary\":\"done\"}".to_string(),
+                is_final: true,
+            },
+        });
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::TurnCompleted { summary: None },
+        });
+
+        let controller = ChildRuntimeController {
+            runtime: None,
+            startup_metadata: RuntimeStartupMetadata {
+                session_id: "child-session".to_string(),
+                rollout_path: None,
+                durability: super::super::engine::SessionDurabilityState {
+                    durable: false,
+                    required: false,
+                },
+                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+                warnings: Vec::new(),
+            },
+            event_rx: rx,
+            submission_id,
+            timeout: None,
+        };
+
+        let result = controller.join().await.unwrap();
+        assert_eq!(result.status, ChildRuntimeStatus::Completed);
+        assert_eq!(
+            result
+                .structured_output
+                .as_ref()
+                .and_then(|v| v.get("summary")),
+            Some(&serde_json::json!("done"))
+        );
+    }
+
+    #[tokio::test]
+    async fn child_runtime_join_backfills_output_from_rollout_without_text_deltas() {
+        let rollout = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            rollout.path(),
+            concat!(
+                "{\"type\":\"session_meta\",\"session_id\":\"child-session\",\"started_at\":\"2026-04-22T13:08:19Z\",\"cwd\":\"/tmp\",\"model\":\"gpt-5.4\"}\n",
+                "{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"{\\\"status\\\":\\\"completed\\\",\\\"summary\\\":\\\"done\\\"}\"}\n"
+            ),
+        )
+        .unwrap();
+
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let submission_id = "sub-rollout".to_string();
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::TurnCompleted {
+                summary: Some("Task completed".to_string()),
+            },
+        });
+
+        let controller = ChildRuntimeController {
+            runtime: None,
+            startup_metadata: RuntimeStartupMetadata {
+                session_id: "child-session".to_string(),
+                rollout_path: Some(rollout.path().to_path_buf()),
+                durability: super::super::engine::SessionDurabilityState {
+                    durable: true,
+                    required: false,
+                },
+                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+                warnings: Vec::new(),
+            },
+            event_rx: rx,
+            submission_id,
+            timeout: None,
+        };
+
+        let result = controller.join().await.unwrap();
+        assert_eq!(result.status, ChildRuntimeStatus::Completed);
+        assert_eq!(
+            result.output_text,
+            "{\"status\":\"completed\",\"summary\":\"done\"}"
+        );
+        assert_eq!(
+            result
+                .structured_output
+                .as_ref()
+                .and_then(|value| value.get("summary")),
+            Some(&serde_json::json!("done"))
+        );
+    }
+
+    #[test]
+    fn parse_child_structured_output_reads_last_json_fence() {
+        let text = "Notes before\n```json\n{\"status\":\"completed\",\"summary\":\"first\"}\n```\nMore notes\n```json\n{\"status\":\"completed\",\"summary\":\"second\"}\n```";
+
+        let parsed = parse_child_structured_output(text).unwrap();
+        assert_eq!(parsed["summary"], serde_json::json!("second"));
+    }
+
+    #[test]
+    fn extract_latest_assistant_text_from_rollout_reads_nested_text_parts() {
+        let contents = concat!(
+            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"first\"}]}}\n",
+            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":null,\"message\":{\"parts\":[{\"type\":\"text\",\"text\":\"second\"},{\"type\":\"tool_request\",\"id\":\"ignored\"}]}}\n"
+        );
+
+        let extracted = extract_latest_assistant_text_from_rollout(contents).unwrap();
+        assert_eq!(extracted, "second");
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -26,6 +26,8 @@ const MAX_DELEGATED_SKILL_ID_CHARS: usize = 120;
 const MAX_DELEGATED_TARGET_CHARS: usize = 120;
 const MAX_DELEGATED_TASK_CHARS: usize = 1_000;
 const MAX_DELEGATED_PATH_CHARS: usize = 1_000;
+const DEFAULT_DELEGATED_TIMEOUT_SECS: u64 = 900;
+const MAX_DELEGATED_TIMEOUT_SECS: u64 = 86_400;
 const MAX_DELEGATED_RESULT_SUMMARY_CHARS: usize = 320;
 const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
@@ -405,8 +407,11 @@ where
     let (persisted_request, result, child_run) =
         match resolve_delegated_skill_invocation(state, &request) {
             Ok(spec) => {
-                let persisted_request = request
-                    .with_launch_paths(spec.launch.workspace_root.clone(), spec.launch.cwd.clone());
+                let persisted_request = request.with_effective_launch_inputs(
+                    spec.launch.workspace_root.clone(),
+                    spec.launch.cwd.clone(),
+                    spec.launch.timeout_secs,
+                );
                 match spawn_child(state, spec, cancel).await {
                     Ok(child_result) => {
                         if cancel.is_cancelled()
@@ -628,7 +633,11 @@ fn build_delegated_spawn_spec(
             task: request.task.clone(),
             cwd,
             workspace_root,
-            timeout_secs: None,
+            timeout_secs: Some(
+                request
+                    .timeout_secs
+                    .unwrap_or(DEFAULT_DELEGATED_TIMEOUT_SECS),
+            ),
             budget_tokens: None,
             output_dir: None,
         },
@@ -876,6 +885,7 @@ fn build_bounded_delegated_tape_record(
         cwd: request.cwd.as_ref().map(|path| {
             truncate_text_with_suffix(&path.to_string_lossy(), MAX_DELEGATED_PATH_CHARS, "...")
         }),
+        timeout_secs: request.timeout_secs,
         result,
     };
     let mut arguments = json!({
@@ -888,6 +898,9 @@ fn build_bounded_delegated_tape_record(
     }
     if let Some(cwd) = record.cwd.as_ref() {
         arguments["cwd"] = json!(cwd);
+    }
+    if let Some(timeout_secs) = record.timeout_secs {
+        arguments["timeout_secs"] = json!(timeout_secs);
     }
 
     (arguments, record)
@@ -907,6 +920,23 @@ fn structured_output_summary(value: Option<&serde_json::Value>) -> Option<String
         .and_then(non_empty_trimmed)
 }
 
+fn is_critical_structured_output_key(key: &str) -> bool {
+    matches!(
+        key,
+        "status"
+            | "summary"
+            | "overall_status"
+            | "verification_attempted"
+            | "attempted_count"
+            | "passed_count"
+            | "failed_count"
+            | "environment_blocked_count"
+            | "blocked_count"
+            | "not_run_count"
+            | "all_passed"
+    )
+}
+
 fn truncate_structured_output(value: serde_json::Value, max_size: usize) -> serde_json::Value {
     let rendered = value.to_string();
     if rendered.len() <= max_size {
@@ -919,24 +949,11 @@ fn truncate_structured_output(value: serde_json::Value, max_size: usize) -> serd
             let mut current_size = 0usize;
 
             for (key, value) in map {
-                let is_critical = matches!(
-                    key.as_str(),
-                    "status"
-                        | "summary"
-                        | "overall_status"
-                        | "verification_attempted"
-                        | "attempted_count"
-                        | "passed_count"
-                        | "failed_count"
-                        | "environment_blocked_count"
-                        | "blocked_count"
-                        | "not_run_count"
-                        | "all_passed"
-                );
+                let is_critical = is_critical_structured_output_key(key.as_str());
                 let processed_value = if is_critical {
-                    value
+                    truncate_structured_output(value, (max_size / 4).max(64))
                 } else {
-                    truncate_structured_output(value, max_size / 2)
+                    truncate_structured_output(value, (max_size / 2).max(64))
                 };
                 let value_size = key.len() + processed_value.to_string().len();
                 if current_size + value_size < max_size * 3 / 4 || is_critical {
@@ -975,7 +992,7 @@ fn truncate_structured_output(value: serde_json::Value, max_size: usize) -> serd
             serde_json::Value::Array(truncated)
         }
         serde_json::Value::String(text) => {
-            serde_json::Value::String(truncate_text_with_suffix(&text, max_size / 8, "..."))
+            serde_json::Value::String(truncate_text_with_suffix(&text, max_size, "..."))
         }
         other => other,
     }
@@ -1377,16 +1394,23 @@ struct DelegatedSkillInvocationRequest {
     task: String,
     workspace_root: Option<PathBuf>,
     cwd: Option<PathBuf>,
+    timeout_secs: Option<u64>,
 }
 
 impl DelegatedSkillInvocationRequest {
-    fn with_launch_paths(&self, workspace_root: Option<PathBuf>, cwd: Option<PathBuf>) -> Self {
+    fn with_effective_launch_inputs(
+        &self,
+        workspace_root: Option<PathBuf>,
+        cwd: Option<PathBuf>,
+        timeout_secs: Option<u64>,
+    ) -> Self {
         Self {
             skill_id: self.skill_id.clone(),
             target: self.target.clone(),
             task: self.task.clone(),
             workspace_root,
             cwd,
+            timeout_secs,
         }
     }
 }
@@ -1399,6 +1423,7 @@ fn parse_delegated_skill_invocation_request(
     let task = arguments.get("task")?.as_str()?.trim().to_string();
     let workspace_root = parse_optional_path_argument(arguments, "workspace_root")?;
     let cwd = parse_optional_path_argument(arguments, "cwd")?;
+    let timeout_secs = parse_optional_timeout_secs_argument(arguments, "timeout_secs")?;
     if skill_id.is_empty() || target.is_empty() || task.is_empty() {
         return None;
     }
@@ -1408,6 +1433,7 @@ fn parse_delegated_skill_invocation_request(
         task,
         workspace_root,
         cwd,
+        timeout_secs,
     })
 }
 
@@ -1423,6 +1449,22 @@ fn parse_optional_path_argument(
                 return Some(None);
             }
             Some(Some(PathBuf::from(path)))
+        }
+    }
+}
+
+fn parse_optional_timeout_secs_argument(
+    arguments: &serde_json::Value,
+    key: &str,
+) -> Option<Option<u64>> {
+    match arguments.get(key) {
+        None => Some(None),
+        Some(value) => {
+            let timeout_secs = value.as_u64()?;
+            if timeout_secs == 0 || timeout_secs > MAX_DELEGATED_TIMEOUT_SECS {
+                return None;
+            }
+            Some(Some(timeout_secs))
         }
     }
 }
@@ -1595,6 +1637,12 @@ fn invoke_delegated_skill_tool_definition() -> ToolDefinition {
                     "type": "string",
                     "description": "Optional nested working directory inside the delegated workspace. When omitted, the delegated runtime starts at `workspace_root` or its default workspace root.",
                     "maxLength": MAX_DELEGATED_PATH_CHARS
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "Optional bounded runtime timeout for the delegated child. When omitted, Alan applies a default bounded child timeout.",
+                    "minimum": 1,
+                    "maximum": MAX_DELEGATED_TIMEOUT_SECS
                 }
             },
             "required": ["skill_id", "target", "task"]
@@ -2306,6 +2354,41 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_delegated_skill_invocation_request_accepts_bounded_timeout() {
+        let request = parse_delegated_skill_invocation_request(&json!({
+            "skill_id": "repo-review",
+            "target": "reviewer",
+            "task": "Review the current diff.",
+            "timeout_secs": 600
+        }))
+        .expect("expected delegated request");
+
+        assert_eq!(request.timeout_secs, Some(600));
+    }
+
+    #[test]
+    fn test_parse_delegated_skill_invocation_request_rejects_invalid_timeout() {
+        assert!(
+            parse_delegated_skill_invocation_request(&json!({
+                "skill_id": "repo-review",
+                "target": "reviewer",
+                "task": "Review the current diff.",
+                "timeout_secs": 0
+            }))
+            .is_none()
+        );
+        assert!(
+            parse_delegated_skill_invocation_request(&json!({
+                "skill_id": "repo-review",
+                "target": "reviewer",
+                "task": "Review the current diff.",
+                "timeout_secs": (MAX_DELEGATED_TIMEOUT_SECS + 1)
+            }))
+            .is_none()
+        );
+    }
+
+    #[test]
     fn test_build_bounded_delegated_invocation_persistence_truncates_fields() {
         let request = DelegatedSkillInvocationRequest {
             skill_id: "s".repeat(MAX_DELEGATED_SKILL_ID_CHARS + 40),
@@ -2319,6 +2402,7 @@ mod tests {
                 "/tmp/{}",
                 "c".repeat(MAX_DELEGATED_PATH_CHARS + 20)
             ))),
+            timeout_secs: Some(DEFAULT_DELEGATED_TIMEOUT_SECS),
         };
         let result = DelegatedSkillResult::failed(
             format!(
@@ -2356,6 +2440,10 @@ mod tests {
                 <= MAX_DELEGATED_PATH_CHARS
         );
         assert!(arguments["cwd"].as_str().unwrap().chars().count() <= MAX_DELEGATED_PATH_CHARS);
+        assert_eq!(
+            arguments["timeout_secs"].as_u64(),
+            Some(DEFAULT_DELEGATED_TIMEOUT_SECS)
+        );
         assert!(record.result.summary.chars().count() <= MAX_DELEGATED_RESULT_SUMMARY_CHARS);
         assert!(record.result.summary.ends_with("..."));
         assert_eq!(
@@ -2372,6 +2460,7 @@ mod tests {
             task: "Review the current diff and summarize risks.".to_string(),
             workspace_root: Some(PathBuf::from("/tmp/repo")),
             cwd: Some(PathBuf::from("/tmp/repo/src")),
+            timeout_secs: Some(600),
         };
         let result = DelegatedSkillResult::completed("Delegated review completed.", None);
         let child_run = Some(DelegatedChildRunReference {
@@ -2396,6 +2485,7 @@ mod tests {
         );
         assert_eq!(tape_payload["workspace_root"], json!("/tmp/repo"));
         assert_eq!(tape_payload["cwd"], json!("/tmp/repo/src"));
+        assert_eq!(tape_payload["timeout_secs"], json!(600));
     }
 
     #[test]
@@ -2458,6 +2548,7 @@ mod tests {
             task: "Review the current diff and summarize risks.".to_string(),
             workspace_root: Some(PathBuf::from("/tmp/repo")),
             cwd: Some(PathBuf::from("/tmp/repo/src")),
+            timeout_secs: None,
         };
         let result = DelegatedSkillResult::completed(
             "Delegated review completed.",
@@ -2472,6 +2563,37 @@ mod tests {
             build_bounded_delegated_invocation_persistence(&request, result, None);
         let structured = tape_record.result.structured_output.unwrap();
         assert!(structured.to_string().len() <= MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS);
+        assert_eq!(structured["status"], json!("completed"));
+    }
+
+    #[test]
+    fn test_build_bounded_delegated_invocation_persistence_truncates_oversized_summary() {
+        let request = DelegatedSkillInvocationRequest {
+            skill_id: "repo-review".to_string(),
+            target: "reviewer".to_string(),
+            task: "Review the current diff and summarize risks.".to_string(),
+            workspace_root: Some(PathBuf::from("/tmp/repo")),
+            cwd: Some(PathBuf::from("/tmp/repo/src")),
+            timeout_secs: None,
+        };
+        let result = DelegatedSkillResult::completed(
+            "Delegated review completed.",
+            Some(json!({
+                "status": "completed",
+                "summary": "y".repeat(MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS * 2),
+                "details": "x".repeat(MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS * 2)
+            })),
+        );
+
+        let (_, tape_record, _) =
+            build_bounded_delegated_invocation_persistence(&request, result, None);
+        let structured = tape_record.result.structured_output.unwrap();
+        let summary = structured["summary"]
+            .as_str()
+            .expect("summary should remain string");
+        assert!(structured.to_string().len() <= MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS);
+        assert!(summary.len() < MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS);
+        assert!(summary.ends_with("..."));
         assert_eq!(structured["status"], json!("completed"));
     }
 
@@ -2762,7 +2884,10 @@ mod tests {
             spec.launch.cwd,
             Some(PathBuf::from("/tmp/alan-delegated-parent"))
         );
-        assert_eq!(spec.launch.timeout_secs, None);
+        assert_eq!(
+            spec.launch.timeout_secs,
+            Some(DEFAULT_DELEGATED_TIMEOUT_SECS)
+        );
 
         let prompt_view = state.session.tape.prompt_view();
         let tool_result = prompt_view

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -27,6 +27,7 @@ const MAX_DELEGATED_TARGET_CHARS: usize = 120;
 const MAX_DELEGATED_TASK_CHARS: usize = 1_000;
 const MAX_DELEGATED_PATH_CHARS: usize = 1_000;
 const MAX_DELEGATED_RESULT_SUMMARY_CHARS: usize = 320;
+const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -496,6 +497,7 @@ async fn spawn_and_join_delegated_child(
             rollout_path: None,
             output_text: String::new(),
             turn_summary: None,
+            structured_output: None,
             warnings: Vec::new(),
             error_message: None,
             pause: None,
@@ -620,16 +622,13 @@ fn build_delegated_spawn_spec(
         request.workspace_root.is_some(),
         parent_default_cwd.as_deref(),
     )?;
-    let timeout_secs = (state.core_config.tool_timeout_secs > 0)
-        .then_some(state.core_config.tool_timeout_secs as u64);
-
     Ok(SpawnSpec {
         target,
         launch: SpawnLaunchInputs {
             task: request.task.clone(),
             cwd,
             workspace_root,
-            timeout_secs,
+            timeout_secs: None,
             budget_tokens: None,
             output_dir: None,
         },
@@ -790,7 +789,10 @@ fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedS
 }
 
 fn delegated_result_from_completed_child(result: &ChildRuntimeResult) -> DelegatedSkillResult {
-    DelegatedSkillResult::completed(completed_child_summary(result), None)
+    DelegatedSkillResult::completed(
+        completed_child_summary(result),
+        result.structured_output.clone(),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -858,6 +860,9 @@ fn build_bounded_delegated_tape_record(
             MAX_DELEGATED_RESULT_SUMMARY_CHARS,
             "...",
         ),
+        structured_output: result
+            .structured_output
+            .map(|value| truncate_structured_output(value, MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS)),
         ..result
     };
 
@@ -889,9 +894,91 @@ fn build_bounded_delegated_tape_record(
 }
 
 fn completed_child_summary(result: &ChildRuntimeResult) -> String {
-    non_empty_trimmed(result.turn_summary.as_deref().unwrap_or_default())
+    structured_output_summary(result.structured_output.as_ref())
         .or_else(|| non_empty_trimmed(&result.output_text))
+        .or_else(|| non_empty_trimmed(result.turn_summary.as_deref().unwrap_or_default()))
         .unwrap_or_else(|| "Delegated runtime completed without textual output.".to_string())
+}
+
+fn structured_output_summary(value: Option<&serde_json::Value>) -> Option<String> {
+    value
+        .and_then(|value| value.get("summary"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(non_empty_trimmed)
+}
+
+fn truncate_structured_output(value: serde_json::Value, max_size: usize) -> serde_json::Value {
+    let rendered = value.to_string();
+    if rendered.len() <= max_size {
+        return value;
+    }
+
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut truncated = serde_json::Map::new();
+            let mut current_size = 0usize;
+
+            for (key, value) in map {
+                let is_critical = matches!(
+                    key.as_str(),
+                    "status"
+                        | "summary"
+                        | "overall_status"
+                        | "verification_attempted"
+                        | "attempted_count"
+                        | "passed_count"
+                        | "failed_count"
+                        | "environment_blocked_count"
+                        | "blocked_count"
+                        | "not_run_count"
+                        | "all_passed"
+                );
+                let processed_value = if is_critical {
+                    value
+                } else {
+                    truncate_structured_output(value, max_size / 2)
+                };
+                let value_size = key.len() + processed_value.to_string().len();
+                if current_size + value_size < max_size * 3 / 4 || is_critical {
+                    truncated.insert(key, processed_value);
+                    current_size += value_size;
+                } else {
+                    truncated.insert(
+                        "_truncated".to_string(),
+                        serde_json::Value::String("Additional fields omitted".to_string()),
+                    );
+                    break;
+                }
+            }
+
+            serde_json::Value::Object(truncated)
+        }
+        serde_json::Value::Array(items) => {
+            let item_budget = (max_size / items.len().max(1)).max(32);
+            let mut truncated = Vec::new();
+            let mut current_size = 0usize;
+
+            for item in items {
+                let processed = truncate_structured_output(item, item_budget);
+                let item_size = processed.to_string().len();
+                if current_size + item_size < max_size * 3 / 4 {
+                    truncated.push(processed);
+                    current_size += item_size;
+                } else {
+                    truncated.push(json!({
+                        "_note": "Additional array items omitted"
+                    }));
+                    break;
+                }
+            }
+
+            serde_json::Value::Array(truncated)
+        }
+        serde_json::Value::String(text) => {
+            serde_json::Value::String(truncate_text_with_suffix(&text, max_size / 8, "..."))
+        }
+        other => other,
+    }
 }
 
 fn non_empty_trimmed(text: &str) -> Option<String> {
@@ -1333,7 +1420,7 @@ fn parse_optional_path_argument(
         Some(value) => {
             let path = value.as_str()?.trim();
             if path.is_empty() {
-                return None;
+                return Some(None);
             }
             Some(Some(PathBuf::from(path)))
         }
@@ -2188,6 +2275,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_delegated_skill_invocation_request_treats_empty_optional_paths_as_absent() {
+        let args = json!({
+            "skill_id": "repo-review",
+            "target": "reviewer",
+            "task": "Review the current diff and summarize risks.",
+            "workspace_root": "",
+            "cwd": "   "
+        });
+
+        let result = parse_delegated_skill_invocation_request(&args).unwrap();
+        assert_eq!(result.workspace_root, None);
+        assert_eq!(result.cwd, None);
+    }
+
+    #[test]
     fn test_parse_delegated_skill_invocation_request_rejects_empty_fields() {
         let missing = json!({
             "skill_id": "repo-review",
@@ -2294,6 +2396,83 @@ mod tests {
         );
         assert_eq!(tape_payload["workspace_root"], json!("/tmp/repo"));
         assert_eq!(tape_payload["cwd"], json!("/tmp/repo/src"));
+    }
+
+    #[test]
+    fn test_delegated_result_from_completed_child_prefers_structured_output_summary() {
+        let child_result = ChildRuntimeResult {
+            status: ChildRuntimeStatus::Completed,
+            session_id: "child-session".to_string(),
+            rollout_path: None,
+            output_text: "{\"status\":\"completed\",\"summary\":\"Structured delivery\"}"
+                .to_string(),
+            turn_summary: Some("Turn summary".to_string()),
+            structured_output: Some(json!({
+                "status": "completed",
+                "summary": "Structured delivery"
+            })),
+            warnings: Vec::new(),
+            error_message: None,
+            pause: None,
+        };
+
+        let delegated = delegated_result_from_completed_child(&child_result);
+        assert_eq!(delegated.summary, "Structured delivery");
+        assert_eq!(
+            delegated
+                .structured_output
+                .as_ref()
+                .and_then(|value| value.get("status")),
+            Some(&json!("completed"))
+        );
+    }
+
+    #[test]
+    fn test_delegated_result_from_completed_child_prefers_output_text_over_turn_summary() {
+        let child_result = ChildRuntimeResult {
+            status: ChildRuntimeStatus::Completed,
+            session_id: "child-session".to_string(),
+            rollout_path: None,
+            output_text: "Verification was environment_blocked: pytest was not installed."
+                .to_string(),
+            turn_summary: Some("Task completed".to_string()),
+            structured_output: None,
+            warnings: Vec::new(),
+            error_message: None,
+            pause: None,
+        };
+
+        let delegated = delegated_result_from_completed_child(&child_result);
+        assert_eq!(
+            delegated.summary,
+            "Verification was environment_blocked: pytest was not installed."
+        );
+        assert!(delegated.structured_output.is_none());
+    }
+
+    #[test]
+    fn test_build_bounded_delegated_invocation_persistence_truncates_structured_output() {
+        let request = DelegatedSkillInvocationRequest {
+            skill_id: "repo-review".to_string(),
+            target: "reviewer".to_string(),
+            task: "Review the current diff and summarize risks.".to_string(),
+            workspace_root: Some(PathBuf::from("/tmp/repo")),
+            cwd: Some(PathBuf::from("/tmp/repo/src")),
+        };
+        let result = DelegatedSkillResult::completed(
+            "Delegated review completed.",
+            Some(json!({
+                "status": "completed",
+                "summary": "Delegated review completed.",
+                "details": "x".repeat(MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS * 2)
+            })),
+        );
+
+        let (_, tape_record, _) =
+            build_bounded_delegated_invocation_persistence(&request, result, None);
+        let structured = tape_record.result.structured_output.unwrap();
+        assert!(structured.to_string().len() <= MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS);
+        assert_eq!(structured["status"], json!("completed"));
     }
 
     // Tests for parse_plan_status
@@ -2543,6 +2722,7 @@ mod tests {
                         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                         output_text: String::new(),
                         turn_summary: Some("Delegated review completed.".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -2582,10 +2762,7 @@ mod tests {
             spec.launch.cwd,
             Some(PathBuf::from("/tmp/alan-delegated-parent"))
         );
-        assert_eq!(
-            spec.launch.timeout_secs,
-            Some(state.core_config.tool_timeout_secs as u64)
-        );
+        assert_eq!(spec.launch.timeout_secs, None);
 
         let prompt_view = state.session.tape.prompt_view();
         let tool_result = prompt_view
@@ -2673,6 +2850,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -2758,6 +2936,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: None,
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -2831,6 +3010,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -2898,6 +3078,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -2975,6 +3156,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3041,6 +3223,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3107,6 +3290,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3168,6 +3352,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: None,
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3239,6 +3424,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("done".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3297,6 +3483,7 @@ Use this skill when asked.
                         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                         output_text: String::new(),
                         turn_summary: Some("Delegated review completed.".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3367,6 +3554,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: Some("Delegated review completed.".to_string()),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3441,6 +3629,7 @@ Use this skill when asked.
                         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                         output_text: String::new(),
                         turn_summary: Some("delegated-result ".repeat(40)),
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3541,6 +3730,7 @@ Use this skill when asked.
                         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                         output_text: String::new(),
                         turn_summary: None,
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,
@@ -3703,6 +3893,7 @@ Use this skill when asked.
                         rollout_path: None,
                         output_text: String::new(),
                         turn_summary: None,
+                        structured_output: None,
                         warnings: Vec::new(),
                         error_message: None,
                         pause: None,

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -1205,6 +1205,8 @@ pub struct DelegatedSkillInvocationRecord {
     pub workspace_root: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
     pub result: DelegatedSkillResult,
 }
 
@@ -2603,6 +2605,7 @@ enabled = true
             task: "Review the current diff.".to_string(),
             workspace_root: Some("/tmp/repo".to_string()),
             cwd: Some("/tmp/repo/src".to_string()),
+            timeout_secs: Some(600),
             result: DelegatedSkillResult::failed(
                 "Child-agent spawn support is not yet available.",
                 Some(serde_json::json!({
@@ -2616,6 +2619,7 @@ enabled = true
         assert_eq!(value["target"], "repo-review");
         assert_eq!(value["workspace_root"], "/tmp/repo");
         assert_eq!(value["cwd"], "/tmp/repo/src");
+        assert_eq!(value["timeout_secs"], 600);
         assert_eq!(value["task"], "Review the current diff.");
         assert_eq!(value["result"]["status"], "failed");
         assert_eq!(

--- a/crates/runtime/src/tools/sandbox.rs
+++ b/crates/runtime/src/tools/sandbox.rs
@@ -288,6 +288,9 @@ impl Sandbox {
                     || prev == b'/'
                     || prev == b'_'
                     || prev == b'-'
+                    || prev == b'*'
+                    || prev == b'?'
+                    || prev == b']'
                     || prev.is_ascii_alphanumeric()
                 {
                     // Skip URL fragments and path segments within relative paths or identifiers.
@@ -4095,6 +4098,31 @@ mod tests {
                 .to_string()
                 .contains("protected subpath .git")
         );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_exec_allows_quoted_relative_glob_path_patterns() {
+        let temp = TempDir::new().unwrap();
+        let sandbox = Sandbox::new(temp.path().to_path_buf());
+        let python_bin = temp.path().join("venv/bin/python");
+        tokio::fs::create_dir_all(python_bin.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&python_bin, "#!/usr/bin/env python\n")
+            .await
+            .unwrap();
+
+        let result = sandbox
+            .exec_with_timeout_and_capability(
+                r#"find . -maxdepth 3 -type f -path "*/bin/python""#,
+                temp.path(),
+                None,
+                Some(alan_protocol::ToolCapability::Read),
+            )
+            .await
+            .expect("quoted relative path pattern should stay workspace-safe");
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("./venv/bin/python"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/tools/sandbox.rs
+++ b/crates/runtime/src/tools/sandbox.rs
@@ -1925,7 +1925,14 @@ fn python_script_interpreter_display(display: &str, args: &[String]) -> Option<S
                 .get(index + 1)
                 .map(|script| format!("{display} {}", script));
         }
-        if matches!(arg, "-m" | "--module" | "-") {
+        if matches!(arg, "-m" | "--module") {
+            let module = args.get(index + 1).map(|value| value.as_str());
+            if module.is_some_and(is_safe_python_module_runner) {
+                return None;
+            }
+            return Some(format!("{display} {arg}"));
+        }
+        if arg == "-" {
             return Some(format!("{display} {arg}"));
         }
         if let Some(step) = python_wrapper_advance(arg) {
@@ -1935,6 +1942,10 @@ fn python_script_interpreter_display(display: &str, args: &[String]) -> Option<S
         return Some(format!("{display} {arg}"));
     }
     Some(format!("{display} <stdin>"))
+}
+
+fn is_safe_python_module_runner(module: &str) -> bool {
+    matches!(module, "pytest" | "unittest")
 }
 
 fn node_script_interpreter_display(display: &str, args: &[String]) -> Option<String> {
@@ -3312,6 +3323,11 @@ mod tests {
                 .to_string()
                 .contains("rejects opaque script interpreters like python3 -m")
         );
+    }
+
+    #[test]
+    fn test_bash_preflight_allows_python_module_pytest() {
+        assert!(Sandbox::bash_preflight_reason("python3 -m pytest -q test_requests.py").is_none());
     }
 
     #[tokio::test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -672,6 +672,10 @@ fn is_local_verification_command(tokens: &[&str]) -> bool {
     let head = command_basename(tokens[0]);
     let pair = tokens.get(1).copied().unwrap_or_default();
 
+    if matches!(head, "tox" | "nox") {
+        return !is_tool_query_command(tokens);
+    }
+
     if matches!(head, "pytest" | "py.test" | "nosetests" | "nosetests3") {
         return true;
     }
@@ -693,6 +697,10 @@ fn is_python_query_command(tokens: &[&str]) -> bool {
         return false;
     }
 
+    is_tool_query_command(tokens)
+}
+
+fn is_tool_query_command(tokens: &[&str]) -> bool {
     tokens
         .iter()
         .skip(1)
@@ -1512,6 +1520,10 @@ fn is_safe_read_command(tokens: &[&str]) -> bool {
     }
 
     if is_python_query_command(tokens) {
+        return true;
+    }
+
+    if matches!(head, "tox" | "nox") && is_tool_query_command(tokens) {
         return true;
     }
 
@@ -3748,6 +3760,30 @@ mod tests {
     #[test]
     fn test_classify_bash_command_python_module_pytest_is_write() {
         let cap = classify_bash_command("python -B -m pytest tests/test_requests.py -k redirect");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_tox_version_is_read() {
+        let cap = classify_bash_command("tox --version");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_nox_help_is_read() {
+        let cap = classify_bash_command("nox --help");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_tox_run_is_write() {
+        let cap = classify_bash_command("tox -e py");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_nox_run_is_write() {
+        let cap = classify_bash_command("nox -s tests");
         assert_eq!(cap, alan_protocol::ToolCapability::Write);
     }
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -283,14 +283,11 @@ impl BashTool {
 
 fn classify_bash_command(command: &str) -> alan_protocol::ToolCapability {
     let normalized = normalize_shell_line_continuations(command).to_lowercase();
-    let flattened = normalized
-        .replace("&&", ";")
-        .replace("||", ";")
-        .replace(['\n', '\r', '|'], ";");
+    let fragments = split_shell_fragments(&normalized);
 
     let mut saw_write = false;
     let mut saw_unknown = false;
-    for fragment in flattened.split(';') {
+    for fragment in fragments {
         let capability = classify_bash_fragment(fragment.trim());
         if matches!(capability, alan_protocol::ToolCapability::Network) {
             return alan_protocol::ToolCapability::Network;
@@ -410,6 +407,118 @@ fn normalize_shell_line_continuations(command: &str) -> String {
     normalized
 }
 
+fn split_shell_fragments(command: &str) -> Vec<String> {
+    let mut fragments = Vec::new();
+    let mut current = String::with_capacity(command.len());
+    let mut chars = command.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_comment = false;
+    let mut escaped = false;
+    let mut word_started = false;
+
+    while let Some(ch) = chars.next() {
+        if in_comment {
+            if matches!(ch, '\n' | '\r') {
+                push_shell_fragment(&mut fragments, &mut current);
+                in_comment = false;
+                word_started = false;
+            }
+            continue;
+        }
+
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            word_started = true;
+            continue;
+        }
+
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            }
+            current.push(ch);
+            word_started = true;
+            continue;
+        }
+
+        if in_double {
+            match ch {
+                '\\' => {
+                    current.push(ch);
+                    escaped = true;
+                }
+                '"' => {
+                    in_double = false;
+                    current.push(ch);
+                    word_started = true;
+                }
+                _ => {
+                    current.push(ch);
+                    word_started = true;
+                }
+            }
+            continue;
+        }
+
+        match ch {
+            '\\' => {
+                current.push(ch);
+                escaped = true;
+                word_started = true;
+            }
+            '\'' => {
+                in_single = true;
+                current.push(ch);
+                word_started = true;
+            }
+            '"' => {
+                in_double = true;
+                current.push(ch);
+                word_started = true;
+            }
+            '#' if !word_started => {
+                in_comment = true;
+            }
+            '&' if matches!(chars.peek(), Some('&')) => {
+                chars.next();
+                push_shell_fragment(&mut fragments, &mut current);
+                word_started = false;
+            }
+            '|' if matches!(chars.peek(), Some('|')) => {
+                chars.next();
+                push_shell_fragment(&mut fragments, &mut current);
+                word_started = false;
+            }
+            ';' | '\n' | '\r' | '|' => {
+                push_shell_fragment(&mut fragments, &mut current);
+                word_started = false;
+            }
+            c if is_shell_word_boundary(c) => {
+                current.push(c);
+                word_started = false;
+            }
+            _ => {
+                current.push(ch);
+                word_started = true;
+            }
+        }
+    }
+
+    push_shell_fragment(&mut fragments, &mut current);
+    fragments
+}
+
+fn push_shell_fragment(fragments: &mut Vec<String>, current: &mut String) {
+    if current.trim().is_empty() {
+        current.clear();
+        return;
+    }
+
+    fragments.push(std::mem::take(current));
+}
+
 fn consume_shell_line_continuation<I>(chars: &mut std::iter::Peekable<I>) -> bool
 where
     I: Iterator<Item = char>,
@@ -518,6 +627,10 @@ fn is_write_command(fragment: &str, tokens: &[&str]) -> bool {
         return true;
     }
 
+    if is_local_verification_command(tokens) {
+        return true;
+    }
+
     if head == "git" {
         if is_git_network_command(tokens) {
             return false;
@@ -547,11 +660,65 @@ fn short_option_cluster_contains_flag(token: &str, flag: char) -> bool {
 }
 
 fn find_has_write_action(tokens: &[&str]) -> bool {
+    tokens.iter().skip(1).copied().any(|token| {
+        matches!(
+            token,
+            "-exec" | "-execdir" | "-delete" | "-ok" | "-okdir" | "-fprint" | "-fprintf" | "-fls"
+        )
+    })
+}
+
+fn is_local_verification_command(tokens: &[&str]) -> bool {
+    let head = command_basename(tokens[0]);
+    let pair = tokens.get(1).copied().unwrap_or_default();
+
+    if matches!(head, "pytest" | "py.test" | "nosetests" | "nosetests3") {
+        return true;
+    }
+
+    if (head == "cargo" && matches!(pair, "test" | "check" | "clippy"))
+        || (head == "go" && pair == "test")
+        || (matches!(head, "npm" | "pnpm" | "yarn" | "bun") && pair == "test")
+        || (matches!(head, "make" | "just") && matches!(pair, "test" | "check"))
+    {
+        return true;
+    }
+
+    python_module_command(tokens).is_some_and(|module| matches!(module, "pytest" | "unittest"))
+}
+
+fn is_python_query_command(tokens: &[&str]) -> bool {
+    let head = command_basename(tokens.first().copied().unwrap_or_default());
+    if !matches!(head, "python" | "python3") {
+        return false;
+    }
+
     tokens
         .iter()
         .skip(1)
         .copied()
-        .any(|token| matches!(token, "-exec" | "-execdir" | "-delete" | "-ok" | "-okdir"))
+        .find(|token| !token.is_empty())
+        .is_some_and(|arg| matches!(arg, "-h" | "--help" | "--version") || arg.starts_with("-V"))
+}
+
+fn python_module_command<'a>(tokens: &'a [&'a str]) -> Option<&'a str> {
+    let head = command_basename(tokens.first().copied()?);
+    if !matches!(head, "python" | "python3") {
+        return None;
+    }
+
+    let mut index = 1;
+    while let Some(token) = tokens.get(index).copied() {
+        if token == "-m" {
+            return tokens.get(index + 1).copied();
+        }
+        if !token.starts_with('-') {
+            return None;
+        }
+        index += 1;
+    }
+
+    None
 }
 
 fn contains_nested_eval_wrapper(tokens: &[&str]) -> bool {
@@ -1316,8 +1483,11 @@ fn is_safe_read_command(tokens: &[&str]) -> bool {
             | "df"
             | "cut"
             | "tr"
+            | "sort"
+            | "uniq"
             | "nl"
             | "tree"
+            | "find"
             | "echo"
             | "printf"
             | "env"
@@ -1337,6 +1507,14 @@ fn is_safe_read_command(tokens: &[&str]) -> bool {
         return true;
     }
 
+    if head == "sed" {
+        return is_sed_safe_read_command(tokens);
+    }
+
+    if is_python_query_command(tokens) {
+        return true;
+    }
+
     if head == "command" {
         return is_command_query(tokens);
     }
@@ -1350,6 +1528,58 @@ fn is_safe_read_command(tokens: &[&str]) -> bool {
     }
 
     false
+}
+
+fn is_sed_safe_read_command(tokens: &[&str]) -> bool {
+    let mut saw_script = false;
+    let mut index = 1;
+    while let Some(token) = tokens.get(index).copied() {
+        if token == "--" {
+            index += 1;
+            break;
+        }
+        if matches!(token, "-n" | "--quiet" | "--silent") {
+            index += 1;
+            continue;
+        }
+        if token == "-e" {
+            let Some(script) = tokens.get(index + 1).copied() else {
+                return false;
+            };
+            if !is_sed_line_range_print_script(script) {
+                return false;
+            }
+            saw_script = true;
+            index += 2;
+            continue;
+        }
+        if token.starts_with('-') {
+            return false;
+        }
+        if !saw_script {
+            if !is_sed_line_range_print_script(token) {
+                return false;
+            }
+            saw_script = true;
+            index += 1;
+            continue;
+        }
+        break;
+    }
+
+    saw_script && index < tokens.len()
+}
+
+fn is_sed_line_range_print_script(token: &str) -> bool {
+    let script = token.trim_matches(|ch| ch == '\'' || ch == '"');
+    let Some(address) = script.strip_suffix('p') else {
+        return false;
+    };
+    !address.is_empty()
+        && address
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || matches!(ch, ',' | '$'))
+        && address.chars().any(|ch| ch.is_ascii_digit() || ch == '$')
 }
 
 fn is_wrapper_query_command(tokens: &[&str]) -> bool {
@@ -3147,6 +3377,14 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_bash_command_treats_regex_pipe_inside_quotes_as_read() {
+        let cap = classify_bash_command(
+            "rg -n \"resolve_redirects|303|307|308|redirect\" requests tests",
+        );
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
     fn test_classify_bash_command_treats_cd_then_read_as_read() {
         let cap = classify_bash_command("cd /tmp/repo && ls");
         assert_eq!(cap, alan_protocol::ToolCapability::Read);
@@ -3482,9 +3720,59 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_bash_command_find_name_defaults_to_unknown() {
+    fn test_classify_bash_command_find_fprint_is_write() {
+        let cap = classify_bash_command("find . -name '*.rs' -fprint /tmp/files.txt");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_find_name_defaults_to_read() {
         let cap = classify_bash_command("find . -name '*.rs'");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_find_pipeline_is_read() {
+        let cap = classify_bash_command(
+            "find . -maxdepth 3 \\( -path './test*' -o -path './tests*' \\) -type d | sort",
+        );
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_pytest_is_write() {
+        let cap = classify_bash_command("pytest tests/test_requests.py -k redirect");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_python_module_pytest_is_write() {
+        let cap = classify_bash_command("python -B -m pytest tests/test_requests.py -k redirect");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_python_version_is_read() {
+        let cap = classify_bash_command("python --version");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_sed_print_is_read() {
+        let cap = classify_bash_command("sed -n '1,80p' test_requests.py");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_sed_write_script_is_unknown() {
+        let cap = classify_bash_command("sed -n '1,80w /tmp/out' test_requests.py");
         assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
+    }
+
+    #[test]
+    fn test_classify_bash_command_cargo_test_is_write() {
+        let cap = classify_bash_command("cargo test -p alan-runtime delegated_skill --lib");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
     }
 
     #[test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -663,7 +663,15 @@ fn find_has_write_action(tokens: &[&str]) -> bool {
     tokens.iter().skip(1).copied().any(|token| {
         matches!(
             token,
-            "-exec" | "-execdir" | "-delete" | "-ok" | "-okdir" | "-fprint" | "-fprintf" | "-fls"
+            "-exec"
+                | "-execdir"
+                | "-delete"
+                | "-ok"
+                | "-okdir"
+                | "-fprint"
+                | "-fprint0"
+                | "-fprintf"
+                | "-fls"
         )
     })
 }
@@ -688,7 +696,12 @@ fn is_local_verification_command(tokens: &[&str]) -> bool {
         return true;
     }
 
-    python_module_command(tokens).is_some_and(|module| matches!(module, "pytest" | "unittest"))
+    if python_module_command(tokens).is_some_and(|module| matches!(module, "pytest" | "unittest")) {
+        return true;
+    }
+
+    local_verification_subject(tokens)
+        .is_some_and(|(command, args)| is_local_verification_entrypoint(command, args))
 }
 
 fn is_python_query_command(tokens: &[&str]) -> bool {
@@ -727,6 +740,101 @@ fn python_module_command<'a>(tokens: &'a [&'a str]) -> Option<&'a str> {
     }
 
     None
+}
+
+fn local_verification_subject<'a>(tokens: &'a [&'a str]) -> Option<(&'a str, &'a [&'a str])> {
+    let command = tokens.first().copied()?;
+    if is_local_command_path(command) {
+        return Some((command, &tokens[1..]));
+    }
+
+    python_script_command(tokens)
+}
+
+fn python_script_command<'a>(tokens: &'a [&'a str]) -> Option<(&'a str, &'a [&'a str])> {
+    let head = command_basename(tokens.first().copied()?);
+    if !matches!(head, "python" | "python3") {
+        return None;
+    }
+
+    let mut index = 1;
+    while let Some(token) = tokens.get(index).copied() {
+        if token == "-m" || token == "-c" || token == "-" {
+            return None;
+        }
+        if !token.starts_with('-') {
+            return Some((token, &tokens[index + 1..]));
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn is_local_verification_entrypoint(command: &str, args: &[&str]) -> bool {
+    if !is_local_command_path(command) {
+        return false;
+    }
+
+    if is_verification_entrypoint_name(command_basename(command)) {
+        return true;
+    }
+
+    first_non_option_arg(args).is_some_and(is_verification_subcommand)
+}
+
+fn is_local_command_path(command: &str) -> bool {
+    if command.is_empty() {
+        return false;
+    }
+
+    if command.starts_with("./") || command.starts_with("../") || command.contains('/') {
+        return true;
+    }
+
+    matches!(
+        Path::new(command).extension().and_then(|ext| ext.to_str()),
+        Some("py" | "sh" | "rb" | "pl" | "php" | "js")
+    ) || matches!(command_basename(command), "gradlew" | "mvnw")
+}
+
+fn is_verification_entrypoint_name(command: &str) -> bool {
+    let stem = Path::new(command)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+        .to_ascii_lowercase();
+
+    matches!(
+        stem.as_str(),
+        "runtests" | "run-tests" | "run_tests" | "pytest" | "nosetests" | "nosetests3"
+    ) || stem == "test"
+        || stem == "tests"
+}
+
+fn first_non_option_arg<'a>(args: &'a [&'a str]) -> Option<&'a str> {
+    let mut saw_double_dash = false;
+    for arg in args {
+        if arg.is_empty() {
+            continue;
+        }
+        if !saw_double_dash {
+            if *arg == "--" {
+                saw_double_dash = true;
+                continue;
+            }
+            if arg.starts_with('-') {
+                continue;
+            }
+        }
+        return Some(*arg);
+    }
+
+    None
+}
+
+fn is_verification_subcommand(arg: &str) -> bool {
+    matches!(arg, "test" | "tests" | "check" | "clippy" | "verify")
 }
 
 fn contains_nested_eval_wrapper(tokens: &[&str]) -> bool {
@@ -1547,7 +1655,6 @@ fn is_sed_safe_read_command(tokens: &[&str]) -> bool {
     let mut index = 1;
     while let Some(token) = tokens.get(index).copied() {
         if token == "--" {
-            index += 1;
             break;
         }
         if matches!(token, "-n" | "--quiet" | "--silent") {
@@ -1558,7 +1665,7 @@ fn is_sed_safe_read_command(tokens: &[&str]) -> bool {
             let Some(script) = tokens.get(index + 1).copied() else {
                 return false;
             };
-            if !is_sed_line_range_print_script(script) {
+            if !is_sed_safe_script(script) {
                 return false;
             }
             saw_script = true;
@@ -1569,7 +1676,7 @@ fn is_sed_safe_read_command(tokens: &[&str]) -> bool {
             return false;
         }
         if !saw_script {
-            if !is_sed_line_range_print_script(token) {
+            if !is_sed_safe_script(token) {
                 return false;
             }
             saw_script = true;
@@ -1579,7 +1686,11 @@ fn is_sed_safe_read_command(tokens: &[&str]) -> bool {
         break;
     }
 
-    saw_script && index < tokens.len()
+    saw_script
+}
+
+fn is_sed_safe_script(token: &str) -> bool {
+    is_sed_line_range_print_script(token) || is_sed_substitute_script(token)
 }
 
 fn is_sed_line_range_print_script(token: &str) -> bool {
@@ -1592,6 +1703,47 @@ fn is_sed_line_range_print_script(token: &str) -> bool {
             .chars()
             .all(|ch| ch.is_ascii_digit() || matches!(ch, ',' | '$'))
         && address.chars().any(|ch| ch.is_ascii_digit() || ch == '$')
+}
+
+fn is_sed_substitute_script(token: &str) -> bool {
+    let script = token.trim_matches(|ch| ch == '\'' || ch == '"');
+    let mut chars = script.chars();
+    if chars.next() != Some('s') {
+        return false;
+    }
+
+    let delimiter = match chars.next() {
+        Some(ch) if !ch.is_ascii_alphanumeric() && !ch.is_ascii_whitespace() => ch,
+        _ => return false,
+    };
+    let body: String = chars.collect();
+    let mut delimiter_count = 0;
+    let mut escaped = false;
+    let mut tail_start = None;
+
+    for (idx, ch) in body.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == delimiter {
+            delimiter_count += 1;
+            if delimiter_count == 2 {
+                tail_start = Some(idx + ch.len_utf8());
+                break;
+            }
+        }
+    }
+
+    let Some(tail_index) = tail_start else {
+        return false;
+    };
+    let tail = body[tail_index..].trim();
+    !tail.contains('w') && !tail.contains('e')
 }
 
 fn is_wrapper_query_command(tokens: &[&str]) -> bool {
@@ -3738,6 +3890,12 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_bash_command_find_fprint0_is_write() {
+        let cap = classify_bash_command("find . -name '*.rs' -fprint0 /tmp/files.bin");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
     fn test_classify_bash_command_find_name_defaults_to_read() {
         let cap = classify_bash_command("find . -name '*.rs'");
         assert_eq!(cap, alan_protocol::ToolCapability::Read);
@@ -3760,6 +3918,36 @@ mod tests {
     #[test]
     fn test_classify_bash_command_python_module_pytest_is_write() {
         let cap = classify_bash_command("python -B -m pytest tests/test_requests.py -k redirect");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_local_runtests_script_is_write() {
+        let cap = classify_bash_command("./tests/runtests.py utils_tests.test_html");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_python_local_runtests_script_is_write() {
+        let cap = classify_bash_command("python3 -B tests/runtests.py utils_tests.test_html");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_manage_py_test_is_write() {
+        let cap = classify_bash_command("python manage.py test auth_tests");
+        assert_eq!(cap, alan_protocol::ToolCapability::Write);
+    }
+
+    #[test]
+    fn test_classify_bash_command_manage_py_shell_stays_unknown() {
+        let cap = classify_bash_command("python manage.py shell");
+        assert_eq!(cap, alan_protocol::ToolCapability::Unknown);
+    }
+
+    #[test]
+    fn test_classify_bash_command_local_gradle_test_wrapper_is_write() {
+        let cap = classify_bash_command("./gradlew test");
         assert_eq!(cap, alan_protocol::ToolCapability::Write);
     }
 
@@ -3796,6 +3984,20 @@ mod tests {
     #[test]
     fn test_classify_bash_command_sed_print_is_read() {
         let cap = classify_bash_command("sed -n '1,80p' test_requests.py");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_sed_substitute_is_read() {
+        let cap = classify_bash_command("sed 's#^./##' test_requests.py");
+        assert_eq!(cap, alan_protocol::ToolCapability::Read);
+    }
+
+    #[test]
+    fn test_classify_bash_command_read_only_find_sed_pipeline_is_read() {
+        let cap = classify_bash_command(
+            "find . -maxdepth 2 -type f | sed 's#^./##' | sort | rg \"(^test|tests|requests/test)\"",
+        );
         assert_eq!(cap, alan_protocol::ToolCapability::Read);
     }
 

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -244,7 +244,7 @@ Start with an automatically executable batch (each must include input script, as
    - Assertions: promotion only if thresholds pass (success rate, cost, boundary violations).
 8. `repo_worker/minimum_loop`
    - Goal: validate the first-party repo-worker package executes task -> plan -> edit -> verify -> deliver.
-   - Assertions: package completeness, loop artifacts, verification success, and delivery-contract validity.
+   - Assertions: package completeness, loop artifacts, verification success, delivery-contract validity, and verification-honesty / behavior-preserving fixture coverage.
 9. `repo_worker/input_modes_stability`
    - Goal: validate `steer/follow_up/next_turn` semantics in repo-worker paths.
    - Assertions: queue behavior, turn-driving semantics, and buffering boundaries.

--- a/docs/harness/scenarios/repo_worker/delivery_contract_examples.json
+++ b/docs/harness/scenarios/repo_worker/delivery_contract_examples.json
@@ -1,0 +1,17 @@
+{
+  "id": "repo_worker/delivery_contract_examples",
+  "category": "repo_worker",
+  "description": "Validate repo-worker delivery-contract fixtures for verification honesty and behavior-preserving reporting rules.",
+  "blocking": true,
+  "command": "bash crates/runtime/skills/repo-coding/scripts/check_delivery_contract_examples.sh",
+  "assertions": [
+    "valid fixtures cover mixed and environment-blocked verification outcomes",
+    "dishonest passed-with-failed-exit fixtures are rejected",
+    "test-only changes without an explicit behavior-level reason are rejected"
+  ],
+  "kpi_tags": [
+    "delivery_contract",
+    "verification_honesty",
+    "behavior_preserving"
+  ]
+}

--- a/docs/harness/scenarios/repo_worker/minimum_loop.json
+++ b/docs/harness/scenarios/repo_worker/minimum_loop.json
@@ -8,12 +8,14 @@
     "repo-worker package layout is complete",
     "minimum repo-worker loop artifacts are emitted",
     "verification command exits zero",
+    "delivery contract examples cover honest verification and behavior-preserving reporting",
     "delivery contract and evaluator boundary validations pass"
   ],
   "kpi_tags": [
     "repo_worker_loop",
     "package_shape",
     "verification",
+    "verification_honesty",
     "delivery_contract"
   ]
 }

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -521,7 +521,7 @@ resolved capability view:
 | ---------- | ------------------------------------------------------------- |
 | **memory** | Persistent pure-text memory across sessions (`{workspace_alan_dir}/memory/`) |
 | **plan**   | Structured execution plans for complex tasks (`.alan/plans/`) |
-| **repo-coding** | First-party repo-scoped coding delegation and child worker package |
+| **repo-coding** | First-party bounded repo-local coding package for steward-owned child execution |
 | **alan-shell-control** | Native Alan terminal shell layout and pane control |
 | **skill-creator** | First-party authoring and eval workflow guidance |
 | **workspace-inspect** | First-party read-only workspace inspection delegation and child reader package |
@@ -563,6 +563,11 @@ alan skills eval path/to/my-skill
 runs the structured eval suite and writes `run.json`, `benchmark.json`, a
 static review bundle, and per-case artifacts. When no manifest exists, Alan
 falls back to legacy `scripts/eval.sh` or `scripts/eval.py`.
+
+For coding packages such as `repo-coding`, external benchmark ladders sit on
+top of this local eval surface as adapter layers. They measure transfer
+quality, but they do not define runtime behavior or justify benchmark-specific
+prompt rules.
 
 Alan now exposes the same local-first management surface from the daemon:
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -119,7 +119,8 @@ steps, it is probably a plan rather than a spec.
   local tasks into explicit target-workspace child runtimes.
 - [alan_coding_eval_contract.md](./alan_coding_eval_contract.md): executable
   validation ladder for steward orchestration, repo-worker harness, and
-  package-local benchmark scaffolding.
+  package-local benchmark scaffolding, with external benchmark adapters framed
+  as measurement rather than product definition.
 - [alan_tui_ui_ux.md](./alan_tui_ui_ux.md): terminal-native TUI operator
   console UX contract.
 - [alan_shell_macos_contract.md](./alan_shell_macos_contract.md): macOS shell

--- a/docs/spec/alan_coding_eval_contract.md
+++ b/docs/spec/alan_coding_eval_contract.md
@@ -24,6 +24,23 @@ This contract does not:
 3. promise that external benchmark adapters are CI-blocking today,
 4. require full transcript-level grading inside parent runtime prompts.
 
+## Evaluation Role
+
+Evaluation exists to measure and regress the coding line, not to define its
+runtime behavior.
+
+Rules:
+
+1. steward harness, repo-worker harness, and package-local evals are the
+   primary surfaces for executable product invariants,
+2. external benchmarks are adapter layers that measure how well those general
+   behaviors transfer to outside corpora,
+3. benchmark failures should drive reusable contract, prompt, policy, or
+   harness improvements rather than repo-specific or benchmark-specific
+   heuristics,
+4. benchmark wins do not justify narrowing the coding product to one corpus or
+   repository family.
+
 ## Validation Ladder
 
 ### 1) Coding Steward Harness
@@ -76,6 +93,10 @@ The intended mapping is:
 2. package-local eval manifests hold comparison-oriented benchmark fixtures,
 3. external benchmark adapters transform outside task corpora into those
    operator-side eval surfaces.
+
+The key boundary is that these adapters measure general coding quality. They do
+not define task-specific runtime behavior and should not be used as the source
+of benchmark-only prompt rules.
 
 The recommended implementation order is Lite-first:
 
@@ -144,4 +165,7 @@ This contract is satisfied when:
 5. external benchmark work is framed as an adapter layer on top of local eval
    surfaces rather than the only measure of coding quality,
 6. the Lite-first adapter includes both single-case bring-up and curated-subset
-   aggregation surfaces before any full-dataset expansion.
+   aggregation surfaces before any full-dataset expansion,
+7. local docs explicitly state that benchmark findings must be generalized back
+   into reusable coding behavior rather than encoded as task-specific
+   heuristics.

--- a/docs/spec/alan_coding_governance_contract.md
+++ b/docs/spec/alan_coding_governance_contract.md
@@ -49,6 +49,41 @@ The child repo-worker fast path should cover:
 The child worker fast path ends when the task attempts to cross trust,
 workspace, credential, or publish boundaries.
 
+## Verification Honesty
+
+Coding governance should treat verification claims as owner-visible evidence,
+not as persuasive copy.
+
+Rules:
+
+1. delivery summaries must derive from actual verification command outcomes,
+2. `passed` verification may only be claimed when the cited commands actually
+   exited successfully,
+3. `mixed`, `environment_blocked`, `blocked`, `failed`, and `not_attempted`
+   states must be reported explicitly rather than paraphrased as generic
+   success,
+4. residual risk must mention blocked environments, missing broader coverage,
+   or failed checks when those conditions exist.
+
+## Behavior-Preserving Change Policy
+
+Repo-scoped coding work should prefer preserving surrounding product behavior
+unless there is strong evidence that behavior itself must change.
+
+Rules:
+
+1. existing tests and nearby behavior guards should be treated as presumptive
+   constraints,
+2. the default repair shape is minimal product-code change plus focused
+   regression coverage,
+3. the worker should not weaken or rewrite existing tests merely to make a
+   guessed patch pass,
+4. modifying an existing test requires an explicit behavior-level reason, not
+   only local convenience,
+5. when the issue statement and existing tests appear to conflict, the worker
+   should surface that discrepancy instead of silently normalizing one side
+   away.
+
 ## Owner-Boundary Classes For Coding
 
 Coding governance should escalate or deny at least these classes:
@@ -137,4 +172,7 @@ This contract is satisfied when:
 4. the first-party repo-worker policy uses explicit rules for publish,
    credential, deploy, and unknown-capability boundaries,
 5. tests and/or harness coverage exist for at least one path-sensitive coding
-   governance rule.
+   governance rule,
+6. local docs require verification claims to match real command evidence,
+7. local docs state that existing tests are behavior constraints, not default
+   rewrite targets.

--- a/docs/spec/alan_coding_steward_contract.md
+++ b/docs/spec/alan_coding_steward_contract.md
@@ -171,8 +171,9 @@ For coding workloads:
    directory where commands should execute.
 3. `launch.workspace_root` should point at the repo or project root that defines
    the worker's writable boundary.
-4. `launch.timeout_secs` should be set when the child should not hold the
-   parent hostage indefinitely.
+4. `launch.timeout_secs` should default to a bounded value so the child cannot
+   hold the parent hostage indefinitely; productized coding paths should only
+   omit it intentionally.
 5. `launch.budget_tokens` is optional and should be used when the parent needs
    a bounded reasoning budget for the worker.
 

--- a/docs/spec/alan_coding_steward_contract.md
+++ b/docs/spec/alan_coding_steward_contract.md
@@ -27,6 +27,26 @@ This contract does not:
 3. define the external benchmark ladder or steward eval harness in detail,
 4. turn `AgentRoot` overlay semantics into runtime parent-child inheritance.
 
+## Design Principles
+
+The coding line should stay aligned to these product principles:
+
+1. **Benchmark results are measurement, not behavior definition.**
+   External benchmark ladders may reveal real gaps, but they must not become
+   the source of repo-specific heuristics, task-specific prompts, or
+   benchmark-corpus special cases.
+2. **The repo worker is a bounded Alan child, not a disposable patch bot.**
+   A repo-scoped child runtime should preserve Alan's product strengths through
+   explicit handles such as `plan`, `conversation_snapshot`, `tool_results`,
+   and, when appropriate, `memory`.
+3. **Improvements should target general coding consensus.**
+   The right optimization surface is reusable coding behavior such as code
+   understanding, change-boundary control, verification discipline, and honest
+   delivery, not familiarity with one repository or evaluation set.
+4. **Continuity must remain explicit and auditable.**
+   Child inheritance is an explicit launch-contract choice rather than ambient
+   parent-session inheritance.
+
 ## Stable Vocabulary
 
 - **Coding steward**: the parent Alan runtime that owns goal intake, workspace
@@ -90,6 +110,8 @@ The child repo worker owns:
 
 The child worker should not silently broaden its workspace, approval, or
 external-action scope beyond what the launch contract granted.
+It should also be optimized for general repo-local coding quality rather than
+for any one repository, benchmark corpus, or issue family.
 
 ## Minimum Repo-Worker Loop
 
@@ -195,6 +217,8 @@ Recommended addition:
 
 Use this only when the repo-scoped child should share durable workspace memory
 for that project. `memory` is not the default coding handoff.
+This is how the coding child inherits Alan's durable project continuity when it
+materially improves the task; it is not a benchmark-only escape hatch.
 
 ### Intentionally Not Inherited By Default
 
@@ -343,4 +367,8 @@ This contract is satisfied when:
 5. local docs point at the productized repo-worker package path rather than a
    top-level `reference/` staging copy,
 6. adjacent docs no longer imply that Alan coding is primarily a default
-   single-repo shell.
+   single-repo shell,
+7. local docs explicitly state that external benchmarks measure coding quality
+   but do not define coding behavior,
+8. local docs describe the repo worker as a bounded Alan child that may inherit
+   explicit continuity handles, including optional `memory`.

--- a/scripts/repo-worker/run_smoke.sh
+++ b/scripts/repo-worker/run_smoke.sh
@@ -52,8 +52,13 @@ required_files=(
     "evals/README.md"
     "evals/evals.json"
     "evals/evaluator_cases.json"
+    "evals/files/delivery_contract_invalid_passed_with_failure_exit.json"
+    "evals/files/delivery_contract_invalid_test_only_without_reason.json"
+    "evals/files/delivery_contract_valid_mixed.json"
+    "evals/files/delivery_contract_valid_environment_blocked.json"
     "evals/files/benchmark_cases.json"
     "scripts/validate_delivery_contract.sh"
+    "scripts/check_delivery_contract_examples.sh"
     "scripts/check_evaluator_boundaries.sh"
     "scripts/run_benchmark_fixture.sh"
     "scripts/grade_benchmark_case.sh"
@@ -184,15 +189,30 @@ cat >"$artifact_root/delivery_contract.json" <<JSON
   "changed_files": [
     "src/lib.rs"
   ],
-  "verification": [
-    {
-      "command": "cargo test --quiet",
-      "scope": "targeted",
-      "status": "$verification_status",
-      "exit_code": $verify_exit,
-      "summary": "$verification_summary"
-    }
+  "behavioral_guards": [
+    "The public add(a, b) function should return the mathematical sum.",
+    "The add_returns_sum unit test remains the nearby deterministic behavior guard."
   ],
+  "verification": {
+    "overall_status": "$verification_status",
+    "verification_attempted": true,
+    "attempted_count": 1,
+    "passed_count": $([[ "$verification_status" == "passed" ]] && echo 1 || echo 0),
+    "failed_count": $([[ "$verification_status" == "failed" ]] && echo 1 || echo 0),
+    "environment_blocked_count": 0,
+    "blocked_count": 0,
+    "not_run_count": 0,
+    "all_passed": $([[ "$verification_status" == "passed" ]] && echo true || echo false),
+    "entries": [
+      {
+        "command": "cargo test --quiet",
+        "scope": "targeted",
+        "status": "$verification_status",
+        "exit_code": $verify_exit,
+        "summary": "$verification_summary"
+      }
+    ]
+  },
   "residual_risks": $residual_risks_json,
   "evaluator": {
     "mode": "$evaluator_mode",
@@ -202,14 +222,17 @@ cat >"$artifact_root/delivery_contract.json" <<JSON
 JSON
 
 set +e
-"$package_root/scripts/validate_delivery_contract.sh" \
+bash "$package_root/scripts/validate_delivery_contract.sh" \
     "$artifact_root/delivery_contract.json" \
     >"$artifact_root/delivery_contract.log" 2>&1
 delivery_contract_exit=$?
-"$package_root/scripts/check_evaluator_boundaries.sh" \
+bash "$package_root/scripts/check_evaluator_boundaries.sh" \
     "$package_root/evals/evaluator_cases.json" \
     >"$artifact_root/evaluator_boundary.log" 2>&1
 evaluator_boundary_exit=$?
+bash "$package_root/scripts/check_delivery_contract_examples.sh" \
+    >"$artifact_root/delivery_contract_examples.log" 2>&1
+delivery_contract_examples_exit=$?
 set -e
 
 delivery_contract_valid=false
@@ -222,8 +245,13 @@ if [[ $evaluator_boundary_exit -eq 0 ]]; then
     evaluator_boundaries_valid=true
 fi
 
+delivery_contract_examples_valid=false
+if [[ $delivery_contract_examples_exit -eq 0 ]]; then
+    delivery_contract_examples_valid=true
+fi
+
 smoke_passed=false
-if [[ "$verified" == "true" && "$delivery_contract_valid" == "true" && "$evaluator_boundaries_valid" == "true" ]]; then
+if [[ "$verified" == "true" && "$delivery_contract_valid" == "true" && "$evaluator_boundaries_valid" == "true" && "$delivery_contract_examples_valid" == "true" ]]; then
     smoke_passed=true
 fi
 
@@ -238,25 +266,27 @@ cat >"$artifact_root/delivery_summary.md" <<SUMMARY
 - verified: $verified
 - evaluator_mode: $evaluator_mode
 - delivery_contract_valid: $delivery_contract_valid
+- delivery_contract_examples_valid: $delivery_contract_examples_valid
 - evaluator_boundaries_valid: $evaluator_boundaries_valid
 SUMMARY
 
 cat >"$artifact_root/assertion_report.json" <<ASSERT
-{"scenario":"repo_worker/minimum_loop_smoke","passed":$smoke_passed,"assertions":[{"name":"package_present","passed":true},{"name":"edit_applied","passed":$edit_applied},{"name":"verify_command_exit_zero","passed":$verified},{"name":"delivery_contract_valid","passed":$delivery_contract_valid},{"name":"evaluator_boundaries_valid","passed":$evaluator_boundaries_valid}]}
+{"scenario":"repo_worker/minimum_loop_smoke","passed":$smoke_passed,"assertions":[{"name":"package_present","passed":true},{"name":"edit_applied","passed":$edit_applied},{"name":"verify_command_exit_zero","passed":$verified},{"name":"delivery_contract_valid","passed":$delivery_contract_valid},{"name":"delivery_contract_examples_valid","passed":$delivery_contract_examples_valid},{"name":"evaluator_boundaries_valid","passed":$evaluator_boundaries_valid}]}
 ASSERT
 
 cat >"$artifact_root/summary.json" <<REPORT
-{"mode":"$mode","status":"$delivery_status","verify_exit":$verify_exit,"verified":$verified,"delivery_contract_valid":$delivery_contract_valid,"evaluator_boundaries_valid":$evaluator_boundaries_valid,"passed":$smoke_passed,"artifact_root":"target/repo-worker/smoke/latest"}
+{"mode":"$mode","status":"$delivery_status","verify_exit":$verify_exit,"verified":$verified,"delivery_contract_valid":$delivery_contract_valid,"delivery_contract_examples_valid":$delivery_contract_examples_valid,"evaluator_boundaries_valid":$evaluator_boundaries_valid,"passed":$smoke_passed,"artifact_root":"target/repo-worker/smoke/latest"}
 REPORT
 
 echo "Repo worker smoke summary:"
 echo "  mode: $mode"
 echo "  verify_exit: $verify_exit"
 echo "  delivery_contract_valid: $delivery_contract_valid"
+echo "  delivery_contract_examples_valid: $delivery_contract_examples_valid"
 echo "  evaluator_boundaries_valid: $evaluator_boundaries_valid"
 echo "  passed: $smoke_passed"
 echo "  artifacts: $artifact_root"
 
-if [[ $verify_exit -ne 0 || $delivery_contract_exit -ne 0 || $evaluator_boundary_exit -ne 0 ]]; then
+if [[ $verify_exit -ne 0 || $delivery_contract_exit -ne 0 || $delivery_contract_examples_exit -ne 0 || $evaluator_boundary_exit -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary
- preserve child repo-worker structured output through delegated runtime results and prefer real child summaries over generic turn summaries
- tighten repo-worker delivery contract for verification honesty, behavioral guards, and test-change reasons
- improve SWE-bench Lite operator scripts for harness preflight/scoring artifacts without making benchmark-specific runtime rules
- refine shell capability classification for quoted pipes, local verification commands, and safer sed/find handling

## Validation
- cargo fmt --all -- --check
- cargo test -p alan-tools classify_bash_command --lib
- cargo test -p alan-runtime runtime::child_agents::tests:: --lib
- cargo test -p alan-runtime runtime::virtual_tools::tests::test_delegated_result_from_completed_child_prefers_structured_output_summary --lib
- cargo test -p alan-runtime runtime::virtual_tools::tests::test_delegated_result_from_completed_child_prefers_output_text_over_turn_summary --lib
- cargo test -p alan-runtime test_builtin_launch_root_agent_configs_parse_as_agent_overlays --lib
- cargo test -p alan-runtime test_bash_preflight_allows_python_module_pytest --lib
- bash crates/runtime/skills/repo-coding/scripts/check_delivery_contract_examples.sh
- bash scripts/repo-worker/run_smoke.sh

Refs #10