### PR TITLE
Compact TUI status HUD and track sub-agent lifecycle work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ lcov.info
 .coverage.*
 htmlcov/
 
+# Local agent/tooling runtime state.
+.alan/sessions/
+.alan/memory/
+.codex/
+
 # Local Ghostty developer artifacts for the Apple client.
 clients/apple/GhosttyKit.xcframework
 clients/apple/GhosttyKit.xcframework.bak-*/

--- a/clients/tui/src/adaptive-surfaces/shared.tsx
+++ b/clients/tui/src/adaptive-surfaces/shared.tsx
@@ -13,12 +13,7 @@ export function AdaptiveSurfacePanel({
   children,
 }: AdaptiveSurfacePanelProps) {
   return (
-    <Box
-      borderStyle="round"
-      borderColor="yellow"
-      flexDirection="column"
-      paddingX={1}
-    >
+    <Box flexDirection="column" paddingX={1} marginY={1}>
       <Text color="yellow" bold>
         {title}
       </Text>

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -73,7 +73,6 @@ import {
   reduceCurrentPlanState,
   type CurrentPlanState,
 } from "./summary-surfaces/plan-state.js";
-import { PlanSurface } from "./summary-surfaces/plan-surface.js";
 import {
   buildCurrentRuntimeSummary,
   createCurrentRuntimeState,
@@ -81,7 +80,7 @@ import {
   type CurrentRuntimeState,
   type ShellRunStatus,
 } from "./summary-surfaces/runtime-state.js";
-import { RuntimeSurface } from "./summary-surfaces/runtime-surface.js";
+import { SummaryHud } from "./summary-surfaces/hud-surface.js";
 
 const AGENTD_URL = resolveAgentdUrlOverride(process.env);
 const AUTO_MANAGE = !AGENTD_URL;
@@ -2803,24 +2802,22 @@ function App() {
 
   return (
     <Box flexDirection="column" width="100%">
-      <Box
-        borderStyle="round"
-        borderColor={getStatusColor()}
-        flexDirection="column"
-        paddingX={1}
-      >
-        <Box>
-          <Text bold>Alan TUI</Text>
-          <Text color="gray"> protocol-first terminal workspace assistant</Text>
-        </Box>
+      <Box paddingX={1} flexWrap="wrap">
+        <Text bold>Alan TUI</Text>
+        <Text color="gray"> protocol-first terminal workspace assistant | </Text>
+        <Text color="gray">
+          mode={STARTUP_INFO.mode === "embedded" ? "local" : "remote"}
+          {" | "}session={shortId(currentSessionId)}
+          {currentSessionId ? "..." : ""}
+          {" | "}
+          {summarizeSessionBinding(currentSessionBinding)}
+          {" | "}pending={pendingLabel}
+          {" | "}events={events.length}
+        </Text>
+      </Box>
+      <Box paddingX={1}>
         <Text color={getStatusColor()}>
           {getStatusGlyph()} {statusMessage}
-        </Text>
-        <Text color="gray">
-          mode={STARTUP_INFO.mode === "embedded" ? "local" : "remote"} |
-          session={shortId(currentSessionId)}
-          {currentSessionId ? "..." : ""} | {summarizeSessionBinding(currentSessionBinding)} |
-          pending={pendingLabel} | events={events.length}
         </Text>
       </Box>
 
@@ -2828,28 +2825,18 @@ function App() {
         ? activeSurface.render(adaptiveSurfaceContext)
         : null}
 
-      {currentPlan ? <PlanSurface plan={currentPlan} /> : null}
-
-      <RuntimeSurface summary={runtimeSummary} />
-
-      <Box
-        borderStyle="single"
-        borderColor="gray"
-        flexDirection="column"
-        paddingX={1}
-      >
+      <Box flexDirection="column" paddingX={1}>
         <MessageList events={events} />
       </Box>
 
-      <Box paddingX={1}>
-        <Text color="gray">{footerHint}</Text>
-      </Box>
+      <SummaryHud
+        plan={currentPlan}
+        runtimeSummary={runtimeSummary}
+        footerHint={footerHint}
+        pending={Boolean(pendingYield)}
+      />
 
-      <Box
-        borderStyle="round"
-        borderColor={pendingYield ? "yellow" : "blue"}
-        paddingX={1}
-      >
+      <Box paddingX={1}>
         <Text color={pendingYield ? "yellow" : "cyan"} bold>
           {pendingYield && activeSurface && adaptiveSurfaceContext
             ? activeSurface.inputLabel({

--- a/clients/tui/src/summary-surfaces/hud-surface.test.ts
+++ b/clients/tui/src/summary-surfaces/hud-surface.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { buildPlanHudSummary, buildRuntimeHudSummary } from "./hud-surface";
+import type { CurrentPlanState } from "./plan-state";
+import type { CurrentRuntimeSummary } from "./runtime-state";
+
+function plan(overrides: Partial<CurrentPlanState> = {}): CurrentPlanState {
+  return {
+    items: [
+      {
+        id: "inspect",
+        content: "Inspect current TUI layout",
+        status: "completed",
+      },
+      {
+        id: "hud",
+        content: "Move status into the input HUD",
+        status: "in_progress",
+      },
+      { id: "verify", content: "Run focused tests", status: "pending" },
+    ],
+    statusCounts: {
+      completed: 1,
+      in_progress: 1,
+      pending: 1,
+    },
+    lastUpdatedEventId: "evt_1",
+    lastUpdatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function runtime(
+  overrides: Partial<CurrentRuntimeSummary> = {},
+): CurrentRuntimeSummary {
+  return {
+    headline: "Running bash",
+    shellRunStatus: "running",
+    activeTool: {
+      callId: "call-1",
+      name: "bash",
+      status: "running",
+    },
+    recentTool: null,
+    recoverableError: null,
+    guidance: "Next: send a request or use /help.",
+    ...overrides,
+  };
+}
+
+describe("summary HUD helpers", () => {
+  test("summarizes the active plan in one compact line", () => {
+    expect(buildPlanHudSummary(plan())).toBe(
+      "Plan: 1 active | 1 pending | 1 completed | > [~] Move status into the input HUD",
+    );
+  });
+
+  test("uses the next pending plan item when nothing is active", () => {
+    expect(
+      buildPlanHudSummary(
+        plan({
+          items: [
+            { id: "verify", content: "Run focused tests", status: "pending" },
+          ],
+          statusCounts: {
+            completed: 0,
+            in_progress: 0,
+            pending: 1,
+          },
+        }),
+      ),
+    ).toBe("Plan: 1 pending | [ ] Run focused tests");
+  });
+
+  test("summarizes runtime state in one compact line", () => {
+    expect(buildRuntimeHudSummary(runtime())).toBe(
+      "Runtime: Running bash | state=running | tool=bash running | send a request or use /help.",
+    );
+  });
+});

--- a/clients/tui/src/summary-surfaces/hud-surface.tsx
+++ b/clients/tui/src/summary-surfaces/hud-surface.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type { CurrentPlanState } from "./plan-state.js";
+import type {
+  CurrentRuntimeSummary,
+  RuntimeToolState,
+} from "./runtime-state.js";
+
+function planItemMarker(
+  status: CurrentPlanState["items"][number]["status"],
+): string {
+  if (status === "completed") {
+    return "[x]";
+  }
+  if (status === "in_progress") {
+    return "[~]";
+  }
+  return "[ ]";
+}
+
+function planItemPrefix(
+  status: CurrentPlanState["items"][number]["status"],
+): string {
+  return status === "in_progress" ? "> " : "";
+}
+
+function planStatusSummary(plan: CurrentPlanState): string {
+  const segments: string[] = [];
+
+  if (plan.statusCounts.in_progress > 0) {
+    segments.push(`${plan.statusCounts.in_progress} active`);
+  }
+  if (plan.statusCounts.pending > 0) {
+    segments.push(`${plan.statusCounts.pending} pending`);
+  }
+  if (plan.statusCounts.completed > 0) {
+    segments.push(`${plan.statusCounts.completed} completed`);
+  }
+
+  return segments.join(" | ");
+}
+
+function prioritizedPlanItem(
+  plan: CurrentPlanState,
+): CurrentPlanState["items"][number] | null {
+  return (
+    plan.items.find((item) => item.status === "in_progress") ??
+    plan.items.find((item) => item.status === "pending") ??
+    plan.items.at(-1) ??
+    null
+  );
+}
+
+function runtimeToolSummary(tool: RuntimeToolState): string {
+  const preview = tool.resultPreview ? ` | ${tool.resultPreview}` : "";
+  return `tool=${tool.name} ${tool.status}${preview}`;
+}
+
+function compactGuidance(guidance: string): string {
+  return guidance.replace(/^Next:\s*/i, "");
+}
+
+export function buildPlanHudSummary(
+  plan: CurrentPlanState | null,
+): string | null {
+  if (!plan || plan.items.length === 0) {
+    return null;
+  }
+
+  const statusSummary = planStatusSummary(plan);
+  const focusItem = prioritizedPlanItem(plan);
+  const focusSummary = focusItem
+    ? `${planItemPrefix(focusItem.status)}${planItemMarker(focusItem.status)} ${
+        focusItem.content
+      }`
+    : null;
+
+  return `Plan: ${[statusSummary, focusSummary].filter(Boolean).join(" | ")}`;
+}
+
+export function buildRuntimeHudSummary(summary: CurrentRuntimeSummary): string {
+  const segments = [summary.headline, `state=${summary.shellRunStatus}`];
+
+  if (summary.activeTool) {
+    segments.push(runtimeToolSummary(summary.activeTool));
+  } else if (summary.recentTool) {
+    segments.push(runtimeToolSummary(summary.recentTool));
+  }
+
+  if (summary.recoverableError) {
+    segments.push(summary.recoverableError.message);
+  }
+
+  segments.push(compactGuidance(summary.guidance));
+
+  return `Runtime: ${segments.join(" | ")}`;
+}
+
+export interface SummaryHudProps {
+  plan: CurrentPlanState | null;
+  runtimeSummary: CurrentRuntimeSummary;
+  footerHint: string;
+  pending: boolean;
+}
+
+export function SummaryHud({
+  plan,
+  runtimeSummary,
+  footerHint,
+  pending,
+}: SummaryHudProps) {
+  const planSummary = buildPlanHudSummary(plan);
+  const runtimeSummaryText = buildRuntimeHudSummary(runtimeSummary);
+  const statusColor =
+    pending || runtimeSummary.recoverableError ? "yellow" : "gray";
+
+  return (
+    <Box flexDirection="column" paddingX={1} marginTop={1}>
+      {planSummary ? <Text color="cyan">{planSummary}</Text> : null}
+      <Text color={statusColor}>{runtimeSummaryText}</Text>
+      <Text color="gray">{footerHint}</Text>
+    </Box>
+  );
+}

--- a/clients/tui/src/summary-surfaces/shared.tsx
+++ b/clients/tui/src/summary-surfaces/shared.tsx
@@ -11,12 +11,7 @@ export function SummarySurfacePanel({
   children,
 }: SummarySurfacePanelProps) {
   return (
-    <Box
-      borderStyle="round"
-      borderColor="cyan"
-      flexDirection="column"
-      paddingX={1}
-    >
+    <Box flexDirection="column" paddingX={1}>
       <Text color="cyan" bold>
         {title}
       </Text>

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -87,6 +87,9 @@ steps, it is probably a plan rather than a spec.
   and auth-layer boundaries.
 - [scheduler_contract.md](./scheduler_contract.md): schedule/sleep/wake source
   of truth semantics.
+- [sub_agent_lifecycle_contract.md](./sub_agent_lifecycle_contract.md): child
+  runtime liveness, lifecycle control, result handoff, and runtime-state hygiene
+  target contract.
 
 ## Governance, Skills, And Extensibility
 

--- a/docs/spec/sub_agent_lifecycle_contract.md
+++ b/docs/spec/sub_agent_lifecycle_contract.md
@@ -1,0 +1,258 @@
+# Sub-Agent Lifecycle Contract
+
+> Status: target runtime, daemon, and TUI contract for delegated child
+> runtimes, result handoff, and runtime-owned state surfaces.
+
+## Goal
+
+Make delegated sub-agent execution observable, controllable, and recoverable
+without forcing parent runtimes or humans to infer child state from hard
+timeouts or truncated memory files.
+
+The target outcome is:
+
+1. child runtimes can prove they are still making progress,
+2. parent runtimes and TUI operators can list, inspect, and terminate child
+   work explicitly,
+3. delegated results preserve enough information for parent integration,
+4. runtime memory and workspace state surfaces remain useful debugging aids
+   instead of lossy or misleading artifacts.
+
+## Non-Goals
+
+This contract does not:
+
+1. define a strict OS sandbox,
+2. replace the `SpawnSpec` launch contract,
+3. require child runtimes to stream every token into the parent tape,
+4. require `.alan/memory/` to become a lossless transcript store,
+5. turn workspace `.alan/agent/` configuration into disposable runtime state.
+
+## Stable Vocabulary
+
+- **Parent runtime**: the runtime that launches and supervises one or more child
+  runtimes.
+- **Child runtime**: a fresh delegated runtime launched through an explicit
+  spawn or delegated-skill contract.
+- **Child run**: the observable lifecycle record for one child runtime launch.
+- **Heartbeat**: a runtime-owned liveness signal emitted by a child while it is
+  still working, even when no user-visible text is produced.
+- **Progress signal**: a heartbeat plus optional status such as current plan
+  item, active tool, recent warning, or latest event cursor.
+- **Idle timeout**: a timeout measured from the latest heartbeat or progress
+  signal.
+- **Wall-clock cap**: an optional maximum runtime duration used only as a final
+  resource guard.
+- **Termination**: an explicit operator or parent-runtime request to stop a
+  child run, recorded with actor, reason, and mode.
+- **Result handoff**: the bounded result object the parent receives after a
+  child reaches a terminal or blocked state.
+- **Runtime-owned state**: `.alan/sessions/`, `.alan/memory/working/`, handoffs,
+  daily notes, and other generated files written by the runtime.
+
+## Child Run Lifecycle
+
+Every child runtime launch must create or register a child run record before
+the first task submission is sent to the child.
+
+A child run record must include:
+
+1. child run id,
+2. child session id,
+3. parent session id,
+4. target workspace root when known,
+5. launch target and delegated skill metadata when applicable,
+6. rollout path when available,
+7. created time,
+8. current status,
+9. latest heartbeat time,
+10. latest event cursor or sequence when available,
+11. latest compact status summary when available.
+
+Child run statuses are:
+
+1. `starting`
+2. `running`
+3. `blocked`
+4. `completed`
+5. `failed`
+6. `timed_out`
+7. `terminating`
+8. `terminated`
+9. `cancelled`
+
+Terminal statuses are `completed`, `failed`, `timed_out`, `terminated`, and
+`cancelled`.
+
+## Liveness And Timeout Semantics
+
+Child supervision should prefer liveness over hard wall-clock expiry.
+
+Rules:
+
+1. Child runtimes must emit progress signals while active.
+2. Any child event observed by the parent updates `latest_event_at`.
+3. A periodic heartbeat updates `latest_heartbeat_at` even when the model or
+   tool has not emitted user-visible output.
+4. Parent supervision must not classify a child as timed out while fresh
+   heartbeat or progress signals are still arriving.
+5. Idle timeout is measured from the latest heartbeat or progress signal.
+6. Wall-clock cap is optional and should be substantially larger than the idle
+   timeout.
+7. When idle timeout expires, the child run becomes `timed_out` and the result
+   handoff must include child run metadata and the latest known progress.
+8. If the runtime actually stops the process, status must distinguish
+   `timed_out` from operator-requested `terminated`.
+
+The child should not be considered healthy solely because its process exists.
+The source of truth is runtime-observed heartbeat or progress.
+
+## Control Plane
+
+The daemon must expose a control plane that can:
+
+1. list child runs for a parent session,
+2. read a child run by id,
+3. terminate a child run with a reason,
+4. expose enough rollout and workspace metadata for debugging.
+
+The parent runtime should also be able to request child termination through a
+governed runtime tool. That tool must record:
+
+1. child run id,
+2. requesting actor,
+3. reason,
+4. whether termination was graceful or forceful,
+5. resulting status.
+
+Human and model-initiated termination must share the same runtime state
+transition path.
+
+## TUI Contract
+
+`alan-tui` must expose child-run management as operator commands.
+
+Minimum commands:
+
+1. `/agents` lists child runs for the current session, grouped by status.
+2. `/agent <id>` shows child run details, including status, workspace, latest
+   heartbeat, current plan or active tool, and rollout path.
+3. `/agent terminate <id> [reason]` requests graceful termination.
+4. `/agent kill <id> [reason]` requests forceful termination when graceful
+   termination is unavailable or stuck.
+
+The TUI should also surface active child-run counts in the compact runtime HUD
+when a parent session has children.
+
+## Delegated Result Handoff
+
+The delegated result object returned to the parent must preserve integration
+fidelity without flooding the parent tape.
+
+Required fields:
+
+1. `status`
+2. `summary`
+3. `summary_preview` when the full summary is too large for the parent tape
+4. `child_run`
+5. `output_text` or `output_ref`
+6. `structured_output` or `structured_output_ref`
+7. `truncation` metadata when any field is shortened
+8. `warnings`
+9. `error_kind` and `error_message` when applicable
+
+Rules:
+
+1. A completed child must not be reduced to an unlabeled 320-character preview.
+2. If the full output is too large to inline, the result must include an
+   inspectable reference such as child session id, rollout path, and output
+   cursor.
+3. The parent must be able to tell the difference between "the child produced
+   only a short answer" and "the child produced a long answer that was
+   intentionally summarized".
+4. Structured output truncation must preserve critical status and summary keys
+   and include explicit truncation metadata.
+
+## Memory Surface Rules
+
+Runtime-owned memory surfaces are curated continuation aids, not arbitrary
+string previews.
+
+Rules:
+
+1. Memory surfaces must not cut Markdown headings, bullets, or code fences in
+   the middle of a token without an explicit truncation marker.
+2. Truncation markers must say what was omitted and where to inspect the source
+   rollout.
+3. Session-summary and handoff surfaces must refresh after terminal turn state
+   is known.
+4. A completed turn must not leave active plan items in `in_progress` unless
+   the runtime has evidence the work is intentionally still open.
+5. Working memory may stay compact, but it must remain semantically coherent.
+
+Raw rollout files remain the source of truth for event replay. Memory surfaces
+must point to rollouts when they omit relevant detail.
+
+## Workspace Runtime State
+
+Generated runtime state must not pollute normal repo status.
+
+Rules:
+
+1. `.alan/sessions/` is runtime-owned generated state.
+2. `.alan/memory/working/` is runtime-owned generated state.
+3. `.alan/memory/handoffs/`, `.alan/memory/daily/`, and
+   `.alan/memory/sessions/` are generated episodic state unless a workspace
+   deliberately opts into tracking them.
+4. `.alan/agent/`, `.alan/agents/`, and workspace-authored policies or skills
+   may be source-controlled when the project wants workspace-local agent
+   configuration.
+5. Repository templates should ignore generated runtime state by default while
+   allowing opt-in tracking for agent definitions.
+
+## Home Workspace And Path Canonicalization
+
+Alan home must not accidentally become a nested workspace that creates
+`~/.alan/.alan/` runtime state.
+
+Rules:
+
+1. When the workspace root is Alan home, runtime state paths must resolve to
+   the canonical Alan home layout instead of appending another `.alan/`.
+2. Workspace identity comparisons must use canonical paths where the platform
+   can provide them.
+3. Case variants such as `/Users/name/Developer/Alan` and
+   `/Users/name/Developer/alan` must not produce separate workspace identities
+   on case-insensitive filesystems.
+4. Migration or cleanup tooling should detect legacy nested Alan-home state and
+   report it before removal.
+
+## Relationship To Other Contracts
+
+1. `workspace_routing_contract.md` defines when parent runtimes should route
+   local work into child runtimes.
+2. `alan_coding_steward_contract.md` defines the coding steward / repo-worker
+   product boundary.
+3. `pure_text_memory_contract.md` defines memory layers and file ownership.
+4. `alan_tui_ui_ux.md` defines the operator console layout and summary-surface
+   behavior.
+5. `execution_model.md` defines the task, run, session, and turn hierarchy.
+
+## Acceptance Criteria
+
+This contract is satisfied when:
+
+1. active child runtimes emit heartbeat or progress signals,
+2. delegated child supervision uses idle timeout rather than a single hard
+   wall-clock timeout,
+3. parent runtimes and the TUI can list and inspect child runs,
+4. parent runtimes and the TUI can terminate child runs explicitly,
+5. completed child output is not silently collapsed into a short preview,
+6. memory surfaces no longer contain broken fragments such as half-rendered
+   Markdown bullets,
+7. terminal session summaries reflect completed plan state,
+8. generated `.alan` runtime state is ignored or clearly separated from
+   source-controlled workspace agent definitions,
+9. Alan home does not create nested `.alan/.alan` runtime state,
+10. workspace identity is canonical enough to avoid duplicate state for path
+    casing variants on case-insensitive filesystems.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/plans/2026-04-28-sub-agent-lifecycle-memory-plan.md
+++ b/plans/2026-04-28-sub-agent-lifecycle-memory-plan.md
@@ -1,0 +1,229 @@
+# Sub-Agent Lifecycle And Memory Reliability Plan (2026-04-28)
+
+> Status: active tracking plan for the child-runtime lifecycle, TUI
+> management, delegated result handoff, and runtime-state hygiene issues found
+> while inspecting root session `441b634c-7344-45c8-bdb4-e45bf7b9868e`.
+
+## Why This Plan Exists
+
+The root session delegated TUI repository inspection to child runtimes. That
+surfaced several related reliability problems:
+
+1. one child timed out and was reduced to `child_timed_out`,
+2. the successful child produced a full answer, but the parent only received a
+   320-character delegated summary,
+3. runtime memory surfaces contained broken fragments such as
+   `### Top-level directories` followed by `- c...`,
+4. memory and handoff files still showed `in_progress` after the task store
+   marked the session complete,
+5. generated workspace `.alan/` state appeared as untracked repository files,
+6. Alan home contained nested `.alan/.alan/` runtime state.
+
+The target contract is `docs/spec/sub_agent_lifecycle_contract.md`.
+
+## Scope
+
+This plan tracks eight issues:
+
+1. child liveness and idle timeout,
+2. child-run lifecycle registry and daemon control plane,
+3. TUI child-agent management commands,
+4. governed parent-runtime child termination tool,
+5. delegated result handoff fidelity,
+6. memory surface truncation and terminal-state refresh,
+7. workspace `.alan` generated-state hygiene,
+8. Alan-home nesting and path canonicalization.
+
+## Current Evidence
+
+Observed in root session `441b634c-7344-45c8-bdb4-e45bf7b9868e`:
+
+1. `/Users/morris/.alan/sessions/rollout-20260428-111136-441b634c-7344-45c8-bdb4-e45bf7b9868e.jsonl`
+   recorded child `abde85e1-3eea-493d-88fd-6acbfd293fc8` as
+   `terminal_status=timed_out`.
+2. The same root rollout recorded child
+   `d54d4327-ce5f-475b-af60-ce76d389f4d8` as completed, but the delegated
+   result summary was exactly 320 characters.
+3. `.alan/sessions/rollout-20260428-111528-d54d4327-ce5f-475b-af60-ce76d389f4d8.jsonl`
+   contains a full final assistant message of 5582 characters.
+4. `.alan/memory/working/d54d4327-ce5f-475b-af60-ce76d389f4d8.md` contains a
+   broken fragment ending with `- c...`.
+5. `/Users/morris/.alan/memory/working/441b634c-7344-45c8-bdb4-e45bf7b9868e.md`
+   still includes `in_progress` plan state after task completion.
+6. `git status --short --ignored .alan` reports `?? .alan/`.
+7. `/Users/morris/.alan/.alan/` exists with generated runtime directories.
+
+Relevant code baseline:
+
+1. `crates/runtime/src/runtime/child_agents.rs` uses a single timeout sleep and
+   calls `abort_runtime()` on expiry.
+2. `crates/runtime/src/runtime/virtual_tools.rs` caps delegated result summary
+   persistence at `MAX_DELEGATED_RESULT_SUMMARY_CHARS = 320`.
+3. `crates/runtime/src/runtime/memory_surfaces.rs` caps inline text at
+   `MAX_INLINE_TEXT_CHARS = 280` and appends `...`.
+4. `clients/tui/src/index.tsx` exposes `/sessions`, `/interrupt`,
+   `/compact`, and `/rollback`, but no child-agent management commands.
+
+## Issue Tracking
+
+1. [#312](https://github.com/realmorrisliu/Alan/issues/312) -
+   runtime/protocol, P0:
+   Replace child hard timeout with heartbeat-backed idle timeout.
+2. [#313](https://github.com/realmorrisliu/Alan/issues/313) -
+   runtime/daemon/protocol, P0:
+   Add child-run lifecycle registry and daemon control plane.
+3. [#314](https://github.com/realmorrisliu/Alan/issues/314) - tui, P1:
+   Add `/agents` and `/agent ...` management commands.
+4. [#315](https://github.com/realmorrisliu/Alan/issues/315) -
+   runtime/governance, P1:
+   Add governed parent-runtime child termination tool.
+5. [#316](https://github.com/realmorrisliu/Alan/issues/316) -
+   runtime/protocol, P0:
+   Preserve delegated result handoff fidelity beyond 320-char previews.
+6. [#317](https://github.com/realmorrisliu/Alan/issues/317) -
+   runtime/memory, P0:
+   Fix memory-surface truncation and completed-session refresh.
+7. [#318](https://github.com/realmorrisliu/Alan/issues/318) -
+   repo/config, P1:
+   Ignore generated workspace `.alan` runtime state by default.
+8. [#319](https://github.com/realmorrisliu/Alan/issues/319) -
+   runtime/paths, P1:
+   Prevent Alan-home `.alan/.alan` nesting and canonicalize workspace paths.
+
+## Delivery Order
+
+Recommended sequence:
+
+1. land the contract and issue map,
+2. implement child-run registry and heartbeat events,
+3. convert delegated supervision to idle-timeout semantics,
+4. add termination control paths,
+5. expose child management in the TUI,
+6. fix delegated result payload truncation,
+7. fix memory-surface rendering and terminal refresh,
+8. clean up runtime-state path and ignore rules.
+
+This order makes lifecycle state available before TUI and termination features
+depend on it.
+
+## Implementation Slices
+
+### Slice 1: Child Liveness And Registry
+
+Files likely affected:
+
+1. `crates/protocol/src/event.rs`
+2. `crates/protocol/src/spawn.rs`
+3. `crates/runtime/src/runtime/child_agents.rs`
+4. `crates/runtime/src/runtime/engine.rs`
+5. `crates/alan/src/daemon/session_store.rs`
+6. `crates/alan/src/daemon/routes.rs`
+
+Exit criteria:
+
+1. child runs are registered before launch,
+2. active children report heartbeat/progress,
+3. idle timeout uses latest progress time,
+4. daemon can list and read child-run state.
+
+### Slice 2: Termination Control
+
+Files likely affected:
+
+1. `crates/runtime/src/runtime/virtual_tools.rs`
+2. `crates/runtime/src/runtime/tool_orchestrator.rs`
+3. `crates/alan/src/daemon/routes.rs`
+4. `crates/alan/src/daemon/runtime_manager.rs`
+5. `docs/governance_current_contract.md`
+
+Exit criteria:
+
+1. human and parent-runtime termination share one state transition path,
+2. termination records actor and reason,
+3. graceful and forceful termination are distinguishable,
+4. terminated children produce inspectable terminal child-run records.
+
+### Slice 3: TUI Child-Agent Management
+
+Files likely affected:
+
+1. `clients/tui/src/client.ts`
+2. `clients/tui/src/index.tsx`
+3. `clients/tui/src/summary-surfaces/runtime-state.ts`
+4. `clients/tui/src/summary-surfaces/hud-surface.tsx`
+5. `clients/tui/src/client.test.ts`
+
+Exit criteria:
+
+1. `/agents` lists children for the current session,
+2. `/agent <id>` shows details,
+3. `/agent terminate <id> [reason]` requests graceful termination,
+4. `/agent kill <id> [reason]` requests forceful termination,
+5. runtime HUD shows active child count when relevant.
+
+### Slice 4: Result Handoff Fidelity
+
+Files likely affected:
+
+1. `crates/runtime/src/runtime/virtual_tools.rs`
+2. `crates/runtime/src/runtime/child_agents.rs`
+3. `crates/runtime/src/skills/types.rs`
+4. `crates/runtime/src/runtime/virtual_tools_tests.rs`
+5. `docs/skills_and_tools.md`
+
+Exit criteria:
+
+1. completed child output is not silently reduced to 320 characters,
+2. full child output is available inline or by reference,
+3. truncation metadata is explicit,
+4. parent prompts can distinguish short output from shortened output.
+
+### Slice 5: Memory Surface Reliability
+
+Files likely affected:
+
+1. `crates/runtime/src/runtime/memory_surfaces.rs`
+2. `crates/runtime/src/runtime/turn_executor.rs`
+3. `crates/runtime/src/runtime/memory_flush.rs`
+4. `crates/runtime/src/runtime/turn_state.rs`
+5. `docs/spec/pure_text_memory_contract.md`
+
+Exit criteria:
+
+1. memory surfaces truncate by coherent sections or lines,
+2. truncation markers point to source rollouts,
+3. terminal refresh writes completed plan state,
+4. handoff and session summaries do not keep stale `in_progress` items after
+   successful completion.
+
+### Slice 6: Runtime State Hygiene
+
+Files likely affected:
+
+1. `.gitignore`
+2. `crates/runtime/src/paths.rs`
+3. `crates/runtime/src/agent_root.rs`
+4. `crates/alan/src/registry.rs`
+5. `docs/architecture.md`
+
+Exit criteria:
+
+1. generated `.alan/sessions/` and `.alan/memory/` runtime files are ignored by
+   default,
+2. workspace `.alan/agent/` remains available for source-controlled agent
+   definitions,
+3. Alan home does not create nested `.alan/.alan/` state,
+4. path casing variants resolve to one workspace identity where supported.
+
+## Review Heuristics
+
+Review this track against these questions:
+
+1. Can an operator tell whether a child is working, blocked, or dead without
+   reading raw rollout files?
+2. Can the parent stop a child without treating timeout as the only control
+   path?
+3. Does the parent receive enough child output to make a faithful final answer?
+4. Are memory files readable by humans and free of misleading half-fragments?
+5. Does repo status stay focused on source changes rather than generated Alan
+   state?

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,6 +13,7 @@ repository. Git history is sufficient for old rollout context.
 
 ## Active Or Still-Relevant Plans
 
+- [2026-04-28-sub-agent-lifecycle-memory-plan.md](./2026-04-28-sub-agent-lifecycle-memory-plan.md)
 - [2026-04-19-repo-worker-package-migration-plan.md](./2026-04-19-repo-worker-package-migration-plan.md)
 - [2026-04-18-alan-coding-steward-boundary-plan.md](./2026-04-18-alan-coding-steward-boundary-plan.md)
 - [2026-04-13-provider-compat-execution-plan.md](./2026-04-13-provider-compat-execution-plan.md)


### PR DESCRIPTION
## Summary
- Compact the TUI header and move plan/runtime state into a HUD above the composer while removing distracting borders.
- Add a sub-agent lifecycle target spec and tracking plan for issues #312-#319.
- Ignore local generated Alan/Codex runtime state while keeping `openspec/` tracked for future specs.

## Test Plan
- [x] `bun run lint` from `clients/tui`
- [x] `git diff --check`
