### PR TITLE
Add child-run lifecycle controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ htmlcov/
 
 # Local agent/tooling runtime state.
 .alan/*
-!.alan/agent/
-!.alan/agent/**
 !.alan/agents/
 !.alan/agents/**
 !.alan/models.toml

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,12 @@ lcov.info
 htmlcov/
 
 # Local agent/tooling runtime state.
-.alan/sessions/
-.alan/memory/
+.alan/*
+!.alan/agent/
+!.alan/agent/**
+!.alan/agents/
+!.alan/agents/**
+!.alan/models.toml
 .codex/
 
 # Local Ghostty developer artifacts for the Apple client.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,23 +400,25 @@ are in `docs/spec/provider_auth_contract.md`.
 Agent definitions are resolved from `AgentRoot`s on disk:
 
 ```text
-~/.alan/agent/                   # global base agent root
+~/.alan/agents/default/          # global default agent root
 ~/.alan/agents/<name>/           # global named agent root
-<workspace>/.alan/agent/         # workspace base agent root
+<workspace>/.alan/agents/default/ # workspace default agent root
 <workspace>/.alan/agents/<name>/ # workspace named agent root
 ```
 
 Each root may contribute `agent.toml`, `persona/`, `skills/`, and `policy.yaml`.
 Alan also scans the standard public skill install directories `~/.agents/skills/`
 and `<workspace>/.agents/skills/` as single-skill package sources for the
-global and workspace base layers.
-Default workspace agents resolve `~/.alan/agent -> <workspace>/.alan/agent`.
+global and workspace default layers.
+Default workspace agents resolve `~/.alan/agents/default -> <workspace>/.alan/agents/default`.
 Named agents extend that chain with `~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`.
 This is definition overlay, not runtime parent-child inheritance.
+The former singular default root `.alan/agent/` is not read; move authored default
+agent files to `.alan/agents/default/`.
 
 ### Config File
 
-Agent-facing configuration loads from `~/.alan/agent/agent.toml` or
+Agent-facing configuration loads from `~/.alan/agents/default/agent.toml` or
 `ALAN_CONFIG_PATH`:
 
 ```toml
@@ -509,7 +511,7 @@ curl -X POST http://localhost:8090/api/v1/sessions \
     "workspace_dir": "/path/to/workspace",
     "agent_name": "default",
     "profile_id": "chatgpt-main",
-    "governance": {"profile": "conservative", "policy_path": ".alan/agent/policy.yaml"},
+    "governance": {"profile": "conservative", "policy_path": ".alan/agents/default/policy.yaml"},
     "streaming_mode": "on",
     "partial_stream_recovery_mode": "continue_once"
   }'
@@ -715,7 +717,7 @@ Session governance is configured via:
 {
   "governance": {
     "profile": "autonomous",
-    "policy_path": ".alan/agent/policy.yaml"
+    "policy_path": ".alan/agents/default/policy.yaml"
   }
 }
 ```
@@ -767,9 +769,9 @@ skill-authored alias.
 Capability sources:
 - Built-in first-party packages embedded in the binary
 - User public skills in `~/.agents/skills/`
-- User agent-root packages in `~/.alan/agent/skills/` and `~/.alan/agents/<name>/skills/`
+- User agent-root packages in `~/.alan/agents/default/skills/` and `~/.alan/agents/<name>/skills/`
 - Workspace public skills in `{workspace}/.agents/skills/`
-- Workspace agent-root packages in `{workspace}/.alan/agent/skills/` and `{workspace}/.alan/agents/<name>/skills/`
+- Workspace agent-root packages in `{workspace}/.alan/agents/default/skills/` and `{workspace}/.alan/agents/<name>/skills/`
 
 Each resolved skill then carries runtime exposure fields:
 - `enabled`

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ just build
 
 ### Configuration
 
-Create `~/.alan/agent/agent.toml`:
+Create `~/.alan/agents/default/agent.toml`:
 
 If you launch `alan chat` or `alan-tui` without a config file, the first-run wizard now starts
 with user-facing service presets such as OpenAI API Platform, ChatGPT/Codex login,
@@ -239,11 +239,11 @@ Host-facing daemon/client settings live in `~/.alan/host.toml`. You can also set
 Alan resolves an agent definition from on-disk `AgentRoot`s:
 
 ```text
-~/.alan/agent/                  # global base agent root
+~/.alan/agents/default/         # global default agent root
 ~/.alan/agents/<name>/          # global named agent root
 
-<workspace>/.alan/agent/        # workspace base agent root
-<workspace>/.alan/agents/<name>/# workspace named agent root
+<workspace>/.alan/agents/default/ # workspace default agent root
+<workspace>/.alan/agents/<name>/  # workspace named agent root
 ```
 
 Each root may contain:
@@ -255,8 +255,11 @@ Each root may contain:
 
 Resolution order is:
 
-- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
-- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+- Default workspace agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default`
+- Named agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+
+The former singular default root `.alan/agent/` is not a supported compatibility
+path. Move authored files from `.alan/agent/` to `.alan/agents/default/`.
 
 Each resolved root contributes its `skills/` directory as a capability-package
 source in the definition layer. Alan combines those sources with built-in
@@ -394,7 +397,7 @@ curl -X POST http://localhost:8090/api/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "workspace_dir": "/path/to/workspace",
-    "governance": {"profile": "autonomous", "policy_path": ".alan/agent/policy.yaml"},
+    "governance": {"profile": "autonomous", "policy_path": ".alan/agents/default/policy.yaml"},
     "streaming_mode": "on"
   }'
 
@@ -443,7 +446,7 @@ curl -N http://localhost:8090/api/v1/sessions/{id}/events
 
 ### Policy Configuration (Optional)
 
-Create `{workspace}/.alan/agent/policy.yaml` to override builtin policy profile rules.
+Create `{workspace}/.alan/agents/default/policy.yaml` to override builtin policy profile rules.
 When present, the file replaces the builtin profile rule set for that session;
 Alan does not implicitly merge policy files with builtin rules.
 

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -6,7 +6,7 @@ Terminal client for Alan (Bun + Ink). By default it auto-manages the backend via
 
 - Auto mode: when `ALAN_AGENTD_URL` is not set, it auto-runs `alan daemon start/stop`
 - First-run setup wizard: starts with service presets, then generates canonical
-  `~/.alan/agent/agent.toml` plus `~/.alan/host.toml`
+  `~/.alan/agents/default/agent.toml` plus `~/.alan/host.toml`
 - Session management: create, connect, and switch sessions
 - Live event stream: receives runtime `EventEnvelope` over WebSocket
 - Protocol-first timeline: renders `alan_protocol` turn/tool/yield/error events
@@ -89,7 +89,7 @@ bun run dev
 
 ## Config File
 
-Agent config path: `~/.alan/agent/agent.toml` (overridable via `ALAN_CONFIG_PATH`)
+Agent config path: `~/.alan/agents/default/agent.toml` (overridable via `ALAN_CONFIG_PATH`)
 
 Connections config path: `~/.alan/connections.toml`
 
@@ -132,5 +132,5 @@ Host-facing daemon/client settings live in `~/.alan/host.toml`.
 ## Troubleshooting
 
 - `alan` not found: run `just install` again
-- Session creation failed: check `~/.alan/agent/agent.toml` (or `ALAN_CONFIG_PATH`) and API key setup
+- Session creation failed: check `~/.alan/agents/default/agent.toml` (or `ALAN_CONFIG_PATH`) and API key setup
 - Enable verbose logs: `ALAN_VERBOSE=1 alan`

--- a/clients/tui/src/agent-commands.test.ts
+++ b/clients/tui/src/agent-commands.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parseAgentCommand } from "./agent-commands";
+
+describe("agent command parsing", () => {
+  test("parses child-run inspection", () => {
+    expect(parseAgentCommand(["child-run-1"])).toEqual({
+      kind: "inspect",
+      childRunId: "child-run-1",
+    });
+  });
+
+  test("parses graceful termination with reason", () => {
+    expect(parseAgentCommand(["terminate", "child-run-1", "not", "needed"])).toEqual({
+      kind: "terminate",
+      childRunId: "child-run-1",
+      mode: "graceful",
+      reason: "not needed",
+    });
+  });
+
+  test("parses forceful kill with default reason", () => {
+    expect(parseAgentCommand(["kill", "child-run-1"])).toEqual({
+      kind: "terminate",
+      childRunId: "child-run-1",
+      mode: "forceful",
+      reason: "operator requested forceful child termination",
+    });
+  });
+
+  test("reports usage for incomplete commands", () => {
+    expect(parseAgentCommand([])).toEqual({
+      kind: "invalid",
+      usage: "Usage: /agent <id>",
+    });
+    expect(parseAgentCommand(["terminate"])).toEqual({
+      kind: "invalid",
+      usage: "Usage: /agent terminate <id> [reason]",
+    });
+  });
+});

--- a/clients/tui/src/agent-commands.ts
+++ b/clients/tui/src/agent-commands.ts
@@ -1,0 +1,53 @@
+import type { ChildRunTerminationMode } from "./types.js";
+
+export type AgentCommand =
+  | {
+      kind: "inspect";
+      childRunId: string;
+    }
+  | {
+      kind: "terminate";
+      childRunId: string;
+      mode: ChildRunTerminationMode;
+      reason: string;
+    }
+  | {
+      kind: "invalid";
+      usage: string;
+    };
+
+export function parseAgentCommand(args: string[]): AgentCommand {
+  const action = args[0];
+  if (!action) {
+    return {
+      kind: "invalid",
+      usage: "Usage: /agent <id>",
+    };
+  }
+
+  if (action === "terminate" || action === "kill") {
+    const childRunId = args[1];
+    if (!childRunId) {
+      return {
+        kind: "invalid",
+        usage: `Usage: /agent ${action} <id> [reason]`,
+      };
+    }
+    const mode = action === "kill" ? "forceful" : "graceful";
+    const fallbackReason =
+      mode === "forceful"
+        ? "operator requested forceful child termination"
+        : "operator requested child termination";
+    return {
+      kind: "terminate",
+      childRunId,
+      mode,
+      reason: args.slice(2).join(" ").trim() || fallbackReason,
+    };
+  }
+
+  return {
+    kind: "inspect",
+    childRunId: action,
+  };
+}

--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { AlanClient } from "./client.js";
-import type { EventEnvelope } from "./types.js";
+import type { ChildRunRecord, EventEnvelope } from "./types.js";
 
 function eventId(sequence: number): string {
   return `evt_${sequence.toString().padStart(16, "0")}`;
@@ -25,6 +25,26 @@ function jsonResponse(body: unknown): Response {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function makeChildRun(overrides: Partial<ChildRunRecord> = {}): ChildRunRecord {
+  return {
+    id: "child-run-1",
+    parent_session_id: "sess-test",
+    child_session_id: "child-session-1",
+    workspace_root: "/tmp/workspace",
+    rollout_path: "/tmp/workspace/.alan/sessions/child.jsonl",
+    launch_target: "repo-coding",
+    status: "running",
+    created_at_ms: 1000,
+    updated_at_ms: 2000,
+    latest_heartbeat_at_ms: 1900,
+    latest_progress_at_ms: 1800,
+    latest_event_kind: "text_delta",
+    latest_status_summary: "editing files",
+    warnings: [],
+    ...overrides,
+  };
 }
 
 const originalFetch = globalThis.fetch;
@@ -401,5 +421,106 @@ describe("AlanClient connections", () => {
     );
     expect(current.effective_source).toBe("global_pin");
     expect(updated.effective_profile).toBe("chatgpt");
+  });
+});
+
+describe("AlanClient child runs", () => {
+  test("lists and reads child runs through the session control surface", async () => {
+    const client = new AlanClient({
+      url: "ws://example.com",
+      autoManageDaemon: false,
+    });
+
+    const requests: string[] = [];
+    installMockFetch(async (input): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      requests.push(url);
+
+      if (url.endsWith("/api/v1/sessions/sess-test/child_runs")) {
+        return jsonResponse({ child_runs: [makeChildRun()] });
+      }
+      if (
+        url.endsWith("/api/v1/sessions/sess-test/child_runs/child-run-1")
+      ) {
+        return jsonResponse({
+          child_run: makeChildRun({ status: "completed" }),
+        });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const childRuns = await client.listChildRuns("sess-test");
+    const childRun = await client.getChildRun("sess-test", "child-run-1");
+
+    expect(requests).toEqual([
+      "http://example.com/api/v1/sessions/sess-test/child_runs",
+      "http://example.com/api/v1/sessions/sess-test/child_runs/child-run-1",
+    ]);
+    expect(childRuns).toHaveLength(1);
+    expect(childRuns[0].latest_status_summary).toBe("editing files");
+    expect(childRun.status).toBe("completed");
+  });
+
+  test("terminates a child run with mode, actor, and reason", async () => {
+    const client = new AlanClient({
+      url: "ws://example.com",
+      autoManageDaemon: false,
+    });
+
+    let requestedUrl = "";
+    let requestedMethod = "";
+    let requestedBody = "";
+    installMockFetch(async (input, init): Promise<Response> => {
+      requestedUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      requestedMethod = init?.method ?? "GET";
+      requestedBody =
+        typeof init?.body === "string" ? init.body : String(init?.body ?? "");
+      return jsonResponse({
+        child_run: makeChildRun({
+          status: "terminated",
+          termination: {
+            actor: "tui",
+            reason: "operator requested stop",
+            mode: "forceful",
+            requested_at_ms: 3000,
+          },
+        }),
+      });
+    });
+
+    const childRun = await client.terminateChildRun(
+      "sess-test",
+      "child-run-1",
+      {
+        actor: "tui",
+        mode: "forceful",
+        reason: "operator requested stop",
+      },
+    );
+
+    expect(requestedUrl).toBe(
+      "http://example.com/api/v1/sessions/sess-test/child_runs/child-run-1/terminate",
+    );
+    expect(requestedMethod).toBe("POST");
+    expect(requestedBody).toBe(
+      JSON.stringify({
+        actor: "tui",
+        mode: "forceful",
+        reason: "operator requested stop",
+      }),
+    );
+    expect(childRun.status).toBe("terminated");
+    expect(childRun.termination?.actor).toBe("tui");
   });
 });

--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -387,7 +387,7 @@ describe("AlanClient connections", () => {
           effective_source: "global_pin",
           global_pin: {
             scope: "global",
-            config_path: "/Users/example/.alan/agent/agent.toml",
+            config_path: "/Users/example/.alan/agents/default/agent.toml",
             profile_id: "kimi",
           },
         });

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -10,6 +10,9 @@ import { WebSocket } from "ws";
 import { DaemonManager, getDaemon } from "./daemon.js";
 import type {
   ClientCapabilities,
+  ChildRunListResponse,
+  ChildRunRecord,
+  ChildRunResponse,
   ConnectionCatalogResponse,
   ConnectionCurrentState,
   ConnectionCredentialStatus,
@@ -30,6 +33,7 @@ import type {
   SessionListResponse,
   SessionListItem,
   SessionReadResponse,
+  TerminateChildRunRequest,
   SetConnectionDefaultRequest,
   StartConnectionBrowserLoginRequest,
   StartConnectionBrowserLoginResponse,
@@ -439,6 +443,69 @@ export class AlanClient {
     }
 
     return (await response.json()) as SessionReadResponse;
+  }
+
+  public async listChildRuns(sessionId: string): Promise<ChildRunRecord[]> {
+    await this.ensureDaemon();
+
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/sessions/${sessionId}/child_runs`,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to list child runs: ${await this.readErrorMessage(response)}`,
+      );
+    }
+
+    const data = (await response.json()) as ChildRunListResponse;
+    return data.child_runs;
+  }
+
+  public async getChildRun(
+    sessionId: string,
+    childRunId: string,
+  ): Promise<ChildRunRecord> {
+    await this.ensureDaemon();
+
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/sessions/${sessionId}/child_runs/${childRunId}`,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to get child run: ${await this.readErrorMessage(response)}`,
+      );
+    }
+
+    const data = (await response.json()) as ChildRunResponse;
+    return data.child_run;
+  }
+
+  public async terminateChildRun(
+    sessionId: string,
+    childRunId: string,
+    request: TerminateChildRunRequest,
+  ): Promise<ChildRunRecord> {
+    await this.ensureDaemon();
+
+    const response = await fetch(
+      `${this.baseUrl}/api/v1/sessions/${sessionId}/child_runs/${childRunId}/terminate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to terminate child run: ${await this.readErrorMessage(response)}`,
+      );
+    }
+
+    const data = (await response.json()) as ChildRunResponse;
+    return data.child_run;
   }
 
   public async submitOperation(sessionId: string, op: Op): Promise<void> {

--- a/clients/tui/src/config-path.test.ts
+++ b/clients/tui/src/config-path.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe("config path resolution", () => {
   const home = "/Users/tester";
-  const canonicalPath = `${home}/.alan/agent/agent.toml`;
+  const canonicalPath = `${home}/.alan/agents/default/agent.toml`;
 
   test("uses default config path when override is unset", () => {
     const candidates = resolveConfigPathCandidates(home, {});

--- a/clients/tui/src/config-path.ts
+++ b/clients/tui/src/config-path.ts
@@ -24,7 +24,13 @@ export function resolveConfigPathCandidates(
   homeDir: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const canonicalPath = join(homeDir, ".alan", "agent", "agent.toml");
+  const canonicalPath = join(
+    homeDir,
+    ".alan",
+    "agents",
+    "default",
+    "agent.toml",
+  );
   const overrideRaw = env.ALAN_CONFIG_PATH?.trim();
   if (!overrideRaw) {
     return [canonicalPath];

--- a/clients/tui/src/config-path.ts
+++ b/clients/tui/src/config-path.ts
@@ -24,6 +24,8 @@ export function resolveConfigPathCandidates(
   homeDir: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
+  // Offline first-run setup mirror of alan_runtime::AgentRootLayout.
+  // Online flows should display daemon-returned canonical paths instead.
   const canonicalPath = join(
     homeDir,
     ".alan",

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -142,7 +142,7 @@ function formatChildRun(run: ChildRunRecord): string {
   const progress = run.latest_progress_at_ms
     ? new Date(run.latest_progress_at_ms).toISOString()
     : "none";
-  return `${shortId(run.id)} | ${run.status} | child=${shortId(run.child_session_id)} | heartbeat=${heartbeat} | progress=${progress}${run.latest_status_summary ? ` | ${run.latest_status_summary}` : ""}`;
+  return `${run.id} | ${run.status} | child=${shortId(run.child_session_id)} | heartbeat=${heartbeat} | progress=${progress}${run.latest_status_summary ? ` | ${run.latest_status_summary}` : ""}`;
 }
 
 function isActiveChildRun(run: ChildRunRecord): boolean {

--- a/clients/tui/src/index.tsx
+++ b/clients/tui/src/index.tsx
@@ -8,6 +8,7 @@ import { render, Box, Text, useApp, useInput } from "ink";
 import TextInput from "ink-text-input";
 import { homedir } from "node:os";
 import { AlanClient } from "./client.js";
+import { parseAgentCommand } from "./agent-commands.js";
 import { openUrlInBrowser } from "./open-url.js";
 import {
   defaultHostConfigPath,
@@ -20,6 +21,7 @@ import {
 import { detectWorkspaceDirFromCwd } from "./workspace-detect.js";
 import type {
   ClientCapabilities,
+  ChildRunRecord,
   ConnectionCurrentState,
   ConnectionCredentialStatus,
   ConnectionPinScope,
@@ -131,6 +133,26 @@ function needsFirstTimeSetup(): boolean {
 function shortId(value: string | null | undefined): string {
   if (!value) return "-";
   return value.slice(0, 8);
+}
+
+function formatChildRun(run: ChildRunRecord): string {
+  const heartbeat = run.latest_heartbeat_at_ms
+    ? new Date(run.latest_heartbeat_at_ms).toISOString()
+    : "none";
+  const progress = run.latest_progress_at_ms
+    ? new Date(run.latest_progress_at_ms).toISOString()
+    : "none";
+  return `${shortId(run.id)} | ${run.status} | child=${shortId(run.child_session_id)} | heartbeat=${heartbeat} | progress=${progress}${run.latest_status_summary ? ` | ${run.latest_status_summary}` : ""}`;
+}
+
+function isActiveChildRun(run: ChildRunRecord): boolean {
+  return ["starting", "running", "blocked", "terminating"].includes(
+    run.status,
+  );
+}
+
+function countActiveChildRuns(runs: ChildRunRecord[]): number {
+  return runs.filter(isActiveChildRun).length;
 }
 
 function parseGovernanceProfile(
@@ -347,6 +369,9 @@ function App() {
     useState<SessionBindingSummary | null>(null);
   const [events, setEvents] = useState<EventEnvelope[]>([]);
   const [currentPlan, setCurrentPlan] = useState<CurrentPlanState | null>(null);
+  const [activeChildRunCount, setActiveChildRunCount] = useState<number | null>(
+    null,
+  );
   const [currentRuntimeState, setCurrentRuntimeState] =
     useState<CurrentRuntimeState>(createCurrentRuntimeState);
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus | null>(null);
@@ -384,6 +409,7 @@ function App() {
 
   useEffect(() => {
     sessionIdRef.current = currentSessionId ?? "";
+    setActiveChildRunCount(null);
   }, [currentSessionId]);
 
   useEffect(() => {
@@ -2343,6 +2369,96 @@ function App() {
         }
         break;
 
+      case "agents": {
+        if (!currentSessionId) {
+          addSystemEvent("system_warning", "No active session.");
+          return;
+        }
+
+        try {
+          const runs = await client.listChildRuns(currentSessionId);
+          setActiveChildRunCount(countActiveChildRuns(runs));
+          addSystemEvent("system_message", `Child runs: ${runs.length}`);
+          runs.forEach((run) => {
+            addSystemEvent("system_message", `  ${formatChildRun(run)}`);
+          });
+        } catch (error) {
+          addSystemEvent(
+            "system_error",
+            `Failed to list child runs: ${(error as Error).message}`,
+          );
+        }
+        break;
+      }
+
+      case "agent": {
+        if (!currentSessionId) {
+          addSystemEvent("system_warning", "No active session.");
+          return;
+        }
+
+        const agentCommand = parseAgentCommand(args);
+        if (agentCommand.kind === "invalid") {
+          addSystemEvent("system_warning", agentCommand.usage);
+          return;
+        }
+
+        if (agentCommand.kind === "terminate") {
+          try {
+            const run = await client.terminateChildRun(
+              currentSessionId,
+              agentCommand.childRunId,
+              {
+                mode: agentCommand.mode,
+                reason: agentCommand.reason,
+                actor: "tui_operator",
+              },
+            );
+            addSystemEvent(
+              "system_message",
+              `Child run ${shortId(run.id)} termination requested: ${run.status}`,
+            );
+            const runs = await client.listChildRuns(currentSessionId);
+            setActiveChildRunCount(countActiveChildRuns(runs));
+          } catch (error) {
+            addSystemEvent(
+              "system_error",
+              `Failed to terminate child run: ${(error as Error).message}`,
+            );
+          }
+          break;
+        }
+
+        try {
+          const run = await client.getChildRun(
+            currentSessionId,
+            agentCommand.childRunId,
+          );
+          addSystemEvent("system_message", formatChildRun(run));
+          if (run.workspace_root) {
+            addSystemEvent("system_message", `  workspace=${run.workspace_root}`);
+          }
+          if (run.rollout_path) {
+            addSystemEvent("system_message", `  rollout=${run.rollout_path}`);
+          }
+          if (run.latest_event_kind) {
+            addSystemEvent(
+              "system_message",
+              `  latest_event=${run.latest_event_kind}`,
+            );
+          }
+          if (run.error_message) {
+            addSystemEvent("system_warning", `  error=${run.error_message}`);
+          }
+        } catch (error) {
+          addSystemEvent(
+            "system_error",
+            `Failed to read child run: ${(error as Error).message}`,
+          );
+        }
+        break;
+      }
+
       case "status":
         if (AUTO_MANAGE) {
           const latestStatus = client.getDaemonStatus() || daemonStatus;
@@ -2668,6 +2784,22 @@ function App() {
         );
         addSystemEvent(
           "system_message",
+          "  /agents                        - List child runs for current session",
+        );
+        addSystemEvent(
+          "system_message",
+          "  /agent <id>                    - Inspect a child run",
+        );
+        addSystemEvent(
+          "system_message",
+          "  /agent terminate <id> [reason] - Gracefully terminate a child run",
+        );
+        addSystemEvent(
+          "system_message",
+          "  /agent kill <id> [reason]      - Forcefully terminate a child run",
+        );
+        addSystemEvent(
+          "system_message",
           "  /status                        - Show daemon status",
         );
         addSystemEvent(
@@ -2832,6 +2964,7 @@ function App() {
       <SummaryHud
         plan={currentPlan}
         runtimeSummary={runtimeSummary}
+        activeChildRunCount={activeChildRunCount}
         footerHint={footerHint}
         pending={Boolean(pendingYield)}
       />

--- a/clients/tui/src/init-files.test.ts
+++ b/clients/tui/src/init-files.test.ts
@@ -15,7 +15,13 @@ import { writeCanonicalSetupFiles } from "./init-files.js";
 describe("writeCanonicalSetupFiles", () => {
   test("writes both agent and host config when host config is missing", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "alan-init-files-"));
-    const agentConfigPath = join(tempRoot, ".alan", "agent", "agent.toml");
+    const agentConfigPath = join(
+      tempRoot,
+      ".alan",
+      "agents",
+      "default",
+      "agent.toml",
+    );
     const connectionsConfigPath = join(tempRoot, ".alan", "connections.toml");
     const hostConfigPath = join(tempRoot, ".alan", "host.toml");
 
@@ -45,7 +51,13 @@ describe("writeCanonicalSetupFiles", () => {
 
   test("preserves an existing host config file", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "alan-init-files-"));
-    const agentConfigPath = join(tempRoot, ".alan", "agent", "agent.toml");
+    const agentConfigPath = join(
+      tempRoot,
+      ".alan",
+      "agents",
+      "default",
+      "agent.toml",
+    );
     const connectionsConfigPath = join(tempRoot, ".alan", "connections.toml");
     const hostConfigPath = join(tempRoot, ".alan", "host.toml");
     const existingHostConfig =
@@ -78,7 +90,13 @@ describe("writeCanonicalSetupFiles", () => {
 
   test("fails before writing agent config when existing host config is invalid", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "alan-init-files-"));
-    const agentConfigPath = join(tempRoot, ".alan", "agent", "agent.toml");
+    const agentConfigPath = join(
+      tempRoot,
+      ".alan",
+      "agents",
+      "default",
+      "agent.toml",
+    );
     const connectionsConfigPath = join(tempRoot, ".alan", "connections.toml");
     const hostConfigPath = join(tempRoot, ".alan", "host.toml");
 

--- a/clients/tui/src/summary-surfaces/hud-surface.test.ts
+++ b/clients/tui/src/summary-surfaces/hud-surface.test.ts
@@ -76,4 +76,10 @@ describe("summary HUD helpers", () => {
       "Runtime: Running bash | state=running | tool=bash running | send a request or use /help.",
     );
   });
+
+  test("includes active child-run count when available", () => {
+    expect(buildRuntimeHudSummary(runtime(), 2)).toBe(
+      "Runtime: Running bash | state=running | children=2 active | tool=bash running | send a request or use /help.",
+    );
+  });
 });

--- a/clients/tui/src/summary-surfaces/hud-surface.tsx
+++ b/clients/tui/src/summary-surfaces/hud-surface.tsx
@@ -78,8 +78,15 @@ export function buildPlanHudSummary(
   return `Plan: ${[statusSummary, focusSummary].filter(Boolean).join(" | ")}`;
 }
 
-export function buildRuntimeHudSummary(summary: CurrentRuntimeSummary): string {
+export function buildRuntimeHudSummary(
+  summary: CurrentRuntimeSummary,
+  activeChildRunCount?: number | null,
+): string {
   const segments = [summary.headline, `state=${summary.shellRunStatus}`];
+
+  if (activeChildRunCount !== undefined && activeChildRunCount !== null) {
+    segments.push(`children=${activeChildRunCount} active`);
+  }
 
   if (summary.activeTool) {
     segments.push(runtimeToolSummary(summary.activeTool));
@@ -99,6 +106,7 @@ export function buildRuntimeHudSummary(summary: CurrentRuntimeSummary): string {
 export interface SummaryHudProps {
   plan: CurrentPlanState | null;
   runtimeSummary: CurrentRuntimeSummary;
+  activeChildRunCount?: number | null;
   footerHint: string;
   pending: boolean;
 }
@@ -106,11 +114,15 @@ export interface SummaryHudProps {
 export function SummaryHud({
   plan,
   runtimeSummary,
+  activeChildRunCount,
   footerHint,
   pending,
 }: SummaryHudProps) {
   const planSummary = buildPlanHudSummary(plan);
-  const runtimeSummaryText = buildRuntimeHudSummary(runtimeSummary);
+  const runtimeSummaryText = buildRuntimeHudSummary(
+    runtimeSummary,
+    activeChildRunCount,
+  );
   const statusColor =
     pending || runtimeSummary.recoverableError ? "yellow" : "gray";
 

--- a/clients/tui/src/types.ts
+++ b/clients/tui/src/types.ts
@@ -32,7 +32,6 @@ export type ProtocolEventType =
   | "tool_call_started"
   | "tool_call_completed"
   | "session_rolled_back"
-  | "runtime_heartbeat"
   | "error";
 
 // Legacy/compat runtime events that may appear in historical logs.

--- a/clients/tui/src/types.ts
+++ b/clients/tui/src/types.ts
@@ -32,6 +32,7 @@ export type ProtocolEventType =
   | "tool_call_started"
   | "tool_call_completed"
   | "session_rolled_back"
+  | "runtime_heartbeat"
   | "error";
 
 // Legacy/compat runtime events that may appear in historical logs.
@@ -222,6 +223,59 @@ export interface SessionReadResponse {
   rollout_path?: string;
   latest_plan_snapshot?: PlanSnapshot;
   messages: unknown[];
+}
+
+export type ChildRunStatus =
+  | "starting"
+  | "running"
+  | "blocked"
+  | "completed"
+  | "failed"
+  | "timed_out"
+  | "terminating"
+  | "terminated"
+  | "cancelled";
+
+export type ChildRunTerminationMode = "graceful" | "forceful";
+
+export interface ChildRunTerminationRequest {
+  actor: string;
+  reason: string;
+  mode: ChildRunTerminationMode;
+  requested_at_ms: number;
+}
+
+export interface ChildRunRecord {
+  id: string;
+  parent_session_id: string;
+  child_session_id: string;
+  workspace_root?: string;
+  rollout_path?: string;
+  launch_target?: string;
+  status: ChildRunStatus;
+  created_at_ms: number;
+  updated_at_ms: number;
+  latest_heartbeat_at_ms?: number;
+  latest_progress_at_ms?: number;
+  latest_event_kind?: string;
+  latest_status_summary?: string;
+  warnings?: string[];
+  error_message?: string;
+  termination?: ChildRunTerminationRequest;
+}
+
+export interface ChildRunListResponse {
+  child_runs: ChildRunRecord[];
+}
+
+export interface ChildRunResponse {
+  child_run: ChildRunRecord;
+}
+
+export interface TerminateChildRunRequest {
+  reason?: string;
+  mode?: ChildRunTerminationMode;
+  actor?: string;
 }
 
 export interface CreateSessionRequest {

--- a/crates/alan/src/cli/ask.rs
+++ b/crates/alan/src/cli/ask.rs
@@ -218,12 +218,15 @@ async fn run_ask_inner(question: &str, options: AskOptions) -> Result<i32, anyho
                 let canonical_config_path = alan_runtime::AlanHomePaths::detect()
                     .map(|paths| paths.global_agent_config_path)
                     .unwrap_or_else(|| {
-                        std::path::PathBuf::from("~/.alan/agents/default/agent.toml")
+                        std::path::PathBuf::from("~").join(
+                            alan_runtime::AgentRootLayout::new().default_agent_config_suffix(),
+                        )
                     });
+                let canonical_config_hint = canonical_config_path.display().to_string();
                 eprintln!("Error: {}", error_detail);
                 eprintln!();
                 eprintln!("Hint: Make sure your LLM config is set.");
-                eprintln!("  {}", canonical_config_path.display());
+                eprintln!("  {}", canonical_config_hint);
                 eprintln!("  (or set ALAN_CONFIG_PATH to a custom file)");
                 return Ok(3);
             } else if status.as_u16() == 500 && error_detail.is_empty() {
@@ -231,7 +234,12 @@ async fn run_ask_inner(question: &str, options: AskOptions) -> Result<i32, anyho
                 eprintln!();
                 eprintln!("Possible causes:");
                 eprintln!("  • LLM config is missing or invalid");
-                eprintln!("    (~/.alan/agents/default/agent.toml or ALAN_CONFIG_PATH)");
+                eprintln!(
+                    "    ({} or ALAN_CONFIG_PATH)",
+                    std::path::PathBuf::from("~")
+                        .join(alan_runtime::AgentRootLayout::new().default_agent_config_suffix())
+                        .display()
+                );
                 eprintln!("  • Daemon encountered an unexpected error");
                 eprintln!();
                 eprintln!("Check daemon logs for details: alan daemon start --foreground");

--- a/crates/alan/src/cli/ask.rs
+++ b/crates/alan/src/cli/ask.rs
@@ -217,7 +217,9 @@ async fn run_ask_inner(question: &str, options: AskOptions) -> Result<i32, anyho
             {
                 let canonical_config_path = alan_runtime::AlanHomePaths::detect()
                     .map(|paths| paths.global_agent_config_path)
-                    .unwrap_or_else(|| std::path::PathBuf::from("~/.alan/agent/agent.toml"));
+                    .unwrap_or_else(|| {
+                        std::path::PathBuf::from("~/.alan/agents/default/agent.toml")
+                    });
                 eprintln!("Error: {}", error_detail);
                 eprintln!();
                 eprintln!("Hint: Make sure your LLM config is set.");
@@ -229,7 +231,7 @@ async fn run_ask_inner(question: &str, options: AskOptions) -> Result<i32, anyho
                 eprintln!();
                 eprintln!("Possible causes:");
                 eprintln!("  • LLM config is missing or invalid");
-                eprintln!("    (~/.alan/agent/agent.toml or ALAN_CONFIG_PATH)");
+                eprintln!("    (~/.alan/agents/default/agent.toml or ALAN_CONFIG_PATH)");
                 eprintln!("  • Daemon encountered an unexpected error");
                 eprintln!();
                 eprintln!("Check daemon logs for details: alan daemon start --foreground");

--- a/crates/alan/src/cli/init.rs
+++ b/crates/alan/src/cli/init.rs
@@ -48,7 +48,8 @@ pub fn create_alan_directory(alan_dir: &Path) -> Result<bool> {
         .parent()
         .context("Workspace .alan directory must have a parent workspace root")?;
 
-    let agent_dir = ensure_fixed_child_dir(&alan_dir, "agent")?;
+    let agents_dir = ensure_fixed_child_dir(&alan_dir, "agents")?;
+    let agent_dir = ensure_fixed_child_dir(&agents_dir, alan_runtime::DEFAULT_AGENT_NAME)?;
     let _skills_dir = ensure_fixed_child_dir(&agent_dir, "skills")?;
     let _sessions_dir = ensure_fixed_child_dir(&alan_dir, "sessions")?;
     let memory_dir = ensure_fixed_child_dir(&alan_dir, "memory")?;
@@ -195,11 +196,24 @@ mod tests {
 
         assert!(created);
         assert!(alan_dir.exists());
-        assert!(alan_dir.join("agent").join("skills").exists());
+        assert!(
+            alan_dir
+                .join("agents")
+                .join("default")
+                .join("skills")
+                .exists()
+        );
+        assert!(!alan_dir.join("agent").exists());
         assert!(alan_dir.join("sessions").exists());
         assert!(alan_dir.join("memory").exists());
         assert!(alan_dir.join("memory/USER.md").exists());
-        assert!(alan_dir.join("agent").join("persona").exists());
+        assert!(
+            alan_dir
+                .join("agents")
+                .join("default")
+                .join("persona")
+                .exists()
+        );
         assert!(alan_dir.join("memory/MEMORY.md").exists());
         assert!(alan_dir.join("memory/handoffs/LATEST.md").exists());
         assert!(alan_dir.join("memory/daily").exists());
@@ -210,7 +224,8 @@ mod tests {
         assert!(tmp.path().join(".agents").join("skills").exists());
         assert!(
             alan_dir
-                .join("agent")
+                .join("agents")
+                .join("default")
                 .join("persona")
                 .join("SOUL.md")
                 .exists()
@@ -227,7 +242,14 @@ mod tests {
 
         let created = create_alan_directory(&alan_dir).unwrap();
         assert!(!created);
-        assert!(alan_dir.join("agent").join("skills").exists());
+        assert!(
+            alan_dir
+                .join("agents")
+                .join("default")
+                .join("skills")
+                .exists()
+        );
+        assert!(!alan_dir.join("agent").exists());
         assert!(alan_dir.join("sessions").exists());
         assert!(alan_dir.join("memory/MEMORY.md").exists());
         assert!(alan_dir.join("memory/USER.md").exists());
@@ -235,7 +257,8 @@ mod tests {
         assert!(tmp.path().join(".agents").join("skills").exists());
         assert!(
             alan_dir
-                .join("agent")
+                .join("agents")
+                .join("default")
                 .join("persona")
                 .join("SOUL.md")
                 .exists()

--- a/crates/alan/src/cli/init.rs
+++ b/crates/alan/src/cli/init.rs
@@ -48,12 +48,23 @@ pub fn create_alan_directory(alan_dir: &Path) -> Result<bool> {
         .parent()
         .context("Workspace .alan directory must have a parent workspace root")?;
 
-    let agents_dir = ensure_fixed_child_dir(&alan_dir, "agents")?;
-    let agent_dir = ensure_fixed_child_dir(&agents_dir, alan_runtime::DEFAULT_AGENT_NAME)?;
-    let _skills_dir = ensure_fixed_child_dir(&agent_dir, "skills")?;
-    let _sessions_dir = ensure_fixed_child_dir(&alan_dir, "sessions")?;
-    let memory_dir = ensure_fixed_child_dir(&alan_dir, "memory")?;
-    let persona_dir = ensure_fixed_child_dir(&agent_dir, "persona")?;
+    let layout = alan_runtime::AgentRootLayout::new();
+    let default_root = layout.workspace_default_root_from_alan_dir(&alan_dir);
+    let _agents_dir = ensure_workspace_layout_dir(
+        workspace_root,
+        &layout.agent_roots_dir_from_alan_dir(&alan_dir),
+    )?;
+    let _agent_dir = ensure_workspace_layout_dir(workspace_root, &default_root.root_dir)?;
+    let _skills_dir = ensure_workspace_layout_dir(workspace_root, &default_root.skills_dir)?;
+    let _sessions_dir = ensure_workspace_layout_dir(
+        workspace_root,
+        &alan_runtime::workspace_sessions_dir_from_alan_dir(&alan_dir),
+    )?;
+    let memory_dir = ensure_workspace_layout_dir(
+        workspace_root,
+        &alan_runtime::workspace_memory_dir_from_alan_dir(&alan_dir),
+    )?;
+    let persona_dir = ensure_workspace_layout_dir(workspace_root, &default_root.persona_dir)?;
     let public_agents_dir = ensure_fixed_child_dir(workspace_root, ".agents")?;
     let _public_skills_dir = ensure_fixed_child_dir(&public_agents_dir, "skills")?;
 
@@ -61,6 +72,19 @@ pub fn create_alan_directory(alan_dir: &Path) -> Result<bool> {
     alan_runtime::prompts::ensure_workspace_bootstrap_files_at(&persona_dir)?;
 
     Ok(created)
+}
+
+fn ensure_workspace_layout_dir(workspace_root: &Path, path: &Path) -> Result<PathBuf> {
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("Cannot create directory: {}", path.display()))?;
+    let canonical = std::fs::canonicalize(path)
+        .with_context(|| format!("Cannot resolve directory: {}", path.display()))?;
+    ensure!(
+        canonical.starts_with(workspace_root),
+        "Workspace directory escaped workspace root: {}",
+        canonical.display()
+    );
+    Ok(canonical)
 }
 
 fn ensure_workspace_alan_dir(alan_dir: &Path) -> Result<PathBuf> {

--- a/crates/alan/src/cli/skills.rs
+++ b/crates/alan/src/cli/skills.rs
@@ -266,8 +266,8 @@ fn render_packages(
 
 fn root_kind_label(kind: &AgentRootKind) -> &'static str {
     match kind {
-        AgentRootKind::GlobalBase => "global-base",
-        AgentRootKind::WorkspaceBase => "workspace-base",
+        AgentRootKind::GlobalDefault => "global-default",
+        AgentRootKind::WorkspaceDefault => "workspace-default",
         AgentRootKind::GlobalNamed(_) => "global-named",
         AgentRootKind::WorkspaceNamed(_) => "workspace-named",
         AgentRootKind::LaunchRoot => "launch-root",
@@ -391,7 +391,7 @@ Body
         let temp = TempDir::new().unwrap();
         let home_paths = AlanHomePaths::from_home_dir(temp.path());
         let workspace_root = temp.path().join("workspace");
-        let workspace_skills_dir = workspace_root.join(".alan/agent/skills");
+        let workspace_skills_dir = workspace_root.join(".alan/agents/default/skills");
         create_skill(&workspace_skills_dir, "repo-skill", "Repo Skill");
 
         let (resolved, registry, host_capabilities) = resolve_registry_with_loaded_config(
@@ -428,7 +428,7 @@ Body
         let temp = TempDir::new().unwrap();
         let home_paths = AlanHomePaths::from_home_dir(temp.path());
         let workspace_root = temp.path().join("workspace");
-        let workspace_skills_dir = workspace_root.join(".alan/agent/skills");
+        let workspace_skills_dir = workspace_root.join(".alan/agents/default/skills");
         let skill_dir = workspace_skills_dir.join("tool-heavy");
         fs::create_dir_all(skill_dir.join("scripts")).unwrap();
         fs::create_dir_all(skill_dir.join("agents/reviewer")).unwrap();
@@ -477,7 +477,7 @@ Body
         let temp = TempDir::new().unwrap();
         let home_paths = AlanHomePaths::from_home_dir(temp.path());
         let workspace_root = temp.path().join("workspace");
-        let workspace_skills_dir = workspace_root.join(".alan/agent/skills");
+        let workspace_skills_dir = workspace_root.join(".alan/agents/default/skills");
         let skill_dir = workspace_skills_dir.join("skill-creator");
         fs::create_dir_all(skill_dir.join("agents/creator")).unwrap();
         fs::create_dir_all(skill_dir.join("agents/grader")).unwrap();

--- a/crates/alan/src/daemon/connection_control.rs
+++ b/crates/alan/src/daemon/connection_control.rs
@@ -2,8 +2,9 @@ use super::auth_control::AuthControlState;
 use crate::registry::normalize_workspace_root_path;
 use alan_runtime::{
     AlanHomePaths, Config, ConnectionCredential, ConnectionProfile, ConnectionsFile,
-    CredentialKind, LlmProvider, ProviderDescriptor, SecretStore, default_credential_backend,
-    normalize_profile_settings, provider_catalog, sanitize_identifier, validate_profile_settings,
+    CredentialKind, DEFAULT_AGENT_NAME, LlmProvider, ProviderDescriptor, SecretStore,
+    default_credential_backend, normalize_profile_settings, provider_catalog, sanitize_identifier,
+    validate_profile_settings,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -17,7 +18,7 @@ use tokio::sync::{Mutex, RwLock, broadcast};
 const DEFAULT_CONNECTION_EVENT_BROADCAST_CAPACITY: usize = 64;
 const DEFAULT_CONNECTION_EVENT_REPLAY_BUFFER_CAPACITY: usize = 256;
 const AGENT_CONFIG_FILE_NAME: &str = "agent.toml";
-const AGENT_ROOT_DIR_NAME: &str = "agent";
+const AGENTS_DIR_NAME: &str = "agents";
 const ALAN_CONFIG_DIR_NAME: &str = ".alan";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1320,15 +1321,23 @@ fn validate_agent_config_path(path: &Path) -> anyhow::Result<()> {
         .and_then(Path::parent)
         .and_then(|parent| parent.file_name())
         .and_then(|name| name.to_str());
+    let great_grandparent_name = path
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str());
     if file_name != Some(AGENT_CONFIG_FILE_NAME)
-        || parent_name != Some(AGENT_ROOT_DIR_NAME)
-        || grandparent_name != Some(ALAN_CONFIG_DIR_NAME)
+        || parent_name != Some(DEFAULT_AGENT_NAME)
+        || grandparent_name != Some(AGENTS_DIR_NAME)
+        || great_grandparent_name != Some(ALAN_CONFIG_DIR_NAME)
     {
         anyhow::bail!(
-            "invalid agent config path {}; expected .../{}/{}/{}",
+            "invalid agent config path {}; expected .../{}/{}/{}/{}",
             path.display(),
             ALAN_CONFIG_DIR_NAME,
-            AGENT_ROOT_DIR_NAME,
+            AGENTS_DIR_NAME,
+            DEFAULT_AGENT_NAME,
             AGENT_CONFIG_FILE_NAME
         );
     }

--- a/crates/alan/src/daemon/connection_control.rs
+++ b/crates/alan/src/daemon/connection_control.rs
@@ -2,9 +2,8 @@ use super::auth_control::AuthControlState;
 use crate::registry::normalize_workspace_root_path;
 use alan_runtime::{
     AlanHomePaths, Config, ConnectionCredential, ConnectionProfile, ConnectionsFile,
-    CredentialKind, DEFAULT_AGENT_NAME, LlmProvider, ProviderDescriptor, SecretStore,
-    default_credential_backend, normalize_profile_settings, provider_catalog, sanitize_identifier,
-    validate_profile_settings,
+    CredentialKind, LlmProvider, ProviderDescriptor, SecretStore, default_credential_backend,
+    normalize_profile_settings, provider_catalog, sanitize_identifier, validate_profile_settings,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -17,9 +16,6 @@ use tokio::sync::{Mutex, RwLock, broadcast};
 
 const DEFAULT_CONNECTION_EVENT_BROADCAST_CAPACITY: usize = 64;
 const DEFAULT_CONNECTION_EVENT_REPLAY_BUFFER_CAPACITY: usize = 256;
-const AGENT_CONFIG_FILE_NAME: &str = "agent.toml";
-const AGENTS_DIR_NAME: &str = "agents";
-const ALAN_CONFIG_DIR_NAME: &str = ".alan";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1311,34 +1307,12 @@ fn validated_profile_id(profile_id: &str) -> anyhow::Result<String> {
 }
 
 fn validate_agent_config_path(path: &Path) -> anyhow::Result<()> {
-    let file_name = path.file_name().and_then(|name| name.to_str());
-    let parent_name = path
-        .parent()
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str());
-    let grandparent_name = path
-        .parent()
-        .and_then(Path::parent)
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str());
-    let great_grandparent_name = path
-        .parent()
-        .and_then(Path::parent)
-        .and_then(Path::parent)
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str());
-    if file_name != Some(AGENT_CONFIG_FILE_NAME)
-        || parent_name != Some(DEFAULT_AGENT_NAME)
-        || grandparent_name != Some(AGENTS_DIR_NAME)
-        || great_grandparent_name != Some(ALAN_CONFIG_DIR_NAME)
-    {
+    let layout = alan_runtime::AgentRootLayout::new();
+    if !layout.is_default_agent_config_path_shape(path) {
         anyhow::bail!(
-            "invalid agent config path {}; expected .../{}/{}/{}/{}",
+            "invalid agent config path {}; expected .../{}",
             path.display(),
-            ALAN_CONFIG_DIR_NAME,
-            AGENTS_DIR_NAME,
-            DEFAULT_AGENT_NAME,
-            AGENT_CONFIG_FILE_NAME
+            layout.default_agent_config_suffix().display()
         );
     }
     Ok(())

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -2314,7 +2314,9 @@ mod tests {
     }
 
     fn create_test_skill(workspace_path: &std::path::Path, skill_name: &str) {
-        let skill_dir = workspace_path.join(".alan/agent/skills").join(skill_name);
+        let skill_dir = workspace_path
+            .join(".alan/agents/default/skills")
+            .join(skill_name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -2399,10 +2401,10 @@ Body
     ) -> (std::path::PathBuf, SessionsDirPermissionGuard) {
         let workspace_path = base_dir.join("workspace");
         let alan_dir = workspace_path.join(".alan");
-        std::fs::create_dir_all(alan_dir.join("agent/skills")).unwrap();
+        std::fs::create_dir_all(alan_dir.join("agents/default/skills")).unwrap();
         std::fs::create_dir_all(alan_dir.join("sessions")).unwrap();
         std::fs::create_dir_all(alan_dir.join("memory")).unwrap();
-        std::fs::create_dir_all(alan_dir.join("agent/persona")).unwrap();
+        std::fs::create_dir_all(alan_dir.join("agents/default/persona")).unwrap();
         std::fs::write(alan_dir.join("memory").join("MEMORY.md"), "# Memory\n").unwrap();
 
         let guard = SessionsDirPermissionGuard::new(alan_dir.join("sessions"));
@@ -2518,7 +2520,11 @@ Body
         .await
         .unwrap();
 
-        assert!(response.config_path.ends_with(".alan/agent/agent.toml"));
+        assert!(
+            response
+                .config_path
+                .ends_with(".alan/agents/default/agent.toml")
+        );
         assert!(
             std::fs::read_to_string(&response.config_path)
                 .unwrap()
@@ -4595,7 +4601,7 @@ Body
             profile_id: None,
             governance: Some(alan_protocol::GovernanceConfig {
                 profile: alan_protocol::GovernanceProfile::Autonomous,
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
             }),
             streaming_mode: Some(alan_runtime::StreamingMode::On),
             partial_stream_recovery_mode: Some(alan_runtime::PartialStreamRecoveryMode::Off),
@@ -4607,7 +4613,7 @@ Body
             parsed.governance,
             Some(alan_protocol::GovernanceConfig {
                 profile: alan_protocol::GovernanceProfile::Autonomous,
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
             })
         );
         assert_eq!(parsed.streaming_mode, Some(alan_runtime::StreamingMode::On));

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -793,9 +793,11 @@ pub async fn terminate_child_run(
         .terminate_child_run(&id, &child_run_id, actor, mode, reason)
         .await
     {
-        Ok(child_run)
-        | Err(alan_runtime::runtime::ChildRunRegistryError::AlreadyTerminal(child_run)) => {
-            Ok(Json(ChildRunResponse { child_run }))
+        Ok(child_run) => Ok(Json(ChildRunResponse { child_run })),
+        Err(alan_runtime::runtime::ChildRunRegistryError::AlreadyTerminal(child_run)) => {
+            Ok(Json(ChildRunResponse {
+                child_run: *child_run,
+            }))
         }
         Err(alan_runtime::runtime::ChildRunRegistryError::NotFound) => Err((
             StatusCode::NOT_FOUND,

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -352,6 +352,23 @@ pub struct SessionListResponse {
 }
 
 #[derive(Serialize)]
+pub struct ChildRunListResponse {
+    pub child_runs: Vec<alan_runtime::runtime::ChildRunRecord>,
+}
+
+#[derive(Serialize)]
+pub struct ChildRunResponse {
+    pub child_run: alan_runtime::runtime::ChildRunRecord,
+}
+
+#[derive(Deserialize, Default)]
+pub struct TerminateChildRunRequest {
+    pub reason: Option<String>,
+    pub mode: Option<alan_runtime::runtime::ChildRunTerminationMode>,
+    pub actor: Option<String>,
+}
+
+#[derive(Serialize)]
 pub struct SessionReadResponse {
     pub session_id: String,
     pub workspace_id: String,
@@ -700,6 +717,91 @@ pub async fn list_sessions(
         .collect();
     data.sort_by(|a, b| a.session_id.cmp(&b.session_id));
     Ok(Json(SessionListResponse { sessions: data }))
+}
+
+pub async fn list_child_runs(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ChildRunListResponse>, StatusCode> {
+    if !state.get_session(&id).await.map_err(|err| {
+        warn!(%id, error = %err, "Failed to recover sessions before listing child runs");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })? {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(Json(ChildRunListResponse {
+        child_runs: state.runtime_manager.list_child_runs(&id).await,
+    }))
+}
+
+pub async fn get_child_run(
+    State(state): State<AppState>,
+    Path((id, child_run_id)): Path<(String, String)>,
+) -> Result<Json<ChildRunResponse>, StatusCode> {
+    if !state.get_session(&id).await.map_err(|err| {
+        warn!(%id, error = %err, "Failed to recover sessions before reading child run");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })? {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    state
+        .runtime_manager
+        .get_child_run(&id, &child_run_id)
+        .await
+        .map(|child_run| Json(ChildRunResponse { child_run }))
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+pub async fn terminate_child_run(
+    State(state): State<AppState>,
+    Path((id, child_run_id)): Path<(String, String)>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<ChildRunResponse>, (StatusCode, Json<serde_json::Value>)> {
+    if !state.get_session(&id).await.map_err(|err| {
+        warn!(%id, error = %err, "Failed to recover sessions before terminating child run");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("{:#}", err) })),
+        )
+    })? {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Session not found" })),
+        ));
+    }
+
+    let payload = parse_optional_json_body::<TerminateChildRunRequest>(&headers, &body)
+        .map_err(json_body_error_response)?
+        .unwrap_or_default();
+    let reason = payload
+        .reason
+        .filter(|reason| !reason.trim().is_empty())
+        .unwrap_or_else(|| "operator requested child termination".to_string());
+    let actor = payload
+        .actor
+        .filter(|actor| !actor.trim().is_empty())
+        .unwrap_or_else(|| "operator".to_string());
+    let mode = payload
+        .mode
+        .unwrap_or(alan_runtime::runtime::ChildRunTerminationMode::Graceful);
+
+    match state
+        .runtime_manager
+        .terminate_child_run(&id, &child_run_id, actor, mode, reason)
+        .await
+    {
+        Ok(child_run)
+        | Err(alan_runtime::runtime::ChildRunRegistryError::AlreadyTerminal(child_run)) => {
+            Ok(Json(ChildRunResponse { child_run }))
+        }
+        Err(alan_runtime::runtime::ChildRunRegistryError::NotFound) => Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Child run not found" })),
+        )),
+    }
 }
 
 /// Read session metadata and persisted message history in one response.
@@ -2054,7 +2156,10 @@ mod tests {
     use alan_protocol::{Event, Op};
     use alan_runtime::{
         Config, MessageRecord,
-        runtime::{RuntimeEventEnvelope, SessionDurabilityState, WorkspaceRuntimeConfig},
+        runtime::{
+            ChildRunRecord, ChildRunStatus, RuntimeEventEnvelope, SessionDurabilityState,
+            WorkspaceRuntimeConfig, global_child_run_registry,
+        },
     };
     use axum::{
         Router,
@@ -2259,6 +2364,17 @@ Body
             None,
         );
         (entry, submission_rx)
+    }
+
+    fn test_child_run_record(child_run_id: &str, parent_session_id: &str) -> ChildRunRecord {
+        ChildRunRecord::new(
+            child_run_id.to_string(),
+            parent_session_id.to_string(),
+            format!("child-session-{child_run_id}"),
+            Some("/tmp/alan-child-route-workspace".to_string()),
+            Some("/tmp/alan-child-route-workspace/.alan/sessions/child.jsonl".to_string()),
+            Some("repo-coding".to_string()),
+        )
     }
 
     struct SessionsDirPermissionGuard {
@@ -2761,6 +2877,147 @@ Body
             .unwrap();
         assert_eq!(status, StatusCode::NO_CONTENT);
         assert!(!state.get_session("sess-del").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn child_run_routes_list_and_read_registered_runs() {
+        let state = test_state();
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_id = format!("sess-child-{}", uuid::Uuid::new_v4());
+        let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+        let (entry, _rx) = session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert(session_id.clone(), entry);
+        global_child_run_registry().register(test_child_run_record(&child_run_id, &session_id));
+
+        let Json(list) = list_child_runs(State(state.clone()), Path(session_id.clone()))
+            .await
+            .unwrap();
+        assert_eq!(list.child_runs.len(), 1);
+        assert_eq!(list.child_runs[0].id, child_run_id);
+
+        let Json(read) = get_child_run(
+            State(state.clone()),
+            Path((session_id.clone(), child_run_id.clone())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(read.child_run.id, child_run_id);
+        assert_eq!(read.child_run.parent_session_id, session_id);
+    }
+
+    #[tokio::test]
+    async fn child_run_routes_return_not_found_for_missing_session_or_child() {
+        let state = test_state();
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_id = format!("sess-child-{}", uuid::Uuid::new_v4());
+        let (entry, _rx) = session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert(session_id.clone(), entry);
+
+        let missing_session = list_child_runs(State(state.clone()), Path("missing".to_string()))
+            .await
+            .err()
+            .unwrap();
+        assert_eq!(missing_session, StatusCode::NOT_FOUND);
+
+        let missing_child = get_child_run(
+            State(state.clone()),
+            Path((session_id, "missing".to_string())),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(missing_child, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn child_run_route_terminates_and_preserves_already_terminal_runs() {
+        let state = test_state();
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_id = format!("sess-child-{}", uuid::Uuid::new_v4());
+        let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+        let (entry, _rx) = session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert(session_id.clone(), entry);
+        global_child_run_registry().register(test_child_run_record(&child_run_id, &session_id));
+
+        let body = Bytes::from(
+            serde_json::json!({
+                "actor": "tui",
+                "reason": "operator stop",
+                "mode": "forceful"
+            })
+            .to_string(),
+        );
+        let Json(terminated) = terminate_child_run(
+            State(state.clone()),
+            Path((session_id.clone(), child_run_id.clone())),
+            json_headers(),
+            body,
+        )
+        .await
+        .unwrap();
+        assert_eq!(terminated.child_run.status, ChildRunStatus::Terminating);
+        let termination = terminated.child_run.termination.as_ref().unwrap();
+        assert_eq!(termination.actor, "tui");
+        assert_eq!(termination.reason, "operator stop");
+
+        global_child_run_registry().mark_terminal(&child_run_id, ChildRunStatus::Terminated, None);
+        let Json(already_terminal) = terminate_child_run(
+            State(state.clone()),
+            Path((session_id, child_run_id)),
+            HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            already_terminal.child_run.status,
+            ChildRunStatus::Terminated
+        );
+        assert_eq!(
+            already_terminal
+                .child_run
+                .termination
+                .as_ref()
+                .map(|request| request.reason.as_str()),
+            Some("operator stop")
+        );
+    }
+
+    #[tokio::test]
+    async fn child_run_route_terminate_unknown_child_returns_json_404() {
+        let state = test_state();
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_id = format!("sess-child-{}", uuid::Uuid::new_v4());
+        let (entry, _rx) = session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert(session_id.clone(), entry);
+
+        let (status, body) = terminate_child_run(
+            State(state.clone()),
+            Path((session_id, "missing-child-run".to_string())),
+            HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body.0["error"], "Child run not found");
     }
 
     #[tokio::test]

--- a/crates/alan/src/daemon/runtime_manager.rs
+++ b/crates/alan/src/daemon/runtime_manager.rs
@@ -4,7 +4,8 @@
 //! middle layer and managing the `session -> runtime` mapping directly.
 
 use alan_runtime::runtime::{
-    RuntimeController, RuntimeHandle, RuntimeStartupMetadata, WorkspaceRuntimeConfig,
+    ChildRunRecord, ChildRunRegistryError, ChildRunTerminationMode, RuntimeController,
+    RuntimeHandle, RuntimeStartupMetadata, WorkspaceRuntimeConfig, global_child_run_registry,
     spawn_with_tool_registry,
 };
 use alan_runtime::{AlanHomePaths, ModelCatalog};
@@ -202,7 +203,7 @@ impl RuntimeManager {
         // Build runtime configuration.
         let mut runtime_config = self.config.runtime_config_template.clone();
         runtime_config.session_id = Some(session_id.clone());
-        runtime_config.workspace_id = generate_workspace_id(&workspace_root_path);
+        runtime_config.workspace_id = generate_workspace_id(&normalized_workspace);
         runtime_config.agent_name = session_policy.agent_name.clone();
         if session_policy.connection_profile.is_some() {
             runtime_config.agent_config.core_config.connection_profile =
@@ -439,6 +440,38 @@ impl RuntimeManager {
             last_activity: e.last_activity,
             is_running: !e.controller.is_finished(),
         })
+    }
+
+    /// List known child runs for a parent session.
+    pub async fn list_child_runs(&self, session_id: &str) -> Vec<ChildRunRecord> {
+        global_child_run_registry().list_for_parent(session_id)
+    }
+
+    /// Read a known child run for a parent session.
+    pub async fn get_child_run(
+        &self,
+        session_id: &str,
+        child_run_id: &str,
+    ) -> Option<ChildRunRecord> {
+        global_child_run_registry().get_for_parent(session_id, child_run_id)
+    }
+
+    /// Request child-run termination through the shared registry transition.
+    pub async fn terminate_child_run(
+        &self,
+        session_id: &str,
+        child_run_id: &str,
+        actor: impl Into<String>,
+        mode: ChildRunTerminationMode,
+        reason: impl Into<String>,
+    ) -> Result<ChildRunRecord, ChildRunRegistryError> {
+        global_child_run_registry().request_termination(
+            session_id,
+            child_run_id,
+            actor,
+            mode,
+            reason,
+        )
     }
 
     /// List all running runtimes

--- a/crates/alan/src/daemon/runtime_manager.rs
+++ b/crates/alan/src/daemon/runtime_manager.rs
@@ -553,7 +553,7 @@ mod tests {
         let alan_dir = workspace_root.join(".alan");
         std::fs::create_dir_all(alan_dir.join("sessions")).unwrap();
         std::fs::create_dir_all(alan_dir.join("memory")).unwrap();
-        std::fs::create_dir_all(alan_dir.join("agent/persona")).unwrap();
+        std::fs::create_dir_all(alan_dir.join("agents/default/persona")).unwrap();
         let guard = SessionsDirPermissionGuard::new(alan_dir.join("sessions"));
         (workspace_root, alan_dir, guard)
     }
@@ -704,7 +704,7 @@ mod tests {
         std::fs::create_dir_all(&alan_dir).unwrap();
         std::fs::create_dir_all(alan_dir.join("sessions")).unwrap();
         std::fs::create_dir_all(alan_dir.join("memory")).unwrap();
-        std::fs::create_dir_all(alan_dir.join("agent/persona")).unwrap();
+        std::fs::create_dir_all(alan_dir.join("agents/default/persona")).unwrap();
         std::fs::write(
             alan_dir.join("models.toml"),
             r#"
@@ -809,7 +809,7 @@ supports_reasoning = true
         let home = TempDir::new().unwrap();
         let (workspace_root, alan_dir, _guard) = recorder_blocked_workspace(&temp);
         std::fs::write(
-            alan_dir.join("agent/agent.toml"),
+            alan_dir.join("agents/default/agent.toml"),
             r#"
 [durability]
 required = true

--- a/crates/alan/src/daemon/server.rs
+++ b/crates/alan/src/daemon/server.rs
@@ -164,6 +164,18 @@ pub async fn run_server_with_loaded_config(loaded_config: LoadedConfig) -> Resul
             post(routes::write_skill_override_route),
         )
         .route("/api/v1/sessions/{id}", get(routes::get_session))
+        .route(
+            "/api/v1/sessions/{id}/child_runs",
+            get(routes::list_child_runs),
+        )
+        .route(
+            "/api/v1/sessions/{id}/child_runs/{child_run_id}",
+            get(routes::get_child_run),
+        )
+        .route(
+            "/api/v1/sessions/{id}/child_runs/{child_run_id}/terminate",
+            post(routes::terminate_child_run),
+        )
         .route("/api/v1/sessions/{id}/read", get(routes::read_session))
         .route(
             "/api/v1/sessions/{id}/reconnect_snapshot",

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -863,10 +863,13 @@ impl AppState {
                 skill_id
             );
         }
-        let writable_root = context.resolved.writable_root_dir.clone().ok_or_else(|| {
-            anyhow::anyhow!("No writable agent root is available for this request")
-        })?;
-        let config_path = writable_root.join("agent.toml");
+        let config_path = context
+            .resolved
+            .writable_config_path
+            .clone()
+            .ok_or_else(|| {
+                anyhow::anyhow!("No writable agent config path is available for this request")
+            })?;
         let _write_guard = self
             .skill_override_lock
             .lock()

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -2413,7 +2413,9 @@ mod tests {
     }
 
     fn create_test_skill(workspace_path: &std::path::Path, skill_name: &str) {
-        let skill_dir = workspace_path.join(".alan/agent/skills").join(skill_name);
+        let skill_dir = workspace_path
+            .join(".alan/agents/default/skills")
+            .join(skill_name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -4447,9 +4449,9 @@ Body
     fn write_skill_override_rejects_unknown_skill_id() {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(workspace.join(".alan/agent/skills/repo-review")).unwrap();
+        std::fs::create_dir_all(workspace.join(".alan/agents/default/skills/repo-review")).unwrap();
         std::fs::write(
-            workspace.join(".alan/agent/skills/repo-review/SKILL.md"),
+            workspace.join(".alan/agents/default/skills/repo-review/SKILL.md"),
             r#"---
 name: Repo Review
 description: Review repositories

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -2549,14 +2549,15 @@ Body
         let state = AppState::with_alan_home(test_runtime_config(), alan_home.clone()).unwrap();
         let snapshot = state.auth_control.status().await.unwrap();
         let runtime_config = state.runtime_manager.runtime_config_template();
+        let expected_auth_path = std::fs::canonicalize(&alan_home).unwrap().join("auth.json");
 
         assert_eq!(
             snapshot.storage_path.as_deref(),
-            Some(alan_home.join("auth.json").to_string_lossy().as_ref())
+            Some(expected_auth_path.to_string_lossy().as_ref())
         );
         assert_eq!(
             runtime_config.chatgpt_auth_storage_path.as_deref(),
-            Some(alan_home.join("auth.json").as_path())
+            Some(expected_auth_path.as_path())
         );
     }
 

--- a/crates/alan/src/daemon/workspace_resolver.rs
+++ b/crates/alan/src/daemon/workspace_resolver.rs
@@ -66,13 +66,6 @@ impl WorkspaceResolver {
         &self.default_workspace_dir
     }
 
-    /// Return legacy nested Alan-home state if `~/.alan/.alan` exists.
-    #[allow(dead_code)]
-    pub fn legacy_nested_alan_home_state_dir(&self) -> Option<PathBuf> {
-        let nested = self.default_workspace_dir.join(".alan");
-        nested.exists().then_some(nested)
-    }
-
     /// Get the default workspace directory (`~/.alan/`)
     fn default_workspace_dir() -> Result<PathBuf> {
         alan_runtime::AlanHomePaths::detect()
@@ -230,7 +223,6 @@ impl WorkspaceResolver {
     /// Get the default workspace
     pub fn default_workspace(&self) -> Result<ResolvedWorkspace> {
         self.ensure_default_workspace_dir_exists()?;
-        self.report_legacy_nested_alan_home_state();
         let path = self.default_workspace_dir.clone();
 
         let id = generate_workspace_id(&path);
@@ -337,35 +329,12 @@ impl WorkspaceResolver {
             self.ensure_workspace_state_layout(&workspace_path, &alan_dir)?;
             alan_dir
         };
-        let layout_containment_root = if alan_dir == self.default_workspace_dir {
-            alan_dir.clone()
-        } else {
-            alan_dir
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|| resolved.path.clone())
-        };
-
-        let layout = alan_runtime::AgentRootLayout::new();
-        let default_root = layout.workspace_default_root_from_alan_dir(&alan_dir);
-        let _agents_dir = Self::ensure_layout_dir_within(
-            &layout_containment_root,
-            &layout.agent_roots_dir_from_alan_dir(&alan_dir),
-        )?;
-        let _agent_dir =
-            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.root_dir)?;
-        let _skills_dir =
-            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.skills_dir)?;
-        let _sessions_dir = Self::ensure_layout_dir_within(
-            &layout_containment_root,
-            &alan_runtime::workspace_sessions_dir_from_alan_dir(&alan_dir),
-        )?;
-        let memory_dir = Self::ensure_layout_dir_within(
-            &layout_containment_root,
-            &alan_runtime::workspace_memory_dir_from_alan_dir(&alan_dir),
-        )?;
-        let persona_dir =
-            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.persona_dir)?;
+        let agents_dir = Self::ensure_fixed_child_dir(&alan_dir, "agents")?;
+        let default_agent_dir = Self::ensure_fixed_child_dir(&agents_dir, "default")?;
+        let _skills_dir = Self::ensure_fixed_child_dir(&default_agent_dir, "skills")?;
+        let _sessions_dir = Self::ensure_fixed_child_dir(&alan_dir, "sessions")?;
+        let memory_dir = Self::ensure_fixed_child_dir(&alan_dir, "memory")?;
+        let persona_dir = Self::ensure_fixed_child_dir(&default_agent_dir, "persona")?;
 
         alan_runtime::prompts::ensure_workspace_memory_layout_at(&memory_dir)?;
         alan_runtime::prompts::ensure_workspace_bootstrap_files_at(&persona_dir)?;
@@ -382,17 +351,7 @@ impl WorkspaceResolver {
                     self.default_workspace_dir.display()
                 )
             })?;
-        self.report_legacy_nested_alan_home_state();
         Ok(())
-    }
-
-    fn report_legacy_nested_alan_home_state(&self) {
-        if let Some(nested) = self.legacy_nested_alan_home_state_dir() {
-            warn!(
-                path = %nested.display(),
-                "Legacy nested Alan-home runtime state detected; Alan will not delete or migrate it automatically"
-            );
-        }
     }
 
     fn ensure_workspace_root_exists(&self, workspace_path: &Path) -> Result<PathBuf> {
@@ -434,21 +393,41 @@ impl WorkspaceResolver {
         Ok(current)
     }
 
-    fn ensure_layout_dir_within(workspace_path: &Path, path: &Path) -> Result<PathBuf> {
-        std::fs::create_dir_all(path)
-            .with_context(|| format!("Failed to create directory: {}", path.display()))?;
-        let dir = std::fs::canonicalize(path).with_context(|| {
+    fn ensure_fixed_child_dir(parent: &Path, child_name: &'static str) -> Result<PathBuf> {
+        Self::ensure_single_normal_component(OsStr::new(child_name))?;
+        let parent = std::fs::canonicalize(parent).with_context(|| {
+            format!(
+                "Failed to canonicalize parent directory: {}",
+                parent.display()
+            )
+        })?;
+        let child_dir = parent.join(child_name);
+        match std::fs::create_dir(&child_dir) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("Failed to create directory: {}", child_dir.display())
+                });
+            }
+        }
+        let child_dir = std::fs::canonicalize(&child_dir).with_context(|| {
             format!(
                 "Failed to canonicalize directory after creation: {}",
-                path.display()
+                child_dir.display()
             )
         })?;
         ensure!(
-            dir.starts_with(workspace_path),
-            "Created directory escaped workspace root: {}",
-            dir.display()
+            child_dir.parent() == Some(parent.as_path()),
+            "Created directory escaped parent: {}",
+            child_dir.display()
         );
-        Ok(dir)
+        ensure!(
+            child_dir.file_name() == Some(OsStr::new(child_name)),
+            "Created directory name changed unexpectedly: {}",
+            child_dir.display()
+        );
+        Ok(child_dir)
     }
 
     fn split_existing_workspace_ancestor(
@@ -695,31 +674,6 @@ mod tests {
             !default.ends_with("workspace"),
             "default workspace dir should not be ~/.alan/workspace"
         );
-    }
-
-    #[test]
-    fn test_legacy_nested_alan_home_state_is_detected_without_changing_default_layout() {
-        let temp = TempDir::new().unwrap();
-        let default_dir = temp.path().join(".alan");
-        let nested = default_dir.join(".alan");
-        std::fs::create_dir_all(nested.join("sessions")).unwrap();
-
-        let registry = WorkspaceRegistry {
-            version: 1,
-            workspaces: vec![],
-        };
-        let resolver = WorkspaceResolver::with_registry(registry, default_dir.clone());
-        let canonical_default_dir = std::fs::canonicalize(&default_dir).unwrap();
-        let canonical_nested = std::fs::canonicalize(&nested).unwrap();
-
-        assert_eq!(
-            resolver.legacy_nested_alan_home_state_dir(),
-            Some(canonical_nested.clone())
-        );
-        let resolved = resolver.resolve(None).unwrap();
-        assert_eq!(resolved.path, canonical_default_dir);
-        assert_eq!(resolved.alan_dir, canonical_default_dir);
-        assert_ne!(resolved.alan_dir, canonical_nested);
     }
 
     #[test]

--- a/crates/alan/src/daemon/workspace_resolver.rs
+++ b/crates/alan/src/daemon/workspace_resolver.rs
@@ -337,14 +337,35 @@ impl WorkspaceResolver {
             self.ensure_workspace_state_layout(&workspace_path, &alan_dir)?;
             alan_dir
         };
+        let layout_containment_root = if alan_dir == self.default_workspace_dir {
+            alan_dir.clone()
+        } else {
+            alan_dir
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| resolved.path.clone())
+        };
 
-        let agents_dir = Self::ensure_fixed_child_dir(&alan_dir, "agents")?;
-        let agent_dir =
-            Self::ensure_fixed_child_dir(&agents_dir, alan_runtime::DEFAULT_AGENT_NAME)?;
-        let _skills_dir = Self::ensure_fixed_child_dir(&agent_dir, "skills")?;
-        let _sessions_dir = Self::ensure_fixed_child_dir(&alan_dir, "sessions")?;
-        let memory_dir = Self::ensure_fixed_child_dir(&alan_dir, "memory")?;
-        let persona_dir = Self::ensure_fixed_child_dir(&agent_dir, "persona")?;
+        let layout = alan_runtime::AgentRootLayout::new();
+        let default_root = layout.workspace_default_root_from_alan_dir(&alan_dir);
+        let _agents_dir = Self::ensure_layout_dir_within(
+            &layout_containment_root,
+            &layout.agent_roots_dir_from_alan_dir(&alan_dir),
+        )?;
+        let _agent_dir =
+            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.root_dir)?;
+        let _skills_dir =
+            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.skills_dir)?;
+        let _sessions_dir = Self::ensure_layout_dir_within(
+            &layout_containment_root,
+            &alan_runtime::workspace_sessions_dir_from_alan_dir(&alan_dir),
+        )?;
+        let memory_dir = Self::ensure_layout_dir_within(
+            &layout_containment_root,
+            &alan_runtime::workspace_memory_dir_from_alan_dir(&alan_dir),
+        )?;
+        let persona_dir =
+            Self::ensure_layout_dir_within(&layout_containment_root, &default_root.persona_dir)?;
 
         alan_runtime::prompts::ensure_workspace_memory_layout_at(&memory_dir)?;
         alan_runtime::prompts::ensure_workspace_bootstrap_files_at(&persona_dir)?;
@@ -413,41 +434,21 @@ impl WorkspaceResolver {
         Ok(current)
     }
 
-    fn ensure_fixed_child_dir(parent: &Path, child_name: &'static str) -> Result<PathBuf> {
-        Self::ensure_single_normal_component(OsStr::new(child_name))?;
-        let parent = std::fs::canonicalize(parent).with_context(|| {
-            format!(
-                "Failed to canonicalize parent directory: {}",
-                parent.display()
-            )
-        })?;
-        let child_dir = parent.join(child_name);
-        match std::fs::create_dir(&child_dir) {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
-            Err(err) => {
-                return Err(err).with_context(|| {
-                    format!("Failed to create directory: {}", child_dir.display())
-                });
-            }
-        }
-        let child_dir = std::fs::canonicalize(&child_dir).with_context(|| {
+    fn ensure_layout_dir_within(workspace_path: &Path, path: &Path) -> Result<PathBuf> {
+        std::fs::create_dir_all(path)
+            .with_context(|| format!("Failed to create directory: {}", path.display()))?;
+        let dir = std::fs::canonicalize(path).with_context(|| {
             format!(
                 "Failed to canonicalize directory after creation: {}",
-                child_dir.display()
+                path.display()
             )
         })?;
         ensure!(
-            child_dir.parent() == Some(parent.as_path()),
-            "Created directory escaped parent: {}",
-            child_dir.display()
+            dir.starts_with(workspace_path),
+            "Created directory escaped workspace root: {}",
+            dir.display()
         );
-        ensure!(
-            child_dir.file_name() == Some(OsStr::new(child_name)),
-            "Created directory name changed unexpectedly: {}",
-            child_dir.display()
-        );
-        Ok(child_dir)
+        Ok(dir)
     }
 
     fn split_existing_workspace_ancestor(

--- a/crates/alan/src/daemon/workspace_resolver.rs
+++ b/crates/alan/src/daemon/workspace_resolver.rs
@@ -338,7 +338,9 @@ impl WorkspaceResolver {
             alan_dir
         };
 
-        let agent_dir = Self::ensure_fixed_child_dir(&alan_dir, "agent")?;
+        let agents_dir = Self::ensure_fixed_child_dir(&alan_dir, "agents")?;
+        let agent_dir =
+            Self::ensure_fixed_child_dir(&agents_dir, alan_runtime::DEFAULT_AGENT_NAME)?;
         let _skills_dir = Self::ensure_fixed_child_dir(&agent_dir, "skills")?;
         let _sessions_dir = Self::ensure_fixed_child_dir(&alan_dir, "sessions")?;
         let memory_dir = Self::ensure_fixed_child_dir(&alan_dir, "memory")?;
@@ -742,7 +744,12 @@ mod tests {
         assert!(resolved.alan_dir.join("memory/MEMORY.md").exists());
         assert!(resolved.alan_dir.join("memory/USER.md").exists());
         assert!(resolved.alan_dir.join("memory/handoffs/LATEST.md").exists());
-        assert!(resolved.alan_dir.join("agent/persona/SOUL.md").exists());
+        assert!(
+            resolved
+                .alan_dir
+                .join("agents/default/persona/SOUL.md")
+                .exists()
+        );
     }
 
     #[test]
@@ -851,7 +858,7 @@ mod tests {
         );
         assert_eq!(
             resolver.workspace_persona_dir(&workspace),
-            workspace.join(".alan/agent/persona")
+            workspace.join(".alan/agents/default/persona")
         );
     }
 

--- a/crates/alan/src/daemon/workspace_resolver.rs
+++ b/crates/alan/src/daemon/workspace_resolver.rs
@@ -44,7 +44,7 @@ impl WorkspaceResolver {
     /// Create a new resolver and load the CLI registry
     pub fn new() -> Result<Self> {
         let registry = WorkspaceRegistry::load()?;
-        let default_workspace_dir = Self::default_workspace_dir()?;
+        let default_workspace_dir = canonicalize_existing_or_self(Self::default_workspace_dir()?);
 
         Ok(Self {
             registry,
@@ -57,13 +57,20 @@ impl WorkspaceResolver {
     pub fn with_registry(registry: WorkspaceRegistry, default_dir: PathBuf) -> Self {
         Self {
             registry,
-            default_workspace_dir: default_dir,
+            default_workspace_dir: canonicalize_existing_or_self(default_dir),
         }
     }
 
     /// Return the resolver's default `.alan` home directory.
     pub fn alan_home_dir(&self) -> &Path {
         &self.default_workspace_dir
+    }
+
+    /// Return legacy nested Alan-home state if `~/.alan/.alan` exists.
+    #[allow(dead_code)]
+    pub fn legacy_nested_alan_home_state_dir(&self) -> Option<PathBuf> {
+        let nested = self.default_workspace_dir.join(".alan");
+        nested.exists().then_some(nested)
     }
 
     /// Get the default workspace directory (`~/.alan/`)
@@ -223,6 +230,7 @@ impl WorkspaceResolver {
     /// Get the default workspace
     pub fn default_workspace(&self) -> Result<ResolvedWorkspace> {
         self.ensure_default_workspace_dir_exists()?;
+        self.report_legacy_nested_alan_home_state();
         let path = self.default_workspace_dir.clone();
 
         let id = generate_workspace_id(&path);
@@ -351,7 +359,17 @@ impl WorkspaceResolver {
                     self.default_workspace_dir.display()
                 )
             })?;
+        self.report_legacy_nested_alan_home_state();
         Ok(())
+    }
+
+    fn report_legacy_nested_alan_home_state(&self) {
+        if let Some(nested) = self.legacy_nested_alan_home_state_dir() {
+            warn!(
+                path = %nested.display(),
+                "Legacy nested Alan-home runtime state detected; Alan will not delete or migrate it automatically"
+            );
+        }
     }
 
     fn ensure_workspace_root_exists(&self, workspace_path: &Path) -> Result<PathBuf> {
@@ -535,6 +553,10 @@ impl WorkspaceResolver {
     }
 }
 
+fn canonicalize_existing_or_self(path: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&path).unwrap_or(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -670,6 +692,31 @@ mod tests {
             !default.ends_with("workspace"),
             "default workspace dir should not be ~/.alan/workspace"
         );
+    }
+
+    #[test]
+    fn test_legacy_nested_alan_home_state_is_detected_without_changing_default_layout() {
+        let temp = TempDir::new().unwrap();
+        let default_dir = temp.path().join(".alan");
+        let nested = default_dir.join(".alan");
+        std::fs::create_dir_all(nested.join("sessions")).unwrap();
+
+        let registry = WorkspaceRegistry {
+            version: 1,
+            workspaces: vec![],
+        };
+        let resolver = WorkspaceResolver::with_registry(registry, default_dir.clone());
+        let canonical_default_dir = std::fs::canonicalize(&default_dir).unwrap();
+        let canonical_nested = std::fs::canonicalize(&nested).unwrap();
+
+        assert_eq!(
+            resolver.legacy_nested_alan_home_state_dir(),
+            Some(canonical_nested.clone())
+        );
+        let resolved = resolver.resolve(None).unwrap();
+        assert_eq!(resolved.path, canonical_default_dir);
+        assert_eq!(resolved.alan_dir, canonical_default_dir);
+        assert_ne!(resolved.alan_dir, canonical_nested);
     }
 
     #[test]

--- a/crates/alan/src/skill_catalog.rs
+++ b/crates/alan/src/skill_catalog.rs
@@ -193,19 +193,13 @@ pub fn build_skill_catalog_snapshot(context: &SkillCatalogContext) -> Result<Ski
         });
     }
 
-    let writable_config_path = context
-        .resolved
-        .writable_root_dir
-        .as_ref()
-        .map(|root| root.join("agent.toml"));
-
     let mut snapshot = SkillCatalogSnapshot {
         cursor: String::new(),
         workspace_root_dir: context.resolved.workspace_root_dir.clone(),
         workspace_alan_dir: context.resolved.workspace_alan_dir.clone(),
         agent_name: context.resolved.agent_name.clone(),
         writable_root_dir: context.resolved.writable_root_dir.clone(),
-        writable_config_path,
+        writable_config_path: context.resolved.writable_config_path.clone(),
         packages: package_snapshots,
         skills,
     };
@@ -901,6 +895,7 @@ enabled = true
             skill_overrides: Vec::new(),
             default_policy_path: None,
             writable_root_dir: None,
+            writable_config_path: None,
             writable_persona_dir: None,
         };
 
@@ -930,6 +925,7 @@ enabled = true
             skill_overrides: Vec::new(),
             default_policy_path: None,
             writable_root_dir: None,
+            writable_config_path: None,
             writable_persona_dir: None,
         };
 

--- a/crates/alan/src/skill_catalog.rs
+++ b/crates/alan/src/skill_catalog.rs
@@ -509,7 +509,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("workspace");
         let workspace_alan_dir = workspace_root.join(".alan");
-        let skills_dir = workspace_alan_dir.join("agent/skills");
+        let skills_dir = workspace_alan_dir.join("agents/default/skills");
         let review_dir = skills_dir.join("repo-review");
         fs::create_dir_all(review_dir.join("agents/repo-review")).unwrap();
         fs::write(
@@ -699,7 +699,7 @@ interface:
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("workspace");
         let workspace_alan_dir = workspace_root.join(".alan");
-        let skills_dir = workspace_alan_dir.join("agent/skills");
+        let skills_dir = workspace_alan_dir.join("agents/default/skills");
         create_skill(
             &skills_dir,
             "hidden-helper",
@@ -753,7 +753,7 @@ Body
         let workspace_root = temp.path().join("workspace");
         let workspace_alan_dir = workspace_root.join(".alan");
         let global_skills_dir = home_paths.global_agent_root_dir.join("skills");
-        let workspace_skills_dir = workspace_alan_dir.join("agent/skills");
+        let workspace_skills_dir = workspace_alan_dir.join("agents/default/skills");
 
         create_skill(
             &global_skills_dir,
@@ -894,7 +894,7 @@ enabled = true
             persona_dirs: Vec::new(),
             capability_view: alan_runtime::skills::ResolvedCapabilityView::from_package_dirs(vec![
                 alan_runtime::skills::ScopedPackageDir {
-                    path: workspace_root.join(".alan/agent/skills"),
+                    path: workspace_root.join(".alan/agents/default/skills"),
                     scope: SkillScope::Repo,
                 },
             ]),

--- a/crates/alan/tests/agent_root_overlay_integration_test.rs
+++ b/crates/alan/tests/agent_root_overlay_integration_test.rs
@@ -188,15 +188,15 @@ fn prepare_overlay_chain(temp: &TempDir) -> (AlanHomePaths, PathBuf, PathBuf, Pa
     write_agent_root(
         &home_paths.global_agent_root_dir,
         128,
-        "global base soul",
-        "global base skill body",
+        "global default soul",
+        "global default skill body",
         None,
     );
     write_agent_root(
-        &workspace_root.join(".alan/agent"),
+        &workspace_root.join(".alan/agents/default"),
         256,
-        "workspace base soul",
-        "workspace base skill body",
+        "workspace default soul",
+        "workspace default skill body",
         None,
     );
     write_agent_root(
@@ -334,10 +334,10 @@ fn assert_overlay_request(request: &GenerationRequest) {
     let system_prompt = request.system_prompt.as_deref().unwrap_or("");
     assert!(system_prompt.contains("workspace named soul"));
     assert!(!system_prompt.contains("global named soul"));
-    assert!(!system_prompt.contains("workspace base soul"));
+    assert!(!system_prompt.contains("workspace default soul"));
     assert!(system_prompt.contains("workspace named skill body"));
     assert!(!system_prompt.contains("global named skill body"));
-    assert!(!system_prompt.contains("workspace base skill body"));
+    assert!(!system_prompt.contains("workspace default skill body"));
     assert_eq!(request.thinking_budget_tokens, Some(1024));
 }
 

--- a/crates/alan/tests/auth_cli_integration_test.rs
+++ b/crates/alan/tests/auth_cli_integration_test.rs
@@ -159,7 +159,8 @@ fn connection_pin_and_current_report_selection_layers() {
         .output()
         .unwrap();
     assert!(pin.status.success(), "{pin:?}");
-    let agent_config = std::fs::read_to_string(home.join(".alan/agent/agent.toml")).unwrap();
+    let agent_config =
+        std::fs::read_to_string(home.join(".alan/agents/default/agent.toml")).unwrap();
     assert!(agent_config.contains("connection_profile = \"chatgpt-main\""));
 
     let current = Command::new(env!("CARGO_BIN_EXE_alan"))

--- a/crates/alan/tests/event_sequence_validation_test.rs
+++ b/crates/alan/tests/event_sequence_validation_test.rs
@@ -101,6 +101,7 @@ fn get_event_type(event: &Event) -> String {
         Event::ToolCallCompleted { .. } => "tool_call_completed",
         Event::PlanUpdated { .. } => "plan_updated",
         Event::SessionRolledBack { .. } => "session_rolled_back",
+        Event::RuntimeHeartbeat { .. } => "runtime_heartbeat",
         Event::CompactionObserved { .. } => "compaction_observed",
         Event::MemoryFlushObserved { .. } => "memory_flush_observed",
         Event::Warning { .. } => "warning",

--- a/crates/alan/tests/event_sequence_validation_test.rs
+++ b/crates/alan/tests/event_sequence_validation_test.rs
@@ -101,7 +101,6 @@ fn get_event_type(event: &Event) -> String {
         Event::ToolCallCompleted { .. } => "tool_call_completed",
         Event::PlanUpdated { .. } => "plan_updated",
         Event::SessionRolledBack { .. } => "session_rolled_back",
-        Event::RuntimeHeartbeat { .. } => "runtime_heartbeat",
         Event::CompactionObserved { .. } => "compaction_observed",
         Event::MemoryFlushObserved { .. } => "memory_flush_observed",
         Event::Warning { .. } => "warning",

--- a/crates/alan/tests/live_runtime_smoke_test.rs
+++ b/crates/alan/tests/live_runtime_smoke_test.rs
@@ -242,7 +242,7 @@ async fn live_chatgpt_runtime_cross_session_memory_smoke() -> Result<()> {
 
     let base_url = non_empty_env(CHATGPT_BASE_URL_ENV);
     let model = non_empty_env(CHATGPT_MODEL_ENV).unwrap_or_else(|| "gpt-5.3-codex".to_string());
-    let persona_user_path = workspace_alan_dir.join("agent/persona/USER.md");
+    let persona_user_path = workspace_alan_dir.join("agents/default/persona/USER.md");
     let wrong_workspace_user_path = workspace_root.join("USER.md");
     let marker = "ALAN_LIVE_RUNTIME_MEMORY_MARKER";
 

--- a/crates/alan/tests/skills_cli_integration_test.rs
+++ b/crates/alan/tests/skills_cli_integration_test.rs
@@ -180,8 +180,8 @@ fn skills_packages_reports_mounts_exports_and_unavailable_skills() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let workspace = temp.path().join("workspace");
-    let global_agent_root = home.join(".alan/agent");
-    let workspace_agent_root = workspace.join(".alan/agent");
+    let global_agent_root = home.join(".alan/agents/default");
+    let workspace_agent_root = workspace.join(".alan/agents/default");
     let workspace_skills_root = workspace_agent_root.join("skills");
 
     std::fs::create_dir_all(&global_agent_root).unwrap();

--- a/crates/alan/tests/smoke_test.rs
+++ b/crates/alan/tests/smoke_test.rs
@@ -714,7 +714,7 @@ async fn smoke_cross_session_persona_memory_is_reinjected() {
     let workspace_alan_dir = workspace_root.join(".alan");
     fs::create_dir_all(&workspace_alan_dir).expect("create workspace .alan");
 
-    let persona_user_path = workspace_alan_dir.join("agent/persona/USER.md");
+    let persona_user_path = workspace_alan_dir.join("agents/default/persona/USER.md");
     let workspace_duplicate_user_path = workspace_root.join("USER.md");
     let marker = "ALAN_SMOKE_PERSONA_MEMORY_MARKER";
 

--- a/crates/protocol/src/event.rs
+++ b/crates/protocol/src/event.rs
@@ -90,6 +90,13 @@ pub enum Event {
         removed_messages: usize,
     },
 
+    /// Runtime-owned liveness signal emitted while a submission is active.
+    RuntimeHeartbeat {
+        /// Compact runtime status suitable for operator surfaces.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+    },
+
     // ========================================================================
     // Unified pending input
     // ========================================================================

--- a/crates/protocol/src/event.rs
+++ b/crates/protocol/src/event.rs
@@ -90,13 +90,6 @@ pub enum Event {
         removed_messages: usize,
     },
 
-    /// Runtime-owned liveness signal emitted while a submission is active.
-    RuntimeHeartbeat {
-        /// Compact runtime status suitable for operator surfaces.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        status: Option<String>,
-    },
-
     // ========================================================================
     // Unified pending input
     // ========================================================================

--- a/crates/protocol/src/spawn.rs
+++ b/crates/protocol/src/spawn.rs
@@ -126,7 +126,7 @@ mod tests {
             ],
             runtime_overrides: SpawnRuntimeOverrides {
                 model: Some("gpt-5.4".to_string()),
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
                 tool_profile: Some(SpawnToolProfileOverride {
                     allowed_tools: vec!["read_file".to_string(), "grep".to_string()],
                 }),

--- a/crates/runtime/skills/memory/SKILL.md
+++ b/crates/runtime/skills/memory/SKILL.md
@@ -128,14 +128,68 @@ Automatic runtime note:
 - Keep `MEMORY.md` curated and stable; do not treat automatic flush output as a replacement for
   maintaining the long-lived index.
 
-4. **Let runtime own the session-handoff surfaces**.
-   Current runtime behavior:
-   - runtime writes/refreshes `handoffs/LATEST.md`
-   - runtime writes a curated session summary under `sessions/`
-   - automatic memory flush may stage candidate memory under `inbox/`
-   - automatic turn-end memory promotion runs a model-mediated write-planning
-     pass over the active-turn user messages and either promotes confirmed facts
-     or stages inbox entries
+4. **Author semantic continuation surfaces when they matter**.
+   If the session changed durable project state, write or refresh compact continuation notes through
+   this visible skill/tool flow instead of assuming runtime will make a hidden model call to choose
+   what matters.
+
+   Recommended `handoffs/LATEST.md` sections:
+   ```markdown
+   # Latest Handoff
+
+   ## Current Goal
+   - ...
+
+   ## What Just Happened
+   - ...
+
+   ## Key Decisions
+   - ...
+
+   ## Open Loops
+   - ...
+
+   ## Next Steps
+   - ...
+
+   ## References
+   - rollout/session/file paths needed for full detail
+   ```
+
+   Recommended session summary sections:
+   ```markdown
+   # Session Summary
+
+   ## Outcome
+   - ...
+
+   ## Completed Work
+   - ...
+
+   ## Remaining Work
+   - ...
+
+   ## Verification
+   - ...
+
+   ## References
+   - ...
+   ```
+
+   Runtime fallback note:
+   - Runtime may write or refresh `working/`, `handoffs/LATEST.md`, `sessions/`, and daily notes
+     from terminal state when the agent did not author a semantic summary or when a write fails.
+   - That fallback must stay deterministic, bounded, line/Markdown-aware, and include source
+     references or omission markers when detail is omitted.
+   - Runtime owns path validation, budgets, provenance, and persistence. Semantic selection for
+     durable summaries should happen in this agent-visible memory skill flow.
+
+   Automatic runtime note:
+   - Soft-threshold pre-compaction memory flush may append a structured entry to the daily note.
+   - Memory promotion may stage candidate memory under `inbox/` or promote confirmed facts according
+     to runtime policy.
+   - Keep `MEMORY.md` curated and stable; do not treat automatic flush or fallback output as a
+     replacement for maintaining the long-lived index.
 
 5. **Ensure clean state**: Code should compile, tests should pass, no half-done work.
 
@@ -178,6 +232,6 @@ Brief description of the project, its goals, and current state.
    into `topics/<slug>.md` and keep only the summary/index link in `MEMORY.md`
 9. **Use inbox-style staging when unsure**: Useful but not fully confirmed information belongs in
    candidate memory or daily/session notes before promotion into stable memory
-10. **Apply the same confirmation discipline everywhere**: Whether memory is being updated
-    manually through this skill or automatically by runtime, semantic judgment should come from the
-    model, while runtime keeps control of validation, provenance, and file writes
+10. **Keep semantic judgment agent-visible**: Durable memory summaries should be authored through
+    this skill or another explicit agent workflow. Runtime may validate, persist, and render
+    deterministic fallbacks, but should not add hidden memory-summary model calls.

--- a/crates/runtime/src/agent_definition.rs
+++ b/crates/runtime/src/agent_definition.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AlanHomePaths, ConfigSourceKind, ResolvedAgentRoots,
+    AgentRootLayout, AlanHomePaths, ConfigSourceKind, ResolvedAgentRoots,
     config::merge_skill_override_overlays_from_paths,
     runtime::WorkspaceRuntimeConfig,
     skills::{ResolvedCapabilityView, ScopedPackageDir, SkillOverride, SkillScope},
@@ -20,6 +20,7 @@ pub struct ResolvedAgentDefinition {
     pub skill_overrides: Vec<SkillOverride>,
     pub default_policy_path: Option<PathBuf>,
     pub writable_root_dir: Option<PathBuf>,
+    pub writable_config_path: Option<PathBuf>,
     pub writable_persona_dir: Option<PathBuf>,
 }
 
@@ -39,8 +40,10 @@ impl ResolvedAgentDefinition {
             .workspace_root_dir
             .clone()
             .or_else(|| infer_workspace_root_from_alan_dir(workspace_alan_dir.as_deref()));
-        let agent_name =
-            crate::normalize_agent_name(config.agent_name.as_deref()).map(str::to_owned);
+        let layout = AgentRootLayout::new();
+        let agent_name = layout
+            .normalize_agent_name(config.agent_name.as_deref())
+            .map(str::to_owned);
         let home_paths = config
             .agent_home_paths
             .clone()
@@ -51,10 +54,7 @@ impl ResolvedAgentDefinition {
             agent_name.as_deref(),
         );
         if let Some(launch_root_dir) = config.launch_root_dir.clone() {
-            roots = roots.with_appended_root(crate::AgentRootPaths::new(
-                crate::AgentRootKind::LaunchRoot,
-                launch_root_dir,
-            ));
+            roots = roots.with_appended_root(layout.launch_root(launch_root_dir));
         }
         let config_overlay_paths = overlay_config_paths(&roots, config.core_config_source);
         let persona_dirs = roots.persona_dirs();
@@ -72,6 +72,7 @@ impl ResolvedAgentDefinition {
             workspace_alan_dir,
             default_policy_path: roots.highest_precedence_policy_path(),
             writable_root_dir: roots.writable_root_dir(),
+            writable_config_path: roots.writable_config_path(),
             writable_persona_dir: roots.writable_persona_dir(),
             roots,
             config_overlay_paths,
@@ -242,20 +243,24 @@ Body
 
         let resolved = ResolvedAgentDefinition::from_runtime_config(&config).unwrap();
         let home_paths = AlanHomePaths::detect().unwrap();
+        let layout = AgentRootLayout::new();
+        let workspace_default_root =
+            layout.workspace_default_root_from_alan_dir(&workspace_alan_dir);
+        let workspace_named_root = layout.workspace_named_root(&workspace_root, "coder");
 
         assert_eq!(
             resolved.config_overlay_paths,
             vec![
-                home_paths.global_agent_config_path,
-                workspace_alan_dir.join("agents/default/agent.toml"),
-                home_paths.global_named_agents_dir.join("coder/agent.toml"),
-                workspace_alan_dir.join("agents/coder/agent.toml"),
+                home_paths.global_agent_config_path.clone(),
+                workspace_default_root.config_path.clone(),
+                layout.global_named_root(&home_paths, "coder").config_path,
+                workspace_named_root.config_path.clone(),
             ]
         );
         assert_eq!(resolved.agent_name.as_deref(), Some("coder"));
         assert_eq!(
             resolved.writable_root_dir,
-            Some(workspace_alan_dir.join("agents/coder"))
+            Some(workspace_named_root.root_dir)
         );
     }
 
@@ -268,13 +273,14 @@ Body
         config.core_config_source = ConfigSourceKind::GlobalAgentHome;
 
         let resolved = ResolvedAgentDefinition::from_runtime_config(&config).unwrap();
+        let layout = AgentRootLayout::new();
 
         assert_eq!(
             resolved.config_overlay_paths,
             vec![
-                workspace_root
-                    .path()
-                    .join(".alan/agents/default/agent.toml")
+                layout
+                    .workspace_default_root(workspace_root.path())
+                    .config_path
             ]
         );
     }
@@ -298,7 +304,11 @@ Body
         );
         assert_eq!(
             resolved.writable_root_dir,
-            Some(workspace_root.path().join(".alan/agents/default"))
+            Some(
+                AgentRootLayout::new()
+                    .workspace_default_root(workspace_root.path())
+                    .root_dir
+            )
         );
     }
 
@@ -308,10 +318,13 @@ Body
         let home = temp.path().join("home");
         let workspace_root = temp.path().join("workspace");
         let home_paths = AlanHomePaths::from_home_dir(&home);
+        let layout = AgentRootLayout::new();
         let global_root = home_paths.global_agent_root_dir.clone();
-        let workspace_agent_root = workspace_root.join(".alan/agents/default");
-        let global_named_root = home_paths.global_named_agents_dir.join("coder");
-        let workspace_named_root = workspace_root.join(".alan/agents/coder");
+        let workspace_agent_root = layout.workspace_default_root(&workspace_root).root_dir;
+        let global_named_root = layout.global_named_root(&home_paths, "coder").root_dir;
+        let workspace_named_root = layout
+            .workspace_named_root(&workspace_root, "coder")
+            .root_dir;
 
         create_test_skill(&workspace_agent_root, "test-skill", "Test Skill");
         std::fs::create_dir_all(&global_root).unwrap();
@@ -366,17 +379,19 @@ enabled = false
 
         let resolved = ResolvedAgentDefinition::from_runtime_config(&config).unwrap();
         let home_paths = AlanHomePaths::detect().unwrap();
+        let workspace_default_root =
+            AgentRootLayout::new().workspace_default_root_from_alan_dir(&workspace_alan_dir);
 
         assert_eq!(
             resolved.config_overlay_paths,
             vec![
                 home_paths.global_agent_config_path,
-                workspace_alan_dir.join("agents/default/agent.toml"),
+                workspace_default_root.config_path.clone(),
             ]
         );
         assert_eq!(
             resolved.writable_root_dir,
-            Some(workspace_alan_dir.join("agents/default"))
+            Some(workspace_default_root.root_dir)
         );
     }
 
@@ -557,6 +572,10 @@ tool_repeat_limit = 9
             Some(&launch_root.join("agent.toml"))
         );
         assert_eq!(resolved.writable_root_dir, Some(launch_root.clone()));
+        assert_eq!(
+            resolved.writable_config_path,
+            Some(launch_root.join("agent.toml"))
+        );
         assert_eq!(
             resolved.writable_persona_dir,
             Some(launch_root.join("persona"))

--- a/crates/runtime/src/agent_definition.rs
+++ b/crates/runtime/src/agent_definition.rs
@@ -91,7 +91,7 @@ fn package_dirs_for_roots(
 
     for root in roots.roots() {
         match root.kind {
-            crate::AgentRootKind::GlobalBase => {
+            crate::AgentRootKind::GlobalDefault => {
                 if let Some(home_paths) = home_paths {
                     package_dirs.push(ScopedPackageDir {
                         path: home_paths.global_public_skills_dir.clone(),
@@ -103,7 +103,7 @@ fn package_dirs_for_roots(
                     scope: SkillScope::User,
                 });
             }
-            crate::AgentRootKind::WorkspaceBase => {
+            crate::AgentRootKind::WorkspaceDefault => {
                 if let Some(workspace_root_dir) = workspace_root_dir {
                     package_dirs.push(ScopedPackageDir {
                         path: workspace_public_skills_dir(workspace_root_dir),
@@ -147,7 +147,7 @@ fn overlay_config_paths(roots: &ResolvedAgentRoots, base_source: ConfigSourceKin
             !matches!(
                 (&root.kind, base_source),
                 (
-                    crate::AgentRootKind::GlobalBase,
+                    crate::AgentRootKind::GlobalDefault,
                     ConfigSourceKind::GlobalAgentHome
                 ) | (_, ConfigSourceKind::EnvOverride)
             )
@@ -247,7 +247,7 @@ Body
             resolved.config_overlay_paths,
             vec![
                 home_paths.global_agent_config_path,
-                workspace_alan_dir.join("agent/agent.toml"),
+                workspace_alan_dir.join("agents/default/agent.toml"),
                 home_paths.global_named_agents_dir.join("coder/agent.toml"),
                 workspace_alan_dir.join("agents/coder/agent.toml"),
             ]
@@ -260,7 +260,7 @@ Body
     }
 
     #[test]
-    fn resolved_agent_definition_skips_global_base_overlay_for_global_home_source() {
+    fn resolved_agent_definition_skips_global_default_overlay_for_global_home_source() {
         let workspace_root = TempDir::new().unwrap();
         let mut config = WorkspaceRuntimeConfig::from(Config::default());
         config.workspace_root_dir = Some(workspace_root.path().to_path_buf());
@@ -271,7 +271,11 @@ Body
 
         assert_eq!(
             resolved.config_overlay_paths,
-            vec![workspace_root.path().join(".alan/agent/agent.toml")]
+            vec![
+                workspace_root
+                    .path()
+                    .join(".alan/agents/default/agent.toml")
+            ]
         );
     }
 
@@ -294,7 +298,7 @@ Body
         );
         assert_eq!(
             resolved.writable_root_dir,
-            Some(workspace_root.path().join(".alan/agent"))
+            Some(workspace_root.path().join(".alan/agents/default"))
         );
     }
 
@@ -305,7 +309,7 @@ Body
         let workspace_root = temp.path().join("workspace");
         let home_paths = AlanHomePaths::from_home_dir(&home);
         let global_root = home_paths.global_agent_root_dir.clone();
-        let workspace_agent_root = workspace_root.join(".alan/agent");
+        let workspace_agent_root = workspace_root.join(".alan/agents/default");
         let global_named_root = home_paths.global_named_agents_dir.join("coder");
         let workspace_named_root = workspace_root.join(".alan/agents/coder");
 
@@ -348,6 +352,94 @@ enabled = false
             .unwrap();
         assert_eq!(override_entry.allow_implicit_invocation, Some(false));
         assert_eq!(override_entry.enabled, Some(false));
+    }
+
+    #[test]
+    fn resolved_agent_definition_treats_explicit_default_as_default_root() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspace");
+        let workspace_alan_dir = workspace_root.join(".alan");
+        let mut config = WorkspaceRuntimeConfig::from(Config::default());
+        config.workspace_root_dir = Some(workspace_root);
+        config.workspace_alan_dir = Some(workspace_alan_dir.clone());
+        config.agent_name = Some(crate::DEFAULT_AGENT_NAME.to_string());
+
+        let resolved = ResolvedAgentDefinition::from_runtime_config(&config).unwrap();
+        let home_paths = AlanHomePaths::detect().unwrap();
+
+        assert_eq!(
+            resolved.config_overlay_paths,
+            vec![
+                home_paths.global_agent_config_path,
+                workspace_alan_dir.join("agents/default/agent.toml"),
+            ]
+        );
+        assert_eq!(
+            resolved.writable_root_dir,
+            Some(workspace_alan_dir.join("agents/default"))
+        );
+    }
+
+    #[test]
+    fn resolved_agent_definition_ignores_legacy_singular_default_roots() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let workspace_root = temp.path().join("workspace");
+        let home_paths = AlanHomePaths::from_home_dir(&home);
+        let legacy_global_root = home.join(".alan/agent");
+        let legacy_workspace_root = workspace_root.join(".alan/agent");
+
+        std::fs::create_dir_all(legacy_global_root.join("skills/legacy-global")).unwrap();
+        std::fs::write(
+            legacy_global_root.join("agent.toml"),
+            "[[skill_overrides]]\nskill = ",
+        )
+        .unwrap();
+        std::fs::write(
+            legacy_global_root.join("skills/legacy-global/SKILL.md"),
+            "---\nname: legacy-global\ndescription: ignored\n---\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(legacy_workspace_root.join("persona")).unwrap();
+        std::fs::create_dir_all(legacy_workspace_root.join("skills/legacy-workspace")).unwrap();
+        std::fs::write(legacy_workspace_root.join("policy.yaml"), "rules: []\n").unwrap();
+        std::fs::write(
+            legacy_workspace_root.join("skills/legacy-workspace/SKILL.md"),
+            "---\nname: legacy-workspace\ndescription: ignored\n---\n",
+        )
+        .unwrap();
+
+        let mut config = WorkspaceRuntimeConfig::from(Config::default());
+        config.workspace_root_dir = Some(workspace_root.clone());
+        config.workspace_alan_dir = Some(workspace_root.join(".alan"));
+        config.agent_home_paths = Some(home_paths);
+
+        let resolved = ResolvedAgentDefinition::from_runtime_config(&config).unwrap();
+
+        assert!(
+            resolved
+                .config_overlay_paths
+                .iter()
+                .all(|path| !path.starts_with(&legacy_global_root)
+                    && !path.starts_with(&legacy_workspace_root))
+        );
+        assert!(
+            resolved
+                .persona_dirs
+                .iter()
+                .all(|path| !path.starts_with(&legacy_workspace_root))
+        );
+        assert_ne!(
+            resolved.default_policy_path,
+            Some(legacy_workspace_root.join("policy.yaml"))
+        );
+        assert!(
+            !resolved
+                .capability_view
+                .packages
+                .iter()
+                .any(|package| package.id.contains("legacy"))
+        );
     }
 
     #[test]

--- a/crates/runtime/src/agent_root.rs
+++ b/crates/runtime/src/agent_root.rs
@@ -5,6 +5,176 @@ use std::{
 };
 
 pub const DEFAULT_AGENT_NAME: &str = "default";
+const ALAN_DIRNAME: &str = ".alan";
+const AGENTS_DIRNAME: &str = "agents";
+const AGENT_CONFIG_FILENAME: &str = "agent.toml";
+const PERSONA_DIRNAME: &str = "persona";
+const SKILLS_DIRNAME: &str = "skills";
+const POLICY_FILENAME: &str = "policy.yaml";
+
+/// Canonical path contract for Alan agent roots.
+///
+/// `AgentRootLayout` is the runtime-owned source of truth for agent definition
+/// roots and their standard assets. Host crates should use these semantic
+/// helpers instead of joining `.alan/agents/default` manually.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AgentRootLayout;
+
+impl AgentRootLayout {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn global_default_root(&self, home_paths: &AlanHomePaths) -> AgentRootPaths {
+        AgentRootPaths::new(
+            AgentRootKind::GlobalDefault,
+            self.global_default_root_dir(home_paths),
+        )
+    }
+
+    pub fn global_default_root_dir(&self, home_paths: &AlanHomePaths) -> PathBuf {
+        self.default_root_dir_from_alan_dir(&home_paths.alan_home_dir)
+    }
+
+    pub fn global_named_agents_dir(&self, home_paths: &AlanHomePaths) -> PathBuf {
+        self.agent_roots_dir_from_alan_dir(&home_paths.alan_home_dir)
+    }
+
+    pub fn global_named_root(&self, home_paths: &AlanHomePaths, name: &str) -> AgentRootPaths {
+        AgentRootPaths::new(
+            AgentRootKind::GlobalNamed(name.to_string()),
+            self.global_named_root_dir(home_paths, name),
+        )
+    }
+
+    pub fn global_named_root_dir(&self, home_paths: &AlanHomePaths, name: &str) -> PathBuf {
+        self.global_named_agents_dir(home_paths).join(name)
+    }
+
+    pub fn workspace_default_root(&self, workspace_root: &Path) -> AgentRootPaths {
+        AgentRootPaths::new(
+            AgentRootKind::WorkspaceDefault,
+            self.workspace_default_root_dir(workspace_root),
+        )
+    }
+
+    pub fn workspace_default_root_from_alan_dir(&self, alan_dir: &Path) -> AgentRootPaths {
+        AgentRootPaths::new(
+            AgentRootKind::WorkspaceDefault,
+            self.default_root_dir_from_alan_dir(alan_dir),
+        )
+    }
+
+    pub fn workspace_default_root_dir(&self, workspace_root: &Path) -> PathBuf {
+        self.default_root_dir_from_alan_dir(&workspace_alan_dir(workspace_root))
+    }
+
+    pub fn workspace_default_root_dir_from_alan_dir(&self, alan_dir: &Path) -> PathBuf {
+        self.default_root_dir_from_alan_dir(alan_dir)
+    }
+
+    pub fn workspace_named_agents_dir(&self, workspace_root: &Path) -> PathBuf {
+        self.agent_roots_dir_from_alan_dir(&workspace_alan_dir(workspace_root))
+    }
+
+    pub fn workspace_named_root(&self, workspace_root: &Path, name: &str) -> AgentRootPaths {
+        AgentRootPaths::new(
+            AgentRootKind::WorkspaceNamed(name.to_string()),
+            self.workspace_named_root_dir(workspace_root, name),
+        )
+    }
+
+    pub fn workspace_named_root_dir(&self, workspace_root: &Path, name: &str) -> PathBuf {
+        self.workspace_named_agents_dir(workspace_root).join(name)
+    }
+
+    pub fn launch_root(&self, root_dir: PathBuf) -> AgentRootPaths {
+        AgentRootPaths::new(AgentRootKind::LaunchRoot, root_dir)
+    }
+
+    pub fn agent_config_path(&self, root_dir: &Path) -> PathBuf {
+        root_dir.join(AGENT_CONFIG_FILENAME)
+    }
+
+    pub fn persona_dir(&self, root_dir: &Path) -> PathBuf {
+        root_dir.join(PERSONA_DIRNAME)
+    }
+
+    pub fn skills_dir(&self, root_dir: &Path) -> PathBuf {
+        root_dir.join(SKILLS_DIRNAME)
+    }
+
+    pub fn policy_path(&self, root_dir: &Path) -> PathBuf {
+        root_dir.join(POLICY_FILENAME)
+    }
+
+    pub fn normalize_agent_name<'a>(&self, agent_name: Option<&'a str>) -> Option<&'a str> {
+        agent_name.and_then(|name| {
+            let trimmed = name.trim();
+            if trimmed.is_empty() || !self.is_single_path_component(trimmed) {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+    }
+
+    pub fn normalize_named_agent_name<'a>(&self, agent_name: Option<&'a str>) -> Option<&'a str> {
+        self.normalize_agent_name(agent_name).and_then(|name| {
+            if name == DEFAULT_AGENT_NAME {
+                None
+            } else {
+                Some(name)
+            }
+        })
+    }
+
+    pub fn is_single_path_component(&self, name: &str) -> bool {
+        let mut components = Path::new(name).components();
+        matches!(components.next(), Some(Component::Normal(component)) if component == OsStr::new(name))
+            && components.next().is_none()
+    }
+
+    pub fn is_default_agent_config_path_shape(&self, path: &Path) -> bool {
+        let file_name = path.file_name().and_then(|name| name.to_str());
+        let parent_name = path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str());
+        let grandparent_name = path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str());
+        let great_grandparent_name = path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str());
+
+        file_name == Some(AGENT_CONFIG_FILENAME)
+            && parent_name == Some(DEFAULT_AGENT_NAME)
+            && grandparent_name == Some(AGENTS_DIRNAME)
+            && great_grandparent_name == Some(ALAN_DIRNAME)
+    }
+
+    pub fn default_agent_config_suffix(&self) -> PathBuf {
+        Path::new(ALAN_DIRNAME)
+            .join(AGENTS_DIRNAME)
+            .join(DEFAULT_AGENT_NAME)
+            .join(AGENT_CONFIG_FILENAME)
+    }
+
+    pub fn agent_roots_dir_from_alan_dir(&self, alan_dir: &Path) -> PathBuf {
+        alan_dir.join(AGENTS_DIRNAME)
+    }
+
+    pub fn default_root_dir_from_alan_dir(&self, alan_dir: &Path) -> PathBuf {
+        self.agent_roots_dir_from_alan_dir(alan_dir)
+            .join(DEFAULT_AGENT_NAME)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentRootKind {
@@ -27,12 +197,13 @@ pub struct AgentRootPaths {
 
 impl AgentRootPaths {
     pub fn new(kind: AgentRootKind, root_dir: PathBuf) -> Self {
+        let layout = AgentRootLayout::new();
         Self {
             kind,
-            config_path: root_dir.join("agent.toml"),
-            persona_dir: root_dir.join("persona"),
-            skills_dir: root_dir.join("skills"),
-            policy_path: root_dir.join("policy.yaml"),
+            config_path: layout.agent_config_path(&root_dir),
+            persona_dir: layout.persona_dir(&root_dir),
+            skills_dir: layout.skills_dir(&root_dir),
+            policy_path: layout.policy_path(&root_dir),
             root_dir,
         }
     }
@@ -53,41 +224,24 @@ impl ResolvedAgentRoots {
         workspace_root: Option<&Path>,
         agent_name: Option<&str>,
     ) -> Self {
+        let layout = AgentRootLayout::new();
         let mut roots = Vec::new();
 
         if let Some(home_paths) = home_paths {
-            roots.push(AgentRootPaths::new(
-                AgentRootKind::GlobalDefault,
-                home_paths.global_agent_root_dir,
-            ));
+            roots.push(layout.global_default_root(&home_paths));
             if let Some(workspace_root) = workspace_root {
-                roots.push(AgentRootPaths::new(
-                    AgentRootKind::WorkspaceDefault,
-                    workspace_agent_root_dir(workspace_root),
-                ));
+                roots.push(layout.workspace_default_root(workspace_root));
             }
-            if let Some(name) = normalize_named_agent_name(agent_name) {
-                roots.push(AgentRootPaths::new(
-                    AgentRootKind::GlobalNamed(name.to_string()),
-                    home_paths.global_named_agents_dir.join(name),
-                ));
+            if let Some(name) = layout.normalize_named_agent_name(agent_name) {
+                roots.push(layout.global_named_root(&home_paths, name));
                 if let Some(workspace_root) = workspace_root {
-                    roots.push(AgentRootPaths::new(
-                        AgentRootKind::WorkspaceNamed(name.to_string()),
-                        workspace_named_agent_root_dir(workspace_root, name),
-                    ));
+                    roots.push(layout.workspace_named_root(workspace_root, name));
                 }
             }
         } else if let Some(workspace_root) = workspace_root {
-            roots.push(AgentRootPaths::new(
-                AgentRootKind::WorkspaceDefault,
-                workspace_agent_root_dir(workspace_root),
-            ));
-            if let Some(name) = normalize_named_agent_name(agent_name) {
-                roots.push(AgentRootPaths::new(
-                    AgentRootKind::WorkspaceNamed(name.to_string()),
-                    workspace_named_agent_root_dir(workspace_root, name),
-                ));
+            roots.push(layout.workspace_default_root(workspace_root));
+            if let Some(name) = layout.normalize_named_agent_name(agent_name) {
+                roots.push(layout.workspace_named_root(workspace_root, name));
             }
         }
 
@@ -140,6 +294,10 @@ impl ResolvedAgentRoots {
         self.roots.last().map(|root| root.root_dir.clone())
     }
 
+    pub fn writable_config_path(&self) -> Option<PathBuf> {
+        self.roots.last().map(|root| root.config_path.clone())
+    }
+
     pub fn writable_persona_dir(&self) -> Option<PathBuf> {
         self.roots
             .iter()
@@ -157,7 +315,7 @@ impl ResolvedAgentRoots {
 }
 
 pub fn workspace_alan_dir(workspace_root: &Path) -> PathBuf {
-    workspace_root.join(".alan")
+    workspace_root.join(ALAN_DIRNAME)
 }
 
 pub fn workspace_sessions_dir(workspace_root: &Path) -> PathBuf {
@@ -181,7 +339,7 @@ pub fn workspace_agent_root_dir(workspace_root: &Path) -> PathBuf {
 }
 
 pub fn workspace_agent_root_dir_from_alan_dir(workspace_alan_dir: &Path) -> PathBuf {
-    workspace_alan_dir.join("agents").join(DEFAULT_AGENT_NAME)
+    AgentRootLayout::new().workspace_default_root_dir_from_alan_dir(workspace_alan_dir)
 }
 
 pub fn workspace_persona_dir(workspace_root: &Path) -> PathBuf {
@@ -189,7 +347,8 @@ pub fn workspace_persona_dir(workspace_root: &Path) -> PathBuf {
 }
 
 pub fn workspace_persona_dir_from_alan_dir(workspace_alan_dir: &Path) -> PathBuf {
-    workspace_agent_root_dir_from_alan_dir(workspace_alan_dir).join("persona")
+    let layout = AgentRootLayout::new();
+    layout.persona_dir(&layout.workspace_default_root_dir_from_alan_dir(workspace_alan_dir))
 }
 
 pub fn workspace_skills_dir(workspace_root: &Path) -> PathBuf {
@@ -197,11 +356,12 @@ pub fn workspace_skills_dir(workspace_root: &Path) -> PathBuf {
 }
 
 pub fn workspace_skills_dir_from_alan_dir(workspace_alan_dir: &Path) -> PathBuf {
-    workspace_agent_root_dir_from_alan_dir(workspace_alan_dir).join("skills")
+    let layout = AgentRootLayout::new();
+    layout.skills_dir(&layout.workspace_default_root_dir_from_alan_dir(workspace_alan_dir))
 }
 
 pub fn workspace_named_agents_dir(workspace_root: &Path) -> PathBuf {
-    workspace_alan_dir(workspace_root).join("agents")
+    AgentRootLayout::new().workspace_named_agents_dir(workspace_root)
 }
 
 pub fn workspace_public_skills_dir(workspace_root: &Path) -> PathBuf {
@@ -209,34 +369,15 @@ pub fn workspace_public_skills_dir(workspace_root: &Path) -> PathBuf {
 }
 
 pub fn workspace_named_agent_root_dir(workspace_root: &Path, agent_name: &str) -> PathBuf {
-    workspace_named_agents_dir(workspace_root).join(agent_name)
+    AgentRootLayout::new().workspace_named_root_dir(workspace_root, agent_name)
 }
 
 pub fn normalize_agent_name(agent_name: Option<&str>) -> Option<&str> {
-    agent_name.and_then(|name| {
-        let trimmed = name.trim();
-        if trimmed.is_empty() || !is_single_path_component(trimmed) {
-            None
-        } else {
-            Some(trimmed)
-        }
-    })
+    AgentRootLayout::new().normalize_agent_name(agent_name)
 }
 
 pub fn normalize_named_agent_name(agent_name: Option<&str>) -> Option<&str> {
-    normalize_agent_name(agent_name).and_then(|name| {
-        if name == DEFAULT_AGENT_NAME {
-            None
-        } else {
-            Some(name)
-        }
-    })
-}
-
-fn is_single_path_component(name: &str) -> bool {
-    let mut components = Path::new(name).components();
-    matches!(components.next(), Some(Component::Normal(component)) if component == OsStr::new(name))
-        && components.next().is_none()
+    AgentRootLayout::new().normalize_named_agent_name(agent_name)
 }
 
 #[cfg(test)]
@@ -429,6 +570,8 @@ mod tests {
     fn workspace_layout_helpers_share_the_same_canonical_layout() {
         let workspace_root = Path::new("/tmp/demo-workspace");
         let alan_dir = workspace_alan_dir(workspace_root);
+        let layout = AgentRootLayout::new();
+        let default_root = layout.workspace_default_root(workspace_root);
 
         assert_eq!(
             workspace_sessions_dir(workspace_root),
@@ -448,31 +591,63 @@ mod tests {
         );
         assert_eq!(
             workspace_agent_root_dir(workspace_root),
-            alan_dir.join("agents").join("default")
+            default_root.root_dir.clone()
         );
         assert_eq!(
             workspace_agent_root_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agents").join("default")
+            default_root.root_dir.clone()
         );
         assert_eq!(
             workspace_persona_dir(workspace_root),
-            alan_dir.join("agents/default/persona")
+            default_root.persona_dir.clone()
         );
         assert_eq!(
             workspace_persona_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agents/default/persona")
+            default_root.persona_dir.clone()
         );
         assert_eq!(
             workspace_skills_dir(workspace_root),
-            alan_dir.join("agents/default/skills")
+            default_root.skills_dir.clone()
         );
         assert_eq!(
             workspace_skills_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agents/default/skills")
+            default_root.skills_dir.clone()
         );
         assert_eq!(
             workspace_named_agents_dir(workspace_root),
-            alan_dir.join("agents")
+            layout.workspace_named_agents_dir(workspace_root)
         );
+    }
+
+    #[test]
+    fn typed_layout_exposes_standard_agent_root_assets() {
+        let layout = AgentRootLayout::new();
+        let root = Path::new("/tmp/demo-workspace/.alan/agents/default");
+
+        assert_eq!(layout.agent_config_path(root), root.join("agent.toml"));
+        assert_eq!(layout.persona_dir(root), root.join("persona"));
+        assert_eq!(layout.skills_dir(root), root.join("skills"));
+        assert_eq!(layout.policy_path(root), root.join("policy.yaml"));
+        assert!(layout.is_default_agent_config_path_shape(&root.join("agent.toml")));
+        assert!(!layout.is_default_agent_config_path_shape(Path::new(
+            "/tmp/demo-workspace/.alan/agents/coder/agent.toml"
+        )));
+    }
+
+    #[test]
+    fn typed_layout_centralizes_agent_name_semantics() {
+        let layout = AgentRootLayout::new();
+
+        assert_eq!(
+            layout.normalize_agent_name(Some(" default ")),
+            Some("default")
+        );
+        assert_eq!(layout.normalize_named_agent_name(Some("default")), None);
+        assert_eq!(
+            layout.normalize_named_agent_name(Some("coder")),
+            Some("coder")
+        );
+        assert_eq!(layout.normalize_agent_name(Some("../coder")), None);
+        assert_eq!(layout.normalize_agent_name(Some("nested/coder")), None);
     }
 }

--- a/crates/runtime/src/agent_root.rs
+++ b/crates/runtime/src/agent_root.rs
@@ -4,10 +4,12 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
+pub const DEFAULT_AGENT_NAME: &str = "default";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentRootKind {
-    GlobalBase,
-    WorkspaceBase,
+    GlobalDefault,
+    WorkspaceDefault,
     GlobalNamed(String),
     WorkspaceNamed(String),
     LaunchRoot,
@@ -55,16 +57,16 @@ impl ResolvedAgentRoots {
 
         if let Some(home_paths) = home_paths {
             roots.push(AgentRootPaths::new(
-                AgentRootKind::GlobalBase,
+                AgentRootKind::GlobalDefault,
                 home_paths.global_agent_root_dir,
             ));
             if let Some(workspace_root) = workspace_root {
                 roots.push(AgentRootPaths::new(
-                    AgentRootKind::WorkspaceBase,
+                    AgentRootKind::WorkspaceDefault,
                     workspace_agent_root_dir(workspace_root),
                 ));
             }
-            if let Some(name) = normalize_agent_name(agent_name) {
+            if let Some(name) = normalize_named_agent_name(agent_name) {
                 roots.push(AgentRootPaths::new(
                     AgentRootKind::GlobalNamed(name.to_string()),
                     home_paths.global_named_agents_dir.join(name),
@@ -78,10 +80,10 @@ impl ResolvedAgentRoots {
             }
         } else if let Some(workspace_root) = workspace_root {
             roots.push(AgentRootPaths::new(
-                AgentRootKind::WorkspaceBase,
+                AgentRootKind::WorkspaceDefault,
                 workspace_agent_root_dir(workspace_root),
             ));
-            if let Some(name) = normalize_agent_name(agent_name) {
+            if let Some(name) = normalize_named_agent_name(agent_name) {
                 roots.push(AgentRootPaths::new(
                     AgentRootKind::WorkspaceNamed(name.to_string()),
                     workspace_named_agent_root_dir(workspace_root, name),
@@ -146,7 +148,7 @@ impl ResolvedAgentRoots {
                 matches!(
                     root.kind,
                     AgentRootKind::LaunchRoot
-                        | AgentRootKind::WorkspaceBase
+                        | AgentRootKind::WorkspaceDefault
                         | AgentRootKind::WorkspaceNamed(_)
                 )
             })
@@ -179,7 +181,7 @@ pub fn workspace_agent_root_dir(workspace_root: &Path) -> PathBuf {
 }
 
 pub fn workspace_agent_root_dir_from_alan_dir(workspace_alan_dir: &Path) -> PathBuf {
-    workspace_alan_dir.join("agent")
+    workspace_alan_dir.join("agents").join(DEFAULT_AGENT_NAME)
 }
 
 pub fn workspace_persona_dir(workspace_root: &Path) -> PathBuf {
@@ -221,6 +223,16 @@ pub fn normalize_agent_name(agent_name: Option<&str>) -> Option<&str> {
     })
 }
 
+pub fn normalize_named_agent_name(agent_name: Option<&str>) -> Option<&str> {
+    normalize_agent_name(agent_name).and_then(|name| {
+        if name == DEFAULT_AGENT_NAME {
+            None
+        } else {
+            Some(name)
+        }
+    })
+}
+
 fn is_single_path_component(name: &str) -> bool {
     let mut components = Path::new(name).components();
     matches!(components.next(), Some(Component::Normal(component)) if component == OsStr::new(name))
@@ -233,7 +245,7 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn resolve_workspace_base_roots_in_overlay_order() {
+    fn resolve_workspace_default_roots_in_overlay_order() {
         let workspace_root = Path::new("/tmp/demo-workspace");
         let roots = ResolvedAgentRoots::with_home_paths(
             Some(AlanHomePaths::from_home_dir(Path::new("/tmp/demo-home"))),
@@ -242,18 +254,21 @@ mod tests {
         );
 
         assert_eq!(roots.roots().len(), 2);
-        assert!(matches!(roots.roots()[0].kind, AgentRootKind::GlobalBase));
+        assert!(matches!(
+            roots.roots()[0].kind,
+            AgentRootKind::GlobalDefault
+        ));
         assert_eq!(
             roots.roots()[0].root_dir,
-            Path::new("/tmp/demo-home/.alan/agent")
+            Path::new("/tmp/demo-home/.alan/agents/default")
         );
         assert!(matches!(
             roots.roots()[1].kind,
-            AgentRootKind::WorkspaceBase
+            AgentRootKind::WorkspaceDefault
         ));
         assert_eq!(
             roots.roots()[1].root_dir,
-            workspace_root.join(".alan").join("agent")
+            workspace_root.join(".alan").join("agents").join("default")
         );
     }
 
@@ -267,10 +282,13 @@ mod tests {
         );
 
         assert_eq!(roots.roots().len(), 4);
-        assert!(matches!(roots.roots()[0].kind, AgentRootKind::GlobalBase));
+        assert!(matches!(
+            roots.roots()[0].kind,
+            AgentRootKind::GlobalDefault
+        ));
         assert!(matches!(
             roots.roots()[1].kind,
-            AgentRootKind::WorkspaceBase
+            AgentRootKind::WorkspaceDefault
         ));
         assert!(
             matches!(roots.roots()[2].kind, AgentRootKind::GlobalNamed(ref name) if name == "coder")
@@ -318,8 +336,38 @@ mod tests {
 
         assert_eq!(
             roots.writable_persona_dir(),
-            Some(workspace_root.join(".alan").join("agent").join("persona"))
+            Some(
+                workspace_root
+                    .join(".alan")
+                    .join("agents")
+                    .join("default")
+                    .join("persona")
+            )
         );
+    }
+
+    #[test]
+    fn explicit_default_agent_name_uses_default_roots_only() {
+        let workspace_root = Path::new("/tmp/demo-workspace");
+        let roots = ResolvedAgentRoots::with_home_paths(
+            Some(AlanHomePaths::from_home_dir(Path::new("/tmp/demo-home"))),
+            Some(workspace_root),
+            Some(DEFAULT_AGENT_NAME),
+        );
+
+        assert_eq!(roots.roots().len(), 2);
+        assert!(matches!(
+            roots.roots()[0].kind,
+            AgentRootKind::GlobalDefault
+        ));
+        assert!(matches!(
+            roots.roots()[1].kind,
+            AgentRootKind::WorkspaceDefault
+        ));
+        assert!(roots.roots().iter().all(|root| !matches!(
+            root.kind,
+            AgentRootKind::GlobalNamed(_) | AgentRootKind::WorkspaceNamed(_)
+        )));
     }
 
     #[test]
@@ -347,10 +395,13 @@ mod tests {
         );
 
         assert_eq!(roots.roots().len(), 2);
-        assert!(matches!(roots.roots()[0].kind, AgentRootKind::GlobalBase));
+        assert!(matches!(
+            roots.roots()[0].kind,
+            AgentRootKind::GlobalDefault
+        ));
         assert!(matches!(
             roots.roots()[1].kind,
-            AgentRootKind::WorkspaceBase
+            AgentRootKind::WorkspaceDefault
         ));
     }
 
@@ -397,27 +448,27 @@ mod tests {
         );
         assert_eq!(
             workspace_agent_root_dir(workspace_root),
-            alan_dir.join("agent")
+            alan_dir.join("agents").join("default")
         );
         assert_eq!(
             workspace_agent_root_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agent")
+            alan_dir.join("agents").join("default")
         );
         assert_eq!(
             workspace_persona_dir(workspace_root),
-            alan_dir.join("agent/persona")
+            alan_dir.join("agents/default/persona")
         );
         assert_eq!(
             workspace_persona_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agent/persona")
+            alan_dir.join("agents/default/persona")
         );
         assert_eq!(
             workspace_skills_dir(workspace_root),
-            alan_dir.join("agent/skills")
+            alan_dir.join("agents/default/skills")
         );
         assert_eq!(
             workspace_skills_dir_from_alan_dir(&alan_dir),
-            alan_dir.join("agent/skills")
+            alan_dir.join("agents/default/skills")
         );
         assert_eq!(
             workspace_named_agents_dir(workspace_root),

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -529,7 +529,7 @@ impl Config {
         connections.apply_profile_to_config(selected_profile.as_deref(), &secret_store, self)
     }
 
-    /// Load agent-facing configuration from `ALAN_CONFIG_PATH` or `~/.alan/agent/agent.toml`.
+    /// Load agent-facing configuration from `ALAN_CONFIG_PATH` or `~/.alan/agents/default/agent.toml`.
     pub fn load() -> anyhow::Result<Self> {
         Ok(Self::load_with_metadata()?.into_config())
     }
@@ -561,7 +561,7 @@ impl Config {
     /// Get the config file path.
     /// Resolution order:
     /// 1. `ALAN_CONFIG_PATH` override
-    /// 2. `~/.alan/agent/agent.toml`
+    /// 2. `~/.alan/agents/default/agent.toml`
     pub fn config_file_path() -> Option<std::path::PathBuf> {
         Self::resolve_config_file_path(
             Self::env_override_config_path(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -32,12 +32,13 @@ pub mod tools;
 
 pub use agent_definition::ResolvedAgentDefinition;
 pub use agent_root::{
-    AgentRootKind, AgentRootPaths, DEFAULT_AGENT_NAME, ResolvedAgentRoots, normalize_agent_name,
-    normalize_named_agent_name, workspace_agent_root_dir, workspace_agent_root_dir_from_alan_dir,
-    workspace_alan_dir, workspace_memory_dir, workspace_memory_dir_from_alan_dir,
-    workspace_named_agent_root_dir, workspace_named_agents_dir, workspace_persona_dir,
-    workspace_persona_dir_from_alan_dir, workspace_public_skills_dir, workspace_sessions_dir,
-    workspace_sessions_dir_from_alan_dir, workspace_skills_dir, workspace_skills_dir_from_alan_dir,
+    AgentRootKind, AgentRootLayout, AgentRootPaths, DEFAULT_AGENT_NAME, ResolvedAgentRoots,
+    normalize_agent_name, normalize_named_agent_name, workspace_agent_root_dir,
+    workspace_agent_root_dir_from_alan_dir, workspace_alan_dir, workspace_memory_dir,
+    workspace_memory_dir_from_alan_dir, workspace_named_agent_root_dir, workspace_named_agents_dir,
+    workspace_persona_dir, workspace_persona_dir_from_alan_dir, workspace_public_skills_dir,
+    workspace_sessions_dir, workspace_sessions_dir_from_alan_dir, workspace_skills_dir,
+    workspace_skills_dir_from_alan_dir,
 };
 pub use config::{
     Config, ConfigSourceKind, LlmProvider, LoadedConfig, PartialStreamRecoveryMode, StreamingMode,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -32,12 +32,12 @@ pub mod tools;
 
 pub use agent_definition::ResolvedAgentDefinition;
 pub use agent_root::{
-    AgentRootKind, AgentRootPaths, ResolvedAgentRoots, normalize_agent_name,
-    workspace_agent_root_dir, workspace_agent_root_dir_from_alan_dir, workspace_alan_dir,
-    workspace_memory_dir, workspace_memory_dir_from_alan_dir, workspace_named_agent_root_dir,
-    workspace_named_agents_dir, workspace_persona_dir, workspace_persona_dir_from_alan_dir,
-    workspace_public_skills_dir, workspace_sessions_dir, workspace_sessions_dir_from_alan_dir,
-    workspace_skills_dir, workspace_skills_dir_from_alan_dir,
+    AgentRootKind, AgentRootPaths, DEFAULT_AGENT_NAME, ResolvedAgentRoots, normalize_agent_name,
+    normalize_named_agent_name, workspace_agent_root_dir, workspace_agent_root_dir_from_alan_dir,
+    workspace_alan_dir, workspace_memory_dir, workspace_memory_dir_from_alan_dir,
+    workspace_named_agent_root_dir, workspace_named_agents_dir, workspace_persona_dir,
+    workspace_persona_dir_from_alan_dir, workspace_public_skills_dir, workspace_sessions_dir,
+    workspace_sessions_dir_from_alan_dir, workspace_skills_dir, workspace_skills_dir_from_alan_dir,
 };
 pub use config::{
     Config, ConfigSourceKind, LlmProvider, LoadedConfig, PartialStreamRecoveryMode, StreamingMode,

--- a/crates/runtime/src/manager/state.rs
+++ b/crates/runtime/src/manager/state.rs
@@ -304,7 +304,7 @@ mod tests {
         let mut runtime_config = crate::runtime::WorkspaceRuntimeConfig::default();
         runtime_config.agent_config.runtime_config.governance = alan_protocol::GovernanceConfig {
             profile: alan_protocol::GovernanceProfile::Conservative,
-            policy_path: Some(".alan/agent/policy.yaml".to_string()),
+            policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
         };
         runtime_config
             .agent_config
@@ -321,7 +321,7 @@ mod tests {
             state.config.governance,
             Some(alan_protocol::GovernanceConfig {
                 profile: alan_protocol::GovernanceProfile::Conservative,
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
             })
         );
         assert_eq!(state.config.context_window_tokens, Some(200_000));

--- a/crates/runtime/src/paths.rs
+++ b/crates/runtime/src/paths.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::agent_root::DEFAULT_AGENT_NAME;
+
 /// Canonical Alan home paths derived from a user home directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlanHomePaths {
@@ -38,8 +40,8 @@ impl AlanHomePaths {
     }
 
     fn from_explicit_alan_home_dir(home_dir: PathBuf, alan_home_dir: PathBuf) -> Self {
-        let global_agent_root_dir = alan_home_dir.join("agent");
         let global_named_agents_dir = alan_home_dir.join("agents");
+        let global_agent_root_dir = global_named_agents_dir.join(DEFAULT_AGENT_NAME);
         let global_public_skills_dir = home_dir.join(".agents").join("skills");
         Self {
             home_dir: home_dir.clone(),
@@ -68,7 +70,7 @@ mod tests {
         assert_eq!(paths.alan_home_dir, Path::new("/tmp/demo-home/.alan"));
         assert_eq!(
             paths.global_agent_root_dir,
-            Path::new("/tmp/demo-home/.alan/agent")
+            Path::new("/tmp/demo-home/.alan/agents/default")
         );
         assert_eq!(
             paths.global_named_agents_dir,
@@ -80,7 +82,7 @@ mod tests {
         );
         assert_eq!(
             paths.global_agent_config_path,
-            Path::new("/tmp/demo-home/.alan/agent/agent.toml")
+            Path::new("/tmp/demo-home/.alan/agents/default/agent.toml")
         );
         assert_eq!(
             paths.global_host_config_path,

--- a/crates/runtime/src/paths.rs
+++ b/crates/runtime/src/paths.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::agent_root::DEFAULT_AGENT_NAME;
+use crate::agent_root::AgentRootLayout;
 
 /// Canonical Alan home paths derived from a user home directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,8 +40,9 @@ impl AlanHomePaths {
     }
 
     fn from_explicit_alan_home_dir(home_dir: PathBuf, alan_home_dir: PathBuf) -> Self {
-        let global_named_agents_dir = alan_home_dir.join("agents");
-        let global_agent_root_dir = global_named_agents_dir.join(DEFAULT_AGENT_NAME);
+        let layout = AgentRootLayout::new();
+        let global_named_agents_dir = layout.agent_roots_dir_from_alan_dir(&alan_home_dir);
+        let global_agent_root_dir = layout.default_root_dir_from_alan_dir(&alan_home_dir);
         let global_public_skills_dir = home_dir.join(".agents").join("skills");
         Self {
             home_dir: home_dir.clone(),
@@ -49,7 +50,7 @@ impl AlanHomePaths {
             global_agent_root_dir: global_agent_root_dir.clone(),
             global_named_agents_dir,
             global_public_skills_dir,
-            global_agent_config_path: global_agent_root_dir.join("agent.toml"),
+            global_agent_config_path: layout.agent_config_path(&global_agent_root_dir),
             global_host_config_path: alan_home_dir.join("host.toml"),
             global_models_path: alan_home_dir.join("models.toml"),
             global_connections_path: alan_home_dir.join("connections.toml"),

--- a/crates/runtime/src/policy.rs
+++ b/crates/runtime/src/policy.rs
@@ -870,9 +870,9 @@ default_action: allow
         let alan_dir = tmp.path().join(".alan");
         let resolved = resolve_policy_path(
             Some(alan_dir.as_path()),
-            Path::new(".alan/agent/policy.yaml"),
+            Path::new(".alan/agents/default/policy.yaml"),
         );
-        assert_eq!(resolved, alan_dir.join("agent/policy.yaml"));
+        assert_eq!(resolved, alan_dir.join("agents/default/policy.yaml"));
     }
 
     #[test]
@@ -881,9 +881,9 @@ default_action: allow
         let alan_dir = tmp.path().join(".alan");
         let resolved = resolve_policy_path(
             Some(alan_dir.as_path()),
-            Path::new("./.alan/agent/policy.yaml"),
+            Path::new("./.alan/agents/default/policy.yaml"),
         );
-        assert_eq!(resolved, alan_dir.join("agent/policy.yaml"));
+        assert_eq!(resolved, alan_dir.join("agents/default/policy.yaml"));
     }
 
     #[test]

--- a/crates/runtime/src/prompts/assembler.rs
+++ b/crates/runtime/src/prompts/assembler.rs
@@ -187,7 +187,7 @@ mod tests {
     fn test_build_agent_system_prompt_injects_workspace_context() {
         let temp_dir = TempDir::new().unwrap();
         let config = test_config_with_workspace(&temp_dir);
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
         let workspace_persona_dirs = resolved_workspace_persona_dirs(&config, None);
 
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_build_agent_system_prompt_uses_existing_workspace_file_content() {
         let temp_dir = TempDir::new().unwrap();
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         fs::create_dir_all(&persona_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
         fs::write(persona_dir.join("SOUL.md"), "custom persona instructions").unwrap();
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn test_prompt_assembly_order() {
         let temp_dir = TempDir::new().unwrap();
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         fs::create_dir_all(&persona_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
         fs::write(persona_dir.join("SOUL.md"), "SOUL content").unwrap();
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn test_build_agent_system_prompt_includes_memory_persistence_guidance() {
         let temp_dir = TempDir::new().unwrap();
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         let memory_dir = temp_dir.path().join(".alan/memory");
         fs::create_dir_all(&persona_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn test_build_agent_system_prompt_includes_memory_bootstrap_when_memory_dir_exists() {
         let temp_dir = TempDir::new().unwrap();
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         let memory_dir = temp_dir.path().join(".alan/memory");
         fs::create_dir_all(&persona_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn test_build_agent_system_prompt_omits_memory_bootstrap_when_memory_disabled() {
         let temp_dir = TempDir::new().unwrap();
-        let persona_dir = temp_dir.path().join(".alan/agent/persona");
+        let persona_dir = temp_dir.path().join(".alan/agents/default/persona");
         let memory_dir = temp_dir.path().join(".alan/memory");
         fs::create_dir_all(&persona_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
@@ -322,8 +322,18 @@ mod tests {
             build_agent_system_prompt_from_persona_dirs("Domain Prompt", &workspace_persona_dirs);
 
         assert!(prompt.contains("Domain Prompt"));
-        assert!(!temp_dir.path().join(".alan/agent/persona/SOUL.md").exists());
-        assert!(!temp_dir.path().join(".alan/agent/persona/ROLE.md").exists());
+        assert!(
+            !temp_dir
+                .path()
+                .join(".alan/agents/default/persona/SOUL.md")
+                .exists()
+        );
+        assert!(
+            !temp_dir
+                .path()
+                .join(".alan/agents/default/persona/ROLE.md")
+                .exists()
+        );
     }
 
     #[test]
@@ -336,7 +346,7 @@ mod tests {
 
         assert_eq!(
             persona_dirs.last(),
-            Some(&temp_dir.path().join(".alan/agent/persona"))
+            Some(&temp_dir.path().join(".alan/agents/default/persona"))
         );
     }
 
@@ -351,7 +361,7 @@ mod tests {
 
         assert_eq!(
             persona_dirs.last(),
-            Some(&workspace_root.join(".alan/agent/persona"))
+            Some(&workspace_root.join(".alan/agents/default/persona"))
         );
     }
 }

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -1607,7 +1607,7 @@ mod tests {
         temp: &TempDir,
     ) -> crate::skills::ResolvedCapabilityView {
         let workspace_root = temp.path().join("repo");
-        let package_root = workspace_root.join(".alan/agent/skills/repo-review");
+        let package_root = workspace_root.join(".alan/agents/default/skills/repo-review");
         std::fs::create_dir_all(package_root.join("agents/reviewer")).unwrap();
         std::fs::write(
             package_root.join("SKILL.md"),
@@ -1627,7 +1627,7 @@ Body
         .unwrap();
         crate::skills::ResolvedCapabilityView::from_package_dirs(vec![
             crate::skills::ScopedPackageDir {
-                path: workspace_root.join(".alan/agent/skills"),
+                path: workspace_root.join(".alan/agents/default/skills"),
                 scope: crate::skills::SkillScope::Repo,
             },
         ])
@@ -2188,7 +2188,7 @@ thinking_budget_tokens = 1024
         );
 
         spec.handles.clear();
-        spec.runtime_overrides.policy_path = Some(".alan/agent/policy.yaml".to_string());
+        spec.runtime_overrides.policy_path = Some(".alan/agents/default/policy.yaml".to_string());
         assert_eq!(
             resolve_child_workspace_alan_dir(
                 &spec,
@@ -2213,7 +2213,8 @@ thinking_budget_tokens = 1024
         assert_eq!(approval_config.core_config.memory.workspace_dir, None);
 
         let mut override_spec = launch_spec(root_dir);
-        override_spec.runtime_overrides.policy_path = Some(".alan/agent/policy.yaml".to_string());
+        override_spec.runtime_overrides.policy_path =
+            Some(".alan/agents/default/policy.yaml".to_string());
         let override_config = build_child_agent_config(&parent, &override_spec);
         assert_eq!(override_config.core_config.memory.workspace_dir, None);
     }
@@ -2222,16 +2223,17 @@ thinking_budget_tokens = 1024
     async fn spawn_child_runtime_does_not_bind_memory_dir_for_policy_context_only_launches() {
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        std::fs::create_dir_all(workspace_root.join(".alan/agent")).unwrap();
+        std::fs::create_dir_all(workspace_root.join(".alan/agents/default")).unwrap();
         std::fs::write(
-            workspace_root.join(".alan/agent/policy.yaml"),
+            workspace_root.join(".alan/agents/default/policy.yaml"),
             "version: 1\nrules: []\n",
         )
         .unwrap();
         let requests = RecordedRequests::default();
         let response = completed_response("Child finished cleanly.");
         let mut parent = make_parent_state(&temp, requests.clone(), response.clone());
-        parent.runtime_config.governance.policy_path = Some(".alan/agent/policy.yaml".to_string());
+        parent.runtime_config.governance.policy_path =
+            Some(".alan/agents/default/policy.yaml".to_string());
         let root_dir = workspace_root.join(".alan/agents/grader");
         std::fs::write(
             root_dir.join("agent.toml"),
@@ -2262,7 +2264,8 @@ thinking_budget_tokens = 1024
         assert_eq!(result.status, ChildRuntimeStatus::Completed);
 
         let mut override_spec = launch_spec(root_dir);
-        override_spec.runtime_overrides.policy_path = Some(".alan/agent/policy.yaml".to_string());
+        override_spec.runtime_overrides.policy_path =
+            Some(".alan/agents/default/policy.yaml".to_string());
         let child = spawn_child_runtime_with_client_factory(&parent, override_spec, |config| {
             seen_configs_for_factory
                 .lock()
@@ -2822,7 +2825,7 @@ thinking_budget_tokens = 1024
         let requests = RecordedRequests::default();
         let response = completed_response("Package child target resolved after refresh.");
         let workspace_root = temp.path().join("repo");
-        let package_root = workspace_root.join(".alan/agent/skills/repo-review");
+        let package_root = workspace_root.join(".alan/agents/default/skills/repo-review");
         std::fs::create_dir_all(&package_root).unwrap();
         std::fs::write(
             package_root.join("SKILL.md"),
@@ -2838,7 +2841,7 @@ Body
 
         let capability_view = crate::skills::ResolvedCapabilityView::from_package_dirs(vec![
             crate::skills::ScopedPackageDir {
-                path: workspace_root.join(".alan/agent/skills"),
+                path: workspace_root.join(".alan/agents/default/skills"),
                 scope: crate::skills::SkillScope::Repo,
             },
         ]);

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -27,6 +27,8 @@ const MAX_CHILD_PLAN_ITEMS: usize = 16;
 const MAX_CHILD_PLAN_ITEM_CHARS: usize = 240;
 const MAX_CHILD_TOOL_RESULTS: usize = 6;
 const MAX_CHILD_TOOL_RESULT_CHARS: usize = 1_200;
+const MAX_OBSERVED_CHILD_WARNINGS: usize = 32;
+const MAX_OBSERVED_CHILD_WARNING_CHARS: usize = 512;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChildRuntimeStatus {
@@ -85,6 +87,35 @@ enum ChildLivenessObservation {
     Progress,
     Ignored,
     Closed,
+}
+
+fn push_bounded_child_warning(warnings: &mut Vec<String>, warning: String) {
+    while warnings.len() >= MAX_OBSERVED_CHILD_WARNINGS {
+        warnings.remove(0);
+    }
+    warnings.push(truncate_child_text_with_suffix(
+        &warning,
+        MAX_OBSERVED_CHILD_WARNING_CHARS,
+        "...",
+    ));
+}
+
+fn truncate_child_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let suffix_len = suffix.chars().count();
+    if max_chars <= suffix_len {
+        return suffix.chars().take(max_chars).collect();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(suffix_len))
+        .collect::<String>();
+    truncated.push_str(suffix);
+    truncated
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -447,8 +478,16 @@ impl ChildRuntimeController {
         &mut self,
         observed: ObservedChildTerminalEvent,
     ) -> Result<ChildRuntimeResult> {
-        let mut warnings = self.startup_metadata.warnings.clone();
-        warnings.extend(observed.warnings);
+        let mut warnings = Vec::new();
+        for warning in self
+            .startup_metadata
+            .warnings
+            .iter()
+            .cloned()
+            .chain(observed.warnings)
+        {
+            push_bounded_child_warning(&mut warnings, warning);
+        }
         self.terminate_runtime().await;
         let rollout_fallback_text = if observed.output_text.trim().is_empty() {
             read_latest_assistant_text_from_rollout(self.startup_metadata.rollout_path.as_deref())
@@ -498,6 +537,10 @@ impl ChildRuntimeController {
             ChildRunStatus::Cancelled,
             None,
         );
+        let mut warnings = Vec::new();
+        for warning in self.startup_metadata.warnings.iter().cloned() {
+            push_bounded_child_warning(&mut warnings, warning);
+        }
         ChildRuntimeResult {
             status: ChildRuntimeStatus::Cancelled,
             session_id: self.startup_metadata.session_id.clone(),
@@ -506,7 +549,7 @@ impl ChildRuntimeController {
             output_text: String::new(),
             turn_summary: None,
             structured_output: None,
-            warnings: self.startup_metadata.warnings.clone(),
+            warnings,
             error_message: None,
             pause: None,
             child_run: global_child_run_registry().get(&self.child_run_id),
@@ -763,7 +806,7 @@ impl ChildRuntimeController {
                             "warning",
                             Some(message.clone()),
                         );
-                        warnings.push(message);
+                        push_bounded_child_warning(warnings, message);
                         ChildEventObservation::Progress
                     }
                     alan_protocol::Event::TurnCompleted { summary } => {
@@ -830,7 +873,7 @@ impl ChildRuntimeController {
                             "recoverable_error",
                             Some(message.clone()),
                         );
-                        warnings.push(message);
+                        push_bounded_child_warning(warnings, message);
                         ChildEventObservation::Progress
                     }
                     alan_protocol::Event::ToolCallStarted { name, .. } => {
@@ -865,7 +908,7 @@ impl ChildRuntimeController {
                 let message = format!(
                     "Child-agent runtime event stream lagged by {skipped} event(s) before a terminal event could be observed"
                 );
-                warnings.push(message.clone());
+                push_bounded_child_warning(warnings, message.clone());
                 ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                     output_text: output_text.clone(),
                     turn_summary: None,
@@ -2365,6 +2408,30 @@ thinking_budget_tokens = 1024
             Some(".alan/agents/default/policy.yaml".to_string());
         let override_config = build_child_agent_config(&parent, &override_spec);
         assert_eq!(override_config.core_config.memory.workspace_dir, None);
+    }
+
+    #[test]
+    fn push_bounded_child_warning_keeps_recent_truncated_warnings() {
+        let mut warnings = Vec::new();
+
+        for index in 0..(MAX_OBSERVED_CHILD_WARNINGS + 2) {
+            push_bounded_child_warning(
+                &mut warnings,
+                format!(
+                    "warning-{index:03}-{}",
+                    "x".repeat(MAX_OBSERVED_CHILD_WARNING_CHARS)
+                ),
+            );
+        }
+
+        assert_eq!(warnings.len(), MAX_OBSERVED_CHILD_WARNINGS);
+        assert!(warnings[0].starts_with("warning-002-"));
+        assert!(
+            warnings
+                .iter()
+                .all(|warning| warning.chars().count() <= MAX_OBSERVED_CHILD_WARNING_CHARS)
+        );
+        assert!(warnings.last().unwrap().ends_with("..."));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -4,8 +4,8 @@ use super::child_runs::{
     global_child_run_registry,
 };
 use super::engine::{
-    AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeStartupMetadata,
-    WorkspaceRuntimeConfig, spawn_with_llm_client_and_tools,
+    AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeLivenessEnvelope,
+    RuntimeStartupMetadata, WorkspaceRuntimeConfig, spawn_with_llm_client_and_tools,
 };
 use crate::llm::LlmClient;
 use crate::tape::{ContentPart, Message};
@@ -74,11 +74,24 @@ enum ChildRuntimeWaitOutcome {
     Cancelled,
 }
 
+enum ChildEventObservation {
+    Terminal(ObservedChildTerminalEvent),
+    Progress,
+    Ignored,
+}
+
+enum ChildLivenessObservation {
+    Progress,
+    Ignored,
+    Closed,
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct ChildRuntimeController {
     runtime: Option<RuntimeController>,
     startup_metadata: RuntimeStartupMetadata,
     event_rx: tokio::sync::broadcast::Receiver<RuntimeEventEnvelope>,
+    liveness_rx: tokio::sync::broadcast::Receiver<RuntimeLivenessEnvelope>,
     submission_id: String,
     child_run_id: String,
     timeout: Option<Duration>,
@@ -230,6 +243,7 @@ where
     );
     global_child_run_registry().register(child_run_record);
     let event_rx = runtime.handle.event_sender.subscribe();
+    let liveness_rx = runtime.handle.liveness_sender.subscribe();
     let submission = Submission::new(Op::Turn {
         parts: vec![ContentPart::text(build_child_task_text(parent, &spec))],
         context: None,
@@ -251,6 +265,7 @@ where
         runtime: Some(runtime),
         startup_metadata,
         event_rx,
+        liveness_rx,
         submission_id: submission.id,
         child_run_id,
         timeout: spec.launch.timeout_secs.map(Duration::from_secs),
@@ -510,6 +525,7 @@ impl ChildRuntimeController {
         let mut latest_liveness_at = Instant::now();
         let started_at = Instant::now();
         let wall_clock_cap = self.timeout.map(|timeout| timeout.saturating_mul(4));
+        let mut liveness_closed = false;
 
         loop {
             if let Some(request) =
@@ -551,6 +567,14 @@ impl ChildRuntimeController {
                         _ = tokio::time::sleep(Duration::from_millis(250)) => {
                             continue;
                         }
+                        liveness = self.liveness_rx.recv(), if !liveness_closed => {
+                            self.apply_liveness_observation(
+                                liveness,
+                                &mut latest_liveness_at,
+                                &mut liveness_closed,
+                            );
+                            continue;
+                        }
                         recv = self.event_rx.recv() => recv,
                     }
                 } else {
@@ -564,6 +588,14 @@ impl ChildRuntimeController {
                         _ = tokio::time::sleep(Duration::from_millis(250)) => {
                             continue;
                         }
+                        liveness = self.liveness_rx.recv(), if !liveness_closed => {
+                            self.apply_liveness_observation(
+                                liveness,
+                                &mut latest_liveness_at,
+                                &mut liveness_closed,
+                            );
+                            continue;
+                        }
                         recv = self.event_rx.recv() => recv,
                     }
                 }
@@ -573,45 +605,105 @@ impl ChildRuntimeController {
                         self.terminate_runtime().await;
                         return Ok(ChildRuntimeWaitOutcome::Cancelled);
                     }
+                    liveness = self.liveness_rx.recv(), if !liveness_closed => {
+                        self.apply_liveness_observation(
+                            liveness,
+                            &mut latest_liveness_at,
+                            &mut liveness_closed,
+                        );
+                        continue;
+                    }
                     recv = self.event_rx.recv() => recv,
                 }
             } else {
-                self.event_rx.recv().await
+                tokio::select! {
+                    liveness = self.liveness_rx.recv(), if !liveness_closed => {
+                        self.apply_liveness_observation(
+                            liveness,
+                            &mut latest_liveness_at,
+                            &mut liveness_closed,
+                        );
+                        continue;
+                    }
+                    recv = self.event_rx.recv() => recv,
+                }
             };
 
-            match self.observe_terminal_event(recv, &mut output_text, &mut warnings) {
-                Some(observed) => return Ok(ChildRuntimeWaitOutcome::Observed(observed)),
-                None => {
+            match self.observe_child_event(recv, &mut output_text, &mut warnings) {
+                ChildEventObservation::Terminal(observed) => {
+                    return Ok(ChildRuntimeWaitOutcome::Observed(observed));
+                }
+                ChildEventObservation::Progress => {
                     latest_liveness_at = Instant::now();
                     continue;
                 }
+                ChildEventObservation::Ignored => continue,
             }
         }
     }
 
-    fn observe_terminal_event(
+    fn apply_liveness_observation(
+        &self,
+        recv: std::result::Result<RuntimeLivenessEnvelope, RecvError>,
+        latest_liveness_at: &mut Instant,
+        liveness_closed: &mut bool,
+    ) {
+        match self.observe_liveness_event(recv) {
+            ChildLivenessObservation::Progress => {
+                *latest_liveness_at = Instant::now();
+            }
+            ChildLivenessObservation::Closed => {
+                *liveness_closed = true;
+            }
+            ChildLivenessObservation::Ignored => {}
+        }
+    }
+
+    fn observe_liveness_event(
+        &self,
+        recv: std::result::Result<RuntimeLivenessEnvelope, RecvError>,
+    ) -> ChildLivenessObservation {
+        match recv {
+            Ok(envelope) => {
+                if envelope.submission_id.as_deref() != Some(self.submission_id.as_str()) {
+                    return ChildLivenessObservation::Ignored;
+                }
+                global_child_run_registry()
+                    .observe_heartbeat(&self.child_run_id, envelope.status.clone());
+                global_child_run_registry().observe_progress(
+                    &self.child_run_id,
+                    "runtime_heartbeat",
+                    envelope.status,
+                );
+                ChildLivenessObservation::Progress
+            }
+            Err(RecvError::Lagged(_)) => {
+                let status = Some("active_submission".to_string());
+                global_child_run_registry().observe_heartbeat(&self.child_run_id, status.clone());
+                global_child_run_registry().observe_progress(
+                    &self.child_run_id,
+                    "runtime_heartbeat",
+                    status,
+                );
+                ChildLivenessObservation::Progress
+            }
+            Err(RecvError::Closed) => ChildLivenessObservation::Closed,
+        }
+    }
+
+    fn observe_child_event(
         &self,
         recv: std::result::Result<RuntimeEventEnvelope, RecvError>,
         output_text: &mut String,
         warnings: &mut Vec<String>,
-    ) -> Option<ObservedChildTerminalEvent> {
+    ) -> ChildEventObservation {
         match recv {
             Ok(envelope) => {
                 if envelope.submission_id.as_deref() != Some(self.submission_id.as_str()) {
-                    return None;
+                    return ChildEventObservation::Ignored;
                 }
 
                 match envelope.event {
-                    alan_protocol::Event::RuntimeHeartbeat { status } => {
-                        global_child_run_registry()
-                            .observe_heartbeat(&self.child_run_id, status.clone());
-                        global_child_run_registry().observe_progress(
-                            &self.child_run_id,
-                            "runtime_heartbeat",
-                            status,
-                        );
-                        None
-                    }
                     alan_protocol::Event::TextDelta { chunk, .. } => {
                         if !chunk.is_empty() {
                             output_text.push_str(&chunk);
@@ -621,7 +713,7 @@ impl ChildRuntimeController {
                                 Some("child emitted text".to_string()),
                             );
                         }
-                        None
+                        ChildEventObservation::Progress
                     }
                     alan_protocol::Event::Warning { message } => {
                         global_child_run_registry()
@@ -632,7 +724,7 @@ impl ChildRuntimeController {
                             Some(message.clone()),
                         );
                         warnings.push(message);
-                        None
+                        ChildEventObservation::Progress
                     }
                     alan_protocol::Event::TurnCompleted { summary } => {
                         global_child_run_registry().observe_progress(
@@ -641,7 +733,7 @@ impl ChildRuntimeController {
                             summary.clone(),
                         );
                         let structured_output = parse_child_structured_output(output_text.as_str());
-                        Some(ObservedChildTerminalEvent {
+                        ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
                             turn_summary: summary,
                             structured_output,
@@ -660,7 +752,7 @@ impl ChildRuntimeController {
                             Some(format!("child yielded for {}", yield_kind_label(&kind))),
                         );
                         let structured_output = parse_child_structured_output(output_text.as_str());
-                        Some(ObservedChildTerminalEvent {
+                        ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
                             turn_summary: None,
                             structured_output,
@@ -680,7 +772,7 @@ impl ChildRuntimeController {
                             Some(message.clone()),
                         );
                         let structured_output = parse_child_structured_output(output_text.as_str());
-                        Some(ObservedChildTerminalEvent {
+                        ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
                             turn_summary: None,
                             structured_output,
@@ -699,7 +791,7 @@ impl ChildRuntimeController {
                             Some(message.clone()),
                         );
                         warnings.push(message);
-                        None
+                        ChildEventObservation::Progress
                     }
                     alan_protocol::Event::ToolCallStarted { name, .. } => {
                         global_child_run_registry().observe_progress(
@@ -707,7 +799,7 @@ impl ChildRuntimeController {
                             "tool_call_started",
                             Some(format!("tool {name} started")),
                         );
-                        None
+                        ChildEventObservation::Progress
                     }
                     alan_protocol::Event::ToolCallCompleted { name, success, .. } => {
                         let tool = name.unwrap_or_else(|| "<unknown>".to_string());
@@ -716,7 +808,7 @@ impl ChildRuntimeController {
                             "tool_call_completed",
                             Some(format!("tool {tool} completed success={success:?}")),
                         );
-                        None
+                        ChildEventObservation::Progress
                     }
                     alan_protocol::Event::PlanUpdated { explanation, .. } => {
                         global_child_run_registry().observe_progress(
@@ -724,9 +816,9 @@ impl ChildRuntimeController {
                             "plan_updated",
                             explanation,
                         );
-                        None
+                        ChildEventObservation::Progress
                     }
-                    _ => None,
+                    _ => ChildEventObservation::Progress,
                 }
             }
             Err(RecvError::Lagged(skipped)) => {
@@ -734,7 +826,7 @@ impl ChildRuntimeController {
                     "Child-agent runtime event stream lagged by {skipped} event(s) before a terminal event could be observed"
                 );
                 warnings.push(message.clone());
-                Some(ObservedChildTerminalEvent {
+                ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                     output_text: output_text.clone(),
                     turn_summary: None,
                     structured_output: parse_child_structured_output(output_text.as_str()),
@@ -744,7 +836,7 @@ impl ChildRuntimeController {
                     status: ChildRuntimeStatus::Failed,
                 })
             }
-            Err(RecvError::Closed) => Some(ObservedChildTerminalEvent {
+            Err(RecvError::Closed) => ChildEventObservation::Terminal(ObservedChildTerminalEvent {
                 output_text: output_text.clone(),
                 turn_summary: None,
                 structured_output: parse_child_structured_output(output_text.as_str()),
@@ -1268,6 +1360,10 @@ mod tests {
     use serde_json::json;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
+
+    fn test_liveness_rx() -> tokio::sync::broadcast::Receiver<RuntimeLivenessEnvelope> {
+        tokio::sync::broadcast::channel(8).0.subscribe()
+    }
 
     #[derive(Clone, Default)]
     struct RecordedRequests(Arc<Mutex<Vec<GenerationRequest>>>);
@@ -2389,6 +2485,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx: test_liveness_rx(),
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
@@ -2429,6 +2526,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx: test_liveness_rx(),
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
@@ -2479,6 +2577,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx: test_liveness_rx(),
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
@@ -2549,6 +2648,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx: test_liveness_rx(),
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
@@ -2599,6 +2699,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx: test_liveness_rx(),
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
@@ -2674,22 +2775,20 @@ thinking_budget_tokens = 1024
     #[tokio::test]
     async fn child_runtime_join_keeps_running_while_heartbeat_is_fresh() {
         let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let (liveness_tx, liveness_rx) = tokio::sync::broadcast::channel(16);
         let submission_id = "sub-heartbeat".to_string();
         let submission_id_for_task = submission_id.clone();
+        let liveness_submission_id_for_task = submission_id.clone();
         tokio::spawn(async move {
-            let _ = tx.send(RuntimeEventEnvelope {
-                submission_id: Some(submission_id_for_task.clone()),
-                event: alan_protocol::Event::RuntimeHeartbeat {
-                    status: Some("still running".to_string()),
-                },
+            let _ = liveness_tx.send(RuntimeLivenessEnvelope {
+                submission_id: Some(liveness_submission_id_for_task.clone()),
+                status: Some("still running".to_string()),
             });
             for _ in 0..4 {
                 tokio::time::sleep(Duration::from_millis(35)).await;
-                let _ = tx.send(RuntimeEventEnvelope {
-                    submission_id: Some(submission_id_for_task.clone()),
-                    event: alan_protocol::Event::RuntimeHeartbeat {
-                        status: Some("still running".to_string()),
-                    },
+                let _ = liveness_tx.send(RuntimeLivenessEnvelope {
+                    submission_id: Some(liveness_submission_id_for_task.clone()),
+                    status: Some("still running".to_string()),
                 });
             }
             let _ = tx.send(RuntimeEventEnvelope {
@@ -2718,6 +2817,7 @@ thinking_budget_tokens = 1024
                 warnings: Vec::new(),
             },
             event_rx: rx,
+            liveness_rx,
             submission_id,
             child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: Some(Duration::from_millis(80)),

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -1,4 +1,8 @@
 use super::agent_loop::RuntimeLoopState;
+use super::child_runs::{
+    ChildRunRecord, ChildRunStatus, ChildRunTerminationMode, ChildRunTerminationRequest,
+    global_child_run_registry,
+};
 use super::engine::{
     AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeStartupMetadata,
     WorkspaceRuntimeConfig, spawn_with_llm_client_and_tools,
@@ -12,7 +16,7 @@ use alan_protocol::{
 use anyhow::{Context, Result, bail};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::RecvError;
 use tokio_util::sync::CancellationToken;
 
@@ -29,6 +33,7 @@ pub(crate) enum ChildRuntimeStatus {
     Paused,
     Cancelled,
     TimedOut,
+    Terminated,
     Failed,
 }
 
@@ -42,6 +47,7 @@ pub(crate) struct ChildRuntimePause {
 pub(crate) struct ChildRuntimeResult {
     pub status: ChildRuntimeStatus,
     pub session_id: String,
+    pub child_run_id: Option<String>,
     pub rollout_path: Option<PathBuf>,
     pub output_text: String,
     pub turn_summary: Option<String>,
@@ -49,6 +55,7 @@ pub(crate) struct ChildRuntimeResult {
     pub warnings: Vec<String>,
     pub error_message: Option<String>,
     pub pause: Option<ChildRuntimePause>,
+    pub child_run: Option<ChildRunRecord>,
 }
 
 #[derive(Debug)]
@@ -73,6 +80,7 @@ pub(crate) struct ChildRuntimeController {
     startup_metadata: RuntimeStartupMetadata,
     event_rx: tokio::sync::broadcast::Receiver<RuntimeEventEnvelope>,
     submission_id: String,
+    child_run_id: String,
     timeout: Option<Duration>,
 }
 
@@ -205,18 +213,46 @@ where
     let runtime = spawn_with_llm_client_and_tools(child_config, llm_client, child_tools)
         .context("Failed to spawn child-agent runtime")?;
     let (runtime, startup_metadata) = wait_for_child_runtime_startup(runtime, cancel).await?;
+    let child_run_id = uuid::Uuid::new_v4().to_string();
+    let child_run_record = ChildRunRecord::new(
+        child_run_id.clone(),
+        parent.session.id.clone(),
+        startup_metadata.session_id.clone(),
+        resolved_child_definition
+            .workspace_root_dir
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        startup_metadata
+            .rollout_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        Some(format!("{:?}", spec.target)),
+    );
+    global_child_run_registry().register(child_run_record);
     let event_rx = runtime.handle.event_sender.subscribe();
     let submission = Submission::new(Op::Turn {
         parts: vec![ContentPart::text(build_child_task_text(parent, &spec))],
         context: None,
     });
-    let runtime = send_initial_child_submission(runtime, submission.clone(), cancel).await?;
+    let runtime = match send_initial_child_submission(runtime, submission.clone(), cancel).await {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            global_child_run_registry().mark_terminal(
+                &child_run_id,
+                ChildRunStatus::Failed,
+                Some(format!("{err:#}")),
+            );
+            return Err(err);
+        }
+    };
+    global_child_run_registry().mark_running(&child_run_id);
 
     Ok(ChildRuntimeController {
         runtime: Some(runtime),
         startup_metadata,
         event_rx,
         submission_id: submission.id,
+        child_run_id,
         timeout: spec.launch.timeout_secs.map(Duration::from_secs),
     })
 }
@@ -411,10 +447,17 @@ impl ChildRuntimeController {
         let structured_output = observed
             .structured_output
             .or_else(|| parse_child_structured_output(output_text.as_str()));
+        let child_status = child_run_status_for_runtime_status(observed.status.clone());
+        global_child_run_registry().mark_terminal(
+            &self.child_run_id,
+            child_status,
+            observed.error_message.clone(),
+        );
 
         Ok(ChildRuntimeResult {
             status: observed.status,
             session_id: self.startup_metadata.session_id.clone(),
+            child_run_id: Some(self.child_run_id.clone()),
             rollout_path: self.startup_metadata.rollout_path.clone(),
             output_text,
             turn_summary: observed.turn_summary,
@@ -422,6 +465,7 @@ impl ChildRuntimeController {
             warnings,
             error_message: observed.error_message,
             pause: observed.pause,
+            child_run: global_child_run_registry().get(&self.child_run_id),
         })
     }
 
@@ -432,9 +476,15 @@ impl ChildRuntimeController {
     }
 
     fn cancelled_result(&self) -> ChildRuntimeResult {
+        global_child_run_registry().mark_terminal(
+            &self.child_run_id,
+            ChildRunStatus::Cancelled,
+            None,
+        );
         ChildRuntimeResult {
             status: ChildRuntimeStatus::Cancelled,
             session_id: self.startup_metadata.session_id.clone(),
+            child_run_id: Some(self.child_run_id.clone()),
             rollout_path: self.startup_metadata.rollout_path.clone(),
             output_text: String::new(),
             turn_summary: None,
@@ -442,6 +492,7 @@ impl ChildRuntimeController {
             warnings: self.startup_metadata.warnings.clone(),
             error_message: None,
             pause: None,
+            child_run: global_child_run_registry().get(&self.child_run_id),
         }
     }
 
@@ -454,35 +505,64 @@ impl ChildRuntimeController {
             return Ok(ChildRuntimeWaitOutcome::Cancelled);
         }
 
-        let timeout_sleep = self.timeout.map(tokio::time::sleep);
-        tokio::pin!(timeout_sleep);
-
         let mut output_text = String::new();
         let mut warnings = Vec::new();
+        let mut latest_liveness_at = Instant::now();
+        let started_at = Instant::now();
+        let wall_clock_cap = self.timeout.map(|timeout| timeout.saturating_mul(4));
 
         loop {
-            let recv = if let Some(timeout_sleep) = timeout_sleep.as_mut().as_pin_mut() {
+            if let Some(request) =
+                global_child_run_registry().termination_request(&self.child_run_id)
+            {
+                match request.mode {
+                    ChildRunTerminationMode::Graceful => self.terminate_runtime().await,
+                    ChildRunTerminationMode::Forceful => self.abort_runtime().await,
+                }
+                return Ok(ChildRuntimeWaitOutcome::Observed(
+                    self.terminated_observed_event(request),
+                ));
+            }
+
+            if let Some(cap) = wall_clock_cap
+                && started_at.elapsed() >= cap
+            {
+                self.abort_runtime().await;
+                return Ok(ChildRuntimeWaitOutcome::Observed(
+                    self.timed_out_observed_event("Child-agent wall-clock cap exceeded"),
+                ));
+            }
+
+            let recv = if let Some(timeout) = self.timeout {
+                let deadline = latest_liveness_at + timeout;
+                let idle_remaining = deadline.saturating_duration_since(Instant::now());
                 if let Some(cancel) = cancel {
                     tokio::select! {
                         _ = cancel.cancelled() => {
                             self.terminate_runtime().await;
                             return Ok(ChildRuntimeWaitOutcome::Cancelled);
                         }
-                        _ = timeout_sleep => {
+                        _ = tokio::time::sleep(idle_remaining) => {
                             self.abort_runtime().await;
                             return Ok(ChildRuntimeWaitOutcome::Observed(
-                                self.timed_out_observed_event(),
+                                self.timed_out_observed_event("Child-agent turn idle timed out"),
                             ));
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(250)) => {
+                            continue;
                         }
                         recv = self.event_rx.recv() => recv,
                     }
                 } else {
                     tokio::select! {
-                        _ = timeout_sleep => {
+                        _ = tokio::time::sleep(idle_remaining) => {
                             self.abort_runtime().await;
                             return Ok(ChildRuntimeWaitOutcome::Observed(
-                                self.timed_out_observed_event(),
+                                self.timed_out_observed_event("Child-agent turn idle timed out"),
                             ));
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(250)) => {
+                            continue;
                         }
                         recv = self.event_rx.recv() => recv,
                     }
@@ -501,7 +581,10 @@ impl ChildRuntimeController {
 
             match self.observe_terminal_event(recv, &mut output_text, &mut warnings) {
                 Some(observed) => return Ok(ChildRuntimeWaitOutcome::Observed(observed)),
-                None => continue,
+                None => {
+                    latest_liveness_at = Instant::now();
+                    continue;
+                }
             }
         }
     }
@@ -519,17 +602,44 @@ impl ChildRuntimeController {
                 }
 
                 match envelope.event {
+                    alan_protocol::Event::RuntimeHeartbeat { status } => {
+                        global_child_run_registry()
+                            .observe_heartbeat(&self.child_run_id, status.clone());
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "runtime_heartbeat",
+                            status,
+                        );
+                        None
+                    }
                     alan_protocol::Event::TextDelta { chunk, .. } => {
                         if !chunk.is_empty() {
                             output_text.push_str(&chunk);
+                            global_child_run_registry().observe_progress(
+                                &self.child_run_id,
+                                "text_delta",
+                                Some("child emitted text".to_string()),
+                            );
                         }
                         None
                     }
                     alan_protocol::Event::Warning { message } => {
+                        global_child_run_registry()
+                            .observe_warning(&self.child_run_id, message.clone());
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "warning",
+                            Some(message.clone()),
+                        );
                         warnings.push(message);
                         None
                     }
                     alan_protocol::Event::TurnCompleted { summary } => {
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "turn_completed",
+                            summary.clone(),
+                        );
                         let structured_output = parse_child_structured_output(output_text.as_str());
                         Some(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
@@ -544,6 +654,11 @@ impl ChildRuntimeController {
                     alan_protocol::Event::Yield {
                         request_id, kind, ..
                     } => {
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "yield",
+                            Some(format!("child yielded for {}", yield_kind_label(&kind))),
+                        );
                         let structured_output = parse_child_structured_output(output_text.as_str());
                         Some(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
@@ -559,6 +674,11 @@ impl ChildRuntimeController {
                         message,
                         recoverable,
                     } if !recoverable => {
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "error",
+                            Some(message.clone()),
+                        );
                         let structured_output = parse_child_structured_output(output_text.as_str());
                         Some(ObservedChildTerminalEvent {
                             output_text: output_text.clone(),
@@ -571,7 +691,39 @@ impl ChildRuntimeController {
                         })
                     }
                     alan_protocol::Event::Error { message, .. } => {
+                        global_child_run_registry()
+                            .observe_warning(&self.child_run_id, message.clone());
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "recoverable_error",
+                            Some(message.clone()),
+                        );
                         warnings.push(message);
+                        None
+                    }
+                    alan_protocol::Event::ToolCallStarted { name, .. } => {
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "tool_call_started",
+                            Some(format!("tool {name} started")),
+                        );
+                        None
+                    }
+                    alan_protocol::Event::ToolCallCompleted { name, success, .. } => {
+                        let tool = name.unwrap_or_else(|| "<unknown>".to_string());
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "tool_call_completed",
+                            Some(format!("tool {tool} completed success={success:?}")),
+                        );
+                        None
+                    }
+                    alan_protocol::Event::PlanUpdated { explanation, .. } => {
+                        global_child_run_registry().observe_progress(
+                            &self.child_run_id,
+                            "plan_updated",
+                            explanation,
+                        );
                         None
                     }
                     _ => None,
@@ -618,15 +770,33 @@ impl ChildRuntimeController {
         }
     }
 
-    fn timed_out_observed_event(&self) -> ObservedChildTerminalEvent {
+    fn timed_out_observed_event(&self, message: &str) -> ObservedChildTerminalEvent {
         ObservedChildTerminalEvent {
             output_text: String::new(),
             turn_summary: None,
             structured_output: None,
             warnings: Vec::new(),
-            error_message: Some("Child-agent turn timed out".to_string()),
+            error_message: Some(message.to_string()),
             pause: None,
             status: ChildRuntimeStatus::TimedOut,
+        }
+    }
+
+    fn terminated_observed_event(
+        &self,
+        request: ChildRunTerminationRequest,
+    ) -> ObservedChildTerminalEvent {
+        ObservedChildTerminalEvent {
+            output_text: String::new(),
+            turn_summary: None,
+            structured_output: None,
+            warnings: Vec::new(),
+            error_message: Some(format!(
+                "Child-agent terminated by {} with {:?} mode: {}",
+                request.actor, request.mode, request.reason
+            )),
+            pause: None,
+            status: ChildRuntimeStatus::Terminated,
         }
     }
 }
@@ -640,6 +810,26 @@ fn parse_child_structured_output(text: &str) -> Option<serde_json::Value> {
     serde_json::from_str::<serde_json::Value>(trimmed)
         .ok()
         .or_else(|| parse_last_json_fenced_block(trimmed))
+}
+
+fn child_run_status_for_runtime_status(status: ChildRuntimeStatus) -> ChildRunStatus {
+    match status {
+        ChildRuntimeStatus::Completed => ChildRunStatus::Completed,
+        ChildRuntimeStatus::Paused => ChildRunStatus::Blocked,
+        ChildRuntimeStatus::Cancelled => ChildRunStatus::Cancelled,
+        ChildRuntimeStatus::TimedOut => ChildRunStatus::TimedOut,
+        ChildRuntimeStatus::Terminated => ChildRunStatus::Terminated,
+        ChildRuntimeStatus::Failed => ChildRunStatus::Failed,
+    }
+}
+
+fn yield_kind_label(kind: &YieldKind) -> String {
+    match kind {
+        YieldKind::Confirmation => "confirmation".to_string(),
+        YieldKind::StructuredInput => "structured_input".to_string(),
+        YieldKind::DynamicTool => "dynamic_tool".to_string(),
+        YieldKind::Custom(value) => value.clone(),
+    }
 }
 
 async fn read_latest_assistant_text_from_rollout(rollout_path: Option<&Path>) -> Option<String> {
@@ -2197,6 +2387,7 @@ thinking_budget_tokens = 1024
             },
             event_rx: rx,
             submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
         };
 
@@ -2236,6 +2427,7 @@ thinking_budget_tokens = 1024
             },
             event_rx: rx,
             submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
         };
 
@@ -2285,6 +2477,7 @@ thinking_budget_tokens = 1024
             },
             event_rx: rx,
             submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
         };
 
@@ -2354,6 +2547,7 @@ thinking_budget_tokens = 1024
             },
             event_rx: rx,
             submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
         };
 
@@ -2403,6 +2597,7 @@ thinking_budget_tokens = 1024
             },
             event_rx: rx,
             submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
             timeout: None,
         };
         let cancel = CancellationToken::new();
@@ -2471,6 +2666,63 @@ thinking_budget_tokens = 1024
 
         let result = child.join_until_cancelled(&cancel).await.unwrap();
         assert_eq!(result.status, ChildRuntimeStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn child_runtime_join_keeps_running_while_heartbeat_is_fresh() {
+        let (tx, rx) = tokio::sync::broadcast::channel(16);
+        let submission_id = "sub-heartbeat".to_string();
+        let submission_id_for_task = submission_id.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(RuntimeEventEnvelope {
+                submission_id: Some(submission_id_for_task.clone()),
+                event: alan_protocol::Event::RuntimeHeartbeat {
+                    status: Some("still running".to_string()),
+                },
+            });
+            for _ in 0..4 {
+                tokio::time::sleep(Duration::from_millis(35)).await;
+                let _ = tx.send(RuntimeEventEnvelope {
+                    submission_id: Some(submission_id_for_task.clone()),
+                    event: alan_protocol::Event::RuntimeHeartbeat {
+                        status: Some("still running".to_string()),
+                    },
+                });
+            }
+            let _ = tx.send(RuntimeEventEnvelope {
+                submission_id: Some(submission_id_for_task.clone()),
+                event: alan_protocol::Event::TextDelta {
+                    chunk: "finished after heartbeat".to_string(),
+                    is_final: true,
+                },
+            });
+            let _ = tx.send(RuntimeEventEnvelope {
+                submission_id: Some(submission_id_for_task),
+                event: alan_protocol::Event::TurnCompleted { summary: None },
+            });
+        });
+
+        let controller = ChildRuntimeController {
+            runtime: None,
+            startup_metadata: RuntimeStartupMetadata {
+                session_id: "child-session".to_string(),
+                rollout_path: None,
+                durability: super::super::engine::SessionDurabilityState {
+                    durable: false,
+                    required: false,
+                },
+                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+                warnings: Vec::new(),
+            },
+            event_rx: rx,
+            submission_id,
+            child_run_id: format!("test-child-run-{}", uuid::Uuid::new_v4()),
+            timeout: Some(Duration::from_millis(80)),
+        };
+
+        let result = controller.join().await.unwrap();
+        assert_eq!(result.status, ChildRuntimeStatus::Completed);
+        assert_eq!(result.output_text, "finished after heartbeat");
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -17,9 +17,10 @@ use anyhow::{Context, Result, bail};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 use tokio_util::sync::CancellationToken;
 
+const CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE: &str = "Child-agent launch cancelled";
 const MAX_CHILD_CONVERSATION_MESSAGES: usize = 8;
 const MAX_CHILD_CONVERSATION_CHARS: usize = 4_000;
 const MAX_CHILD_PLAN_ITEMS: usize = 16;
@@ -162,7 +163,7 @@ where
     F: FnOnce(&crate::Config) -> Result<LlmClient>,
 {
     if cancel.is_some_and(CancellationToken::is_cancelled) {
-        bail!("Child-agent launch cancelled");
+        bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
     }
 
     validate_child_launch_contract(&spec)?;
@@ -251,9 +252,10 @@ where
     let runtime = match send_initial_child_submission(runtime, submission.clone(), cancel).await {
         Ok(runtime) => runtime,
         Err(err) => {
+            let status = child_run_status_for_launch_error(&err);
             global_child_run_registry().mark_terminal(
                 &child_run_id,
-                ChildRunStatus::Failed,
+                status,
                 Some(format!("{err:#}")),
             );
             return Err(err);
@@ -279,12 +281,12 @@ async fn wait_for_child_runtime_startup(
     let startup_metadata = if let Some(cancel) = cancel {
         if cancel.is_cancelled() {
             runtime.abort().await;
-            bail!("Child-agent launch cancelled");
+            bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
         }
         tokio::select! {
             _ = cancel.cancelled() => {
                 runtime.abort().await;
-                bail!("Child-agent launch cancelled");
+                bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
             }
             ready = runtime.wait_until_ready() => {
                 ready.context("Child-agent runtime failed to start")?
@@ -308,12 +310,12 @@ async fn send_initial_child_submission(
     if let Some(cancel) = cancel {
         if cancel.is_cancelled() {
             runtime.abort().await;
-            bail!("Child-agent launch cancelled");
+            bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
         }
         tokio::select! {
             _ = cancel.cancelled() => {
                 runtime.abort().await;
-                bail!("Child-agent launch cancelled");
+                bail!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
             }
             result = runtime.handle.submission_tx.send(submission) => {
                 result.context("Failed to submit initial child-agent turn")?
@@ -528,9 +530,24 @@ impl ChildRuntimeController {
         let mut liveness_closed = false;
 
         loop {
+            if let Some(observed) = self.observe_buffered_child_events(
+                &mut output_text,
+                &mut warnings,
+                &mut latest_liveness_at,
+            ) {
+                return Ok(ChildRuntimeWaitOutcome::Observed(observed));
+            }
+
             if let Some(request) =
                 global_child_run_registry().termination_request(&self.child_run_id)
             {
+                if let Some(observed) = self.observe_buffered_child_events(
+                    &mut output_text,
+                    &mut warnings,
+                    &mut latest_liveness_at,
+                ) {
+                    return Ok(ChildRuntimeWaitOutcome::Observed(observed));
+                }
                 match request.mode {
                     ChildRunTerminationMode::Graceful => self.terminate_runtime().await,
                     ChildRunTerminationMode::Forceful => self.abort_runtime().await,
@@ -638,6 +655,29 @@ impl ChildRuntimeController {
                     continue;
                 }
                 ChildEventObservation::Ignored => continue,
+            }
+        }
+    }
+
+    fn observe_buffered_child_events(
+        &mut self,
+        output_text: &mut String,
+        warnings: &mut Vec<String>,
+        latest_liveness_at: &mut Instant,
+    ) -> Option<ObservedChildTerminalEvent> {
+        loop {
+            let recv = match self.event_rx.try_recv() {
+                Ok(envelope) => Ok(envelope),
+                Err(TryRecvError::Empty) => return None,
+                Err(TryRecvError::Lagged(skipped)) => Err(RecvError::Lagged(skipped)),
+                Err(TryRecvError::Closed) => Err(RecvError::Closed),
+            };
+            match self.observe_child_event(recv, output_text, warnings) {
+                ChildEventObservation::Terminal(observed) => return Some(observed),
+                ChildEventObservation::Progress => {
+                    *latest_liveness_at = Instant::now();
+                }
+                ChildEventObservation::Ignored => {}
             }
         }
     }
@@ -907,11 +947,23 @@ fn parse_child_structured_output(text: &str) -> Option<serde_json::Value> {
 fn child_run_status_for_runtime_status(status: ChildRuntimeStatus) -> ChildRunStatus {
     match status {
         ChildRuntimeStatus::Completed => ChildRunStatus::Completed,
-        ChildRuntimeStatus::Paused => ChildRunStatus::Blocked,
+        ChildRuntimeStatus::Paused => ChildRunStatus::Failed,
         ChildRuntimeStatus::Cancelled => ChildRunStatus::Cancelled,
         ChildRuntimeStatus::TimedOut => ChildRunStatus::TimedOut,
         ChildRuntimeStatus::Terminated => ChildRunStatus::Terminated,
         ChildRuntimeStatus::Failed => ChildRunStatus::Failed,
+    }
+}
+
+fn child_run_status_for_launch_error(error: &anyhow::Error) -> ChildRunStatus {
+    if error.chain().any(|cause| {
+        cause
+            .to_string()
+            .contains(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE)
+    }) {
+        ChildRunStatus::Cancelled
+    } else {
+        ChildRunStatus::Failed
     }
 }
 
@@ -2712,6 +2764,121 @@ thinking_budget_tokens = 1024
     }
 
     #[tokio::test]
+    async fn child_runtime_join_prefers_buffered_terminal_event_over_termination_request() {
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let submission_id = "sub-terminal-before-termination".to_string();
+        let child_run_id = format!("test-child-run-{}", uuid::Uuid::new_v4());
+        global_child_run_registry().register(ChildRunRecord::new(
+            child_run_id.clone(),
+            "parent-session".to_string(),
+            "child-session".to_string(),
+            None,
+            None,
+            None,
+        ));
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::TextDelta {
+                chunk: "finished".to_string(),
+                is_final: true,
+            },
+        });
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::TurnCompleted {
+                summary: Some("done".to_string()),
+            },
+        });
+        global_child_run_registry()
+            .request_termination(
+                "parent-session",
+                &child_run_id,
+                "operator",
+                ChildRunTerminationMode::Forceful,
+                "late stop",
+            )
+            .unwrap();
+
+        let controller = ChildRuntimeController {
+            runtime: None,
+            startup_metadata: RuntimeStartupMetadata {
+                session_id: "child-session".to_string(),
+                rollout_path: None,
+                durability: super::super::engine::SessionDurabilityState {
+                    durable: false,
+                    required: false,
+                },
+                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+                warnings: Vec::new(),
+            },
+            event_rx: rx,
+            liveness_rx: test_liveness_rx(),
+            submission_id,
+            child_run_id: child_run_id.clone(),
+            timeout: None,
+        };
+
+        let result = controller.join().await.unwrap();
+        assert_eq!(result.status, ChildRuntimeStatus::Completed);
+        assert_eq!(result.output_text, "finished");
+        assert_eq!(
+            global_child_run_registry()
+                .get(&child_run_id)
+                .unwrap()
+                .status,
+            ChildRunStatus::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn child_runtime_join_marks_paused_child_run_terminal_after_shutdown() {
+        let (tx, rx) = tokio::sync::broadcast::channel(8);
+        let submission_id = "sub-yield".to_string();
+        let child_run_id = format!("test-child-run-{}", uuid::Uuid::new_v4());
+        global_child_run_registry().register(ChildRunRecord::new(
+            child_run_id.clone(),
+            "parent-session".to_string(),
+            "child-session".to_string(),
+            None,
+            None,
+            None,
+        ));
+        let _ = tx.send(RuntimeEventEnvelope {
+            submission_id: Some(submission_id.clone()),
+            event: alan_protocol::Event::Yield {
+                request_id: "yield-1".to_string(),
+                kind: YieldKind::Confirmation,
+                payload: serde_json::json!({}),
+            },
+        });
+
+        let controller = ChildRuntimeController {
+            runtime: None,
+            startup_metadata: RuntimeStartupMetadata {
+                session_id: "child-session".to_string(),
+                rollout_path: None,
+                durability: super::super::engine::SessionDurabilityState {
+                    durable: false,
+                    required: false,
+                },
+                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+                warnings: Vec::new(),
+            },
+            event_rx: rx,
+            liveness_rx: test_liveness_rx(),
+            submission_id,
+            child_run_id: child_run_id.clone(),
+            timeout: None,
+        };
+
+        let result = controller.join().await.unwrap();
+        assert_eq!(result.status, ChildRuntimeStatus::Paused);
+        let child_run = global_child_run_registry().get(&child_run_id).unwrap();
+        assert_eq!(child_run.status, ChildRunStatus::Failed);
+        assert!(child_run.status.is_terminal());
+    }
+
+    #[tokio::test]
     async fn cancel_child_runtime_returns_cancelled_status() {
         let temp = TempDir::new().unwrap();
         let requests = RecordedRequests::default();
@@ -2847,6 +3014,21 @@ thinking_budget_tokens = 1024
         };
 
         assert!(err.to_string().contains("Child-agent launch cancelled"));
+    }
+
+    #[test]
+    fn child_run_status_for_launch_error_maps_cancelled_launches_to_cancelled() {
+        let cancelled = anyhow::anyhow!(CHILD_AGENT_LAUNCH_CANCELLED_MESSAGE);
+        let failed = anyhow::anyhow!("Failed to submit initial child-agent turn");
+
+        assert_eq!(
+            child_run_status_for_launch_error(&cancelled),
+            ChildRunStatus::Cancelled
+        );
+        assert_eq!(
+            child_run_status_for_launch_error(&failed),
+            ChildRunStatus::Failed
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_runs.rs
+++ b/crates/runtime/src/runtime/child_runs.rs
@@ -4,6 +4,12 @@ use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_TERMINAL_CHILD_RUN_RECORDS: usize = 256;
+const MAX_CHILD_RUN_WARNINGS: usize = 32;
+const MAX_CHILD_RUN_WARNING_CHARS: usize = 512;
+const MAX_CHILD_RUN_STATUS_SUMMARY_CHARS: usize = 512;
+const MAX_CHILD_RUN_ERROR_MESSAGE_CHARS: usize = 1_000;
+const MAX_CHILD_RUN_TERMINATION_ACTOR_CHARS: usize = 120;
+const MAX_CHILD_RUN_TERMINATION_REASON_CHARS: usize = 512;
 
 /// Lifecycle state for a delegated child runtime launch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -168,7 +174,11 @@ impl ChildRunRegistry {
             if !record.status.is_terminal() {
                 record.latest_heartbeat_at_ms = Some(now);
                 if let Some(summary) = summary {
-                    record.latest_status_summary = Some(summary);
+                    record.latest_status_summary = Some(truncate_text_with_suffix(
+                        &summary,
+                        MAX_CHILD_RUN_STATUS_SUMMARY_CHARS,
+                        "...",
+                    ));
                 }
             }
         });
@@ -185,7 +195,11 @@ impl ChildRunRegistry {
                 record.latest_progress_at_ms = Some(now);
                 record.latest_event_kind = Some(event_kind.into());
                 if let Some(summary) = summary {
-                    record.latest_status_summary = Some(summary);
+                    record.latest_status_summary = Some(truncate_text_with_suffix(
+                        &summary,
+                        MAX_CHILD_RUN_STATUS_SUMMARY_CHARS,
+                        "...",
+                    ));
                 }
             }
         });
@@ -193,7 +207,7 @@ impl ChildRunRegistry {
 
     pub fn observe_warning(&self, child_run_id: &str, warning: String) {
         self.update(child_run_id, |record, _| {
-            record.warnings.push(warning);
+            push_bounded_warning(&mut record.warnings, warning);
         });
     }
 
@@ -207,7 +221,9 @@ impl ChildRunRegistry {
         let now = now_ms();
         if let Some(record) = records.get_mut(child_run_id) {
             record.status = status;
-            record.error_message = error_message;
+            record.error_message = error_message.map(|message| {
+                truncate_text_with_suffix(&message, MAX_CHILD_RUN_ERROR_MESSAGE_CHARS, "...")
+            });
             record.latest_progress_at_ms = Some(now);
             record.updated_at_ms = now;
         }
@@ -238,9 +254,15 @@ impl ChildRunRegistry {
         let now = now_ms();
         record.status = ChildRunStatus::Terminating;
         record.updated_at_ms = now;
+        let actor = actor.into();
+        let reason = reason.into();
         record.termination = Some(ChildRunTerminationRequest {
-            actor: actor.into(),
-            reason: reason.into(),
+            actor: truncate_text_with_suffix(&actor, MAX_CHILD_RUN_TERMINATION_ACTOR_CHARS, "..."),
+            reason: truncate_text_with_suffix(
+                &reason,
+                MAX_CHILD_RUN_TERMINATION_REASON_CHARS,
+                "...",
+            ),
             mode,
             requested_at_ms: now,
         });
@@ -271,6 +293,35 @@ impl ChildRunRegistry {
             record.updated_at_ms = now;
         }
     }
+}
+
+fn push_bounded_warning(warnings: &mut Vec<String>, warning: String) {
+    while warnings.len() >= MAX_CHILD_RUN_WARNINGS {
+        warnings.remove(0);
+    }
+    warnings.push(truncate_text_with_suffix(
+        &warning,
+        MAX_CHILD_RUN_WARNING_CHARS,
+        "...",
+    ));
+}
+
+fn truncate_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let suffix_len = suffix.chars().count();
+    if max_chars <= suffix_len {
+        return suffix.chars().take(max_chars).collect();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(suffix_len))
+        .collect::<String>();
+    truncated.push_str(suffix);
+    truncated
 }
 
 fn prune_terminal_records(
@@ -384,6 +435,89 @@ mod tests {
             after_late_progress.latest_status_summary,
             terminal.latest_status_summary
         );
+    }
+
+    #[test]
+    fn registry_caps_warning_retention_per_run() {
+        let registry = ChildRunRegistry::default();
+        registry.register(test_record("run-1", "parent-1"));
+
+        for index in 0..(MAX_CHILD_RUN_WARNINGS + 2) {
+            registry.observe_warning(
+                "run-1",
+                format!(
+                    "warning-{index:03}-{}",
+                    "x".repeat(MAX_CHILD_RUN_WARNING_CHARS)
+                ),
+            );
+        }
+
+        let record = registry.get("run-1").unwrap();
+        assert_eq!(record.warnings.len(), MAX_CHILD_RUN_WARNINGS);
+        assert!(record.warnings[0].starts_with("warning-002-"));
+        assert!(
+            record
+                .warnings
+                .iter()
+                .all(|warning| warning.chars().count() <= MAX_CHILD_RUN_WARNING_CHARS)
+        );
+        assert!(record.warnings.last().unwrap().ends_with("..."));
+    }
+
+    #[test]
+    fn registry_bounds_child_run_string_payloads() {
+        let registry = ChildRunRegistry::default();
+        registry.register(test_record("run-1", "parent-1"));
+
+        registry.observe_progress(
+            "run-1",
+            "warning",
+            Some("s".repeat(MAX_CHILD_RUN_STATUS_SUMMARY_CHARS + 10)),
+        );
+        let running = registry.get("run-1").unwrap();
+        assert!(
+            running
+                .latest_status_summary
+                .as_ref()
+                .unwrap()
+                .chars()
+                .count()
+                <= MAX_CHILD_RUN_STATUS_SUMMARY_CHARS
+        );
+        assert!(
+            running
+                .latest_status_summary
+                .as_ref()
+                .unwrap()
+                .ends_with("...")
+        );
+
+        let terminating = registry
+            .request_termination(
+                "parent-1",
+                "run-1",
+                "a".repeat(MAX_CHILD_RUN_TERMINATION_ACTOR_CHARS + 10),
+                ChildRunTerminationMode::Graceful,
+                "r".repeat(MAX_CHILD_RUN_TERMINATION_REASON_CHARS + 10),
+            )
+            .unwrap();
+        let termination = terminating.termination.unwrap();
+        assert!(termination.actor.chars().count() <= MAX_CHILD_RUN_TERMINATION_ACTOR_CHARS);
+        assert!(termination.reason.chars().count() <= MAX_CHILD_RUN_TERMINATION_REASON_CHARS);
+        assert!(termination.actor.ends_with("..."));
+        assert!(termination.reason.ends_with("..."));
+
+        registry.mark_terminal(
+            "run-1",
+            ChildRunStatus::Failed,
+            Some("e".repeat(MAX_CHILD_RUN_ERROR_MESSAGE_CHARS + 10)),
+        );
+        let terminal = registry.get("run-1").unwrap();
+        assert!(
+            terminal.error_message.as_ref().unwrap().chars().count()
+                <= MAX_CHILD_RUN_ERROR_MESSAGE_CHARS
+        );
+        assert!(terminal.error_message.unwrap().ends_with("..."));
     }
 
     #[test]

--- a/crates/runtime/src/runtime/child_runs.rs
+++ b/crates/runtime/src/runtime/child_runs.rs
@@ -230,7 +230,9 @@ impl ChildRunRegistry {
             return Err(ChildRunRegistryError::NotFound);
         }
         if record.status.is_terminal() {
-            return Err(ChildRunRegistryError::AlreadyTerminal(record.clone()));
+            return Err(ChildRunRegistryError::AlreadyTerminal(Box::new(
+                record.clone(),
+            )));
         }
 
         let now = now_ms();
@@ -305,7 +307,7 @@ fn prune_terminal_records(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChildRunRegistryError {
     NotFound,
-    AlreadyTerminal(ChildRunRecord),
+    AlreadyTerminal(Box<ChildRunRecord>),
 }
 
 static GLOBAL_CHILD_RUN_REGISTRY: OnceLock<ChildRunRegistry> = OnceLock::new();

--- a/crates/runtime/src/runtime/child_runs.rs
+++ b/crates/runtime/src/runtime/child_runs.rs
@@ -1,0 +1,420 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Lifecycle state for a delegated child runtime launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildRunStatus {
+    Starting,
+    Running,
+    Blocked,
+    Completed,
+    Failed,
+    TimedOut,
+    Terminating,
+    Terminated,
+    Cancelled,
+}
+
+impl ChildRunStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::TimedOut | Self::Terminated | Self::Cancelled
+        )
+    }
+}
+
+/// Requested child termination mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChildRunTerminationMode {
+    Graceful,
+    Forceful,
+}
+
+/// Audit metadata for an explicit child termination request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChildRunTerminationRequest {
+    pub actor: String,
+    pub reason: String,
+    pub mode: ChildRunTerminationMode,
+    pub requested_at_ms: u64,
+}
+
+/// Observable lifecycle record for one delegated child runtime launch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChildRunRecord {
+    pub id: String,
+    pub parent_session_id: String,
+    pub child_session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollout_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_target: Option<String>,
+    pub status: ChildRunStatus,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_heartbeat_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_progress_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_event_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_status_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub termination: Option<ChildRunTerminationRequest>,
+}
+
+impl ChildRunRecord {
+    pub fn new(
+        id: String,
+        parent_session_id: String,
+        child_session_id: String,
+        workspace_root: Option<String>,
+        rollout_path: Option<String>,
+        launch_target: Option<String>,
+    ) -> Self {
+        let now = now_ms();
+        Self {
+            id,
+            parent_session_id,
+            child_session_id,
+            workspace_root,
+            rollout_path,
+            launch_target,
+            status: ChildRunStatus::Starting,
+            created_at_ms: now,
+            updated_at_ms: now,
+            latest_heartbeat_at_ms: None,
+            latest_progress_at_ms: None,
+            latest_event_kind: None,
+            latest_status_summary: None,
+            warnings: Vec::new(),
+            error_message: None,
+            termination: None,
+        }
+    }
+}
+
+/// Process-local registry for active and recently terminal child runs.
+#[derive(Debug, Clone, Default)]
+pub struct ChildRunRegistry {
+    inner: Arc<RwLock<HashMap<String, ChildRunRecord>>>,
+}
+
+impl ChildRunRegistry {
+    pub fn register(&self, record: ChildRunRecord) {
+        let mut records = self.inner.write().expect("child run registry poisoned");
+        records.insert(record.id.clone(), record);
+    }
+
+    pub fn list_for_parent(&self, parent_session_id: &str) -> Vec<ChildRunRecord> {
+        let mut records = self
+            .inner
+            .read()
+            .expect("child run registry poisoned")
+            .values()
+            .filter(|record| record.parent_session_id == parent_session_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.created_at_ms);
+        records
+    }
+
+    pub fn get_for_parent(
+        &self,
+        parent_session_id: &str,
+        child_run_id: &str,
+    ) -> Option<ChildRunRecord> {
+        self.inner
+            .read()
+            .expect("child run registry poisoned")
+            .get(child_run_id)
+            .filter(|record| record.parent_session_id == parent_session_id)
+            .cloned()
+    }
+
+    pub fn get(&self, child_run_id: &str) -> Option<ChildRunRecord> {
+        self.inner
+            .read()
+            .expect("child run registry poisoned")
+            .get(child_run_id)
+            .cloned()
+    }
+
+    pub fn mark_running(&self, child_run_id: &str) {
+        self.update(child_run_id, |record, now| {
+            if !record.status.is_terminal() {
+                record.status = ChildRunStatus::Running;
+                record.latest_progress_at_ms = Some(now);
+            }
+        });
+    }
+
+    pub fn observe_heartbeat(&self, child_run_id: &str, summary: Option<String>) {
+        self.update(child_run_id, |record, now| {
+            if !record.status.is_terminal() {
+                record.latest_heartbeat_at_ms = Some(now);
+                if let Some(summary) = summary {
+                    record.latest_status_summary = Some(summary);
+                }
+            }
+        });
+    }
+
+    pub fn observe_progress(
+        &self,
+        child_run_id: &str,
+        event_kind: impl Into<String>,
+        summary: Option<String>,
+    ) {
+        self.update(child_run_id, |record, now| {
+            if !record.status.is_terminal() {
+                record.latest_progress_at_ms = Some(now);
+                record.latest_event_kind = Some(event_kind.into());
+                if let Some(summary) = summary {
+                    record.latest_status_summary = Some(summary);
+                }
+            }
+        });
+    }
+
+    pub fn observe_warning(&self, child_run_id: &str, warning: String) {
+        self.update(child_run_id, |record, _| {
+            record.warnings.push(warning);
+        });
+    }
+
+    pub fn mark_terminal(
+        &self,
+        child_run_id: &str,
+        status: ChildRunStatus,
+        error_message: Option<String>,
+    ) {
+        self.update(child_run_id, |record, now| {
+            record.status = status;
+            record.error_message = error_message;
+            record.latest_progress_at_ms = Some(now);
+        });
+    }
+
+    pub fn request_termination(
+        &self,
+        parent_session_id: &str,
+        child_run_id: &str,
+        actor: impl Into<String>,
+        mode: ChildRunTerminationMode,
+        reason: impl Into<String>,
+    ) -> Result<ChildRunRecord, ChildRunRegistryError> {
+        let mut records = self.inner.write().expect("child run registry poisoned");
+        let Some(record) = records.get_mut(child_run_id) else {
+            return Err(ChildRunRegistryError::NotFound);
+        };
+        if record.parent_session_id != parent_session_id {
+            return Err(ChildRunRegistryError::NotFound);
+        }
+        if record.status.is_terminal() {
+            return Err(ChildRunRegistryError::AlreadyTerminal(record.clone()));
+        }
+
+        let now = now_ms();
+        record.status = ChildRunStatus::Terminating;
+        record.updated_at_ms = now;
+        record.termination = Some(ChildRunTerminationRequest {
+            actor: actor.into(),
+            reason: reason.into(),
+            mode,
+            requested_at_ms: now,
+        });
+        Ok(record.clone())
+    }
+
+    pub fn termination_request(&self, child_run_id: &str) -> Option<ChildRunTerminationRequest> {
+        self.inner
+            .read()
+            .expect("child run registry poisoned")
+            .get(child_run_id)
+            .and_then(|record| record.termination.clone())
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.inner
+            .write()
+            .expect("child run registry poisoned")
+            .clear();
+    }
+
+    fn update(&self, child_run_id: &str, update: impl FnOnce(&mut ChildRunRecord, u64)) {
+        let mut records = self.inner.write().expect("child run registry poisoned");
+        if let Some(record) = records.get_mut(child_run_id) {
+            let now = now_ms();
+            update(record, now);
+            record.updated_at_ms = now;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChildRunRegistryError {
+    NotFound,
+    AlreadyTerminal(ChildRunRecord),
+}
+
+static GLOBAL_CHILD_RUN_REGISTRY: OnceLock<ChildRunRegistry> = OnceLock::new();
+
+pub fn global_child_run_registry() -> &'static ChildRunRegistry {
+    GLOBAL_CHILD_RUN_REGISTRY.get_or_init(ChildRunRegistry::default)
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_record(child_run_id: &str, parent_session_id: &str) -> ChildRunRecord {
+        ChildRunRecord::new(
+            child_run_id.to_string(),
+            parent_session_id.to_string(),
+            format!("child-session-{child_run_id}"),
+            Some("/tmp/workspace".to_string()),
+            Some("/tmp/workspace/.alan/sessions/child.jsonl".to_string()),
+            Some("repo-coding".to_string()),
+        )
+    }
+
+    #[test]
+    fn registry_tracks_liveness_progress_and_terminal_state() {
+        let registry = ChildRunRegistry::default();
+        registry.register(test_record("run-1", "parent-1"));
+        registry.register(test_record("run-2", "parent-2"));
+
+        registry.mark_running("run-1");
+        registry.observe_heartbeat("run-1", Some("alive".to_string()));
+        registry.observe_progress(
+            "run-1",
+            "tool_call_started",
+            Some("running bash".to_string()),
+        );
+        registry.observe_warning("run-1", "first warning".to_string());
+
+        let parent_runs = registry.list_for_parent("parent-1");
+        assert_eq!(parent_runs.len(), 1);
+        assert_eq!(parent_runs[0].id, "run-1");
+
+        let running = registry.get_for_parent("parent-1", "run-1").unwrap();
+        assert_eq!(running.status, ChildRunStatus::Running);
+        assert_eq!(
+            running.latest_event_kind.as_deref(),
+            Some("tool_call_started")
+        );
+        assert_eq!(
+            running.latest_status_summary.as_deref(),
+            Some("running bash")
+        );
+        assert_eq!(running.warnings, vec!["first warning"]);
+        assert!(running.latest_heartbeat_at_ms.is_some());
+        assert!(running.latest_progress_at_ms.is_some());
+
+        registry.mark_terminal("run-1", ChildRunStatus::Completed, None);
+        let terminal = registry.get("run-1").unwrap();
+        registry.observe_progress("run-1", "text_delta", Some("late update".to_string()));
+        let after_late_progress = registry.get("run-1").unwrap();
+        assert_eq!(after_late_progress.status, ChildRunStatus::Completed);
+        assert_eq!(
+            after_late_progress.latest_event_kind,
+            terminal.latest_event_kind
+        );
+        assert_eq!(
+            after_late_progress.latest_status_summary,
+            terminal.latest_status_summary
+        );
+    }
+
+    #[test]
+    fn registry_records_termination_and_rejects_unknown_or_terminal_runs() {
+        let registry = ChildRunRegistry::default();
+        registry.register(test_record("run-1", "parent-1"));
+
+        assert_eq!(
+            registry.request_termination(
+                "parent-2",
+                "run-1",
+                "parent_runtime",
+                ChildRunTerminationMode::Graceful,
+                "wrong parent",
+            ),
+            Err(ChildRunRegistryError::NotFound)
+        );
+        assert_eq!(
+            registry.request_termination(
+                "parent-1",
+                "missing",
+                "parent_runtime",
+                ChildRunTerminationMode::Graceful,
+                "missing child",
+            ),
+            Err(ChildRunRegistryError::NotFound)
+        );
+
+        let terminating = registry
+            .request_termination(
+                "parent-1",
+                "run-1",
+                "parent_runtime",
+                ChildRunTerminationMode::Forceful,
+                "operator requested stop",
+            )
+            .unwrap();
+        assert_eq!(terminating.status, ChildRunStatus::Terminating);
+        assert_eq!(
+            terminating.termination.as_ref().map(|request| (
+                request.actor.as_str(),
+                request.reason.as_str(),
+                request.mode
+            )),
+            Some((
+                "parent_runtime",
+                "operator requested stop",
+                ChildRunTerminationMode::Forceful
+            ))
+        );
+
+        registry.mark_terminal("run-1", ChildRunStatus::Terminated, None);
+        match registry.request_termination(
+            "parent-1",
+            "run-1",
+            "parent_runtime",
+            ChildRunTerminationMode::Graceful,
+            "duplicate",
+        ) {
+            Err(ChildRunRegistryError::AlreadyTerminal(record)) => {
+                assert_eq!(record.status, ChildRunStatus::Terminated);
+                assert_eq!(
+                    record
+                        .termination
+                        .as_ref()
+                        .map(|request| request.reason.as_str()),
+                    Some("operator requested stop")
+                );
+            }
+            other => panic!("expected already-terminal error, got {other:?}"),
+        }
+    }
+}

--- a/crates/runtime/src/runtime/child_runs.rs
+++ b/crates/runtime/src/runtime/child_runs.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const MAX_TERMINAL_CHILD_RUN_RECORDS: usize = 256;
+
 /// Lifecycle state for a delegated child runtime launch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -201,11 +203,15 @@ impl ChildRunRegistry {
         status: ChildRunStatus,
         error_message: Option<String>,
     ) {
-        self.update(child_run_id, |record, now| {
+        let mut records = self.inner.write().expect("child run registry poisoned");
+        let now = now_ms();
+        if let Some(record) = records.get_mut(child_run_id) {
             record.status = status;
             record.error_message = error_message;
             record.latest_progress_at_ms = Some(now);
-        });
+            record.updated_at_ms = now;
+        }
+        prune_terminal_records(&mut records, MAX_TERMINAL_CHILD_RUN_RECORDS);
     }
 
     pub fn request_termination(
@@ -262,6 +268,37 @@ impl ChildRunRegistry {
             update(record, now);
             record.updated_at_ms = now;
         }
+    }
+}
+
+fn prune_terminal_records(
+    records: &mut HashMap<String, ChildRunRecord>,
+    terminal_retention_limit: usize,
+) {
+    let terminal_count = records
+        .values()
+        .filter(|record| record.status.is_terminal())
+        .count();
+    if terminal_count <= terminal_retention_limit {
+        return;
+    }
+
+    let mut terminal_records = records
+        .values()
+        .filter(|record| record.status.is_terminal())
+        .map(|record| {
+            (
+                record.updated_at_ms,
+                record.created_at_ms,
+                record.id.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    terminal_records.sort();
+
+    let remove_count = terminal_count - terminal_retention_limit;
+    for (_, _, id) in terminal_records.into_iter().take(remove_count) {
+        records.remove(&id);
     }
 }
 
@@ -416,5 +453,39 @@ mod tests {
             }
             other => panic!("expected already-terminal error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn registry_prunes_old_terminal_runs_without_removing_active_runs() {
+        let registry = ChildRunRegistry::default();
+        let parent_session_id = "parent-1";
+        for index in 0..(MAX_TERMINAL_CHILD_RUN_RECORDS + 2) {
+            let id = format!("terminal-{index:03}");
+            let mut record = test_record(&id, parent_session_id);
+            record.created_at_ms = index as u64;
+            record.updated_at_ms = index as u64;
+            registry.register(record);
+            registry.mark_terminal(&id, ChildRunStatus::Completed, None);
+        }
+
+        registry.register(test_record("active-run", parent_session_id));
+        registry.mark_running("active-run");
+
+        let runs = registry.list_for_parent(parent_session_id);
+        let terminal_count = runs
+            .iter()
+            .filter(|record| record.status.is_terminal())
+            .count();
+        assert_eq!(terminal_count, MAX_TERMINAL_CHILD_RUN_RECORDS);
+        assert!(runs.iter().any(|record| record.id == "active-run"));
+        assert!(registry.get("terminal-000").is_none());
+        assert!(
+            registry
+                .get(&format!(
+                    "terminal-{:03}",
+                    MAX_TERMINAL_CHILD_RUN_RECORDS + 1
+                ))
+                .is_some()
+        );
     }
 }

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -123,6 +123,15 @@ pub struct RuntimeEventEnvelope {
     pub event: Event,
 }
 
+/// Internal runtime liveness metadata for supervision-only consumers.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeLivenessEnvelope {
+    /// Submission id that is still active, if any.
+    pub submission_id: Option<String>,
+    /// Compact runtime status suitable for operator child-run records.
+    pub status: Option<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct SubmissionEventContext {
     current_submission_id: Arc<Mutex<Option<String>>>,
@@ -316,6 +325,7 @@ pub struct RuntimeHandle {
     pub submission_tx: mpsc::Sender<Submission>,
     /// Broadcast sender for events - create a receiver by calling subscribe()
     pub event_sender: tokio::sync::broadcast::Sender<RuntimeEventEnvelope>,
+    pub(crate) liveness_sender: tokio::sync::broadcast::Sender<RuntimeLivenessEnvelope>,
     /// Shutdown signal sender for graceful shutdown
     shutdown_tx: Option<mpsc::Sender<()>>,
 }
@@ -955,6 +965,8 @@ pub fn spawn_with_llm_client_and_tools(
     let (sub_tx, mut sub_rx) = mpsc::channel::<Submission>(32);
     let (evt_tx, mut evt_rx) = mpsc::channel::<RuntimeEventEnvelope>(256);
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
+    let (liveness_tx, _) = tokio::sync::broadcast::channel::<RuntimeLivenessEnvelope>(256);
+    let liveness_tx_for_task = liveness_tx.clone();
     let (ready_tx, ready_rx) =
         oneshot::channel::<std::result::Result<RuntimeStartupMetadata, String>>();
 
@@ -1226,14 +1238,10 @@ pub fn spawn_with_llm_client_and_tools(
                                 }
                             }
                             _ = heartbeat_interval.tick() => {
-                                let _ = evt_tx
-                                    .send(RuntimeEventEnvelope {
-                                        submission_id: submission_event_ctx.get_submission_id(),
-                                        event: Event::RuntimeHeartbeat {
-                                            status: Some("active_submission".to_string()),
-                                        },
-                                    })
-                                    .await;
+                                let _ = liveness_tx_for_task.send(RuntimeLivenessEnvelope {
+                                    submission_id: submission_event_ctx.get_submission_id(),
+                                    status: Some("active_submission".to_string()),
+                                });
                             }
                             _ = shutdown_rx.recv() => {
                                 shutdown_requested = true;
@@ -1310,6 +1318,7 @@ pub fn spawn_with_llm_client_and_tools(
         handle: RuntimeHandle {
             submission_tx: sub_tx,
             event_sender: broadcast_tx,
+            liveness_sender: liveness_tx,
             shutdown_tx: Some(shutdown_tx),
         },
         task_handle: Some(task_handle),
@@ -1707,6 +1716,7 @@ mod tests {
         let handle = RuntimeHandle {
             submission_tx: sub_tx,
             event_sender: tokio::sync::broadcast::channel(10).0,
+            liveness_sender: tokio::sync::broadcast::channel(10).0,
             shutdown_tx: None,
         };
 
@@ -1724,6 +1734,7 @@ mod tests {
         let handle = RuntimeHandle {
             submission_tx: sub_tx,
             event_sender: tokio::sync::broadcast::channel(10).0,
+            liveness_sender: tokio::sync::broadcast::channel(10).0,
             shutdown_tx: None,
         };
 
@@ -1749,6 +1760,7 @@ mod tests {
         let handle = RuntimeHandle {
             submission_tx: sub_tx,
             event_sender: tokio::sync::broadcast::channel(10).0,
+            liveness_sender: tokio::sync::broadcast::channel(10).0,
             shutdown_tx: None,
         };
 
@@ -2563,6 +2575,7 @@ thinking_budget_tokens = 1024
         let handle = RuntimeHandle {
             submission_tx: sub_tx,
             event_sender: tokio::sync::broadcast::channel(10).0,
+            liveness_sender: tokio::sync::broadcast::channel(10).0,
             shutdown_tx: Some(shutdown_tx),
         };
 

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -631,9 +631,9 @@ fn merge_runtime_config_from_core_overlay(
 pub struct WorkspaceRuntimeConfig {
     /// Agent capabilities (reusable across workspaces)
     pub agent_config: AgentConfig,
-    /// Source used to resolve the base agent configuration before workspace overlays.
+    /// Source used to resolve the default agent configuration before workspace overlays.
     pub core_config_source: crate::ConfigSourceKind,
-    /// Optional named agent root to resolve on top of the base workspace agent.
+    /// Optional named agent root to resolve on top of the default workspace agent.
     pub agent_name: Option<String>,
     /// Session identifier to use when creating a fresh persistent runtime session.
     pub session_id: Option<String>,
@@ -645,7 +645,7 @@ pub struct WorkspaceRuntimeConfig {
     pub workspace_alan_dir: Option<std::path::PathBuf>,
     /// Optional rollout path to resume/fork from when starting this runtime
     pub resume_rollout_path: Option<std::path::PathBuf>,
-    /// Optional explicit child launch root layered on top of the resolved workspace/base roots.
+    /// Optional explicit child launch root layered on top of the resolved workspace/default roots.
     pub launch_root_dir: Option<std::path::PathBuf>,
     /// Optional default cwd override for the runtime tool context.
     pub default_cwd_override: Option<std::path::PathBuf>,
@@ -1904,7 +1904,7 @@ thinking_budget_tokens = 1024
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("workspace");
         let workspace_alan_dir = workspace_root.join(".alan");
-        let overlay_path = workspace_alan_dir.join("agent/agent.toml");
+        let overlay_path = workspace_alan_dir.join("agents/default/agent.toml");
         std::fs::create_dir_all(overlay_path.parent().unwrap()).unwrap();
         std::fs::write(
             &overlay_path,
@@ -2482,7 +2482,7 @@ required = true
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("workspace");
         let workspace_alan_dir = workspace_root.join(".alan");
-        let overlay_path = workspace_alan_dir.join("agent/agent.toml");
+        let overlay_path = workspace_alan_dir.join("agents/default/agent.toml");
         std::fs::create_dir_all(overlay_path.parent().unwrap()).unwrap();
         std::fs::write(
             &overlay_path,
@@ -2540,7 +2540,7 @@ thinking_budget_tokens = 1024
             partial_stream_recovery_mode: None,
             governance: Some(alan_protocol::GovernanceConfig {
                 profile: alan_protocol::GovernanceProfile::Autonomous,
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
             }),
         };
 
@@ -2550,7 +2550,7 @@ thinking_budget_tokens = 1024
             config.agent_config.runtime_config.governance,
             alan_protocol::GovernanceConfig {
                 profile: alan_protocol::GovernanceProfile::Autonomous,
-                policy_path: Some(".alan/agent/policy.yaml".to_string()),
+                policy_path: Some(".alan/agents/default/policy.yaml".to_string()),
             }
         );
     }
@@ -2772,7 +2772,7 @@ thinking_budget_tokens = 1024
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         let alan_dir = workspace_root.join(".alan");
-        let persona_dir = alan_dir.join("agent/persona");
+        let persona_dir = alan_dir.join("agents/default/persona");
 
         std::fs::create_dir_all(&persona_dir).unwrap();
         std::fs::write(persona_dir.join("SOUL.md"), "existing persona").unwrap();
@@ -2804,7 +2804,7 @@ thinking_budget_tokens = 1024
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         let memory_dir = workspace_root.join(".alan/memory");
-        let persona_dir = workspace_root.join(".alan/agent/persona");
+        let persona_dir = workspace_root.join(".alan/agents/default/persona");
         std::fs::create_dir_all(&memory_dir).unwrap();
 
         let config = WorkspaceRuntimeConfig {

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -1168,6 +1169,8 @@ pub fn spawn_with_llm_client_and_tools(
                             &mut state, submission, &mut emit, &cancel,
                         ))
                     };
+                    let mut heartbeat_interval = tokio::time::interval(Duration::from_secs(5));
+                    heartbeat_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
                     loop {
                         tokio::select! {
@@ -1221,6 +1224,16 @@ pub fn spawn_with_llm_client_and_tools(
                                         cancel.cancel();
                                     }
                                 }
+                            }
+                            _ = heartbeat_interval.tick() => {
+                                let _ = evt_tx
+                                    .send(RuntimeEventEnvelope {
+                                        submission_id: submission_event_ctx.get_submission_id(),
+                                        event: Event::RuntimeHeartbeat {
+                                            status: Some("active_submission".to_string()),
+                                        },
+                                    })
+                                    .await;
                             }
                             _ = shutdown_rx.recv() => {
                                 shutdown_requested = true;

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -115,6 +115,7 @@ fn render_memory_surfaces(
 }
 
 fn derive_current_goal(session: &Session, turn_state: &TurnState) -> String {
+    let source_ref = memory_source_ref(session);
     turn_state
         .plan_snapshot()
         .and_then(|snapshot| snapshot.explanation.as_deref())
@@ -129,13 +130,14 @@ fn derive_current_goal(session: &Session, turn_state: &TurnState) -> String {
                 .rev()
                 .find(|message| message.is_user())
                 .map(Message::text_content)
-                .map(|text| truncate_chars(text.trim(), MAX_INLINE_TEXT_CHARS))
+                .map(|text| truncate_memory_text(text.trim(), MAX_INLINE_TEXT_CHARS, &source_ref))
                 .filter(|value| !value.is_empty())
         })
         .unwrap_or_else(|| "No current goal recorded.".to_string())
 }
 
 fn derive_latest_assistant_state(session: &Session, turn_state: &TurnState) -> String {
+    let source_ref = memory_source_ref(session);
     let messages = turn_state
         .active_turn_message_start()
         .and_then(|start| session.tape.messages().get(start..))
@@ -146,7 +148,7 @@ fn derive_latest_assistant_state(session: &Session, turn_state: &TurnState) -> S
         .rev()
         .find(|message| message.is_assistant())
         .map(Message::non_thinking_text_content)
-        .map(|text| truncate_chars(text.trim(), MAX_INLINE_TEXT_CHARS))
+        .map(|text| truncate_memory_text(text.trim(), MAX_INLINE_TEXT_CHARS, &source_ref))
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| {
             if turn_state.active_turn_message_start().is_some() {
@@ -199,6 +201,7 @@ fn format_plan_status(status: &alan_protocol::PlanItemStatus) -> &'static str {
 }
 
 fn render_recent_messages(session: &Session) -> String {
+    let source_ref = memory_source_ref(session);
     let items: Vec<String> = session
         .tape
         .messages()
@@ -215,7 +218,7 @@ fn render_recent_messages(session: &Session) -> String {
                 format!(
                     "- {}: {}",
                     role,
-                    truncate_chars(trimmed, MAX_INLINE_TEXT_CHARS)
+                    truncate_memory_text(trimmed, MAX_INLINE_TEXT_CHARS, &source_ref)
                 )
             })
         })
@@ -234,12 +237,13 @@ fn render_recent_messages(session: &Session) -> String {
 }
 
 fn render_compaction_summary(session: &Session) -> String {
+    let source_ref = memory_source_ref(session);
     session
         .tape
         .summary()
         .map(str::trim)
         .filter(|summary| !summary.is_empty())
-        .map(|summary| truncate_chars(summary, MAX_COMPACTION_SUMMARY_CHARS))
+        .map(|summary| truncate_memory_text(summary, MAX_COMPACTION_SUMMARY_CHARS, &source_ref))
         .unwrap_or_else(|| "No compaction summary recorded.".to_string())
 }
 
@@ -318,18 +322,50 @@ async fn append_text_file(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-fn truncate_chars(text: &str, max_chars: usize) -> String {
+fn memory_source_ref(session: &Session) -> String {
+    session
+        .rollout_path()
+        .map(|path| format!("rollout {}", path.display()))
+        .unwrap_or_else(|| format!("session {}", session.id))
+}
+
+fn truncate_memory_text(text: &str, max_chars: usize, source_ref: &str) -> String {
     let text = text.trim();
     if text.chars().count() <= max_chars {
         return text.to_string();
     }
 
-    let mut truncated = text
-        .chars()
-        .take(max_chars.saturating_sub(3))
-        .collect::<String>();
-    truncated.push_str("...");
-    truncated
+    let marker = format!("\n[... truncated; inspect {source_ref} for full text]");
+    let budget = max_chars.saturating_sub(marker.chars().count()).max(24);
+    let mut rendered = String::new();
+    let mut used = 0usize;
+    let mut in_code_fence = false;
+
+    for line in text.lines() {
+        let line_chars = line.chars().count();
+        let separator_chars = usize::from(!rendered.is_empty());
+        if used + separator_chars + line_chars > budget {
+            break;
+        }
+        if !rendered.is_empty() {
+            rendered.push('\n');
+            used += 1;
+        }
+        rendered.push_str(line);
+        used += line_chars;
+        if line.trim_start().starts_with("```") {
+            in_code_fence = !in_code_fence;
+        }
+    }
+
+    if rendered.trim().is_empty() {
+        rendered = text.chars().take(budget).collect::<String>();
+    }
+    if in_code_fence {
+        rendered.push_str("\n```");
+    }
+    rendered.push_str(&marker);
+    rendered
 }
 
 #[cfg(test)]
@@ -416,6 +452,30 @@ mod tests {
         assert!(rendered.handoff.contains(
             "## What Just Happened\n- This turn completed without a new assistant response."
         ));
+    }
+
+    #[test]
+    fn truncate_memory_text_keeps_markdown_lines_and_marks_source() {
+        let text = "### Top-level directories\n- crates/runtime has the runtime code\n- clients/tui has the terminal UI\n- docs/spec has contracts\n";
+
+        let truncated = truncate_memory_text(text, 96, "rollout /tmp/rollout.jsonl");
+
+        assert!(truncated.contains("### Top-level directories"));
+        assert!(!truncated.contains("- c..."));
+        assert!(truncated.contains("truncated"));
+        assert!(truncated.contains("rollout /tmp/rollout.jsonl"));
+    }
+
+    #[test]
+    fn truncate_memory_text_closes_code_fence_when_omitting_detail() {
+        let text = "```rust\nfn main() {\n    println!(\"important detail\");\n    println!(\"more detail that exceeds the memory surface budget\");\n}\n```\n\n## Follow-up\n- keep going\n";
+
+        let truncated = truncate_memory_text(text, 120, "session sess-code");
+
+        assert!(truncated.contains("```rust"));
+        assert!(truncated.matches("```").count() >= 2);
+        assert!(truncated.contains("truncated"));
+        assert!(truncated.contains("session sess-code"));
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/memory_surfaces.rs
+++ b/crates/runtime/src/runtime/memory_surfaces.rs
@@ -15,6 +15,10 @@ const MAX_INLINE_TEXT_CHARS: usize = 280;
 const MAX_RECENT_MESSAGE_ITEMS: usize = 6;
 const MAX_PLAN_ITEMS_PER_SECTION: usize = 6;
 const MAX_COMPACTION_SUMMARY_CHARS: usize = 1_000;
+const MIN_TRUNCATED_MEMORY_BODY_CHARS: usize = 24;
+const MEMORY_TRUNCATION_MARKER_PREFIX: &str = "\n[... truncated; inspect ";
+const MEMORY_TRUNCATION_MARKER_SUFFIX: &str = " for full text]";
+const CODE_FENCE_CLOSE: &str = "\n```";
 
 #[derive(Debug, Clone)]
 struct RenderedMemorySurfaces {
@@ -334,17 +338,33 @@ fn truncate_memory_text(text: &str, max_chars: usize, source_ref: &str) -> Strin
     if text.chars().count() <= max_chars {
         return text.to_string();
     }
+    if max_chars == 0 {
+        return String::new();
+    }
 
-    let marker = format!("\n[... truncated; inspect {source_ref} for full text]");
-    let budget = max_chars.saturating_sub(marker.chars().count()).max(24);
+    let marker_budget = max_chars.saturating_sub(MIN_TRUNCATED_MEMORY_BODY_CHARS);
+    let marker = bounded_memory_truncation_marker(source_ref, marker_budget);
+    let budget = max_chars.saturating_sub(marker.chars().count());
     let mut rendered = String::new();
     let mut used = 0usize;
     let mut in_code_fence = false;
+    let code_fence_close_chars = CODE_FENCE_CLOSE.chars().count();
 
     for line in text.lines() {
         let line_chars = line.chars().count();
         let separator_chars = usize::from(!rendered.is_empty());
-        if used + separator_chars + line_chars > budget {
+        let toggles_code_fence = line.trim_start().starts_with("```");
+        let would_be_in_code_fence = if toggles_code_fence {
+            !in_code_fence
+        } else {
+            in_code_fence
+        };
+        let close_budget = if would_be_in_code_fence {
+            code_fence_close_chars
+        } else {
+            0
+        };
+        if used + separator_chars + line_chars + close_budget > budget {
             break;
         }
         if !rendered.is_empty() {
@@ -353,19 +373,68 @@ fn truncate_memory_text(text: &str, max_chars: usize, source_ref: &str) -> Strin
         }
         rendered.push_str(line);
         used += line_chars;
-        if line.trim_start().starts_with("```") {
+        if toggles_code_fence {
             in_code_fence = !in_code_fence;
         }
     }
 
     if rendered.trim().is_empty() {
         rendered = text.chars().take(budget).collect::<String>();
+        used = rendered.chars().count();
     }
-    if in_code_fence {
-        rendered.push_str("\n```");
+    if in_code_fence && used + code_fence_close_chars <= budget {
+        rendered.push_str(CODE_FENCE_CLOSE);
     }
     rendered.push_str(&marker);
     rendered
+}
+
+fn bounded_memory_truncation_marker(source_ref: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let marker =
+        format!("{MEMORY_TRUNCATION_MARKER_PREFIX}{source_ref}{MEMORY_TRUNCATION_MARKER_SUFFIX}");
+    if marker.chars().count() <= max_chars {
+        return marker;
+    }
+
+    let fixed_marker_chars = MEMORY_TRUNCATION_MARKER_PREFIX.chars().count()
+        + MEMORY_TRUNCATION_MARKER_SUFFIX.chars().count();
+    if max_chars > fixed_marker_chars {
+        let source_budget = max_chars - fixed_marker_chars;
+        let source_ref = truncate_text_with_suffix(source_ref, source_budget, "...");
+        let marker = format!(
+            "{MEMORY_TRUNCATION_MARKER_PREFIX}{source_ref}{MEMORY_TRUNCATION_MARKER_SUFFIX}"
+        );
+        if marker.chars().count() <= max_chars {
+            return marker;
+        }
+    }
+
+    truncate_text_with_suffix(&marker, max_chars, "...")
+}
+
+fn truncate_text_with_suffix(text: &str, max_chars: usize, suffix: &str) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let suffix_chars = suffix.chars().count();
+    if suffix_chars >= max_chars {
+        return suffix.chars().take(max_chars).collect();
+    }
+
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(suffix_chars))
+        .collect::<String>();
+    truncated.push_str(suffix);
+    truncated
 }
 
 #[cfg(test)]
@@ -460,6 +529,7 @@ mod tests {
 
         let truncated = truncate_memory_text(text, 96, "rollout /tmp/rollout.jsonl");
 
+        assert!(truncated.chars().count() <= 96);
         assert!(truncated.contains("### Top-level directories"));
         assert!(!truncated.contains("- c..."));
         assert!(truncated.contains("truncated"));
@@ -472,10 +542,33 @@ mod tests {
 
         let truncated = truncate_memory_text(text, 120, "session sess-code");
 
+        assert!(truncated.chars().count() <= 120);
         assert!(truncated.contains("```rust"));
         assert!(truncated.matches("```").count() >= 2);
         assert!(truncated.contains("truncated"));
         assert!(truncated.contains("session sess-code"));
+    }
+
+    #[test]
+    fn truncate_memory_text_bounds_long_source_ref_marker() {
+        let text = "Important memory detail. ".repeat(80);
+        let source_ref = format!("rollout /{}", "deep/path/segment/".repeat(80));
+
+        let truncated = truncate_memory_text(&text, 120, &source_ref);
+
+        assert!(truncated.chars().count() <= 120);
+        assert!(truncated.contains("truncated"));
+        assert!(!truncated.contains(&source_ref));
+    }
+
+    #[test]
+    fn truncate_memory_text_respects_tiny_budget() {
+        let text = "Important memory detail. ".repeat(10);
+        let source_ref = format!("rollout /{}", "deep/path/segment/".repeat(20));
+
+        let truncated = truncate_memory_text(&text, 12, &source_ref);
+
+        assert!(truncated.chars().count() <= 12);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 
 mod agent_loop;
 mod child_agents;
+mod child_runs;
 mod compaction;
 mod engine;
 mod loop_guard;
@@ -22,6 +23,10 @@ mod turn_state;
 mod turn_support;
 mod virtual_tools;
 
+pub use child_runs::{
+    ChildRunRecord, ChildRunRegistryError, ChildRunStatus, ChildRunTerminationMode,
+    ChildRunTerminationRequest, global_child_run_registry,
+};
 pub use engine::{
     AgentConfig, RuntimeController, RuntimeEventEnvelope, RuntimeHandle, RuntimeStartupMetadata,
     SessionDurabilityState, WorkspaceRuntimeConfig, effective_core_config_for_runtime, spawn,

--- a/crates/runtime/src/runtime/prompt_cache.rs
+++ b/crates/runtime/src/runtime/prompt_cache.rs
@@ -1053,7 +1053,9 @@ mod tests {
         description: &str,
         body: &str,
     ) {
-        let skill_dir = workspace_root.join(".alan/agent/skills").join(dir_name);
+        let skill_dir = workspace_root
+            .join(".alan/agents/default/skills")
+            .join(dir_name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1076,7 +1078,9 @@ description: {description}
         frontmatter: &str,
         body: &str,
     ) {
-        let skill_dir = workspace_root.join(".alan/agent/skills").join(dir_name);
+        let skill_dir = workspace_root
+            .join(".alan/agents/default/skills")
+            .join(dir_name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1091,7 +1095,7 @@ description: {description}
         agent_name: &str,
     ) {
         let agent_root = workspace_root
-            .join(".alan/agent/skills")
+            .join(".alan/agents/default/skills")
             .join(package_dir)
             .join("agents")
             .join(agent_name);
@@ -1107,7 +1111,7 @@ description: {description}
         workspace_root: &std::path::Path,
     ) -> ResolvedCapabilityView {
         ResolvedCapabilityView::from_package_dirs(vec![ScopedPackageDir {
-            path: workspace_root.join(".alan/agent/skills"),
+            path: workspace_root.join(".alan/agents/default/skills"),
             scope: SkillScope::Repo,
         }])
     }
@@ -1140,7 +1144,7 @@ description: {description}
     fn prompt_cache_hits_on_repeated_builds() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let persona_dir = workspace_root.join(".alan/agent/persona");
+        let persona_dir = workspace_root.join(".alan/agents/default/persona");
         std::fs::create_dir_all(&workspace_root).unwrap();
         ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
         create_repo_skill(
@@ -1171,7 +1175,7 @@ description: {description}
     fn prompt_cache_includes_workspace_memory_bootstrap_when_configured() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let persona_dir = workspace_root.join(".alan/agent/persona");
+        let persona_dir = workspace_root.join(".alan/agents/default/persona");
         let memory_dir = workspace_root.join(".alan/memory");
         std::fs::create_dir_all(&workspace_root).unwrap();
         ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
@@ -1199,7 +1203,7 @@ description: {description}
     fn workspace_persona_cache_uses_prefix_fingerprints_for_tracked_files() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let persona_dir = workspace_root.join(".alan/agent/persona");
+        let persona_dir = workspace_root.join(".alan/agents/default/persona");
         std::fs::create_dir_all(&workspace_root).unwrap();
         ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
 
@@ -1285,7 +1289,8 @@ description: {description}
 
         let active_skill = &prompt.active_skills[0];
         let expected_root =
-            std::fs::canonicalize(workspace_root.join(".alan/agent/skills/my-skill")).unwrap();
+            std::fs::canonicalize(workspace_root.join(".alan/agents/default/skills/my-skill"))
+                .unwrap();
         assert_eq!(active_skill.metadata.id, "my-skill");
         assert_eq!(
             active_skill.metadata.package_id.as_deref(),
@@ -1387,7 +1392,7 @@ description: {description}
         assert_eq!(first.active_skills.len(), 1);
 
         std::fs::write(
-            workspace_root.join(".alan/agent/skills/release-check/SKILL.md"),
+            workspace_root.join(".alan/agents/default/skills/release-check/SKILL.md"),
             r#"---
 name: Release Check
 description: Review risky release actions
@@ -1437,7 +1442,8 @@ Do not use stale instructions.
         let first = cache.build(Some(&user_input));
         assert_eq!(first.active_skills.len(), 1);
 
-        std::fs::remove_dir_all(workspace_root.join(".alan/agent/skills/release-check")).unwrap();
+        std::fs::remove_dir_all(workspace_root.join(".alan/agents/default/skills/release-check"))
+            .unwrap();
 
         let resumed = cache.build_with_active_skills(&first.active_skills, None);
 
@@ -1757,7 +1763,7 @@ capabilities:
         let first = cache.build(Some(&user_input));
         std::thread::sleep(std::time::Duration::from_millis(20));
         std::fs::write(
-            workspace_root.join(".alan/agent/skills/my-skill/SKILL.md"),
+            workspace_root.join(".alan/agents/default/skills/my-skill/SKILL.md"),
             r#"---
 name: My Skill
 description: Custom test skill
@@ -1800,7 +1806,7 @@ WXYZ
 "#;
         assert_eq!(initial.len(), updated.len());
 
-        let skill_path = workspace_root.join(".alan/agent/skills/my-skill/SKILL.md");
+        let skill_path = workspace_root.join(".alan/agents/default/skills/my-skill/SKILL.md");
         std::fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
         std::fs::write(&skill_path, initial).unwrap();
 
@@ -1820,7 +1826,7 @@ WXYZ
     fn prompt_cache_uses_disclosure_level2_file() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/my-skill");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/my-skill");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1853,7 +1859,7 @@ Fallback instructions.
     fn prompt_cache_invalidates_when_disclosed_resource_changes() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/my-skill");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/my-skill");
         let references_dir = skill_dir.join("references");
         std::fs::create_dir_all(&references_dir).unwrap();
         std::fs::write(
@@ -1893,7 +1899,7 @@ Read `references/guide.md` before acting.
 
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skills_root = workspace_root.join(".alan/agent/skills");
+        let skills_root = workspace_root.join(".alan/agents/default/skills");
         let pack_v1 = temp.path().join("pack-v1");
         let pack_v2 = temp.path().join("pack-v2");
         let linked_pack = skills_root.join("linked-pack");
@@ -2016,7 +2022,7 @@ Version two.
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         std::fs::create_dir_all(&workspace_root).unwrap();
-        let skill_dir = workspace_root.join(".alan/agent/skills/hidden-helper");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/hidden-helper");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -2065,7 +2071,7 @@ Use this skill when asked.
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         std::fs::create_dir_all(&workspace_root).unwrap();
-        let skill_dir = workspace_root.join(".alan/agent/skills/tool-heavy");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/tool-heavy");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -2222,7 +2228,7 @@ Use this skill when asked.
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         std::fs::create_dir_all(&workspace_root).unwrap();
-        let skill_dir = workspace_root.join(".alan/agent/skills/dynamic-helper");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/dynamic-helper");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -1050,7 +1050,7 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         std::fs::create_dir_all(&workspace_root).unwrap();
-        let skill_dir = workspace_root.join(".alan/agent/skills/dynamic-helper");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/dynamic-helper");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1072,7 +1072,7 @@ Use this skill when asked.
             crate::runtime::prompt_cache::PromptAssemblyCache::with_fixed_capability_view(
                 crate::skills::ResolvedCapabilityView::from_package_dirs(vec![
                     crate::skills::ScopedPackageDir {
-                        path: workspace_root.join(".alan/agent/skills"),
+                        path: workspace_root.join(".alan/agents/default/skills"),
                         scope: crate::skills::SkillScope::Repo,
                     },
                 ]),
@@ -1146,7 +1146,7 @@ Use this skill when asked.
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         std::fs::create_dir_all(&workspace_root).unwrap();
-        let skill_dir = workspace_root.join(".alan/agent/skills/jq-helper");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/jq-helper");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -1190,7 +1190,7 @@ Use this skill when asked.
             crate::runtime::prompt_cache::PromptAssemblyCache::with_fixed_capability_view(
                 crate::skills::ResolvedCapabilityView::from_package_dirs(vec![
                     crate::skills::ScopedPackageDir {
-                        path: workspace_root.join(".alan/agent/skills"),
+                        path: workspace_root.join(".alan/agents/default/skills"),
                         scope: crate::skills::SkillScope::Repo,
                     },
                 ]),

--- a/crates/runtime/src/runtime/tool_orchestrator.rs
+++ b/crates/runtime/src/runtime/tool_orchestrator.rs
@@ -438,8 +438,15 @@ where
         return Ok(ToolOrchestratorOutcome::EndTurn);
     }
 
-    match try_handle_virtual_tool_call(state, tool_call, &tool_arguments, inputs.cancel, emit)
-        .await?
+    match try_handle_virtual_tool_call(
+        state,
+        tool_call,
+        &tool_arguments,
+        inputs.cancel,
+        allow_approved_tool_escalation_execution,
+        emit,
+    )
+    .await?
     {
         VirtualToolOutcome::NotVirtual => {}
         VirtualToolOutcome::Continue { refresh_context } => {

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -2338,7 +2338,7 @@ mod tests {
         workspace_persona_dirs: Vec<std::path::PathBuf>,
     ) -> crate::runtime::prompt_cache::PromptAssemblyCache {
         let capability_view = ResolvedCapabilityView::from_package_dirs(vec![ScopedPackageDir {
-            path: workspace_root.join(".alan/agent/skills"),
+            path: workspace_root.join(".alan/agents/default/skills"),
             scope: SkillScope::Repo,
         }]);
         crate::runtime::prompt_cache::PromptAssemblyCache::with_fixed_capability_view(
@@ -2355,7 +2355,9 @@ mod tests {
         description: &str,
         body: &str,
     ) {
-        let skill_dir = workspace_root.join(".alan/agent/skills").join(dir_name);
+        let skill_dir = workspace_root
+            .join(".alan/agents/default/skills")
+            .join(dir_name);
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -2483,7 +2485,7 @@ description: {description}
         let temp = TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
         let alan_dir = workspace_root.join(".alan");
-        let persona_dir = alan_dir.join("agent/persona");
+        let persona_dir = alan_dir.join("agents/default/persona");
         let memory_dir = alan_dir.join("memory");
         std::fs::create_dir_all(&memory_dir).unwrap();
         crate::prompts::ensure_workspace_bootstrap_files_at(&persona_dir).unwrap();
@@ -4763,7 +4765,7 @@ description: {description}
     async fn test_run_turn_confirmation_includes_active_skill_permission_hints() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/release-check");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/release-check");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -5269,7 +5271,7 @@ runtime:
     async fn test_run_turn_resume_turn_preserves_active_skill_context() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/release-check");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/release-check");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -5365,7 +5367,7 @@ runtime:
     async fn test_run_turn_resume_turn_with_steer_preserves_active_skill_context() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/release-check");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/release-check");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -5463,7 +5465,7 @@ runtime:
     async fn test_run_turn_resume_turn_without_prior_active_skills_can_activate_skill_from_steer() {
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
-        let skill_dir = workspace_root.join(".alan/agent/skills/release-check");
+        let skill_dir = workspace_root.join(".alan/agents/default/skills/release-check");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
@@ -5555,7 +5557,7 @@ runtime:
         let temp = tempfile::TempDir::new().unwrap();
         let workspace_root = temp.path().join("repo");
 
-        let release_skill_dir = workspace_root.join(".alan/agent/skills/release-check");
+        let release_skill_dir = workspace_root.join(".alan/agents/default/skills/release-check");
         std::fs::create_dir_all(&release_skill_dir).unwrap();
         std::fs::write(
             release_skill_dir.join("SKILL.md"),
@@ -5579,7 +5581,7 @@ runtime:
         )
         .unwrap();
 
-        let audit_skill_dir = workspace_root.join(".alan/agent/skills/safety-audit");
+        let audit_skill_dir = workspace_root.join(".alan/agents/default/skills/safety-audit");
         std::fs::create_dir_all(&audit_skill_dir).unwrap();
         std::fs::write(
             audit_skill_dir.join("SKILL.md"),

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -39,6 +39,8 @@ const MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS: usize = 4_000;
 const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
 
+type DelegatedSkillSpawnResult<T> = std::result::Result<T, Box<DelegatedSkillResult>>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum VirtualToolOutcome {
     NotVirtual,
@@ -746,7 +748,7 @@ where
                     }
                 }
             }
-            Err(result) => (request.clone(), result, None),
+            Err(result) => (request.clone(), *result, None),
         };
 
     let (persisted_arguments, tape_record, rollout_record) =
@@ -814,7 +816,7 @@ async fn spawn_and_join_delegated_child(
 fn resolve_delegated_skill_invocation(
     state: &mut RuntimeLoopState,
     request: &DelegatedSkillInvocationRequest,
-) -> std::result::Result<SpawnSpec, DelegatedSkillResult> {
+) -> DelegatedSkillSpawnResult<SpawnSpec> {
     let active_skill = state
         .turn_state
         .active_skills()
@@ -824,7 +826,7 @@ fn resolve_delegated_skill_invocation(
 
     let skill_metadata = if let Some(skill) = active_skill {
         if !skill.availability.is_available() {
-            return Err(DelegatedSkillResult::failed(
+            return Err(Box::new(DelegatedSkillResult::failed(
                 format!(
                     "Delegated skill '{}' is {}.",
                     request.skill_id,
@@ -833,7 +835,7 @@ fn resolve_delegated_skill_invocation(
                 Some(json!({
                     "error_kind": "skill_unavailable"
                 })),
-            ));
+            )));
         }
         skill.metadata
     } else {
@@ -843,7 +845,7 @@ fn resolve_delegated_skill_invocation(
         {
             Ok(Some(metadata)) => metadata,
             Ok(None) => {
-                return Err(DelegatedSkillResult::failed(
+                return Err(Box::new(DelegatedSkillResult::failed(
                     format!(
                         "Delegated skill '{}' is not active and is not listed for implicit use in the current runtime.",
                         request.skill_id
@@ -851,10 +853,10 @@ fn resolve_delegated_skill_invocation(
                     Some(json!({
                         "error_kind": "skill_not_visible"
                     })),
-                ));
+                )));
             }
             Err(err) => {
-                return Err(DelegatedSkillResult::failed(
+                return Err(Box::new(DelegatedSkillResult::failed(
                     format!(
                         "Failed to resolve delegated skill '{}' from the runtime catalog: {err}",
                         request.skill_id
@@ -862,13 +864,13 @@ fn resolve_delegated_skill_invocation(
                     Some(json!({
                         "error_kind": "skill_resolution_failed"
                     })),
-                ));
+                )));
             }
         }
     };
 
     let Some(resolved_target) = skill_metadata.execution.delegate_target() else {
-        return Err(DelegatedSkillResult::failed(
+        return Err(Box::new(DelegatedSkillResult::failed(
             format!(
                 "Skill '{}' is not resolved for delegated execution.",
                 request.skill_id
@@ -876,11 +878,11 @@ fn resolve_delegated_skill_invocation(
             Some(json!({
                 "error_kind": "skill_not_delegated"
             })),
-        ));
+        )));
     };
 
     if resolved_target != request.target {
-        return Err(DelegatedSkillResult::failed(
+        return Err(Box::new(DelegatedSkillResult::failed(
             format!(
                 "Delegated skill '{}' resolves to delegated target '{}' rather than '{}'.",
                 request.skill_id, resolved_target, request.target
@@ -889,11 +891,11 @@ fn resolve_delegated_skill_invocation(
                 "error_kind": "delegate_target_mismatch",
                 "resolved_target": resolved_target
             })),
-        ));
+        )));
     }
 
     let Some(spawn_target) = skill_metadata.delegated_spawn_target() else {
-        return Err(DelegatedSkillResult::failed(
+        return Err(Box::new(DelegatedSkillResult::failed(
             format!(
                 "Delegated skill '{}' does not expose a package-local launch target.",
                 request.skill_id
@@ -901,7 +903,7 @@ fn resolve_delegated_skill_invocation(
             Some(json!({
                 "error_kind": "delegate_target_missing"
             })),
-        ));
+        )));
     };
 
     build_delegated_spawn_spec(state, request, spawn_target)
@@ -911,7 +913,7 @@ fn build_delegated_spawn_spec(
     state: &RuntimeLoopState,
     request: &DelegatedSkillInvocationRequest,
     target: alan_protocol::SpawnTarget,
-) -> std::result::Result<SpawnSpec, DelegatedSkillResult> {
+) -> DelegatedSkillSpawnResult<SpawnSpec> {
     let inferred_workspace_root = bound_workspace_root(state);
     let parent_default_cwd = state.tools.default_cwd();
     let workspace_root = normalize_delegated_workspace_root(
@@ -948,7 +950,7 @@ fn normalize_delegated_workspace_root(
     requested_workspace_root: Option<&Path>,
     parent_default_cwd: Option<&Path>,
     inferred_workspace_root: Option<&Path>,
-) -> std::result::Result<Option<PathBuf>, DelegatedSkillResult> {
+) -> DelegatedSkillSpawnResult<Option<PathBuf>> {
     match requested_workspace_root {
         None => Ok(inferred_workspace_root.map(lexically_normalize_path)),
         Some(path) => resolve_delegated_launch_path(
@@ -965,7 +967,7 @@ fn normalize_delegated_cwd(
     workspace_root: Option<&Path>,
     explicit_workspace_root_provided: bool,
     parent_default_cwd: Option<&Path>,
-) -> std::result::Result<Option<PathBuf>, DelegatedSkillResult> {
+) -> DelegatedSkillSpawnResult<Option<PathBuf>> {
     match requested_cwd {
         Some(path) => {
             resolve_delegated_launch_path(path, workspace_root.or(parent_default_cwd), "cwd")
@@ -985,13 +987,13 @@ fn resolve_delegated_launch_path(
     requested_path: &Path,
     base: Option<&Path>,
     field_name: &str,
-) -> std::result::Result<PathBuf, DelegatedSkillResult> {
+) -> DelegatedSkillSpawnResult<PathBuf> {
     if requested_path.is_absolute() {
         return Ok(lexically_normalize_path(requested_path));
     }
 
     let Some(base) = base else {
-        return Err(DelegatedSkillResult::failed(
+        return Err(Box::new(DelegatedSkillResult::failed(
             format!(
                 "Delegated skill invocation provided relative {field_name} '{}' but the parent runtime has no base path to resolve it.",
                 requested_path.display()
@@ -1000,7 +1002,7 @@ fn resolve_delegated_launch_path(
                 "error_kind": "relative_launch_path_unresolvable",
                 "field": field_name
             })),
-        ));
+        )));
     };
 
     Ok(lexically_normalize_path(&base.join(requested_path)))

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -37,6 +37,9 @@ const MAX_DELEGATED_TIMEOUT_SECS: u64 = 86_400;
 const MAX_DELEGATED_RESULT_SUMMARY_CHARS: usize = 320;
 const MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS: usize = 4_000;
 const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
+const MAX_DELEGATED_CHILD_RUN_METADATA_CHARS: usize = 2_000;
+const MAX_DELEGATED_RESULT_WARNINGS: usize = 16;
+const MAX_DELEGATED_RESULT_WARNING_CHARS: usize = 512;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
 
 type DelegatedSkillSpawnResult<T> = std::result::Result<T, Box<DelegatedSkillResult>>;
@@ -1280,6 +1283,7 @@ fn build_bounded_delegated_tape_record(
             result.truncation = Some(truncation);
         }
     }
+    bound_delegated_result_sidecars(&mut result);
 
     let record = DelegatedSkillInvocationRecord {
         skill_id,
@@ -1310,6 +1314,64 @@ fn build_bounded_delegated_tape_record(
     }
 
     (arguments, record)
+}
+
+fn bound_delegated_result_sidecars(result: &mut DelegatedSkillResult) {
+    if let Some(value) = result.child_run.take() {
+        let serialized_size = serde_json::to_string(&value)
+            .map(|text| text.chars().count())
+            .unwrap_or(MAX_DELEGATED_CHILD_RUN_METADATA_CHARS + 1);
+        result.child_run = Some(truncate_structured_output(
+            value,
+            MAX_DELEGATED_CHILD_RUN_METADATA_CHARS,
+        ));
+        if serialized_size > MAX_DELEGATED_CHILD_RUN_METADATA_CHARS {
+            let truncation = result.truncation.get_or_insert_with(Default::default);
+            truncation.child_run = true;
+            truncation.original_child_run_chars = Some(serialized_size);
+            append_truncation_note(truncation, "Child-run metadata was truncated.");
+        }
+    }
+
+    let original_warning_count = result.warnings.len();
+    let (warnings, truncated) = bounded_delegated_warnings(std::mem::take(&mut result.warnings));
+    result.warnings = warnings;
+    if truncated {
+        let truncation = result.truncation.get_or_insert_with(Default::default);
+        truncation.warnings = true;
+        truncation.original_warning_count = Some(original_warning_count);
+        append_truncation_note(truncation, "Warnings were truncated to recent entries.");
+    }
+}
+
+fn bounded_delegated_warnings(warnings: Vec<String>) -> (Vec<String>, bool) {
+    let original_count = warnings.len();
+    let skip_count = original_count.saturating_sub(MAX_DELEGATED_RESULT_WARNINGS);
+    let mut truncated = skip_count > 0;
+    let warnings = warnings
+        .into_iter()
+        .skip(skip_count)
+        .map(|warning| {
+            let bounded =
+                truncate_text_with_suffix(&warning, MAX_DELEGATED_RESULT_WARNING_CHARS, "...");
+            if bounded != warning {
+                truncated = true;
+            }
+            bounded
+        })
+        .collect();
+    (warnings, truncated)
+}
+
+fn append_truncation_note(truncation: &mut DelegatedSkillResultTruncation, note: &str) {
+    match truncation.note.as_mut() {
+        Some(existing) if !existing.contains(note) => {
+            existing.push(' ');
+            existing.push_str(note);
+        }
+        Some(_) => {}
+        None => truncation.note = Some(note.to_string()),
+    }
 }
 
 fn completed_child_summary(result: &ChildRuntimeResult) -> String {

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -11,15 +11,21 @@ use std::pin::Pin;
 use tokio_util::sync::CancellationToken;
 
 use crate::approval::{PendingConfirmation, append_skill_permission_hints};
+use crate::approval::{TOOL_ESCALATION_CHECKPOINT_PREFIX, TOOL_ESCALATION_CHECKPOINT_TYPE};
 use crate::llm::ToolDefinition;
 use crate::skills::{
-    DelegatedSkillInvocationRecord, DelegatedSkillResult, DelegatedSkillResultStatus,
+    DelegatedSkillInvocationRecord, DelegatedSkillOutputRef, DelegatedSkillResult,
+    DelegatedSkillResultStatus, DelegatedSkillResultTruncation,
 };
 
 use super::agent_loop::{NormalizedToolCall, RuntimeLoopState};
 use super::child_agents::{
     ChildRuntimeResult, ChildRuntimeStatus, bound_workspace_root, spawn_child_runtime_cancellable,
 };
+use super::child_runs::{
+    ChildRunRegistryError, ChildRunTerminationMode, global_child_run_registry,
+};
+use super::tool_policy::{ToolPolicyDecision, evaluate_tool_policy};
 use super::turn_support::{check_turn_cancelled, tool_result_preview};
 
 const MAX_DELEGATED_SKILL_ID_CHARS: usize = 120;
@@ -29,6 +35,7 @@ const MAX_DELEGATED_PATH_CHARS: usize = 1_000;
 const DEFAULT_DELEGATED_TIMEOUT_SECS: u64 = 900;
 const MAX_DELEGATED_TIMEOUT_SECS: u64 = 86_400;
 const MAX_DELEGATED_RESULT_SUMMARY_CHARS: usize = 320;
+const MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS: usize = 4_000;
 const MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS: usize = 4_000;
 const WORKSPACE_INSPECT_READ_ONLY_TOOLS: [&str; 4] = ["read_file", "grep", "glob", "list_dir"];
 
@@ -48,6 +55,7 @@ pub(super) fn virtual_tool_definitions(include_delegated_skill: bool) -> Vec<Too
     ];
     if include_delegated_skill {
         defs.push(invoke_delegated_skill_tool_definition());
+        defs.push(terminate_child_run_tool_definition());
     }
     defs
 }
@@ -57,6 +65,7 @@ pub(super) async fn try_handle_virtual_tool_call<E, F>(
     tool_call: &NormalizedToolCall,
     tool_arguments: &serde_json::Value,
     cancel: &CancellationToken,
+    allow_approved_tool_escalation_execution: bool,
     emit: &mut E,
 ) -> Result<VirtualToolOutcome>
 where
@@ -310,7 +319,294 @@ where
             )
             .await
         }
+        "terminate_child_run" => {
+            handle_terminate_child_run(
+                state,
+                tool_call,
+                tool_arguments,
+                allow_approved_tool_escalation_execution,
+                emit,
+            )
+            .await
+        }
         _ => Ok(VirtualToolOutcome::NotVirtual),
+    }
+}
+
+async fn handle_terminate_child_run<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    allow_approved_tool_escalation_execution: bool,
+    emit: &mut E,
+) -> Result<VirtualToolOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let Some((child_run_id, reason, mode)) = parse_terminate_child_run_request(tool_arguments)
+    else {
+        let audit = runtime_virtual_tool_audit("invalid child-run termination payload");
+        let payload = json!({
+            "status": "invalid_request",
+            "error": "Invalid child-run termination payload."
+        });
+        emit(Event::ToolCallCompleted {
+            id: tool_call.id.clone(),
+            name: Some(tool_call.name.clone()),
+            success: Some(false),
+            result_preview: tool_result_preview(&payload),
+            audit: Some(audit.clone()),
+        })
+        .await;
+        state.session.record_tool_call_with_audit(
+            &tool_call.name,
+            tool_arguments.clone(),
+            payload.clone(),
+            false,
+            Some(audit),
+        );
+        state
+            .session
+            .add_tool_message(&tool_call.id, &tool_call.name, payload);
+        return Ok(VirtualToolOutcome::Continue {
+            refresh_context: true,
+        });
+    };
+
+    let audit = match evaluate_terminate_child_run_policy(
+        state,
+        tool_call,
+        tool_arguments,
+        allow_approved_tool_escalation_execution,
+        emit,
+    )
+    .await?
+    {
+        TerminateChildRunPolicyOutcome::Allow(audit) => audit,
+        TerminateChildRunPolicyOutcome::PauseTurn => return Ok(VirtualToolOutcome::PauseTurn),
+        TerminateChildRunPolicyOutcome::Continue { refresh_context } => {
+            return Ok(VirtualToolOutcome::Continue { refresh_context });
+        }
+    };
+
+    emit(Event::ToolCallStarted {
+        id: tool_call.id.clone(),
+        name: tool_call.name.clone(),
+        audit: Some(audit.clone()),
+    })
+    .await;
+
+    let result = global_child_run_registry().request_termination(
+        &state.session.id,
+        &child_run_id,
+        "parent_runtime",
+        mode,
+        reason,
+    );
+    let (payload, success) = match result {
+        Ok(record) => (
+            json!({
+                "status": "termination_requested",
+                "child_run": record
+            }),
+            true,
+        ),
+        Err(ChildRunRegistryError::AlreadyTerminal(record)) => (
+            json!({
+                "status": "already_terminal",
+                "child_run": record
+            }),
+            true,
+        ),
+        Err(ChildRunRegistryError::NotFound) => (
+            json!({
+                "status": "not_found",
+                "error": "Child run not found for this parent session.",
+                "child_run_id": child_run_id
+            }),
+            false,
+        ),
+    };
+
+    emit(Event::ToolCallCompleted {
+        id: tool_call.id.clone(),
+        name: Some(tool_call.name.clone()),
+        success: Some(success),
+        result_preview: tool_result_preview(&payload),
+        audit: Some(audit.clone()),
+    })
+    .await;
+    state.session.record_tool_call_with_audit(
+        &tool_call.name,
+        tool_arguments.clone(),
+        payload.clone(),
+        success,
+        Some(audit),
+    );
+    state
+        .session
+        .add_tool_message(&tool_call.id, &tool_call.name, payload);
+    Ok(VirtualToolOutcome::Continue {
+        refresh_context: true,
+    })
+}
+
+fn runtime_virtual_tool_audit(reason: &str) -> alan_protocol::ToolDecisionAudit {
+    alan_protocol::ToolDecisionAudit {
+        policy_source: "runtime_virtual_tool".to_string(),
+        rule_id: None,
+        action: "allow".to_string(),
+        reason: Some(reason.to_string()),
+        capability: "write".to_string(),
+        sandbox_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+    }
+}
+
+enum TerminateChildRunPolicyOutcome {
+    Allow(alan_protocol::ToolDecisionAudit),
+    PauseTurn,
+    Continue { refresh_context: bool },
+}
+
+async fn evaluate_terminate_child_run_policy<E, F>(
+    state: &mut RuntimeLoopState,
+    tool_call: &NormalizedToolCall,
+    tool_arguments: &serde_json::Value,
+    allow_approved_tool_escalation_execution: bool,
+    emit: &mut E,
+) -> Result<TerminateChildRunPolicyOutcome>
+where
+    E: FnMut(Event) -> F,
+    F: std::future::Future<Output = ()>,
+{
+    let policy_decision = maybe_allow_approved_virtual_tool_escalation_replay(
+        evaluate_tool_policy(
+            &state.runtime_config.policy_engine,
+            &state.runtime_config.governance,
+            &tool_call.name,
+            tool_arguments,
+            alan_protocol::ToolCapability::Write,
+            state.tools.default_cwd().as_deref(),
+        ),
+        allow_approved_tool_escalation_execution,
+    );
+    let policy_audit = match &policy_decision {
+        ToolPolicyDecision::Allow { audit }
+        | ToolPolicyDecision::Escalate { audit, .. }
+        | ToolPolicyDecision::Forbidden { audit, .. } => audit.clone(),
+    };
+    state.session.record_event(
+        "tool_policy_decision",
+        json!({
+            "tool_call_id": tool_call.id,
+            "tool_name": tool_call.name,
+            "policy_source": policy_audit.policy_source,
+            "rule_id": policy_audit.rule_id,
+            "action": policy_audit.action,
+            "reason": policy_audit.reason,
+            "capability": policy_audit.capability,
+            "sandbox_backend": policy_audit.sandbox_backend,
+        }),
+    );
+
+    match policy_decision {
+        ToolPolicyDecision::Allow { audit } => Ok(TerminateChildRunPolicyOutcome::Allow(audit)),
+        ToolPolicyDecision::Escalate {
+            summary,
+            mut details,
+            audit,
+        } => {
+            details["replay_tool_call"] = json!({
+                "call_id": tool_call.id,
+                "tool_name": tool_call.name,
+                "arguments": tool_arguments,
+            });
+            details = append_skill_permission_hints(details, state.turn_state.active_skills());
+            let pending = PendingConfirmation {
+                checkpoint_id: format!("{TOOL_ESCALATION_CHECKPOINT_PREFIX}{}", tool_call.id),
+                checkpoint_type: TOOL_ESCALATION_CHECKPOINT_TYPE.to_string(),
+                summary,
+                details,
+                options: vec!["approve".to_string(), "reject".to_string()],
+            };
+            state.session.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                json!({"status":"escalation_required"}),
+                true,
+                Some(audit),
+            );
+            state.turn_state.set_confirmation(pending.clone());
+            emit(Event::Yield {
+                request_id: pending.checkpoint_id,
+                kind: YieldKind::Confirmation,
+                payload: serde_json::to_value(ConfirmationYieldPayload {
+                    checkpoint_type: pending.checkpoint_type,
+                    summary: pending.summary,
+                    details: Some(pending.details),
+                    options: pending.options,
+                    default_option: Some("approve".to_string()),
+                    presentation_hints: vec![AdaptivePresentationHint::Dangerous],
+                })
+                .unwrap_or_else(|_| json!({})),
+            })
+            .await;
+            Ok(TerminateChildRunPolicyOutcome::PauseTurn)
+        }
+        ToolPolicyDecision::Forbidden { reason, audit } => {
+            let blocked_payload = json!({
+                "status": "blocked_by_policy",
+                "error": reason
+            });
+            emit(Event::Error {
+                message: blocked_payload["error"]
+                    .as_str()
+                    .unwrap_or("Tool blocked by policy")
+                    .to_string(),
+                recoverable: true,
+            })
+            .await;
+            emit(Event::ToolCallCompleted {
+                id: tool_call.id.clone(),
+                name: Some(tool_call.name.clone()),
+                success: Some(false),
+                result_preview: tool_result_preview(&blocked_payload),
+                audit: Some(audit.clone()),
+            })
+            .await;
+            state.session.record_tool_call_with_audit(
+                &tool_call.name,
+                tool_arguments.clone(),
+                blocked_payload.clone(),
+                false,
+                Some(audit),
+            );
+            state
+                .session
+                .add_tool_message(&tool_call.id, &tool_call.name, blocked_payload);
+            Ok(TerminateChildRunPolicyOutcome::Continue {
+                refresh_context: false,
+            })
+        }
+    }
+}
+
+fn maybe_allow_approved_virtual_tool_escalation_replay(
+    policy_decision: ToolPolicyDecision,
+    allow_approved_tool_escalation_execution: bool,
+) -> ToolPolicyDecision {
+    match policy_decision {
+        ToolPolicyDecision::Escalate { audit, .. } if allow_approved_tool_escalation_execution => {
+            ToolPolicyDecision::Allow {
+                audit: alan_protocol::ToolDecisionAudit {
+                    action: "allow".to_string(),
+                    reason: Some("approved tool escalation replay".to_string()),
+                    ..audit
+                },
+            }
+        }
+        other => other,
     }
 }
 
@@ -499,6 +795,7 @@ async fn spawn_and_join_delegated_child(
         return Ok(ChildRuntimeResult {
             status: ChildRuntimeStatus::Cancelled,
             session_id: String::new(),
+            child_run_id: None,
             rollout_path: None,
             output_text: String::new(),
             turn_summary: None,
@@ -506,6 +803,7 @@ async fn spawn_and_join_delegated_child(
             warnings: Vec::new(),
             error_message: None,
             pause: None,
+            child_run: None,
         });
     }
 
@@ -746,7 +1044,7 @@ fn delegated_tool_profile(skill_id: &str) -> Option<SpawnToolProfileOverride> {
 fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedSkillResult {
     match result.status {
         ChildRuntimeStatus::Completed => delegated_result_from_completed_child(result),
-        ChildRuntimeStatus::Failed => DelegatedSkillResult::failed(
+        ChildRuntimeStatus::Failed => child_failure_result(
             format!(
                 "Delegated runtime failed: {}",
                 result
@@ -755,21 +1053,26 @@ fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedS
                     .or_else(|| non_empty_trimmed(&result.output_text))
                     .unwrap_or_else(|| "unknown failure".to_string())
             ),
-            Some(json!({
-                "error_kind": "child_failed"
-            })),
+            "child_failed",
+            result,
         ),
-        ChildRuntimeStatus::TimedOut => DelegatedSkillResult::failed(
+        ChildRuntimeStatus::TimedOut => child_failure_result(
             "Delegated runtime timed out.".to_string(),
-            Some(json!({
-                "error_kind": "child_timed_out"
-            })),
+            "child_timed_out",
+            result,
         ),
-        ChildRuntimeStatus::Cancelled => DelegatedSkillResult::failed(
+        ChildRuntimeStatus::Cancelled => child_failure_result(
             "Delegated runtime was cancelled.".to_string(),
-            Some(json!({
-                "error_kind": "child_cancelled"
-            })),
+            "child_cancelled",
+            result,
+        ),
+        ChildRuntimeStatus::Terminated => child_failure_result(
+            result
+                .error_message
+                .clone()
+                .unwrap_or_else(|| "Delegated runtime was terminated.".to_string()),
+            "child_terminated",
+            result,
         ),
         ChildRuntimeStatus::Paused => {
             let (pause_kind, request_id) = result
@@ -782,7 +1085,7 @@ fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedS
                     )
                 })
                 .unwrap_or_else(|| ("unknown".to_string(), None));
-            DelegatedSkillResult::failed(
+            let mut delegated = DelegatedSkillResult::failed(
                 format!(
                     "Delegated runtime paused for {} and cannot continue in v1 delegated execution.",
                     pause_kind
@@ -792,20 +1095,81 @@ fn delegated_result_from_child_result(result: &ChildRuntimeResult) -> DelegatedS
                     "pause_kind": pause_kind,
                     "request_id": request_id
                 })),
-            )
+            );
+            delegated.error_kind = Some("child_paused".to_string());
+            delegated.error_message = result.error_message.clone();
+            delegated.child_run = child_run_value(result);
+            delegated.warnings = result.warnings.clone();
+            delegated
         }
     }
 }
 
 fn delegated_result_from_completed_child(result: &ChildRuntimeResult) -> DelegatedSkillResult {
-    DelegatedSkillResult::completed(
+    let output_text = non_empty_trimmed(&result.output_text);
+    let mut delegated = DelegatedSkillResult::completed(
         completed_child_summary(result),
         result.structured_output.clone(),
-    )
+    );
+    delegated.child_run = child_run_value(result);
+    delegated.warnings = result.warnings.clone();
+
+    if let Some(output_text) = output_text {
+        let output_chars = output_text.chars().count();
+        if output_chars <= MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS {
+            delegated.output_text = Some(output_text);
+        } else {
+            delegated.summary_preview = Some(truncate_text_with_suffix(
+                &output_text,
+                MAX_DELEGATED_RESULT_SUMMARY_CHARS,
+                "... [truncated; inspect output_ref]",
+            ));
+            delegated.output_ref = Some(output_ref(result, "output_text"));
+            delegated.truncation = Some(DelegatedSkillResultTruncation {
+                output_text: true,
+                original_output_chars: Some(output_chars),
+                note: Some("Full child output is available from output_ref.".to_string()),
+                ..DelegatedSkillResultTruncation::default()
+            });
+        }
+    }
+
+    delegated
+}
+
+fn child_failure_result(
+    summary: String,
+    error_kind: &str,
+    result: &ChildRuntimeResult,
+) -> DelegatedSkillResult {
+    let mut delegated = DelegatedSkillResult::failed(
+        summary.clone(),
+        Some(json!({
+            "error_kind": error_kind
+        })),
+    );
+    delegated.error_kind = Some(error_kind.to_string());
+    delegated.error_message = result.error_message.clone();
+    delegated.child_run = child_run_value(result);
+    delegated.warnings = result.warnings.clone();
+    if !result.output_text.trim().is_empty() {
+        delegated.output_ref = Some(output_ref(result, "output_text"));
+        delegated.truncation = Some(DelegatedSkillResultTruncation {
+            output_text: true,
+            original_output_chars: Some(result.output_text.chars().count()),
+            note: Some(
+                "Child produced output before terminal failure; inspect output_ref.".to_string(),
+            ),
+            ..DelegatedSkillResultTruncation::default()
+        });
+    }
+    delegated
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct DelegatedChildRunReference {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    child_run_id: Option<String>,
     session_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     rollout_path: Option<PathBuf>,
@@ -822,9 +1186,33 @@ struct DelegatedSkillRolloutRecord {
 
 fn delegated_child_run_reference(result: &ChildRuntimeResult) -> DelegatedChildRunReference {
     DelegatedChildRunReference {
+        child_run_id: result.child_run_id.clone(),
         session_id: result.session_id.clone(),
         rollout_path: result.rollout_path.clone(),
         terminal_status: child_runtime_status_label(result.status.clone()),
+    }
+}
+
+fn child_run_value(result: &ChildRuntimeResult) -> Option<serde_json::Value> {
+    result
+        .child_run
+        .as_ref()
+        .and_then(|record| serde_json::to_value(record).ok())
+        .or_else(|| {
+            serde_json::to_value(delegated_child_run_reference(result))
+                .ok()
+                .filter(|value| !value.is_null())
+        })
+}
+
+fn output_ref(result: &ChildRuntimeResult, field: &str) -> DelegatedSkillOutputRef {
+    DelegatedSkillOutputRef {
+        session_id: result.session_id.clone(),
+        rollout_path: result
+            .rollout_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        field: field.to_string(),
     }
 }
 
@@ -834,6 +1222,7 @@ fn child_runtime_status_label(status: ChildRuntimeStatus) -> String {
         ChildRuntimeStatus::Paused => "paused".to_string(),
         ChildRuntimeStatus::Cancelled => "cancelled".to_string(),
         ChildRuntimeStatus::TimedOut => "timed_out".to_string(),
+        ChildRuntimeStatus::Terminated => "terminated".to_string(),
         ChildRuntimeStatus::Failed => "failed".to_string(),
     }
 }
@@ -863,17 +1252,32 @@ fn build_bounded_delegated_tape_record(
         truncate_text_with_suffix(&request.skill_id, MAX_DELEGATED_SKILL_ID_CHARS, "...");
     let target = truncate_text_with_suffix(&request.target, MAX_DELEGATED_TARGET_CHARS, "...");
     let task = truncate_text_with_suffix(&request.task, MAX_DELEGATED_TASK_CHARS, "...");
-    let result = DelegatedSkillResult {
-        summary: truncate_text_with_suffix(
-            &result.summary,
-            MAX_DELEGATED_RESULT_SUMMARY_CHARS,
-            "...",
-        ),
-        structured_output: result
-            .structured_output
-            .map(|value| truncate_structured_output(value, MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS)),
-        ..result
-    };
+    let mut result = result;
+    let summary_chars = result.summary.chars().count();
+    if summary_chars > MAX_DELEGATED_RESULT_SUMMARY_CHARS {
+        let preview =
+            truncate_text_with_suffix(&result.summary, MAX_DELEGATED_RESULT_SUMMARY_CHARS, "...");
+        result.summary = preview.clone();
+        result.summary_preview = Some(preview);
+        let mut truncation = result.truncation.take().unwrap_or_default();
+        truncation.summary = true;
+        truncation.original_summary_chars = Some(summary_chars);
+        result.truncation = Some(truncation);
+    }
+    if let Some(value) = result.structured_output.take() {
+        let serialized_size = serde_json::to_string(&value)
+            .map(|text| text.chars().count())
+            .unwrap_or(MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS + 1);
+        result.structured_output = Some(truncate_structured_output(
+            value,
+            MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS,
+        ));
+        if serialized_size > MAX_DELEGATED_STRUCTURED_OUTPUT_CHARS {
+            let mut truncation = result.truncation.take().unwrap_or_default();
+            truncation.structured_output = true;
+            result.truncation = Some(truncation);
+        }
+    }
 
     let record = DelegatedSkillInvocationRecord {
         skill_id,
@@ -908,7 +1312,15 @@ fn build_bounded_delegated_tape_record(
 
 fn completed_child_summary(result: &ChildRuntimeResult) -> String {
     structured_output_summary(result.structured_output.as_ref())
-        .or_else(|| non_empty_trimmed(&result.output_text))
+        .or_else(|| {
+            non_empty_trimmed(&result.output_text).map(|text| {
+                truncate_text_with_suffix(
+                    &text,
+                    MAX_DELEGATED_RESULT_SUMMARY_CHARS,
+                    "... [truncated; inspect output_text or output_ref]",
+                )
+            })
+        })
         .or_else(|| non_empty_trimmed(result.turn_summary.as_deref().unwrap_or_default()))
         .unwrap_or_else(|| "Delegated runtime completed without textual output.".to_string())
 }
@@ -1437,6 +1849,32 @@ fn parse_delegated_skill_invocation_request(
     })
 }
 
+fn parse_terminate_child_run_request(
+    arguments: &serde_json::Value,
+) -> Option<(String, String, ChildRunTerminationMode)> {
+    let child_run_id = arguments.get("child_run_id")?.as_str()?.trim().to_string();
+    if child_run_id.is_empty() {
+        return None;
+    }
+    let reason = arguments
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("parent runtime requested child termination")
+        .to_string();
+    let mode = match arguments
+        .get("mode")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("graceful")
+    {
+        "graceful" => ChildRunTerminationMode::Graceful,
+        "forceful" | "kill" => ChildRunTerminationMode::Forceful,
+        _ => return None,
+    };
+    Some((child_run_id, reason, mode))
+}
+
 fn parse_optional_path_argument(
     arguments: &serde_json::Value,
     key: &str,
@@ -1646,6 +2084,32 @@ fn invoke_delegated_skill_tool_definition() -> ToolDefinition {
                 }
             },
             "required": ["skill_id", "target", "task"]
+        }),
+    }
+}
+
+fn terminate_child_run_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "terminate_child_run".to_string(),
+        description: "Request termination of a delegated child run launched by this parent runtime. Use graceful mode first unless the child is stuck or unsafe to keep running.".to_string(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "child_run_id": {
+                    "type": "string",
+                    "description": "Child-run id from a delegated result child_run record."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Brief reason recorded in the child-run termination audit trail."
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["graceful", "forceful"],
+                    "description": "graceful requests shutdown; forceful aborts when the child is stuck."
+                }
+            },
+            "required": ["child_run_id", "reason", "mode"]
         }),
     }
 }

--- a/crates/runtime/src/runtime/virtual_tools_tests.rs
+++ b/crates/runtime/src/runtime/virtual_tools_tests.rs
@@ -891,6 +891,68 @@ fn test_build_bounded_delegated_invocation_persistence_keeps_child_run_out_of_ta
 }
 
 #[test]
+fn test_build_bounded_delegated_invocation_persistence_bounds_result_sidecars() {
+    let request = DelegatedSkillInvocationRequest {
+        skill_id: "repo-review".to_string(),
+        target: "reviewer".to_string(),
+        task: "Review the current diff and summarize risks.".to_string(),
+        workspace_root: Some(PathBuf::from("/tmp/repo")),
+        cwd: Some(PathBuf::from("/tmp/repo/src")),
+        timeout_secs: None,
+    };
+    let mut result = DelegatedSkillResult::failed("Delegated review failed.", None);
+    result.child_run = Some(json!({
+        "id": "child-run-1",
+        "status": "failed",
+        "warnings": vec!["child-warning".repeat(200); MAX_DELEGATED_RESULT_WARNINGS + 8],
+        "large_metadata": "x".repeat(MAX_DELEGATED_CHILD_RUN_METADATA_CHARS * 2)
+    }));
+    result.warnings = (0..(MAX_DELEGATED_RESULT_WARNINGS + 3))
+        .map(|index| {
+            format!(
+                "warning-{index:03}-{}",
+                "x".repeat(MAX_DELEGATED_RESULT_WARNING_CHARS)
+            )
+        })
+        .collect();
+
+    let (_, tape_record, _) =
+        build_bounded_delegated_invocation_persistence(&request, result, None);
+
+    assert_eq!(
+        tape_record.result.warnings.len(),
+        MAX_DELEGATED_RESULT_WARNINGS
+    );
+    assert!(tape_record.result.warnings[0].starts_with("warning-003-"));
+    assert!(
+        tape_record
+            .result
+            .warnings
+            .iter()
+            .all(|warning| warning.chars().count() <= MAX_DELEGATED_RESULT_WARNING_CHARS)
+    );
+    assert!(tape_record.result.warnings.last().unwrap().ends_with("..."));
+    assert!(
+        tape_record
+            .result
+            .child_run
+            .as_ref()
+            .unwrap()
+            .to_string()
+            .len()
+            <= MAX_DELEGATED_CHILD_RUN_METADATA_CHARS
+    );
+    let truncation = tape_record.result.truncation.unwrap();
+    assert!(truncation.child_run);
+    assert!(truncation.warnings);
+    assert!(truncation.original_child_run_chars.unwrap() > MAX_DELEGATED_CHILD_RUN_METADATA_CHARS);
+    assert_eq!(
+        truncation.original_warning_count,
+        Some(MAX_DELEGATED_RESULT_WARNINGS + 3)
+    );
+}
+
+#[test]
 fn test_delegated_result_from_completed_child_prefers_structured_output_summary() {
     let child_result = ChildRuntimeResult {
         status: ChildRuntimeStatus::Completed,

--- a/crates/runtime/src/runtime/virtual_tools_tests.rs
+++ b/crates/runtime/src/runtime/virtual_tools_tests.rs
@@ -3,7 +3,10 @@ use crate::{
     config::Config,
     llm::LlmClient,
     rollout::{RolloutItem, RolloutRecorder},
-    runtime::{RuntimeConfig, TurnState, turn_state::TurnActivityState},
+    runtime::{
+        ChildRunRecord, ChildRunStatus, RuntimeConfig, TurnState, global_child_run_registry,
+        turn_state::TurnActivityState,
+    },
     session::Session,
     skills::{
         ActiveSkillEnvelope, ResolvedCapabilityView, ResolvedSkillExecution, ScopedPackageDir,
@@ -150,6 +153,37 @@ fn capability_view_for_workspace_skill(workspace_root: &std::path::Path) -> Reso
     }])
 }
 
+fn test_child_run_record(child_run_id: &str, parent_session_id: &str) -> ChildRunRecord {
+    ChildRunRecord::new(
+        child_run_id.to_string(),
+        parent_session_id.to_string(),
+        format!("child-session-{child_run_id}"),
+        Some("/tmp/alan-delegated-parent".to_string()),
+        Some("/tmp/alan-delegated-parent/.alan/sessions/child.jsonl".to_string()),
+        Some("repo-coding".to_string()),
+    )
+}
+
+fn tool_result_text_for_call(
+    state: &super::super::agent_loop::RuntimeLoopState,
+    call_id: &str,
+) -> String {
+    state
+        .session
+        .tape
+        .prompt_view()
+        .messages
+        .iter()
+        .find_map(|message| match message {
+            crate::tape::Message::Tool { responses } => responses
+                .iter()
+                .find(|response| response.id == call_id)
+                .map(crate::tape::ToolResponse::text_content),
+            _ => None,
+        })
+        .expect("expected tool result")
+}
+
 async fn try_handle_virtual_tool_call_for_test<E, F>(
     state: &mut super::super::agent_loop::RuntimeLoopState,
     tool_call: &NormalizedToolCall,
@@ -160,7 +194,7 @@ where
     F: std::future::Future<Output = ()>,
 {
     let cancel = CancellationToken::new();
-    try_handle_virtual_tool_call(state, tool_call, &tool_call.arguments, &cancel, emit).await
+    try_handle_virtual_tool_call(state, tool_call, &tool_call.arguments, &cancel, false, emit).await
 }
 
 #[test]
@@ -177,6 +211,7 @@ fn test_virtual_tool_definitions_include_all_runtime_virtual_tools() {
 fn test_virtual_tool_definitions_can_include_delegated_skill() {
     let defs = virtual_tool_definitions(true);
     assert!(defs.iter().any(|d| d.name == "invoke_delegated_skill"));
+    assert!(defs.iter().any(|d| d.name == "terminate_child_run"));
 }
 
 #[test]
@@ -255,6 +290,27 @@ fn test_invoke_delegated_skill_tool_definition() {
         "string"
     );
     assert_eq!(def.parameters["properties"]["cwd"]["type"], "string");
+}
+
+#[test]
+fn test_terminate_child_run_tool_definition() {
+    let def = terminate_child_run_tool_definition();
+    assert_eq!(def.name, "terminate_child_run");
+    assert!(def.description.contains("child run"));
+    assert_eq!(def.parameters["type"], "object");
+    assert_eq!(
+        def.parameters["properties"]["child_run_id"]["type"],
+        "string"
+    );
+    assert_eq!(def.parameters["properties"]["reason"]["type"], "string");
+    assert_eq!(
+        def.parameters["properties"]["mode"]["enum"],
+        json!(["graceful", "forceful"])
+    );
+    assert_eq!(
+        def.parameters["required"],
+        json!(["child_run_id", "reason", "mode"])
+    );
 }
 
 // Tests for parse_confirmation_request
@@ -760,6 +816,7 @@ fn test_build_bounded_delegated_invocation_persistence_truncates_fields() {
 
     let child_run = Some(DelegatedChildRunReference {
         session_id: "child-session".to_string(),
+        child_run_id: None,
         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
         terminal_status: "completed".to_string(),
     });
@@ -809,6 +866,7 @@ fn test_build_bounded_delegated_invocation_persistence_keeps_child_run_out_of_ta
     let result = DelegatedSkillResult::completed("Delegated review completed.", None);
     let child_run = Some(DelegatedChildRunReference {
         session_id: "child-session".to_string(),
+        child_run_id: None,
         rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
         terminal_status: "completed".to_string(),
     });
@@ -837,6 +895,7 @@ fn test_delegated_result_from_completed_child_prefers_structured_output_summary(
     let child_result = ChildRuntimeResult {
         status: ChildRuntimeStatus::Completed,
         session_id: "child-session".to_string(),
+        child_run_id: None,
         rollout_path: None,
         output_text: "{\"status\":\"completed\",\"summary\":\"Structured delivery\"}".to_string(),
         turn_summary: Some("Turn summary".to_string()),
@@ -847,6 +906,7 @@ fn test_delegated_result_from_completed_child_prefers_structured_output_summary(
         warnings: Vec::new(),
         error_message: None,
         pause: None,
+        child_run: None,
     };
 
     let delegated = delegated_result_from_completed_child(&child_result);
@@ -865,6 +925,7 @@ fn test_delegated_result_from_completed_child_prefers_output_text_over_turn_summ
     let child_result = ChildRuntimeResult {
         status: ChildRuntimeStatus::Completed,
         session_id: "child-session".to_string(),
+        child_run_id: None,
         rollout_path: None,
         output_text: "Verification was environment_blocked: pytest was not installed.".to_string(),
         turn_summary: Some("Task completed".to_string()),
@@ -872,6 +933,7 @@ fn test_delegated_result_from_completed_child_prefers_output_text_over_turn_summ
         warnings: Vec::new(),
         error_message: None,
         pause: None,
+        child_run: None,
     };
 
     let delegated = delegated_result_from_completed_child(&child_result);
@@ -880,6 +942,136 @@ fn test_delegated_result_from_completed_child_prefers_output_text_over_turn_summ
         "Verification was environment_blocked: pytest was not installed."
     );
     assert!(delegated.structured_output.is_none());
+}
+
+#[test]
+fn test_delegated_result_from_completed_child_inlines_short_output() {
+    let child_result = ChildRuntimeResult {
+        status: ChildRuntimeStatus::Completed,
+        session_id: "child-session".to_string(),
+        child_run_id: Some("child-run-1".to_string()),
+        rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
+        output_text: "Short delegated delivery.".to_string(),
+        turn_summary: Some("Turn summary".to_string()),
+        structured_output: None,
+        warnings: Vec::new(),
+        error_message: None,
+        pause: None,
+        child_run: None,
+    };
+
+    let delegated = delegated_result_from_completed_child(&child_result);
+    assert_eq!(
+        delegated.output_text.as_deref(),
+        Some("Short delegated delivery.")
+    );
+    assert!(delegated.output_ref.is_none());
+    assert!(delegated.truncation.is_none());
+    assert_eq!(
+        delegated
+            .child_run
+            .as_ref()
+            .and_then(|value| value.get("child_run_id")),
+        Some(&json!("child-run-1"))
+    );
+}
+
+#[test]
+fn test_delegated_result_from_completed_child_uses_ref_for_long_output() {
+    let child_result = ChildRuntimeResult {
+        status: ChildRuntimeStatus::Completed,
+        session_id: "child-session".to_string(),
+        child_run_id: Some("child-run-1".to_string()),
+        rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
+        output_text: "x".repeat(MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS + 1),
+        turn_summary: Some("Turn summary".to_string()),
+        structured_output: None,
+        warnings: Vec::new(),
+        error_message: None,
+        pause: None,
+        child_run: None,
+    };
+
+    let delegated = delegated_result_from_completed_child(&child_result);
+    assert!(delegated.output_text.is_none());
+    assert_eq!(
+        delegated.output_ref.as_ref().map(|reference| (
+            reference.session_id.as_str(),
+            reference.rollout_path.as_deref(),
+            reference.field.as_str()
+        )),
+        Some((
+            "child-session",
+            Some("/tmp/child-rollout.jsonl"),
+            "output_text"
+        ))
+    );
+    assert_eq!(
+        delegated
+            .truncation
+            .as_ref()
+            .map(|truncation| truncation.output_text),
+        Some(true)
+    );
+    assert_eq!(
+        delegated
+            .truncation
+            .as_ref()
+            .and_then(|truncation| truncation.original_output_chars),
+        Some(MAX_DELEGATED_RESULT_OUTPUT_INLINE_CHARS + 1)
+    );
+}
+
+#[test]
+fn test_delegated_result_from_timed_out_child_includes_metadata() {
+    let child_result = ChildRuntimeResult {
+        status: ChildRuntimeStatus::TimedOut,
+        session_id: "child-session".to_string(),
+        child_run_id: Some("child-run-1".to_string()),
+        rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
+        output_text: "partial output before timeout".to_string(),
+        turn_summary: None,
+        structured_output: None,
+        warnings: vec!["child was idle".to_string()],
+        error_message: Some("idle timeout exceeded".to_string()),
+        pause: None,
+        child_run: Some(test_child_run_record("child-run-1", "parent-session")),
+    };
+
+    let delegated = delegated_result_from_child_result(&child_result);
+    assert_eq!(delegated.status, DelegatedSkillResultStatus::Failed);
+    assert_eq!(delegated.error_kind.as_deref(), Some("child_timed_out"));
+    assert_eq!(
+        delegated.error_message.as_deref(),
+        Some("idle timeout exceeded")
+    );
+    assert_eq!(delegated.warnings, vec!["child was idle"]);
+    assert_eq!(
+        delegated
+            .child_run
+            .as_ref()
+            .and_then(|value| value.get("status")),
+        Some(&json!("starting"))
+    );
+    assert_eq!(
+        delegated.output_ref.as_ref().map(|reference| (
+            reference.session_id.as_str(),
+            reference.rollout_path.as_deref(),
+            reference.field.as_str()
+        )),
+        Some((
+            "child-session",
+            Some("/tmp/child-rollout.jsonl"),
+            "output_text"
+        ))
+    );
+    assert_eq!(
+        delegated
+            .truncation
+            .as_ref()
+            .map(|truncation| truncation.output_text),
+        Some(true)
+    );
 }
 
 #[test]
@@ -1145,6 +1337,266 @@ async fn test_try_handle_virtual_tool_call_invalid_update_plan() {
 }
 
 #[tokio::test]
+async fn test_try_handle_virtual_tool_call_terminate_child_run_success() {
+    let mut state = create_test_agent_loop_state();
+    let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+    global_child_run_registry().register(test_child_run_record(&child_run_id, &state.session.id));
+
+    let tool_call = NormalizedToolCall {
+        id: "call_terminate".to_string(),
+        name: "terminate_child_run".to_string(),
+        arguments: json!({
+            "child_run_id": child_run_id,
+            "reason": "no longer needed",
+            "mode": "forceful"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: true
+        }
+    ));
+
+    let record = global_child_run_registry()
+        .get(tool_call.arguments["child_run_id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(record.status, ChildRunStatus::Terminating);
+    let termination = record.termination.as_ref().unwrap();
+    assert_eq!(termination.actor, "parent_runtime");
+    assert_eq!(termination.reason, "no longer needed");
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallStarted { audit: Some(audit), .. }
+            if audit.action == "allow"
+                && audit.capability == "write"
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(true), audit: Some(audit), .. }
+            if audit.action == "allow" && audit.capability == "write"
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_terminate");
+    assert!(tool_result.contains("\"status\":\"termination_requested\""));
+    assert!(tool_result.contains("\"status\":\"terminating\""));
+    assert!(tool_result.contains("\"actor\":\"parent_runtime\""));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_terminate_child_run_unknown_child() {
+    let mut state = create_test_agent_loop_state();
+    let child_run_id = format!("missing-child-run-{}", uuid::Uuid::new_v4());
+
+    let tool_call = NormalizedToolCall {
+        id: "call_terminate".to_string(),
+        name: "terminate_child_run".to_string(),
+        arguments: json!({
+            "child_run_id": child_run_id,
+            "reason": "stop missing child",
+            "mode": "graceful"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: true
+        }
+    ));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
+            if audit.action == "allow" && audit.capability == "write"
+    )));
+
+    let tool_result = tool_result_text_for_call(&state, "call_terminate");
+    assert!(tool_result.contains("\"status\":\"not_found\""));
+    assert!(tool_result.contains(tool_call.arguments["child_run_id"].as_str().unwrap()));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_terminate_child_run_already_terminal() {
+    let mut state = create_test_agent_loop_state();
+    let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+    global_child_run_registry().register(test_child_run_record(&child_run_id, &state.session.id));
+    global_child_run_registry().mark_terminal(&child_run_id, ChildRunStatus::Completed, None);
+
+    let tool_call = NormalizedToolCall {
+        id: "call_terminate".to_string(),
+        name: "terminate_child_run".to_string(),
+        arguments: json!({
+            "child_run_id": child_run_id,
+            "reason": "already done",
+            "mode": "graceful"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: true
+        }
+    ));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(true), audit: Some(audit), .. }
+            if audit.action == "allow" && audit.capability == "write"
+    )));
+
+    let record = global_child_run_registry()
+        .get(tool_call.arguments["child_run_id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(record.status, ChildRunStatus::Completed);
+    assert!(record.termination.is_none());
+
+    let tool_result = tool_result_text_for_call(&state, "call_terminate");
+    assert!(tool_result.contains("\"status\":\"already_terminal\""));
+    assert!(tool_result.contains("\"status\":\"completed\""));
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_terminate_child_run_escalates_under_conservative_policy()
+{
+    let mut state = create_test_agent_loop_state();
+    state.runtime_config.governance = alan_protocol::GovernanceConfig {
+        profile: alan_protocol::GovernanceProfile::Conservative,
+        policy_path: None,
+    };
+    state.runtime_config.policy_engine =
+        crate::policy::PolicyEngine::for_profile(crate::policy::PolicyProfile::Conservative);
+    let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+    global_child_run_registry().register(test_child_run_record(&child_run_id, &state.session.id));
+
+    let tool_call = NormalizedToolCall {
+        id: "call_terminate".to_string(),
+        name: "terminate_child_run".to_string(),
+        arguments: json!({
+            "child_run_id": child_run_id,
+            "reason": "needs review",
+            "mode": "graceful"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(result.unwrap(), VirtualToolOutcome::PauseTurn));
+    assert!(state.turn_state.pending_confirmation().is_some());
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::Yield { kind: alan_protocol::YieldKind::Confirmation, payload, .. }
+            if payload["details"]["replay_tool_call"]["tool_name"] == json!("terminate_child_run")
+    )));
+
+    let record = global_child_run_registry()
+        .get(tool_call.arguments["child_run_id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(record.status, ChildRunStatus::Starting);
+    assert!(record.termination.is_none());
+}
+
+#[tokio::test]
+async fn test_try_handle_virtual_tool_call_terminate_child_run_denied_by_policy() {
+    let mut state = create_test_agent_loop_state();
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("policy.yaml"),
+        r#"
+rules:
+  - id: deny-child-termination
+    tool: terminate_child_run
+    capability: write
+    action: deny
+    reason: child termination disabled
+default_action: allow
+"#,
+    )
+    .unwrap();
+    state.runtime_config.governance = alan_protocol::GovernanceConfig {
+        profile: alan_protocol::GovernanceProfile::Autonomous,
+        policy_path: None,
+    };
+    state.runtime_config.policy_engine = crate::policy::PolicyEngine::load_or_profile(
+        Some(temp.path()),
+        crate::policy::PolicyProfile::Autonomous,
+    );
+    let child_run_id = format!("child-run-{}", uuid::Uuid::new_v4());
+    global_child_run_registry().register(test_child_run_record(&child_run_id, &state.session.id));
+
+    let tool_call = NormalizedToolCall {
+        id: "call_terminate".to_string(),
+        name: "terminate_child_run".to_string(),
+        arguments: json!({
+            "child_run_id": child_run_id,
+            "reason": "policy should deny",
+            "mode": "graceful"
+        }),
+    };
+
+    let mut events = vec![];
+    let mut emit = |event: Event| {
+        events.push(event);
+        async {}
+    };
+
+    let result = try_handle_virtual_tool_call_for_test(&mut state, &tool_call, &mut emit).await;
+    assert!(result.is_ok());
+    assert!(matches!(
+        result.unwrap(),
+        VirtualToolOutcome::Continue {
+            refresh_context: false
+        }
+    ));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        Event::ToolCallCompleted { success: Some(false), audit: Some(audit), .. }
+            if audit.action == "deny" && audit.rule_id.as_deref() == Some("deny-child-termination")
+    )));
+
+    let record = global_child_run_registry()
+        .get(tool_call.arguments["child_run_id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(record.status, ChildRunStatus::Starting);
+    assert!(record.termination.is_none());
+
+    let tool_result = tool_result_text_for_call(&state, "call_terminate");
+    assert!(tool_result.contains("\"status\":\"blocked_by_policy\""));
+    assert!(tool_result.contains("child termination disabled"));
+}
+
+#[tokio::test]
 async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
     let mut state = create_test_agent_loop_state();
     state.core_config.memory.workspace_dir =
@@ -1183,6 +1635,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                     output_text: String::new(),
                     turn_summary: Some("Delegated review completed.".to_string()),
@@ -1190,6 +1643,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1246,8 +1700,8 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill() {
     assert!(tool_result.contains("\"task\":\"Review the current diff and summarize risks.\""));
     assert!(tool_result.contains("\"status\":\"completed\""));
     assert!(tool_result.contains("Delegated review completed."));
-    assert!(!tool_result.contains("child_run"));
-    assert!(!tool_result.contains("child-session"));
+    assert!(tool_result.contains("child_run"));
+    assert!(tool_result.contains("child-session"));
 }
 
 #[tokio::test]
@@ -1314,6 +1768,7 @@ Use this skill when asked.
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1321,6 +1776,7 @@ Use this skill when asked.
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1400,6 +1856,7 @@ Use this skill when asked.
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: String::new(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: None,
@@ -1407,6 +1864,7 @@ Use this skill when asked.
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1474,6 +1932,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_keeps_workspac
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1481,6 +1940,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_keeps_workspac
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1542,6 +2002,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_explici
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1549,6 +2010,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_explici
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1620,6 +2082,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_does_not_promo
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1627,6 +2090,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_does_not_promo
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1687,6 +2151,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_uses_bound_wor
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1694,6 +2159,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_uses_bound_wor
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1754,6 +2220,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_normalizes_rel
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1761,6 +2228,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_normalizes_rel
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1816,6 +2284,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_rejects_unreso
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: String::new(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: None,
@@ -1823,6 +2292,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_rejects_unreso
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1888,6 +2358,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_leaves_workspa
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("done".to_string()),
@@ -1895,6 +2366,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_leaves_workspa
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -1946,6 +2418,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_succes
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                     output_text: String::new(),
                     turn_summary: Some("Delegated review completed.".to_string()),
@@ -1953,6 +2426,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_succes
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -2017,6 +2491,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_normal
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: Some("Delegated review completed.".to_string()),
@@ -2024,6 +2499,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_records_normal
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -2092,6 +2568,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                     output_text: String::new(),
                     turn_summary: Some("delegated-result ".repeat(40)),
@@ -2099,6 +2576,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_bounds_preview
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -2191,6 +2669,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Cancelled,
                     session_id: "child-session".to_string(),
+                    child_run_id: None,
                     rollout_path: Some(PathBuf::from("/tmp/child-rollout.jsonl")),
                     output_text: String::new(),
                     turn_summary: None,
@@ -2198,6 +2677,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_honors_interru
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },
@@ -2354,6 +2834,7 @@ async fn test_try_handle_virtual_tool_call_rejects_target_mismatch() {
                 Ok(ChildRuntimeResult {
                     status: ChildRuntimeStatus::Completed,
                     session_id: String::new(),
+                    child_run_id: None,
                     rollout_path: None,
                     output_text: String::new(),
                     turn_summary: None,
@@ -2361,6 +2842,7 @@ async fn test_try_handle_virtual_tool_call_rejects_target_mismatch() {
                     warnings: Vec::new(),
                     error_message: None,
                     pause: None,
+                    child_run: None,
                 })
             })
         },

--- a/crates/runtime/src/runtime/virtual_tools_tests.rs
+++ b/crates/runtime/src/runtime/virtual_tools_tests.rs
@@ -148,7 +148,7 @@ fn activate_test_delegated_skill(
 
 fn capability_view_for_workspace_skill(workspace_root: &std::path::Path) -> ResolvedCapabilityView {
     ResolvedCapabilityView::from_package_dirs(vec![ScopedPackageDir {
-        path: workspace_root.join(".alan/agent/skills"),
+        path: workspace_root.join(".alan/agents/default/skills"),
         scope: SkillScope::Repo,
     }])
 }
@@ -1709,7 +1709,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_from_catalog_w
 {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("repo");
-    let skill_dir = workspace_root.join(".alan/agent/skills/repo-review");
+    let skill_dir = workspace_root.join(".alan/agents/default/skills/repo-review");
     std::fs::create_dir_all(skill_dir.join("agents/reviewer")).unwrap();
     std::fs::write(
         skill_dir.join("SKILL.md"),
@@ -1803,7 +1803,7 @@ async fn test_try_handle_virtual_tool_call_invoke_delegated_skill_rejects_when_r
  {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("repo");
-    let skill_dir = workspace_root.join(".alan/agent/skills/repo-review");
+    let skill_dir = workspace_root.join(".alan/agents/default/skills/repo-review");
     std::fs::create_dir_all(skill_dir.join("agents/reviewer")).unwrap();
     std::fs::write(
         skill_dir.join("SKILL.md"),

--- a/crates/runtime/src/skills/injector.rs
+++ b/crates/runtime/src/skills/injector.rs
@@ -266,7 +266,9 @@ This skill executes through Alan's delegated runtime path.
 Do not inline or restate the full `SKILL.md` body in this session.
 When you need this capability, call `invoke_delegated_skill` with a concise bounded task for the delegated runtime.
 If the delegated task targets a different local workspace than the current runtime, include an explicit `workspace_root` and, when helpful, a narrower nested `cwd`.
-The tool returns a bounded result object with `status`, `summary`, and optional `structured_output`.
+The tool returns a bounded result object with `status`, `summary`, optional `child_run`, optional inline `output_text`, optional `output_ref`, optional `structured_output`, and explicit `truncation` metadata.
+If `output_ref` or truncation metadata is present, treat the inline text as a preview and inspect the referenced child rollout/session only when the full delegated output is needed.
+Use `child_run` metadata to inspect or terminate a still-active child run through the available child-run controls.
 
 ```json
 {{
@@ -1259,6 +1261,8 @@ mod tests {
 
         assert!(rendered.contains("### Delegated Capability"));
         assert!(rendered.contains("invoke_delegated_skill"));
+        assert!(rendered.contains("output_ref"));
+        assert!(rendered.contains("child_run"));
         assert!(rendered.contains("\"target\": \"reviewer\""));
         assert!(!rendered.contains("SECRET INLINE BODY"));
     }

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -1211,10 +1211,18 @@ pub struct DelegatedSkillResultTruncation {
     pub output_text: bool,
     #[serde(default)]
     pub structured_output: bool,
+    #[serde(default)]
+    pub child_run: bool,
+    #[serde(default)]
+    pub warnings: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub original_summary_chars: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub original_output_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_child_run_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_warning_count: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
 }

--- a/crates/runtime/src/skills/types.rs
+++ b/crates/runtime/src/skills/types.rs
@@ -1172,7 +1172,51 @@ pub struct DelegatedSkillResult {
     pub status: DelegatedSkillResultStatus,
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_run: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_ref: Option<DelegatedSkillOutputRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub structured_output: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_output_ref: Option<DelegatedSkillOutputRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<DelegatedSkillResultTruncation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+/// Inspectable reference for omitted delegated child output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegatedSkillOutputRef {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollout_path: Option<String>,
+    pub field: String,
+}
+
+/// Explicit truncation metadata for delegated child handoff fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DelegatedSkillResultTruncation {
+    #[serde(default)]
+    pub summary: bool,
+    #[serde(default)]
+    pub output_text: bool,
+    #[serde(default)]
+    pub structured_output: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_summary_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_output_chars: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 impl DelegatedSkillResult {
@@ -1183,7 +1227,16 @@ impl DelegatedSkillResult {
         Self {
             status: DelegatedSkillResultStatus::Completed,
             summary: summary.into(),
+            summary_preview: None,
+            child_run: None,
+            output_text: None,
+            output_ref: None,
             structured_output,
+            structured_output_ref: None,
+            truncation: None,
+            warnings: Vec::new(),
+            error_kind: None,
+            error_message: None,
         }
     }
 
@@ -1194,7 +1247,16 @@ impl DelegatedSkillResult {
         Self {
             status: DelegatedSkillResultStatus::Failed,
             summary: summary.into(),
+            summary_preview: None,
+            child_run: None,
+            output_text: None,
+            output_ref: None,
             structured_output,
+            structured_output_ref: None,
+            truncation: None,
+            warnings: Vec::new(),
+            error_kind: None,
+            error_message: None,
         }
     }
 }

--- a/crates/runtime/src/tools/sandbox_tests.rs
+++ b/crates/runtime/src/tools/sandbox_tests.rs
@@ -90,7 +90,7 @@ async fn test_sandbox_blocks_write_to_protected_subpath() {
 async fn test_sandbox_allows_read_from_protected_subpath() {
     let temp = TempDir::new().unwrap();
     let sandbox = Sandbox::new(temp.path().to_path_buf());
-    let protected = temp.path().join(".alan/agent/policy.yaml");
+    let protected = temp.path().join(".alan/agents/default/policy.yaml");
     tokio::fs::create_dir_all(protected.parent().unwrap())
         .await
         .unwrap();
@@ -104,7 +104,7 @@ async fn test_sandbox_allows_read_from_protected_subpath() {
 async fn test_sandbox_allows_write_to_workspace_persona_subpath() {
     let temp = TempDir::new().unwrap();
     let sandbox = Sandbox::new(temp.path().to_path_buf());
-    let persona_file = temp.path().join(".alan/agent/persona/USER.md");
+    let persona_file = temp.path().join(".alan/agents/default/persona/USER.md");
 
     sandbox
         .write(&persona_file, b"# USER\n- Preferred name: Test\n")
@@ -131,11 +131,13 @@ async fn test_sandbox_allows_write_to_workspace_memory_subpath() {
 async fn test_sandbox_blocks_write_with_parent_dir_bypass_into_protected_subpath() {
     let temp = TempDir::new().unwrap();
     let sandbox = Sandbox::new(temp.path().to_path_buf());
-    tokio::fs::create_dir_all(temp.path().join(".alan/agent"))
+    tokio::fs::create_dir_all(temp.path().join(".alan/agents/default"))
         .await
         .unwrap();
 
-    let bypass_path = temp.path().join(".alan/agent/persona/../policy.yaml");
+    let bypass_path = temp
+        .path()
+        .join(".alan/agents/default/persona/../policy.yaml");
     let result = sandbox.write(&bypass_path, b"rules: []\n").await;
 
     assert!(result.is_err());
@@ -175,13 +177,13 @@ async fn test_sandbox_exec_allows_direct_command_for_workspace_memory_subpath() 
 async fn test_sandbox_exec_blocks_parent_dir_bypass_into_protected_subpath() {
     let temp = TempDir::new().unwrap();
     let sandbox = Sandbox::new(temp.path().to_path_buf());
-    tokio::fs::create_dir_all(temp.path().join(".alan/agent"))
+    tokio::fs::create_dir_all(temp.path().join(".alan/agents/default"))
         .await
         .unwrap();
 
     let result = sandbox
         .exec_with_timeout_and_capability(
-            "touch .alan/agent/persona/../policy.yaml",
+            "touch .alan/agents/default/persona/../policy.yaml",
             temp.path(),
             None,
             Some(alan_protocol::ToolCapability::Write),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,14 @@ The former singular default root `.alan/agent/` is removed from the runtime
 contract. It is not read as a fallback and is not merged with
 `.alan/agents/default/`; move authored files to the `default/` root.
 
+Rust code treats this layout as a runtime-owned contract. The canonical API is
+`alan_runtime::AgentRootLayout`, with semantic helpers for default roots, named
+roots, `agent.toml`, `persona/`, `skills/`, and `policy.yaml`. Host crates such
+as `alan` should call that API for reads and writes instead of joining
+`agents/default` path segments locally. TypeScript setup code may keep a small
+offline mirror for first-run setup, but online flows should prefer paths returned
+by the daemon.
+
 This overlay chain defines an agent. It is not runtime process ancestry, and it
 is distinct from delegated child-agent runs created during a session.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,11 +68,16 @@ An **AgentRoot** is the filesystem form of an agent definition. Alan resolves on
 effective agent by overlaying multiple roots.
 
 ```text
-~/.alan/agent/                   # global base agent root
-~/.alan/agents/<name>/           # global named agent root
-<workspace>/.alan/agent/         # workspace base agent root
-<workspace>/.alan/agents/<name>/ # workspace named agent root
+~/.alan/agent/                   # global default agent definition root
+~/.alan/agents/<name>/           # global named agent definition root
+<workspace>/.alan/agent/         # workspace default agent definition root
+<workspace>/.alan/agents/<name>/ # workspace named agent definition root
 ```
+
+The singular `agent/` path is the default definition root used when no
+`agent_name` is selected. The plural `agents/` path is a collection of named
+definition roots; each child directory is selected by `agent_name`. A named
+agent extends the default roots rather than replacing them.
 
 Each root may contain:
 
@@ -81,12 +86,20 @@ Each root may contain:
 - `skills/`
 - `policy.yaml`
 
+Workspace `.alan` contains both authored agent definition files and generated
+runtime state. The repository ignores workspace `.alan/*` by default, then
+explicitly allows authored roots such as `.alan/agent/`, `.alan/agents/`, and
+workspace model overlays like `.alan/models.toml` to remain source-controlled.
+Generated runtime files such as `.alan/sessions/` and `.alan/memory/` are local
+continuation/debugging state and stay ignored by default.
+
 Overlay order is:
 
 - Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
 - Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
 
-This overlay chain defines an agent. It is not runtime process ancestry.
+This overlay chain defines an agent. It is not runtime process ancestry, and it
+is distinct from delegated child-agent runs created during a session.
 
 ### Capability Packages In The Definition Layer
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,16 +68,16 @@ An **AgentRoot** is the filesystem form of an agent definition. Alan resolves on
 effective agent by overlaying multiple roots.
 
 ```text
-~/.alan/agent/                   # global default agent definition root
+~/.alan/agents/default/                   # global default agent definition root
 ~/.alan/agents/<name>/           # global named agent definition root
-<workspace>/.alan/agent/         # workspace default agent definition root
+<workspace>/.alan/agents/default/         # workspace default agent definition root
 <workspace>/.alan/agents/<name>/ # workspace named agent definition root
 ```
 
-The singular `agent/` path is the default definition root used when no
-`agent_name` is selected. The plural `agents/` path is a collection of named
-definition roots; each child directory is selected by `agent_name`. A named
-agent extends the default roots rather than replacing them.
+All default and named agent definitions live under `agents/`. The reserved
+`default/` child is selected when `agent_name` is omitted or set to `default`.
+Other child directories are named definition roots selected by `agent_name`. A
+named agent extends the default roots rather than replacing them.
 
 Each root may contain:
 
@@ -88,15 +88,19 @@ Each root may contain:
 
 Workspace `.alan` contains both authored agent definition files and generated
 runtime state. The repository ignores workspace `.alan/*` by default, then
-explicitly allows authored roots such as `.alan/agent/`, `.alan/agents/`, and
+explicitly allows authored roots under `.alan/agents/` and
 workspace model overlays like `.alan/models.toml` to remain source-controlled.
 Generated runtime files such as `.alan/sessions/` and `.alan/memory/` are local
 continuation/debugging state and stay ignored by default.
 
 Overlay order is:
 
-- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
-- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+- Default workspace agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default`
+- Named agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+
+The former singular default root `.alan/agent/` is removed from the runtime
+contract. It is not read as a fallback and is not merged with
+`.alan/agents/default/`; move authored files to the `default/` root.
 
 This overlay chain defines an agent. It is not runtime process ancestry, and it
 is distinct from delegated child-agent runs created during a session.
@@ -112,7 +116,7 @@ does not drift in multiple places.
 Each resolved `AgentRoot` contributes its `skills/` directory as a capability
 package source. Alan also adapts `~/.agents/skills/` and
 `<workspace>/.agents/skills/` as public single-skill package sources for the
-global and workspace base layers. Alan combines those root-backed and public
+global and workspace default layers. Alan combines those root-backed and public
 sources with built-in first-party packages into one `ResolvedCapabilityView`,
 which is then consumed by runtime instead of the older mixed
 `repo/user/builtin` skill-loading paths.
@@ -169,12 +173,12 @@ pub struct WorkspaceRuntimeConfig {
 
 ```
 {home}/.alan/
-├── agent/
-│   ├── agent.toml          # global base agent config
-│   ├── persona/            # global base persona overlays
-│   ├── skills/             # global base skills
-│   └── policy.yaml         # optional global base policy override
 ├── agents/
+│   ├── default/
+│   │   ├── agent.toml      # global default agent config
+│   │   ├── persona/        # global default persona overlays
+│   │   ├── skills/         # global default skills
+│   │   └── policy.yaml     # optional global default policy override
 │   └── <name>/
 │       ├── agent.toml      # global named agent config
 │       ├── persona/
@@ -187,12 +191,12 @@ pub struct WorkspaceRuntimeConfig {
 
 {workspace_root}/.alan/
 ├── state.json              # workspace state (status, config, current session), when persisted
-├── agent/
-│   ├── agent.toml          # workspace base agent config
-│   ├── persona/            # workspace base persona overlays
-│   ├── skills/             # workspace base skills
-│   └── policy.yaml         # optional workspace base policy override
 ├── agents/
+│   ├── default/
+│   │   ├── agent.toml      # workspace default agent config
+│   │   ├── persona/        # workspace default persona overlays
+│   │   ├── skills/         # workspace default skills
+│   │   └── policy.yaml     # optional workspace default policy override
 │   └── <name>/
 │       ├── agent.toml      # workspace named agent config
 │       ├── persona/

--- a/docs/governance_current_contract.md
+++ b/docs/governance_current_contract.md
@@ -24,7 +24,7 @@ Policy resolution order is:
 
 Default workspace agents resolve:
 
-- `~/.alan/agent/policy.yaml -> {workspace}/.alan/agent/policy.yaml`
+- `~/.alan/agents/default/policy.yaml -> {workspace}/.alan/agents/default/policy.yaml`
 
 Named agents extend that chain with:
 

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -477,9 +477,9 @@ separate `repo/user/builtin` loading path. The current capability sources are:
 | -------------- | ------------------------------------------------------- | ----------------------------- |
 | **Built-in**   | Embedded first-party package assets                     | Core Alan capabilities        |
 | **User public skills** | `~/.agents/skills/`                              | Zero-conversion public installs |
-| **User roots** | `~/.alan/agent/skills/` and `~/.alan/agents/<name>/skills/` | Alan-native cross-project capability sources |
+| **User roots** | `~/.alan/agents/default/skills/` and `~/.alan/agents/<name>/skills/` | Alan-native cross-project capability sources |
 | **Workspace public skills** | `<workspace>/.agents/skills/`              | Zero-conversion workspace installs |
-| **Workspace roots** | `.alan/agent/skills/` and `.alan/agents/<name>/skills/` | Alan-native project/workspace capability sources |
+| **Workspace roots** | `.alan/agents/default/skills/` and `.alan/agents/<name>/skills/` | Alan-native project/workspace capability sources |
 
 Within the user and workspace sources, Alan follows the resolved `AgentRoot`
 overlay chain, and later roots override earlier ones when skill IDs collide.
@@ -488,8 +488,8 @@ definition root selected by `agent_name`; named roots extend the default roots.
 
 Overlay order is:
 
-- Default workspace agent: `~/.alan/agent -> <workspace>/.alan/agent`
-- Named agent: `~/.alan/agent -> <workspace>/.alan/agent -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
+- Default workspace agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default`
+- Named agent: `~/.alan/agents/default -> <workspace>/.alan/agents/default -> ~/.alan/agents/<name> -> <workspace>/.alan/agents/<name>`
 
 A standards-compatible skill directory with `SKILL.md` and optional
 `scripts/`, `references/`, `assets/`, or package-local launch targets under
@@ -614,7 +614,7 @@ filesystem path.
 
 The write path persists to the resolved writable `agent.toml` for the target
 agent definition layer. For example, the workspace default agent writes
-`<workspace>/.alan/agent/agent.toml`, while a workspace named agent writes
+`<workspace>/.alan/agents/default/agent.toml`, while a workspace named agent writes
 `<workspace>/.alan/agents/<name>/agent.toml`.
 
 `enabled: null` / `allowImplicitInvocation: null` removes an existing explicit

--- a/docs/skills_and_tools.md
+++ b/docs/skills_and_tools.md
@@ -399,22 +399,37 @@ parent tape:
   "result": {
     "status": "completed",
     "summary": "High-level delegated outcome",
+    "child_run": {
+      "session_id": "child-session-id",
+      "child_run_id": "child-run-id",
+      "rollout_path": ".alan/sessions/child-rollout.jsonl"
+    },
+    "output_ref": {
+      "session_id": "child-session-id",
+      "rollout_path": ".alan/sessions/child-rollout.jsonl",
+      "field": "output_text"
+    },
     "structured_output": {
       "optional": "capability-specific data"
+    },
+    "truncation": {
+      "output_truncated": true
     }
   }
 }
 ```
 
 The parent consumes that bounded record instead of replaying the child's full
-transcript into parent context.
+transcript into parent context. If `output_text` is present, it is the complete
+inline child output. If `output_ref` or truncation metadata is present, the
+inline text is only a preview and the parent or operator should inspect the
+referenced child rollout/session for full detail.
 
 The parent rollout keeps a richer out-of-band reference for debugging and
-auditing. Its delegated tool-call record additionally stores a `child_run`
-object with the child session id, rollout path when durable, and terminal
-status. That metadata stays out of the parent tape by default, so future prompt
-assembly does not absorb child rollout details while operators can still inspect
-the child run separately when needed.
+auditing. Its delegated tool-call record stores the `child_run` object with the
+child session id, child-run id, rollout path when durable, and terminal status.
+Operators can inspect that child run separately and, when it is still active,
+request termination through the child-run control plane.
 
 `alan skills list` and `alan skills packages` also surface each resolved
 execution mode and flag unresolved delegated-package shapes with explicit
@@ -468,6 +483,8 @@ separate `repo/user/builtin` loading path. The current capability sources are:
 
 Within the user and workspace sources, Alan follows the resolved `AgentRoot`
 overlay chain, and later roots override earlier ones when skill IDs collide.
+Here `agent/` is the default definition root and `agents/<name>/` is one named
+definition root selected by `agent_name`; named roots extend the default roots.
 
 Overlay order is:
 
@@ -596,7 +613,7 @@ workspace or a registered workspace alias / short id, not an arbitrary
 filesystem path.
 
 The write path persists to the resolved writable `agent.toml` for the target
-agent definition layer. For example, a workspace-base request writes
+agent definition layer. For example, the workspace default agent writes
 `<workspace>/.alan/agent/agent.toml`, while a workspace named agent writes
 `<workspace>/.alan/agents/<name>/agent.toml`.
 

--- a/docs/spec/connection_profile_contract.md
+++ b/docs/spec/connection_profile_contract.md
@@ -245,8 +245,8 @@ Rules:
 For new-session creation, Alan resolves profiles in this precedence order:
 
 1. explicit session-create `profile_id`
-2. workspace pin from `{workspace}/.alan/agent/agent.toml`
-3. global pin from `~/.alan/agent/agent.toml`
+2. workspace pin from `{workspace}/.alan/agents/default/agent.toml`
+3. global pin from `~/.alan/agents/default/agent.toml`
 4. `~/.alan/connections.toml.default_profile`
 
 Rules:
@@ -463,7 +463,7 @@ Connection-selection shape:
   "workspace_dir": "/Users/morris/Developer/Alan",
   "global_pin": {
     "scope": "global",
-    "config_path": "/Users/morris/.alan/agent/agent.toml",
+    "config_path": "/Users/morris/.alan/agents/default/agent.toml",
     "profile_id": "kimi"
   },
   "workspace_pin": null,

--- a/docs/spec/hite_governance.md
+++ b/docs/spec/hite_governance.md
@@ -181,7 +181,7 @@ In other words:
 When `governance.policy_path` is not provided, workspace policy is resolved from
 the `AgentRoot` chain. Default workspace agents use:
 
-- `~/.alan/agent/policy.yaml -> {workspace}/.alan/agent/policy.yaml`
+- `~/.alan/agents/default/policy.yaml -> {workspace}/.alan/agents/default/policy.yaml`
 
 Named agents extend that chain with:
 

--- a/docs/spec/kernel_contract.md
+++ b/docs/spec/kernel_contract.md
@@ -40,7 +40,7 @@ This document has higher priority than philosophy docs. Protocol details remain 
 - Defines the on-disk agent root: `agent.toml`, `persona/`, `skills/`, `policy.yaml`.
 - Standard public skill install directories such as `~/.agents/skills/` and
   `<workspace>/.agents/skills/` may also feed the resolved capability view as
-  single-skill packages associated with the base layers.
+  single-skill packages associated with the default layers.
 - Multiple `AgentRoot`s may overlay into one effective agent definition.
 - Definition overlay is separate from runtime supervision or process ancestry.
 

--- a/docs/spec/sub_agent_lifecycle_contract.md
+++ b/docs/spec/sub_agent_lifecycle_contract.md
@@ -204,9 +204,10 @@ Rules:
 3. `.alan/memory/handoffs/`, `.alan/memory/daily/`, and
    `.alan/memory/sessions/` are generated episodic state unless a workspace
    deliberately opts into tracking them.
-4. `.alan/agent/`, `.alan/agents/`, and workspace-authored policies or skills
-   may be source-controlled when the project wants workspace-local agent
-   configuration.
+4. `.alan/agent/` is the workspace default agent definition root.
+   `.alan/agents/<name>/` contains workspace named agent definition roots.
+   These authored definitions, policies, or skills may be source-controlled
+   when the project wants workspace-local agent configuration.
 5. Repository templates should ignore generated runtime state by default while
    allowing opt-in tracking for agent definitions.
 

--- a/docs/spec/sub_agent_lifecycle_contract.md
+++ b/docs/spec/sub_agent_lifecycle_contract.md
@@ -94,6 +94,8 @@ Rules:
 2. Any child event observed by the parent updates `latest_event_at`.
 3. A periodic heartbeat updates `latest_heartbeat_at` even when the model or
    tool has not emitted user-visible output.
+   Heartbeats are internal supervision signals and are not appended to the
+   user-visible session event stream or replay buffer.
 4. Parent supervision must not classify a child as timed out while fresh
    heartbeat or progress signals are still arriving.
 5. Idle timeout is measured from the latest heartbeat or progress signal.

--- a/docs/spec/sub_agent_lifecycle_contract.md
+++ b/docs/spec/sub_agent_lifecycle_contract.md
@@ -26,7 +26,7 @@ This contract does not:
 2. replace the `SpawnSpec` launch contract,
 3. require child runtimes to stream every token into the parent tape,
 4. require `.alan/memory/` to become a lossless transcript store,
-5. turn workspace `.alan/agent/` configuration into disposable runtime state.
+5. turn workspace `.alan/agents/default/` configuration into disposable runtime state.
 
 ## Stable Vocabulary
 
@@ -204,7 +204,7 @@ Rules:
 3. `.alan/memory/handoffs/`, `.alan/memory/daily/`, and
    `.alan/memory/sessions/` are generated episodic state unless a workspace
    deliberately opts into tracking them.
-4. `.alan/agent/` is the workspace default agent definition root.
+4. `.alan/agents/default/` is the workspace default agent definition root.
    `.alan/agents/<name>/` contains workspace named agent definition roots.
    These authored definitions, policies, or skills may be source-controlled
    when the project wants workspace-local agent configuration.

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ fmt:
 fmt-check:
     cargo fmt --all -- --check
 
+# Check agent-root layout ownership guardrails
+guard-agent-root-layout:
+    ./scripts/check-agent-root-layout-strings.sh
+
 # Run clippy
 lint:
     cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/openspec/changes/centralize-agent-root-layout-contract/.openspec.yaml
+++ b/openspec/changes/centralize-agent-root-layout-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/centralize-agent-root-layout-contract/design.md
+++ b/openspec/changes/centralize-agent-root-layout-contract/design.md
@@ -1,0 +1,134 @@
+## Context
+
+The current canonical layout is `.alan/agents/default/` for the default agent and
+`.alan/agents/<name>/` for named agents. The layout itself is now clearer, but the
+implementation still lets many modules construct agent-root paths directly. Runtime
+helpers exist, yet CLI, daemon, tests, and TUI code can still join literal path
+segments such as `.alan`, `agents`, `default`, `skills`, `persona`, and `agent.toml`
+on their own.
+
+That creates an architectural amplification surface: a layout change requires many
+call-site edits, and a missed writer can silently create files in the wrong location.
+The desired state is that `alan-runtime` owns agent-root layout semantics, while outer
+crates consume an explicit typed contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `alan-runtime` the single Rust source of truth for agent-root layout.
+- Provide typed helpers for every canonical agent-root asset path: root,
+  `agent.toml`, `persona/`, `skills/`, and `policy.yaml`.
+- Make omitted `agent_name`, explicit `default`, and named agents flow through one
+  normalization API.
+- Convert CLI and daemon write/read sites to the typed layout API.
+- Add tests or checks that make new production-code raw layout strings visible in
+  review.
+- Keep TUI setup behavior aligned without duplicating more path knowledge than needed.
+
+**Non-Goals:**
+
+- Changing the public on-disk layout again.
+- Reintroducing compatibility reads from `.alan/agent/`.
+- Moving all workspace path helpers out of their current crates.
+- Eliminating user-facing documentation examples of canonical paths.
+- Sharing Rust constants directly with TypeScript through code generation unless that
+  proves necessary.
+
+## Decisions
+
+### Introduce a typed `AgentRootLayout` API
+
+Add a small runtime-owned type such as `AgentRootLayout` or `AgentRootPaths` with
+methods for default and named roots:
+
+```text
+global_default_root()
+workspace_default_root(workspace_alan_dir)
+global_named_root(name)
+workspace_named_root(workspace_alan_dir, name)
+agent_config_path(root)
+persona_dir(root)
+skills_dir(root)
+policy_path(root)
+```
+
+The current free functions can either delegate to this type or be folded into it.
+The important boundary is that consumers ask for semantic paths rather than joining
+layout segments directly.
+
+Alternative considered: keep the current helper set and only add more tests. That
+would catch some regressions, but it does not make ownership obvious at call sites.
+
+### Keep agent-name normalization central
+
+The `default` reservation and single-component validation should live beside the
+layout API. Callers should not decide locally whether `default` is a named overlay or
+whether a candidate name is safe.
+
+Alternative considered: leave validation in daemon route helpers. That keeps local
+error messages simple, but it duplicates the most fragile semantic rule.
+
+### Make CLI and daemon writers depend on runtime layout
+
+`alan init`, connection pinning, workspace resolver creation, skill catalog, and
+skill override writes should all call runtime layout helpers. This keeps read and
+write paths symmetrical and prevents setup flows from creating paths runtime will not
+load.
+
+Alternative considered: introduce a separate `alan` crate helper. That would improve
+local deduplication but still leaves runtime and host crates with two layout owners.
+
+### Treat TypeScript as a small explicit contract
+
+The TUI currently needs a canonical default config path before the daemon is
+necessarily running. For now, keep a small TUI path helper and tests, but document it
+as a mirror of the runtime contract. Where daemon APIs already return canonical paths,
+the TUI should display returned values instead of recomputing them.
+
+Alternative considered: generate a shared constants file. That may be useful later,
+but it adds build-system complexity for a small client surface.
+
+### Add a guardrail for raw layout strings
+
+Add a focused test or script that scans Rust production files for raw canonical
+agent-root strings such as `.alan/agents/default`, `agents/default`, or
+`.join("agents").join("default")` outside approved modules and tests. The allowlist
+should include docs, OpenSpec changes, tests, and the runtime layout module.
+
+Alternative considered: rely on review discipline. The previous change showed that
+path strings are easy to copy, so a cheap mechanical guardrail is justified.
+
+## Risks / Trade-offs
+
+- Helper churn across many call sites -> Keep API small and add compatibility wrappers
+  for existing helper names during the refactor.
+- Over-abstracting simple paths -> Only model stable semantic assets, not every
+  transient runtime path.
+- Guardrail false positives -> Start with warning-style or focused test allowlists and
+  tune before making it too broad.
+- TUI still mirrors one path -> Keep it isolated in `config-path.ts` and prefer daemon
+  returned paths for all online flows.
+
+## Migration Plan
+
+1. Add runtime layout type and central name normalization while preserving current
+   helper functions as delegates.
+2. Move runtime internals to the new type.
+3. Convert CLI and daemon consumers in focused slices: init/workspace creation,
+   connection pinning, skill catalog, skill override, session creation.
+4. Update tests to use semantic helpers where possible, leaving literal paths only
+   where testing the actual external contract.
+5. Add raw-string guardrail and document the allowlist.
+6. Archive once OpenSpec tasks and focused verification pass.
+
+Rollback is straightforward because this change should not alter persisted data: keep
+the existing helper functions and revert call-site conversions if the new API proves
+awkward.
+
+## Open Questions
+
+- Should the guardrail live as a Rust test, a shell script under `scripts/`, or a
+  `just` target?
+- Should TUI eventually receive canonical setup paths from a lightweight CLI command
+  rather than mirroring path construction?

--- a/openspec/changes/centralize-agent-root-layout-contract/proposal.md
+++ b/openspec/changes/centralize-agent-root-layout-contract/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The `.alan/agent/` to `.alan/agents/default/` change exposed that agent-root
+layout is not owned by one module: runtime, daemon, CLI, TUI, docs, tests, and
+fixtures all had local path construction or duplicated canonical strings. That
+turns a layout-contract change into broad mechanical churn and makes missed
+writers/readers easy.
+
+## What Changes
+
+- Introduce a runtime-owned typed agent-root layout API that is the canonical
+  source for default and named agent paths.
+- Move `agent.toml`, `persona/`, `skills/`, and `policy.yaml` path construction
+  behind helper methods instead of local string joins.
+- Update CLI and daemon writers/readers to use runtime layout helpers rather than
+  duplicating `.alan/agents/default/` knowledge.
+- Add repository checks or focused tests that reject new raw canonical agent-root
+  layout strings in Rust production code outside the layout module.
+- Keep TypeScript/TUI behavior aligned through daemon-provided paths or a small
+  explicit client contract, rather than scattering path strings through UI code.
+- Do not change the public on-disk layout introduced by `unify-agent-root-paths`;
+  this is an ownership and coupling reduction change.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-root-layout-contract`: Defines ownership, typed APIs, allowed consumers,
+  and guardrails for canonical agent-root layout construction.
+
+### Modified Capabilities
+
+- None. No archived OpenSpec capabilities exist for agent-root layout yet.
+
+## Impact
+
+- `crates/runtime/src/agent_root.rs`, `paths.rs`, and related config/persona/policy
+  resolution code.
+- `crates/alan` CLI/daemon setup, connection pinning, workspace creation, skill
+  catalog, and skill override write paths.
+- TUI setup/config path detection if canonical path data remains duplicated in
+  TypeScript.
+- Tests and fixtures that currently assert literal `.alan/agents/default/...`
+  paths.
+- Documentation may be lightly updated to point to the canonical contract, but
+  this change should primarily reduce code coupling rather than alter user-facing
+  behavior.

--- a/openspec/changes/centralize-agent-root-layout-contract/specs/agent-root-layout-contract/spec.md
+++ b/openspec/changes/centralize-agent-root-layout-contract/specs/agent-root-layout-contract/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Runtime-owned agent-root layout
+Alan SHALL expose a runtime-owned typed API for canonical agent-root layout
+construction. Production Rust code outside the layout owner SHALL use that API for
+default roots, named roots, and standard agent-root asset paths.
+
+#### Scenario: Default root paths are requested semantically
+- **WHEN** a caller needs the global or workspace default agent root
+- **THEN** the caller can request the default root through the runtime layout API
+- **AND** the caller does not need to join literal `agents/default` path segments
+
+#### Scenario: Standard asset paths are requested semantically
+- **WHEN** a caller needs `agent.toml`, `persona/`, `skills/`, or `policy.yaml` under an agent root
+- **THEN** the caller can request the asset path through the runtime layout API
+- **AND** the returned path uses the canonical agent-root layout
+
+### Requirement: Centralized agent-name semantics
+Alan SHALL centralize agent-name normalization, validation, and `default` reservation
+semantics in the runtime layout contract.
+
+#### Scenario: Explicit default name is normalized once
+- **WHEN** a CLI, daemon, or runtime caller receives `agent_name = "default"`
+- **THEN** the caller uses the runtime normalization API
+- **AND** the result selects the default root chain rather than a named overlay
+
+#### Scenario: Named agent validation is shared
+- **WHEN** a caller receives a named agent value
+- **THEN** the runtime layout contract validates that it is a safe single path component
+- **AND** callers do not duplicate path traversal checks for agent-root layout decisions
+
+### Requirement: Writers and readers use the same layout contract
+Alan SHALL use the same runtime layout contract for agent-root reads and writes. Setup
+and mutation flows MUST NOT construct default agent-root paths independently from the
+runtime resolver.
+
+#### Scenario: Setup writes a loadable default config
+- **WHEN** `alan init`, connection pinning, or a setup flow writes a default `agent.toml`
+- **THEN** it writes to the path returned by the runtime layout contract
+- **AND** the runtime default config loader can read that same path without extra mapping
+
+#### Scenario: Workspace APIs write loadable assets
+- **WHEN** daemon workspace APIs write persona, policy, skill packages, or skill overrides
+- **THEN** they write to paths returned by the runtime layout contract
+- **AND** runtime discovery can load those assets from the same roots
+
+### Requirement: Client path mirrors are constrained
+Alan SHALL keep non-Rust mirrors of canonical setup paths isolated and explicitly
+tested. Daemon responses that already include canonical paths SHALL be preferred over
+client-side recomputation for online flows.
+
+#### Scenario: TUI setup needs an offline default config path
+- **WHEN** the TUI runs setup before a daemon is available
+- **THEN** any local default config path construction is isolated in a small helper
+- **AND** tests assert that helper matches the canonical user-facing path
+
+#### Scenario: TUI displays daemon-provided paths
+- **WHEN** a daemon API response includes a canonical config or agent-root path
+- **THEN** the TUI displays that returned path
+- **AND** the TUI does not recompute an equivalent path from duplicated layout rules
+
+### Requirement: Raw layout-string guardrail
+Alan SHALL provide a mechanical guardrail that detects new raw canonical agent-root
+layout strings in Rust production code outside approved layout-owner locations.
+
+#### Scenario: Production code adds a raw default-root string
+- **WHEN** production Rust code outside the runtime layout owner introduces a raw string such as `.alan/agents/default`
+- **THEN** the guardrail reports the occurrence
+- **AND** the fix is to use the runtime layout contract or add an explicit allowlist entry with justification
+
+#### Scenario: Tests and documentation use literal paths
+- **WHEN** tests, documentation, or OpenSpec artifacts use literal canonical paths to describe the external contract
+- **THEN** the guardrail allows those paths through an explicit scope or allowlist
+- **AND** the allowed usage does not become a production-code layout owner

--- a/openspec/changes/centralize-agent-root-layout-contract/tasks.md
+++ b/openspec/changes/centralize-agent-root-layout-contract/tasks.md
@@ -1,0 +1,39 @@
+## 1. Runtime Layout API
+
+- [ ] 1.1 Add a runtime-owned typed layout API for global/workspace default roots, named roots, and launch roots where applicable.
+- [ ] 1.2 Add semantic methods for `agent.toml`, `persona/`, `skills/`, and `policy.yaml` paths under an agent root.
+- [ ] 1.3 Centralize omitted/default/named agent-name normalization and single-component validation in the runtime layout module.
+- [ ] 1.4 Keep existing public path helper functions as delegates or update call sites in a compatibility-preserving order.
+
+## 2. Runtime Consumers
+
+- [ ] 2.1 Convert agent definition overlay resolution to use the typed layout API.
+- [ ] 2.2 Convert config overlay, persona assembly, prompt cache, policy resolution, and skill discovery tests/helpers to semantic layout helpers where practical.
+- [ ] 2.3 Preserve negative tests proving legacy `.alan/agent/` roots are not read or written.
+- [ ] 2.4 Verify package-local child-agent roots under skill-package `agents/<name>/` remain outside the workspace agent-root layout API.
+
+## 3. CLI And Daemon Consumers
+
+- [ ] 3.1 Convert `alan init` workspace structure creation to runtime layout helpers.
+- [ ] 3.2 Convert connection pin/default config path validation and writes to runtime layout helpers.
+- [ ] 3.3 Convert daemon workspace resolver, session creation, runtime manager, skill catalog, and skill override path construction to runtime layout helpers.
+- [ ] 3.4 Update route and integration tests to assert behavior through semantic helpers except where literal paths are the user-facing contract.
+
+## 4. TUI And Client Contract
+
+- [ ] 4.1 Keep TUI offline setup path construction isolated in `config-path.ts` and document it as a mirror of the runtime contract.
+- [ ] 4.2 Prefer daemon-returned canonical paths in TUI online flows and avoid recomputing equivalent paths in UI code.
+- [ ] 4.3 Update TUI tests to cover the isolated mirror and daemon-returned path display behavior.
+
+## 5. Guardrails And Documentation
+
+- [ ] 5.1 Add a raw-layout-string guardrail for Rust production code with an explicit allowlist for the runtime layout owner, tests, docs, and OpenSpec artifacts.
+- [ ] 5.2 Document the layout API ownership boundary in architecture or spec docs.
+- [ ] 5.3 Run a repo-wide search for `.alan/agents/default`, `agents/default`, and `.join("agents").join("default")`; convert production occurrences or justify allowlist entries.
+
+## 6. Verification
+
+- [ ] 6.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
+- [ ] 6.2 Run focused alan CLI/daemon tests for init, connection pinning, workspace routing, skill catalog, skill override, and session creation.
+- [ ] 6.3 Run focused TUI tests for setup/config path behavior.
+- [ ] 6.4 Run formatting, `cargo check -p alan-runtime -p alan`, `bun run lint` in `clients/tui`, guardrail checks, and OpenSpec validation.

--- a/openspec/changes/centralize-agent-root-layout-contract/tasks.md
+++ b/openspec/changes/centralize-agent-root-layout-contract/tasks.md
@@ -1,39 +1,39 @@
 ## 1. Runtime Layout API
 
-- [ ] 1.1 Add a runtime-owned typed layout API for global/workspace default roots, named roots, and launch roots where applicable.
-- [ ] 1.2 Add semantic methods for `agent.toml`, `persona/`, `skills/`, and `policy.yaml` paths under an agent root.
-- [ ] 1.3 Centralize omitted/default/named agent-name normalization and single-component validation in the runtime layout module.
-- [ ] 1.4 Keep existing public path helper functions as delegates or update call sites in a compatibility-preserving order.
+- [x] 1.1 Add a runtime-owned typed layout API for global/workspace default roots, named roots, and launch roots where applicable.
+- [x] 1.2 Add semantic methods for `agent.toml`, `persona/`, `skills/`, and `policy.yaml` paths under an agent root.
+- [x] 1.3 Centralize omitted/default/named agent-name normalization and single-component validation in the runtime layout module.
+- [x] 1.4 Keep existing public path helper functions as delegates or update call sites in a compatibility-preserving order.
 
 ## 2. Runtime Consumers
 
-- [ ] 2.1 Convert agent definition overlay resolution to use the typed layout API.
-- [ ] 2.2 Convert config overlay, persona assembly, prompt cache, policy resolution, and skill discovery tests/helpers to semantic layout helpers where practical.
-- [ ] 2.3 Preserve negative tests proving legacy `.alan/agent/` roots are not read or written.
-- [ ] 2.4 Verify package-local child-agent roots under skill-package `agents/<name>/` remain outside the workspace agent-root layout API.
+- [x] 2.1 Convert agent definition overlay resolution to use the typed layout API.
+- [x] 2.2 Convert config overlay, persona assembly, prompt cache, policy resolution, and skill discovery tests/helpers to semantic layout helpers where practical.
+- [x] 2.3 Preserve negative tests proving legacy `.alan/agent/` roots are not read or written.
+- [x] 2.4 Verify package-local child-agent roots under skill-package `agents/<name>/` remain outside the workspace agent-root layout API.
 
 ## 3. CLI And Daemon Consumers
 
-- [ ] 3.1 Convert `alan init` workspace structure creation to runtime layout helpers.
-- [ ] 3.2 Convert connection pin/default config path validation and writes to runtime layout helpers.
-- [ ] 3.3 Convert daemon workspace resolver, session creation, runtime manager, skill catalog, and skill override path construction to runtime layout helpers.
-- [ ] 3.4 Update route and integration tests to assert behavior through semantic helpers except where literal paths are the user-facing contract.
+- [x] 3.1 Convert `alan init` workspace structure creation to runtime layout helpers.
+- [x] 3.2 Convert connection pin/default config path validation and writes to runtime layout helpers.
+- [x] 3.3 Convert daemon workspace resolver, session creation, runtime manager, skill catalog, and skill override path construction to runtime layout helpers.
+- [x] 3.4 Update route and integration tests to assert behavior through semantic helpers except where literal paths are the user-facing contract.
 
 ## 4. TUI And Client Contract
 
-- [ ] 4.1 Keep TUI offline setup path construction isolated in `config-path.ts` and document it as a mirror of the runtime contract.
-- [ ] 4.2 Prefer daemon-returned canonical paths in TUI online flows and avoid recomputing equivalent paths in UI code.
-- [ ] 4.3 Update TUI tests to cover the isolated mirror and daemon-returned path display behavior.
+- [x] 4.1 Keep TUI offline setup path construction isolated in `config-path.ts` and document it as a mirror of the runtime contract.
+- [x] 4.2 Prefer daemon-returned canonical paths in TUI online flows and avoid recomputing equivalent paths in UI code.
+- [x] 4.3 Update TUI tests to cover the isolated mirror and daemon-returned path display behavior.
 
 ## 5. Guardrails And Documentation
 
-- [ ] 5.1 Add a raw-layout-string guardrail for Rust production code with an explicit allowlist for the runtime layout owner, tests, docs, and OpenSpec artifacts.
-- [ ] 5.2 Document the layout API ownership boundary in architecture or spec docs.
-- [ ] 5.3 Run a repo-wide search for `.alan/agents/default`, `agents/default`, and `.join("agents").join("default")`; convert production occurrences or justify allowlist entries.
+- [x] 5.1 Add a raw-layout-string guardrail for Rust production code with an explicit allowlist for the runtime layout owner, tests, docs, and OpenSpec artifacts.
+- [x] 5.2 Document the layout API ownership boundary in architecture or spec docs.
+- [x] 5.3 Run a repo-wide search for `.alan/agents/default`, `agents/default`, and `.join("agents").join("default")`; convert production occurrences or justify allowlist entries.
 
 ## 6. Verification
 
-- [ ] 6.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
-- [ ] 6.2 Run focused alan CLI/daemon tests for init, connection pinning, workspace routing, skill catalog, skill override, and session creation.
-- [ ] 6.3 Run focused TUI tests for setup/config path behavior.
-- [ ] 6.4 Run formatting, `cargo check -p alan-runtime -p alan`, `bun run lint` in `clients/tui`, guardrail checks, and OpenSpec validation.
+- [x] 6.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
+- [x] 6.2 Run focused alan CLI/daemon tests for init, connection pinning, workspace routing, skill catalog, skill override, and session creation.
+- [x] 6.3 Run focused TUI tests for setup/config path behavior.
+- [x] 6.4 Run formatting, `cargo check -p alan-runtime -p alan`, `bun run lint` in `clients/tui`, guardrail checks, and OpenSpec validation.

--- a/openspec/changes/centralize-daemon-api-contract/.openspec.yaml
+++ b/openspec/changes/centralize-daemon-api-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/centralize-daemon-api-contract/design.md
+++ b/openspec/changes/centralize-daemon-api-contract/design.md
@@ -1,0 +1,174 @@
+## Context
+
+Alan's daemon API is consumed by several in-repo clients and transport layers:
+the Axum daemon, CLI commands, the TUI client, relay proxying, remote-control
+scope enforcement, WebSocket handling, tests, and docs. Today those layers share
+the API contract mostly by convention:
+
+- `server.rs` registers literal route patterns.
+- `routes.rs` builds response URL fields with literal strings.
+- `remote_control.rs` infers required scopes with path prefix/suffix checks.
+- `relay.rs` parses forwarded paths and rewrites response URLs with local string
+  logic.
+- `clients/tui/src/client.ts` builds endpoint URLs manually.
+- `scripts/generate-ts-types.sh` writes fixed TypeScript text while claiming to
+  generate it from Rust protocol definitions.
+
+This is a high-amplification surface because a path, route capability, response
+shape, or event type change can silently drift in one consumer while compiling
+elsewhere.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make daemon endpoint identity, route patterns, URL construction, remote scope,
+  and relay behavior explicit in one Rust-owned contract.
+- Keep first-pass public routes stable while replacing local string construction.
+- Give Rust clients and TypeScript clients a generated or checked endpoint
+  surface instead of manually reconstructing paths.
+- Add drift checks that catch missing endpoint metadata, stale generated client
+  helpers, stale protocol event types, and incomplete remote/relay coverage.
+- Keep the implementation incremental so route registration can migrate without a
+  daemon rewrite.
+
+**Non-Goals:**
+
+- Do not introduce `/api/v2` or rename endpoints as part of this change.
+- Do not require every daemon response/request payload to have complete OpenAPI
+  coverage before the path and scope contract lands.
+- Do not split large daemon/TUI modules for its own sake.
+- Do not change runtime protocol semantics.
+
+## Decisions
+
+### Decision: Add a Rust-first daemon API contract module
+
+Create a daemon module such as `crates/alan/src/daemon/api_contract.rs` that owns
+endpoint IDs, methods, Axum route patterns, concrete path builders, client URL
+builders, remote scope metadata, relay forwarding policy, and response URL field
+metadata.
+
+Rationale: The daemon is the server authority and already owns handler wiring.
+Keeping the source in Rust lets server registration, Rust clients, relay, and
+remote-control checks share a typed surface without a separate schema compiler
+becoming the source of truth.
+
+Alternative considered: make TypeScript or OpenAPI the source of truth. That
+would make the TUI comfortable but invert ownership away from the daemon and add
+more migration work before the existing Rust path consumers can benefit.
+
+### Decision: Keep route registration explicit, but driven by constants/helpers
+
+Axum route wiring can remain readable in `server.rs`, but path strings must come
+from the contract module. For example, a session create/list endpoint can expose
+a `SESSIONS` route pattern and concrete builders for `/api/v1/sessions`, while
+session-specific endpoints expose typed builders for `{id}` paths.
+
+Rationale: A full declarative router table would force all handler registration
+through a larger abstraction. The first implementation only needs to remove
+duplicated route knowledge, not hide Axum.
+
+Alternative considered: generate the Axum router from endpoint descriptors. This
+could be attractive later, but it is a larger refactor and makes handler-specific
+method composition harder to review.
+
+### Decision: Store remote scope and relay policy with endpoint metadata
+
+Each endpoint that participates in remote access must have explicit metadata for
+the required `SessionScope` and relay behavior. `remote_control.rs` should match
+requests against the contract rather than relying on broad suffix rules such as
+`ends_with("/submit")` or `starts_with("/api/v1/connections")`. `relay.rs` should
+use the same contract to decide which forwarded paths are allowed, which paths
+are streaming/WebSocket, and which response fields need relay URL rewriting.
+
+Rationale: Security and transport semantics are part of the API contract. They
+should not be inferred independently from path spelling.
+
+Alternative considered: keep path-based matching and add more tests. Tests help,
+but they still require every endpoint author to remember parallel logic in
+server, relay, and auth code.
+
+### Decision: Generate TypeScript endpoint helpers from a daemon manifest
+
+Expose a deterministic API contract manifest from Rust, either through a small
+binary/test helper or a scriptable command, and generate
+`clients/tui/src/generated/api-contract.ts` from it. The generated helper should
+provide endpoint IDs and URL builder functions, and TUI client code should call
+those helpers instead of embedding `/api/v1/...` strings.
+
+Rationale: Endpoint helper generation removes the biggest TUI string-drift
+surface without requiring full payload schema generation to be solved first.
+
+Alternative considered: manually mirror endpoint constants in TypeScript. That
+would improve local organization but preserve the cross-language drift problem.
+
+### Decision: Convert protocol/API type generation into a checked surface
+
+Replace the current hard-coded `generate-ts-types.sh` behavior with one of:
+
+1. real Rust-to-TypeScript generation for protocol and selected daemon payloads,
+   if a lightweight dependency fits the workspace; or
+2. schema/snapshot checks that compare Rust-emitted event/payload metadata
+   against the TypeScript generated files.
+
+The implementation must stop presenting static heredocs as generated from Rust.
+
+Rationale: A complete OpenAPI effort is not required to remove immediate drift,
+but the current script gives false confidence. A generated or checked surface is
+needed before protocol and client evolution can be trusted.
+
+Alternative considered: leave payload types manual and only generate endpoint
+paths. That would solve route churn but leave known event/type drift unresolved.
+
+### Decision: Start with session, connection, skill, relay, and health endpoints
+
+The initial contract must cover every endpoint registered by the daemon today:
+health, connections, sessions, skills, WebSocket, events, and relay routes. The
+first migration should avoid adding new endpoints until existing ones are
+described.
+
+Rationale: Partial route registries are easy to ignore. The value comes from a
+testable inventory that fails when a new route is added without metadata.
+
+Alternative considered: only cover session endpoints first. That would reduce
+scope, but remote-control and relay risks cross sessions/connections/relay.
+
+## Risks / Trade-offs
+
+- Rust contract manifest grows too large -> Split descriptors by area
+  (`sessions`, `connections`, `skills`, `relay`) behind one public registry.
+- Route matching becomes subtly different from Axum matching -> Add table-driven
+  tests that assert representative concrete paths resolve to the same endpoint
+  metadata and handler expectations.
+- TypeScript generation adds build friction -> Keep generation as an explicit
+  script/test first, and fail drift in CI rather than during normal `cargo build`.
+- Payload type generation is harder than endpoint generation -> Land endpoint
+  helpers and event/type drift checks first, then expand payload coverage in
+  focused tasks.
+- Remote access authorization changes accidentally -> Preserve existing scopes
+  with golden tests before moving logic behind the contract.
+
+## Migration Plan
+
+1. Add the contract module with descriptors for all current daemon endpoints and
+   tests that the inventory contains every route pattern from `server.rs`.
+2. Replace response URL construction in daemon route responses with contract
+   builders.
+3. Replace remote-control scope inference and relay route handling with contract
+   matching while preserving existing behavior.
+4. Generate TypeScript endpoint helpers from the manifest and migrate TUI client
+   calls to them.
+5. Replace or constrain the TypeScript type generation script so protocol event
+   and selected daemon payload types are generated or checked against Rust.
+6. Update docs/tests to reference contract helpers or generated surfaces instead
+   of raw endpoint strings where practical.
+
+## Open Questions
+
+- Which Rust-to-TS tool, if any, best fits the workspace without adding heavy
+  compile-time dependencies?
+- Should the daemon expose the API contract manifest through an internal command
+  only, or also as a debug endpoint?
+- Should Apple client helpers be generated in the same phase or covered by a
+  follow-up once the TUI path is proven?

--- a/openspec/changes/centralize-daemon-api-contract/proposal.md
+++ b/openspec/changes/centralize-daemon-api-contract/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Daemon API changes currently fan out across manually maintained route strings,
+response structs, relay path rewriting, remote-control scope checks, CLI clients,
+TUI clients, tests, and documentation. The route and payload contract needs one
+owned source so endpoint changes are deliberate instead of broad mechanical
+search-and-edit work.
+
+## What Changes
+
+- Introduce a daemon-owned API contract layer for canonical endpoint identifiers,
+  route patterns, URL builders, and response URL construction.
+- Route Axum registration, daemon response URL fields, CLI calls, relay rewriting,
+  and remote-control authorization through the same endpoint contract.
+- Replace ad hoc frontend API strings with a client endpoint helper generated
+  from, or checked against, the daemon contract.
+- Replace the current hand-written "generated" TypeScript protocol/API file with
+  a real generated or schema-checked contract for protocol events and selected
+  daemon API payloads.
+- Add drift checks that fail when server routes, remote-control scope rules,
+  relay path handling, or TypeScript client endpoint/type surfaces diverge.
+- Keep existing public endpoint paths stable in the first implementation unless
+  an individual task explicitly marks a breaking route change.
+
+## Capabilities
+
+### New Capabilities
+
+- `daemon-api-contract`: Defines canonical ownership, route construction,
+  client-facing URL helpers, remote access scope metadata, relay rewrite rules,
+  and generated/schema-checked type surfaces for the daemon HTTP/WebSocket API.
+
+### Modified Capabilities
+
+- None. No archived OpenSpec capability currently owns the daemon API contract.
+
+## Impact
+
+- `crates/alan/src/daemon/server.rs`, `routes.rs`, `websocket.rs`,
+  `relay.rs`, and `remote_control.rs`.
+- `crates/alan/src/cli/ask.rs` and any other Rust clients that construct daemon
+  URLs.
+- `clients/tui/src/client.ts`, `clients/tui/src/types.ts`,
+  `clients/tui/src/generated/`, `clients/tui/src/client.test.ts`, and the TS type
+  generation script.
+- Protocol and daemon API serialization tests, especially event and session
+  response compatibility tests.
+- Documentation examples that show daemon API routes.

--- a/openspec/changes/centralize-daemon-api-contract/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/centralize-daemon-api-contract/specs/daemon-api-contract/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Canonical Endpoint Registry
+The daemon SHALL define a canonical endpoint registry that lists every supported
+HTTP and WebSocket endpoint with a stable endpoint id, HTTP method, route pattern,
+path parameters, and API area.
+
+#### Scenario: all registered daemon routes have endpoint metadata
+- **WHEN** the daemon router is built
+- **THEN** every public route registered by the daemon has a matching endpoint
+  registry entry
+
+#### Scenario: adding a route without metadata fails verification
+- **WHEN** a developer adds a public daemon route without adding a registry entry
+- **THEN** the route contract verification fails
+
+### Requirement: Shared URL Construction
+The daemon SHALL use endpoint contract helpers to construct session response URLs
+and client-facing API paths instead of hand-written route strings.
+
+#### Scenario: create-session response uses contract builders
+- **WHEN** a session is created
+- **THEN** the returned `websocket_url`, `events_url`, and `submit_url` values are
+  built from the canonical endpoint contract
+
+#### Scenario: fork-session response uses contract builders
+- **WHEN** a session is forked
+- **THEN** the returned child session URLs are built from the canonical endpoint
+  contract
+
+### Requirement: Remote Access Scope Metadata
+The daemon SHALL derive remote-control authorization requirements from endpoint
+contract metadata rather than independent path prefix or suffix rules.
+
+#### Scenario: endpoint scope is resolved from metadata
+- **WHEN** remote-control middleware evaluates a daemon request
+- **THEN** it resolves the required `SessionScope` from the matched endpoint
+  metadata
+
+#### Scenario: unknown API path is not silently treated as a known endpoint
+- **WHEN** remote-control middleware evaluates an unknown `/api/v1/...` path
+- **THEN** it applies the configured unknown-path behavior explicitly and records
+  that no endpoint metadata matched
+
+### Requirement: Relay Policy Metadata
+The daemon SHALL derive relay forwarding, streaming exclusion, WebSocket
+exclusion, session binding extraction, and response URL rewriting from endpoint
+contract metadata.
+
+#### Scenario: relay forwarding allows only contract-approved endpoints
+- **WHEN** a relay request attempts to forward a daemon API path
+- **THEN** the relay layer allows forwarding only when the matched endpoint
+  metadata permits relay forwarding
+
+#### Scenario: relay URL rewriting uses response URL metadata
+- **WHEN** a relayed session lifecycle response contains daemon-relative URL
+  fields
+- **THEN** the relay layer rewrites only the response fields identified by the
+  endpoint contract
+
+### Requirement: Generated Client Endpoint Helpers
+The repository SHALL generate or verify TypeScript client endpoint helpers from
+the daemon endpoint contract, and the TUI daemon client SHALL use those helpers
+for API path construction.
+
+#### Scenario: generated endpoint helper is current
+- **WHEN** the daemon endpoint contract changes
+- **THEN** the generated TypeScript endpoint helper changes deterministically or
+  a drift check fails
+
+#### Scenario: TUI client avoids raw daemon route construction
+- **WHEN** the TUI daemon client calls a supported API endpoint
+- **THEN** it constructs the path through the generated endpoint helper rather
+  than embedding a raw `/api/v1/...` string
+
+### Requirement: Protocol And Payload Drift Checks
+The repository SHALL replace static hand-written generated TypeScript protocol
+files with a real generated or schema-checked surface for protocol event types
+and selected daemon API payloads.
+
+#### Scenario: protocol event list drifts
+- **WHEN** the Rust protocol event enum adds, removes, or renames a serialized
+  event type
+- **THEN** the TypeScript generated or checked protocol surface detects the
+  difference
+
+#### Scenario: selected daemon payload drifts
+- **WHEN** a selected daemon API response shape changes in Rust
+- **THEN** the TypeScript generated or checked payload surface detects the
+  difference
+
+### Requirement: Public Route Compatibility
+The first implementation SHALL preserve existing public daemon route paths unless
+a task explicitly marks a route change as breaking and provides migration notes.
+
+#### Scenario: contract migration keeps route paths stable
+- **WHEN** the endpoint registry is introduced
+- **THEN** existing public session, connection, skill, relay, WebSocket, and
+  health route paths continue to resolve as before
+
+### Requirement: Raw Route String Guardrail
+The repository SHALL include focused guardrails that prevent new raw canonical
+daemon route strings in production client, relay, remote-control, and daemon URL
+construction code outside the approved contract or generated files.
+
+#### Scenario: raw route string is added outside allowed files
+- **WHEN** production code outside the approved contract or generated files adds
+  a new raw `/api/v1/...` route string
+- **THEN** the route string guardrail fails and points to the endpoint contract
+  helper surface

--- a/openspec/changes/centralize-daemon-api-contract/tasks.md
+++ b/openspec/changes/centralize-daemon-api-contract/tasks.md
@@ -1,0 +1,48 @@
+## 1. Endpoint Contract Inventory
+
+- [ ] 1.1 Add a daemon API contract module with endpoint ids, methods, route patterns, path parameters, API areas, and public metadata types.
+- [ ] 1.2 Describe every current health, connection, session, skill, WebSocket, events, and relay endpoint in the endpoint registry.
+- [ ] 1.3 Add endpoint path builder helpers for concrete client-facing paths, including encoded path parameters where needed.
+- [ ] 1.4 Add tests that fail when a route registered by the daemon is missing endpoint metadata.
+
+## 2. Server And Rust Client Consumers
+
+- [ ] 2.1 Convert daemon route registration to use contract route-pattern constants or helpers while preserving existing paths.
+- [ ] 2.2 Convert create-session and fork-session response URL construction to use endpoint contract builders.
+- [ ] 2.3 Convert Rust daemon clients such as `alan ask` to use endpoint contract URL/path helpers instead of hand-written API strings.
+- [ ] 2.4 Add compatibility tests for representative existing route paths and session response URL fields.
+
+## 3. Remote Access And Relay
+
+- [ ] 3.1 Add explicit remote `SessionScope` metadata for all endpoints that participate in remote access.
+- [ ] 3.2 Convert remote-control required-scope resolution to match endpoint metadata rather than prefix/suffix rules.
+- [ ] 3.3 Add explicit relay forwarding, streaming, WebSocket, lifecycle, and response-rewrite metadata to the endpoint contract.
+- [ ] 3.4 Convert relay forwarding validation, session id extraction, lifecycle detection, and response URL rewriting to contract helpers.
+- [ ] 3.5 Preserve existing remote-control and relay behavior with table-driven tests for session, connection, skill, relay, unknown, streaming, and WebSocket paths.
+
+## 4. TypeScript Endpoint Surface
+
+- [ ] 4.1 Add a deterministic Rust-emitted daemon API contract manifest suitable for TypeScript generation or drift checks.
+- [ ] 4.2 Generate `clients/tui/src/generated/api-contract.ts` endpoint ids and path builders from the daemon manifest.
+- [ ] 4.3 Convert `clients/tui/src/client.ts` to use generated endpoint helpers for supported API calls.
+- [ ] 4.4 Update TUI client tests to assert behavior through generated helpers instead of duplicating raw paths where practical.
+
+## 5. Protocol And Payload Drift Checks
+
+- [ ] 5.1 Replace the static heredoc-only `scripts/generate-ts-types.sh` flow with real generation or Rust-backed schema/snapshot checks.
+- [ ] 5.2 Cover protocol event type serialization drift, including runtime heartbeat, compaction observed, and memory flush observed events.
+- [ ] 5.3 Cover selected daemon payload drift for session creation/list/read responses, child-run responses, and connection profile responses.
+- [ ] 5.4 Document any payload types intentionally left manual and add follow-up TODOs only where there is a concrete blocker.
+
+## 6. Guardrails And Documentation
+
+- [ ] 6.1 Add a raw route string guardrail for production daemon, CLI, relay, remote-control, and TUI client code outside approved contract/generated files.
+- [ ] 6.2 Update daemon API documentation examples to reference the canonical contract and keep public path examples stable.
+- [ ] 6.3 Run a repo-wide search for raw `/api/v1/` strings and convert production occurrences or justify allowlist entries.
+
+## 7. Verification
+
+- [ ] 7.1 Run focused Rust tests for daemon route registration, route matching, response URL builders, remote-control scope resolution, and relay rewriting.
+- [ ] 7.2 Run focused TUI tests for generated endpoint helpers and daemon client API calls.
+- [ ] 7.3 Run the TypeScript generation or drift-check script and verify no generated files are stale.
+- [ ] 7.4 Run formatting, `cargo check -p alan`, relevant `cargo test -p alan` filters, relevant TUI tests, guardrail checks, and OpenSpec validation.

--- a/openspec/changes/sub-agent-lifecycle-control/.openspec.yaml
+++ b/openspec/changes/sub-agent-lifecycle-control/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/sub-agent-lifecycle-control/design.md
+++ b/openspec/changes/sub-agent-lifecycle-control/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Issues #312-#319 come from the same operational failure mode: delegated work exists, but the parent runtime and human operator do not have a reliable lifecycle record for it. The current child runtime path in `crates/runtime/src/runtime/child_agents.rs` launches a child, waits for terminal events, and uses a single timeout sleep. `crates/runtime/src/runtime/virtual_tools.rs` then persists a bounded delegated result whose summary is silently capped at 320 characters. Memory surfaces in `crates/runtime/src/runtime/memory_surfaces.rs` use arbitrary character truncation, and daemon/TUI surfaces have no child-run control plane.
+
+The target contract is already documented in `docs/spec/sub_agent_lifecycle_contract.md`, and the issue map is tracked in `plans/2026-04-28-sub-agent-lifecycle-memory-plan.md`. This OpenSpec change turns that contract into implementation slices.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every delegated child launch observable through a child-run record before initial submission.
+- Use heartbeat/progress freshness for child timeout classification instead of only launch wall-clock duration.
+- Give daemon, TUI, and parent runtime paths the same termination state transition.
+- Preserve completed child output fidelity through full output fields or inspectable references plus explicit preview/truncation metadata.
+- Keep generated memory and `.alan` runtime state coherent, human-readable, and out of normal source status.
+- Canonicalize workspace identity paths sufficiently to avoid Alan-home `.alan/.alan` nesting and case-variant duplicates.
+
+**Non-Goals:**
+
+- Replace the spawn/skill execution contract wholesale.
+- Stream all child tokens into the parent tape.
+- Build durable recovery for child-run records beyond the metadata already persisted in sessions/rollouts.
+- Make generated memory files a lossless transcript store.
+- Remove support for source-controlled `.alan/agent/`, `.alan/agents/`, policies, or authored skills.
+
+## Decisions
+
+### Child-Run Registry Lives In Runtime, Mirrored By Daemon
+
+Add runtime-owned child-run metadata types and a registry handle that child launch/supervision updates directly. Parent runtime execution needs this state before the daemon sees it, so the runtime is the source of truth for lifecycle transitions. The daemon exposes read/list/terminate APIs by querying runtime manager state for active sessions and by returning the last known metadata stored in session state.
+
+Alternative considered: daemon-only registry keyed by session events. That would miss child launches before events are bridged and would not help parent-runtime virtual tools terminate children without going through HTTP.
+
+### Liveness Uses Idle Timeout Plus Optional Wall-Clock Cap
+
+Child supervision tracks `latest_progress_at` and `latest_heartbeat_at`. Any child event for the active submission updates progress. A heartbeat ticker updates heartbeat while the child controller is waiting, so long-running but live children do not trip the delegated timeout. `timeout_secs` becomes the idle timeout. A larger wall-clock cap can be derived as a guard, but timeout classification is based on idle freshness.
+
+Alternative considered: simply increase `timeout_secs`. That only masks the issue and still cannot distinguish dead children from quiet but healthy children.
+
+### Termination Is A Shared Lifecycle Transition
+
+Daemon endpoints, TUI commands, and the parent virtual tool all call one runtime-manager termination path with `{child_run_id, actor, mode, reason}`. Graceful termination calls child shutdown/cancellation first; forceful termination aborts. The child-run record moves through `terminating` to `terminated` or remains terminal if it was already complete.
+
+Alternative considered: implement separate TUI-only and model-only kill paths. That would produce divergent audit semantics and make lifecycle tests brittle.
+
+### Result Handoff Separates Preview From Output
+
+Keep a compact tape payload, but change the delegated result shape so truncation is explicit. A completed child result contains `summary`, optional `summary_preview`, `child_run`, `output_text` or `output_ref`, optional structured output/ref, and a `truncation` object. Rollout payloads keep enough metadata to retrieve full text from child rollout when the tape preview is bounded.
+
+Alternative considered: store full child output directly in every parent tool message. That preserves fidelity but increases parent tape size and makes compaction worse.
+
+### Memory Surfaces Are Agent-Authored Through The Memory Skill
+
+Semantic memory surfaces should be produced by the active agent through the `memory` skill or another explicit agent-visible memory workflow. That lets the same governed turn decide durable decisions, constraints, open loops, references, and next actions without adding an uncontrolled runtime-internal model call. Runtime still owns validation, path/budget enforcement, persistence, and deterministic fallback rendering.
+
+Deterministic line-aware truncation remains the fallback when the skill is unavailable, the agent does not author a summary, memory writes fail, cancellation prevents a final summary, or hard safety budgets require a bounded generated surface.
+
+Alternative considered: hidden runtime LLM summarization. That would preserve more semantics than truncation, but it introduces an ungoverned model call outside the agent's visible skill/tool flow. Another alternative was only using Markdown-aware truncation. That prevents broken fragments but still lets length, not semantic importance, decide what survives.
+
+### Path Hygiene Uses Existing Workspace Resolver Boundaries
+
+Fix Alan-home nesting and path canonicalization in `workspace_resolver`, `registry`, runtime path helpers, and runtime manager comparisons rather than inventing a new workspace identity service. Generated `.alan` runtime paths are ignored by repo rules, while authored agent roots remain trackable.
+
+Alternative considered: make all `.alan/` ignored. That would block workspace-local agent definitions and policies from being intentionally committed.
+
+## Risks / Trade-offs
+
+- Registry only in memory for active runtimes -> expose rollout/session references in terminal records and preserve enough payload metadata for debugging after runtime shutdown.
+- Heartbeat ticker may report liveness while a child is stuck in a long tool call -> treat heartbeat as runtime liveness, not user-visible progress, and keep optional wall-clock cap plus active tool/progress metadata.
+- Result payload shape changes can affect prompt expectations -> keep `status` and `summary` stable, add fields compatibly, and update skill injection/docs.
+- Skill-authored memory summaries depend on agent behavior -> keep deterministic fallback rendering, make the memory skill explicit about continuation summaries, and never block turn completion on a memory surface failure.
+- TUI command scope can grow quickly -> implement the minimum commands from the contract and keep formatting text-only.
+- Path canonicalization differs by filesystem -> canonicalize when the path exists, normalize stored identities, and test case behavior conditionally where the platform supports it.
+
+## Migration Plan
+
+1. Add OpenSpec specs/tasks and keep `docs/spec/sub_agent_lifecycle_contract.md` as the narrative target contract.
+2. Implement runtime child-run metadata, liveness, result payload, and memory/path fixes with focused unit tests.
+3. Add daemon endpoints and TUI commands once runtime state is available.
+4. Update docs and `.gitignore`.
+5. Run `cargo test` for touched crates and `bun test` for TUI command/client coverage.
+
+Rollback is source-level: the change adds metadata and endpoints compatibly, so reverting the implementation and generated OpenSpec artifacts restores the prior behavior.
+
+## Open Questions
+
+- Whether child-run metadata should be persisted as its own file format or remain recoverable through rollout/session state in the first implementation.
+- The exact wall-clock cap default when `timeout_secs` is small or absent.
+- Whether parent-runtime `terminate_child_run` should be included in all virtual tool sets or only when delegated skills are available.

--- a/openspec/changes/sub-agent-lifecycle-control/design.md
+++ b/openspec/changes/sub-agent-lifecycle-control/design.md
@@ -21,7 +21,7 @@ The target contract is already documented in `docs/spec/sub_agent_lifecycle_cont
 - Stream all child tokens into the parent tape.
 - Build durable recovery for child-run records beyond the metadata already persisted in sessions/rollouts.
 - Make generated memory files a lossless transcript store.
-- Remove support for source-controlled `.alan/agent/`, `.alan/agents/`, policies, or authored skills.
+- Remove support for source-controlled `.alan/agents/default/`, `.alan/agents/<name>/`, policies, or authored skills.
 
 ## Decisions
 

--- a/openspec/changes/sub-agent-lifecycle-control/proposal.md
+++ b/openspec/changes/sub-agent-lifecycle-control/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Delegated child runtimes currently fail as opaque side effects: parents see hard timeouts, lossy 320-character summaries, and generated memory/runtime files that are hard to trust. Issues #312-#319 need one coordinated change because liveness, child-run state, result handoff, memory surfaces, and workspace path hygiene all affect whether a parent runtime or operator can safely supervise delegated work.
+
+## What Changes
+
+- Add first-class child-run lifecycle state with heartbeat/progress timestamps, terminal status, rollout metadata, and daemon read/list/control APIs.
+- Replace delegated child hard timeout behavior with idle-timeout semantics backed by child heartbeat/progress, with an optional larger wall-clock cap as a resource guard.
+- Add explicit child termination paths shared by daemon/TUI operators and governed parent-runtime tooling, recording actor, reason, mode, and final state.
+- Preserve delegated result fidelity by separating full output from bounded previews and adding explicit truncation/reference metadata.
+- Make semantic memory/handoff summaries an agent-visible memory skill behavior, with runtime line/section-aware fallback rendering after completed turn state is known.
+- Ignore generated workspace `.alan` runtime state by default while keeping authored agent roots trackable.
+- Canonicalize workspace identities enough to prevent Alan-home `.alan/.alan` nesting and path-case duplicates on case-insensitive filesystems.
+
+## Capabilities
+
+### New Capabilities
+
+- `child-run-lifecycle`: Child runtimes expose lifecycle records, liveness, timeout classification, daemon control, TUI inspection, and governed termination.
+- `delegated-result-handoff`: Delegated child results preserve full output or inspectable references while keeping previews bounded and labeled.
+- `runtime-memory-surfaces`: Agent-authored memory and handoff summaries preserve semantic state, while generated fallback surfaces truncate coherently and reflect terminal turn/plan state.
+- `workspace-runtime-state-hygiene`: Generated `.alan` runtime state is separated from source-controlled agent definitions and workspace identity paths are canonicalized.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Runtime/protocol: child event handling, spawn supervision, virtual tools, result payloads, rollout references, memory refresh.
+- Daemon API: child-run list/read/terminate endpoints and runtime-manager/session-store state.
+- TUI: `/agents`, `/agent <id>`, `/agent terminate`, `/agent kill`, help text, client calls, compact HUD child count.
+- Repository/docs: `.gitignore`, generated-state documentation, path-resolution behavior.
+- Tests: runtime lifecycle and timeout tests, daemon route tests, TUI command parsing/client tests, memory skill/fallback surface tests, and path hygiene tests.

--- a/openspec/changes/sub-agent-lifecycle-control/specs/child-run-lifecycle/spec.md
+++ b/openspec/changes/sub-agent-lifecycle-control/specs/child-run-lifecycle/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Child Run Registration
+The system SHALL create a child-run record before submitting the first operation to a delegated child runtime.
+
+#### Scenario: Delegated child is launched
+- **WHEN** a parent runtime launches a delegated child runtime
+- **THEN** the child-run registry contains a record with parent session id, child session id, workspace metadata, rollout path when available, launch metadata, created time, and `starting` or `running` status before the child receives its initial turn
+
+#### Scenario: Child launch fails after runtime startup
+- **WHEN** child launch fails after a child session id or rollout path is known
+- **THEN** the child-run record is updated to `failed` with terminal metadata instead of disappearing from the registry
+
+### Requirement: Child Liveness And Timeout Classification
+The system SHALL classify child timeouts by idle liveness freshness rather than only elapsed launch wall-clock time.
+
+#### Scenario: Child exceeds original timeout while heartbeat is fresh
+- **WHEN** a child runtime runs longer than its configured idle timeout duration but heartbeat or progress signals continue to arrive within the idle window
+- **THEN** the parent runtime MUST NOT classify the child as `timed_out`
+
+#### Scenario: Child becomes idle
+- **WHEN** no child heartbeat or progress signal arrives within the idle timeout window
+- **THEN** the child-run record is updated to `timed_out` and the handoff includes latest heartbeat/progress metadata
+
+### Requirement: Child Progress Metadata
+The system SHALL update child-run progress metadata from child events and heartbeat signals.
+
+#### Scenario: Child emits a runtime event
+- **WHEN** the parent observes a child event for the active child submission
+- **THEN** the child-run record updates latest progress time, latest event cursor or sequence when available, and current compact status when derivable
+
+#### Scenario: Child is active but quiet
+- **WHEN** a child runtime is still active but produces no user-visible output
+- **THEN** the child runtime or supervising controller records heartbeat freshness so the operator can distinguish quiet activity from a dead child
+
+### Requirement: Daemon Child-Run Control Plane
+The daemon SHALL expose APIs to list, read, and terminate child runs for a parent session.
+
+#### Scenario: List child runs
+- **WHEN** a client requests child runs for a parent session
+- **THEN** the daemon returns all known child runs for that session with status, workspace, rollout path, latest heartbeat/progress, and terminal metadata
+
+#### Scenario: Read one child run
+- **WHEN** a client requests a child run by id under a parent session
+- **THEN** the daemon returns the child-run record or a not-found error if the parent has no matching child run
+
+#### Scenario: Request termination
+- **WHEN** a client requests child termination with a reason and graceful or forceful mode
+- **THEN** the daemon routes the request through the runtime child-run lifecycle transition and records actor, reason, mode, requested time, and final status
+
+### Requirement: TUI Child-Agent Commands
+The TUI SHALL expose child-agent management commands backed by the daemon child-run control plane.
+
+#### Scenario: List child agents
+- **WHEN** the operator enters `/agents`
+- **THEN** the TUI lists child runs for the current session grouped or marked by lifecycle status
+
+#### Scenario: Inspect child agent
+- **WHEN** the operator enters `/agent <id>`
+- **THEN** the TUI shows status, workspace, rollout path, latest heartbeat/progress, and current tool or plan summary when available
+
+#### Scenario: Terminate child agent
+- **WHEN** the operator enters `/agent terminate <id> [reason]`
+- **THEN** the TUI requests graceful child-run termination and reports the resulting lifecycle state
+
+#### Scenario: Kill child agent
+- **WHEN** the operator enters `/agent kill <id> [reason]`
+- **THEN** the TUI requests forceful child-run termination and reports the resulting lifecycle state
+
+### Requirement: Governed Parent Child Termination
+The parent runtime SHALL expose a governed virtual tool for terminating a known child run.
+
+#### Scenario: Parent terminates known child
+- **WHEN** the parent runtime invokes child termination with a known child id, reason, and mode
+- **THEN** the runtime applies governance/audit semantics and records the termination request on the child-run record
+
+#### Scenario: Parent terminates unknown child
+- **WHEN** the parent runtime invokes child termination for an unknown child id
+- **THEN** the tool returns a structured failure without changing unrelated child-run records
+
+#### Scenario: Parent terminates terminal child
+- **WHEN** the parent runtime invokes child termination for a child run that is already terminal
+- **THEN** the tool returns the existing terminal state and records no duplicate termination transition

--- a/openspec/changes/sub-agent-lifecycle-control/specs/delegated-result-handoff/spec.md
+++ b/openspec/changes/sub-agent-lifecycle-control/specs/delegated-result-handoff/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Completed Child Output Fidelity
+The system SHALL preserve completed delegated child output as full inline text or an inspectable output reference instead of silently replacing it with an unlabeled short preview.
+
+#### Scenario: Child returns short output
+- **WHEN** a completed delegated child returns output that fits the parent tape budget
+- **THEN** the delegated result includes the full `output_text` and does not mark it as truncated
+
+#### Scenario: Child returns long output
+- **WHEN** a completed delegated child returns output that exceeds the parent tape budget
+- **THEN** the delegated result includes a bounded preview, an `output_ref` or rollout/session reference for the full text, and truncation metadata that states what was omitted
+
+### Requirement: Delegated Result Shape
+The delegated result payload SHALL distinguish summary, preview, full output, child-run reference, structured output, and truncation metadata.
+
+#### Scenario: Completed child result is persisted
+- **WHEN** a completed child result is recorded in the parent tape or rollout
+- **THEN** the result contains `status`, `summary`, `child_run`, and either `output_text` or `output_ref`
+
+#### Scenario: Summary is shortened
+- **WHEN** the result summary is shortened for tape compactness
+- **THEN** the result includes `summary_preview` and truncation metadata so the parent can tell the summary was intentionally shortened
+
+#### Scenario: Structured output is large
+- **WHEN** structured output exceeds the inline budget
+- **THEN** the result preserves critical keys such as `status` and `summary`, includes a structured output reference or bounded structured preview, and records explicit truncation metadata
+
+### Requirement: Failed Child Handoff Metadata
+The system SHALL include child-run metadata and latest progress information when a child fails, pauses, is cancelled, is terminated, or times out.
+
+#### Scenario: Child times out
+- **WHEN** a delegated child reaches idle timeout
+- **THEN** the delegated result includes `error_kind`, `error_message`, child-run reference, rollout path when available, latest heartbeat/progress metadata, and terminal status `timed_out`
+
+#### Scenario: Child is explicitly terminated
+- **WHEN** a delegated child is terminated by operator or parent request
+- **THEN** the delegated result distinguishes `terminated` from `timed_out` and includes termination actor, reason, and mode when available

--- a/openspec/changes/sub-agent-lifecycle-control/specs/runtime-memory-surfaces/spec.md
+++ b/openspec/changes/sub-agent-lifecycle-control/specs/runtime-memory-surfaces/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Skill-Authored Semantic Memory Surfaces
+Memory and handoff surfaces SHOULD prefer semantic summaries authored by the active agent through the memory skill or another explicit agent-visible memory workflow.
+
+#### Scenario: Agent wraps significant work
+- **WHEN** a turn or session changes durable project state, decisions, constraints, open loops, or next steps
+- **THEN** the memory skill instructs the agent to write a bounded semantic continuation summary using ordinary governed tools rather than relying on a hidden runtime summarization call
+
+#### Scenario: Runtime refreshes memory surfaces
+- **WHEN** runtime refreshes generated memory surfaces at turn end
+- **THEN** it SHALL NOT initiate an extra hidden model request solely to summarize memory state
+
+### Requirement: Coherent Fallback Memory Truncation
+Generated fallback memory surfaces SHALL truncate text on coherent Markdown or line boundaries and mark omissions explicitly.
+
+#### Scenario: Long Markdown assistant output is rendered by fallback
+- **WHEN** memory rendering includes a long Markdown assistant message containing headings, bullets, or code fences
+- **THEN** the rendered memory surface does not cut a heading, bullet, or code fence mid-fragment
+
+#### Scenario: Memory text is omitted
+- **WHEN** memory rendering omits text due to size limits
+- **THEN** the rendered surface includes an explicit truncation marker and a source session or rollout reference when available
+
+### Requirement: Terminal Plan State Refresh
+Agent-authored or generated fallback memory, handoff, session-summary, and daily-note surfaces SHALL refresh after terminal turn state is known.
+
+#### Scenario: Turn completes successfully
+- **WHEN** a turn completes successfully after plan items were in progress
+- **THEN** the generated surfaces do not retain stale `in_progress` plan items unless the final plan snapshot still marks them as open
+
+#### Scenario: Turn ends without assistant text
+- **WHEN** a turn ends through tool-only or cancellation paths
+- **THEN** memory surfaces render an accurate terminal state message instead of implying active work is still ongoing
+
+### Requirement: Rollout Remains Source Of Truth
+Memory surfaces SHALL stay compact continuation aids and point to rollouts when detail is omitted.
+
+#### Scenario: Detail exceeds memory budget
+- **WHEN** recent conversation detail exceeds the memory surface budget
+- **THEN** the memory surface keeps a coherent summary and identifies where to inspect the raw rollout for full detail

--- a/openspec/changes/sub-agent-lifecycle-control/specs/workspace-runtime-state-hygiene/spec.md
+++ b/openspec/changes/sub-agent-lifecycle-control/specs/workspace-runtime-state-hygiene/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Generated Workspace State Ignore Rules
+Repository ignore rules SHALL ignore generated workspace `.alan` runtime state by default while allowing authored agent definitions to remain trackable.
+
+#### Scenario: Generated sessions and memory exist
+- **WHEN** a workspace contains generated `.alan` runtime state such as `.alan/sessions/` or `.alan/memory/`
+- **THEN** normal repository status does not show those generated files as untracked source changes
+
+#### Scenario: Authored agent definitions exist
+- **WHEN** a workspace contains `.alan/agent/`, `.alan/agents/`, `.alan/models.toml`, policies, or authored skill packages intended for source control
+- **THEN** repository ignore rules do not prevent those authored files from being tracked
+- **AND** documentation explains that `.alan/agent/` is the workspace default agent definition root while `.alan/agents/<name>/` is the workspace named-agent definition root
+
+### Requirement: Alan Home Workspace State
+The system SHALL prevent Alan home from being treated as a normal workspace that creates nested `~/.alan/.alan/` runtime state.
+
+#### Scenario: Alan home is selected as workspace
+- **WHEN** the resolved workspace root is Alan home
+- **THEN** runtime state paths resolve to the canonical Alan home layout rather than appending another `.alan`
+
+#### Scenario: Legacy nested state exists
+- **WHEN** legacy nested Alan-home runtime state is detected
+- **THEN** the system reports the condition safely without deleting data implicitly
+
+### Requirement: Canonical Workspace Identity
+The system SHALL compare workspace identities using canonical paths where available.
+
+#### Scenario: Same workspace uses path casing variants
+- **WHEN** two paths refer to the same workspace on a case-insensitive filesystem
+- **THEN** runtime manager and registry identity checks resolve them to one workspace identity
+
+#### Scenario: Path cannot be canonicalized
+- **WHEN** a workspace path cannot be canonicalized because it does not exist yet
+- **THEN** the system uses a deterministic normalized fallback and canonicalizes after creation where practical
+
+### Requirement: Generated State Documentation
+The documentation SHALL explain which `.alan` paths are generated runtime state and which paths may be source-controlled.
+
+#### Scenario: Developer reads workspace state docs
+- **WHEN** a developer checks the repository documentation for `.alan` workspace state
+- **THEN** the docs identify generated sessions/memory paths separately from authored agent roots, policies, and skills

--- a/openspec/changes/sub-agent-lifecycle-control/specs/workspace-runtime-state-hygiene/spec.md
+++ b/openspec/changes/sub-agent-lifecycle-control/specs/workspace-runtime-state-hygiene/spec.md
@@ -8,9 +8,9 @@ Repository ignore rules SHALL ignore generated workspace `.alan` runtime state b
 - **THEN** normal repository status does not show those generated files as untracked source changes
 
 #### Scenario: Authored agent definitions exist
-- **WHEN** a workspace contains `.alan/agent/`, `.alan/agents/`, `.alan/models.toml`, policies, or authored skill packages intended for source control
+- **WHEN** a workspace contains `.alan/agents/default/`, `.alan/agents/<name>/`, `.alan/models.toml`, policies, or authored skill packages intended for source control
 - **THEN** repository ignore rules do not prevent those authored files from being tracked
-- **AND** documentation explains that `.alan/agent/` is the workspace default agent definition root while `.alan/agents/<name>/` is the workspace named-agent definition root
+- **AND** documentation explains that `.alan/agents/default/` is the workspace default agent definition root while `.alan/agents/<name>/` is the workspace named-agent definition root
 
 ### Requirement: Alan Home Workspace State
 The system SHALL prevent Alan home from being treated as a normal workspace that creates nested `~/.alan/.alan/` runtime state.

--- a/openspec/changes/sub-agent-lifecycle-control/tasks.md
+++ b/openspec/changes/sub-agent-lifecycle-control/tasks.md
@@ -1,0 +1,58 @@
+## 1. Runtime Child-Run Lifecycle
+
+- [x] 1.1 Add child-run status, liveness, termination, and handoff metadata types to runtime/protocol surfaces.
+- [x] 1.2 Add an in-memory child-run registry owned by parent runtime state and register child runs before initial submission.
+- [x] 1.3 Update child event observation to refresh latest progress, heartbeat, warnings, active tool/plan summaries, and terminal metadata.
+- [x] 1.4 Replace child supervision hard timeout with idle-timeout semantics and an optional larger wall-clock cap.
+- [x] 1.5 Add runtime tests for healthy long-running heartbeat, idle timeout, failure, cancellation, and terminal status transitions.
+
+## 2. Daemon Control Plane
+
+- [x] 2.1 Expose runtime-manager APIs to list/read child-run records for a parent session.
+- [x] 2.2 Add daemon routes for list child runs, read child run, and terminate child run.
+- [x] 2.3 Route graceful and forceful termination through one shared child-run lifecycle transition.
+- [x] 2.4 Add daemon tests for list/read/terminate, unknown child id, already-terminal child, and timed-out child metadata.
+
+## 3. Parent Runtime Termination Tool
+
+- [x] 3.1 Add `terminate_child_run` virtual tool definition with child id, reason, and graceful/forceful mode.
+- [x] 3.2 Apply governance/audit semantics and record termination actor/reason/mode on child-run records.
+- [x] 3.3 Add virtual tool tests for successful termination, unknown child id, already-terminal child, and denied/escalated policy behavior.
+
+## 4. Delegated Result Handoff
+
+- [x] 4.1 Extend delegated result and invocation record types with child-run reference, output text/ref, preview fields, and truncation metadata.
+- [x] 4.2 Update completed, failed, timed-out, cancelled, paused, and terminated child handoff construction.
+- [x] 4.3 Keep parent tape payload bounded while preserving full output in rollout/reference metadata.
+- [x] 4.4 Update skill injector/docs so parent prompts know how to inspect full child output.
+- [x] 4.5 Add tests for long output, short output, structured output truncation, and timeout metadata.
+
+## 5. Memory Surface Reliability
+
+- [x] 5.1 Update the memory skill/docs so semantic continuation summaries are agent-authored through the visible skill/tool flow.
+- [x] 5.2 Replace arbitrary character truncation fallback with line/Markdown-aware truncation helpers and explicit omission markers.
+- [x] 5.3 Add source session/rollout references to fallback memory truncation markers where available.
+- [x] 5.4 Refresh working memory, handoff, session summary, and daily notes after terminal turn state is final.
+- [x] 5.5 Add memory tests for long Markdown output, code fences, truncation markers, and terminal plan-state refresh.
+
+## 6. TUI Child-Agent Management
+
+- [x] 6.1 Add TUI client methods and types for child-run list/read/terminate APIs.
+- [x] 6.2 Implement `/agents`, `/agent <id>`, `/agent terminate <id> [reason]`, and `/agent kill <id> [reason]`.
+- [x] 6.3 Surface active child-run count in the compact runtime HUD when available.
+- [x] 6.4 Update `/help` and add TUI tests for command parsing and client calls.
+
+## 7. Runtime State And Path Hygiene
+
+- [x] 7.1 Update `.gitignore` to ignore generated `.alan/sessions/` and generated `.alan/memory/` runtime files while keeping agent definitions trackable.
+- [x] 7.2 Fix workspace resolver/runtime path handling so Alan home does not create nested `.alan/.alan` state.
+- [x] 7.3 Canonicalize workspace identity comparisons and generated workspace ids where paths exist.
+- [x] 7.4 Add safe detection/reporting for legacy nested Alan-home runtime state.
+- [x] 7.5 Update docs explaining generated `.alan` paths versus source-controlled agent roots.
+- [x] 7.6 Add tests or repo checks for ignore patterns, Alan-home path resolution, and path casing normalization where practical.
+
+## 8. Verification
+
+- [x] 8.1 Run focused Rust tests for runtime child agents, virtual tools, memory surfaces, daemon routes, workspace resolver, and registry.
+- [x] 8.2 Run focused TUI tests for client and command handling.
+- [x] 8.3 Run `openspec status --change sub-agent-lifecycle-control` and record final implementation status.

--- a/openspec/changes/unify-agent-root-paths/.openspec.yaml
+++ b/openspec/changes/unify-agent-root-paths/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/unify-agent-root-paths/design.md
+++ b/openspec/changes/unify-agent-root-paths/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Alan currently models default agent definitions and named agent definitions with two
+different directory shapes:
+
+```text
+~/.alan/agent/
+~/.alan/agents/<name>/
+<workspace>/.alan/agent/
+<workspace>/.alan/agents/<name>/
+```
+
+This makes `.alan/agent/` a special case even though it has the same internal shape
+as every named agent root (`agent.toml`, `persona/`, `skills/`, `policy.yaml`). The
+new layout makes every agent root live under `.alan/agents/`:
+
+```text
+~/.alan/agents/default/
+~/.alan/agents/<name>/
+<workspace>/.alan/agents/default/
+<workspace>/.alan/agents/<name>/
+```
+
+The user explicitly accepts the breaking change, so this design does not preserve a
+compatibility fallback from `.alan/agent/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the default agent an explicit reserved agent root named `default`.
+- Remove all runtime, CLI, daemon, docs, test, and ignore-pattern dependence on
+  `.alan/agent/`.
+- Preserve the existing overlay model except for the default-root path.
+- Keep omitted `agent_name` ergonomic while making `agent_name = "default"` equivalent.
+- Make write paths and displayed paths match the canonical layout.
+
+**Non-Goals:**
+
+- Automatic migration of local or workspace files from `.alan/agent/` to
+  `.alan/agents/default/`.
+- Compatibility reads, merged fallback overlays, or precedence rules involving
+  `.alan/agent/`.
+- Changes to public `.agents/skills/` package installs.
+- Changes to package-local child-agent roots under a skill package's `agents/`
+  directory.
+
+## Decisions
+
+### Use `.alan/agents/default/` as the only default root
+
+Alan will derive the global default root from `~/.alan/agents/default/` and the
+workspace default root from `<workspace>/.alan/agents/default/`. The old singular
+path will not be read or written.
+
+Alternative considered: support both paths during a compatibility window. That would
+reduce migration pain, but it would keep two ways to define the same base agent and
+make overlay debugging harder. Since the breaking change is accepted, direct removal
+is simpler and easier to reason about.
+
+### Treat `default` as reserved, not as a normal named overlay
+
+An omitted `agent_name` and an explicit `agent_name = "default"` will select the same
+default chain:
+
+```text
+~/.alan/agents/default
+    -> <workspace>/.alan/agents/default
+```
+
+For a named agent such as `reviewer`, Alan will keep the existing default-then-named
+layering, with updated paths:
+
+```text
+~/.alan/agents/default
+    -> <workspace>/.alan/agents/default
+    -> ~/.alan/agents/reviewer
+    -> <workspace>/.alan/agents/reviewer
+```
+
+Alternative considered: let `default` behave like a normal named agent layered on top
+of a hidden base. That would reintroduce a hidden default concept, so the reserved
+name is cleaner.
+
+### Keep internal root kinds semantic
+
+The implementation can either rename `GlobalBase` / `WorkspaceBase` to
+`GlobalDefault` / `WorkspaceDefault` or keep the old enum names temporarily while
+changing paths. The preferred implementation is to rename labels and user-facing
+strings to "default" because this change is intended to remove the confusing base vs
+named vocabulary.
+
+### Update all writers before readers are considered complete
+
+Any command or API that creates default agent config, persona files, skills, policy
+files, or skill overrides must write under `.alan/agents/default/`. A partial change
+that only updates runtime reads would leave newly initialized installations in the old
+layout, so write surfaces are part of the core scope.
+
+### Detecting the old path is diagnostic only
+
+Implementations may surface a warning when `.alan/agent/` exists, but they must not
+load, merge, migrate, or otherwise use files from it. Diagnostics are allowed only to
+help users understand why old definitions no longer apply.
+
+## Risks / Trade-offs
+
+- Existing installs stop loading config/persona/skills from `.alan/agent/` ->
+  Mitigation: document the manual move to `.alan/agents/default/` and update setup
+  errors/help text to name the new path.
+- Hidden references in tests/docs keep creating old roots -> Mitigation: add repo-wide
+  tests/search checks for `.alan/agent` references, allowing only migration notes or
+  explicit negative tests.
+- API clients may omit `agent_name` today -> Mitigation: keep omitted `agent_name`
+  selecting the default agent while accepting explicit `"default"` as the same agent.
+- Source-control rules may accidentally re-allow `.alan/agent/` -> Mitigation:
+  update `.gitignore` to allow `.alan/agents/**` and `.alan/models.toml`, but not the
+  singular root.
+
+## Migration Plan
+
+1. Update runtime path helpers and agent-root resolution to produce only
+   `.alan/agents/default/` for default roots.
+2. Update all write surfaces to create files in the new default root.
+3. Update docs, examples, tests, and fixture paths.
+4. Add negative tests proving `.alan/agent/` is ignored.
+5. Users migrate manually with an equivalent move, for example:
+
+   ```bash
+   mkdir -p .alan/agents
+   mv .alan/agent .alan/agents/default
+   ```
+
+Rollback means running an older Alan build and moving files back to `.alan/agent/`.
+
+## Open Questions
+
+- None for this proposal. The breaking-change policy is explicit: no compatibility
+  fallback from `.alan/agent/`.

--- a/openspec/changes/unify-agent-root-paths/proposal.md
+++ b/openspec/changes/unify-agent-root-paths/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The current split between `.alan/agent/` for the default agent and `.alan/agents/<name>/`
+for named agents makes the on-disk model harder to explain and harder to map to
+`agent_name`. Moving the default agent into `.alan/agents/default/` makes every
+agent definition addressable through the same directory shape.
+
+## What Changes
+
+- **BREAKING** Remove `.alan/agent/` as an agent definition root.
+- **BREAKING** Resolve the default agent from `.alan/agents/default/` in both Alan home
+  and workspace scopes.
+- Keep named agents under `.alan/agents/<name>/`, with `default` reserved for the
+  default agent.
+- Resolve named agents by layering `.alan/agents/default/` first, then
+  `.alan/agents/<name>/`.
+- Update config, policy, persona, skill, CLI, daemon, TUI, docs, and tests that
+  currently point at `.alan/agent/`.
+- Do not add a compatibility fallback or automatic merge from `.alan/agent/`; users
+  must move authored files to `.alan/agents/default/`.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-root-layout`: Defines the canonical on-disk layout and resolution order for
+  default and named agent roots.
+
+### Modified Capabilities
+
+- None. There are no archived OpenSpec capabilities for agent root layout yet.
+
+## Impact
+
+- Runtime agent root resolution in `crates/runtime/src/agent_root.rs`,
+  `agent_definition.rs`, `paths.rs`, prompt/persona loading, skill discovery, policy
+  resolution, and config loading.
+- CLI/daemon setup and reporting surfaces that create or display default agent config
+  paths.
+- TUI setup/help text and tests that mention `~/.alan/agent/agent.toml`.
+- Repository hygiene and documentation for source-controlled `.alan` roots.
+- Existing local installs and workspaces using `.alan/agent/` will need manual
+  migration to `.alan/agents/default/`.

--- a/openspec/changes/unify-agent-root-paths/specs/agent-root-layout/spec.md
+++ b/openspec/changes/unify-agent-root-paths/specs/agent-root-layout/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Canonical agent root directories
+Alan SHALL store every default and named agent definition root under an `agents`
+directory. The default agent root SHALL be named `default`.
+
+#### Scenario: Default roots use the reserved default directory
+- **WHEN** Alan resolves default agent roots for an Alan home and a workspace
+- **THEN** the global default root is `~/.alan/agents/default/`
+- **AND** the workspace default root is `<workspace>/.alan/agents/default/`
+- **AND** Alan does not include `~/.alan/agent/` or `<workspace>/.alan/agent/` in the resolved roots
+
+#### Scenario: Named roots remain under agents by name
+- **WHEN** Alan resolves a named agent root for `reviewer`
+- **THEN** the global named root is `~/.alan/agents/reviewer/`
+- **AND** the workspace named root is `<workspace>/.alan/agents/reviewer/`
+
+### Requirement: Default agent name semantics
+Alan SHALL treat the agent name `default` as the reserved default agent identifier.
+Omitting `agent_name` SHALL select the same agent definition as explicitly providing
+`agent_name = "default"`.
+
+#### Scenario: Omitted agent name selects default
+- **WHEN** a session, CLI command, or daemon request omits `agent_name`
+- **THEN** Alan resolves only the default agent root chain
+- **AND** the root chain is `~/.alan/agents/default/ -> <workspace>/.alan/agents/default/` when both scopes exist
+
+#### Scenario: Explicit default selects default
+- **WHEN** a session, CLI command, or daemon request sets `agent_name` to `default`
+- **THEN** Alan resolves the same root chain as omitted `agent_name`
+- **AND** Alan does not add a separate named overlay for `default`
+
+#### Scenario: Default cannot be used as an ordinary named specialization
+- **WHEN** a user creates files under `.alan/agents/default/`
+- **THEN** Alan treats those files as the default agent definition
+- **AND** Alan does not treat `default` as a named specialization layered on top of another default root
+
+### Requirement: Named agent overlay order
+Alan SHALL resolve named agents by layering default roots first and the selected named
+roots after them, preserving the existing precedence model with updated paths.
+
+#### Scenario: Named workspace session resolves default then named roots
+- **WHEN** Alan resolves `agent_name = "reviewer"` for a workspace session
+- **THEN** the root order is `~/.alan/agents/default/`
+- **AND** then `<workspace>/.alan/agents/default/`
+- **AND** then `~/.alan/agents/reviewer/`
+- **AND** then `<workspace>/.alan/agents/reviewer/`
+
+#### Scenario: Missing scopes are skipped without changing relative precedence
+- **WHEN** Alan resolves a named agent without an Alan home or without a workspace
+- **THEN** Alan skips roots from the missing scope
+- **AND** remaining default roots still appear before remaining named roots
+
+### Requirement: Agent definition assets load from canonical roots
+Alan SHALL load agent-root `agent.toml`, `persona/`, `skills/`, and `policy.yaml`
+assets from the resolved canonical roots only.
+
+#### Scenario: Default config path changes
+- **WHEN** Alan loads the default global agent-facing config without `ALAN_CONFIG_PATH`
+- **THEN** the default config path is `~/.alan/agents/default/agent.toml`
+- **AND** `~/.alan/agent/agent.toml` is not read
+
+#### Scenario: Workspace default assets load from new root
+- **WHEN** a workspace default root contains `persona/`, `skills/`, or `policy.yaml`
+- **THEN** Alan loads those assets from `<workspace>/.alan/agents/default/`
+- **AND** equivalent files under `<workspace>/.alan/agent/` are ignored
+
+#### Scenario: Named agent assets extend default assets
+- **WHEN** `agent_name = "reviewer"` and both default and reviewer roots contain assets
+- **THEN** Alan loads default assets from `.alan/agents/default/`
+- **AND** Alan loads reviewer assets from `.alan/agents/reviewer/`
+- **AND** reviewer assets have higher overlay precedence than default assets in the same resolution chain
+
+### Requirement: Writes target canonical default roots
+Alan SHALL create or update default agent configuration, policy, persona, and agent-root
+skill files under `.alan/agents/default/`.
+
+#### Scenario: Global setup writes default agent config
+- **WHEN** setup or connection commands create the global default agent config
+- **THEN** they write `~/.alan/agents/default/agent.toml`
+- **AND** they do not create `~/.alan/agent/agent.toml`
+
+#### Scenario: Workspace default writes use agents default
+- **WHEN** workspace-scoped APIs or commands write default agent persona, policy, skill overrides, or skill packages
+- **THEN** they write under `<workspace>/.alan/agents/default/`
+- **AND** they do not create `<workspace>/.alan/agent/`
+
+#### Scenario: Named writes still use the selected agent directory
+- **WHEN** workspace-scoped APIs or commands write for `agent_name = "reviewer"`
+- **THEN** they write under `<workspace>/.alan/agents/reviewer/`
+
+### Requirement: Singular agent root removal
+Alan SHALL remove `.alan/agent/` from the agent-root contract. The singular path SHALL
+not be a compatibility alias, fallback, or lower-precedence root.
+
+#### Scenario: Old path exists next to new path
+- **WHEN** both `<workspace>/.alan/agent/` and `<workspace>/.alan/agents/default/` exist
+- **THEN** Alan loads only `<workspace>/.alan/agents/default/`
+- **AND** Alan does not merge files from `<workspace>/.alan/agent/`
+
+#### Scenario: Only old path exists
+- **WHEN** `<workspace>/.alan/agent/` exists and `<workspace>/.alan/agents/default/` does not exist
+- **THEN** Alan does not load the old path as an agent root
+- **AND** the workspace contributes no default agent-root overlay from the old path
+
+#### Scenario: Diagnostics do not imply compatibility
+- **WHEN** Alan reports that `.alan/agent/` is no longer a supported root
+- **THEN** the report is diagnostic only
+- **AND** Alan still does not read, write, merge, or migrate files from `.alan/agent/`
+
+### Requirement: Repository hygiene reflects canonical roots
+Repository ignore rules and documentation SHALL distinguish generated `.alan` runtime
+state from authored agent definitions using the canonical `.alan/agents/` layout.
+
+#### Scenario: Source-controlled agent roots remain trackable
+- **WHEN** a workspace contains authored files under `.alan/agents/default/` or `.alan/agents/<name>/`
+- **THEN** repository ignore rules allow those files to be tracked
+- **AND** generated `.alan/sessions/` and `.alan/memory/` files remain ignored
+
+#### Scenario: Old singular root is not allowlisted
+- **WHEN** a workspace contains files under `.alan/agent/`
+- **THEN** repository ignore rules do not allowlist that path as an authored agent root
+- **AND** documentation instructs users to move authored files to `.alan/agents/default/`

--- a/openspec/changes/unify-agent-root-paths/tasks.md
+++ b/openspec/changes/unify-agent-root-paths/tasks.md
@@ -1,0 +1,38 @@
+## 1. Runtime Path Model
+
+- [ ] 1.1 Add a canonical `default` agent-name constant and helper semantics so omitted `agent_name` and explicit `default` select the same default agent.
+- [ ] 1.2 Change Alan home path helpers so the global default agent root and config path resolve to `~/.alan/agents/default/`.
+- [ ] 1.3 Change workspace path helpers so the workspace default agent root resolves to `<workspace>/.alan/agents/default/`.
+- [ ] 1.4 Update `ResolvedAgentRoots` ordering so default sessions use global/workspace default roots and named sessions append global/workspace named roots after the default chain.
+- [ ] 1.5 Ensure `agent_name = "default"` does not append a named `default` overlay on top of the default chain.
+- [ ] 1.6 Rename or relabel root kinds and user-facing strings from base/default-agent split terminology to default/named terminology where practical.
+
+## 2. Runtime Loading And Write Semantics
+
+- [ ] 2.1 Update agent config overlay loading, `ALAN_CONFIG_PATH` fallback text, and global default config loading to use `~/.alan/agents/default/agent.toml`.
+- [ ] 2.2 Update persona, policy, skill package, and skill override discovery to load default assets only from `.alan/agents/default/`.
+- [ ] 2.3 Update writable default agent root selection so generated default persona, policy, config, and skill files are written under `.alan/agents/default/`.
+- [ ] 2.4 Add negative tests proving `.alan/agent/agent.toml`, `.alan/agent/persona/`, `.alan/agent/skills/`, and `.alan/agent/policy.yaml` are ignored.
+- [ ] 2.5 Keep package-local child-agent roots under skill-package `agents/<name>/` directories unchanged.
+
+## 3. CLI, Daemon, And Client Surfaces
+
+- [ ] 3.1 Update `alan init`, setup flows, connection commands, and config-path reporting to create/display `~/.alan/agents/default/agent.toml`.
+- [ ] 3.2 Update daemon session, skill catalog, skill override, and workspace APIs that create or report default agent-root paths.
+- [ ] 3.3 Update TUI setup/help/error text and tests that mention `~/.alan/agent/agent.toml`.
+- [ ] 3.4 Accept `agent_name = "default"` through CLI and daemon validation as the default agent rather than a named specialization.
+- [ ] 3.5 Update event, session, and API fixtures that include `.alan/agent/` paths.
+
+## 4. Documentation And Repository Hygiene
+
+- [ ] 4.1 Update `.gitignore` to allowlist `.alan/agents/**` and `.alan/models.toml` while no longer allowlisting `.alan/agent/**`.
+- [ ] 4.2 Update `README.md`, `AGENTS.md`, architecture docs, governance docs, connection-profile docs, skill docs, and sub-agent docs to use `.alan/agents/default/`.
+- [ ] 4.3 Add migration notes explaining that `.alan/agent/` was removed and users must move authored files to `.alan/agents/default/`.
+- [ ] 4.4 Run a repo-wide search for `.alan/agent` and either update each reference or mark it as an explicit old-path negative test/migration note.
+
+## 5. Verification
+
+- [ ] 5.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
+- [ ] 5.2 Run focused alan CLI/daemon tests for init/setup, skill catalog, skill override, session creation, and workspace routing.
+- [ ] 5.3 Run focused TUI tests after setup/help/config path updates.
+- [ ] 5.4 Run formatting, `cargo check -p alan-runtime -p alan`, `git diff --check`, and OpenSpec status/apply validation.

--- a/openspec/changes/unify-agent-root-paths/tasks.md
+++ b/openspec/changes/unify-agent-root-paths/tasks.md
@@ -1,38 +1,38 @@
 ## 1. Runtime Path Model
 
-- [ ] 1.1 Add a canonical `default` agent-name constant and helper semantics so omitted `agent_name` and explicit `default` select the same default agent.
-- [ ] 1.2 Change Alan home path helpers so the global default agent root and config path resolve to `~/.alan/agents/default/`.
-- [ ] 1.3 Change workspace path helpers so the workspace default agent root resolves to `<workspace>/.alan/agents/default/`.
-- [ ] 1.4 Update `ResolvedAgentRoots` ordering so default sessions use global/workspace default roots and named sessions append global/workspace named roots after the default chain.
-- [ ] 1.5 Ensure `agent_name = "default"` does not append a named `default` overlay on top of the default chain.
-- [ ] 1.6 Rename or relabel root kinds and user-facing strings from base/default-agent split terminology to default/named terminology where practical.
+- [x] 1.1 Add a canonical `default` agent-name constant and helper semantics so omitted `agent_name` and explicit `default` select the same default agent.
+- [x] 1.2 Change Alan home path helpers so the global default agent root and config path resolve to `~/.alan/agents/default/`.
+- [x] 1.3 Change workspace path helpers so the workspace default agent root resolves to `<workspace>/.alan/agents/default/`.
+- [x] 1.4 Update `ResolvedAgentRoots` ordering so default sessions use global/workspace default roots and named sessions append global/workspace named roots after the default chain.
+- [x] 1.5 Ensure `agent_name = "default"` does not append a named `default` overlay on top of the default chain.
+- [x] 1.6 Rename or relabel root kinds and user-facing strings from base/default-agent split terminology to default/named terminology where practical.
 
 ## 2. Runtime Loading And Write Semantics
 
-- [ ] 2.1 Update agent config overlay loading, `ALAN_CONFIG_PATH` fallback text, and global default config loading to use `~/.alan/agents/default/agent.toml`.
-- [ ] 2.2 Update persona, policy, skill package, and skill override discovery to load default assets only from `.alan/agents/default/`.
-- [ ] 2.3 Update writable default agent root selection so generated default persona, policy, config, and skill files are written under `.alan/agents/default/`.
-- [ ] 2.4 Add negative tests proving `.alan/agent/agent.toml`, `.alan/agent/persona/`, `.alan/agent/skills/`, and `.alan/agent/policy.yaml` are ignored.
-- [ ] 2.5 Keep package-local child-agent roots under skill-package `agents/<name>/` directories unchanged.
+- [x] 2.1 Update agent config overlay loading, `ALAN_CONFIG_PATH` fallback text, and global default config loading to use `~/.alan/agents/default/agent.toml`.
+- [x] 2.2 Update persona, policy, skill package, and skill override discovery to load default assets only from `.alan/agents/default/`.
+- [x] 2.3 Update writable default agent root selection so generated default persona, policy, config, and skill files are written under `.alan/agents/default/`.
+- [x] 2.4 Add negative tests proving `.alan/agent/agent.toml`, `.alan/agent/persona/`, `.alan/agent/skills/`, and `.alan/agent/policy.yaml` are ignored.
+- [x] 2.5 Keep package-local child-agent roots under skill-package `agents/<name>/` directories unchanged.
 
 ## 3. CLI, Daemon, And Client Surfaces
 
-- [ ] 3.1 Update `alan init`, setup flows, connection commands, and config-path reporting to create/display `~/.alan/agents/default/agent.toml`.
-- [ ] 3.2 Update daemon session, skill catalog, skill override, and workspace APIs that create or report default agent-root paths.
-- [ ] 3.3 Update TUI setup/help/error text and tests that mention `~/.alan/agent/agent.toml`.
-- [ ] 3.4 Accept `agent_name = "default"` through CLI and daemon validation as the default agent rather than a named specialization.
-- [ ] 3.5 Update event, session, and API fixtures that include `.alan/agent/` paths.
+- [x] 3.1 Update `alan init`, setup flows, connection commands, and config-path reporting to create/display `~/.alan/agents/default/agent.toml`.
+- [x] 3.2 Update daemon session, skill catalog, skill override, and workspace APIs that create or report default agent-root paths.
+- [x] 3.3 Update TUI setup/help/error text and tests that mention `~/.alan/agent/agent.toml`.
+- [x] 3.4 Accept `agent_name = "default"` through CLI and daemon validation as the default agent rather than a named specialization.
+- [x] 3.5 Update event, session, and API fixtures that include `.alan/agent/` paths.
 
 ## 4. Documentation And Repository Hygiene
 
-- [ ] 4.1 Update `.gitignore` to allowlist `.alan/agents/**` and `.alan/models.toml` while no longer allowlisting `.alan/agent/**`.
-- [ ] 4.2 Update `README.md`, `AGENTS.md`, architecture docs, governance docs, connection-profile docs, skill docs, and sub-agent docs to use `.alan/agents/default/`.
-- [ ] 4.3 Add migration notes explaining that `.alan/agent/` was removed and users must move authored files to `.alan/agents/default/`.
-- [ ] 4.4 Run a repo-wide search for `.alan/agent` and either update each reference or mark it as an explicit old-path negative test/migration note.
+- [x] 4.1 Update `.gitignore` to allowlist `.alan/agents/**` and `.alan/models.toml` while no longer allowlisting `.alan/agent/**`.
+- [x] 4.2 Update `README.md`, `AGENTS.md`, architecture docs, governance docs, connection-profile docs, skill docs, and sub-agent docs to use `.alan/agents/default/`.
+- [x] 4.3 Add migration notes explaining that `.alan/agent/` was removed and users must move authored files to `.alan/agents/default/`.
+- [x] 4.4 Run a repo-wide search for `.alan/agent` and either update each reference or mark it as an explicit old-path negative test/migration note.
 
 ## 5. Verification
 
-- [ ] 5.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
-- [ ] 5.2 Run focused alan CLI/daemon tests for init/setup, skill catalog, skill override, session creation, and workspace routing.
-- [ ] 5.3 Run focused TUI tests after setup/help/config path updates.
-- [ ] 5.4 Run formatting, `cargo check -p alan-runtime -p alan`, `git diff --check`, and OpenSpec status/apply validation.
+- [x] 5.1 Run focused runtime tests for agent root resolution, config overlays, persona assembly, policy resolution, prompt cache, and skill discovery.
+- [x] 5.2 Run focused alan CLI/daemon tests for init/setup, skill catalog, skill override, session creation, and workspace routing.
+- [x] 5.3 Run focused TUI tests after setup/help/config path updates.
+- [x] 5.4 Run formatting, `cargo check -p alan-runtime -p alan`, `git diff --check`, and OpenSpec status/apply validation.

--- a/plans/2026-04-28-sub-agent-lifecycle-memory-plan.md
+++ b/plans/2026-04-28-sub-agent-lifecycle-memory-plan.md
@@ -210,8 +210,8 @@ Exit criteria:
 
 1. generated `.alan/sessions/` and `.alan/memory/` runtime files are ignored by
    default,
-2. workspace `.alan/agent/` remains available for source-controlled agent
-   definitions,
+2. workspace `.alan/agents/default/` and `.alan/agents/<name>/` remain available
+   for source-controlled agent definitions,
 3. Alan home does not create nested `.alan/.alan/` state,
 4. path casing variants resolve to one workspace identity where supported.
 

--- a/scripts/check-agent-root-layout-strings.sh
+++ b/scripts/check-agent-root-layout-strings.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-.}"
+violations=()
+
+is_allowed_file() {
+  case "$1" in
+    "$repo_root/crates/runtime/src/agent_root.rs") return 0 ;;
+    "$repo_root/crates/runtime/src/paths.rs") return 0 ;;
+    "$repo_root"/crates/*/tests/*.rs) return 0 ;;
+    *_tests.rs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_comment_line() {
+  [[ "$1" =~ ^[[:space:]]*// ]]
+}
+
+line_has_forbidden_layout_string() {
+  [[ "$1" == *".alan/agents/default"* ]] && return 0
+  [[ "$1" == *"agents/default"* ]] && return 0
+  [[ "$1" == *'.join("agents").join("default")'* ]] && return 0
+  return 1
+}
+
+while IFS= read -r file; do
+  if is_allowed_file "$file"; then
+    continue
+  fi
+
+  in_test_module=0
+  line_number=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    if [[ "$line" =~ ^[[:space:]]*#\[cfg\(test\)\] ]]; then
+      in_test_module=1
+      continue
+    fi
+    if (( in_test_module )); then
+      continue
+    fi
+    if is_comment_line "$line"; then
+      continue
+    fi
+    if line_has_forbidden_layout_string "$line"; then
+      violations+=("$file:$line_number: $line")
+    fi
+  done <"$file"
+done < <(find "$repo_root/crates" -path '*/target/*' -prune -o -name '*.rs' -print | sort)
+
+if ((${#violations[@]})); then
+  printf 'Raw default agent-root layout strings found outside the runtime layout owner:\n' >&2
+  printf '%s\n' "${violations[@]}" >&2
+  printf '\nUse alan_runtime::AgentRootLayout or add a focused allowlist entry with justification.\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add OpenSpec-backed child-run lifecycle, heartbeat, termination, daemon control plane, and delegated result handoff changes
- add TUI child-run commands and HUD active child-run count
- improve memory continuation surfaces and .alan runtime-state hygiene
- add OpenSpec proposal for the breaking .alan/agents/default agent-root layout change

## Verification
- bun run lint
- cargo check -p alan-runtime -p alan
- cargo test -p alan-runtime child -- --nocapture
- cargo test -p alan-runtime delegated -- --nocapture
- cargo test -p alan-runtime memory_surfaces -- --nocapture
- cargo test -p alan child_run -- --nocapture
- cargo test -p alan workspace_resolver -- --nocapture
- git diff --check
- openspec instructions apply --change sub-agent-lifecycle-control --json
- openspec status --change unify-agent-root-paths --json