### PR TITLE
docs: propose macOS shell terminal stabilization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,60 @@ serving as the primary user-facing hosting model.
 
 ---
 
+## Design Context
+
+### Users
+
+Alan's native macOS experience is designed first for the project owner and
+developer users who live inside terminal, code, and agent workflows. They need a
+real terminal workspace that remains fast to scan, comfortable for long sessions,
+and readable by both humans and agents.
+
+The core job is to organize developer work into spaces, tabs, and splits while
+making Alan available as an optional capability layered onto the terminal rather
+than the reason the interface exists.
+
+### Brand Personality
+
+The product personality is calm, precise, and intelligent.
+
+Alan should feel confident and quiet: a native tool that understands developer
+workflow, removes unnecessary surface area, and exposes power through structure
+instead of decoration. The interface should evoke focus, control, and trust
+rather than novelty or spectacle.
+
+### Aesthetic Direction
+
+The target visual reference is Arc's macOS browser shell: a translucent,
+material-driven sidebar that blends with the desktop background, vertical
+space/tab organization, lightweight rows, compact controls, and an expansive
+content area. The goal is not a fixed pale-purple sidebar color; the sidebar
+should feel like native material interacting with the user's wallpaper and
+window environment.
+
+Build light mode first. Dark mode can come later, but the initial design system
+should be coherent and polished in light appearance.
+
+The product must not look like VS Code, a traditional terminal chrome, a web app,
+a dashboard, or an interface filled with complex/redundant buttons. Avoid
+card-heavy layouts, page-like headers, visible implementation jargon, and
+debug-first composition.
+
+### Design Principles
+
+1. Terminal first: the active terminal tab is the center of gravity, with Alan
+   status and debug details kept secondary.
+2. Arc-like organization: spaces and tabs live in a native, material sidebar
+   built for scanning and switching, not in dashboard sections.
+3. Calm precision: prefer fewer controls, restrained typography, subtle
+   selection states, and clear hierarchy over decorative emphasis.
+4. Native material over flat color: use macOS materials and light-mode surfaces
+   that blend with the desktop instead of hard-coded themed panels.
+5. Progressive disclosure: default UI hides raw IDs, bindings, runtime phases,
+   and diagnostics unless the user opens an explicit debug surface.
+
+---
+
 ## Project Structure
 
 ```
@@ -793,11 +847,14 @@ Resolved skill execution may be `inline` or
 ## Development Workflow
 
 1. **Before committing**: `just check`
-2. **Adding a new LLM provider**: Implement `LlmProvider` trait in
+2. **After Rust code changes under `crates/`**: run `just verify` for the core
+   flow. If `~/.alan` LLM config is available locally, run `just verify-full`
+   for the end-to-end validation path.
+3. **Adding a new LLM provider**: Implement `LlmProvider` trait in
    `crates/llm/src/`, add connection-profile/provider-descriptor support,
    update model metadata, and document capability degradation
-3. **Adding new tools**: Implement `Tool` trait in `crates/tools/src/`, register via `create_core_tools()`
-4. **Adding skills**: Create a directory-backed skill package under
+4. **Adding new tools**: Implement `Tool` trait in `crates/tools/src/`, register via `create_core_tools()`
+5. **Adding skills**: Create a directory-backed skill package under
    `crates/runtime/skills/<skill-id>/` for first-party built-ins, use
    `alan skills init` for scaffolding ordinary packages, or add packages under
    an agent-root `skills/` directory / the zero-conversion public install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-## Verification Loop
-
-After each Rust code change under `crates/`, run `just verify` to confirm the core flow is healthy.
-If `~/.alan` LLM config is available on your machine, run `just verify-full` for end-to-end validation.
-If verification fails, inspect logs, identify the issue, and fix it before proceeding.

--- a/openspec/changes/stabilize-macos-shell-terminal/.openspec.yaml
+++ b/openspec/changes/stabilize-macos-shell-terminal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/stabilize-macos-shell-terminal/design.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/design.md
@@ -1,0 +1,255 @@
+## Context
+
+The native Apple client currently mixes three responsibilities that need clearer
+boundaries before the macOS shell can behave like a dependable terminal:
+
+- SwiftUI scene and selection state live in `MacShellRootView`, `TerminalPaneView`,
+  `ShellModel`, and `ShellHostController`.
+- The actual terminal host is bridged through `TerminalHostView`,
+  `GhosttyLiveHost`, and `TerminalHostRuntime`.
+- Agents and scripts mutate/read shell state through `ShellControlPlane`,
+  file-command fallbacks, persisted shell snapshots, and event files.
+
+The review found that terminal processes and Ghostty surfaces are effectively
+owned by the currently rendered view. Switching tab selection can therefore
+tear down a background terminal. The control plane also reports some mutations
+as successful before the runtime has actually accepted them, uses shared
+window/state paths across a `WindowGroup`, and has a serial socket loop with no
+clear request size or duration bounds.
+
+The UI has drifted from the documented macOS shell direction in
+`docs/spec/alan_macos_shell_ui_ux.md`: it reads more like a diagnostic dashboard
+than a terminal-first workspace with a space rail, active-space tab list,
+restrained toolbar, and optional inspector. Build metadata is also inconsistent:
+documentation advertises older OS requirements while the Xcode project targets
+newer platforms, and local Ghostty artifacts are referenced in ways that make a
+clean dependency setup hard to verify.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve terminal runtimes, process state, renderer state, focus, and metadata
+  across SwiftUI view creation/destruction and tab selection changes.
+- Make runtime-dependent control-plane mutations return authoritative results:
+  accepted, queued, or rejected with stable error codes.
+- Give each macOS window its own shell identity, socket path, persisted state,
+  event stream, and control directory.
+- Bound local IPC request size, client lifetime, and main-actor command duration.
+- Make persistence, event, and file-command failures visible to developers and
+  control clients.
+- Bring the default macOS UI back to the documented shell information
+  architecture without removing useful debug data.
+- Align build documentation, deployment targets, Ghostty dependency setup, and
+  focused automated tests.
+
+**Non-Goals:**
+
+- Do not redesign Alan daemon/runtime protocol semantics as part of this change.
+- Do not replace Ghostty or implement a custom terminal emulator.
+- Do not build a complete cross-platform Apple UI rewrite; the scope is the
+  macOS shell experience and testable model/control boundaries.
+- Do not add remote network shell control. This change hardens the local control
+  surface that already exists.
+
+## Decisions
+
+### Decision: Own terminal runtimes outside transient views
+
+Introduce a window-scoped terminal runtime registry owned by the shell host/model
+layer, keyed by stable pane IDs. The registry should expose a narrow runtime
+handle protocol for attach, detach, focus, resize, send text, metadata updates,
+and teardown. `TerminalHostView` should attach an AppKit/Ghostty surface to an
+existing pane runtime when rendered and detach from it when removed, but view
+deallocation must not imply process teardown.
+
+Rationale: SwiftUI views are a projection of state, not the correct owner for
+terminal processes. A registry keeps terminal identity aligned with pane
+identity and lets background tabs keep running.
+
+Alternative considered: keep the current view-owned host and cache invisible
+views. That would fight SwiftUI lifecycle behavior, make memory use harder to
+reason about, and still leave control-plane delivery tied to rendering.
+
+### Decision: Replace notification-only text delivery with runtime results
+
+Route `pane.send_text` and future runtime-dependent mutations through the
+runtime registry. The response must distinguish:
+
+- accepted by a live runtime, with accepted byte count;
+- queued in a pane-specific buffer with explicit durability/flush semantics; or
+- rejected with a stable error code.
+
+NotificationCenter may still be used internally for UI observation, but it must
+not be the source of truth for whether a terminal accepted input.
+
+Rationale: Agents need to know whether input reached the target shell. A
+fire-and-forget notification can disappear when the target pane is not rendered.
+
+Alternative considered: keep returning `applied: true` after posting a
+notification and add logs for missed observers. Logs would help debugging but
+would preserve misleading control responses.
+
+### Decision: Generate a per-window shell context at scene creation
+
+Create a per-scene shell context object containing `window_id`, control
+directory, socket path, persisted state path, event path, and runtime registry.
+Each `WindowGroup` instance should construct or restore one context rather than
+using fixed identifiers such as `window_main`. Window restoration may reuse a
+previous context only when the restored scene identity explicitly matches.
+
+Rationale: A macOS `WindowGroup` implies multiple independent windows. Shared
+state paths make one window's agents, tabs, panes, and file commands bleed into
+another.
+
+Alternative considered: force the app to a single window. That would avoid some
+bugs but conflict with native macOS expectations and leave the implementation
+less general than the declared scene model.
+
+### Decision: Make the control socket bounded and concurrent per request
+
+Keep the local socket protocol simple, but enforce a maximum request byte size,
+a request read deadline, a command execution deadline, and bounded per-client
+work. Accepting new connections should not be blocked by one client waiting on
+newline input or a slow main-actor mutation. Responses should use a stable
+success/error envelope that includes machine-readable codes.
+
+Rationale: The control plane is a local automation boundary. It should be
+predictable under malformed clients, slow handlers, and missing targets.
+
+Alternative considered: retain the serial accept/read/handle loop and rely on
+well-behaved clients. That is insufficient for an agent-facing surface because
+failed tool calls can leave stale clients or partial requests behind.
+
+### Decision: Surface persistence and file-command failures
+
+Change shell state/event/command/binding file operations to return or record
+`Result` values instead of ignoring errors. Use `os.Logger` for developer
+diagnostics and keep a small inspectable diagnostic surface in shell state or
+debug inspector data for recent control-plane failures.
+
+Rationale: Silent IO failure turns state divergence into guesswork. The app
+does not need to stop on every failure, but developers and control clients need
+evidence when state publication or command ingestion fails.
+
+Alternative considered: only add logging around the highest-level publish call.
+That would miss lower-level decode/delete/write failures that currently erase
+the best debugging evidence.
+
+### Decision: Reframe the UI around spaces, tabs, terminal, and inspector
+
+Keep the existing shell model concepts, but render them with the documented
+information architecture:
+
+- compact space rail;
+- active-space tab list;
+- terminal-first content region with minimal pane chrome;
+- restrained native toolbar with command entry and frequent actions;
+- optional inspector split into Overview and Debug layers.
+
+Raw identifiers, runtime phases, socket paths, binding paths, and JSON snapshots
+should move behind the Debug inspector rather than appearing in the default
+workflow.
+
+Rationale: The app is a terminal product surface, not primarily a runtime
+debugger. Debug information is valuable, but it should not dominate the
+default interaction model.
+
+Alternative considered: keep the dashboard layout and polish spacing/copy. That
+would improve presentation but would not satisfy the existing macOS shell UI/UX
+contract.
+
+### Decision: Treat impeccable design guidance as the UI acceptance layer
+
+The impeccable design guidance now serves as the concrete acceptance layer for
+the UI portion of this change. It does not create a second redesign track; it
+sharpens how the existing `macos-shell-ui-ux-conformance` requirements should be
+implemented and reviewed.
+
+The implementation should optimize for:
+
+- terminal-first composition, where the active terminal tab remains the clear
+  center of gravity;
+- Arc-like organization, with a material space rail and active-space tab list
+  instead of dashboard sections;
+- quiet native macOS light-mode surfaces, using material and subtle separators
+  rather than hard-coded themed panels;
+- compact, scan-friendly rows and controls rather than cards, pills, or
+  explanatory chrome;
+- progressive disclosure, where runtime IDs, bindings, socket paths, JSON, and
+  phases remain available only in the Debug inspector.
+
+This decision makes UI work reviewable before it is considered complete. A task
+that changes the macOS shell chrome should be checked against the documented
+layout contract, the OpenSpec scenarios, and a running app screenshot in the
+default light appearance.
+
+Rationale: the product direction is already documented, but implementation can
+still drift toward a polished diagnostic dashboard if the acceptance criteria are
+too abstract. Binding the impeccable guidance to the OpenSpec change gives the
+implementation pass a specific visual and interaction target without expanding
+scope beyond the macOS shell experience.
+
+### Decision: Add a testable terminal-host boundary and dependency checks
+
+Extract enough of the terminal host behind protocols or small adapter types that
+model/control-plane tests can run with a mock runtime instead of real Ghostty.
+Add a dependency check for required local Ghostty artifacts and keep deployment
+target documentation synchronized with Xcode project settings.
+
+Rationale: The highest-risk behavior is state/routing/lifecycle logic, not the
+real terminal renderer itself. Tests need a deterministic runtime double, while
+the build needs explicit failure modes when local artifacts are missing.
+
+Alternative considered: test only by launching the full app. That would catch
+some integration bugs but would be slow, brittle, and unlikely to cover
+background-pane and socket edge cases.
+
+## Risks / Trade-offs
+
+- Runtime registry leaks processes if close paths are incomplete -> Centralize
+  tab/pane close teardown through the registry and add tests for exactly-once
+  teardown.
+- Durable input queue semantics become ambiguous -> Either implement a real
+  per-pane queue with flush tests or reject unavailable runtimes explicitly.
+  Do not claim queued delivery without a verifiable flush path.
+- Per-window persistence changes break existing local files -> Treat legacy
+  fixed-path state as best-effort readable for one migration release, but publish
+  new state under window-scoped paths.
+- Socket timeouts reject legitimate long-running commands -> Keep local
+  commands small and return accepted async work only when there is a separate
+  status/event path to observe completion.
+- UI refactor risks hiding diagnostics developers use today -> Preserve debug
+  data in an explicit inspector debug layer and keep copy/export affordances for
+  paths and JSON snapshots.
+- Ghostty dependency checks may add setup friction -> Make the error actionable
+  and keep the documented preparation command close to the failing build step.
+
+## Migration Plan
+
+1. Introduce the runtime handle protocol and mock runtime without changing the
+   visible UI.
+2. Add the window-scoped shell context and move socket/state/event paths off
+   fixed `window_main`-style identifiers.
+3. Route `pane.send_text` through the runtime registry and update control
+   responses to report accepted, queued, or rejected outcomes.
+4. Move `TerminalHostView` attach/detach behavior onto existing runtime handles
+   and reserve teardown for explicit pane/tab/window close.
+5. Add bounded IPC handling, stable error codes, and observable persistence/file
+   command diagnostics.
+6. Refactor the sidebar, toolbar, terminal content, and inspector to match the
+   macOS shell UI/UX contract while preserving debug affordances.
+7. Align Apple README/spec build requirements with Xcode deployment targets and
+   add Ghostty dependency setup checks.
+8. Add focused tests for shell model mutation, control-plane commands, runtime
+   delivery semantics, window isolation, and IPC bounds.
+
+## Open Questions
+
+- Should background pane text delivery prefer immediate rejection when a runtime
+  is not booted, or should the first implementation include a durable per-pane
+  queue?
+- What is the intended migration behavior for existing local shell state files
+  written under the fixed `window_main` identity?
+- Should the runtime registry live directly in `ShellHostController`, or should
+  it be a separate `@MainActor` service injected into the controller/model?

--- a/openspec/changes/stabilize-macos-shell-terminal/proposal.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The native macOS app is meant to be a real terminal host for both humans and
+agents, but the current prototype still has lifecycle, control-plane, build, and
+UI-contract risks that can make tabs unreliable or misleading. Recording these
+issues as an OpenSpec change gives the next implementation pass a concrete
+contract instead of leaving the review as informal notes.
+
+## What Changes
+
+- Stabilize terminal runtime ownership so tabs and panes keep their process and
+  Ghostty surface lifecycles independently of whether SwiftUI is currently
+  rendering them.
+- Make `pane.send_text` and related control-plane mutations report delivery
+  truthfully, including failure when the target pane is not reachable.
+- Make each macOS window use isolated shell state, persistence, socket paths, and
+  event streams.
+- Harden the local shell control socket and file-command fallback against stalled
+  clients, oversized requests, and silent persistence failures.
+- Refactor the default macOS UI toward the existing `Alan` product contract:
+  space rail, active-space tab list, terminal-first content, restrained toolbar,
+  and progressive inspector.
+- Align the Apple project build contract with documented system requirements and
+  make Ghostty dependencies explicit and verifiable.
+- Add focused tests for shell state mutation, control-plane behavior, terminal
+  lifecycle routing, and UI contract-sensitive model behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-shell-terminal-lifecycle`: Terminal tabs and panes preserve process,
+  renderer, focus, metadata, and text-delivery semantics across selection and
+  view lifecycle changes.
+- `macos-shell-control-plane-reliability`: The local shell control surface uses
+  stable window-scoped identities, bounded IPC behavior, explicit mutation
+  acknowledgements, and inspectable failure states.
+- `macos-shell-ui-ux-conformance`: The macOS app default UI conforms to the
+  documented Alan shell UI/UX contract and keeps terminal content as the visual
+  and functional center.
+- `macos-shell-build-test-contract`: The Apple client has a documented,
+  reproducible build/dependency contract and focused test coverage for shell
+  model and control-plane risks.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Apple client: `AlanNativeApp.swift`, `MacShellRootView.swift`,
+  `TerminalPaneView.swift`, `TerminalHostView.swift`, `GhosttyLiveHost.swift`,
+  `TerminalHostRuntime.swift`, `ShellHostController.swift`,
+  `ShellControlPlane.swift`, `ShellModel.swift`, and the Xcode project.
+- Product specs: `docs/spec/alan_shell_macos_contract.md` and
+  `docs/spec/alan_macos_shell_ui_ux.md` remain the narrative source of truth;
+  this change adds implementation-ready OpenSpec requirements.
+- Build/dependencies: local Ghostty artifact setup, deployment targets,
+  resources, framework linking, and warning policy.
+- Tests: shell model mutation tests, control-plane IPC/file command tests,
+  terminal lifecycle/delivery tests with a mock host boundary, and project build
+  verification.

--- a/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Build requirements match documentation
+The Apple client SHALL keep documented system requirements, deployment targets,
+and project settings aligned.
+
+#### Scenario: Deployment target changes
+- **WHEN** the Xcode project deployment targets are changed
+- **THEN** `clients/apple/README.md` and relevant specs are updated in the same change
+
+#### Scenario: Documented build command
+- **WHEN** a developer runs the documented macOS build command after preparing dependencies
+- **THEN** the command succeeds or fails with documented, actionable dependency setup instructions
+
+### Requirement: Ghostty dependency setup is explicit
+The Apple project SHALL treat Ghostty framework, resources, and terminfo as an
+explicit local dependency with a verifiable setup path.
+
+#### Scenario: Dependencies are missing
+- **WHEN** `GhosttyKit.xcframework`, `ghostty-resources`, or `ghostty-terminfo` are absent
+- **THEN** the build or setup check reports the missing dependency and points to the supported preparation command
+
+#### Scenario: Dependencies are present
+- **WHEN** local Ghostty artifacts are prepared
+- **THEN** the macOS app build links/copies them without module-map or umbrella-header warnings that obscure real failures
+
+### Requirement: Shell model behavior has focused tests
+The Apple client SHALL have focused automated tests for shell state mutation and
+control-plane behavior that can run without launching the full app UI.
+
+#### Scenario: State mutation tests
+- **WHEN** shell spaces, tabs, and panes are created, split, moved, lifted, focused, and closed
+- **THEN** tests verify focused IDs, pane trees, space membership, attention state, and failure cases
+
+#### Scenario: Control-plane tests
+- **WHEN** control-plane query and mutation commands are executed against a test host
+- **THEN** tests verify successful responses, missing-target errors, event records, and text-delivery acknowledgement semantics
+
+### Requirement: Terminal host boundary is testable
+The terminal host SHALL expose a testable boundary for runtime attachment,
+teardown, and text delivery without requiring the real Ghostty library in every
+test.
+
+#### Scenario: Mock runtime accepts text
+- **WHEN** a test runtime is registered for a pane and `pane.send_text` is issued
+- **THEN** the test verifies the text reaches the runtime and the control response reports accepted bytes
+
+#### Scenario: Mock runtime unavailable
+- **WHEN** no runtime is registered for a pane and `pane.send_text` is issued
+- **THEN** the test verifies the response reports failure or durable queueing according to the delivery contract

--- a/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-control-plane-reliability/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Windows have isolated shell identities
+Each macOS window SHALL have a unique shell window identity, control directory,
+socket path, event stream, and persisted shell state unless the user explicitly
+opens a restored instance of the same window.
+
+#### Scenario: Opening a second window
+- **WHEN** the user opens a second Alan macOS window
+- **THEN** the second window uses a different `window_id`, socket path, control directory, and persisted state from the first window
+
+#### Scenario: Reading window state
+- **WHEN** an agent queries one window's shell state
+- **THEN** the response contains only spaces, tabs, panes, events, and focus state for that window
+
+### Requirement: IPC requests are bounded
+The local shell control socket SHALL bound request size, request duration, and
+per-client work so a stalled or oversized client cannot block other control
+requests indefinitely.
+
+#### Scenario: Client never sends newline
+- **WHEN** a socket client connects and does not complete a request within the configured deadline
+- **THEN** the server closes that client and continues accepting later clients
+
+#### Scenario: Client sends oversized request
+- **WHEN** a socket client sends more than the maximum accepted request bytes
+- **THEN** the server rejects that request, closes the client, and keeps serving later requests
+
+#### Scenario: Main actor command handling is slow
+- **WHEN** a command requires main-actor handling and the handler exceeds the response deadline
+- **THEN** the server returns or records a timeout failure instead of hanging the socket loop
+
+### Requirement: Mutations report authoritative results
+Control-plane mutation commands SHALL return responses derived from authoritative
+shell/runtime state after the requested mutation has been accepted or rejected.
+
+#### Scenario: Missing target
+- **WHEN** a mutation references a missing space, tab, or pane ID
+- **THEN** the response reports `applied: false` with a stable error code
+
+#### Scenario: Runtime-dependent mutation
+- **WHEN** a mutation depends on terminal runtime availability
+- **THEN** the response reflects whether the runtime accepted, queued, or rejected the operation
+
+### Requirement: Persistence and event failures are observable
+The shell control plane SHALL surface state, event, command, and binding file IO
+failures through logs, diagnostics, or control responses instead of ignoring all
+write/read errors.
+
+#### Scenario: State file cannot be written
+- **WHEN** publishing shell state fails to write the state file
+- **THEN** the control plane records a diagnostic that can be inspected during debugging
+
+#### Scenario: Command file cannot be decoded
+- **WHEN** a file-command request cannot be decoded
+- **THEN** the control plane records or writes a failure result rather than silently deleting the only evidence

--- a/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Terminal runtimes survive view selection changes
+The macOS shell host SHALL keep a tab's terminal process, renderer surface,
+runtime metadata, and buffered control state owned by the shell model or a
+dedicated runtime registry rather than by the transient SwiftUI/AppKit view that
+happens to be visible.
+
+#### Scenario: Switching away from a tab
+- **WHEN** a user switches from one tab to another and the first tab is no longer rendered
+- **THEN** the first tab's terminal process and runtime record remain alive unless the tab or pane is explicitly closed
+
+#### Scenario: Switching back to a tab
+- **WHEN** a user returns to a previously selected tab
+- **THEN** the host reattaches the visible view to the existing terminal runtime instead of booting a new shell process
+
+#### Scenario: Closing a tab
+- **WHEN** a tab is explicitly closed
+- **THEN** all terminal runtimes owned by that tab are torn down exactly once and their final state is reflected in shell state
+
+### Requirement: Pane text delivery is truthful
+The macOS shell host SHALL only acknowledge `pane.send_text` as applied when the
+target pane runtime accepts the text or queues it in a durable pane-specific
+delivery buffer that will be flushed when the runtime is attached.
+
+#### Scenario: Visible pane accepts text
+- **WHEN** `pane.send_text` targets a visible pane with a ready terminal runtime
+- **THEN** the response reports `applied: true` and includes the accepted byte count
+
+#### Scenario: Background pane accepts text
+- **WHEN** `pane.send_text` targets a background pane with an existing terminal runtime
+- **THEN** the text is delivered to that runtime without requiring the tab to become visible
+
+#### Scenario: Target pane cannot accept text
+- **WHEN** `pane.send_text` targets a missing, closed, or not-yet-bootable pane
+- **THEN** the response reports `applied: false` with a specific error code and does not claim accepted bytes
+
+### Requirement: Focus and metadata follow runtime identity
+The macOS shell host SHALL associate focus, cwd, title, process status,
+attention, renderer phase, and last-command metadata with stable pane IDs.
+
+#### Scenario: Runtime metadata arrives for a background pane
+- **WHEN** a background pane reports cwd, title, process, or attention changes
+- **THEN** the shell state for that pane updates without changing the user's selected tab
+
+#### Scenario: Visible focus changes
+- **WHEN** the user focuses a visible pane
+- **THEN** shell state updates the focused pane while preserving the runtime records for all other panes
+
+### Requirement: Host fallback state is user-safe
+The macOS shell host SHALL make unavailable Ghostty or failed terminal runtime
+states explicit and actionable without presenting a fake usable terminal.
+
+#### Scenario: Ghostty is unavailable
+- **WHEN** the app launches without a linked or loadable Ghostty runtime
+- **THEN** the affected pane reports a non-ready terminal state and the UI provides setup/debug information without accepting terminal input as if it succeeded
+
+#### Scenario: Surface creation fails
+- **WHEN** a terminal surface cannot be created for a pane
+- **THEN** the pane records the failure reason and control-plane mutations against that pane fail or queue according to the delivery contract

--- a/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Sidebar matches space rail plus tab list
+The default macOS sidebar SHALL present spaces as a compact vertical rail and
+tabs for the active space as the primary sidebar list.
+
+#### Scenario: Default sidebar reading order
+- **WHEN** a user opens the macOS app
+- **THEN** the sidebar reads as a space switcher plus active-space tab list, not as unrelated dashboard sections
+
+#### Scenario: Space selection
+- **WHEN** a user selects a space in the rail
+- **THEN** the tab list updates to show only tabs belonging to that active space
+
+#### Scenario: Separate creation affordances
+- **WHEN** a user creates a new space or a new tab
+- **THEN** space creation is presented as a compact rail affordance and tab creation is presented in the active-space tab list or toolbar context
+
+#### Scenario: Lightweight tab rows
+- **WHEN** the active-space tab list contains terminal and Alan tabs
+- **THEN** each tab appears as a skimmable row with a compact marker, title, secondary context, and low-emphasis status rather than as a card or dashboard tile
+
+### Requirement: Visual system follows native material guidance
+The default macOS shell SHALL use a light-mode-first native material visual
+system that feels calm, precise, and terminal-oriented. It SHALL avoid
+card-heavy dashboard composition, decorative gradients, hard-coded dominant
+theme panels, and ornamental controls.
+
+#### Scenario: Material sidebar
+- **WHEN** the app window is visible in the default light appearance
+- **THEN** the space rail and tab list use material-backed surfaces, subtle separators, and restrained selection states rather than an opaque themed sidebar panel
+
+#### Scenario: Stable compact controls
+- **WHEN** the user hovers, selects, inserts, closes, or switches tabs and spaces
+- **THEN** rows, icon controls, counters, and status marks keep stable dimensions and do not resize the sidebar or terminal content
+
+#### Scenario: No dashboard treatment
+- **WHEN** the user views the default shell without the Debug inspector selected
+- **THEN** the UI does not present page-like sections, nested cards, large explanatory panels, or marketing-style hero composition
+
+### Requirement: Terminal content is the center of gravity
+The main content region SHALL make the active terminal canvas visually dominant
+and SHALL avoid nested decorative panels around the terminal in the default
+single-pane state.
+
+#### Scenario: Single-pane tab
+- **WHEN** a tab contains one pane
+- **THEN** the terminal appears nearly full-bleed within the content region and does not show a pane selector strip
+
+#### Scenario: Split-pane tab
+- **WHEN** a tab contains multiple panes
+- **THEN** pane chrome stays lightweight and focus is conveyed by subtle selection treatment rather than explicit engineering labels
+
+#### Scenario: Alan as optional capability
+- **WHEN** a terminal tab is active and no Alan-specific surface has been opened
+- **THEN** Alan appears as an optional command or attachment capability layered onto the terminal workflow, not as the structural center of the window
+
+### Requirement: Default UI hides implementation jargon
+The default macOS UI SHALL avoid exposing raw pane IDs, `tab_id`, binding,
+runtime phases, `window attached`, `title updated`, and other implementation
+terms outside explicit debug surfaces.
+
+#### Scenario: Normal terminal workflow
+- **WHEN** a user creates, selects, splits, or closes tabs and panes
+- **THEN** visible copy uses product terms such as Space, Tab, Split, Inspector, Go to or Command, Open in Alan, and Ask Alan
+
+#### Scenario: Command search results
+- **WHEN** the command UI shows tabs, panes, actions, routing candidates, or attention items
+- **THEN** result titles and summaries use user-facing names where available and do not expose raw pane IDs as the primary label unless the user is in a debug context
+
+#### Scenario: Debug inspector
+- **WHEN** the user opens the inspector debug section
+- **THEN** implementation details may be shown with clear debug framing
+
+### Requirement: Toolbar is native and restrained
+The macOS toolbar/titlebar SHALL feel like native window chrome and contain only
+the current tab title/context, one command entry point, a small number of
+frequent actions, and an optional inspector toggle.
+
+#### Scenario: Toolbar default state
+- **WHEN** no urgent attention item exists
+- **THEN** the toolbar does not show attention as a large standalone primary control
+
+#### Scenario: Command entry
+- **WHEN** the user invokes the command UI
+- **THEN** the entry point is labeled and organized as `Go to or Command...`
+
+### Requirement: Inspector uses progressive disclosure
+The inspector SHALL be optional, off by default, and separated into Overview and
+Debug layers.
+
+#### Scenario: Overview selected
+- **WHEN** the inspector overview is visible
+- **THEN** it shows only user-relevant secondary state such as focused tab or pane summary, cwd or repo context, Alan attachment summary, attention summary, and minimal process status
+
+#### Scenario: Debug selected
+- **WHEN** the inspector debug layer is visible
+- **THEN** debug data such as JSON snapshots, runtime phase, Ghostty data, control paths, and Alan binding details can be inspected without dominating the default layout
+
+### Requirement: UI conformance is verified visually
+Mac shell UI changes SHALL be reviewed against the documented UI contract before
+the UI conformance tasks are marked complete.
+
+#### Scenario: Default screenshot review
+- **WHEN** a UI conformance implementation pass is ready for review
+- **THEN** maintainers can inspect a running-app screenshot of the default light-mode window showing the space rail, active-space tab list, terminal-first content area, and inspector-off state
+
+#### Scenario: Inspector screenshot review
+- **WHEN** inspector-related UI tasks are marked complete
+- **THEN** maintainers can inspect screenshots or recorded notes for both Overview and Debug inspector states, confirming that debug data is hidden from the default workflow and visible in the Debug layer

--- a/openspec/changes/stabilize-macos-shell-terminal/tasks.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/tasks.md
@@ -1,0 +1,65 @@
+## 1. Terminal Runtime Ownership
+
+- [ ] 1.1 Add a pane-keyed terminal runtime handle protocol and registry that can be owned by the shell host/model layer.
+- [ ] 1.2 Add a mock terminal runtime implementation for tests, including attach, detach, send text, metadata update, and teardown observation.
+- [ ] 1.3 Move terminal process, renderer phase, cwd, title, attention, and last-command metadata updates onto stable pane IDs.
+- [ ] 1.4 Update tab and pane close paths to tear down registry-owned runtimes exactly once.
+- [ ] 1.5 Update `TerminalHostView` so view removal detaches from a runtime but does not tear down the pane process.
+- [ ] 1.6 Add lifecycle tests for switching tabs, returning to a tab, closing a pane, and closing a tab.
+
+## 2. Text Delivery And Mutation Acknowledgements
+
+- [ ] 2.1 Define stable control-plane result types/error codes for accepted, queued, rejected, missing target, unavailable runtime, and timeout outcomes.
+- [ ] 2.2 Route `pane.send_text` through the runtime registry instead of treating NotificationCenter delivery as success.
+- [ ] 2.3 Implement background-pane text delivery for existing runtimes without changing the selected tab.
+- [ ] 2.4 Implement the unavailable-runtime behavior chosen for this change: explicit rejection or a durable pane-specific queue with flush tests.
+- [ ] 2.5 Update control-plane responses and shell events to include accepted byte counts or stable rejection details.
+- [ ] 2.6 Add tests for visible delivery, background delivery, missing pane, closed pane, and unavailable runtime responses.
+
+## 3. Window-Scoped Shell Context
+
+- [ ] 3.1 Introduce a per-window shell context containing `window_id`, control directory, socket path, state path, event path, and runtime registry.
+- [ ] 3.2 Replace fixed `window_main` state/socket/control paths with context-derived paths in the app scene and shell controller.
+- [ ] 3.3 Ensure a second `WindowGroup` instance creates or restores a distinct context and does not share shell state with the first window.
+- [ ] 3.4 Add best-effort migration or clear handling for legacy fixed-path shell state files.
+- [ ] 3.5 Add tests for opening two contexts, publishing independent state, and querying only one window's data.
+
+## 4. IPC, Persistence, And Diagnostics
+
+- [ ] 4.1 Add maximum request byte size enforcement to the local shell control socket.
+- [ ] 4.2 Add request read deadlines and command execution deadlines so stalled clients cannot block later clients.
+- [ ] 4.3 Refactor socket handling so one slow client or main-actor command does not stall the accept loop.
+- [ ] 4.4 Convert shell state, event, binding, and file-command IO operations to record or return failures.
+- [ ] 4.5 Add inspectable diagnostics for recent control-plane persistence, decode, timeout, and delivery failures.
+- [ ] 4.6 Add tests for no-newline clients, oversized requests, slow command handling, state write failure, and undecodable file commands.
+
+## 5. macOS Shell UI Conformance
+
+- [ ] 5.1 Audit `MacShellRootView`, `TerminalPaneView`, and command UI against the impeccable/OpenSpec design acceptance layer before refactoring.
+- [ ] 5.2 Refactor the sidebar into a compact space rail plus active-space tab list.
+- [ ] 5.3 Separate space creation and tab creation affordances so each lives in its expected rail/list or toolbar context.
+- [ ] 5.4 Update space selection so the tab list filters to the active space and preserves terminal runtime identity.
+- [ ] 5.5 Make tab rows compact, stable, and skimmable, with row-level attention/status treatment instead of cards or repeated pills.
+- [ ] 5.6 Make the single-pane terminal region visually dominant without a pane selector strip or nested decorative panel.
+- [ ] 5.7 Keep split-pane chrome lightweight and use subtle focus treatment instead of engineering labels.
+- [ ] 5.8 Replace default raw identifiers and runtime jargon with product terms in normal workflows, including command search result titles and summaries.
+- [ ] 5.9 Move raw pane IDs, socket paths, runtime phases, binding data, and JSON snapshots behind an explicit Debug inspector layer.
+- [ ] 5.10 Restrain the toolbar to current context, `Go to or Command...`, frequent actions, and optional inspector toggle.
+- [ ] 5.11 Apply the light-mode native-material pass to the sidebar, toolbar, terminal surround, and inspector so the shell does not read as a hard-coded themed dashboard.
+- [ ] 5.12 Capture or record default, Overview inspector, and Debug inspector UI review evidence before marking UI conformance complete.
+
+## 6. Build Contract And Dependency Setup
+
+- [ ] 6.1 Align Apple README and relevant specs with the Xcode project deployment targets.
+- [ ] 6.2 Add or document a supported Ghostty dependency preparation/check command for framework, resources, and terminfo artifacts.
+- [ ] 6.3 Make missing Ghostty artifacts fail with actionable setup guidance instead of opaque project or linker errors.
+- [ ] 6.4 Remove or suppress avoidable Ghostty module-map/umbrella-header warnings that obscure real build failures.
+- [ ] 6.5 Add a documented macOS build verification command for the prepared dependency state.
+
+## 7. Verification
+
+- [ ] 7.1 Run focused Apple tests for shell model mutation, runtime delivery, window isolation, and control-plane behavior.
+- [ ] 7.2 Run the documented macOS Xcode build command after preparing Ghostty dependencies.
+- [ ] 7.3 Run `openspec status --change stabilize-macos-shell-terminal` and confirm the change is implementation-complete.
+- [ ] 7.4 Update review notes or follow-up OpenSpec items for any intentionally deferred runtime queueing, migration, or UI debug-surface decisions.
+- [ ] 7.5 Confirm UI review evidence covers the default light-mode shell, Overview inspector, and Debug inspector states.


### PR DESCRIPTION
## Summary

- Add OpenSpec proposal, design, requirements, and tasks for stabilizing the native macOS shell terminal experience.
- Add macOS shell design context to AGENTS.md so agents have the product direction in the shared guide.
- Remove CLAUDE.md after moving its verification-loop guidance into AGENTS.md.

## Validation

- openspec status --change stabilize-macos-shell-terminal --json
- git diff --cached --check