### PR TITLE
OpenSpec: integrate openrouter-rs

### DIFF
--- a/openspec/changes/integrate-openrouter-rs/.openspec.yaml
+++ b/openspec/changes/integrate-openrouter-rs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/integrate-openrouter-rs/design.md
+++ b/openspec/changes/integrate-openrouter-rs/design.md
@@ -25,8 +25,8 @@ projection and response normalization.
 
 - Make `openrouter` a user-facing provider id in connection profiles and runtime
   resolved state.
-- Provide a one-time migration/repair path for saved connection metadata that
-  still names `openrouter_openai_chat_completions_compatible`.
+- Hard-remove the retired OpenRouter-compatible provider id and route because it
+  was not a supported user-facing configuration and has no known users.
 - Back OpenRouter generation and streaming with `openrouter-rs`, not Alan's
   generic OpenAI-compatible HTTP client.
 - Preserve Alan's common core semantics for text, reasoning, tool calls, tool
@@ -47,8 +47,8 @@ projection and response normalization.
 - Do not migrate Alan's core provider abstraction to the OpenRouter Responses or
   Messages endpoints.
 - Do not remove the generic `openai_chat_completions_compatible` provider.
-- Do not keep `openrouter_openai_chat_completions_compatible` as a runtime alias
-  or provider factory path after migration.
+- Do not migrate, repair, or alias
+  `openrouter_openai_chat_completions_compatible`.
 - Do not guarantee that every OpenRouter model supports every provider-level
   capability; model-specific limitations remain upstream behavior.
 
@@ -92,13 +92,19 @@ Add `LlmProvider::OpenRouter` serialized as `openrouter`, add
 `ProviderType::OpenRouter`, and add an OpenRouter descriptor to the connection
 catalog. Remove the old
 `openrouter_openai_chat_completions_compatible` provider type/path instead of
-keeping it as a compatibility alias. New runtime state, connection profiles,
-docs, tests, and provider-name detection should use `openrouter` only.
+keeping it as a compatibility alias or adding a migration. New runtime state,
+connection profiles, docs, tests, and provider-name detection should use
+`openrouter` only. The retired id should be absent from provider descriptors,
+`alan connection add`, daemon catalogs, runtime resolved provider state,
+persisted provider state, and LLM factory dispatch.
 
-The retired string may remain recognizable only at the connection-file boundary
-so Alan can diagnose or migrate existing `connections.toml` files. It must not
-appear in provider descriptors, `alan connection add`, daemon catalogs, runtime
-resolved provider state, or LLM factory dispatch.
+If an unsupported local `connections.toml` still contains the retired id, Alan
+may fail to load that file as unsupported configuration. That is acceptable for
+this change because the old id was an implementation-detail path rather than a
+supported user-facing provider, and there are no known users to migrate.
+Implementors may add a targeted diagnostic that names `openrouter` as the
+replacement when doing so is simple, but they should not add automatic rewrite or
+alias behavior.
 
 Rationale: The old id describes an implementation detail instead of the product
 provider. Keeping it as an alias would preserve the compatible-path concept this
@@ -183,10 +189,10 @@ uniformity of model behavior behind the aggregator.
 - Streaming tool-call deltas can arrive fragmented or out of order -> Reuse the
   existing Alan stream aggregation rules where possible and add adapter-specific
   tests for argument assembly, malformed JSON, and final chunks.
-- Provider-id hard cutover can break saved profile or persisted-state fixtures
-  that still name `openrouter_openai_chat_completions_compatible` -> Add a
-  one-time connection metadata migration/repair path for saved profiles and
-  credentials, then reject the retired id anywhere it would create a provider.
+- Provider-id hard cutover can break local unsupported profile or persisted-state
+  fixtures that still name `openrouter_openai_chat_completions_compatible` ->
+  Update or remove those fixtures as part of the change and fail fast on the old
+  id rather than silently treating it as OpenRouter.
 
 ## Migration Plan
 
@@ -197,25 +203,22 @@ uniformity of model behavior behind the aggregator.
    detection, and explicit capabilities.
 3. Add `LlmProvider::OpenRouter` to runtime config, connection profiles,
    persisted provider state, daemon session metadata, and CLI/daemon connection
-   parsing.
-4. Add a connection metadata migration/repair path that rewrites retired
-   `openrouter_openai_chat_completions_compatible` profile providers and
-   credential provider families to `openrouter` while preserving profile ids,
-   credential ids, secrets, and compatible settings that OpenRouter still owns.
-5. Remove the old OpenRouter-compatible provider factory type/path, and make any
+   parsing, and remove the old OpenRouter-compatible provider id/path without a
+   migration alias.
+4. Remove the old OpenRouter-compatible provider factory type/path, and make any
    remaining attempts to construct it fail fast instead of acting as an alias.
-6. Add OpenRouter resolved config fields for API key, base URL, model,
+5. Add OpenRouter resolved config fields for API key, base URL, model,
    `http_referer`, `x_title`, and `app_categories`; keep them internal resolved
    state rather than new user-facing `agent.toml` examples.
-7. Implement non-streaming request/response mapping and focused unit tests.
-8. Implement streaming mapping and tests for content deltas, reasoning deltas,
+6. Implement non-streaming request/response mapping and focused unit tests.
+7. Implement streaming mapping and tests for content deltas, reasoning deltas,
    tool-call deltas, usage, finish reason, response id, and stream errors.
-9. Add or extend live provider harness support gated by
+8. Add or extend live provider harness support gated by
    `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional
    OpenRouter metadata env vars.
-10. Update docs and provider capability text from "OpenRouter via adapter" to the
+9. Update docs and provider capability text from "OpenRouter via adapter" to the
    new SDK-backed provider path.
-11. Run `cargo fmt --all`, focused `cargo test -p alan-llm` filters, focused
+10. Run `cargo fmt --all`, focused `cargo test -p alan-llm` filters, focused
    `cargo test -p alan-runtime` / `cargo test -p alan` filters for connection
    profiles, and the live harness only when credentials are available.
 

--- a/openspec/changes/integrate-openrouter-rs/design.md
+++ b/openspec/changes/integrate-openrouter-rs/design.md
@@ -25,6 +25,8 @@ projection and response normalization.
 
 - Make `openrouter` a user-facing provider id in connection profiles and runtime
   resolved state.
+- Provide a one-time migration/repair path for saved connection metadata that
+  still names `openrouter_openai_chat_completions_compatible`.
 - Back OpenRouter generation and streaming with `openrouter-rs`, not Alan's
   generic OpenAI-compatible HTTP client.
 - Preserve Alan's common core semantics for text, reasoning, tool calls, tool
@@ -45,6 +47,8 @@ projection and response normalization.
 - Do not migrate Alan's core provider abstraction to the OpenRouter Responses or
   Messages endpoints.
 - Do not remove the generic `openai_chat_completions_compatible` provider.
+- Do not keep `openrouter_openai_chat_completions_compatible` as a runtime alias
+  or provider factory path after migration.
 - Do not guarantee that every OpenRouter model supports every provider-level
   capability; model-specific limitations remain upstream behavior.
 
@@ -90,6 +94,11 @@ catalog. Remove the old
 `openrouter_openai_chat_completions_compatible` provider type/path instead of
 keeping it as a compatibility alias. New runtime state, connection profiles,
 docs, tests, and provider-name detection should use `openrouter` only.
+
+The retired string may remain recognizable only at the connection-file boundary
+so Alan can diagnose or migrate existing `connections.toml` files. It must not
+appear in provider descriptors, `alan connection add`, daemon catalogs, runtime
+resolved provider state, or LLM factory dispatch.
 
 Rationale: The old id describes an implementation detail instead of the product
 provider. Keeping it as an alias would preserve the compatible-path concept this
@@ -175,9 +184,9 @@ uniformity of model behavior behind the aggregator.
   existing Alan stream aggregation rules where possible and add adapter-specific
   tests for argument assembly, malformed JSON, and final chunks.
 - Provider-id hard cutover can break saved profile or persisted-state fixtures
-  that still name `openrouter_openai_chat_completions_compatible` -> Update or
-  remove those fixtures as part of the change and fail fast on the old id rather
-  than silently treating it as OpenRouter.
+  that still name `openrouter_openai_chat_completions_compatible` -> Add a
+  one-time connection metadata migration/repair path for saved profiles and
+  credentials, then reject the retired id anywhere it would create a provider.
 
 ## Migration Plan
 
@@ -188,19 +197,25 @@ uniformity of model behavior behind the aggregator.
    detection, and explicit capabilities.
 3. Add `LlmProvider::OpenRouter` to runtime config, connection profiles,
    persisted provider state, daemon session metadata, and CLI/daemon connection
-   parsing, and remove the old OpenRouter-compatible provider type/path.
-4. Add OpenRouter resolved config fields for API key, base URL, model,
+   parsing.
+4. Add a connection metadata migration/repair path that rewrites retired
+   `openrouter_openai_chat_completions_compatible` profile providers and
+   credential provider families to `openrouter` while preserving profile ids,
+   credential ids, secrets, and compatible settings that OpenRouter still owns.
+5. Remove the old OpenRouter-compatible provider factory type/path, and make any
+   remaining attempts to construct it fail fast instead of acting as an alias.
+6. Add OpenRouter resolved config fields for API key, base URL, model,
    `http_referer`, `x_title`, and `app_categories`; keep them internal resolved
    state rather than new user-facing `agent.toml` examples.
-5. Implement non-streaming request/response mapping and focused unit tests.
-6. Implement streaming mapping and tests for content deltas, reasoning deltas,
+7. Implement non-streaming request/response mapping and focused unit tests.
+8. Implement streaming mapping and tests for content deltas, reasoning deltas,
    tool-call deltas, usage, finish reason, response id, and stream errors.
-7. Add or extend live provider harness support gated by
+9. Add or extend live provider harness support gated by
    `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional
    OpenRouter metadata env vars.
-8. Update docs and provider capability text from "OpenRouter via adapter" to the
+10. Update docs and provider capability text from "OpenRouter via adapter" to the
    new SDK-backed provider path.
-9. Run `cargo fmt --all`, focused `cargo test -p alan-llm` filters, focused
+11. Run `cargo fmt --all`, focused `cargo test -p alan-llm` filters, focused
    `cargo test -p alan-runtime` / `cargo test -p alan` filters for connection
    profiles, and the live harness only when credentials are available.
 

--- a/openspec/changes/integrate-openrouter-rs/design.md
+++ b/openspec/changes/integrate-openrouter-rs/design.md
@@ -118,8 +118,8 @@ changes but keeps the public contract tied to the adapter Alan is removing.
 The OpenRouter profile descriptor should use secret-string credentials and
 settings owned by OpenRouter:
 
-- required: `base_url`, `model`
-- optional: `http_referer`, `x_title`, `app_categories`
+- required: `model`
+- optional: `base_url`, `http_referer`, `x_title`, `app_categories`
 - default `base_url`: `https://openrouter.ai/api/v1`
 
 The model setting should remain explicit in the profile or command line. If a

--- a/openspec/changes/integrate-openrouter-rs/design.md
+++ b/openspec/changes/integrate-openrouter-rs/design.md
@@ -1,0 +1,224 @@
+## Context
+
+Issue 77 asks Alan to replace the current OpenRouter adapter with
+`openrouter-rs`. The current `alan-llm` implementation has an internal
+`ProviderType::OpenRouterOpenAiChatCompletionsCompatible`, but factory creation
+still routes it through `OpenAiChatCompletionsClient::openrouter_compatible_with_params(...)`.
+The runtime-facing `LlmProvider` enum, connection catalog, and CLI parser do not
+yet expose a first-class `openrouter` provider id.
+
+`openrouter-rs` 0.8.x is now a better fit for this boundary: it exposes
+`OpenRouterClient::builder()`, domain clients such as `chat()`, streaming and
+unified streaming methods, reasoning support, typed/manual tools, multimodal
+content, and OpenRouter-specific client metadata (`http_referer`, `x_title`,
+`app_categories`). The SDK intentionally leaves profile/config resolution to
+the application, which matches Alan's existing connection-profile model.
+
+The implementation must preserve Alan's provider-agnostic kernel contract:
+runtime code should continue to speak `GenerationRequest`, `GenerationResponse`,
+and `StreamChunk`, while the provider adapter owns OpenRouter-specific request
+projection and response normalization.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `openrouter` a user-facing provider id in connection profiles and runtime
+  resolved state.
+- Back OpenRouter generation and streaming with `openrouter-rs`, not Alan's
+  generic OpenAI-compatible HTTP client.
+- Preserve Alan's common core semantics for text, reasoning, tool calls, tool
+  results, finish reasons, usage, provider response ids, and stream completion.
+- Keep OpenRouter-specific settings separate from generic
+  `openai_chat_completions_compatible` settings.
+- Add tests that prove factory routing, request mapping, response mapping,
+  streaming aggregation, profile resolution, and CLI/daemon catalog behavior.
+- Update provider docs so OpenRouter is documented as a dedicated provider path
+  with an SDK-backed implementation.
+
+**Non-Goals:**
+
+- Do not adopt the `openrouter-rs` CLI/profile configuration system. Alan
+  remains responsible for connection profiles and secrets.
+- Do not expose OpenRouter management, model discovery, TTS, video, rerank, or
+  embeddings through Alan's LLM provider trait in this change.
+- Do not migrate Alan's core provider abstraction to the OpenRouter Responses or
+  Messages endpoints.
+- Do not remove the generic `openai_chat_completions_compatible` provider.
+- Do not guarantee that every OpenRouter model supports every provider-level
+  capability; model-specific limitations remain upstream behavior.
+
+## Decisions
+
+### Decision: Add a dedicated `OpenRouterClient` adapter module
+
+Create a new `crates/llm/src/openrouter.rs` module that implements
+`LlmProvider` for an Alan-owned wrapper around `openrouter_rs::OpenRouterClient`.
+The wrapper should own the resolved model and client settings, expose
+`provider_name() == "openrouter"`, and be constructed by
+`ProviderType::OpenRouter`.
+
+Rationale: A separate module gives Alan a clear OpenRouter boundary and avoids
+spreading SDK-specific types through the existing OpenAI-compatible adapter.
+
+Alternative considered: keep the existing OpenAI-compatible adapter and add
+headers/options. That would still make OpenRouter behavior depend on generic
+request/stream parsing and would not use the SDK surfaces issue 77 calls out.
+
+### Decision: Use `openrouter-rs` chat domain APIs for V1
+
+Map Alan requests to `openrouter-rs` chat-completion requests and call
+`client.chat().create(...)` for non-streaming generation. Streaming should use
+the SDK streaming surface, preferring `stream_unified` if it carries the needed
+reasoning/tool/completion events cleanly; otherwise use the chat stream and
+adapt its chunks directly.
+
+Rationale: Alan's current provider trait is closest to chat-completion semantics
+and already models message history plus tool calls. The OpenRouter Responses and
+Messages endpoints are useful SDK capabilities, but adopting them would require
+new runtime semantics that are outside this issue.
+
+Alternative considered: use OpenRouter Responses for all models. That would
+increase the semantic gap against Alan's current message/tool projection and is
+not needed to replace the thin adapter.
+
+### Decision: Make `openrouter` the only OpenRouter provider id
+
+Add `LlmProvider::OpenRouter` serialized as `openrouter`, add
+`ProviderType::OpenRouter`, and add an OpenRouter descriptor to the connection
+catalog. Remove the old
+`openrouter_openai_chat_completions_compatible` provider type/path instead of
+keeping it as a compatibility alias. New runtime state, connection profiles,
+docs, tests, and provider-name detection should use `openrouter` only.
+
+Rationale: The old id describes an implementation detail instead of the product
+provider. Keeping it as an alias would preserve the compatible-path concept this
+change is intentionally retiring.
+
+Alternative considered: preserve the long provider id. That avoids small enum
+changes but keeps the public contract tied to the adapter Alan is removing.
+
+### Decision: Keep OpenRouter settings in connection profiles
+
+The OpenRouter profile descriptor should use secret-string credentials and
+settings owned by OpenRouter:
+
+- required: `base_url`, `model`
+- optional: `http_referer`, `x_title`, `app_categories`
+- default `base_url`: `https://openrouter.ai/api/v1`
+
+The model setting should remain explicit in the profile or command line. If a
+default model is added later, it should be a curated Alan model-catalog decision,
+not a hidden SDK default.
+
+Rationale: Alan's current direction puts provider setup in
+`~/.alan/connections.toml` plus the secret store. OpenRouter's app-identifying
+headers are provider-specific and should not pollute the generic compatible
+provider.
+
+Alternative considered: add more `agent.toml` inline provider fields. That
+would expand a compatibility surface the project is already moving away from.
+
+### Decision: Use explicit mapping helpers and an allowlist for extra params
+
+The adapter should convert Alan messages, tool definitions, tool results,
+temperature, max tokens, and thinking budget into SDK request fields through
+OpenRouter-owned mapping helpers. OpenRouter-specific `extra_params` should be
+handled through an allowlist of SDK-supported request fields. Unsupported
+`extra_params` must not be silently dropped; the adapter should either return a
+clear error before dispatch or surface an explicit warning where the runtime
+already supports provider warnings.
+
+Rationale: The generic OpenAI-compatible path can forward arbitrary JSON, but a
+typed SDK adapter should make the supported contract deliberate. Silent loss of
+request knobs would be harder to debug than an explicit unsupported-parameter
+failure.
+
+Alternative considered: serialize through raw JSON and bypass typed SDK fields
+for maximum compatibility. That would undercut the reason to adopt the SDK and
+make tests less valuable.
+
+### Decision: Declare OpenRouter capabilities explicitly, but keep it in Tier C
+
+OpenRouter should no longer inherit the generic compatible provider capability
+matrix. It should declare supported API-surface behavior explicitly, including
+streaming text, streaming tool calls, reasoning text when exposed by the chosen
+model, multimodal input when the request projection supports it, token usage,
+and provider response ids. It should not claim server-managed continuation,
+background execution, retrieve/cancel, provider compaction, or provider status
+unless Alan maps those surfaces through the provider trait.
+
+OpenRouter should remain a Tier C compatibility provider in the provider
+capability contract because it routes to multiple upstream model families and
+does not provide one lossless cross-vendor semantic contract.
+
+Rationale: "First-class adapter" and "full-fidelity provider semantics" are
+different things. The SDK-backed path is first-class in Alan's code, while the
+provider capability tier remains conservative.
+
+Alternative considered: promote OpenRouter to Tier B. That would overstate the
+uniformity of model behavior behind the aggregator.
+
+## Risks / Trade-offs
+
+- `openrouter-rs` 0.8.1 currently depends on a different `reqwest` line than
+  Alan's workspace dependency -> Keep SDK transport types behind the adapter
+  boundary and accept duplicate transitive dependencies unless implementation
+  shows measurable build/runtime cost.
+- SDK typed request structs may not expose every OpenRouter request knob Alan
+  users expect -> Start with a tested allowlist and add new mappings as concrete
+  use cases appear.
+- OpenRouter model behavior varies by upstream provider -> Document that the
+  capability matrix describes the API/adapter surface, not a guarantee for every
+  model.
+- Streaming tool-call deltas can arrive fragmented or out of order -> Reuse the
+  existing Alan stream aggregation rules where possible and add adapter-specific
+  tests for argument assembly, malformed JSON, and final chunks.
+- Provider-id hard cutover can break saved profile or persisted-state fixtures
+  that still name `openrouter_openai_chat_completions_compatible` -> Update or
+  remove those fixtures as part of the change and fail fast on the old id rather
+  than silently treating it as OpenRouter.
+
+## Migration Plan
+
+1. Add the `openrouter-rs` dependency to `alan-llm` and wire the new module into
+   `lib.rs`.
+2. Add `ProviderType::OpenRouter`, the `ProviderConfig::openrouter(...)`
+   constructor, factory creation through the SDK adapter, provider-name
+   detection, and explicit capabilities.
+3. Add `LlmProvider::OpenRouter` to runtime config, connection profiles,
+   persisted provider state, daemon session metadata, and CLI/daemon connection
+   parsing, and remove the old OpenRouter-compatible provider type/path.
+4. Add OpenRouter resolved config fields for API key, base URL, model,
+   `http_referer`, `x_title`, and `app_categories`; keep them internal resolved
+   state rather than new user-facing `agent.toml` examples.
+5. Implement non-streaming request/response mapping and focused unit tests.
+6. Implement streaming mapping and tests for content deltas, reasoning deltas,
+   tool-call deltas, usage, finish reason, response id, and stream errors.
+7. Add or extend live provider harness support gated by
+   `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional
+   OpenRouter metadata env vars.
+8. Update docs and provider capability text from "OpenRouter via adapter" to the
+   new SDK-backed provider path.
+9. Run `cargo fmt --all`, focused `cargo test -p alan-llm` filters, focused
+   `cargo test -p alan-runtime` / `cargo test -p alan` filters for connection
+   profiles, and the live harness only when credentials are available.
+
+Rollback is straightforward before release: remove the public `openrouter`
+descriptor and restore factory routing to the existing compatible client. After
+release, keep the `openrouter` provider id and revert only the SDK-backed
+adapter internals if an SDK regression appears.
+
+## Open Questions
+
+- Should Alan ship a curated default OpenRouter model, or require every
+  OpenRouter profile to set `model` explicitly?
+- Does `stream_unified` expose all content, reasoning, tool-call, usage, finish,
+  and response-id fields Alan needs, or should V1 use `chat().stream(...)`
+  directly?
+- Which OpenRouter-specific request knobs should be in the first
+  `extra_params` allowlist beyond reasoning, provider preferences, transforms,
+  route, and response format?
+- Should the model catalog gain an `openrouter` provider section now, or should
+  OpenRouter model validation initially accept any non-empty model id because
+  OpenRouter's catalog changes frequently?

--- a/openspec/changes/integrate-openrouter-rs/proposal.md
+++ b/openspec/changes/integrate-openrouter-rs/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Alan currently treats OpenRouter as an OpenAI Chat Completions-compatible
+endpoint, even though the product and provider capability docs describe a
+dedicated OpenRouter path. `openrouter-rs` has reached a stable enough 0.8.x
+surface to replace the thin alias with a first-class adapter that can preserve
+OpenRouter-specific streaming, reasoning, tool, and client-identification
+semantics.
+
+## What Changes
+
+- Add `openrouter-rs` as the implementation dependency behind Alan's OpenRouter
+  provider path.
+- Introduce a dedicated OpenRouter LLM adapter in `alan-llm` that maps Alan's
+  `GenerationRequest`, `GenerationResponse`, and `StreamChunk` contracts to the
+  SDK's domain-oriented chat API.
+- Stop constructing OpenRouter providers through the generic
+  `OpenAiChatCompletionsClient::openrouter_compatible_with_params(...)` path.
+- Add a user-facing `openrouter` provider/profile surface with OpenRouter-owned
+  defaults and optional settings such as `http_referer`, `x_title`, and
+  `app_categories`.
+- Update provider capability declarations so OpenRouter's supported reasoning,
+  streaming, tool-call, usage, and response-id behavior is explicit rather than
+  inherited from the pessimistic compatible-provider defaults.
+- Update configuration, connection-profile, testing, and documentation examples
+  so the documented OpenRouter path matches the real implementation.
+- Keep the generic `openai_chat_completions_compatible` provider available for
+  non-OpenRouter endpoints.
+
+## Capabilities
+
+### New Capabilities
+
+- `openrouter-provider-adapter`: Defines Alan's first-class OpenRouter provider
+  behavior, configuration/profile surface, SDK-backed generation and streaming
+  mapping, capability matrix, and verification requirements.
+
+### Modified Capabilities
+
+- None. No archived OpenSpec capability currently owns provider adapters or
+  connection-profile behavior.
+
+## Impact
+
+- `crates/llm`: new OpenRouter adapter module, `ProviderType` wiring, SDK
+  dependency, request/response/stream mapping tests, and live provider harness
+  coverage.
+- `crates/runtime`: `LlmProvider` enum/profile resolution, config defaults,
+  provider capability detection, model validation/catalog behavior, and
+  persisted provider-state handling.
+- `crates/alan`: `alan connection` parsing, daemon connection catalog/control
+  plane, and provider test behavior.
+- `docs/` and `AGENTS.md` examples that mention provider setup, provider
+  capability tiers, or OpenRouter via adapter.
+- Cargo dependency graph and lockfile.

--- a/openspec/changes/integrate-openrouter-rs/proposal.md
+++ b/openspec/changes/integrate-openrouter-rs/proposal.md
@@ -19,9 +19,9 @@ semantics.
 - Add a user-facing `openrouter` provider/profile surface with OpenRouter-owned
   defaults and optional settings such as `http_referer`, `x_title`, and
   `app_categories`.
-- Add a one-time migration or repair path for saved connection metadata that
-  still names the retired OpenRouter-compatible provider id, without keeping
-  that id as a runtime alias.
+- Hard-remove the retired OpenRouter-compatible provider id rather than
+  migrating it; the old id was not a supported user-facing configuration and has
+  no known users.
 - Update provider capability declarations so OpenRouter's supported reasoning,
   streaming, tool-call, usage, and response-id behavior is explicit rather than
   inherited from the pessimistic compatible-provider defaults.

--- a/openspec/changes/integrate-openrouter-rs/proposal.md
+++ b/openspec/changes/integrate-openrouter-rs/proposal.md
@@ -19,6 +19,9 @@ semantics.
 - Add a user-facing `openrouter` provider/profile surface with OpenRouter-owned
   defaults and optional settings such as `http_referer`, `x_title`, and
   `app_categories`.
+- Add a one-time migration or repair path for saved connection metadata that
+  still names the retired OpenRouter-compatible provider id, without keeping
+  that id as a runtime alias.
 - Update provider capability declarations so OpenRouter's supported reasoning,
   streaming, tool-call, usage, and response-id behavior is explicit rather than
   inherited from the pessimistic compatible-provider defaults.

--- a/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
@@ -44,7 +44,9 @@ OpenAI-compatible settings.
 
 #### Scenario: Profile descriptor settings
 - **WHEN** the daemon or CLI lists provider descriptors
-- **THEN** the OpenRouter descriptor includes `base_url` and `model` as required settings and `http_referer`, `x_title`, and `app_categories` as optional settings
+- **THEN** the OpenRouter descriptor includes `model` as a required setting
+- **AND** the descriptor includes `base_url`, `http_referer`, `x_title`, and `app_categories` as optional settings
+- **AND** the descriptor declares the default `base_url`
 
 #### Scenario: Default base URL
 - **WHEN** an OpenRouter profile omits `base_url`

--- a/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: OpenRouter provider identity
+Alan SHALL expose OpenRouter as a first-class provider id named `openrouter` in
+runtime configuration, connection profiles, daemon connection catalogs, and CLI
+connection commands.
+
+#### Scenario: Creating an OpenRouter profile
+- **WHEN** an operator runs `alan connection add openrouter --profile openrouter-main --setting model=<model-id>`
+- **THEN** Alan creates a secret-backed connection profile whose provider is `openrouter`
+
+#### Scenario: Resolving an OpenRouter profile
+- **WHEN** a session starts with `connection_profile = "openrouter-main"`
+- **THEN** Alan resolves the runtime provider to OpenRouter rather than `openai_chat_completions_compatible`
+
+#### Scenario: Rejecting the retired OpenRouter-compatible id
+- **WHEN** Alan encounters a provider id named `openrouter_openai_chat_completions_compatible`
+- **THEN** Alan rejects it instead of treating it as an OpenRouter alias
+
+### Requirement: OpenRouter connection settings
+Alan SHALL keep OpenRouter-specific settings separate from generic
+OpenAI-compatible settings.
+
+#### Scenario: Profile descriptor settings
+- **WHEN** the daemon or CLI lists provider descriptors
+- **THEN** the OpenRouter descriptor includes `base_url` and `model` as required settings and `http_referer`, `x_title`, and `app_categories` as optional settings
+
+#### Scenario: Default base URL
+- **WHEN** an OpenRouter profile omits `base_url`
+- **THEN** Alan uses `https://openrouter.ai/api/v1` as the resolved OpenRouter base URL
+
+#### Scenario: Unknown OpenRouter setting
+- **WHEN** an OpenRouter profile includes a setting that is not declared by the OpenRouter descriptor
+- **THEN** Alan rejects the profile with a provider-setting validation error
+
+#### Scenario: Generic compatible settings remain isolated
+- **WHEN** an operator configures `openai_chat_completions_compatible`
+- **THEN** OpenRouter-only settings such as `http_referer`, `x_title`, and `app_categories` are not accepted by the generic compatible provider
+
+### Requirement: SDK-backed provider construction
+Alan SHALL construct OpenRouter providers through `openrouter-rs` and SHALL NOT
+route OpenRouter generation through Alan's generic OpenAI Chat Completions
+compatible client.
+
+#### Scenario: Factory creates OpenRouter SDK adapter
+- **WHEN** `ProviderConfig::openrouter(...)` is passed to the LLM provider factory
+- **THEN** the factory returns an OpenRouter SDK-backed provider whose `provider_name()` is `openrouter`
+
+#### Scenario: Retired OpenRouter-compatible factory path
+- **WHEN** code or configuration tries to construct `openrouter_openai_chat_completions_compatible`
+- **THEN** Alan fails fast because the retired compatible path is no longer supported
+
+#### Scenario: Non-streaming dispatch uses SDK
+- **WHEN** the OpenRouter provider executes a non-streaming generation request
+- **THEN** the provider dispatches through the `openrouter-rs` OpenRouter client chat API
+
+#### Scenario: Streaming dispatch uses SDK
+- **WHEN** the OpenRouter provider executes a streaming generation request
+- **THEN** the provider dispatches through an `openrouter-rs` streaming API and converts SDK stream events into Alan `StreamChunk` values
+
+### Requirement: OpenRouter request projection
+Alan SHALL map Alan generation requests to OpenRouter SDK chat requests without
+requiring runtime code to depend on OpenRouter SDK types.
+
+#### Scenario: Basic message projection
+- **WHEN** a request contains a system prompt and user, assistant, context, and tool messages
+- **THEN** the OpenRouter adapter maps them to the SDK chat message roles and content fields expected by OpenRouter
+
+#### Scenario: Tool definition projection
+- **WHEN** a request contains Alan tool definitions
+- **THEN** the OpenRouter adapter maps them to OpenRouter chat tool definitions and enables automatic tool choice behavior
+
+#### Scenario: Tool result projection
+- **WHEN** a request contains a tool-result message with a tool call id
+- **THEN** the OpenRouter adapter preserves the tool call id in the projected OpenRouter message
+
+#### Scenario: Reasoning budget projection
+- **WHEN** a request contains `thinking_budget_tokens`
+- **THEN** the OpenRouter adapter maps the budget to OpenRouter reasoning request fields supported by the SDK
+
+#### Scenario: Unsupported provider extra parameter
+- **WHEN** a request contains an OpenRouter `extra_params` key that the adapter does not support
+- **THEN** the adapter fails before dispatching the request or returns an explicit provider warning rather than silently dropping the parameter
+
+### Requirement: OpenRouter response normalization
+Alan SHALL normalize OpenRouter SDK responses into Alan's provider-agnostic
+response types.
+
+#### Scenario: Non-streaming content and reasoning
+- **WHEN** OpenRouter returns final assistant content and reasoning text
+- **THEN** Alan returns a `GenerationResponse` with `content` and `thinking` populated
+
+#### Scenario: Non-streaming tool call
+- **WHEN** OpenRouter returns model-issued tool calls with JSON arguments
+- **THEN** Alan returns `GenerationResponse.tool_calls` with the tool id, name, and parsed arguments
+
+#### Scenario: Malformed non-streaming tool arguments
+- **WHEN** OpenRouter returns a tool call whose arguments are not valid JSON
+- **THEN** Alan does not execute the malformed tool call and surfaces a provider warning
+
+#### Scenario: Usage and finish reason
+- **WHEN** OpenRouter returns token usage and a finish reason
+- **THEN** Alan preserves both values in `GenerationResponse`
+
+#### Scenario: Provider response id
+- **WHEN** OpenRouter returns a provider-native response id
+- **THEN** Alan stores that id in `provider_response_id`
+
+### Requirement: OpenRouter stream normalization
+Alan SHALL normalize OpenRouter SDK streaming events into Alan `StreamChunk`
+values and emit a terminal chunk.
+
+#### Scenario: Streaming text delta
+- **WHEN** OpenRouter streams assistant content
+- **THEN** Alan emits `StreamChunk.text` deltas in provider order
+
+#### Scenario: Streaming reasoning delta
+- **WHEN** OpenRouter streams reasoning content
+- **THEN** Alan emits `StreamChunk.thinking` deltas in provider order
+
+#### Scenario: Streaming tool-call delta
+- **WHEN** OpenRouter streams a model-issued tool call over multiple events
+- **THEN** Alan emits `StreamChunk.tool_call_delta` values that allow the runtime to assemble the final tool call
+
+#### Scenario: Streaming completion metadata
+- **WHEN** the OpenRouter stream reaches completion
+- **THEN** Alan emits a final chunk with `is_finished = true`, finish reason, usage when available, and provider response id when available
+
+#### Scenario: Streaming error after partial output
+- **WHEN** the OpenRouter SDK stream returns an error after partial output
+- **THEN** Alan propagates the stream failure through the provider stream channel so runtime partial-stream recovery policy can handle it
+
+### Requirement: OpenRouter capability matrix
+Alan SHALL declare OpenRouter capabilities explicitly instead of inheriting the
+generic OpenAI-compatible capability matrix.
+
+#### Scenario: Capability query
+- **WHEN** runtime code queries the OpenRouter provider capabilities
+- **THEN** the returned matrix reflects OpenRouter adapter support for streaming text, streaming tool calls, reasoning text, token usage, and provider response ids
+
+#### Scenario: Unsupported stateful capabilities
+- **WHEN** runtime code queries OpenRouter provider capabilities
+- **THEN** the returned matrix does not claim server-managed continuation, background execution, retrieve/cancel, provider compaction, or provider status unless those behaviors are implemented for OpenRouter
+
+#### Scenario: Capability tier
+- **WHEN** provider capability documentation describes OpenRouter
+- **THEN** OpenRouter remains documented as a compatibility-tier provider with a first-class SDK-backed adapter
+
+### Requirement: Generic compatible provider preservation
+Alan SHALL preserve the existing generic OpenAI Chat Completions-compatible
+provider for non-OpenRouter endpoints.
+
+#### Scenario: Generic compatible factory path
+- **WHEN** `ProviderConfig::openai_chat_completions_compatible(...)` is passed to the provider factory
+- **THEN** Alan still constructs the generic OpenAI-compatible provider path
+
+#### Scenario: OpenRouter does not alter compatible defaults
+- **WHEN** a generic compatible profile omits optional OpenRouter metadata settings
+- **THEN** Alan resolves the profile exactly as it did before this change
+
+### Requirement: Verification and documentation
+Alan SHALL include focused automated coverage and documentation for the
+OpenRouter SDK-backed provider path.
+
+#### Scenario: Unit and integration coverage
+- **WHEN** the change is implemented
+- **THEN** tests cover provider factory routing, profile resolution, CLI parser behavior, request mapping, response mapping, stream mapping, and capability declarations
+
+#### Scenario: Live provider harness
+- **WHEN** OpenRouter live-test credentials are available
+- **THEN** the live provider harness can validate OpenRouter non-streaming and streaming behavior through the SDK-backed adapter
+
+#### Scenario: Documentation examples
+- **WHEN** docs show OpenRouter setup
+- **THEN** they use the `openrouter` provider id and OpenRouter-specific connection settings rather than the generic compatible provider

--- a/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
@@ -3,7 +3,8 @@
 ### Requirement: OpenRouter provider identity
 Alan SHALL expose OpenRouter as a first-class provider id named `openrouter` in
 runtime configuration, connection profiles, daemon connection catalogs, and CLI
-connection commands.
+connection commands. Alan SHALL NOT expose the retired
+`openrouter_openai_chat_completions_compatible` id as a provider choice.
 
 #### Scenario: Creating an OpenRouter profile
 - **WHEN** an operator runs `alan connection add openrouter --profile openrouter-main --setting model=<model-id>`
@@ -13,9 +14,33 @@ connection commands.
 - **WHEN** a session starts with `connection_profile = "openrouter-main"`
 - **THEN** Alan resolves the runtime provider to OpenRouter rather than `openai_chat_completions_compatible`
 
-#### Scenario: Rejecting the retired OpenRouter-compatible id
-- **WHEN** Alan encounters a provider id named `openrouter_openai_chat_completions_compatible`
-- **THEN** Alan rejects it instead of treating it as an OpenRouter alias
+#### Scenario: Creating a profile with the retired OpenRouter-compatible id
+- **WHEN** an operator runs `alan connection add openrouter_openai_chat_completions_compatible`
+- **THEN** Alan rejects the command with an error that names `openrouter` as the replacement provider id
+
+#### Scenario: Retired id is absent from provider catalogs
+- **WHEN** the CLI or daemon lists available connection providers
+- **THEN** `openrouter` is present
+- **AND** `openrouter_openai_chat_completions_compatible` is absent
+
+### Requirement: Retired OpenRouter provider migration
+Alan SHALL provide a one-time migration or repair path for connection metadata
+that still names `openrouter_openai_chat_completions_compatible`, without
+keeping that id as a runtime alias.
+
+#### Scenario: Loading saved connection metadata with retired provider values
+- **WHEN** `~/.alan/connections.toml` contains `openrouter_openai_chat_completions_compatible` in either `profiles.<id>.provider` or `credentials.<id>.provider_family`
+- **THEN** Alan can identify the affected profile or credential instead of failing with a generic unknown-enum parse error
+
+#### Scenario: Migrating a retired OpenRouter profile
+- **WHEN** the OpenRouter migration or repair step is applied to a saved profile whose provider is `openrouter_openai_chat_completions_compatible`
+- **THEN** Alan rewrites the saved provider value to `openrouter`
+- **AND** Alan preserves the profile id, credential reference, secret id, `base_url`, and `model` settings
+- **AND** Alan rewrites the matching OpenRouter credential `provider_family` to `openrouter` when it used the retired id
+
+#### Scenario: Retired id does not dispatch after migration boundary
+- **WHEN** code, daemon input, or unresolved configuration still tries to use `openrouter_openai_chat_completions_compatible` as a provider after the migration boundary
+- **THEN** Alan rejects it with an actionable error instead of treating it as an OpenRouter alias
 
 ### Requirement: OpenRouter connection settings
 Alan SHALL keep OpenRouter-specific settings separate from generic

--- a/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/changes/integrate-openrouter-rs/specs/openrouter-provider-adapter/spec.md
@@ -23,24 +23,20 @@ connection commands. Alan SHALL NOT expose the retired
 - **THEN** `openrouter` is present
 - **AND** `openrouter_openai_chat_completions_compatible` is absent
 
-### Requirement: Retired OpenRouter provider migration
-Alan SHALL provide a one-time migration or repair path for connection metadata
-that still names `openrouter_openai_chat_completions_compatible`, without
-keeping that id as a runtime alias.
+### Requirement: Retired OpenRouter provider removal
+Alan SHALL remove `openrouter_openai_chat_completions_compatible` as a supported
+configuration value, provider catalog entry, and provider construction path
+without providing automatic migration or alias behavior.
 
-#### Scenario: Loading saved connection metadata with retired provider values
-- **WHEN** `~/.alan/connections.toml` contains `openrouter_openai_chat_completions_compatible` in either `profiles.<id>.provider` or `credentials.<id>.provider_family`
-- **THEN** Alan can identify the affected profile or credential instead of failing with a generic unknown-enum parse error
+#### Scenario: Saved connection metadata uses the retired provider value
+- **WHEN** `~/.alan/connections.toml` contains `openrouter_openai_chat_completions_compatible` in `profiles.<id>.provider` or `credentials.<id>.provider_family`
+- **THEN** Alan treats the file as containing unsupported legacy configuration
+- **AND** Alan does not automatically rewrite the value to `openrouter`
+- **AND** Alan does not resolve or dispatch it as OpenRouter
 
-#### Scenario: Migrating a retired OpenRouter profile
-- **WHEN** the OpenRouter migration or repair step is applied to a saved profile whose provider is `openrouter_openai_chat_completions_compatible`
-- **THEN** Alan rewrites the saved provider value to `openrouter`
-- **AND** Alan preserves the profile id, credential reference, secret id, `base_url`, and `model` settings
-- **AND** Alan rewrites the matching OpenRouter credential `provider_family` to `openrouter` when it used the retired id
-
-#### Scenario: Retired id does not dispatch after migration boundary
-- **WHEN** code, daemon input, or unresolved configuration still tries to use `openrouter_openai_chat_completions_compatible` as a provider after the migration boundary
-- **THEN** Alan rejects it with an actionable error instead of treating it as an OpenRouter alias
+#### Scenario: Retired id reaches provider construction
+- **WHEN** code or unresolved configuration still tries to use `openrouter_openai_chat_completions_compatible` as a provider
+- **THEN** Alan rejects it instead of treating it as an OpenRouter alias
 
 ### Requirement: OpenRouter connection settings
 Alan SHALL keep OpenRouter-specific settings separate from generic

--- a/openspec/changes/integrate-openrouter-rs/tasks.md
+++ b/openspec/changes/integrate-openrouter-rs/tasks.md
@@ -1,0 +1,65 @@
+## 1. SDK Dependency And Provider Skeleton
+
+- [ ] 1.1 Add `openrouter-rs = "0.8.1"` to `alan-llm` dependencies and update the lockfile.
+- [ ] 1.2 Add `crates/llm/src/openrouter.rs` and export it from `crates/llm/src/lib.rs`.
+- [ ] 1.3 Add `ProviderType::OpenRouter`, `ProviderConfig::openrouter(...)`, and OpenRouter-specific config fields for base URL, model, `http_referer`, `x_title`, and `app_categories`.
+- [ ] 1.4 Route `ProviderType::OpenRouter` through the new SDK-backed adapter in the provider factory.
+- [ ] 1.5 Remove the retired `OpenRouterOpenAiChatCompletionsCompatible` provider type/path and make `openrouter_openai_chat_completions_compatible` fail fast instead of acting as an alias.
+
+## 2. OpenRouter Request Mapping
+
+- [ ] 2.1 Implement Alan message-role conversion to OpenRouter SDK chat messages, including system prompts, context messages, assistant tool calls, and tool-result messages.
+- [ ] 2.2 Implement Alan tool-definition conversion to OpenRouter SDK chat tool definitions with automatic tool choice.
+- [ ] 2.3 Map temperature, max tokens, and `thinking_budget_tokens` to SDK request fields.
+- [ ] 2.4 Add an explicit allowlist for OpenRouter `extra_params` and reject or warn on unsupported keys before dispatch.
+- [ ] 2.5 Add unit tests for message, tool, reasoning-budget, and unsupported-extra-parameter projection.
+
+## 3. Non-Streaming Response Mapping
+
+- [ ] 3.1 Implement `generate(...)` using `openrouter-rs` `client.chat().create(...)`.
+- [ ] 3.2 Map content, reasoning text, tool calls, usage, finish reason, and provider response id into `GenerationResponse`.
+- [ ] 3.3 Handle malformed tool-call JSON by dropping the malformed call and surfacing a provider warning.
+- [ ] 3.4 Add unit tests for content-only, reasoning, tool-call, malformed-tool-call, usage, finish-reason, and response-id responses.
+
+## 4. Streaming Response Mapping
+
+- [ ] 4.1 Implement `generate_stream(...)` using an `openrouter-rs` streaming API, preferring `stream_unified` if it exposes the required fields.
+- [ ] 4.2 Convert SDK content events to `StreamChunk.text` deltas in order.
+- [ ] 4.3 Convert SDK reasoning events to `StreamChunk.thinking` deltas in order.
+- [ ] 4.4 Convert streamed tool-call events to `StreamChunk.tool_call_delta` values that preserve id, name, index, and argument deltas.
+- [ ] 4.5 Emit a final chunk with `is_finished = true`, finish reason, usage when available, and provider response id when available.
+- [ ] 4.6 Propagate SDK stream errors through the provider stream channel so runtime partial-stream recovery can run.
+- [ ] 4.7 Add streaming unit tests for text, reasoning, fragmented tool calls, completion metadata, and stream errors after partial output.
+
+## 5. Runtime And Connection Profiles
+
+- [ ] 5.1 Add `LlmProvider::OpenRouter` serialized as `openrouter` and update `as_str()`, config defaults, reset/merge behavior, effective model lookup, and `to_provider_config()`.
+- [ ] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
+- [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `base_url` and `model`, optional `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
+- [ ] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
+- [ ] 5.5 Update persisted provider enums and runtime provider detection so only `openrouter` is accepted for OpenRouter state.
+- [ ] 5.6 Add runtime tests for profile validation, profile application, effective model handling, old-id rejection, and provider detection.
+
+## 6. CLI, Daemon, And Catalog Surfaces
+
+- [ ] 6.1 Update `alan connection` provider parsing so `openrouter` can be added, listed, tested, pinned, and set as default.
+- [ ] 6.2 Update daemon connection control/routes so `/api/v1/connections/catalog` exposes OpenRouter metadata and connection profile operations accept the provider.
+- [ ] 6.3 Update provider test behavior to exercise the SDK-backed OpenRouter provider when an OpenRouter profile is tested.
+- [ ] 6.4 Add focused CLI and daemon tests for OpenRouter provider parsing, catalog output, profile creation, and profile resolution.
+
+## 7. Provider Capabilities And Documentation
+
+- [ ] 7.1 Declare explicit `ProviderCapabilities` for OpenRouter rather than sharing the generic compatible-provider branch.
+- [ ] 7.2 Update `docs/spec/provider_capability_contract.md` so OpenRouter is documented as `openrouter` with a first-class SDK-backed adapter and compatibility-tier semantics.
+- [ ] 7.3 Update provider setup documentation and examples to use `alan connection add openrouter ...` with OpenRouter-specific optional settings.
+- [ ] 7.4 Search docs and code comments for stale "OpenRouter via adapter" or `openrouter_openai_chat_completions_compatible` public wording and update it where appropriate.
+
+## 8. Live Harness And Verification
+
+- [ ] 8.1 Extend the live provider harness with an OpenRouter case gated by `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional OpenRouter metadata env vars.
+- [ ] 8.2 Add harness coverage for OpenRouter non-streaming generation, streaming generation, reasoning when the configured model supports it, and tool calls when the configured model supports them.
+- [ ] 8.3 Run `cargo fmt --all`.
+- [ ] 8.4 Run focused `cargo test -p alan-llm` tests for OpenRouter adapter mapping and factory behavior.
+- [ ] 8.5 Run focused `cargo test -p alan-runtime` and `cargo test -p alan` tests for provider config, connection profiles, CLI parsing, and daemon catalog behavior.
+- [ ] 8.6 Run the OpenRouter live provider harness when credentials are available; otherwise document that live verification was skipped.
+- [ ] 8.7 Run `openspec status --change integrate-openrouter-rs` and ensure the change is apply-ready.

--- a/openspec/changes/integrate-openrouter-rs/tasks.md
+++ b/openspec/changes/integrate-openrouter-rs/tasks.md
@@ -37,10 +37,9 @@
 - [ ] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
 - [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `base_url` and `model`, optional `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
 - [ ] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
-- [ ] 5.5 Add a migration or repair routine for saved connection metadata that rewrites retired `profiles.<id>.provider` and `credentials.<id>.provider_family` values to `openrouter` while preserving profile ids, credential ids, secrets, `base_url`, and `model`.
-- [ ] 5.6 Keep the retired OpenRouter-compatible id recognizable only at the connection-file diagnostic/migration boundary; exclude it from provider descriptors, resolved runtime state, session metadata, and provider factory dispatch.
-- [ ] 5.7 Update persisted provider enums and runtime provider detection so only `openrouter` is accepted for OpenRouter state after the migration boundary.
-- [ ] 5.8 Add runtime tests for profile validation, profile application, effective model handling, provider detection, old-id migration, old-id rejection after migration, and old-id appearances in both profile providers and credential provider families.
+- [ ] 5.5 Remove the retired OpenRouter-compatible provider id from supported connection metadata and persisted provider state; do not add automatic rewrite, repair, or alias behavior for `profiles.<id>.provider` or `credentials.<id>.provider_family`.
+- [ ] 5.6 Exclude the retired id from provider descriptors, resolved runtime state, session metadata, CLI/daemon provider parsing, and provider factory dispatch.
+- [ ] 5.7 Add runtime tests for profile validation, profile application, effective model handling, provider detection, old-id rejection, and old-id appearances in both profile providers and credential provider families.
 
 ## 6. CLI, Daemon, And Catalog Surfaces
 

--- a/openspec/changes/integrate-openrouter-rs/tasks.md
+++ b/openspec/changes/integrate-openrouter-rs/tasks.md
@@ -4,7 +4,7 @@
 - [ ] 1.2 Add `crates/llm/src/openrouter.rs` and export it from `crates/llm/src/lib.rs`.
 - [ ] 1.3 Add `ProviderType::OpenRouter`, `ProviderConfig::openrouter(...)`, and OpenRouter-specific config fields for base URL, model, `http_referer`, `x_title`, and `app_categories`.
 - [ ] 1.4 Route `ProviderType::OpenRouter` through the new SDK-backed adapter in the provider factory.
-- [ ] 1.5 Remove the retired `OpenRouterOpenAiChatCompletionsCompatible` provider type/path and make `openrouter_openai_chat_completions_compatible` fail fast instead of acting as an alias.
+- [ ] 1.5 Remove the retired `OpenRouterOpenAiChatCompletionsCompatible` provider factory type/path and make `openrouter_openai_chat_completions_compatible` fail fast instead of acting as an alias.
 
 ## 2. OpenRouter Request Mapping
 
@@ -37,8 +37,10 @@
 - [ ] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
 - [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `base_url` and `model`, optional `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
 - [ ] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
-- [ ] 5.5 Update persisted provider enums and runtime provider detection so only `openrouter` is accepted for OpenRouter state.
-- [ ] 5.6 Add runtime tests for profile validation, profile application, effective model handling, old-id rejection, and provider detection.
+- [ ] 5.5 Add a migration or repair routine for saved connection metadata that rewrites retired `profiles.<id>.provider` and `credentials.<id>.provider_family` values to `openrouter` while preserving profile ids, credential ids, secrets, `base_url`, and `model`.
+- [ ] 5.6 Keep the retired OpenRouter-compatible id recognizable only at the connection-file diagnostic/migration boundary; exclude it from provider descriptors, resolved runtime state, session metadata, and provider factory dispatch.
+- [ ] 5.7 Update persisted provider enums and runtime provider detection so only `openrouter` is accepted for OpenRouter state after the migration boundary.
+- [ ] 5.8 Add runtime tests for profile validation, profile application, effective model handling, provider detection, old-id migration, old-id rejection after migration, and old-id appearances in both profile providers and credential provider families.
 
 ## 6. CLI, Daemon, And Catalog Surfaces
 

--- a/openspec/changes/integrate-openrouter-rs/tasks.md
+++ b/openspec/changes/integrate-openrouter-rs/tasks.md
@@ -35,7 +35,7 @@
 
 - [ ] 5.1 Add `LlmProvider::OpenRouter` serialized as `openrouter` and update `as_str()`, config defaults, reset/merge behavior, effective model lookup, and `to_provider_config()`.
 - [ ] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
-- [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `base_url` and `model`, optional `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
+- [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `model`, optional `base_url`, `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
 - [ ] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
 - [ ] 5.5 Remove the retired OpenRouter-compatible provider id from supported connection metadata and persisted provider state; do not add automatic rewrite, repair, or alias behavior for `profiles.<id>.provider` or `credentials.<id>.provider_family`.
 - [ ] 5.6 Exclude the retired id from provider descriptors, resolved runtime state, session metadata, CLI/daemon provider parsing, and provider factory dispatch.


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal/design/spec/tasks for replacing the OpenRouter compatible adapter with openrouter-rs
- Define hard cutover to the public openrouter provider id with no legacy compatible-path alias
- Scope runtime, llm, connection profile, CLI/daemon, docs, tests, and live harness work

Refs #77

## Verification
- openspec validate integrate-openrouter-rs
- openspec status --change integrate-openrouter-rs