### PR TITLE
Add first-class OpenRouter provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ serving as the primary user-facing hosting model.
 | Serialization | Serde (JSON, YAML, TOML)              |
 | Tracing       | tracing, tracing-subscriber           |
 | HTTP Client   | reqwest                               |
-| LLM Providers | ChatGPT/Codex managed Responses surface, OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API (runtime); OpenRouter via adapter |
+| LLM Providers | ChatGPT/Codex managed Responses surface, OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API, OpenRouter SDK-backed chat |
 | License       | Apache License 2.0                    |
 
 ---
@@ -143,6 +143,7 @@ Alan/
 │   │       ├── google_gemini_generate_content.rs  # Google Gemini GenerateContent API
 │   │       ├── openai_responses.rs
 │   │       ├── openai_chat_completions.rs
+│   │       ├── openrouter.rs       # OpenRouter SDK-backed chat adapter
 │   │       └── anthropic_messages.rs
 │   │
 │   ├── runtime/               # Core runtime (the "machine")
@@ -441,6 +442,7 @@ alan connection current --workspace /path/to/workspace
 alan connection add chatgpt --profile chatgpt-main
 alan connection login chatgpt-main browser
 alan connection add openai_responses --profile openai-main --setting model=gpt-5.4
+alan connection add openrouter --profile openrouter-main --setting model=moonshotai/kimi-k2.6
 alan connection set-secret openai-main
 alan connection default set chatgpt-main
 alan connection pin chatgpt-main --scope global

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sha2",
@@ -69,7 +69,7 @@ dependencies = [
  "chrono",
  "dirs",
  "rand 0.10.1",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sha2",
@@ -93,8 +93,9 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "futures-core",
+ "openrouter-rs",
  "pin-utils",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -133,7 +134,7 @@ dependencies = [
  "pin-utils",
  "rand 0.10.1",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "semver",
  "serde",
  "serde_json",
@@ -156,7 +157,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -257,7 +258,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -504,7 +505,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -598,10 +599,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "digest"
@@ -653,7 +720,25 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dotenvy_macro"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0235d912a8c749f4e0c9f18ca253b4c28cfefc1d2518096016d6e3230b6424"
+dependencies = [
+ "dotenvy",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -661,6 +746,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "email_address"
@@ -840,7 +931,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1071,6 +1162,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1206,6 +1298,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1350,7 +1448,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "serde",
  "serde_json",
@@ -1580,6 +1678,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openrouter-rs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5de66d46faeac035a618ee8292434a0ed8243fb05e0aecda707c94ee242d278"
+dependencies = [
+ "derive_builder",
+ "dotenvy_macro",
+ "futures-util",
+ "http",
+ "reqwest 0.12.28",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "urlencoding",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,7 +1781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1829,7 +1947,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1880,6 +1998,47 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -1918,7 +2077,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -1963,6 +2122,7 @@ checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2061,6 +2221,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,7 +2307,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2272,6 +2468,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2298,7 +2505,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2340,7 +2547,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2351,7 +2558,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2413,7 +2620,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2568,7 +2775,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2827,7 +3034,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2860,6 +3067,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2917,6 +3137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,7 +3175,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2957,7 +3186,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3242,7 +3471,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3258,7 +3487,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3325,7 +3554,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3346,7 +3575,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3366,7 +3595,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3406,7 +3635,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Alan/
 | Crate           | Role                                                                |
 | --------------- | ------------------------------------------------------------------- |
 | `alan-protocol` | Wire format — Events (output), Operations (input), ContentPart      |
-| `alan-llm`      | Pluggable LLM adapters — OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API (+ OpenRouter via adapter) |
+| `alan-llm`      | Pluggable LLM adapters — OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API, and OpenRouter SDK-backed chat |
 | `alan-runtime`  | Core engine — session, tape, agent loop, tool registry, skills      |
 | `alan-tools`    | Builtin tool implementations (`read_file`, `bash`, `grep`, etc.)    |
 | `alan`          | Unified CLI & daemon — workspace lifecycle, HTTP/WS API, ask, chat  |
@@ -115,7 +115,7 @@ Alan/
 
 ## Features
 
-- **Multi-Provider LLM**: OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API
+- **Multi-Provider LLM**: OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Google Gemini GenerateContent API, Anthropic Messages API, OpenRouter
 - **Streaming Responses**: Real-time token streaming with tool call support
 - **Layered Tool Profiles**:
   - Core (default): `read_file`, `write_file`, `edit_file`, `bash`
@@ -144,6 +144,7 @@ Alan exposes a unified `thinking_budget_tokens` switch in runtime config. Curren
 - **OpenAI Responses API**: preserves thinking metadata when available
 - **OpenAI Chat Completions API**: preserves thinking metadata when available
 - **OpenAI Chat Completions API-compatible**: chat-completions-compatible path with reasoning field support (for example `reasoning_content` and reasoning metadata)
+- **OpenRouter**: SDK-backed chat adapter that preserves OpenRouter reasoning and reasoning-detail metadata when available
 - **Google Gemini GenerateContent API**: currently does not emit/consume thinking content in Alan's wire path
 
 Notes:
@@ -205,6 +206,10 @@ source = "managed"
 [profiles.openai-main.settings]
 base_url = "https://api.openai.com/v1"
 model = "gpt-5.4"
+
+# OpenRouter profile example:
+# alan connection add openrouter --profile openrouter-main --setting model=moonshotai/kimi-k2.6
+# alan connection set-secret openrouter-main
 
 # Optional explicit pin
 # connection_profile = "openai-main"

--- a/crates/alan/src/cli/connection.rs
+++ b/crates/alan/src/cli/connection.rs
@@ -51,6 +51,7 @@ fn parse_provider_id(raw: &str) -> Result<LlmProvider> {
         "openai_responses" => Ok(LlmProvider::OpenAiResponses),
         "openai_chat_completions" => Ok(LlmProvider::OpenAiChatCompletions),
         "openai_chat_completions_compatible" => Ok(LlmProvider::OpenAiChatCompletionsCompatible),
+        "openrouter" => Ok(LlmProvider::OpenRouter),
         "anthropic_messages" => Ok(LlmProvider::AnthropicMessages),
         other => anyhow::bail!("unknown provider `{other}`"),
     }
@@ -184,6 +185,7 @@ fn suggested_profile_id(provider: LlmProvider, requested: Option<String>) -> Res
         LlmProvider::OpenAiResponses => "openai-main",
         LlmProvider::OpenAiChatCompletions => "openai-chat",
         LlmProvider::OpenAiChatCompletionsCompatible => "compatible-main",
+        LlmProvider::OpenRouter => "openrouter-main",
         LlmProvider::GoogleGeminiGenerateContent => "gemini",
         LlmProvider::AnthropicMessages => "anthropic-main",
     };
@@ -552,4 +554,25 @@ pub async fn run_connection_remove(profile_id: &str) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_provider_id_accepts_openrouter() {
+        assert_eq!(
+            parse_provider_id("openrouter").unwrap(),
+            LlmProvider::OpenRouter
+        );
+    }
+
+    #[test]
+    fn suggested_profile_id_defaults_openrouter() {
+        assert_eq!(
+            suggested_profile_id(LlmProvider::OpenRouter, None).unwrap(),
+            "openrouter-main"
+        );
+    }
 }

--- a/crates/alan/src/daemon/connection_routes.rs
+++ b/crates/alan/src/daemon/connection_routes.rs
@@ -575,35 +575,6 @@ fn normalize_workspace_dir(raw: Option<String>) -> Option<PathBuf> {
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn provider_descriptor_view_includes_openrouter_catalog_metadata() {
-        let descriptor = alan_runtime::ConnectionsFile::profile_descriptor(LlmProvider::OpenRouter);
-        let view = provider_descriptor_view(descriptor.clone());
-
-        assert_eq!(view.provider_id, LlmProvider::OpenRouter);
-        assert_eq!(
-            view.credential_kind,
-            alan_runtime::CredentialKind::SecretString
-        );
-        assert!(view.supports_secret_entry);
-        assert!(view.required_settings.contains(&"model".to_string()));
-        assert!(view.optional_settings.contains(&"http_referer".to_string()));
-        assert!(view.optional_settings.contains(&"x_title".to_string()));
-        assert!(
-            view.optional_settings
-                .contains(&"app_categories".to_string())
-        );
-        assert_eq!(
-            view.default_settings.get("model").map(String::as_str),
-            Some("moonshotai/kimi-k2.6")
-        );
-    }
-}
-
 fn request_has_json_content_type(headers: &HeaderMap) -> bool {
     headers
         .get(header::CONTENT_TYPE)
@@ -665,4 +636,33 @@ async fn send_json_event(
     let mut line = serde_json::to_vec(value).map_err(|_| ())?;
     line.push(b'\n');
     tx.send(Ok(Bytes::from(line))).await.map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_descriptor_view_includes_openrouter_catalog_metadata() {
+        let descriptor = alan_runtime::ConnectionsFile::profile_descriptor(LlmProvider::OpenRouter);
+        let view = provider_descriptor_view(descriptor.clone());
+
+        assert_eq!(view.provider_id, LlmProvider::OpenRouter);
+        assert_eq!(
+            view.credential_kind,
+            alan_runtime::CredentialKind::SecretString
+        );
+        assert!(view.supports_secret_entry);
+        assert!(view.required_settings.contains(&"model".to_string()));
+        assert!(view.optional_settings.contains(&"http_referer".to_string()));
+        assert!(view.optional_settings.contains(&"x_title".to_string()));
+        assert!(
+            view.optional_settings
+                .contains(&"app_categories".to_string())
+        );
+        assert_eq!(
+            view.default_settings.get("model").map(String::as_str),
+            Some("moonshotai/kimi-k2.6")
+        );
+    }
 }

--- a/crates/alan/src/daemon/connection_routes.rs
+++ b/crates/alan/src/daemon/connection_routes.rs
@@ -575,6 +575,35 @@ fn normalize_workspace_dir(raw: Option<String>) -> Option<PathBuf> {
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_descriptor_view_includes_openrouter_catalog_metadata() {
+        let descriptor = alan_runtime::ConnectionsFile::profile_descriptor(LlmProvider::OpenRouter);
+        let view = provider_descriptor_view(descriptor.clone());
+
+        assert_eq!(view.provider_id, LlmProvider::OpenRouter);
+        assert_eq!(
+            view.credential_kind,
+            alan_runtime::CredentialKind::SecretString
+        );
+        assert!(view.supports_secret_entry);
+        assert!(view.required_settings.contains(&"model".to_string()));
+        assert!(view.optional_settings.contains(&"http_referer".to_string()));
+        assert!(view.optional_settings.contains(&"x_title".to_string()));
+        assert!(
+            view.optional_settings
+                .contains(&"app_categories".to_string())
+        );
+        assert_eq!(
+            view.default_settings.get("model").map(String::as_str),
+            Some("moonshotai/kimi-k2.6")
+        );
+    }
+}
+
 fn request_has_json_content_type(headers: &HeaderMap) -> bool {
     headers
         .get(header::CONTENT_TYPE)

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -13,6 +13,7 @@ alan-auth.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 futures.workspace = true
+openrouter-rs = "0.8.1"
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides a unified, trait-based interface for different LLM providers
 //! (Google Gemini GenerateContent API, OpenAI Responses API, OpenAI Chat Completions API,
-//! Anthropic Messages API, and OpenRouter's OpenAI Chat Completions API-compatible adapter)
+//! Anthropic Messages API, and OpenRouter's SDK-backed chat adapter)
 //! with support for both sync and streaming generation.
 //!
 //! # Architecture
@@ -48,6 +48,7 @@ pub mod chatgpt_responses;
 pub mod google_gemini_generate_content;
 pub mod openai_chat_completions;
 pub mod openai_responses;
+pub mod openrouter;
 mod sse;
 pub(crate) use sse::SseEventParser;
 
@@ -57,6 +58,7 @@ pub use chatgpt_responses::ChatgptResponsesClient;
 pub use google_gemini_generate_content::GoogleGeminiGenerateContentClient;
 pub use openai_chat_completions::OpenAiChatCompletionsClient;
 pub use openai_responses::OpenAiResponsesClient;
+pub use openrouter::OpenRouterClient;
 
 // ============================================================================
 // Core Types
@@ -305,6 +307,12 @@ impl GenerationRequest {
     /// Set max tokens
     pub fn with_max_tokens(mut self, tokens: i32) -> Self {
         self.max_tokens = Some(tokens);
+        self
+    }
+
+    /// Set provider-specific thinking/reasoning budget tokens.
+    pub fn with_thinking_budget_tokens(mut self, tokens: u32) -> Self {
+        self.thinking_budget_tokens = Some(tokens);
         self
     }
 
@@ -580,6 +588,9 @@ pub mod factory {
         pub custom_headers: Option<HashMap<String, String>>, // Custom HTTP headers
         pub client_name: Option<String>,         // Client name for usage tracking
         pub user_agent: Option<String>,          // User-Agent header
+        pub http_referer: Option<String>,        // OpenRouter HTTP-Referer metadata
+        pub x_title: Option<String>,             // OpenRouter X-Title metadata
+        pub app_categories: Option<Vec<String>>, // OpenRouter app category metadata
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -589,8 +600,8 @@ pub mod factory {
         OpenAiResponses,
         OpenAiChatCompletions,
         OpenAiChatCompletionsCompatible,
+        OpenRouter,
         AnthropicMessages,
-        OpenRouterOpenAiChatCompletionsCompatible,
     }
 
     impl ProviderConfig {
@@ -611,6 +622,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -628,6 +642,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -645,6 +662,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -665,6 +685,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -685,6 +708,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -702,21 +728,18 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
-        /// Create a new provider config for OpenRouter's OpenAI Chat Completions API-compatible adapter.
-        ///
-        /// OpenRouter provides unified access to 100+ LLM models through a single API.
-        /// Get your API key from: <https://openrouter.ai/keys>
-        pub fn openrouter_openai_chat_completions_compatible(
-            api_key: impl Into<String>,
-            model: impl Into<String>,
-        ) -> Self {
+        /// Create a new provider config for OpenRouter's SDK-backed chat adapter.
+        pub fn openrouter(api_key: impl Into<String>, model: impl Into<String>) -> Self {
             Self {
-                provider_type: ProviderType::OpenRouterOpenAiChatCompletionsCompatible,
+                provider_type: ProviderType::OpenRouter,
                 api_key: Some(api_key.into()),
-                base_url: Some("https://openrouter.ai/api/v1".to_string()),
+                base_url: Some(openrouter::OPENROUTER_BASE_URL.to_string()),
                 model: model.into(),
                 expected_account_id: None,
                 chatgpt_auth_storage_path: None,
@@ -725,6 +748,9 @@ pub mod factory {
                 custom_headers: None,
                 client_name: None,
                 user_agent: None,
+                http_referer: None,
+                x_title: None,
+                app_categories: None,
             }
         }
 
@@ -767,6 +793,28 @@ pub mod factory {
         /// Set User-Agent header
         pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
             self.user_agent = Some(user_agent.into());
+            self
+        }
+
+        /// Set OpenRouter HTTP-Referer client metadata.
+        pub fn with_http_referer(mut self, http_referer: impl Into<String>) -> Self {
+            self.http_referer = Some(http_referer.into());
+            self
+        }
+
+        /// Set OpenRouter X-Title client metadata.
+        pub fn with_x_title(mut self, x_title: impl Into<String>) -> Self {
+            self.x_title = Some(x_title.into());
+            self
+        }
+
+        /// Set OpenRouter app category metadata.
+        pub fn with_app_categories<I, S>(mut self, app_categories: I) -> Self
+        where
+            I: IntoIterator<Item = S>,
+            S: Into<String>,
+        {
+            self.app_categories = Some(app_categories.into_iter().map(Into::into).collect());
             self
         }
     }
@@ -845,6 +893,25 @@ pub mod factory {
                     ),
                 ))
             }
+            ProviderType::OpenRouter => {
+                let api_key = config
+                    .api_key
+                    .ok_or_else(|| anyhow::anyhow!("OpenRouter provider requires api_key"))?;
+                let base_url = config
+                    .base_url
+                    .unwrap_or_else(|| openrouter::OPENROUTER_BASE_URL.to_string());
+                let metadata = openrouter::OpenRouterClientMetadata {
+                    http_referer: config.http_referer,
+                    x_title: config.x_title,
+                    app_categories: config.app_categories,
+                };
+                Ok(Box::new(OpenRouterClient::with_metadata(
+                    &api_key,
+                    &base_url,
+                    &config.model,
+                    metadata,
+                )?))
+            }
             ProviderType::AnthropicMessages => {
                 let api_key = config.api_key.ok_or_else(|| {
                     anyhow::anyhow!("Anthropic Messages API provider requires api_key")
@@ -867,25 +934,6 @@ pub mod factory {
                     client = client.with_user_agent(&user_agent);
                 }
 
-                Ok(Box::new(client))
-            }
-            ProviderType::OpenRouterOpenAiChatCompletionsCompatible => {
-                let api_key = config
-                    .api_key
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "OpenRouter OpenAI Chat Completions API-compatible provider requires api_key"
-                        )
-                    })?;
-                let base_url = config
-                    .base_url
-                    .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
-
-                let client = OpenAiChatCompletionsClient::openrouter_compatible_with_params(
-                    &api_key,
-                    &base_url,
-                    &config.model,
-                );
                 Ok(Box::new(client))
             }
         }
@@ -967,27 +1015,42 @@ impl factory::ProviderType {
                 instruction_role: InstructionRole::Developer,
                 compatibility_tier: CompatibilityTier::TierBFullFidelityStateless,
             },
-            factory::ProviderType::OpenAiChatCompletionsCompatible
-            | factory::ProviderType::OpenRouterOpenAiChatCompletionsCompatible => {
-                ProviderCapabilities {
-                    supports_streaming_text: true,
-                    supports_streaming_tool_calls: true,
-                    supports_provider_response_id: false,
-                    supports_provider_response_status: false,
-                    supports_reasoning_text: false,
-                    supports_reasoning_signature: false,
-                    supports_redacted_thinking: false,
-                    supports_multimodal_input: false,
-                    supports_document_input: false,
-                    supports_cached_token_usage: false,
-                    supports_server_managed_continuation: false,
-                    supports_background_execution: false,
-                    supports_retrieve_cancel: false,
-                    supports_provider_compaction: false,
-                    instruction_role: InstructionRole::System,
-                    compatibility_tier: CompatibilityTier::TierCBestEffortCompatible,
-                }
-            }
+            factory::ProviderType::OpenAiChatCompletionsCompatible => ProviderCapabilities {
+                supports_streaming_text: true,
+                supports_streaming_tool_calls: true,
+                supports_provider_response_id: false,
+                supports_provider_response_status: false,
+                supports_reasoning_text: false,
+                supports_reasoning_signature: false,
+                supports_redacted_thinking: false,
+                supports_multimodal_input: false,
+                supports_document_input: false,
+                supports_cached_token_usage: false,
+                supports_server_managed_continuation: false,
+                supports_background_execution: false,
+                supports_retrieve_cancel: false,
+                supports_provider_compaction: false,
+                instruction_role: InstructionRole::System,
+                compatibility_tier: CompatibilityTier::TierCBestEffortCompatible,
+            },
+            factory::ProviderType::OpenRouter => ProviderCapabilities {
+                supports_streaming_text: true,
+                supports_streaming_tool_calls: true,
+                supports_provider_response_id: true,
+                supports_provider_response_status: false,
+                supports_reasoning_text: true,
+                supports_reasoning_signature: true,
+                supports_redacted_thinking: false,
+                supports_multimodal_input: false,
+                supports_document_input: false,
+                supports_cached_token_usage: false,
+                supports_server_managed_continuation: false,
+                supports_background_execution: false,
+                supports_retrieve_cancel: false,
+                supports_provider_compaction: false,
+                instruction_role: InstructionRole::System,
+                compatibility_tier: CompatibilityTier::TierCBestEffortCompatible,
+            },
             factory::ProviderType::AnthropicMessages => ProviderCapabilities {
                 supports_streaming_text: true,
                 supports_streaming_tool_calls: true,
@@ -1383,18 +1446,25 @@ mod tests {
         );
         assert_eq!(anthropic_messages.api_key, Some("sk-ant".to_string()));
 
-        let openrouter = factory::ProviderConfig::openrouter_openai_chat_completions_compatible(
-            "sk-or-xxx",
-            "anthropic/claude-3-opus",
-        );
-        assert_eq!(
-            openrouter.provider_type,
-            factory::ProviderType::OpenRouterOpenAiChatCompletionsCompatible
-        );
+        let openrouter =
+            factory::ProviderConfig::openrouter("sk-or-xxx", "anthropic/claude-3-opus")
+                .with_http_referer("https://alan.local")
+                .with_x_title("Alan")
+                .with_app_categories(["cli-agent"]);
+        assert_eq!(openrouter.provider_type, factory::ProviderType::OpenRouter);
         assert_eq!(openrouter.api_key, Some("sk-or-xxx".to_string()));
         assert_eq!(
             openrouter.base_url,
             Some("https://openrouter.ai/api/v1".to_string())
+        );
+        assert_eq!(
+            openrouter.http_referer.as_deref(),
+            Some("https://alan.local")
+        );
+        assert_eq!(openrouter.x_title.as_deref(), Some("Alan"));
+        assert_eq!(
+            openrouter.app_categories,
+            Some(vec!["cli-agent".to_string()])
         );
     }
 
@@ -1403,6 +1473,7 @@ mod tests {
         let chatgpt = factory::ProviderType::ChatgptResponses.capabilities();
         let openai_responses = factory::ProviderType::OpenAiResponses.capabilities();
         let openai_chat = factory::ProviderType::OpenAiChatCompletions.capabilities();
+        let openrouter = factory::ProviderType::OpenRouter.capabilities();
         let anthropic = factory::ProviderType::AnthropicMessages.capabilities();
 
         assert_eq!(
@@ -1432,6 +1503,17 @@ mod tests {
         assert_eq!(openai_chat.instruction_role, InstructionRole::Developer);
         assert!(openai_chat.supports_multimodal_input);
         assert!(!openai_chat.supports_server_managed_continuation);
+
+        assert_eq!(
+            openrouter.compatibility_tier,
+            CompatibilityTier::TierCBestEffortCompatible
+        );
+        assert!(openrouter.supports_streaming_text);
+        assert!(openrouter.supports_streaming_tool_calls);
+        assert!(openrouter.supports_provider_response_id);
+        assert!(openrouter.supports_reasoning_text);
+        assert!(!openrouter.supports_server_managed_continuation);
+        assert!(!openrouter.supports_provider_compaction);
 
         assert_eq!(
             anthropic.compatibility_tier,

--- a/crates/llm/src/openai_chat_completions.rs
+++ b/crates/llm/src/openai_chat_completions.rs
@@ -1,7 +1,7 @@
 //! OpenAI Chat Completions API client.
 //!
-//! Supports the official OpenAI Chat Completions API, OpenAI Chat Completions API-compatible
-//! endpoints, and OpenRouter's OpenAI Chat Completions API-compatible adapter.
+//! Supports the official OpenAI Chat Completions API and generic OpenAI Chat
+//! Completions API-compatible endpoints.
 
 use anyhow::{Context, Result};
 use futures::StreamExt;
@@ -29,7 +29,6 @@ pub struct OpenAiChatCompletionsClient {
 enum OpenAiChatCompletionsApiFlavor {
     Official,
     Compatible,
-    OpenRouterCompatible,
 }
 
 // ============================================================================
@@ -366,8 +365,7 @@ impl OpenAiChatCompletionsClient {
     fn instruction_role_name(&self) -> &'static str {
         match self.api_flavor {
             OpenAiChatCompletionsApiFlavor::Official => "developer",
-            OpenAiChatCompletionsApiFlavor::Compatible
-            | OpenAiChatCompletionsApiFlavor::OpenRouterCompatible => "system",
+            OpenAiChatCompletionsApiFlavor::Compatible => "system",
         }
     }
 
@@ -403,16 +401,6 @@ impl OpenAiChatCompletionsClient {
             base_url,
             model,
             OpenAiChatCompletionsApiFlavor::Compatible,
-        )
-    }
-
-    /// Create a client for OpenRouter's OpenAI Chat Completions API-compatible surface.
-    pub fn openrouter_compatible_with_params(api_key: &str, base_url: &str, model: &str) -> Self {
-        Self::new(
-            api_key,
-            base_url,
-            model,
-            OpenAiChatCompletionsApiFlavor::OpenRouterCompatible,
         )
     }
 
@@ -2255,9 +2243,6 @@ impl LlmProvider for OpenAiChatCompletionsClient {
         match self.api_flavor {
             OpenAiChatCompletionsApiFlavor::Official => "openai_chat_completions",
             OpenAiChatCompletionsApiFlavor::Compatible => "openai_chat_completions_compatible",
-            OpenAiChatCompletionsApiFlavor::OpenRouterCompatible => {
-                "openrouter_openai_chat_completions_compatible"
-            }
         }
     }
 }

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -3,8 +3,9 @@
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use futures::StreamExt;
+#[cfg(test)]
+use openrouter_rs::types::UnifiedStreamEvent;
 use openrouter_rs::{
-    OpenRouterClient as OpenRouterSdkClient,
     api::chat::{
         ChatCompletionRequest, ChatCompletionRequestBuilder, DebugOptions, Message as OrMessage,
         Modality, Plugin, StopSequence, StreamOptions, TraceOptions,
@@ -12,7 +13,7 @@ use openrouter_rs::{
     types::{
         Effort, FinishReason, FunctionCall as OrFunctionCall, ProviderPreferences, ReasoningConfig,
         ResponseFormat, ResponseUsage, Role, Tool as OrTool, ToolCall as OrToolCall,
-        UnifiedStreamEvent, completion::CompletionsResponse,
+        completion::CompletionsResponse,
     },
 };
 use serde::de::DeserializeOwned;
@@ -31,7 +32,10 @@ pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 /// Alan LLM provider backed by the `openrouter-rs` SDK.
 #[derive(Clone)]
 pub struct OpenRouterClient {
-    client: OpenRouterSdkClient,
+    http_client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    metadata: OpenRouterClientMetadata,
     model: String,
 }
 
@@ -58,34 +62,38 @@ impl OpenRouterClient {
         model: &str,
         metadata: OpenRouterClientMetadata,
     ) -> Result<Self> {
-        let mut builder = OpenRouterSdkClient::builder();
-        builder.api_key(api_key).base_url(base_url);
-        if let Some(http_referer) = metadata.http_referer {
-            builder.http_referer(http_referer);
-        }
-        if let Some(x_title) = metadata.x_title {
-            builder.x_title(x_title);
-        }
-        if let Some(app_categories) = metadata.app_categories {
-            builder.app_categories(app_categories);
-        }
+        validate_app_categories(metadata.app_categories.as_deref())?;
 
         Ok(Self {
-            client: builder
-                .build()
-                .context("failed to build OpenRouter client")?,
+            http_client: reqwest::Client::new(),
+            api_key: api_key.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            metadata,
             model: model.to_string(),
         })
     }
 
     async fn generate_chat(&self, request: GenerationRequest) -> Result<GenerationResponse> {
-        let chat_request = build_openrouter_chat_request(&self.model, request)?;
+        let payload = build_openrouter_chat_request_payload(&self.model, request)?;
         let response = self
-            .client
-            .chat()
-            .create(&chat_request)
+            .request_builder()?
+            .json(&payload)
+            .send()
             .await
             .context("OpenRouter chat completion request failed")?;
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .context("failed to read OpenRouter chat completion response")?;
+        if !status.is_success() {
+            bail!(
+                "OpenRouter chat completion request failed with status {status}: {}",
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+        let response = serde_json::from_slice(&bytes)
+            .context("failed to decode OpenRouter chat completion response")?;
         Ok(convert_openrouter_response(response))
     }
 
@@ -93,23 +101,54 @@ impl OpenRouterClient {
         &self,
         request: GenerationRequest,
     ) -> Result<mpsc::Receiver<StreamChunk>> {
-        let chat_request = build_openrouter_chat_request(&self.model, request)?;
+        let mut payload = build_openrouter_chat_request_payload(&self.model, request)?;
+        payload["stream"] = Value::Bool(true);
+        let response = self
+            .request_builder()?
+            .json(&payload)
+            .send()
+            .await
+            .context("OpenRouter stream request failed")?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("<failed to read body>"));
+            bail!("OpenRouter stream request failed with status {status}: {body}");
+        }
+
         let (tx, rx) = mpsc::channel(100);
-        let client = self.client.clone();
 
         tokio::spawn(async move {
-            let stream = match client.chat().stream_unified(&chat_request).await {
-                Ok(stream) => stream,
-                Err(error) => {
-                    debug!(?error, "OpenRouter stream failed before yielding output");
-                    return;
-                }
-            };
-
-            consume_openrouter_stream(stream, tx).await;
+            consume_openrouter_raw_stream(response, tx).await;
         });
 
         Ok(rx)
+    }
+
+    fn request_builder(&self) -> Result<reqwest::RequestBuilder> {
+        let mut request = self
+            .http_client
+            .post(format!("{}/chat/completions", self.base_url))
+            .bearer_auth(&self.api_key);
+
+        let x_title = self.metadata.x_title.as_deref().unwrap_or("openrouter-rs");
+        request = request
+            .header("X-OpenRouter-Title", x_title)
+            .header("X-Title", x_title);
+
+        if let Some(http_referer) = &self.metadata.http_referer {
+            request = request.header("HTTP-Referer", http_referer);
+        }
+        if let Some(app_categories) = &self.metadata.app_categories {
+            request = request.header(
+                "X-OpenRouter-Categories",
+                serialize_app_categories(app_categories)?,
+            );
+        }
+
+        Ok(request)
     }
 }
 
@@ -157,7 +196,7 @@ pub(crate) fn build_openrouter_chat_request(
     if let Some(system_prompt) = system_prompt.filter(|value| !value.is_empty()) {
         projected_messages.push(OrMessage::new(Role::System, system_prompt));
     }
-    projected_messages.extend(convert_messages_for_openrouter(messages));
+    projected_messages.extend(convert_messages_for_openrouter(messages)?);
 
     let mut builder = ChatCompletionRequest::builder();
     builder.model(model).messages(projected_messages);
@@ -184,21 +223,79 @@ pub(crate) fn build_openrouter_chat_request(
         .context("failed to build OpenRouter chat completion request")
 }
 
-pub(crate) fn convert_messages_for_openrouter(messages: Vec<Message>) -> Vec<OrMessage> {
+fn build_openrouter_chat_request_payload(model: &str, request: GenerationRequest) -> Result<Value> {
+    let mut alan_messages = Vec::new();
+    if let Some(system_prompt) = request
+        .system_prompt
+        .as_ref()
+        .filter(|value| !value.is_empty())
+    {
+        alan_messages.push(Message::system(system_prompt.clone()));
+    }
+    alan_messages.extend(request.messages.clone());
+
+    let chat_request = build_openrouter_chat_request(model, request)?;
+    let mut payload = serde_json::to_value(chat_request)
+        .context("failed to encode OpenRouter chat completion request")?;
+    preserve_openrouter_reasoning_fields(&mut payload, &alan_messages)?;
+    Ok(payload)
+}
+
+fn preserve_openrouter_reasoning_fields(payload: &mut Value, messages: &[Message]) -> Result<()> {
+    let Some(projected_messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    if projected_messages.len() != messages.len() {
+        bail!("OpenRouter message projection lost message alignment");
+    }
+
+    for (projected, source) in projected_messages.iter_mut().zip(messages) {
+        if source.role != MessageRole::Assistant {
+            continue;
+        }
+        let Some(projected) = projected.as_object_mut() else {
+            continue;
+        };
+        if let Some(thinking) = source
+            .thinking
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            projected.insert(
+                "reasoning_content".to_string(),
+                Value::String(thinking.clone()),
+            );
+        }
+        if let Some(signature) = source
+            .thinking_signature
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            projected.insert(
+                "reasoning".to_string(),
+                serde_json::json!({ "encrypted_content": signature }),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn convert_messages_for_openrouter(messages: Vec<Message>) -> Result<Vec<OrMessage>> {
     messages
         .into_iter()
         .map(|message| {
             let Message {
                 role,
                 content,
-                thinking: _,
-                thinking_signature: _,
+                thinking: _thinking,
+                thinking_signature: _thinking_signature,
                 redacted_thinking: _,
                 tool_calls,
                 tool_call_id,
             } = message;
 
-            match role {
+            Ok(match role {
                 MessageRole::System => OrMessage::new(Role::System, content),
                 MessageRole::User => OrMessage::new(Role::User, content),
                 MessageRole::Assistant => {
@@ -211,11 +308,18 @@ pub(crate) fn convert_messages_for_openrouter(messages: Vec<Message>) -> Vec<OrM
                     }
                 }
                 MessageRole::Tool => {
-                    let tool_call_id = tool_call_id.unwrap_or_default();
+                    let tool_call_id = tool_call_id
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "OpenRouter tool response messages require a non-empty tool_call_id"
+                            )
+                        })?;
                     OrMessage::tool_response(&tool_call_id, content)
                 }
                 MessageRole::Context => OrMessage::new(Role::System, content),
-            }
+            })
         })
         .collect()
 }
@@ -274,6 +378,7 @@ pub(crate) fn convert_openrouter_response(response: CompletionsResponse) -> Gene
     }
 }
 
+#[cfg(test)]
 async fn consume_openrouter_stream(
     mut stream: openrouter_rs::types::UnifiedStream,
     tx: mpsc::Sender<StreamChunk>,
@@ -353,6 +458,161 @@ async fn consume_openrouter_stream(
             finish_reason: latest_finish_reason,
         })
         .await;
+}
+
+async fn consume_openrouter_raw_stream(response: reqwest::Response, tx: mpsc::Sender<StreamChunk>) {
+    let mut emitted_payload = false;
+    let mut latest_usage = None;
+    let mut latest_response_id = None;
+    let mut latest_finish_reason = None;
+    let mut parser = crate::SseEventParser::new();
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                debug!(?error, "OpenRouter stream failed while reading bytes");
+                if emitted_payload {
+                    latest_finish_reason = Some("stream_error".to_string());
+                    break;
+                }
+                return;
+            }
+        };
+
+        let mut done = false;
+        for event in parser.push(&chunk) {
+            if event.trim() == "[DONE]" {
+                done = true;
+                break;
+            }
+            match serde_json::from_str::<CompletionsResponse>(&event) {
+                Ok(response) => {
+                    emit_openrouter_stream_response(
+                        response,
+                        &tx,
+                        &mut emitted_payload,
+                        &mut latest_response_id,
+                        &mut latest_finish_reason,
+                        &mut latest_usage,
+                    )
+                    .await;
+                }
+                Err(error) => {
+                    debug!(?error, event, "failed to decode OpenRouter stream event");
+                    if emitted_payload {
+                        latest_finish_reason = Some("stream_error".to_string());
+                        done = true;
+                        break;
+                    }
+                    return;
+                }
+            }
+        }
+        if done {
+            break;
+        }
+    }
+
+    for event in parser.finish() {
+        if event.trim() == "[DONE]" {
+            break;
+        }
+        match serde_json::from_str::<CompletionsResponse>(&event) {
+            Ok(response) => {
+                emit_openrouter_stream_response(
+                    response,
+                    &tx,
+                    &mut emitted_payload,
+                    &mut latest_response_id,
+                    &mut latest_finish_reason,
+                    &mut latest_usage,
+                )
+                .await;
+            }
+            Err(error) => {
+                debug!(
+                    ?error,
+                    event, "failed to decode trailing OpenRouter stream event"
+                );
+                if emitted_payload {
+                    latest_finish_reason = Some("stream_error".to_string());
+                    break;
+                }
+                return;
+            }
+        }
+    }
+
+    let _ = tx
+        .send(StreamChunk {
+            text: None,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            usage: latest_usage,
+            provider_response_id: latest_response_id,
+            provider_response_status: None,
+            sequence_number: None,
+            tool_call_delta: None,
+            is_finished: true,
+            finish_reason: latest_finish_reason,
+        })
+        .await;
+}
+
+async fn emit_openrouter_stream_response(
+    response: CompletionsResponse,
+    tx: &mpsc::Sender<StreamChunk>,
+    emitted_payload: &mut bool,
+    latest_response_id: &mut Option<String>,
+    latest_finish_reason: &mut Option<String>,
+    latest_usage: &mut Option<TokenUsage>,
+) {
+    *latest_response_id = Some(response.id.clone());
+    if let Some(usage) = response.usage {
+        *latest_usage = Some(convert_usage(usage));
+    }
+
+    for choice in &response.choices {
+        if let Some(content) = choice.content().filter(|value| !value.is_empty()) {
+            *emitted_payload = true;
+            let _ = tx.send(stream_text_chunk(content.to_string())).await;
+        }
+        if let Some(reasoning) = choice.reasoning().filter(|value| !value.is_empty()) {
+            *emitted_payload = true;
+            let _ = tx.send(stream_thinking_chunk(reasoning.to_string())).await;
+        }
+        if let Some(details) = choice.reasoning_details() {
+            for detail in details {
+                if let Some(thinking) = detail.content().filter(|value| !value.is_empty()) {
+                    *emitted_payload = true;
+                    let _ = tx.send(stream_thinking_chunk(thinking.to_string())).await;
+                }
+                if let Some(signature) = detail.signature.as_ref().filter(|value| !value.is_empty())
+                {
+                    *emitted_payload = true;
+                    let _ = tx
+                        .send(stream_thinking_signature_chunk(signature.clone()))
+                        .await;
+                }
+            }
+        }
+        if let Some(partials) = choice.partial_tool_calls() {
+            for partial in partials {
+                if let Ok(value) = serde_json::to_value(partial)
+                    && let Some(delta) = tool_delta_from_value(value)
+                {
+                    *emitted_payload = true;
+                    let _ = tx.send(stream_tool_chunk(delta)).await;
+                }
+            }
+        }
+        if let Some(reason) = choice.finish_reason() {
+            *latest_finish_reason = Some(finish_reason_to_string(reason).to_string());
+        }
+    }
 }
 
 fn apply_openrouter_extra_params(
@@ -448,6 +708,42 @@ fn tool_delta_from_value(value: Value) -> Option<ToolCallDelta> {
     })
 }
 
+fn validate_app_categories(app_categories: Option<&[String]>) -> Result<()> {
+    if let Some(app_categories) = app_categories {
+        let _ = serialize_app_categories(app_categories)?;
+    }
+    Ok(())
+}
+
+fn serialize_app_categories(app_categories: &[String]) -> Result<String> {
+    if app_categories.is_empty() {
+        bail!("OpenRouter app_categories cannot be empty when provided");
+    }
+    if app_categories.len() > 2 {
+        bail!("OpenRouter app_categories supports at most 2 categories per request");
+    }
+
+    let mut serialized = Vec::with_capacity(app_categories.len());
+    for category in app_categories {
+        let trimmed = category.trim();
+        if trimmed.is_empty() {
+            bail!("OpenRouter app_categories cannot contain empty values");
+        }
+        if trimmed.len() > 30 {
+            bail!("OpenRouter app category `{trimmed}` exceeds the 30 character limit");
+        }
+        if !trimmed
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        {
+            bail!("OpenRouter app category `{trimmed}` must be lowercase and hyphen-separated");
+        }
+        serialized.push(trimmed.to_string());
+    }
+
+    Ok(serialized.join(","))
+}
+
 fn first_reasoning_signature(response: &CompletionsResponse) -> Option<String> {
     response
         .choices
@@ -478,6 +774,7 @@ fn convert_usage(usage: ResponseUsage) -> TokenUsage {
     }
 }
 
+#[cfg(test)]
 fn usage_from_value(value: Value) -> Option<TokenUsage> {
     serde_json::from_value::<ResponseUsage>(value)
         .ok()
@@ -644,6 +941,47 @@ mod tests {
         assert_eq!(value["tools"][0]["function"]["name"], "lookup");
         assert_eq!(value["tool_choice"], "auto");
         assert_eq!(value["reasoning"]["max_tokens"], 512);
+    }
+
+    #[test]
+    fn request_payload_preserves_assistant_reasoning_fields() {
+        let mut request = GenerationRequest::new().with_user_message("hello");
+        request.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: "answer".to_string(),
+            thinking: Some("step by step".to_string()),
+            thinking_signature: Some("encrypted_state".to_string()),
+            redacted_thinking: None,
+            tool_calls: None,
+            tool_call_id: None,
+        });
+
+        let value = build_openrouter_chat_request_payload("openrouter/model", request).unwrap();
+
+        assert_eq!(value["messages"][1]["role"], "assistant");
+        assert_eq!(value["messages"][1]["reasoning_content"], "step by step");
+        assert_eq!(
+            value["messages"][1]["reasoning"]["encrypted_content"],
+            "encrypted_state"
+        );
+    }
+
+    #[test]
+    fn missing_tool_call_id_fails_projection_before_dispatch() {
+        let mut request = GenerationRequest::new().with_user_message("hello");
+        request.messages.push(Message {
+            role: MessageRole::Tool,
+            content: "tool result".to_string(),
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            tool_calls: None,
+            tool_call_id: None,
+        });
+
+        let error = build_openrouter_chat_request("openrouter/model", request).unwrap_err();
+
+        assert!(error.to_string().contains("tool_call_id"));
     }
 
     #[test]

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -1,0 +1,900 @@
+//! OpenRouter SDK-backed chat adapter.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use futures::StreamExt;
+use openrouter_rs::{
+    OpenRouterClient as OpenRouterSdkClient,
+    api::chat::{
+        ChatCompletionRequest, ChatCompletionRequestBuilder, DebugOptions, Message as OrMessage,
+        Modality, Plugin, StopSequence, StreamOptions, TraceOptions,
+    },
+    types::{
+        Effort, FinishReason, FunctionCall as OrFunctionCall, ProviderPreferences, ReasoningConfig,
+        ResponseFormat, ResponseUsage, Role, Tool as OrTool, ToolCall as OrToolCall,
+        UnifiedStreamEvent, completion::CompletionsResponse,
+    },
+};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use crate::{
+    GenerationRequest, GenerationResponse, LlmProvider, Message, MessageRole, StreamChunk,
+    TokenUsage, ToolCall, ToolCallDelta, ToolDefinition,
+};
+
+pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+
+/// Alan LLM provider backed by the `openrouter-rs` SDK.
+#[derive(Clone)]
+pub struct OpenRouterClient {
+    client: OpenRouterSdkClient,
+    model: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OpenRouterClientMetadata {
+    pub http_referer: Option<String>,
+    pub x_title: Option<String>,
+    pub app_categories: Option<Vec<String>>,
+}
+
+impl OpenRouterClient {
+    pub fn with_params(api_key: &str, base_url: &str, model: &str) -> Result<Self> {
+        Self::with_metadata(
+            api_key,
+            base_url,
+            model,
+            OpenRouterClientMetadata::default(),
+        )
+    }
+
+    pub fn with_metadata(
+        api_key: &str,
+        base_url: &str,
+        model: &str,
+        metadata: OpenRouterClientMetadata,
+    ) -> Result<Self> {
+        let mut builder = OpenRouterSdkClient::builder();
+        builder.api_key(api_key).base_url(base_url);
+        if let Some(http_referer) = metadata.http_referer {
+            builder.http_referer(http_referer);
+        }
+        if let Some(x_title) = metadata.x_title {
+            builder.x_title(x_title);
+        }
+        if let Some(app_categories) = metadata.app_categories {
+            builder.app_categories(app_categories);
+        }
+
+        Ok(Self {
+            client: builder
+                .build()
+                .context("failed to build OpenRouter client")?,
+            model: model.to_string(),
+        })
+    }
+
+    async fn generate_chat(&self, request: GenerationRequest) -> Result<GenerationResponse> {
+        let chat_request = build_openrouter_chat_request(&self.model, request)?;
+        let response = self
+            .client
+            .chat()
+            .create(&chat_request)
+            .await
+            .context("OpenRouter chat completion request failed")?;
+        Ok(convert_openrouter_response(response))
+    }
+
+    async fn generate_chat_stream(
+        &self,
+        request: GenerationRequest,
+    ) -> Result<mpsc::Receiver<StreamChunk>> {
+        let chat_request = build_openrouter_chat_request(&self.model, request)?;
+        let (tx, rx) = mpsc::channel(100);
+        let client = self.client.clone();
+
+        tokio::spawn(async move {
+            let stream = match client.chat().stream_unified(&chat_request).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    debug!(?error, "OpenRouter stream failed before yielding output");
+                    return;
+                }
+            };
+
+            consume_openrouter_stream(stream, tx).await;
+        });
+
+        Ok(rx)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenRouterClient {
+    async fn generate(&mut self, request: GenerationRequest) -> Result<GenerationResponse> {
+        self.generate_chat(request).await
+    }
+
+    async fn chat(&mut self, system: Option<&str>, user: &str) -> Result<String> {
+        let mut request = GenerationRequest::new().with_user_message(user);
+        if let Some(system) = system {
+            request = request.with_system_prompt(system);
+        }
+        Ok(self.generate_chat(request).await?.content)
+    }
+
+    async fn generate_stream(
+        &mut self,
+        request: GenerationRequest,
+    ) -> Result<mpsc::Receiver<StreamChunk>> {
+        self.generate_chat_stream(request).await
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "openrouter"
+    }
+}
+
+pub(crate) fn build_openrouter_chat_request(
+    model: &str,
+    request: GenerationRequest,
+) -> Result<ChatCompletionRequest> {
+    let GenerationRequest {
+        system_prompt,
+        messages,
+        tools,
+        temperature,
+        max_tokens,
+        thinking_budget_tokens,
+        extra_params,
+    } = request;
+
+    let mut projected_messages = Vec::new();
+    if let Some(system_prompt) = system_prompt.filter(|value| !value.is_empty()) {
+        projected_messages.push(OrMessage::new(Role::System, system_prompt));
+    }
+    projected_messages.extend(convert_messages_for_openrouter(messages));
+
+    let mut builder = ChatCompletionRequest::builder();
+    builder.model(model).messages(projected_messages);
+
+    if let Some(temperature) = temperature {
+        builder.temperature(f64::from(temperature));
+    }
+    if let Some(max_tokens) = max_tokens {
+        builder.max_tokens(non_negative_u32("max_tokens", max_tokens)?);
+    }
+    if let Some(thinking_budget_tokens) = thinking_budget_tokens {
+        builder.reasoning(ReasoningConfig::with_max_tokens(thinking_budget_tokens));
+    }
+
+    let tools = convert_tools_for_openrouter(tools);
+    if !tools.is_empty() {
+        builder.tools(tools);
+        builder.tool_choice_auto();
+    }
+
+    apply_openrouter_extra_params(&mut builder, extra_params)?;
+    builder
+        .build()
+        .context("failed to build OpenRouter chat completion request")
+}
+
+pub(crate) fn convert_messages_for_openrouter(messages: Vec<Message>) -> Vec<OrMessage> {
+    messages
+        .into_iter()
+        .map(|message| {
+            let Message {
+                role,
+                content,
+                thinking: _,
+                thinking_signature: _,
+                redacted_thinking: _,
+                tool_calls,
+                tool_call_id,
+            } = message;
+
+            match role {
+                MessageRole::System => OrMessage::new(Role::System, content),
+                MessageRole::User => OrMessage::new(Role::User, content),
+                MessageRole::Assistant => {
+                    let tool_calls = tool_calls.map(convert_tool_calls_for_openrouter);
+                    match tool_calls {
+                        Some(tool_calls) if !tool_calls.is_empty() => {
+                            OrMessage::assistant_with_tool_calls(content, tool_calls)
+                        }
+                        _ => OrMessage::new(Role::Assistant, content),
+                    }
+                }
+                MessageRole::Tool => {
+                    let tool_call_id = tool_call_id.unwrap_or_default();
+                    OrMessage::tool_response(&tool_call_id, content)
+                }
+                MessageRole::Context => OrMessage::new(Role::System, content),
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn convert_tools_for_openrouter(tools: Vec<ToolDefinition>) -> Vec<OrTool> {
+    tools
+        .into_iter()
+        .map(|tool| OrTool::new(&tool.name, &tool.description, tool.parameters))
+        .collect()
+}
+
+pub(crate) fn convert_openrouter_response(response: CompletionsResponse) -> GenerationResponse {
+    let mut content = String::new();
+    let mut thinking = String::new();
+    let mut tool_calls = Vec::new();
+    let mut warnings = Vec::new();
+    let mut finish_reason = None;
+
+    for choice in &response.choices {
+        if let Some(choice_content) = choice.content() {
+            content.push_str(choice_content);
+        }
+        if let Some(choice_reasoning) = choice.reasoning() {
+            thinking.push_str(choice_reasoning);
+        } else if let Some(details) = choice.reasoning_details() {
+            for detail in details {
+                if let Some(part) = detail.content() {
+                    thinking.push_str(part);
+                }
+            }
+        }
+        if let Some(reason) = choice.finish_reason() {
+            finish_reason = Some(finish_reason_to_string(reason).to_string());
+        }
+        if let Some(calls) = choice.tool_calls() {
+            for call in calls {
+                match convert_openrouter_tool_call(call) {
+                    Ok(call) => tool_calls.push(call),
+                    Err(warning) => warnings.push(warning),
+                }
+            }
+        }
+    }
+
+    GenerationResponse {
+        content,
+        thinking: (!thinking.is_empty()).then_some(thinking),
+        thinking_signature: first_reasoning_signature(&response),
+        redacted_thinking: Vec::new(),
+        tool_calls,
+        usage: response.usage.map(convert_usage),
+        finish_reason,
+        provider_response_id: Some(response.id),
+        provider_response_status: None,
+        warnings,
+    }
+}
+
+async fn consume_openrouter_stream(
+    mut stream: openrouter_rs::types::UnifiedStream,
+    tx: mpsc::Sender<StreamChunk>,
+) {
+    let mut emitted_payload = false;
+    let mut latest_usage = None;
+    let mut latest_response_id = None;
+    let mut latest_finish_reason = None;
+
+    while let Some(event) = stream.next().await {
+        match event {
+            UnifiedStreamEvent::ContentDelta(text) => {
+                if !text.is_empty() {
+                    emitted_payload = true;
+                    let _ = tx.send(stream_text_chunk(text)).await;
+                }
+            }
+            UnifiedStreamEvent::ReasoningDelta(thinking) => {
+                if !thinking.is_empty() {
+                    emitted_payload = true;
+                    let _ = tx.send(stream_thinking_chunk(thinking)).await;
+                }
+            }
+            UnifiedStreamEvent::ReasoningDetailsDelta(details) => {
+                for detail in details {
+                    if let Some(thinking) = detail.content().filter(|value| !value.is_empty()) {
+                        emitted_payload = true;
+                        let _ = tx.send(stream_thinking_chunk(thinking.to_string())).await;
+                    }
+                    if let Some(signature) = detail.signature.filter(|value| !value.is_empty()) {
+                        emitted_payload = true;
+                        let _ = tx.send(stream_thinking_signature_chunk(signature)).await;
+                    }
+                }
+            }
+            UnifiedStreamEvent::ToolDelta(value) => {
+                if let Some(delta) = tool_delta_from_value(value) {
+                    emitted_payload = true;
+                    let _ = tx.send(stream_tool_chunk(delta)).await;
+                }
+            }
+            UnifiedStreamEvent::Done {
+                id,
+                finish_reason,
+                usage,
+                ..
+            } => {
+                latest_response_id = id;
+                latest_finish_reason = finish_reason;
+                latest_usage = usage.and_then(usage_from_value);
+                break;
+            }
+            UnifiedStreamEvent::Error(error) => {
+                debug!(?error, "OpenRouter stream failed");
+                if emitted_payload {
+                    latest_finish_reason = Some("stream_error".to_string());
+                    break;
+                }
+                return;
+            }
+            UnifiedStreamEvent::Raw { .. } => {}
+        }
+    }
+
+    let _ = tx
+        .send(StreamChunk {
+            text: None,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            usage: latest_usage,
+            provider_response_id: latest_response_id,
+            provider_response_status: None,
+            sequence_number: None,
+            tool_call_delta: None,
+            is_finished: true,
+            finish_reason: latest_finish_reason,
+        })
+        .await;
+}
+
+fn apply_openrouter_extra_params(
+    builder: &mut ChatCompletionRequestBuilder,
+    extra_params: HashMap<String, Value>,
+) -> Result<()> {
+    for (key, value) in extra_params {
+        match key.as_str() {
+            "max_completion_tokens" => builder.max_completion_tokens(value_as_u32(&key, value)?),
+            "seed" => builder.seed(value_as_u32(&key, value)?),
+            "top_p" => builder.top_p(value_as_f64(&key, value)?),
+            "top_k" => builder.top_k(value_as_u32(&key, value)?),
+            "frequency_penalty" => builder.frequency_penalty(value_as_f64(&key, value)?),
+            "presence_penalty" => builder.presence_penalty(value_as_f64(&key, value)?),
+            "repetition_penalty" => builder.repetition_penalty(value_as_f64(&key, value)?),
+            "logit_bias" => builder.logit_bias(value_as::<HashMap<String, f64>>(&key, value)?),
+            "logprobs" => builder.logprobs(value_as_bool(&key, value)?),
+            "top_logprobs" => builder.top_logprobs(value_as_u32(&key, value)?),
+            "min_p" => builder.min_p(value_as_f64(&key, value)?),
+            "top_a" => builder.top_a(value_as_f64(&key, value)?),
+            "transforms" => builder.transforms(value_as::<Vec<String>>(&key, value)?),
+            "models" => builder.models(value_as::<Vec<String>>(&key, value)?),
+            "route" => builder.route(value_as_string(&key, value)?),
+            "user" => builder.user(value_as_string(&key, value)?),
+            "session_id" => builder.session_id(value_as_string(&key, value)?),
+            "trace" => builder.trace(value_as::<TraceOptions>(&key, value)?),
+            "provider" => builder.provider(value_as::<ProviderPreferences>(&key, value)?),
+            "metadata" => builder.metadata(value_as::<HashMap<String, String>>(&key, value)?),
+            "plugins" => builder.plugins(value_as::<Vec<Plugin>>(&key, value)?),
+            "modalities" => builder.modalities(value_as::<Vec<Modality>>(&key, value)?),
+            "image_config" => {
+                builder.image_config(value_as::<HashMap<String, Value>>(&key, value)?)
+            }
+            "response_format" => builder.response_format(value_as::<ResponseFormat>(&key, value)?),
+            "reasoning" => builder.reasoning(value_as::<ReasoningConfig>(&key, value)?),
+            "reasoning_effort" => builder.reasoning_effort(effort_from_value(&key, value)?),
+            "reasoning_max_tokens" => builder.reasoning_max_tokens(value_as_u32(&key, value)?),
+            "include_reasoning" => builder.include_reasoning(value_as_bool(&key, value)?),
+            "stop" => builder.stop(value_as::<StopSequence>(&key, value)?),
+            "stream_options" => builder.stream_options(value_as::<StreamOptions>(&key, value)?),
+            "debug" => builder.debug(value_as::<DebugOptions>(&key, value)?),
+            "parallel_tool_calls" => builder.parallel_tool_calls(value_as_bool(&key, value)?),
+            unsupported => {
+                bail!("OpenRouter provider does not support extra parameter `{unsupported}`");
+            }
+        };
+    }
+    Ok(())
+}
+
+fn convert_tool_calls_for_openrouter(tool_calls: Vec<ToolCall>) -> Vec<OrToolCall> {
+    tool_calls
+        .into_iter()
+        .map(|call| OrToolCall {
+            id: call.id.unwrap_or_default(),
+            type_: "function".to_string(),
+            function: OrFunctionCall {
+                name: call.name,
+                arguments: call.arguments.to_string(),
+            },
+            index: None,
+        })
+        .collect()
+}
+
+fn convert_openrouter_tool_call(call: &OrToolCall) -> std::result::Result<ToolCall, String> {
+    let arguments = match serde_json::from_str::<Value>(call.arguments_json()) {
+        Ok(arguments) => arguments,
+        Err(_) => {
+            return Err(format!(
+                "Dropped malformed OpenRouter tool call `{}` arguments.",
+                call.name()
+            ));
+        }
+    };
+
+    Ok(ToolCall {
+        id: Some(call.id().to_string()),
+        name: call.name().to_string(),
+        arguments,
+    })
+}
+
+fn tool_delta_from_value(value: Value) -> Option<ToolCallDelta> {
+    let partial: openrouter_rs::types::PartialToolCall = serde_json::from_value(value).ok()?;
+    let function = partial.function;
+    Some(ToolCallDelta {
+        index: partial.index.unwrap_or(0) as usize,
+        id: partial.id,
+        name: function.as_ref().and_then(|function| function.name.clone()),
+        arguments_delta: function.and_then(|function| function.arguments),
+        arguments: None,
+    })
+}
+
+fn first_reasoning_signature(response: &CompletionsResponse) -> Option<String> {
+    response
+        .choices
+        .iter()
+        .filter_map(|choice| choice.reasoning_details())
+        .flat_map(|details| details.iter())
+        .filter_map(|detail| detail.signature.clone())
+        .find(|value| !value.is_empty())
+}
+
+fn finish_reason_to_string(reason: &FinishReason) -> &'static str {
+    match reason {
+        FinishReason::ToolCalls => "tool_calls",
+        FinishReason::Stop => "stop",
+        FinishReason::Length => "length",
+        FinishReason::ContentFilter => "content_filter",
+        FinishReason::Error => "error",
+    }
+}
+
+fn convert_usage(usage: ResponseUsage) -> TokenUsage {
+    TokenUsage {
+        prompt_tokens: usage.prompt_tokens.min(i32::MAX as u32) as i32,
+        cached_prompt_tokens: None,
+        completion_tokens: usage.completion_tokens.min(i32::MAX as u32) as i32,
+        total_tokens: usage.total_tokens.min(i32::MAX as u32) as i32,
+        reasoning_tokens: None,
+    }
+}
+
+fn usage_from_value(value: Value) -> Option<TokenUsage> {
+    serde_json::from_value::<ResponseUsage>(value)
+        .ok()
+        .map(convert_usage)
+}
+
+fn stream_text_chunk(text: String) -> StreamChunk {
+    StreamChunk {
+        text: Some(text),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: None,
+        usage: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        sequence_number: None,
+        tool_call_delta: None,
+        is_finished: false,
+        finish_reason: None,
+    }
+}
+
+fn stream_thinking_chunk(thinking: String) -> StreamChunk {
+    StreamChunk {
+        text: None,
+        thinking: Some(thinking),
+        thinking_signature: None,
+        redacted_thinking: None,
+        usage: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        sequence_number: None,
+        tool_call_delta: None,
+        is_finished: false,
+        finish_reason: None,
+    }
+}
+
+fn stream_thinking_signature_chunk(thinking_signature: String) -> StreamChunk {
+    StreamChunk {
+        text: None,
+        thinking: None,
+        thinking_signature: Some(thinking_signature),
+        redacted_thinking: None,
+        usage: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        sequence_number: None,
+        tool_call_delta: None,
+        is_finished: false,
+        finish_reason: None,
+    }
+}
+
+fn stream_tool_chunk(tool_call_delta: ToolCallDelta) -> StreamChunk {
+    StreamChunk {
+        text: None,
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: None,
+        usage: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        sequence_number: None,
+        tool_call_delta: Some(tool_call_delta),
+        is_finished: false,
+        finish_reason: None,
+    }
+}
+
+fn non_negative_u32(label: &str, value: i32) -> Result<u32> {
+    u32::try_from(value).with_context(|| format!("`{label}` must be a non-negative integer"))
+}
+
+fn value_as<T>(key: &str, value: Value) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(value).with_context(|| {
+        format!("OpenRouter extra parameter `{key}` has an unsupported value shape")
+    })
+}
+
+fn value_as_string(key: &str, value: Value) -> Result<String> {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("OpenRouter extra parameter `{key}` must be a string"))
+}
+
+fn value_as_bool(key: &str, value: Value) -> Result<bool> {
+    value
+        .as_bool()
+        .ok_or_else(|| anyhow::anyhow!("OpenRouter extra parameter `{key}` must be a boolean"))
+}
+
+fn value_as_u32(key: &str, value: Value) -> Result<u32> {
+    match value.as_u64().and_then(|value| u32::try_from(value).ok()) {
+        Some(value) => Ok(value),
+        None => bail!("OpenRouter extra parameter `{key}` must be an unsigned 32-bit integer"),
+    }
+}
+
+fn value_as_f64(key: &str, value: Value) -> Result<f64> {
+    value
+        .as_f64()
+        .ok_or_else(|| anyhow::anyhow!("OpenRouter extra parameter `{key}` must be a number"))
+}
+
+fn effort_from_value(key: &str, value: Value) -> Result<Effort> {
+    let raw = value_as_string(key, value)?;
+    match raw.as_str() {
+        "xhigh" => Ok(Effort::Xhigh),
+        "high" => Ok(Effort::High),
+        "medium" => Ok(Effort::Medium),
+        "low" => Ok(Effort::Low),
+        "minimal" => Ok(Effort::Minimal),
+        "none" => Ok(Effort::None),
+        _ => bail!("OpenRouter extra parameter `{key}` has unsupported reasoning effort `{raw}`"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openrouter_rs::types::{
+        Choice, NonStreamingChoice, ObjectType, ReasoningDetail,
+        completion::Message as OrResponseMessage,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn projects_messages_tools_and_reasoning_budget() {
+        let mut request = GenerationRequest::new()
+            .with_system_prompt("system")
+            .with_user_message("hello")
+            .with_assistant_message("thinking done")
+            .with_tool(ToolDefinition::new("lookup", "Lookup data"))
+            .with_thinking_budget_tokens(512);
+        request.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            tool_calls: Some(vec![
+                ToolCall::new("lookup", json!({"q":"rust"})).with_id("call-1"),
+            ]),
+            tool_call_id: None,
+        });
+        request
+            .messages
+            .push(Message::tool("call-1", "tool result"));
+
+        let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
+        let value = serde_json::to_value(projected).unwrap();
+
+        assert_eq!(value["model"], "openrouter/model");
+        assert_eq!(value["messages"][0]["role"], "system");
+        assert_eq!(value["messages"][1]["role"], "user");
+        assert_eq!(value["messages"][3]["tool_calls"][0]["id"], "call-1");
+        assert_eq!(value["messages"][4]["role"], "tool");
+        assert_eq!(value["messages"][4]["tool_call_id"], "call-1");
+        assert_eq!(value["tools"][0]["function"]["name"], "lookup");
+        assert_eq!(value["tool_choice"], "auto");
+        assert_eq!(value["reasoning"]["max_tokens"], 512);
+    }
+
+    #[test]
+    fn unsupported_extra_parameter_fails_projection() {
+        let mut request = GenerationRequest::new().with_user_message("hello");
+        request
+            .extra_params
+            .insert("unsupported".to_string(), json!(true));
+
+        let error = build_openrouter_chat_request("openrouter/model", request).unwrap_err();
+        assert!(error.to_string().contains("unsupported"));
+    }
+
+    #[test]
+    fn supported_extra_parameters_are_projected() {
+        let mut request = GenerationRequest::new().with_user_message("hello");
+        request
+            .extra_params
+            .insert("route".to_string(), json!("fallback"));
+        request.extra_params.insert(
+            "provider".to_string(),
+            json!({ "allow_fallbacks": false, "require_parameters": true }),
+        );
+        request
+            .extra_params
+            .insert("transforms".to_string(), json!(["middle-out"]));
+        request
+            .extra_params
+            .insert("reasoning_effort".to_string(), json!("high"));
+
+        let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
+        let value = serde_json::to_value(projected).unwrap();
+
+        assert_eq!(value["route"], "fallback");
+        assert_eq!(value["provider"]["allow_fallbacks"], false);
+        assert_eq!(value["transforms"][0], "middle-out");
+        assert_eq!(value["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn maps_content_reasoning_usage_finish_and_response_id() {
+        let response = response_with_choice(Choice::NonStreaming(NonStreamingChoice {
+            finish_reason: Some(FinishReason::Stop),
+            native_finish_reason: None,
+            message: OrResponseMessage {
+                content: Some("answer".to_string()),
+                role: Some("assistant".to_string()),
+                name: None,
+                tool_calls: None,
+                reasoning: Some("because".to_string()),
+                reasoning_details: None,
+                images: None,
+                audio: None,
+                refusal: None,
+                annotations: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        }));
+
+        let converted = convert_openrouter_response(response);
+        assert_eq!(converted.content, "answer");
+        assert_eq!(converted.thinking.as_deref(), Some("because"));
+        assert_eq!(converted.finish_reason.as_deref(), Some("stop"));
+        assert_eq!(converted.provider_response_id.as_deref(), Some("resp-1"));
+        assert_eq!(converted.usage.unwrap().total_tokens, 7);
+    }
+
+    #[test]
+    fn maps_tool_call_and_drops_malformed_arguments() {
+        let response = response_with_choice(Choice::NonStreaming(NonStreamingChoice {
+            finish_reason: Some(FinishReason::ToolCalls),
+            native_finish_reason: None,
+            message: OrResponseMessage {
+                content: Some(String::new()),
+                role: Some("assistant".to_string()),
+                name: None,
+                tool_calls: Some(vec![
+                    OrToolCall {
+                        id: "call-ok".to_string(),
+                        type_: "function".to_string(),
+                        function: OrFunctionCall {
+                            name: "lookup".to_string(),
+                            arguments: "{\"q\":\"rust\"}".to_string(),
+                        },
+                        index: Some(0),
+                    },
+                    OrToolCall {
+                        id: "call-bad".to_string(),
+                        type_: "function".to_string(),
+                        function: OrFunctionCall {
+                            name: "broken".to_string(),
+                            arguments: "{bad".to_string(),
+                        },
+                        index: Some(1),
+                    },
+                ]),
+                reasoning: None,
+                reasoning_details: None,
+                images: None,
+                audio: None,
+                refusal: None,
+                annotations: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        }));
+
+        let converted = convert_openrouter_response(response);
+        assert_eq!(converted.tool_calls.len(), 1);
+        assert_eq!(converted.tool_calls[0].id.as_deref(), Some("call-ok"));
+        assert_eq!(converted.tool_calls[0].arguments["q"], "rust");
+        assert_eq!(converted.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(converted.warnings.len(), 1);
+        assert!(converted.warnings[0].contains("broken"));
+    }
+
+    #[test]
+    fn maps_reasoning_detail_signature() {
+        let response = response_with_choice(Choice::NonStreaming(NonStreamingChoice {
+            finish_reason: Some(FinishReason::Stop),
+            native_finish_reason: None,
+            message: OrResponseMessage {
+                content: Some("answer".to_string()),
+                role: Some("assistant".to_string()),
+                name: None,
+                tool_calls: None,
+                reasoning: None,
+                reasoning_details: Some(vec![ReasoningDetail {
+                    block_type: "reasoning.text".to_string(),
+                    text: Some("detail".to_string()),
+                    data: None,
+                    signature: Some("sig".to_string()),
+                    format: None,
+                    id: None,
+                    index: None,
+                }]),
+                images: None,
+                audio: None,
+                refusal: None,
+                annotations: None,
+            },
+            error: None,
+            index: Some(0),
+            logprobs: None,
+        }));
+
+        let converted = convert_openrouter_response(response);
+        assert_eq!(converted.thinking.as_deref(), Some("detail"));
+        assert_eq!(converted.thinking_signature.as_deref(), Some("sig"));
+    }
+
+    #[test]
+    fn maps_stream_tool_delta() {
+        let delta = tool_delta_from_value(json!({
+            "index": 2,
+            "id": "call-1",
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "arguments": "{\"q\""
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(delta.index, 2);
+        assert_eq!(delta.id.as_deref(), Some("call-1"));
+        assert_eq!(delta.name.as_deref(), Some("lookup"));
+        assert_eq!(delta.arguments_delta.as_deref(), Some("{\"q\""));
+    }
+
+    #[tokio::test]
+    async fn maps_stream_text_reasoning_completion_and_errors() {
+        let events = futures::stream::iter(vec![
+            UnifiedStreamEvent::ContentDelta("hel".to_string()),
+            UnifiedStreamEvent::ReasoningDelta("why".to_string()),
+            UnifiedStreamEvent::ToolDelta(json!({
+                "index": 0,
+                "id": "call-1",
+                "type": "function",
+                "function": { "name": "lookup", "arguments": "{}" }
+            })),
+            UnifiedStreamEvent::Done {
+                source: openrouter_rs::types::UnifiedStreamSource::Chat,
+                id: Some("resp-stream".to_string()),
+                model: Some("model".to_string()),
+                finish_reason: Some("tool_calls".to_string()),
+                usage: Some(json!({
+                    "prompt_tokens": 2,
+                    "completion_tokens": 3,
+                    "total_tokens": 5
+                })),
+            },
+        ])
+        .boxed();
+        let (tx, mut rx) = mpsc::channel(10);
+        consume_openrouter_stream(events, tx).await;
+
+        assert_eq!(rx.recv().await.unwrap().text.as_deref(), Some("hel"));
+        assert_eq!(rx.recv().await.unwrap().thinking.as_deref(), Some("why"));
+        assert_eq!(
+            rx.recv()
+                .await
+                .unwrap()
+                .tool_call_delta
+                .unwrap()
+                .name
+                .as_deref(),
+            Some("lookup")
+        );
+        let done = rx.recv().await.unwrap();
+        assert!(done.is_finished);
+        assert_eq!(done.provider_response_id.as_deref(), Some("resp-stream"));
+        assert_eq!(done.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(done.usage.unwrap().total_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn stream_error_after_partial_output_emits_terminal_error_chunk() {
+        let events = futures::stream::iter(vec![
+            UnifiedStreamEvent::ContentDelta("partial".to_string()),
+            UnifiedStreamEvent::Error(openrouter_rs::error::OpenRouterError::Unknown(
+                "boom".to_string(),
+            )),
+        ])
+        .boxed();
+        let (tx, mut rx) = mpsc::channel(10);
+        consume_openrouter_stream(events, tx).await;
+
+        assert_eq!(rx.recv().await.unwrap().text.as_deref(), Some("partial"));
+        let done = rx.recv().await.unwrap();
+        assert!(done.is_finished);
+        assert_eq!(done.finish_reason.as_deref(), Some("stream_error"));
+    }
+
+    fn response_with_choice(choice: Choice) -> CompletionsResponse {
+        CompletionsResponse {
+            id: "resp-1".to_string(),
+            choices: vec![choice],
+            created: 1,
+            model: "openrouter/model".to_string(),
+            object_type: ObjectType::ChatCompletion,
+            provider: Some("openrouter".to_string()),
+            system_fingerprint: None,
+            usage: Some(ResponseUsage {
+                prompt_tokens: 3,
+                completion_tokens: 4,
+                total_tokens: 7,
+            }),
+        }
+    }
+}

--- a/crates/llm/tests/live_provider_harness.rs
+++ b/crates/llm/tests/live_provider_harness.rs
@@ -1,5 +1,5 @@
 use alan_llm::factory::{self, ProviderConfig};
-use alan_llm::{GenerationRequest, LlmProvider, StreamChunk};
+use alan_llm::{GenerationRequest, LlmProvider, StreamChunk, ToolDefinition};
 use anyhow::{Context, Result, ensure};
 use std::env;
 use std::path::PathBuf;
@@ -125,6 +125,38 @@ fn provider_harness_or_skip(provider: &'static str) -> Option<LiveProviderHarnes
                 config,
             })
         }
+        "openrouter" => {
+            let Some(api_key) = non_empty_env("ALAN_LIVE_OPENROUTER_API_KEY") else {
+                eprintln!(
+                    "[live-provider-harness] skipping openrouter: ALAN_LIVE_OPENROUTER_API_KEY is unset"
+                );
+                return None;
+            };
+            let model = non_empty_env("ALAN_LIVE_OPENROUTER_MODEL")
+                .unwrap_or_else(|| "moonshotai/kimi-k2.6".to_string());
+            let mut config = ProviderConfig::openrouter(api_key, model);
+            if let Some(base_url) = non_empty_env("ALAN_LIVE_OPENROUTER_BASE_URL") {
+                config = config.with_base_url(base_url);
+            }
+            if let Some(http_referer) = non_empty_env("ALAN_LIVE_OPENROUTER_HTTP_REFERER") {
+                config = config.with_http_referer(http_referer);
+            }
+            if let Some(x_title) = non_empty_env("ALAN_LIVE_OPENROUTER_X_TITLE") {
+                config = config.with_x_title(x_title);
+            }
+            if let Some(app_categories) = non_empty_env("ALAN_LIVE_OPENROUTER_APP_CATEGORIES") {
+                config = config.with_app_categories(
+                    app_categories
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty()),
+                );
+            }
+            Some(LiveProviderHarness {
+                label: "openrouter",
+                config,
+            })
+        }
         "anthropic_messages" => {
             let Some(api_key) = non_empty_env("ALAN_LIVE_ANTHROPIC_MESSAGES_API_KEY") else {
                 eprintln!(
@@ -151,6 +183,15 @@ fn provider_harness_or_skip(provider: &'static str) -> Option<LiveProviderHarnes
         }
         other => panic!("unsupported live harness provider: {other}"),
     }
+}
+
+fn env_truthy(name: &str) -> Option<bool> {
+    non_empty_env(name).map(|value| {
+        matches!(
+            value.as_str(),
+            "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+        )
+    })
 }
 
 fn exact_reply_request(token: &str) -> GenerationRequest {
@@ -361,6 +402,114 @@ async fn run_responses_continuation(harness: &LiveProviderHarness) -> Result<()>
     Ok(())
 }
 
+fn openrouter_model_indicates_reasoning(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.contains("kimi-k2.6") || model.contains("kimi-k2-thinking")
+}
+
+fn openrouter_model_indicates_tool_calls(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.contains("kimi-k2.6") || model.contains("kimi-k2")
+}
+
+async fn run_openrouter_reasoning_if_supported(harness: &LiveProviderHarness) -> Result<()> {
+    let should_run = env_truthy("ALAN_LIVE_OPENROUTER_REASONING")
+        .unwrap_or_else(|| openrouter_model_indicates_reasoning(&harness.config.model));
+    if !should_run {
+        eprintln!(
+            "[live-provider-harness] skipping openrouter reasoning: configured model support not asserted"
+        );
+        return Ok(());
+    }
+
+    let token = "ALAN_LIVE_OPENROUTER_REASONING_OK";
+    let mut provider = create_provider(harness.config.clone())
+        .await
+        .context("failed to construct openrouter provider for reasoning check")?;
+    let response = timeout(
+        REQUEST_TIMEOUT,
+        provider.generate(
+            exact_reply_request(token)
+                .with_thinking_budget_tokens(256)
+                .with_extra_param("include_reasoning", serde_json::json!(true)),
+        ),
+    )
+    .await
+    .context("openrouter reasoning generation timed out")?
+    .context("openrouter reasoning generation failed")?;
+
+    ensure!(
+        response.content.contains(token),
+        "openrouter reasoning generation did not contain expected token `{token}`: {:?}",
+        response.content
+    );
+    ensure!(
+        response
+            .thinking
+            .as_deref()
+            .is_some_and(|value| !value.is_empty()),
+        "openrouter reasoning generation did not surface reasoning text"
+    );
+
+    Ok(())
+}
+
+async fn run_openrouter_tool_call_if_supported(harness: &LiveProviderHarness) -> Result<()> {
+    let should_run = env_truthy("ALAN_LIVE_OPENROUTER_TOOL_CALLS")
+        .unwrap_or_else(|| openrouter_model_indicates_tool_calls(&harness.config.model));
+    if !should_run {
+        eprintln!(
+            "[live-provider-harness] skipping openrouter tool calls: configured model support not asserted"
+        );
+        return Ok(());
+    }
+
+    let mut provider = create_provider(harness.config.clone())
+        .await
+        .context("failed to construct openrouter provider for tool-call check")?;
+    let tool = ToolDefinition::new("record_status", "Record a required status token.")
+        .with_parameters(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "The exact status token."
+                }
+            },
+            "required": ["token"],
+            "additionalProperties": false
+        }));
+    let request = GenerationRequest::new()
+        .with_system_prompt(
+            "You are a tool-call conformance harness. When the user asks you to record a token, call the provided tool exactly once and do not answer in text.",
+        )
+        .with_user_message("Record the exact token ALAN_LIVE_OPENROUTER_TOOL_OK.")
+        .with_tool(tool)
+        .with_temperature(0.0)
+        .with_max_tokens(128);
+    let response = timeout(REQUEST_TIMEOUT, provider.generate(request))
+        .await
+        .context("openrouter tool-call generation timed out")?
+        .context("openrouter tool-call generation failed")?;
+
+    let tool_call = response
+        .tool_calls
+        .iter()
+        .find(|tool_call| tool_call.name == "record_status")
+        .context("openrouter did not emit the expected record_status tool call")?;
+    ensure!(
+        tool_call
+            .arguments
+            .get("token")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value.contains("ALAN_LIVE_OPENROUTER_TOOL_OK")),
+        "openrouter tool call did not include the expected token: {:?}",
+        tool_call.arguments
+    );
+
+    Ok(())
+}
+
 async fn run_live_contract(harness: LiveProviderHarness) -> Result<()> {
     let basic_token = format!("ALAN_LIVE_{}_BASIC_OK", harness.label.to_uppercase());
     let stream_token = format!("ALAN_LIVE_{}_STREAM_OK", harness.label.to_uppercase());
@@ -413,6 +562,17 @@ async fn live_openai_chat_completions_compatible_contract() -> Result<()> {
         return Ok(());
     };
     run_live_contract(harness).await
+}
+
+#[tokio::test]
+#[ignore = "live network test; requires ALAN_LIVE_PROVIDER_TESTS=1 and OpenRouter credentials"]
+async fn live_openrouter_contract() -> Result<()> {
+    let Some(harness) = provider_harness_or_skip("openrouter") else {
+        return Ok(());
+    };
+    run_live_contract(harness.clone()).await?;
+    run_openrouter_reasoning_if_supported(&harness).await?;
+    run_openrouter_tool_call_if_supported(&harness).await
 }
 
 #[tokio::test]

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -5,7 +5,7 @@ use crate::models::{self, ModelCatalogProvider, ModelInfo};
 use crate::paths::AlanHomePaths;
 use crate::skills::{SkillOverride, merge_skill_overrides};
 use anyhow::Context;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -35,7 +35,7 @@ pub struct DurabilityConfig {
     pub required: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum LlmProvider {
     #[serde(rename = "google_gemini_generate_content")]
     GoogleGeminiGenerateContent,
@@ -47,6 +47,8 @@ pub enum LlmProvider {
     OpenAiChatCompletions,
     #[serde(rename = "openai_chat_completions_compatible")]
     OpenAiChatCompletionsCompatible,
+    #[serde(rename = "openrouter")]
+    OpenRouter,
     #[serde(rename = "anthropic_messages")]
     AnthropicMessages,
 }
@@ -59,7 +61,37 @@ impl LlmProvider {
             Self::OpenAiResponses => "openai_responses",
             Self::OpenAiChatCompletions => "openai_chat_completions",
             Self::OpenAiChatCompletionsCompatible => "openai_chat_completions_compatible",
+            Self::OpenRouter => "openrouter",
             Self::AnthropicMessages => "anthropic_messages",
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LlmProvider {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const SUPPORTED: &[&str] = &[
+            "google_gemini_generate_content",
+            "chatgpt",
+            "openai_responses",
+            "openai_chat_completions",
+            "openai_chat_completions_compatible",
+            "openrouter",
+            "anthropic_messages",
+        ];
+
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "google_gemini_generate_content" => Ok(Self::GoogleGeminiGenerateContent),
+            "chatgpt" => Ok(Self::Chatgpt),
+            "openai_responses" => Ok(Self::OpenAiResponses),
+            "openai_chat_completions" => Ok(Self::OpenAiChatCompletions),
+            "openai_chat_completions_compatible" => Ok(Self::OpenAiChatCompletionsCompatible),
+            "openrouter" => Ok(Self::OpenRouter),
+            "anthropic_messages" => Ok(Self::AnthropicMessages),
+            other => Err(de::Error::unknown_variant(other, SUPPORTED)),
         }
     }
 }
@@ -218,6 +250,33 @@ pub struct Config {
     pub openai_chat_completions_compatible_model: String,
 
     // ========================================================================
+    // OpenRouter Configuration
+    // ========================================================================
+    /// OPENROUTER_API_KEY
+    #[serde(skip, default)]
+    pub openrouter_api_key: Option<String>,
+
+    /// OPENROUTER_BASE_URL (default: <https://openrouter.ai/api/v1>)
+    #[serde(skip, default = "default_openrouter_base_url")]
+    pub openrouter_base_url: String,
+
+    /// OPENROUTER_MODEL
+    #[serde(skip, default = "default_openrouter_model")]
+    pub openrouter_model: String,
+
+    /// OPENROUTER_HTTP_REFERER
+    #[serde(skip, default)]
+    pub openrouter_http_referer: Option<String>,
+
+    /// OPENROUTER_X_TITLE
+    #[serde(skip, default)]
+    pub openrouter_x_title: Option<String>,
+
+    /// OPENROUTER_APP_CATEGORIES
+    #[serde(skip, default)]
+    pub openrouter_app_categories: Vec<String>,
+
+    // ========================================================================
     // Anthropic Messages API Configuration
     // ========================================================================
     /// ANTHROPIC_MESSAGES_API_KEY
@@ -371,6 +430,14 @@ fn default_openai_chat_completions_compatible_model() -> String {
     models::default_model_slug(ModelCatalogProvider::OpenAiChatCompletionsCompatible).to_string()
 }
 
+fn default_openrouter_base_url() -> String {
+    alan_llm::openrouter::OPENROUTER_BASE_URL.to_string()
+}
+
+fn default_openrouter_model() -> String {
+    "moonshotai/kimi-k2.6".to_string()
+}
+
 fn default_anthropic_messages_base_url() -> String {
     "https://api.anthropic.com/v1".to_string()
 }
@@ -430,6 +497,12 @@ impl Default for Config {
                 default_openai_chat_completions_compatible_base_url(),
             openai_chat_completions_compatible_model:
                 default_openai_chat_completions_compatible_model(),
+            openrouter_api_key: None,
+            openrouter_base_url: default_openrouter_base_url(),
+            openrouter_model: default_openrouter_model(),
+            openrouter_http_referer: None,
+            openrouter_x_title: None,
+            openrouter_app_categories: Vec::new(),
             anthropic_messages_api_key: None,
             anthropic_messages_base_url: default_anthropic_messages_base_url(),
             anthropic_messages_model: default_anthropic_messages_model(),
@@ -478,6 +551,12 @@ impl Config {
             default_openai_chat_completions_compatible_base_url();
         self.openai_chat_completions_compatible_model =
             default_openai_chat_completions_compatible_model();
+        self.openrouter_api_key = None;
+        self.openrouter_base_url = default_openrouter_base_url();
+        self.openrouter_model = default_openrouter_model();
+        self.openrouter_http_referer = None;
+        self.openrouter_x_title = None;
+        self.openrouter_app_categories.clear();
         self.anthropic_messages_api_key = None;
         self.anthropic_messages_base_url = default_anthropic_messages_base_url();
         self.anthropic_messages_model = default_anthropic_messages_model();
@@ -508,6 +587,12 @@ impl Config {
             other.openai_chat_completions_compatible_base_url.clone();
         self.openai_chat_completions_compatible_model =
             other.openai_chat_completions_compatible_model.clone();
+        self.openrouter_api_key = other.openrouter_api_key.clone();
+        self.openrouter_base_url = other.openrouter_base_url.clone();
+        self.openrouter_model = other.openrouter_model.clone();
+        self.openrouter_http_referer = other.openrouter_http_referer.clone();
+        self.openrouter_x_title = other.openrouter_x_title.clone();
+        self.openrouter_app_categories = other.openrouter_app_categories.clone();
         self.anthropic_messages_api_key = other.anthropic_messages_api_key.clone();
         self.anthropic_messages_base_url = other.anthropic_messages_base_url.clone();
         self.anthropic_messages_model = other.anthropic_messages_model.clone();
@@ -805,6 +890,30 @@ impl Config {
         }
     }
 
+    pub fn for_openrouter(
+        api_key: &str,
+        base_url: Option<&str>,
+        model: Option<&str>,
+        http_referer: Option<&str>,
+        x_title: Option<&str>,
+        app_categories: Vec<String>,
+    ) -> Self {
+        Self {
+            llm_provider: LlmProvider::OpenRouter,
+            openrouter_api_key: Some(api_key.to_string()),
+            openrouter_base_url: base_url
+                .map(ToString::to_string)
+                .unwrap_or_else(default_openrouter_base_url),
+            openrouter_model: model
+                .map(ToString::to_string)
+                .unwrap_or_else(default_openrouter_model),
+            openrouter_http_referer: http_referer.map(ToString::to_string),
+            openrouter_x_title: x_title.map(ToString::to_string),
+            openrouter_app_categories: app_categories,
+            ..Self::default()
+        }
+    }
+
     pub fn for_anthropic_messages(
         api_key: &str,
         base_url: Option<&str>,
@@ -839,6 +948,10 @@ impl Config {
         self.openai_chat_completions_compatible_api_key.is_some()
     }
 
+    pub fn has_openrouter_config(&self) -> bool {
+        self.openrouter_api_key.is_some() && !self.openrouter_model.trim().is_empty()
+    }
+
     pub fn has_anthropic_messages_config(&self) -> bool {
         self.anthropic_messages_api_key.is_some()
     }
@@ -854,6 +967,7 @@ impl Config {
             LlmProvider::OpenAiChatCompletionsCompatible => {
                 self.has_openai_chat_completions_compatible_config()
             }
+            LlmProvider::OpenRouter => self.has_openrouter_config(),
             LlmProvider::AnthropicMessages => self.has_anthropic_messages_config(),
         }
     }
@@ -867,6 +981,7 @@ impl Config {
             LlmProvider::OpenAiChatCompletionsCompatible => {
                 &self.openai_chat_completions_compatible_model
             }
+            LlmProvider::OpenRouter => &self.openrouter_model,
             LlmProvider::AnthropicMessages => &self.anthropic_messages_model,
         }
     }
@@ -888,6 +1003,9 @@ impl Config {
             }
             LlmProvider::OpenAiChatCompletionsCompatible => {
                 self.openai_chat_completions_compatible_model = model;
+            }
+            LlmProvider::OpenRouter => {
+                self.openrouter_model = model;
             }
             LlmProvider::AnthropicMessages => {
                 self.anthropic_messages_model = model;
@@ -916,7 +1034,9 @@ impl Config {
                     &self.openai_chat_completions_compatible_model,
                 )
             }
-            LlmProvider::GoogleGeminiGenerateContent | LlmProvider::AnthropicMessages => None,
+            LlmProvider::OpenRouter
+            | LlmProvider::GoogleGeminiGenerateContent
+            | LlmProvider::AnthropicMessages => None,
         }
     }
 
@@ -1035,6 +1155,26 @@ impl Config {
                     &self.openai_chat_completions_compatible_model,
                 )
                 .with_base_url(&self.openai_chat_completions_compatible_base_url))
+            }
+            LlmProvider::OpenRouter => {
+                let api_key = self.openrouter_api_key.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("OpenRouter provider requires openrouter_api_key")
+                })?;
+                if self.openrouter_model.trim().is_empty() {
+                    anyhow::bail!("OpenRouter provider requires openrouter_model");
+                }
+                let mut config = ProviderConfig::openrouter(api_key, &self.openrouter_model)
+                    .with_base_url(&self.openrouter_base_url);
+                if let Some(http_referer) = &self.openrouter_http_referer {
+                    config = config.with_http_referer(http_referer);
+                }
+                if let Some(x_title) = &self.openrouter_x_title {
+                    config = config.with_x_title(x_title);
+                }
+                if !self.openrouter_app_categories.is_empty() {
+                    config = config.with_app_categories(self.openrouter_app_categories.clone());
+                }
+                Ok(config)
             }
             LlmProvider::AnthropicMessages => {
                 let api_key = self.anthropic_messages_api_key.as_ref().ok_or_else(|| {
@@ -1157,7 +1297,8 @@ fn inferred_context_window_tokens(provider: LlmProvider) -> u32 {
         LlmProvider::Chatgpt => 400_000,
         LlmProvider::OpenAiResponses
         | LlmProvider::OpenAiChatCompletions
-        | LlmProvider::OpenAiChatCompletionsCompatible => 32_768,
+        | LlmProvider::OpenAiChatCompletionsCompatible
+        | LlmProvider::OpenRouter => 32_768,
     }
 }
 
@@ -1214,6 +1355,10 @@ mod tests {
             config.openai_chat_completions_compatible_model,
             "qwen3.5-plus"
         );
+        assert_eq!(config.openrouter_base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(config.openrouter_model, "moonshotai/kimi-k2.6");
+        assert!(config.openrouter_api_key.is_none());
+        assert!(config.openrouter_app_categories.is_empty());
         assert_eq!(
             config.anthropic_messages_base_url,
             "https://api.anthropic.com/v1"
@@ -1398,6 +1543,30 @@ mod tests {
     }
 
     #[test]
+    fn test_config_for_openrouter() {
+        let config = Config::for_openrouter(
+            "sk-or",
+            None,
+            Some("anthropic/claude-sonnet-4"),
+            Some("https://alan.local"),
+            Some("Alan"),
+            vec!["cli-agent".to_string()],
+        );
+        assert_eq!(config.llm_provider, LlmProvider::OpenRouter);
+        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or"));
+        assert_eq!(config.openrouter_base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(config.openrouter_model, "anthropic/claude-sonnet-4");
+        assert_eq!(
+            config.openrouter_http_referer.as_deref(),
+            Some("https://alan.local")
+        );
+        assert_eq!(config.openrouter_x_title.as_deref(), Some("Alan"));
+        assert_eq!(config.openrouter_app_categories, vec!["cli-agent"]);
+        assert!(config.has_openrouter_config());
+        assert!(config.has_llm_config());
+    }
+
+    #[test]
     fn test_config_for_anthropic_messages() {
         let config = Config::for_anthropic_messages(
             "ak-test",
@@ -1470,6 +1639,16 @@ mod tests {
 
         let anthropic = Config::for_anthropic_messages("k", None, Some("claude-3-5-sonnet"));
         assert_eq!(anthropic.effective_model(), "claude-3-5-sonnet");
+
+        let openrouter = Config::for_openrouter(
+            "sk-or",
+            None,
+            Some("openai/gpt-5.4"),
+            None,
+            None,
+            Vec::new(),
+        );
+        assert_eq!(openrouter.effective_model(), "openai/gpt-5.4");
     }
 
     #[test]
@@ -1490,6 +1669,12 @@ mod tests {
 
         config.llm_provider = LlmProvider::OpenAiChatCompletionsCompatible;
         assert!(!config.has_openai_chat_completions_compatible_config());
+        assert!(!config.has_llm_config());
+
+        config.llm_provider = LlmProvider::OpenRouter;
+        config.openrouter_api_key = Some("sk-or".to_string());
+        config.openrouter_model.clear();
+        assert!(!config.has_openrouter_config());
         assert!(!config.has_llm_config());
 
         config.llm_provider = LlmProvider::AnthropicMessages;
@@ -1537,6 +1722,9 @@ mod tests {
             openai_chat_completions_compatible,
             LlmProvider::OpenAiChatCompletionsCompatible
         );
+
+        let openrouter: LlmProvider = serde_json::from_str("\"openrouter\"").unwrap();
+        assert_eq!(openrouter, LlmProvider::OpenRouter);
 
         let anthropic: LlmProvider = serde_json::from_str("\"anthropic_messages\"").unwrap();
         assert_eq!(anthropic, LlmProvider::AnthropicMessages);
@@ -2356,6 +2544,51 @@ supports_reasoning = true
     }
 
     #[test]
+    fn test_to_provider_config_openrouter() {
+        let config = Config::for_openrouter(
+            "sk-or",
+            Some("https://openrouter.example/api/v1"),
+            Some("anthropic/claude-sonnet-4"),
+            Some("https://alan.local"),
+            Some("Alan"),
+            vec!["cli-agent".to_string()],
+        );
+        let provider_config = config.to_provider_config().unwrap();
+        assert_eq!(
+            provider_config.provider_type,
+            alan_llm::factory::ProviderType::OpenRouter
+        );
+        assert_eq!(provider_config.api_key.as_deref(), Some("sk-or"));
+        assert_eq!(
+            provider_config.base_url.as_deref(),
+            Some("https://openrouter.example/api/v1")
+        );
+        assert_eq!(provider_config.model, "anthropic/claude-sonnet-4");
+        assert_eq!(
+            provider_config.http_referer.as_deref(),
+            Some("https://alan.local")
+        );
+        assert_eq!(provider_config.x_title.as_deref(), Some("Alan"));
+        assert_eq!(
+            provider_config.app_categories,
+            Some(vec!["cli-agent".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_to_provider_config_openrouter_missing_model() {
+        let config = Config {
+            llm_provider: LlmProvider::OpenRouter,
+            openrouter_api_key: Some("sk-or".to_string()),
+            openrouter_model: String::new(),
+            ..Config::default()
+        };
+        let result = config.to_provider_config();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("openrouter_model"));
+    }
+
+    #[test]
     fn test_to_provider_config_openai_chat_completions_compatible_accepts_snapshot_and_vendor_prefix()
      {
         let config = Config::for_openai_chat_completions_compatible(
@@ -2535,6 +2768,11 @@ supports_reasoning = true
             default_openai_chat_completions_compatible_model(),
             "qwen3.5-plus"
         );
+        assert_eq!(
+            default_openrouter_base_url(),
+            "https://openrouter.ai/api/v1"
+        );
+        assert_eq!(default_openrouter_model(), "moonshotai/kimi-k2.6");
         assert_eq!(
             default_anthropic_messages_base_url(),
             "https://api.anthropic.com/v1"

--- a/crates/runtime/src/connections.rs
+++ b/crates/runtime/src/connections.rs
@@ -404,6 +404,13 @@ pub fn provider_catalog() -> &'static [ProviderDescriptor] {
         ("model", "qwen3.5-plus"),
     ];
 
+    const OPENROUTER_REQUIRED: &[&str] = &["model"];
+    const OPENROUTER_OPTIONAL: &[&str] = &["base_url", "http_referer", "x_title", "app_categories"];
+    const OPENROUTER_DEFAULTS: &[(&str, &str)] = &[
+        ("base_url", "https://openrouter.ai/api/v1"),
+        ("model", "moonshotai/kimi-k2.6"),
+    ];
+
     const ANTHROPIC_REQUIRED: &[&str] = &["base_url", "model"];
     const ANTHROPIC_OPTIONAL: &[&str] = &["client_name", "user_agent"];
     const ANTHROPIC_DEFAULTS: &[(&str, &str)] = &[
@@ -475,6 +482,19 @@ pub fn provider_catalog() -> &'static [ProviderDescriptor] {
                     required_settings: OPENAI_REQUIRED,
                     optional_settings: &[],
                     default_settings: OPENAI_COMPAT_DEFAULTS,
+                },
+                ProviderDescriptor {
+                    provider_id: LlmProvider::OpenRouter,
+                    display_name: "OpenRouter",
+                    credential_kind: CredentialKind::SecretString,
+                    supports_browser_login: false,
+                    supports_device_login: false,
+                    supports_secret_entry: true,
+                    supports_logout: false,
+                    supports_test: true,
+                    required_settings: OPENROUTER_REQUIRED,
+                    optional_settings: OPENROUTER_OPTIONAL,
+                    default_settings: OPENROUTER_DEFAULTS,
                 },
                 ProviderDescriptor {
                     provider_id: LlmProvider::AnthropicMessages,
@@ -736,6 +756,47 @@ fn apply_resolved_profile_to_config(
                 resolved.settings["base_url"].clone();
             config.openai_chat_completions_compatible_model = resolved.settings["model"].clone();
         }
+        LlmProvider::OpenRouter => {
+            let credential_id = resolved.credential_id.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("Profile `{}` is missing a credential", resolved.profile_id)
+            })?;
+            let api_key = secret_store.load(credential_id)?.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Credential `{credential_id}` for profile `{}` is missing a secret",
+                    resolved.profile_id
+                )
+            })?;
+            config.llm_provider = LlmProvider::OpenRouter;
+            config.openrouter_api_key = Some(api_key);
+            config.openrouter_base_url = resolved
+                .settings
+                .get("base_url")
+                .cloned()
+                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
+            config.openrouter_model = resolved.settings["model"].clone();
+            config.openrouter_http_referer = resolved
+                .settings
+                .get("http_referer")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+            config.openrouter_x_title = resolved
+                .settings
+                .get("x_title")
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+            config.openrouter_app_categories = resolved
+                .settings
+                .get("app_categories")
+                .map(|value| {
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+        }
         LlmProvider::AnthropicMessages => {
             let credential_id = resolved.credential_id.as_deref().ok_or_else(|| {
                 anyhow::anyhow!("Profile `{}` is missing a credential", resolved.profile_id)
@@ -789,6 +850,47 @@ mod tests {
     }
 
     #[test]
+    fn openrouter_descriptor_exposes_default_model_and_metadata_settings() {
+        let descriptor = ConnectionsFile::profile_descriptor(LlmProvider::OpenRouter);
+        assert_eq!(descriptor.provider_id, LlmProvider::OpenRouter);
+        assert_eq!(descriptor.credential_kind, CredentialKind::SecretString);
+        assert!(descriptor.supports_secret_entry);
+        assert!(descriptor.required_settings.contains(&"model"));
+        assert!(descriptor.optional_settings.contains(&"base_url"));
+        assert!(descriptor.optional_settings.contains(&"http_referer"));
+        assert!(descriptor.optional_settings.contains(&"x_title"));
+        assert!(descriptor.optional_settings.contains(&"app_categories"));
+
+        let normalized = normalize_profile_settings(LlmProvider::OpenRouter, &BTreeMap::new());
+        assert_eq!(
+            normalized.get("base_url").map(String::as_str),
+            Some("https://openrouter.ai/api/v1")
+        );
+        assert_eq!(
+            normalized.get("model").map(String::as_str),
+            Some("moonshotai/kimi-k2.6")
+        );
+        validate_profile_settings(LlmProvider::OpenRouter, &normalized).unwrap();
+    }
+
+    #[test]
+    fn openrouter_settings_are_not_accepted_by_generic_compatible_provider() {
+        let settings = BTreeMap::from([
+            (
+                "base_url".to_string(),
+                "https://proxy.example/v1".to_string(),
+            ),
+            ("model".to_string(), "qwen3.5-plus".to_string()),
+            ("http_referer".to_string(), "https://alan.local".to_string()),
+        ]);
+
+        let result =
+            validate_profile_settings(LlmProvider::OpenAiChatCompletionsCompatible, &settings);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("http_referer"));
+    }
+
+    #[test]
     fn secret_store_round_trips_secret() {
         let temp = TempDir::new().unwrap();
         let home_paths = AlanHomePaths::from_home_dir(temp.path());
@@ -832,6 +934,66 @@ mod tests {
         assert_eq!(
             resolved.settings.get("model").map(String::as_str),
             Some("gpt-5.3-codex")
+        );
+    }
+
+    #[test]
+    fn apply_openrouter_profile_to_config_loads_secret_and_metadata() {
+        let temp = TempDir::new().unwrap();
+        let home_paths = AlanHomePaths::from_home_dir(temp.path());
+        let store = SecretStore::from_home_paths(&home_paths).unwrap();
+        store.save("openrouter-main", "sk-or").unwrap();
+
+        let file = ConnectionsFile {
+            credentials: BTreeMap::from([(
+                "openrouter-main".to_string(),
+                ConnectionCredential {
+                    kind: CredentialKind::SecretString,
+                    provider_family: LlmProvider::OpenRouter,
+                    label: "OpenRouter credential".to_string(),
+                    backend: SECRET_STORE_BACKEND.to_string(),
+                },
+            )]),
+            profiles: BTreeMap::from([(
+                "openrouter-main".to_string(),
+                ConnectionProfile {
+                    provider: LlmProvider::OpenRouter,
+                    label: Some("OpenRouter".to_string()),
+                    credential_id: Some("openrouter-main".to_string()),
+                    created_at: default_profile_timestamp(),
+                    updated_at: default_profile_timestamp(),
+                    source: default_profile_source(),
+                    settings: BTreeMap::from([
+                        ("http_referer".to_string(), "https://alan.local".to_string()),
+                        ("x_title".to_string(), "Alan".to_string()),
+                        (
+                            "app_categories".to_string(),
+                            "cli-agent,devtool".to_string(),
+                        ),
+                    ]),
+                },
+            )]),
+            ..ConnectionsFile::default()
+        };
+
+        let mut config = Config::default();
+        let resolved = file
+            .apply_profile_to_config(Some("openrouter-main"), &store, &mut config)
+            .unwrap();
+
+        assert_eq!(resolved.provider, LlmProvider::OpenRouter);
+        assert_eq!(config.llm_provider, LlmProvider::OpenRouter);
+        assert_eq!(config.openrouter_api_key.as_deref(), Some("sk-or"));
+        assert_eq!(config.openrouter_base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(config.openrouter_model, "moonshotai/kimi-k2.6");
+        assert_eq!(
+            config.openrouter_http_referer.as_deref(),
+            Some("https://alan.local")
+        );
+        assert_eq!(config.openrouter_x_title.as_deref(), Some("Alan"));
+        assert_eq!(
+            config.openrouter_app_categories,
+            vec!["cli-agent", "devtool"]
         );
     }
 }

--- a/crates/runtime/src/llm.rs
+++ b/crates/runtime/src/llm.rs
@@ -73,9 +73,7 @@ fn projection_for(provider_type: ProviderType) -> Box<dyn LlmProjection> {
         | ProviderType::OpenAiResponses
         | ProviderType::OpenAiChatCompletions
         | ProviderType::OpenAiChatCompletionsCompatible
-        | ProviderType::OpenRouterOpenAiChatCompletionsCompatible => {
-            Box::new(PreserveThinkingProjection)
-        }
+        | ProviderType::OpenRouter => Box::new(PreserveThinkingProjection),
         _ => Box::new(DropThinkingProjection),
     }
 }
@@ -103,9 +101,7 @@ impl LlmClient {
             "openai_responses" => ProviderType::OpenAiResponses,
             "openai_chat_completions" => ProviderType::OpenAiChatCompletions,
             "openai_chat_completions_compatible" => ProviderType::OpenAiChatCompletionsCompatible,
-            "openrouter_openai_chat_completions_compatible" => {
-                ProviderType::OpenRouterOpenAiChatCompletionsCompatible
-            }
+            "openrouter" => ProviderType::OpenRouter,
             "anthropic_messages" => ProviderType::AnthropicMessages,
             _ => ProviderType::OpenAiChatCompletionsCompatible, // Default fallback
         };
@@ -209,8 +205,12 @@ impl LlmClient {
         matches!(
             self.provider_type,
             ProviderType::OpenAiChatCompletionsCompatible
-                | ProviderType::OpenRouterOpenAiChatCompletionsCompatible
         )
+    }
+
+    /// Check if this is the OpenRouter SDK-backed provider.
+    pub fn is_openrouter(&self) -> bool {
+        matches!(self.provider_type, ProviderType::OpenRouter)
     }
 
     /// Check if this is an Anthropic Messages API client.
@@ -530,7 +530,7 @@ mod tests {
     use super::*;
     use alan_llm::{
         AnthropicMessagesClient, ChatgptResponsesClient, MockLlmProvider,
-        OpenAiChatCompletionsClient, OpenAiResponsesClient,
+        OpenAiChatCompletionsClient, OpenAiResponsesClient, OpenRouterClient,
     };
     use std::collections::HashMap;
 
@@ -663,6 +663,31 @@ mod tests {
         );
         assert!(anthropic_caps.supports_document_input);
         assert!(anthropic_caps.supports_redacted_thinking);
+    }
+
+    #[test]
+    fn test_llm_client_detects_openrouter_provider() {
+        let client = LlmClient::new(
+            OpenRouterClient::with_params(
+                "sk-or-test",
+                alan_llm::openrouter::OPENROUTER_BASE_URL,
+                "moonshotai/kimi-k2.6",
+            )
+            .unwrap(),
+        );
+
+        assert!(client.is_openrouter());
+        assert!(!client.is_openai_chat_completions_compatible());
+        assert!(client.capabilities().supports_reasoning_text);
+
+        let mut session = crate::session::Session::new();
+        session.add_assistant_message("hi", Some("openrouter thinking"));
+        let messages = session.tape.messages();
+        let projected = client.project_messages(messages);
+        assert_eq!(
+            projected[0].thinking.as_deref(),
+            Some("openrouter thinking")
+        );
     }
 
     #[test]

--- a/crates/runtime/src/manager/state.rs
+++ b/crates/runtime/src/manager/state.rs
@@ -17,6 +17,8 @@ pub enum PersistedLlmProvider {
     OpenAiChatCompletions,
     #[serde(rename = "openai_chat_completions_compatible")]
     OpenAiChatCompletionsCompatible,
+    #[serde(rename = "openrouter")]
+    OpenRouter,
     #[serde(rename = "anthropic_messages")]
     AnthropicMessages,
 }
@@ -212,6 +214,7 @@ impl WorkspaceState {
                 LlmProvider::OpenAiChatCompletionsCompatible => {
                     PersistedLlmProvider::OpenAiChatCompletionsCompatible
                 }
+                LlmProvider::OpenRouter => PersistedLlmProvider::OpenRouter,
                 LlmProvider::AnthropicMessages => PersistedLlmProvider::AnthropicMessages,
             });
         self.config.llm_model = Some(

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -560,6 +560,7 @@ impl AgentConfig {
                 PersistedLlmProvider::OpenAiChatCompletionsCompatible => {
                     LlmProvider::OpenAiChatCompletionsCompatible
                 }
+                PersistedLlmProvider::OpenRouter => LlmProvider::OpenRouter,
                 PersistedLlmProvider::AnthropicMessages => LlmProvider::AnthropicMessages,
             };
         }
@@ -580,6 +581,7 @@ impl AgentConfig {
                 LlmProvider::OpenAiChatCompletionsCompatible => {
                     self.core_config.openai_chat_completions_compatible_model = model.clone()
                 }
+                LlmProvider::OpenRouter => self.core_config.openrouter_model = model.clone(),
                 LlmProvider::AnthropicMessages => {
                     self.core_config.anthropic_messages_model = model.clone()
                 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -357,7 +357,7 @@ Target V2 design: [HITE Governance](./spec/hite_governance.md).
 | Crate           | Role                                                             |
 | --------------- | ---------------------------------------------------------------- |
 | `alan-protocol` | Wire format — Events (output) and Operations (input)             |
-| `alan-llm`      | Pluggable LLM adapters — Google Gemini GenerateContent API, OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Anthropic Messages API (+ OpenRouter via adapter) |
+| `alan-llm`      | Pluggable LLM adapters — Google Gemini GenerateContent API, OpenAI Responses API, OpenAI Chat Completions API, OpenAI Chat Completions API-compatible, Anthropic Messages API, and OpenRouter SDK-backed chat |
 | `alan-runtime`  | Core engine — session, tape, agent loop, tool registry, skills   |
 | `alan-tools`    | Builtin tool implementations (`read_file`, `bash`, `grep`, etc.) |
 | `alan`          | Unified CLI + daemon — workspace lifecycle, HTTP/WS API, session mgmt |

--- a/docs/spec/connection_profile_contract.md
+++ b/docs/spec/connection_profile_contract.md
@@ -161,6 +161,7 @@ V1 provider catalog:
 | `openai_responses` | `secret_string` | no | yes | API key |
 | `openai_chat_completions` | `secret_string` | no | yes | API key |
 | `openai_chat_completions_compatible` | `secret_string` | no | yes | API key or token-like secret |
+| `openrouter` | `secret_string` | no | yes | OpenRouter API key; default model `moonshotai/kimi-k2.6` |
 | `anthropic_messages` | `secret_string` | no | yes | API key or provider-compatible secret |
 | `google_gemini_generate_content` | `ambient_cloud_auth` | no | no | requires project/location/model and valid local Google auth |
 
@@ -286,6 +287,12 @@ provider_family = "anthropic_messages"
 label = "Kimi Coding API key"
 backend = "alan_home_secret_store"
 
+[credentials.openrouter-key]
+kind = "secret_string"
+provider_family = "openrouter"
+label = "OpenRouter API key"
+backend = "alan_home_secret_store"
+
 [profiles.chatgpt-main]
 provider = "chatgpt"
 credential_id = "chatgpt"
@@ -306,6 +313,18 @@ base_url = "https://api.kimi.com/coding"
 model = "k2p5"
 client_name = ""
 user_agent = ""
+
+[profiles.openrouter-main]
+provider = "openrouter"
+credential_id = "openrouter-key"
+source = "managed"
+
+[profiles.openrouter-main.settings]
+base_url = "https://openrouter.ai/api/v1"
+model = "moonshotai/kimi-k2.6"
+http_referer = ""
+x_title = ""
+app_categories = ""
 ```
 
 ### Secret And Managed Credential Storage
@@ -435,6 +454,11 @@ ChatGPT/Codex model identifiers must track upstream Codex bundled model
 metadata. Alan must not invent synthetic ChatGPT model slugs. At the time of
 this spec revision, upstream bundled examples include `gpt-5.3-codex`,
 `gpt-5.2-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini`.
+
+The OpenRouter descriptor uses `provider_id = "openrouter"`, secret-string
+credentials, required `model`, optional `base_url`, `http_referer`, `x_title`,
+and `app_categories`, and defaults to `model = "moonshotai/kimi-k2.6"` with
+`base_url = "https://openrouter.ai/api/v1"`.
 
 Connection profile summary shape:
 
@@ -603,6 +627,14 @@ alan connection pin <profile-id> [--scope global|workspace] [--workspace <path>]
 alan connection unpin [--scope global|workspace] [--workspace <path>]
 alan connection test [<profile-id>]
 alan connection remove <profile-id>
+```
+
+OpenRouter setup example:
+
+```bash
+alan connection add openrouter --profile openrouter-main --setting model=moonshotai/kimi-k2.6
+alan connection set-secret openrouter-main
+alan connection test openrouter-main
 ```
 
 Rules:

--- a/docs/spec/provider_auth_contract.md
+++ b/docs/spec/provider_auth_contract.md
@@ -84,7 +84,9 @@ Current target split:
    API Platform only.
 3. `openai_chat_completions_compatible`
    Generic compatible endpoints only.
-4. `chatgpt`
+4. `openrouter`
+   OpenRouter API-key auth and SDK-backed chat surface.
+5. `chatgpt`
    ChatGPT/Codex subscription auth surface, implemented separately from API-key providers.
 
 Normative boundary:
@@ -92,6 +94,7 @@ Normative boundary:
 1. `openai_*` providers must not depend on ChatGPT login state.
 2. `chatgpt` must not read API keys from the OpenAI Platform config fields.
 3. `openai_chat_completions_compatible` remains a generic endpoint family and must not imply ChatGPT semantics.
+4. `openrouter` must not be treated as an alias for the generic compatible provider family.
 
 ## Auth Surface Split
 

--- a/docs/spec/provider_capability_contract.md
+++ b/docs/spec/provider_capability_contract.md
@@ -147,7 +147,13 @@ reliable cross-vendor contract beyond a conservative subset.
 V1 targets:
 
 1. `openai_chat_completions_compatible`
-2. `openrouter_openai_chat_completions_compatible`
+2. `openrouter`
+
+`openrouter` is a first-class Alan provider id with an SDK-backed adapter, but
+its upstream surface routes across multiple model/provider implementations.
+For capability-tier purposes it remains Tier C: Alan must preserve verified
+OpenRouter fields explicitly and must not infer universal semantics from the
+generic OpenAI-compatible wire shape.
 
 ## Common Core Contract
 
@@ -409,6 +415,30 @@ Normative rules:
 3. Features such as native multimodal inputs, cached-token accounting,
    response retrieval, or official reasoning-state continuity must default to
    unsupported unless explicitly verified.
+
+### OpenRouter
+
+OpenRouter is represented by the `openrouter` provider id and uses the
+OpenRouter SDK-backed chat adapter rather than Alan's generic
+`openai_chat_completions_compatible` path.
+
+Required fidelity target:
+
+1. text input and output
+2. streaming text
+3. OpenAI-style tool calls when the selected OpenRouter model/provider route
+   supports them
+4. OpenRouter reasoning text and reasoning-detail metadata when returned
+5. usage, finish reason, and provider response id when returned
+
+Normative rules:
+
+1. OpenRouter-specific metadata such as `http_referer`, `x_title`, and
+   `app_categories` must remain provider-specific connection settings.
+2. Alan must not silently route `openrouter` through the generic compatible
+   provider family.
+3. Alan must keep unsupported OpenRouter request extras explicit by allowlist,
+   rejection, or observable warning.
 
 ## Capability Matrix
 

--- a/openspec/changes/integrate-openrouter-rs/tasks.md
+++ b/openspec/changes/integrate-openrouter-rs/tasks.md
@@ -1,66 +1,66 @@
 ## 1. SDK Dependency And Provider Skeleton
 
-- [ ] 1.1 Add `openrouter-rs = "0.8.1"` to `alan-llm` dependencies and update the lockfile.
-- [ ] 1.2 Add `crates/llm/src/openrouter.rs` and export it from `crates/llm/src/lib.rs`.
-- [ ] 1.3 Add `ProviderType::OpenRouter`, `ProviderConfig::openrouter(...)`, and OpenRouter-specific config fields for base URL, model, `http_referer`, `x_title`, and `app_categories`.
-- [ ] 1.4 Route `ProviderType::OpenRouter` through the new SDK-backed adapter in the provider factory.
-- [ ] 1.5 Remove the retired `OpenRouterOpenAiChatCompletionsCompatible` provider factory type/path and make `openrouter_openai_chat_completions_compatible` fail fast instead of acting as an alias.
+- [x] 1.1 Add `openrouter-rs = "0.8.1"` to `alan-llm` dependencies and update the lockfile.
+- [x] 1.2 Add `crates/llm/src/openrouter.rs` and export it from `crates/llm/src/lib.rs`.
+- [x] 1.3 Add `ProviderType::OpenRouter`, `ProviderConfig::openrouter(...)`, and OpenRouter-specific config fields for base URL, model, `http_referer`, `x_title`, and `app_categories`.
+- [x] 1.4 Route `ProviderType::OpenRouter` through the new SDK-backed adapter in the provider factory.
+- [x] 1.5 Remove the retired `OpenRouterOpenAiChatCompletionsCompatible` provider factory type/path and make `openrouter_openai_chat_completions_compatible` fail fast instead of acting as an alias.
 
 ## 2. OpenRouter Request Mapping
 
-- [ ] 2.1 Implement Alan message-role conversion to OpenRouter SDK chat messages, including system prompts, context messages, assistant tool calls, and tool-result messages.
-- [ ] 2.2 Implement Alan tool-definition conversion to OpenRouter SDK chat tool definitions with automatic tool choice.
-- [ ] 2.3 Map temperature, max tokens, and `thinking_budget_tokens` to SDK request fields.
-- [ ] 2.4 Add an explicit allowlist for OpenRouter `extra_params` and reject or warn on unsupported keys before dispatch.
-- [ ] 2.5 Add unit tests for message, tool, reasoning-budget, and unsupported-extra-parameter projection.
+- [x] 2.1 Implement Alan message-role conversion to OpenRouter SDK chat messages, including system prompts, context messages, assistant tool calls, and tool-result messages.
+- [x] 2.2 Implement Alan tool-definition conversion to OpenRouter SDK chat tool definitions with automatic tool choice.
+- [x] 2.3 Map temperature, max tokens, and `thinking_budget_tokens` to SDK request fields.
+- [x] 2.4 Add an explicit allowlist for OpenRouter `extra_params` and reject or warn on unsupported keys before dispatch.
+- [x] 2.5 Add unit tests for message, tool, reasoning-budget, and unsupported-extra-parameter projection.
 
 ## 3. Non-Streaming Response Mapping
 
-- [ ] 3.1 Implement `generate(...)` using `openrouter-rs` `client.chat().create(...)`.
-- [ ] 3.2 Map content, reasoning text, tool calls, usage, finish reason, and provider response id into `GenerationResponse`.
-- [ ] 3.3 Handle malformed tool-call JSON by dropping the malformed call and surfacing a provider warning.
-- [ ] 3.4 Add unit tests for content-only, reasoning, tool-call, malformed-tool-call, usage, finish-reason, and response-id responses.
+- [x] 3.1 Implement `generate(...)` using `openrouter-rs` `client.chat().create(...)`.
+- [x] 3.2 Map content, reasoning text, tool calls, usage, finish reason, and provider response id into `GenerationResponse`.
+- [x] 3.3 Handle malformed tool-call JSON by dropping the malformed call and surfacing a provider warning.
+- [x] 3.4 Add unit tests for content-only, reasoning, tool-call, malformed-tool-call, usage, finish-reason, and response-id responses.
 
 ## 4. Streaming Response Mapping
 
-- [ ] 4.1 Implement `generate_stream(...)` using an `openrouter-rs` streaming API, preferring `stream_unified` if it exposes the required fields.
-- [ ] 4.2 Convert SDK content events to `StreamChunk.text` deltas in order.
-- [ ] 4.3 Convert SDK reasoning events to `StreamChunk.thinking` deltas in order.
-- [ ] 4.4 Convert streamed tool-call events to `StreamChunk.tool_call_delta` values that preserve id, name, index, and argument deltas.
-- [ ] 4.5 Emit a final chunk with `is_finished = true`, finish reason, usage when available, and provider response id when available.
-- [ ] 4.6 Propagate SDK stream errors through the provider stream channel so runtime partial-stream recovery can run.
-- [ ] 4.7 Add streaming unit tests for text, reasoning, fragmented tool calls, completion metadata, and stream errors after partial output.
+- [x] 4.1 Implement `generate_stream(...)` using an `openrouter-rs` streaming API, preferring `stream_unified` if it exposes the required fields.
+- [x] 4.2 Convert SDK content events to `StreamChunk.text` deltas in order.
+- [x] 4.3 Convert SDK reasoning events to `StreamChunk.thinking` deltas in order.
+- [x] 4.4 Convert streamed tool-call events to `StreamChunk.tool_call_delta` values that preserve id, name, index, and argument deltas.
+- [x] 4.5 Emit a final chunk with `is_finished = true`, finish reason, usage when available, and provider response id when available.
+- [x] 4.6 Propagate SDK stream errors through the provider stream channel so runtime partial-stream recovery can run.
+- [x] 4.7 Add streaming unit tests for text, reasoning, fragmented tool calls, completion metadata, and stream errors after partial output.
 
 ## 5. Runtime And Connection Profiles
 
-- [ ] 5.1 Add `LlmProvider::OpenRouter` serialized as `openrouter` and update `as_str()`, config defaults, reset/merge behavior, effective model lookup, and `to_provider_config()`.
-- [ ] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
-- [ ] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `model`, optional `base_url`, `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
-- [ ] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
-- [ ] 5.5 Remove the retired OpenRouter-compatible provider id from supported connection metadata and persisted provider state; do not add automatic rewrite, repair, or alias behavior for `profiles.<id>.provider` or `credentials.<id>.provider_family`.
-- [ ] 5.6 Exclude the retired id from provider descriptors, resolved runtime state, session metadata, CLI/daemon provider parsing, and provider factory dispatch.
-- [ ] 5.7 Add runtime tests for profile validation, profile application, effective model handling, provider detection, old-id rejection, and old-id appearances in both profile providers and credential provider families.
+- [x] 5.1 Add `LlmProvider::OpenRouter` serialized as `openrouter` and update `as_str()`, config defaults, reset/merge behavior, effective model lookup, and `to_provider_config()`.
+- [x] 5.2 Add OpenRouter resolved config fields to `Config` without documenting new inline `agent.toml` provider examples.
+- [x] 5.3 Add an OpenRouter `ProviderDescriptor` with secret-string credentials, required `model`, optional `base_url`, `http_referer`, `x_title`, and `app_categories`, and the OpenRouter base URL default.
+- [x] 5.4 Update `apply_resolved_profile_to_config(...)` to load the OpenRouter secret and resolved settings into runtime config.
+- [x] 5.5 Remove the retired OpenRouter-compatible provider id from supported connection metadata and persisted provider state; do not add automatic rewrite, repair, or alias behavior for `profiles.<id>.provider` or `credentials.<id>.provider_family`.
+- [x] 5.6 Exclude the retired id from provider descriptors, resolved runtime state, session metadata, CLI/daemon provider parsing, and provider factory dispatch.
+- [x] 5.7 Add runtime tests for profile validation, profile application, effective model handling, provider detection, old-id rejection, and old-id appearances in both profile providers and credential provider families.
 
 ## 6. CLI, Daemon, And Catalog Surfaces
 
-- [ ] 6.1 Update `alan connection` provider parsing so `openrouter` can be added, listed, tested, pinned, and set as default.
-- [ ] 6.2 Update daemon connection control/routes so `/api/v1/connections/catalog` exposes OpenRouter metadata and connection profile operations accept the provider.
-- [ ] 6.3 Update provider test behavior to exercise the SDK-backed OpenRouter provider when an OpenRouter profile is tested.
-- [ ] 6.4 Add focused CLI and daemon tests for OpenRouter provider parsing, catalog output, profile creation, and profile resolution.
+- [x] 6.1 Update `alan connection` provider parsing so `openrouter` can be added, listed, tested, pinned, and set as default.
+- [x] 6.2 Update daemon connection control/routes so `/api/v1/connections/catalog` exposes OpenRouter metadata and connection profile operations accept the provider.
+- [x] 6.3 Update provider test behavior to exercise the SDK-backed OpenRouter provider when an OpenRouter profile is tested.
+- [x] 6.4 Add focused CLI and daemon tests for OpenRouter provider parsing, catalog output, profile creation, and profile resolution.
 
 ## 7. Provider Capabilities And Documentation
 
-- [ ] 7.1 Declare explicit `ProviderCapabilities` for OpenRouter rather than sharing the generic compatible-provider branch.
-- [ ] 7.2 Update `docs/spec/provider_capability_contract.md` so OpenRouter is documented as `openrouter` with a first-class SDK-backed adapter and compatibility-tier semantics.
-- [ ] 7.3 Update provider setup documentation and examples to use `alan connection add openrouter ...` with OpenRouter-specific optional settings.
-- [ ] 7.4 Search docs and code comments for stale "OpenRouter via adapter" or `openrouter_openai_chat_completions_compatible` public wording and update it where appropriate.
+- [x] 7.1 Declare explicit `ProviderCapabilities` for OpenRouter rather than sharing the generic compatible-provider branch.
+- [x] 7.2 Update `docs/spec/provider_capability_contract.md` so OpenRouter is documented as `openrouter` with a first-class SDK-backed adapter and compatibility-tier semantics.
+- [x] 7.3 Update provider setup documentation and examples to use `alan connection add openrouter ...` with OpenRouter-specific optional settings.
+- [x] 7.4 Search docs and code comments for stale "OpenRouter via adapter" or `openrouter_openai_chat_completions_compatible` public wording and update it where appropriate.
 
 ## 8. Live Harness And Verification
 
-- [ ] 8.1 Extend the live provider harness with an OpenRouter case gated by `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional OpenRouter metadata env vars.
-- [ ] 8.2 Add harness coverage for OpenRouter non-streaming generation, streaming generation, reasoning when the configured model supports it, and tool calls when the configured model supports them.
-- [ ] 8.3 Run `cargo fmt --all`.
-- [ ] 8.4 Run focused `cargo test -p alan-llm` tests for OpenRouter adapter mapping and factory behavior.
-- [ ] 8.5 Run focused `cargo test -p alan-runtime` and `cargo test -p alan` tests for provider config, connection profiles, CLI parsing, and daemon catalog behavior.
-- [ ] 8.6 Run the OpenRouter live provider harness when credentials are available; otherwise document that live verification was skipped.
-- [ ] 8.7 Run `openspec status --change integrate-openrouter-rs` and ensure the change is apply-ready.
+- [x] 8.1 Extend the live provider harness with an OpenRouter case gated by `ALAN_LIVE_OPENROUTER_API_KEY`, `ALAN_LIVE_OPENROUTER_MODEL`, and optional OpenRouter metadata env vars.
+- [x] 8.2 Add harness coverage for OpenRouter non-streaming generation, streaming generation, reasoning when the configured model supports it, and tool calls when the configured model supports them.
+- [x] 8.3 Run `cargo fmt --all`.
+- [x] 8.4 Run focused `cargo test -p alan-llm` tests for OpenRouter adapter mapping and factory behavior.
+- [x] 8.5 Run focused `cargo test -p alan-runtime` and `cargo test -p alan` tests for provider config, connection profiles, CLI parsing, and daemon catalog behavior.
+- [x] 8.6 Run the OpenRouter live provider harness when credentials are available; otherwise document that live verification was skipped.
+- [x] 8.7 Run `openspec status --change integrate-openrouter-rs` and ensure the change is apply-ready.


### PR DESCRIPTION
## Summary
- add SDK-backed OpenRouter provider using openrouter-rs 0.8.1
- wire OpenRouter into runtime config, connection profiles, CLI/daemon catalog, docs, and live harness
- remove the retired OpenRouter-compatible provider path without alias behavior
- address review feedback by preserving assistant reasoning fields in the OpenRouter payload and rejecting tool responses without `tool_call_id` before dispatch

Closes #77

## Verification
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo check -p alan-llm
- cargo check -p alan-runtime
- cargo check -p alan
- cargo test -p alan-llm openrouter
- cargo test -p alan-llm test_factory_config
- cargo test -p alan-llm test_provider_capabilities_distinguish_provider_families
- cargo test -p alan-runtime openrouter
- cargo test -p alan openrouter
- git diff --check
- openspec status --change integrate-openrouter-rs --json
- openspec instructions apply --change integrate-openrouter-rs --json

OpenRouter live verification was skipped because ALAN_LIVE_PROVIDER_TESTS and ALAN_LIVE_OPENROUTER_API_KEY are not set locally.