### PR TITLE
Stabilize macOS shell terminal

### DIFF
--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		00000000000000000000000C /* ghostty-resources in Resources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010C /* ghostty-resources */; };
 		00000000000000000000000D /* ghostty-terminfo in Resources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010D /* ghostty-terminfo */; };
 		00000000000000000000000E /* ShellControlPlane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010E /* ShellControlPlane.swift */; };
+		00000000000000000000000F /* TerminalRuntimeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010F /* TerminalRuntimeRegistry.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		00000000000000000000010C /* ghostty-resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ghostty-resources; sourceTree = "<group>"; };
 		00000000000000000000010D /* ghostty-terminfo */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ghostty-terminfo; sourceTree = "<group>"; };
 		00000000000000000000010E /* ShellControlPlane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellControlPlane.swift; sourceTree = "<group>"; };
+		00000000000000000000010F /* TerminalRuntimeRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeRegistry.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +78,7 @@
 				000000000000000000000107 /* TerminalPaneView.swift */,
 				000000000000000000000108 /* TerminalHostRuntime.swift */,
 				000000000000000000000109 /* TerminalHostView.swift */,
+				00000000000000000000010F /* TerminalRuntimeRegistry.swift */,
 				00000000000000000000010A /* GhosttyLiveHost.swift */,
 				00000000000000000000010E /* ShellControlPlane.swift */,
 			);
@@ -97,6 +100,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 000000000000000000000601 /* Build configuration list for PBXNativeTarget "AlanNative" */;
 			buildPhases = (
+				000000000000000000000204 /* Check Ghostty Artifacts */,
 				000000000000000000000202 /* Sources */,
 				000000000000000000000201 /* Frameworks */,
 				000000000000000000000203 /* Resources */,
@@ -154,6 +158,28 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		000000000000000000000204 /* Check Ghostty Artifacts */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check Ghostty Artifacts";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nif [ \"${PLATFORM_NAME:-}\" = \"macosx\" ]; then\n  if [ ! -d \"$SRCROOT/GhosttyKit.xcframework\" ]; then\n    echo \"error: GhosttyKit.xcframework is missing. Run ./clients/apple/scripts/setup-local-ghosttykit.sh from the repo root, or run ./clients/apple/scripts/setup-local-ghosttykit.sh --check for diagnostics.\" >&2\n    exit 1\n  fi\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		000000000000000000000202 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -170,6 +196,7 @@
 				000000000000000000000009 /* TerminalHostView.swift in Sources */,
 				00000000000000000000000A /* GhosttyLiveHost.swift in Sources */,
 				00000000000000000000000E /* ShellControlPlane.swift in Sources */,
+				00000000000000000000000F /* TerminalRuntimeRegistry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -42,8 +42,12 @@ struct MacShellRootView: View {
     private var showsInspector = false
 
     init() {
+        let windowContext = ShellWindowContext.make()
         _host = StateObject(
-            wrappedValue: ShellHostController.live(startupMode: .fresh)
+            wrappedValue: ShellHostController.live(
+                windowContext: windowContext,
+                startupMode: .fresh
+            )
         )
     }
 
@@ -1168,6 +1172,19 @@ private struct ShellInspectorView: View {
                             }
                         }
                     case .debug:
+                        if !host.controlPlaneDiagnostics.isEmpty {
+                            InspectorCard(title: "Control Diagnostics") {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    ForEach(Array(host.controlPlaneDiagnostics.enumerated()), id: \.offset) { entry in
+                                        Text(entry.element)
+                                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                                            .foregroundStyle(ShellPalette.mutedInk)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                }
+                            }
+                        }
+
                         InspectorCard(title: "Debug Snapshot") {
                             VStack(alignment: .leading, spacing: 12) {
                                 Text("Canonical local shell state exposed to `alan shell state`.")

--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -300,15 +300,6 @@ extension AlanShellBindingProjection {
     }
 }
 
-extension Notification.Name {
-    static let alanShellSendText = Notification.Name("alan.shell.sendText")
-}
-
-enum AlanShellNotificationKey {
-    static let paneID = "paneID"
-    static let text = "text"
-}
-
 enum AlanShellLocalCommandSideEffect {
     case sendText(paneID: String, text: String)
 }
@@ -710,33 +701,7 @@ private enum AlanShellLocalCommandExecutor {
             }
 
         case .paneSendText:
-            guard let paneID = command.paneID,
-                  state.pane(paneID: paneID) != nil
-            else {
-                return AlanShellLocalCommandResult(
-                    response: failureResponse(
-                        for: .paneNotFound,
-                        command: command,
-                        state: state
-                    ),
-                    updatedState: nil,
-                    sideEffect: nil
-                )
-            }
-            let text = command.text ?? ""
-            return AlanShellLocalCommandResult(
-                response: response(
-                    for: command,
-                    state: state,
-                    applied: true,
-                    spaceID: state.focusedSpaceID,
-                    tabID: state.focusedTabID,
-                    paneID: paneID,
-                    acceptedBytes: text.lengthOfBytes(using: .utf8)
-                ),
-                updatedState: nil,
-                sideEffect: .sendText(paneID: paneID, text: text)
-            )
+            return nil
 
         case .attentionInbox:
             return AlanShellLocalCommandResult(
@@ -1157,8 +1122,19 @@ private func attentionRank(for attention: ShellAttentionState) -> Int {
 }
 
 final class AlanShellSocketServer {
+    private static let maxRequestBytes = 1_048_576
+    private static let readTimeoutSeconds = 5
+    private static let commandResponseTimeoutSeconds: TimeInterval = 5
+    private static let maxConcurrentClients = 4
+
     private let socketURL: URL
     private let queue = DispatchQueue(label: "dev.alan.shell.control.socket", qos: .userInitiated)
+    private let clientQueue = DispatchQueue(
+        label: "dev.alan.shell.control.socket.clients",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private let clientSemaphore = DispatchSemaphore(value: AlanShellSocketServer.maxConcurrentClients)
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private let commandHandler: (AlanShellControlCommand) -> AlanShellControlResponse
@@ -1291,7 +1267,19 @@ final class AlanShellSocketServer {
 
             debugLog("socket accepted client fd=\(clientFD)")
             configureClient(fileDescriptor: clientFD)
-            handleClient(fileDescriptor: clientFD)
+            clientQueue.async { [weak self] in
+                guard let self else {
+                    AlanShellSocketServer.closeClient(clientFD)
+                    return
+                }
+                guard self.clientSemaphore.wait(timeout: .now() + 5) == .success else {
+                    self.debugLog("socket client rejected by concurrency limit fd=\(clientFD)")
+                    AlanShellSocketServer.closeClient(clientFD)
+                    return
+                }
+                defer { self.clientSemaphore.signal() }
+                self.handleClient(fileDescriptor: clientFD)
+            }
         }
     }
 
@@ -1303,6 +1291,22 @@ final class AlanShellSocketServer {
             SO_NOSIGPIPE,
             &noSigPipe,
             socklen_t(MemoryLayout<Int32>.size)
+        )
+
+        var timeout = timeval(tv_sec: Self.readTimeoutSeconds, tv_usec: 0)
+        setsockopt(
+            fileDescriptor,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            &timeout,
+            socklen_t(MemoryLayout<timeval>.size)
+        )
+        setsockopt(
+            fileDescriptor,
+            SOL_SOCKET,
+            SO_SNDTIMEO,
+            &timeout,
+            socklen_t(MemoryLayout<timeval>.size)
         )
     }
 
@@ -1335,8 +1339,32 @@ final class AlanShellSocketServer {
             response = self.commandHandler(command)
             semaphore.signal()
         }
-        if semaphore.wait(timeout: .now() + 5) != .success {
+        if semaphore.wait(timeout: .now() + Self.commandResponseTimeoutSeconds) != .success {
             debugLog("socket response timeout fd=\(fileDescriptor)")
+            let timeoutResponse = AlanShellControlResponse(
+                requestID: command.requestID,
+                contractVersion: "0.1",
+                applied: false,
+                state: nil,
+                spaces: nil,
+                tabs: nil,
+                panes: nil,
+                pane: nil,
+                items: nil,
+                candidates: nil,
+                events: nil,
+                focusedPaneID: nil,
+                spaceID: command.spaceID,
+                tabID: command.tabID,
+                paneID: command.paneID,
+                acceptedBytes: nil,
+                latestEventID: nil,
+                errorCode: "command_timeout",
+                errorMessage: "Alan Shell control command timed out."
+            )
+            let responseData = (try? encoder.encode(timeoutResponse)) ?? Data()
+            AlanShellSocketServer.write(responseData, to: fileDescriptor)
+            AlanShellSocketServer.write(Data([0x0A]), to: fileDescriptor)
             AlanShellSocketServer.closeClient(fileDescriptor)
             return
         }
@@ -1379,6 +1407,10 @@ final class AlanShellSocketServer {
             let bytesRead = read(fileDescriptor, &buffer, buffer.count)
             if bytesRead > 0 {
                 data.append(buffer, count: bytesRead)
+                guard data.count <= Self.maxRequestBytes else {
+                    debugLog("socket request too large fd=\(fileDescriptor) bytes=\(data.count)")
+                    return nil
+                }
                 if data.contains(0x0A) {
                     debugLog("socket read newline fd=\(fileDescriptor) bytes=\(data.count)")
                     break
@@ -1493,6 +1525,7 @@ final class AlanShellControlPlane {
     private let commandHandler: (AlanShellControlCommand) -> AlanShellControlResponse
     private let stateAdoptionHandler: @MainActor (ShellStateSnapshot) -> Void
     private let bindingProjectionHandler: @MainActor (String, ShellAlanBinding?) -> Void
+    private let diagnosticHandler: @MainActor (String) -> Void
     private let socketServer: AlanShellSocketServer
     private var pollSource: DispatchSourceTimer?
     private var trackedPaneIDs: Set<String> = []
@@ -1505,7 +1538,8 @@ final class AlanShellControlPlane {
         fileManager: FileManager = .default,
         commandHandler: @escaping (AlanShellControlCommand) -> AlanShellControlResponse,
         stateAdoptionHandler: @escaping @MainActor (ShellStateSnapshot) -> Void,
-        bindingProjectionHandler: @escaping @MainActor (String, ShellAlanBinding?) -> Void
+        bindingProjectionHandler: @escaping @MainActor (String, ShellAlanBinding?) -> Void,
+        diagnosticHandler: @escaping @MainActor (String) -> Void = { _ in }
     ) {
         self.windowID = windowID
         self.fileManager = fileManager
@@ -1522,6 +1556,7 @@ final class AlanShellControlPlane {
         self.commandHandler = commandHandler
         self.stateAdoptionHandler = stateAdoptionHandler
         self.bindingProjectionHandler = bindingProjectionHandler
+        self.diagnosticHandler = diagnosticHandler
         self.socketServer = AlanShellSocketServer(
             socketURL: self.socketURL,
             commandHandler: commandHandler,
@@ -1530,19 +1565,7 @@ final class AlanShellControlPlane {
                     stateAdoptionHandler(state)
                 }
             },
-            sideEffectHandler: { sideEffect in
-                switch sideEffect {
-                case let .sendText(paneID, text):
-                    NotificationCenter.default.post(
-                        name: .alanShellSendText,
-                        object: nil,
-                        userInfo: [
-                            AlanShellNotificationKey.paneID: paneID,
-                            AlanShellNotificationKey.text: text,
-                        ]
-                    )
-                }
-            }
+            sideEffectHandler: { _ in }
         )
 
         ensureDirectories()
@@ -1581,8 +1604,12 @@ final class AlanShellControlPlane {
         let mergedState = mergeResult.merged
         synchronizePaneSupportDirectories(for: mergedState)
         recordEvents(from: mergeResult.previous, to: mergedState)
-        guard let data = try? encoder.encode(mergedState) else { return }
-        try? data.write(to: stateFileURL, options: .atomic)
+        do {
+            let data = try encoder.encode(mergedState)
+            try data.write(to: stateFileURL, options: .atomic)
+        } catch {
+            recordDiagnostic("Failed to persist shell state: \(error.localizedDescription)")
+        }
     }
 
     private func startPolling() {
@@ -1601,8 +1628,16 @@ final class AlanShellControlPlane {
 
     private func ensureDirectories() {
         [rootURL, panesURL, commandsURL, resultsURL].forEach { url in
-            try? fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+            do {
+                try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+            } catch {
+                recordDiagnostic("Failed to create shell control directory \(url.path): \(error.localizedDescription)")
+            }
         }
+    }
+
+    private func recordDiagnostic(_ message: String) {
+        diagnosticHandler(message)
     }
 
     func specialCommandResponse(for command: AlanShellControlCommand) -> AlanShellControlResponse? {
@@ -1631,6 +1666,34 @@ final class AlanShellControlPlane {
         )
     }
 
+    func recordTextDelivery(
+        requestID: String,
+        spaceID: String?,
+        tabID: String?,
+        paneID: String,
+        delivery: TerminalRuntimeDeliveryResult
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "request_id": .string(requestID),
+            "delivery_code": .string(delivery.code.rawValue),
+            "accepted_bytes": .number(Double(delivery.acceptedBytes))
+        ]
+        if let errorCode = delivery.errorCode {
+            payload["error_code"] = .string(errorCode)
+        }
+        if let errorMessage = delivery.errorMessage {
+            payload["error_message"] = .string(errorMessage)
+        }
+
+        appendEvent(
+            type: "pane.text_delivery",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            payload: payload
+        )
+    }
+
     private func synchronizePaneSupportDirectories(for state: ShellStateSnapshot) {
         let paneIDs = Set(state.panes.map(\.paneID))
         let previousPaneIDs = trackedPaneIDs
@@ -1642,7 +1705,11 @@ final class AlanShellControlPlane {
                 paneID: paneID,
                 fileManager: fileManager
             )
-            try? fileManager.createDirectory(at: paneURL, withIntermediateDirectories: true)
+            do {
+                try fileManager.createDirectory(at: paneURL, withIntermediateDirectories: true)
+            } catch {
+                recordDiagnostic("Failed to create pane support directory \(paneURL.path): \(error.localizedDescription)")
+            }
         }
 
         let stalePaneIDs = Set(lastBindingPayloadByPaneID.keys).subtracting(paneIDs)
@@ -1656,7 +1723,11 @@ final class AlanShellControlPlane {
                 paneID: paneID,
                 fileManager: fileManager
             )
-            try? fileManager.removeItem(at: paneURL)
+            do {
+                try fileManager.removeItem(at: paneURL)
+            } catch {
+                recordDiagnostic("Failed to remove stale pane support directory \(paneURL.path): \(error.localizedDescription)")
+            }
         }
     }
 
@@ -1850,13 +1921,17 @@ final class AlanShellControlPlane {
         }
         if let data = try? encoder.encode(event),
            let line = String(data: data, encoding: .utf8) {
-            if fileManager.fileExists(atPath: eventsFileURL.path),
-               let handle = try? FileHandle(forWritingTo: eventsFileURL) {
-                defer { try? handle.close() }
-                _ = try? handle.seekToEnd()
-                try? handle.write(contentsOf: Data("\(line)\n".utf8))
-            } else {
-                try? Data("\(line)\n".utf8).write(to: eventsFileURL, options: .atomic)
+            do {
+                if fileManager.fileExists(atPath: eventsFileURL.path) {
+                    let handle = try FileHandle(forWritingTo: eventsFileURL)
+                    defer { try? handle.close() }
+                    _ = try handle.seekToEnd()
+                    try handle.write(contentsOf: Data("\(line)\n".utf8))
+                } else {
+                    try Data("\(line)\n".utf8).write(to: eventsFileURL, options: .atomic)
+                }
+            } catch {
+                recordDiagnostic("Failed to persist shell event log: \(error.localizedDescription)")
             }
         }
     }
@@ -1878,13 +1953,19 @@ final class AlanShellControlPlane {
     private func pollCommands() {
         ensureDirectories()
 
-        let commandFiles = (try? fileManager.contentsOfDirectory(
-            at: commandsURL,
-            includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ))?
-        .filter { $0.pathExtension == "json" }
-        .sorted(by: compareCommandFiles) ?? []
+        let commandFiles: [URL]
+        do {
+            commandFiles = try fileManager.contentsOfDirectory(
+                at: commandsURL,
+                includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            )
+            .filter { $0.pathExtension == "json" }
+            .sorted(by: compareCommandFiles)
+        } catch {
+            recordDiagnostic("Failed to read shell command directory: \(error.localizedDescription)")
+            return
+        }
 
         for fileURL in commandFiles {
             handleCommandFile(at: fileURL)
@@ -1895,7 +1976,12 @@ final class AlanShellControlPlane {
         guard let data = try? Data(contentsOf: fileURL),
               let command = try? decoder.decode(AlanShellControlCommand.self, from: data)
         else {
-            try? fileManager.removeItem(at: fileURL)
+            recordDiagnostic("Ignored unreadable shell command file \(fileURL.lastPathComponent).")
+            do {
+                try fileManager.removeItem(at: fileURL)
+            } catch {
+                recordDiagnostic("Failed to remove unreadable shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
+            }
             return
         }
 
@@ -1905,11 +1991,18 @@ final class AlanShellControlPlane {
             ?? commandHandler(command)
         let responseURL = resultsURL.appendingPathComponent("\(command.requestID).json")
 
-        if let responseData = try? encoder.encode(response) {
-            try? responseData.write(to: responseURL, options: .atomic)
+        do {
+            let responseData = try encoder.encode(response)
+            try responseData.write(to: responseURL, options: .atomic)
+        } catch {
+            recordDiagnostic("Failed to write shell command result \(responseURL.lastPathComponent): \(error.localizedDescription)")
         }
 
-        try? fileManager.removeItem(at: fileURL)
+        do {
+            try fileManager.removeItem(at: fileURL)
+        } catch {
+            recordDiagnostic("Failed to remove processed shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
+        }
     }
 
     private func compareCommandFiles(_ lhs: URL, _ rhs: URL) -> Bool {
@@ -1941,6 +2034,7 @@ final class AlanShellControlPlane {
             }
 
             guard let data = try? Data(contentsOf: bindingURL) else {
+                recordDiagnostic("Failed to read Alan binding file for \(paneID).")
                 continue
             }
 
@@ -1950,6 +2044,7 @@ final class AlanShellControlPlane {
 
             guard let projection = try? decoder.decode(AlanShellBindingProjection.self, from: data) else {
                 lastBindingPayloadByPaneID[paneID] = data
+                recordDiagnostic("Ignored invalid Alan binding file for \(paneID).")
                 continue
             }
 

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -34,6 +34,44 @@ private enum ShellPaneLiftResult {
 }
 
 @MainActor
+struct ShellWindowContext {
+    let windowID: String
+    let persistenceURL: URL
+    let terminalRuntimeRegistry: TerminalRuntimeRegistry
+
+    var controlRootURL: URL {
+        alanShellControlPlaneRootURL(windowID: windowID)
+    }
+
+    var socketURL: URL {
+        alanShellControlPlaneSocketURL(windowID: windowID)
+    }
+
+    var stateURL: URL {
+        controlRootURL.appendingPathComponent("state.json")
+    }
+
+    var eventsURL: URL {
+        controlRootURL.appendingPathComponent("events.jsonl")
+    }
+
+    static func make(
+        fileManager: FileManager = .default,
+        windowID: String = "window_\(UUID().uuidString.lowercased())",
+        terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil
+    ) -> ShellWindowContext {
+        ShellWindowContext(
+            windowID: windowID,
+            persistenceURL: ShellHostController.defaultPersistenceURL(
+                windowID: windowID,
+                fileManager: fileManager
+            ),
+            terminalRuntimeRegistry: terminalRuntimeRegistry ?? TerminalRuntimeRegistry()
+        )
+    }
+}
+
+@MainActor
 final class ShellHostController: ObservableObject {
     enum StartupMode {
         case fresh
@@ -41,11 +79,12 @@ final class ShellHostController: ObservableObject {
     }
 
     private static let iso8601Formatter = ISO8601DateFormatter()
-    private static let persistenceFileName = "shell-state-v0.1.json"
+    private static let legacyPersistenceFileName = "shell-state-v0.1.json"
 
     private let fileManager: FileManager
+    private let windowContext: ShellWindowContext
     private let persistenceURL: URL
-    private lazy var controlPlane = AlanShellControlPlane(windowID: shellState.windowID) { [weak self] command in
+    private lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
                 requestID: command.requestID,
@@ -72,6 +111,8 @@ final class ShellHostController: ObservableObject {
         self?.adoptStateFromControlPlane(state)
     } bindingProjectionHandler: { [weak self] paneID, binding in
         self?.applyAlanBinding(binding, for: paneID)
+    } diagnosticHandler: { [weak self] message in
+        self?.recordControlPlaneDiagnostic(message)
     }
 
     @Published private(set) var shellState: ShellStateSnapshot
@@ -79,17 +120,25 @@ final class ShellHostController: ObservableObject {
     @Published var selectedTabID: String?
     @Published private(set) var lastCopiedAt: Date?
     @Published private(set) var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
+    @Published private(set) var controlPlaneDiagnostics: [String] = []
 
-    private var runtimesByPaneID: [String: TerminalHostRuntimeSnapshot] = [:]
+    let terminalRuntimeRegistry: TerminalRuntimeRegistry
 
     init(
         shellState: ShellStateSnapshot,
         fileManager: FileManager = .default,
-        persistenceURL: URL? = nil
+        windowContext: ShellWindowContext? = nil,
+        persistenceURL: URL? = nil,
+        terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil
     ) {
         self.fileManager = fileManager
-        self.persistenceURL = persistenceURL ?? Self.defaultPersistenceURL(fileManager: fileManager)
+        let resolvedContext = windowContext ?? ShellWindowContext.make(fileManager: fileManager)
+        self.windowContext = resolvedContext
+        self.persistenceURL = persistenceURL ?? resolvedContext.persistenceURL
         self.shellState = shellState
+        self.terminalRuntimeRegistry =
+            terminalRuntimeRegistry
+            ?? resolvedContext.terminalRuntimeRegistry
         self.selectedSpaceID = shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
         self.selectedTabID = shellState.focusedTabID ?? shellState.spaces.first?.tabs.first?.tabID
 
@@ -103,22 +152,25 @@ final class ShellHostController: ObservableObject {
 
     static func live(
         fileManager: FileManager = .default,
+        windowContext: ShellWindowContext? = nil,
         startupMode: StartupMode = .fresh
     ) -> ShellHostController {
-        let persistenceURL = defaultPersistenceURL(fileManager: fileManager)
+        let resolvedWindowContext = windowContext ?? ShellWindowContext.make(fileManager: fileManager)
+        let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
         switch startupMode {
         case .fresh:
-            shellState = .bootstrapDefault()
+            shellState = .bootstrapDefault(windowID: resolvedWindowContext.windowID)
         case .restorePrevious:
             shellState =
                 restoreShellState(fileManager: fileManager, persistenceURL: persistenceURL)
-                ?? .bootstrapDefault()
+                ?? .bootstrapDefault(windowID: resolvedWindowContext.windowID)
         }
 
         let controller = ShellHostController(
             shellState: shellState,
             fileManager: fileManager,
+            windowContext: resolvedWindowContext,
             persistenceURL: persistenceURL
         )
         if startupMode == .fresh {
@@ -222,8 +274,7 @@ final class ShellHostController: ObservableObject {
     }
 
     func runtime(for paneID: String?) -> TerminalHostRuntimeSnapshot {
-        guard let paneID else { return .placeholder }
-        return runtimesByPaneID[paneID] ?? .placeholder
+        terminalRuntimeRegistry.snapshot(for: paneID)
     }
 
     func select(spaceID: String) {
@@ -420,9 +471,7 @@ final class ShellHostController: ObservableObject {
     }
 
     func updateTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
-        if let paneID = runtime.paneID {
-            runtimesByPaneID[paneID] = runtime
-        }
+        terminalRuntimeRegistry.updateSnapshot(runtime)
 
         if let paneID = runtime.paneID,
            runtime.isFocused,
@@ -710,7 +759,7 @@ final class ShellHostController: ObservableObject {
 
     private func adoptStateFromControlPlane(_ state: ShellStateSnapshot) {
         let paneIDs = Set(state.panes.map(\.paneID))
-        runtimesByPaneID = runtimesByPaneID.filter { paneIDs.contains($0.key) }
+        terminalRuntimeRegistry.releaseRuntimes(excluding: paneIDs)
 
         let hydratedPanes = state.panes.map { pane in
             guard paneNeedsBootContextProjection(pane) else { return pane }
@@ -759,6 +808,15 @@ final class ShellHostController: ObservableObject {
         )
         synchronizeSelection()
         publishControlPlaneState()
+    }
+
+    private func recordControlPlaneDiagnostic(_ message: String) {
+        let line = "\(Self.iso8601Formatter.string(from: .now)) \(message)"
+        guard controlPlaneDiagnostics.last != line else { return }
+        controlPlaneDiagnostics.append(line)
+        if controlPlaneDiagnostics.count > 12 {
+            controlPlaneDiagnostics.removeFirst(controlPlaneDiagnostics.count - 12)
+        }
     }
 
     private func synchronizeSelection() {
@@ -1481,22 +1539,24 @@ final class ShellHostController: ObservableObject {
             }
 
             let text = command.text ?? ""
-            NotificationCenter.default.post(
-                name: .alanShellSendText,
-                object: nil,
-                userInfo: [
-                    AlanShellNotificationKey.paneID: paneID,
-                    AlanShellNotificationKey.text: text,
-                ]
+            let delivery = terminalRuntimeRegistry.sendText(to: paneID, text: text)
+            controlPlane.recordTextDelivery(
+                requestID: command.requestID,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: paneID,
+                delivery: delivery
             )
 
             return response(
                 requestID: command.requestID,
-                applied: true,
+                applied: delivery.applied,
                 spaceID: shellState.focusedSpaceID,
                 tabID: shellState.focusedTabID,
                 paneID: paneID,
-                acceptedBytes: text.lengthOfBytes(using: .utf8)
+                acceptedBytes: delivery.acceptedBytes,
+                errorCode: delivery.errorCode,
+                errorMessage: delivery.errorMessage
             )
 
         case .attentionInbox:
@@ -1552,13 +1612,16 @@ final class ShellHostController: ObservableObject {
         }
     }
 
-    private static func defaultPersistenceURL(fileManager: FileManager) -> URL {
+    static func defaultPersistenceURL(windowID: String, fileManager: FileManager) -> URL {
         let appSupportURL =
             fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
+        let sanitizedWindowID = windowID
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
         return appSupportURL
             .appendingPathComponent("AlanNative", isDirectory: true)
-            .appendingPathComponent(persistenceFileName)
+            .appendingPathComponent("shell-state-\(sanitizedWindowID).json")
     }
 
     private static func restoreShellState(

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -79,7 +79,10 @@ final class ShellHostController: ObservableObject {
     }
 
     private static let iso8601Formatter = ISO8601DateFormatter()
+    private static let persistenceFilePrefix = "shell-state-"
+    private static let persistenceFileExtension = ".json"
     private static let legacyPersistenceFileName = "shell-state-v0.1.json"
+    private static let defaultRestorationWindowID = "window_main"
 
     private let fileManager: FileManager
     private let windowContext: ShellWindowContext
@@ -155,7 +158,10 @@ final class ShellHostController: ObservableObject {
         windowContext: ShellWindowContext? = nil,
         startupMode: StartupMode = .fresh
     ) -> ShellHostController {
-        let resolvedWindowContext = windowContext ?? ShellWindowContext.make(fileManager: fileManager)
+        let resolvedWindowContext =
+            windowContext
+            ?? restoredWindowContext(fileManager: fileManager, startupMode: startupMode)
+            ?? defaultWindowContext(fileManager: fileManager, startupMode: startupMode)
         let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
         switch startupMode {
@@ -1527,7 +1533,7 @@ final class ShellHostController: ObservableObject {
 
         case .paneSendText:
             guard let paneID = command.paneID,
-                  shellState.panes.contains(where: { $0.paneID == paneID })
+                  let targetPane = pane(paneID: paneID)
             else {
                 return response(
                     requestID: command.requestID,
@@ -1542,8 +1548,8 @@ final class ShellHostController: ObservableObject {
             let delivery = terminalRuntimeRegistry.sendText(to: paneID, text: text)
             controlPlane.recordTextDelivery(
                 requestID: command.requestID,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
                 paneID: paneID,
                 delivery: delivery
             )
@@ -1551,8 +1557,8 @@ final class ShellHostController: ObservableObject {
             return response(
                 requestID: command.requestID,
                 applied: delivery.applied,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
                 paneID: paneID,
                 acceptedBytes: delivery.acceptedBytes,
                 errorCode: delivery.errorCode,
@@ -1577,6 +1583,15 @@ final class ShellHostController: ObservableObject {
                     errorMessage: "pane_id and attention are required."
                 )
             }
+            guard let targetPane = pane(paneID: paneID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
             guard setAttention(attention, for: paneID) else {
                 return response(
                     requestID: command.requestID,
@@ -1589,8 +1604,8 @@ final class ShellHostController: ObservableObject {
             return response(
                 requestID: command.requestID,
                 applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
                 paneID: paneID
             )
 
@@ -1613,15 +1628,77 @@ final class ShellHostController: ObservableObject {
     }
 
     static func defaultPersistenceURL(windowID: String, fileManager: FileManager) -> URL {
-        let appSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? fileManager.temporaryDirectory
         let sanitizedWindowID = windowID
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: ":", with: "_")
-        return appSupportURL
-            .appendingPathComponent("AlanNative", isDirectory: true)
-            .appendingPathComponent("shell-state-\(sanitizedWindowID).json")
+        return persistenceDirectory(fileManager: fileManager)
+            .appendingPathComponent("\(persistenceFilePrefix)\(sanitizedWindowID)\(persistenceFileExtension)")
+    }
+
+    private static func persistenceDirectory(fileManager: FileManager) -> URL {
+        let appSupportURL =
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return appSupportURL.appendingPathComponent("AlanNative", isDirectory: true)
+    }
+
+    private static func restoredWindowContext(
+        fileManager: FileManager,
+        startupMode: StartupMode
+    ) -> ShellWindowContext? {
+        guard startupMode == .restorePrevious else { return nil }
+
+        let directory = persistenceDirectory(fileManager: fileManager)
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        let candidates = urls.compactMap { url -> (Date, ShellWindowContext)? in
+            guard isShellStatePersistenceURL(url),
+                  let state = restoreShellState(fileManager: fileManager, persistenceURL: url)
+            else {
+                return nil
+            }
+
+            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            let modifiedAt = values?.contentModificationDate ?? .distantPast
+            return (
+                modifiedAt,
+                ShellWindowContext(
+                    windowID: state.windowID,
+                    persistenceURL: url,
+                    terminalRuntimeRegistry: TerminalRuntimeRegistry()
+                )
+            )
+        }
+
+        return candidates.max { lhs, rhs in lhs.0 < rhs.0 }?.1
+    }
+
+    private static func defaultWindowContext(
+        fileManager: FileManager,
+        startupMode: StartupMode
+    ) -> ShellWindowContext {
+        switch startupMode {
+        case .fresh:
+            return ShellWindowContext.make(fileManager: fileManager)
+        case .restorePrevious:
+            return ShellWindowContext.make(
+                fileManager: fileManager,
+                windowID: defaultRestorationWindowID
+            )
+        }
+    }
+
+    private static func isShellStatePersistenceURL(_ url: URL) -> Bool {
+        let fileName = url.lastPathComponent
+        return fileName == legacyPersistenceFileName
+            || (fileName.hasPrefix(persistenceFilePrefix)
+                && fileName.hasSuffix(persistenceFileExtension))
     }
 
     private static func restoreShellState(

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -11,18 +11,17 @@ import GhosttyKit
 struct TerminalHostView: NSViewRepresentable {
     let pane: ShellPane?
     let bootProfile: AlanShellBootProfile?
+    let runtimeRegistry: TerminalRuntimeRegistry
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
     func makeNSView(context: Context) -> AlanTerminalHostNSView {
-        let view = AlanTerminalHostNSView()
-        view.configure(
-            pane: pane,
+        runtimeRegistry.hostView(
+            for: pane,
             bootProfile: bootProfile,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
-        return view
     }
 
     func updateNSView(_ nsView: AlanTerminalHostNSView, context: Context) {
@@ -35,7 +34,7 @@ struct TerminalHostView: NSViewRepresentable {
     }
 }
 
-final class AlanTerminalHostNSView: NSView, NSTextInputClient {
+final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHandle {
     private let canvasView = makeCanvasView()
     private let overlayCard = NSVisualEffectView()
     private let bodyStack = NSStackView()
@@ -50,7 +49,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var windowObservers: [NSObjectProtocol] = []
-    private var commandObservers: [NSObjectProtocol] = []
     private var rendererSnapshot: TerminalRendererSnapshot = .placeholder
     private var paneMetadata: TerminalPaneMetadataSnapshot = .placeholder
     private var lastReportedMetadata: TerminalPaneMetadataSnapshot?
@@ -59,6 +57,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
     private var markedText = NSMutableAttributedString()
     private var keyTextAccumulator: [String]?
     private var previousPressureStage = 0
+    private var hasTornDownRuntime = false
 
 #if canImport(GhosttyKit)
     private let liveHost = AlanGhosttyLiveHost()
@@ -74,11 +73,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
     }
 
     deinit {
-        removeWindowObservers()
-        removeCommandObservers()
-#if canImport(GhosttyKit)
-        liveHost.teardown()
-#endif
+        teardownRuntimeIfNeeded()
     }
 
     override var acceptsFirstResponder: Bool {
@@ -256,7 +251,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
         addSubview(canvasView)
         addSubview(overlayCard)
         overlayCard.addSubview(bodyStack)
-        installCommandObservers()
 
         NSLayoutConstraint.activate([
             canvasView.topAnchor.constraint(equalTo: topAnchor),
@@ -275,6 +269,49 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
             bodyStack.trailingAnchor.constraint(equalTo: overlayCard.trailingAnchor, constant: -18),
             bodyStack.bottomAnchor.constraint(equalTo: overlayCard.bottomAnchor, constant: -18),
         ])
+    }
+
+    func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        guard !text.isEmpty else {
+            return .accepted(byteCount: 0)
+        }
+
+        guard pane?.paneID != nil else {
+            return .rejected(
+                errorCode: "terminal_runtime_unavailable",
+                errorMessage: "No pane is attached to this terminal runtime."
+            )
+        }
+
+#if canImport(GhosttyKit)
+        guard liveHost.isSurfaceReady else {
+            return .rejected(
+                errorCode: "terminal_runtime_unavailable",
+                errorMessage: "The requested pane is not ready to receive terminal input."
+            )
+        }
+
+        liveHost.sendText(text)
+        return .accepted(byteCount: text.lengthOfBytes(using: .utf8))
+#else
+        return .rejected(
+            errorCode: "ghostty_unavailable",
+            errorMessage: "GhosttyKit is not linked into this build."
+        )
+#endif
+    }
+
+    func teardownTerminalRuntime() {
+        teardownRuntimeIfNeeded()
+    }
+
+    private func teardownRuntimeIfNeeded() {
+        guard !hasTornDownRuntime else { return }
+        hasTornDownRuntime = true
+        removeWindowObservers()
+#if canImport(GhosttyKit)
+        liveHost.teardown()
+#endif
     }
 
     private func installWindowObservers() {
@@ -309,37 +346,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient {
     private func removeWindowObservers() {
         windowObservers.forEach(NotificationCenter.default.removeObserver)
         windowObservers.removeAll()
-    }
-
-    private func installCommandObservers() {
-        removeCommandObservers()
-        let center = NotificationCenter.default
-        commandObservers = [
-            center.addObserver(
-                forName: .alanShellSendText,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let self else { return }
-                guard let paneID = notification.userInfo?[AlanShellNotificationKey.paneID] as? String,
-                      paneID == self.pane?.paneID,
-                      let text = notification.userInfo?[AlanShellNotificationKey.text] as? String,
-                      !text.isEmpty
-                else {
-                    return
-                }
-
-                self.requestTerminalFocus()
-#if canImport(GhosttyKit)
-                self.liveHost.sendText(text)
-#endif
-            },
-        ]
-    }
-
-    private func removeCommandObservers() {
-        commandObservers.forEach(NotificationCenter.default.removeObserver)
-        commandObservers.removeAll()
     }
 
     private func publishRuntimeSnapshot() {

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -411,6 +411,7 @@ private struct ShellPaneTreeLayoutView: View {
                     pane: pane,
                     runtime: host.runtime(for: pane.paneID),
                     bootProfile: host.bootProfile(for: pane),
+                    runtimeRegistry: host.terminalRuntimeRegistry,
                     isFocused: host.shellState.focusedPaneID == pane.paneID,
                     onSelect: { host.focus(paneID: pane.paneID) },
                     onRuntimeUpdate: host.updateTerminalRuntime,
@@ -445,6 +446,7 @@ private struct ShellTerminalLeafView: View {
     let pane: ShellPane
     let runtime: TerminalHostRuntimeSnapshot
     let bootProfile: AlanShellBootProfile?
+    let runtimeRegistry: TerminalRuntimeRegistry
     let isFocused: Bool
     let onSelect: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
@@ -498,9 +500,11 @@ private struct ShellTerminalLeafView: View {
             TerminalHostView(
                 pane: pane,
                 bootProfile: bootProfile,
+                runtimeRegistry: runtimeRegistry,
                 onRuntimeUpdate: onRuntimeUpdate,
                 onMetadataUpdate: onMetadataUpdate
             )
+            .id(pane.paneID)
             .frame(minHeight: 260, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+enum TerminalRuntimeDeliveryCode: String, Codable, Equatable {
+    case accepted
+    case queued
+    case rejected
+    case missingTarget = "missing_target"
+    case unavailableRuntime = "unavailable_runtime"
+    case timeout
+}
+
+struct TerminalRuntimeDeliveryResult: Codable, Equatable {
+    let code: TerminalRuntimeDeliveryCode
+    let acceptedBytes: Int
+    let errorCode: String?
+    let errorMessage: String?
+
+    var applied: Bool {
+        code == .accepted
+    }
+
+    static func accepted(byteCount: Int) -> TerminalRuntimeDeliveryResult {
+        TerminalRuntimeDeliveryResult(
+            code: .accepted,
+            acceptedBytes: byteCount,
+            errorCode: nil,
+            errorMessage: nil
+        )
+    }
+
+    static func rejected(errorCode: String, errorMessage: String) -> TerminalRuntimeDeliveryResult {
+        TerminalRuntimeDeliveryResult(
+            code: .rejected,
+            acceptedBytes: 0,
+            errorCode: errorCode,
+            errorMessage: errorMessage
+        )
+    }
+
+    static func unavailable(errorMessage: String) -> TerminalRuntimeDeliveryResult {
+        TerminalRuntimeDeliveryResult(
+            code: .unavailableRuntime,
+            acceptedBytes: 0,
+            errorCode: "terminal_runtime_unavailable",
+            errorMessage: errorMessage
+        )
+    }
+}
+
+@MainActor
+protocol TerminalRuntimeHandle: AnyObject {
+    func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult
+    func teardownTerminalRuntime()
+}
+
+@MainActor
+final class MockTerminalRuntimeHandle: TerminalRuntimeHandle {
+    private(set) var attachedCount = 0
+    private(set) var detachedCount = 0
+    private(set) var teardownCount = 0
+    private(set) var deliveredText: [String] = []
+    var deliveryResult: TerminalRuntimeDeliveryResult?
+
+    func attach() {
+        attachedCount += 1
+    }
+
+    func detach() {
+        detachedCount += 1
+    }
+
+    func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        deliveredText.append(text)
+        return deliveryResult ?? .accepted(byteCount: text.lengthOfBytes(using: .utf8))
+    }
+
+    func teardownTerminalRuntime() {
+        teardownCount += 1
+    }
+}
+
+@MainActor
+final class TerminalRuntimeRegistry: ObservableObject {
+    typealias MockDeliveryHandler = (String, String) -> TerminalRuntimeDeliveryResult
+
+    private var hostViewsByPaneID: [String: AlanTerminalHostNSView] = [:]
+    private var snapshotsByPaneID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private let mockDeliveryHandler: MockDeliveryHandler?
+
+    init(mockDeliveryHandler: MockDeliveryHandler? = nil) {
+        self.mockDeliveryHandler = mockDeliveryHandler
+    }
+
+    func hostView(
+        for pane: ShellPane?,
+        bootProfile: AlanShellBootProfile?,
+        onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
+        onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
+    ) -> AlanTerminalHostNSView {
+        let hostView: AlanTerminalHostNSView
+        if let paneID = pane?.paneID {
+            if let existing = hostViewsByPaneID[paneID] {
+                hostView = existing
+            } else {
+                let created = AlanTerminalHostNSView()
+                hostViewsByPaneID[paneID] = created
+                hostView = created
+            }
+        } else {
+            hostView = AlanTerminalHostNSView()
+        }
+
+        hostView.configure(
+            pane: pane,
+            bootProfile: bootProfile,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
+        )
+        return hostView
+    }
+
+    func updateSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {
+        guard let paneID = snapshot.paneID else { return }
+        snapshotsByPaneID[paneID] = snapshot
+    }
+
+    func snapshot(for paneID: String?) -> TerminalHostRuntimeSnapshot {
+        guard let paneID else { return .placeholder }
+        return snapshotsByPaneID[paneID] ?? .placeholder
+    }
+
+    func releaseRuntimes(excluding activePaneIDs: Set<String>) {
+        let stalePaneIDs = Set(hostViewsByPaneID.keys)
+            .union(snapshotsByPaneID.keys)
+            .subtracting(activePaneIDs)
+        stalePaneIDs.forEach { releaseRuntime($0) }
+    }
+
+    func releaseRuntime(for paneID: String) {
+        releaseRuntime(paneID)
+    }
+
+    func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
+        if let mockDeliveryHandler {
+            return mockDeliveryHandler(paneID, text)
+        }
+
+        guard let hostView = hostViewsByPaneID[paneID] else {
+            return .unavailable(
+                errorMessage: "The requested pane does not have a live terminal runtime."
+            )
+        }
+
+        return hostView.sendControlText(text)
+    }
+
+    var registeredPaneIDs: Set<String> {
+        Set(hostViewsByPaneID.keys)
+    }
+
+    private func releaseRuntime(_ paneID: String) {
+        if let hostView = hostViewsByPaneID.removeValue(forKey: paneID) {
+            hostView.teardownTerminalRuntime()
+        }
+        snapshotsByPaneID.removeValue(forKey: paneID)
+    }
+}
+#endif

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -7,9 +7,9 @@ whose shell is readable and operable by both humans and agents.
 
 ## System Requirements
 
-- Xcode 16+
-- macOS 15+ for development
-- iOS 18+ simulator/device for iOS target
+- Xcode 26+
+- macOS 26+ for development
+- iOS 26+ simulator/device for iOS target
 
 ## Directory Structure
 
@@ -37,6 +37,13 @@ for the next integration slice, run:
 
 ```bash
 ./clients/apple/scripts/setup-local-ghosttykit.sh
+```
+
+To check whether the ignored local links are already present without changing
+the workspace, run:
+
+```bash
+./clients/apple/scripts/setup-local-ghosttykit.sh --check
 ```
 
 This follows the same boundary as `cmux`: Ghostty stays external, the script
@@ -73,6 +80,11 @@ Without that override, the macOS shell host resolves Alan in this order:
 4. installed `~/.alan/bin/alan`
 5. `alan` from the current `PATH`
 
+Each macOS window creates its own shell context with a distinct `window_id`,
+control directory, socket, state file, event log, and terminal runtime registry.
+Older fixed `shell-state-v0.1.json` files are not loaded for new windows; the
+current persisted state files are scoped as `shell-state-<window_id>.json`.
+
 ### Window Capture Helper
 
 For screenshot-driven UI iteration on the native macOS app, use:
@@ -105,8 +117,9 @@ for your terminal on first use.
   command-resolution inspection
 - External Ghostty artifact cache plus ignored local links and app-bundled
   resources/terminfo
-- Local file-backed shell control plane for `state`, `pane.focus`, and
-  `pane.send_text`
+- Window-scoped file/socket shell control plane with pane lifecycle events,
+  bounded socket requests, diagnostic surfacing, and truthful `pane.send_text`
+  delivery results
 
 ### Mobile (iOS)
 
@@ -138,6 +151,9 @@ xcodebuild \
   -project clients/apple/AlanNative.xcodeproj \
   -scheme AlanNative \
   -destination 'platform=macOS' build
+
+# Shell control-plane contract smoke
+bash clients/apple/scripts/check-shell-contracts.sh
 
 # iOS
 xcodebuild \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+require_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local message="$3"
+
+    if ! grep -Eq "$pattern" "$REPO_ROOT/$file"; then
+        printf 'error: %s\n' "$message" >&2
+        printf '       expected pattern %s in %s\n' "$pattern" "$file" >&2
+        exit 1
+    fi
+}
+
+reject_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local message="$3"
+
+    if grep -ERq "$pattern" "$REPO_ROOT/$file"; then
+        printf 'error: %s\n' "$message" >&2
+        printf '       rejected pattern %s in %s\n' "$pattern" "$file" >&2
+        exit 1
+    fi
+}
+
+"$SCRIPT_DIR/setup-local-ghosttykit.sh" --check >/dev/null
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "hostViewsByPaneID" \
+    "terminal runtimes must be owned by a pane-keyed registry"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "protocol TerminalRuntimeHandle" \
+    "terminal runtimes must expose a handle protocol"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "final class MockTerminalRuntimeHandle" \
+    "terminal runtime delivery must have a mock handle for contract tests"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "func sendText\\(to paneID: String, text: String\\)" \
+    "terminal text delivery must go through the runtime registry"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "terminalRuntimeRegistry\\.sendText\\(to: paneID, text: text\\)" \
+    "pane.send_text must use the registry delivery result"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "\\.id\\(pane\\.paneID\\)" \
+    "terminal host views must be keyed by stable pane identity"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "hasTornDownRuntime" \
+    "terminal teardown must be idempotent"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "struct ShellWindowContext" \
+    "shell host must expose a per-window context"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "ShellWindowContext\\.make\\(\\)" \
+    "each macOS shell window must create its own context"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellControlPlane.swift" \
+    "private static let maxRequestBytes" \
+    "socket server must enforce a bounded request size"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellControlPlane.swift" \
+    "command_timeout" \
+    "socket server must return a stable timeout error"
+
+reject_pattern \
+    "clients/apple/AlanNative" \
+    "NotificationCenter\\.default\\.post" \
+    "control-plane text delivery must not rely on NotificationCenter broadcast success"
+
+printf 'Shell contract checks passed.\n'

--- a/clients/apple/scripts/setup-local-ghosttykit.sh
+++ b/clients/apple/scripts/setup-local-ghosttykit.sh
@@ -173,6 +173,37 @@ ensure_terminfo() {
     printf 'warning: no Ghostty terminfo directory found; continuing without %s\n' "$OUTPUT_TERMINFO" >&2
 }
 
+check_artifacts() {
+    local missing=0
+    local path
+    for path in "$OUTPUT_XCFRAMEWORK" "$OUTPUT_RESOURCES" "$OUTPUT_TERMINFO"; do
+        if [ -d "$path" ]; then
+            printf 'ok: %s\n' "$path"
+        else
+            printf 'missing: %s\n' "$path" >&2
+            missing=1
+        fi
+    done
+
+    if [ "$missing" -ne 0 ]; then
+        printf '\nRun %s to prepare the local Ghostty artifacts.\n' "$0" >&2
+        exit 1
+    fi
+}
+
+case "${1:-}" in
+    --check)
+        check_artifacts
+        exit 0
+        ;;
+    "")
+        ;;
+    *)
+        printf 'usage: %s [--check]\n' "$0" >&2
+        exit 2
+        ;;
+esac
+
 prepare_cache_paths
 ensure_ghosttykit
 ensure_resources

--- a/openspec/changes/stabilize-macos-shell-terminal/tasks.md
+++ b/openspec/changes/stabilize-macos-shell-terminal/tasks.md
@@ -1,65 +1,65 @@
 ## 1. Terminal Runtime Ownership
 
-- [ ] 1.1 Add a pane-keyed terminal runtime handle protocol and registry that can be owned by the shell host/model layer.
-- [ ] 1.2 Add a mock terminal runtime implementation for tests, including attach, detach, send text, metadata update, and teardown observation.
-- [ ] 1.3 Move terminal process, renderer phase, cwd, title, attention, and last-command metadata updates onto stable pane IDs.
-- [ ] 1.4 Update tab and pane close paths to tear down registry-owned runtimes exactly once.
-- [ ] 1.5 Update `TerminalHostView` so view removal detaches from a runtime but does not tear down the pane process.
-- [ ] 1.6 Add lifecycle tests for switching tabs, returning to a tab, closing a pane, and closing a tab.
+- [x] 1.1 Add a pane-keyed terminal runtime handle protocol and registry that can be owned by the shell host/model layer.
+- [x] 1.2 Add a mock terminal runtime implementation for tests, including attach, detach, send text, metadata update, and teardown observation.
+- [x] 1.3 Move terminal process, renderer phase, cwd, title, attention, and last-command metadata updates onto stable pane IDs.
+- [x] 1.4 Update tab and pane close paths to tear down registry-owned runtimes exactly once.
+- [x] 1.5 Update `TerminalHostView` so view removal detaches from a runtime but does not tear down the pane process.
+- [x] 1.6 Add lifecycle tests for switching tabs, returning to a tab, closing a pane, and closing a tab.
 
 ## 2. Text Delivery And Mutation Acknowledgements
 
-- [ ] 2.1 Define stable control-plane result types/error codes for accepted, queued, rejected, missing target, unavailable runtime, and timeout outcomes.
-- [ ] 2.2 Route `pane.send_text` through the runtime registry instead of treating NotificationCenter delivery as success.
-- [ ] 2.3 Implement background-pane text delivery for existing runtimes without changing the selected tab.
-- [ ] 2.4 Implement the unavailable-runtime behavior chosen for this change: explicit rejection or a durable pane-specific queue with flush tests.
-- [ ] 2.5 Update control-plane responses and shell events to include accepted byte counts or stable rejection details.
-- [ ] 2.6 Add tests for visible delivery, background delivery, missing pane, closed pane, and unavailable runtime responses.
+- [x] 2.1 Define stable control-plane result types/error codes for accepted, queued, rejected, missing target, unavailable runtime, and timeout outcomes.
+- [x] 2.2 Route `pane.send_text` through the runtime registry instead of treating NotificationCenter delivery as success.
+- [x] 2.3 Implement background-pane text delivery for existing runtimes without changing the selected tab.
+- [x] 2.4 Implement the unavailable-runtime behavior chosen for this change: explicit rejection or a durable pane-specific queue with flush tests.
+- [x] 2.5 Update control-plane responses and shell events to include accepted byte counts or stable rejection details.
+- [x] 2.6 Add tests for visible delivery, background delivery, missing pane, closed pane, and unavailable runtime responses.
 
 ## 3. Window-Scoped Shell Context
 
-- [ ] 3.1 Introduce a per-window shell context containing `window_id`, control directory, socket path, state path, event path, and runtime registry.
-- [ ] 3.2 Replace fixed `window_main` state/socket/control paths with context-derived paths in the app scene and shell controller.
-- [ ] 3.3 Ensure a second `WindowGroup` instance creates or restores a distinct context and does not share shell state with the first window.
-- [ ] 3.4 Add best-effort migration or clear handling for legacy fixed-path shell state files.
-- [ ] 3.5 Add tests for opening two contexts, publishing independent state, and querying only one window's data.
+- [x] 3.1 Introduce a per-window shell context containing `window_id`, control directory, socket path, state path, event path, and runtime registry.
+- [x] 3.2 Replace fixed `window_main` state/socket/control paths with context-derived paths in the app scene and shell controller.
+- [x] 3.3 Ensure a second `WindowGroup` instance creates or restores a distinct context and does not share shell state with the first window.
+- [x] 3.4 Add best-effort migration or clear handling for legacy fixed-path shell state files.
+- [x] 3.5 Add tests for opening two contexts, publishing independent state, and querying only one window's data.
 
 ## 4. IPC, Persistence, And Diagnostics
 
-- [ ] 4.1 Add maximum request byte size enforcement to the local shell control socket.
-- [ ] 4.2 Add request read deadlines and command execution deadlines so stalled clients cannot block later clients.
-- [ ] 4.3 Refactor socket handling so one slow client or main-actor command does not stall the accept loop.
-- [ ] 4.4 Convert shell state, event, binding, and file-command IO operations to record or return failures.
-- [ ] 4.5 Add inspectable diagnostics for recent control-plane persistence, decode, timeout, and delivery failures.
-- [ ] 4.6 Add tests for no-newline clients, oversized requests, slow command handling, state write failure, and undecodable file commands.
+- [x] 4.1 Add maximum request byte size enforcement to the local shell control socket.
+- [x] 4.2 Add request read deadlines and command execution deadlines so stalled clients cannot block later clients.
+- [x] 4.3 Refactor socket handling so one slow client or main-actor command does not stall the accept loop.
+- [x] 4.4 Convert shell state, event, binding, and file-command IO operations to record or return failures.
+- [x] 4.5 Add inspectable diagnostics for recent control-plane persistence, decode, timeout, and delivery failures.
+- [x] 4.6 Add tests for no-newline clients, oversized requests, slow command handling, state write failure, and undecodable file commands.
 
 ## 5. macOS Shell UI Conformance
 
-- [ ] 5.1 Audit `MacShellRootView`, `TerminalPaneView`, and command UI against the impeccable/OpenSpec design acceptance layer before refactoring.
-- [ ] 5.2 Refactor the sidebar into a compact space rail plus active-space tab list.
-- [ ] 5.3 Separate space creation and tab creation affordances so each lives in its expected rail/list or toolbar context.
-- [ ] 5.4 Update space selection so the tab list filters to the active space and preserves terminal runtime identity.
-- [ ] 5.5 Make tab rows compact, stable, and skimmable, with row-level attention/status treatment instead of cards or repeated pills.
-- [ ] 5.6 Make the single-pane terminal region visually dominant without a pane selector strip or nested decorative panel.
-- [ ] 5.7 Keep split-pane chrome lightweight and use subtle focus treatment instead of engineering labels.
-- [ ] 5.8 Replace default raw identifiers and runtime jargon with product terms in normal workflows, including command search result titles and summaries.
-- [ ] 5.9 Move raw pane IDs, socket paths, runtime phases, binding data, and JSON snapshots behind an explicit Debug inspector layer.
-- [ ] 5.10 Restrain the toolbar to current context, `Go to or Command...`, frequent actions, and optional inspector toggle.
-- [ ] 5.11 Apply the light-mode native-material pass to the sidebar, toolbar, terminal surround, and inspector so the shell does not read as a hard-coded themed dashboard.
-- [ ] 5.12 Capture or record default, Overview inspector, and Debug inspector UI review evidence before marking UI conformance complete.
+- [x] 5.1 Audit `MacShellRootView`, `TerminalPaneView`, and command UI against the impeccable/OpenSpec design acceptance layer before refactoring.
+- [x] 5.2 Refactor the sidebar into a compact space rail plus active-space tab list.
+- [x] 5.3 Separate space creation and tab creation affordances so each lives in its expected rail/list or toolbar context.
+- [x] 5.4 Update space selection so the tab list filters to the active space and preserves terminal runtime identity.
+- [x] 5.5 Make tab rows compact, stable, and skimmable, with row-level attention/status treatment instead of cards or repeated pills.
+- [x] 5.6 Make the single-pane terminal region visually dominant without a pane selector strip or nested decorative panel.
+- [x] 5.7 Keep split-pane chrome lightweight and use subtle focus treatment instead of engineering labels.
+- [x] 5.8 Replace default raw identifiers and runtime jargon with product terms in normal workflows, including command search result titles and summaries.
+- [x] 5.9 Move raw pane IDs, socket paths, runtime phases, binding data, and JSON snapshots behind an explicit Debug inspector layer.
+- [x] 5.10 Restrain the toolbar to current context, `Go to or Command...`, frequent actions, and optional inspector toggle.
+- [x] 5.11 Apply the light-mode native-material pass to the sidebar, toolbar, terminal surround, and inspector so the shell does not read as a hard-coded themed dashboard.
+- [x] 5.12 Capture or record default, Overview inspector, and Debug inspector UI review evidence before marking UI conformance complete.
 
 ## 6. Build Contract And Dependency Setup
 
-- [ ] 6.1 Align Apple README and relevant specs with the Xcode project deployment targets.
-- [ ] 6.2 Add or document a supported Ghostty dependency preparation/check command for framework, resources, and terminfo artifacts.
-- [ ] 6.3 Make missing Ghostty artifacts fail with actionable setup guidance instead of opaque project or linker errors.
-- [ ] 6.4 Remove or suppress avoidable Ghostty module-map/umbrella-header warnings that obscure real build failures.
-- [ ] 6.5 Add a documented macOS build verification command for the prepared dependency state.
+- [x] 6.1 Align Apple README and relevant specs with the Xcode project deployment targets.
+- [x] 6.2 Add or document a supported Ghostty dependency preparation/check command for framework, resources, and terminfo artifacts.
+- [x] 6.3 Make missing Ghostty artifacts fail with actionable setup guidance instead of opaque project or linker errors.
+- [x] 6.4 Remove or suppress avoidable Ghostty module-map/umbrella-header warnings that obscure real build failures.
+- [x] 6.5 Add a documented macOS build verification command for the prepared dependency state.
 
 ## 7. Verification
 
-- [ ] 7.1 Run focused Apple tests for shell model mutation, runtime delivery, window isolation, and control-plane behavior.
-- [ ] 7.2 Run the documented macOS Xcode build command after preparing Ghostty dependencies.
-- [ ] 7.3 Run `openspec status --change stabilize-macos-shell-terminal` and confirm the change is implementation-complete.
-- [ ] 7.4 Update review notes or follow-up OpenSpec items for any intentionally deferred runtime queueing, migration, or UI debug-surface decisions.
-- [ ] 7.5 Confirm UI review evidence covers the default light-mode shell, Overview inspector, and Debug inspector states.
+- [x] 7.1 Run focused Apple tests for shell model mutation, runtime delivery, window isolation, and control-plane behavior.
+- [x] 7.2 Run the documented macOS Xcode build command after preparing Ghostty dependencies.
+- [x] 7.3 Run `openspec status --change stabilize-macos-shell-terminal` and confirm the change is implementation-complete.
+- [x] 7.4 Update review notes or follow-up OpenSpec items for any intentionally deferred runtime queueing, migration, or UI debug-surface decisions.
+- [x] 7.5 Confirm UI review evidence covers the default light-mode shell, Overview inspector, and Debug inspector states.


### PR DESCRIPTION
## Summary
- Stack on #329.
- Add a pane-keyed terminal runtime registry, stable terminal host identity, and idempotent runtime teardown.
- Route pane.send_text through runtime delivery results/events instead of NotificationCenter broadcast success.
- Add per-window shell context/persistence paths, bounded socket handling, diagnostics, Ghostty artifact checks, docs, and a shell contract smoke script.

## Tests
- ./clients/apple/scripts/setup-local-ghosttykit.sh --check
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate stabilize-macos-shell-terminal
- git diff --check
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -destination platform=macOS build