### PR TITLE
Centralize provider request controls

### DIFF
--- a/clients/tui/src/types.ts
+++ b/clients/tui/src/types.ts
@@ -327,6 +327,23 @@ export interface CreateSessionResponse {
   durability: SessionDurabilityInfo;
 }
 
+export interface ForkSessionResponse {
+  session_id: string;
+  forked_from_session_id: string;
+  websocket_url: string;
+  events_url: string;
+  submit_url: string;
+  agent_name?: string;
+  profile_id?: string;
+  provider?: ProviderId;
+  resolved_model: string;
+  reasoning_effort?: ReasoningEffort;
+  governance: GovernanceConfig;
+  streaming_mode: StreamingMode;
+  partial_stream_recovery_mode: PartialStreamRecoveryMode;
+  durability: SessionDurabilityInfo;
+}
+
 export interface ProviderDescriptor {
   provider_id: ProviderId;
   display_name: string;

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -1118,6 +1118,7 @@ pub async fn fork_session(
         source_workspace_id,
         source_agent_name,
         source_profile_id,
+        inherited_reasoning_effort,
         source_governance,
         source_streaming_mode,
         source_partial_stream_recovery_mode,
@@ -1131,6 +1132,7 @@ pub async fn fork_session(
             entry.workspace_id.clone(),
             entry.agent_name.clone(),
             entry.profile_id.clone(),
+            entry.reasoning_effort,
             entry.governance.clone(),
             entry.streaming_mode,
             entry.partial_stream_recovery_mode,
@@ -1157,6 +1159,10 @@ pub async fn fork_session(
     } = JsonLikeFork::from_payload(payload);
     let effective_agent_name = agent_name.or(source_agent_name);
     let effective_profile_id = profile_id.or(source_profile_id);
+    let selected_reasoning_effort = match reasoning_effort {
+        Some(effort) => Some(effort),
+        None => inherited_reasoning_effort,
+    };
     let effective_governance = governance.unwrap_or(source_governance);
     let effective_streaming_mode = streaming_mode.unwrap_or(source_streaming_mode);
     let effective_partial_stream_recovery_mode =
@@ -1182,7 +1188,7 @@ pub async fn fork_session(
             resume_rollout_path: Some(rollout_path),
             agent_name: effective_agent_name,
             profile_id: effective_profile_id,
-            reasoning_effort,
+            reasoning_effort: selected_reasoning_effort,
             governance: Some(effective_governance.clone()),
             streaming_mode: Some(effective_streaming_mode),
             partial_stream_recovery_mode: Some(effective_partial_stream_recovery_mode),
@@ -4405,7 +4411,7 @@ Body
     }
 
     #[tokio::test]
-    async fn fork_session_without_reasoning_override_uses_destination_default() {
+    async fn fork_session_without_reasoning_override_preserves_source_metadata() {
         let state = test_state();
         let temp = tempfile::TempDir::new().unwrap();
         let (mut entry, _submission_rx) = session_entry(temp.path());
@@ -4444,7 +4450,7 @@ Body
 
         assert_eq!(
             resp.reasoning_effort,
-            Some(alan_protocol::ReasoningEffort::Medium)
+            Some(alan_protocol::ReasoningEffort::High)
         );
     }
 

--- a/crates/alan/src/daemon/runtime_manager.rs
+++ b/crates/alan/src/daemon/runtime_manager.rs
@@ -34,6 +34,14 @@ struct RuntimeEntry {
     controller: RuntimeController,
     /// Startup metadata describing durability/warnings for this runtime.
     startup: RuntimeStartupMetadata,
+    /// Resolved connection profile id reported at startup.
+    resolved_profile_id: Option<String>,
+    /// Resolved provider reported at startup.
+    resolved_provider: Option<alan_runtime::LlmProvider>,
+    /// Resolved model reported at startup.
+    resolved_model: String,
+    /// Resolved reasoning effort reported at startup.
+    effective_reasoning_effort: Option<alan_protocol::ReasoningEffort>,
     /// Creation timestamp
     #[allow(dead_code)]
     created_at: Instant,
@@ -155,21 +163,10 @@ impl RuntimeManager {
                 return Ok(RuntimeStartResult {
                     handle: entry.controller.handle.clone(),
                     startup: entry.startup.clone(),
-                    resolved_profile_id: None,
-                    resolved_provider: None,
-                    resolved_model: self
-                        .config
-                        .runtime_config_template
-                        .agent_config
-                        .core_config
-                        .effective_model()
-                        .to_string(),
-                    effective_reasoning_effort: self
-                        .config
-                        .runtime_config_template
-                        .agent_config
-                        .core_config
-                        .effective_model_reasoning_effort(),
+                    resolved_profile_id: entry.resolved_profile_id.clone(),
+                    resolved_provider: entry.resolved_provider,
+                    resolved_model: entry.resolved_model.clone(),
+                    effective_reasoning_effort: entry.effective_reasoning_effort,
                 });
             }
         }
@@ -251,7 +248,6 @@ impl RuntimeManager {
         let resolved_core_config =
             alan_runtime::runtime::effective_core_config_for_runtime(&runtime_config)?;
         let resolved_model = resolved_core_config.effective_model().to_string();
-        let effective_reasoning_effort = resolved_core_config.effective_model_reasoning_effort();
         let resolved_connection = if let Some(home_paths) = runtime_config
             .agent_home_paths
             .clone()
@@ -286,14 +282,26 @@ impl RuntimeManager {
         };
 
         let handle = controller.handle.clone();
+        let effective_reasoning_effort = startup.request_controls.reasoning_effort();
 
         // Store runtime entry.
+        let resolved_profile_id = resolved_connection
+            .as_ref()
+            .map(|resolved| resolved.profile_id.clone());
+        let resolved_provider = resolved_connection
+            .as_ref()
+            .map(|resolved| resolved.provider);
+
         let entry = RuntimeEntry {
             session_id: session_id.clone(),
             workspace_root_path,
             workspace_alan_dir,
             controller,
             startup: startup.clone(),
+            resolved_profile_id: resolved_profile_id.clone(),
+            resolved_provider,
+            resolved_model: resolved_model.clone(),
+            effective_reasoning_effort,
             created_at: Instant::now(),
             last_activity: Instant::now(),
         };
@@ -305,12 +313,8 @@ impl RuntimeManager {
         Ok(RuntimeStartResult {
             handle,
             startup,
-            resolved_profile_id: resolved_connection
-                .as_ref()
-                .map(|resolved| resolved.profile_id.clone()),
-            resolved_provider: resolved_connection
-                .as_ref()
-                .map(|resolved| resolved.provider),
+            resolved_profile_id,
+            resolved_provider,
             resolved_model,
             effective_reasoning_effort,
         })

--- a/crates/alan/src/daemon/state.rs
+++ b/crates/alan/src/daemon/state.rs
@@ -1741,6 +1741,7 @@ impl AppState {
                                 alan_runtime::tools::Sandbox::backend_name_static().to_string()
                             })
                     },
+                    request_controls: alan_runtime::ResolvedRequestControls::default(),
                     warnings: Vec::new(),
                 },
                 resolved_profile_id: None,

--- a/crates/alan/tests/daemon_payload_contract_test.rs
+++ b/crates/alan/tests/daemon_payload_contract_test.rs
@@ -5,8 +5,8 @@ use alan::daemon::connection_routes::{
     ConnectionCatalogResponse, ConnectionListResponse, ProviderDescriptorView,
 };
 use alan::daemon::routes::{
-    ChildRunListResponse, ChildRunResponse, CreateSessionResponse, SessionDurabilityInfo,
-    SessionListItem, SessionListResponse, SessionReadResponse,
+    ChildRunListResponse, ChildRunResponse, CreateSessionResponse, ForkSessionResponse,
+    SessionDurabilityInfo, SessionListItem, SessionListResponse, SessionReadResponse,
 };
 use alan_protocol::GovernanceConfig;
 use alan_runtime::runtime::ChildRunRecord;
@@ -22,6 +22,11 @@ fn tui_types_cover_selected_daemon_payload_fields() {
         &types_source,
         "CreateSessionResponse",
         &sample_create_session_response(),
+    );
+    assert_interface_covers_value(
+        &types_source,
+        "ForkSessionResponse",
+        &sample_fork_session_response(),
     );
     assert_interface_covers_value(
         &types_source,
@@ -128,6 +133,25 @@ fn sample_create_session_response() -> CreateSessionResponse {
         provider: Some(LlmProvider::Chatgpt),
         resolved_model: "gpt-5.3-codex".to_string(),
         reasoning_effort: Some(alan_protocol::ReasoningEffort::Medium),
+        durability: sample_durability(),
+    }
+}
+
+fn sample_fork_session_response() -> ForkSessionResponse {
+    ForkSessionResponse {
+        session_id: "sess-fork".to_string(),
+        forked_from_session_id: "sess-1".to_string(),
+        websocket_url: "/api/v1/sessions/sess-fork/ws".to_string(),
+        events_url: "/api/v1/sessions/sess-fork/events".to_string(),
+        submit_url: "/api/v1/sessions/sess-fork/submit".to_string(),
+        agent_name: Some("default".to_string()),
+        governance: GovernanceConfig::default(),
+        streaming_mode: StreamingMode::Auto,
+        partial_stream_recovery_mode: PartialStreamRecoveryMode::ContinueOnce,
+        profile_id: Some("chatgpt-main".to_string()),
+        provider: Some(LlmProvider::Chatgpt),
+        resolved_model: "gpt-5.3-codex".to_string(),
+        reasoning_effort: Some(alan_protocol::ReasoningEffort::Low),
         durability: sample_durability(),
     }
 }

--- a/crates/llm/src/anthropic_messages.rs
+++ b/crates/llm/src/anthropic_messages.rs
@@ -936,7 +936,7 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
+            thinking_budget_tokens: _,
             reasoning,
             mut extra_params,
         } = request;
@@ -955,7 +955,7 @@ impl LlmProvider for AnthropicMessagesClient {
 
         let (thinking, temperature, max_tokens) = build_thinking_params(
             reasoning.effort,
-            &reasoning.budget_tokens.or(thinking_budget_tokens),
+            &reasoning.budget_tokens,
             temperature,
             max_tokens.unwrap_or(4096),
         )?;
@@ -991,7 +991,7 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
+            thinking_budget_tokens: _,
             reasoning,
             mut extra_params,
         } = request;
@@ -1010,7 +1010,7 @@ impl LlmProvider for AnthropicMessagesClient {
 
         let (thinking, temperature, max_tokens) = build_thinking_params(
             reasoning.effort,
-            &reasoning.budget_tokens.or(thinking_budget_tokens),
+            &reasoning.budget_tokens,
             temperature,
             max_tokens.unwrap_or(4096),
         )?;

--- a/crates/llm/src/anthropic_messages.rs
+++ b/crates/llm/src/anthropic_messages.rs
@@ -936,10 +936,12 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens: _,
+            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
+        let thinking_budget_tokens =
+            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let messages =
             take_anthropic_messages_extra_param("anthropic_messages", &mut extra_params)?
@@ -955,7 +957,7 @@ impl LlmProvider for AnthropicMessagesClient {
 
         let (thinking, temperature, max_tokens) = build_thinking_params(
             reasoning.effort,
-            &reasoning.budget_tokens,
+            &thinking_budget_tokens,
             temperature,
             max_tokens.unwrap_or(4096),
         )?;
@@ -991,10 +993,12 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens: _,
+            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
+        let thinking_budget_tokens =
+            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let messages =
             take_anthropic_messages_extra_param("anthropic_messages", &mut extra_params)?
@@ -1010,7 +1014,7 @@ impl LlmProvider for AnthropicMessagesClient {
 
         let (thinking, temperature, max_tokens) = build_thinking_params(
             reasoning.effort,
-            &reasoning.budget_tokens,
+            &thinking_budget_tokens,
             temperature,
             max_tokens.unwrap_or(4096),
         )?;

--- a/crates/llm/src/google_gemini_generate_content.rs
+++ b/crates/llm/src/google_gemini_generate_content.rs
@@ -697,7 +697,10 @@ impl LlmProvider for GoogleGeminiGenerateContentClient {
         let thinking_config = build_gemini_thinking_config(
             &self.model,
             request.reasoning.effort,
-            request.reasoning.budget_tokens,
+            crate::effective_thinking_budget_tokens(
+                request.reasoning,
+                request.thinking_budget_tokens,
+            ),
         )?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request
@@ -862,7 +865,10 @@ impl LlmProvider for GoogleGeminiGenerateContentClient {
         let thinking_config = build_gemini_thinking_config(
             &self.model,
             request.reasoning.effort,
-            request.reasoning.budget_tokens,
+            crate::effective_thinking_budget_tokens(
+                request.reasoning,
+                request.thinking_budget_tokens,
+            ),
         )?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request

--- a/crates/llm/src/google_gemini_generate_content.rs
+++ b/crates/llm/src/google_gemini_generate_content.rs
@@ -697,10 +697,7 @@ impl LlmProvider for GoogleGeminiGenerateContentClient {
         let thinking_config = build_gemini_thinking_config(
             &self.model,
             request.reasoning.effort,
-            request
-                .reasoning
-                .budget_tokens
-                .or(request.thinking_budget_tokens),
+            request.reasoning.budget_tokens,
         )?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request
@@ -865,10 +862,7 @@ impl LlmProvider for GoogleGeminiGenerateContentClient {
         let thinking_config = build_gemini_thinking_config(
             &self.model,
             request.reasoning.effort,
-            request
-                .reasoning
-                .budget_tokens
-                .or(request.thinking_budget_tokens),
+            request.reasoning.budget_tokens,
         )?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -401,6 +401,13 @@ impl GenerationRequest {
     }
 }
 
+pub(crate) fn effective_thinking_budget_tokens(
+    reasoning: ReasoningControls,
+    thinking_budget_tokens: Option<u32>,
+) -> Option<u32> {
+    reasoning.budget_tokens.or(thinking_budget_tokens)
+}
+
 impl Default for GenerationRequest {
     fn default() -> Self {
         Self::new()
@@ -1384,6 +1391,22 @@ mod tests {
 
         assert_eq!(budgeted.reasoning.budget_tokens, Some(512));
         assert_eq!(budgeted.thinking_budget_tokens, Some(512));
+    }
+
+    #[test]
+    fn test_effective_thinking_budget_tokens_preserves_legacy_field() {
+        let mut request = GenerationRequest::new();
+        request.thinking_budget_tokens = Some(2048);
+        assert_eq!(
+            effective_thinking_budget_tokens(request.reasoning, request.thinking_budget_tokens),
+            Some(2048)
+        );
+
+        request.reasoning.budget_tokens = Some(512);
+        assert_eq!(
+            effective_thinking_budget_tokens(request.reasoning, request.thinking_budget_tokens),
+            Some(512)
+        );
     }
 
     #[test]

--- a/crates/llm/src/openai_chat_completions.rs
+++ b/crates/llm/src/openai_chat_completions.rs
@@ -1479,10 +1479,12 @@ pub(crate) fn build_responses_request_for_model(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens: _,
+        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
+    let thinking_budget_tokens =
+        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let previous_response_id = take_string_extra_param("previous_response_id", &mut extra_params);
     let background = take_bool_extra_param("background", &mut extra_params);
@@ -1493,7 +1495,7 @@ pub(crate) fn build_responses_request_for_model(
 
     let reasoning = build_openai_responses_reasoning(
         reasoning.effort,
-        reasoning.budget_tokens,
+        thinking_budget_tokens,
         &mut extra_params,
     );
     let include = normalize_responses_include(
@@ -1533,14 +1535,16 @@ pub(crate) fn build_responses_input_tokens_request_for_model(
         tools,
         temperature: _,
         max_tokens: _,
-        thinking_budget_tokens: _,
+        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
+    let thinking_budget_tokens =
+        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let reasoning = build_openai_responses_reasoning(
         reasoning.effort,
-        reasoning.budget_tokens,
+        thinking_budget_tokens,
         &mut extra_params,
     );
     let (response_tools, tool_choice) = convert_tools_for_openai_responses(tools);
@@ -1662,10 +1666,12 @@ fn build_chat_completions_request_for_model(
         tools: request_tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens: _,
+        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
+    let thinking_budget_tokens =
+        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let mut messages: Vec<serde_json::Value> = Vec::new();
     if let Some(system) = system_prompt {
@@ -1685,7 +1691,7 @@ fn build_chat_completions_request_for_model(
 
     let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
     let reasoning_effort =
-        build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
+        build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
     let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
     OpenAiChatCompletionsRequest {
@@ -2329,10 +2335,12 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens: _,
+            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
+        let thinking_budget_tokens =
+            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if let Some(system) = system_prompt {
@@ -2355,7 +2363,7 @@ impl OpenAiChatCompletionsClient {
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
         let reasoning_effort =
-            build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
+            build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -2385,10 +2393,12 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens: _,
+            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
+        let thinking_budget_tokens =
+            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if let Some(system) = system_prompt {
@@ -2411,7 +2421,7 @@ impl OpenAiChatCompletionsClient {
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
         let reasoning_effort =
-            build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
+            build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -3147,6 +3157,29 @@ mod tests {
 
         assert_eq!(built.reasoning_effort.as_deref(), Some("low"));
         assert!(!built.extra_params.contains_key("reasoning_effort"));
+    }
+
+    #[test]
+    fn test_build_responses_request_preserves_legacy_thinking_budget_field() {
+        let mut request = GenerationRequest::new().with_user_message("Hello");
+        request.thinking_budget_tokens = Some(512);
+
+        let built = build_responses_request_for_model("gpt-5.4".to_string(), request, false);
+
+        assert_eq!(
+            built.reasoning.map(|reasoning| reasoning.effort),
+            Some("low".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_chat_completions_request_preserves_legacy_thinking_budget_field() {
+        let mut request = GenerationRequest::new().with_user_message("Hello");
+        request.thinking_budget_tokens = Some(512);
+
+        let built = build_chat_completions_request_for_model("gpt-5.4".to_string(), request);
+
+        assert_eq!(built.reasoning_effort.as_deref(), Some("low"));
     }
 
     #[test]

--- a/crates/llm/src/openai_chat_completions.rs
+++ b/crates/llm/src/openai_chat_completions.rs
@@ -1479,7 +1479,7 @@ pub(crate) fn build_responses_request_for_model(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
+        thinking_budget_tokens: _,
         reasoning,
         mut extra_params,
     } = request;
@@ -1493,7 +1493,7 @@ pub(crate) fn build_responses_request_for_model(
 
     let reasoning = build_openai_responses_reasoning(
         reasoning.effort,
-        reasoning.budget_tokens.or(thinking_budget_tokens),
+        reasoning.budget_tokens,
         &mut extra_params,
     );
     let include = normalize_responses_include(
@@ -1533,14 +1533,14 @@ pub(crate) fn build_responses_input_tokens_request_for_model(
         tools,
         temperature: _,
         max_tokens: _,
-        thinking_budget_tokens,
+        thinking_budget_tokens: _,
         reasoning,
         mut extra_params,
     } = request;
 
     let reasoning = build_openai_responses_reasoning(
         reasoning.effort,
-        reasoning.budget_tokens.or(thinking_budget_tokens),
+        reasoning.budget_tokens,
         &mut extra_params,
     );
     let (response_tools, tool_choice) = convert_tools_for_openai_responses(tools);
@@ -1662,7 +1662,7 @@ fn build_chat_completions_request_for_model(
         tools: request_tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
+        thinking_budget_tokens: _,
         reasoning,
         mut extra_params,
     } = request;
@@ -1684,11 +1684,8 @@ fn build_chat_completions_request_for_model(
     );
 
     let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-    let reasoning_effort = build_reasoning_effort(
-        reasoning.effort,
-        reasoning.budget_tokens.or(thinking_budget_tokens),
-        &mut extra_params,
-    );
+    let reasoning_effort =
+        build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
     let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
     OpenAiChatCompletionsRequest {
@@ -2192,6 +2189,11 @@ pub(crate) fn build_reasoning_effort(
         return Some(effort.as_str().to_string());
     }
 
+    if let Some(tokens) = thinking_budget_tokens {
+        extra_params.remove("reasoning_effort");
+        return Some(map_thinking_budget_to_effort(tokens).to_string());
+    }
+
     if let Some(value) = extra_params.remove("reasoning_effort") {
         if let Some(effort) = value.as_str() {
             if is_valid_reasoning_effort(effort) {
@@ -2209,9 +2211,7 @@ pub(crate) fn build_reasoning_effort(
         }
     }
 
-    thinking_budget_tokens
-        .map(map_thinking_budget_to_effort)
-        .map(str::to_string)
+    None
 }
 
 pub(crate) fn build_max_completion_tokens(
@@ -2329,7 +2329,7 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
+            thinking_budget_tokens: _,
             reasoning,
             mut extra_params,
         } = request;
@@ -2354,11 +2354,8 @@ impl OpenAiChatCompletionsClient {
         );
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-        let reasoning_effort = build_reasoning_effort(
-            reasoning.effort,
-            reasoning.budget_tokens.or(thinking_budget_tokens),
-            &mut extra_params,
-        );
+        let reasoning_effort =
+            build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -2388,7 +2385,7 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
+            thinking_budget_tokens: _,
             reasoning,
             mut extra_params,
         } = request;
@@ -2413,11 +2410,8 @@ impl OpenAiChatCompletionsClient {
         );
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-        let reasoning_effort = build_reasoning_effort(
-            reasoning.effort,
-            reasoning.budget_tokens.or(thinking_budget_tokens),
-            &mut extra_params,
-        );
+        let reasoning_effort =
+            build_reasoning_effort(reasoning.effort, reasoning.budget_tokens, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -3071,7 +3065,7 @@ mod tests {
             serde_json::Value::String("high".to_string()),
         )]);
 
-        let effort = build_reasoning_effort(None, Some(256), &mut extra_params);
+        let effort = build_reasoning_effort(None, None, &mut extra_params);
         assert_eq!(effort.as_deref(), Some("high"));
         assert!(!extra_params.contains_key("reasoning_effort"));
     }
@@ -3103,12 +3097,25 @@ mod tests {
     }
 
     #[test]
+    fn test_build_reasoning_effort_prefers_canonical_budget_over_extra_params() {
+        let mut extra_params = HashMap::from([(
+            "reasoning_effort".to_string(),
+            serde_json::Value::String("high".to_string()),
+        )]);
+
+        let effort = build_reasoning_effort(None, Some(512), &mut extra_params);
+
+        assert_eq!(effort.as_deref(), Some("low"));
+        assert!(!extra_params.contains_key("reasoning_effort"));
+    }
+
+    #[test]
     fn test_build_reasoning_effort_accepts_extended_values() {
         let mut extra_params = HashMap::from([(
             "reasoning_effort".to_string(),
             serde_json::Value::String("xhigh".to_string()),
         )]);
-        let effort = build_reasoning_effort(None, Some(256), &mut extra_params);
+        let effort = build_reasoning_effort(None, None, &mut extra_params);
         assert_eq!(effort.as_deref(), Some("xhigh"));
         assert!(!extra_params.contains_key("reasoning_effort"));
     }

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -188,7 +188,7 @@ pub(crate) fn build_openrouter_chat_request(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
+        thinking_budget_tokens: _,
         reasoning,
         mut extra_params,
     } = request;
@@ -211,8 +211,8 @@ pub(crate) fn build_openrouter_chat_request(
     if let Some(effort) = reasoning.effort {
         extra_params.remove("reasoning_effort");
         builder.reasoning_effort(openrouter_effort(effort));
-    } else if let Some(thinking_budget_tokens) = reasoning.budget_tokens.or(thinking_budget_tokens)
-    {
+    } else if let Some(thinking_budget_tokens) = reasoning.budget_tokens {
+        extra_params.remove("reasoning_effort");
         builder.reasoning(ReasoningConfig::with_max_tokens(thinking_budget_tokens));
     }
 
@@ -1035,6 +1035,20 @@ mod tests {
         assert_eq!(value["provider"]["allow_fallbacks"], false);
         assert_eq!(value["transforms"][0], "middle-out");
         assert_eq!(value["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn canonical_budget_overrides_reasoning_effort_extra_parameter() {
+        let request = GenerationRequest::new()
+            .with_user_message("hello")
+            .with_thinking_budget_tokens(512)
+            .with_extra_param("reasoning_effort", json!("high"));
+
+        let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
+        let value = serde_json::to_value(projected).unwrap();
+
+        assert_eq!(value["reasoning"]["max_tokens"], 512);
+        assert!(value["reasoning"].get("effort").is_none());
     }
 
     #[test]

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -188,10 +188,12 @@ pub(crate) fn build_openrouter_chat_request(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens: _,
+        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
+    let thinking_budget_tokens =
+        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let mut projected_messages = Vec::new();
     if let Some(system_prompt) = system_prompt.filter(|value| !value.is_empty()) {
@@ -211,7 +213,7 @@ pub(crate) fn build_openrouter_chat_request(
     if let Some(effort) = reasoning.effort {
         extra_params.remove("reasoning_effort");
         builder.reasoning_effort(openrouter_effort(effort));
-    } else if let Some(thinking_budget_tokens) = reasoning.budget_tokens {
+    } else if let Some(thinking_budget_tokens) = thinking_budget_tokens {
         extra_params.remove("reasoning_effort");
         builder.reasoning(ReasoningConfig::with_max_tokens(thinking_budget_tokens));
     }
@@ -1049,6 +1051,17 @@ mod tests {
 
         assert_eq!(value["reasoning"]["max_tokens"], 512);
         assert!(value["reasoning"].get("effort").is_none());
+    }
+
+    #[test]
+    fn legacy_budget_field_projects_reasoning_budget() {
+        let mut request = GenerationRequest::new().with_user_message("hello");
+        request.thinking_budget_tokens = Some(512);
+
+        let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
+        let value = serde_json::to_value(projected).unwrap();
+
+        assert_eq!(value["reasoning"]["max_tokens"], 512);
     }
 
     #[test]

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -1057,49 +1057,6 @@ impl Config {
             .unwrap_or_else(|| inferred_context_window_tokens(self.llm_provider))
     }
 
-    pub fn effective_model_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        if self.model_reasoning_effort.is_some() {
-            return self.model_reasoning_effort;
-        }
-
-        if self.thinking_budget_tokens.is_some() {
-            return None;
-        }
-
-        self.effective_model_info()
-            .and_then(|model_info| model_info.default_reasoning_effort)
-    }
-
-    pub fn validate_reasoning_effort_for_resolved_model(
-        &self,
-        effort: ReasoningEffort,
-    ) -> anyhow::Result<()> {
-        let Some(model_info) = self.effective_model_info() else {
-            return Ok(());
-        };
-
-        if model_info.supported_reasoning_efforts.contains(&effort) {
-            return Ok(());
-        }
-
-        let supported = if model_info.supported_reasoning_efforts.is_empty() {
-            "none declared".to_string()
-        } else {
-            model_info
-                .supported_reasoning_efforts
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        anyhow::bail!(
-            "model `{}` does not support reasoning effort `{}`; supported efforts: {}",
-            model_info.slug,
-            effort,
-            supported
-        );
-    }
-
     pub fn effective_compaction_hard_trigger_ratio(&self) -> f32 {
         self.compaction_hard_trigger_ratio
             .or(self.compaction_trigger_ratio)
@@ -1855,20 +1812,30 @@ thinking_budget_tokens = 2048
     }
 
     #[test]
-    fn test_effective_model_reasoning_effort_uses_model_default_without_budget() {
+    fn test_request_control_resolver_uses_model_default_without_budget() {
         let config = Config::for_openai_responses("sk-test", None, Some("gpt-5.4"));
-        assert_eq!(
-            config.effective_model_reasoning_effort(),
-            Some(ReasoningEffort::Medium)
-        );
+        let resolved = crate::resolve_session_request_controls(
+            &config,
+            crate::provider_capabilities_for_config(&config),
+            crate::RequestControlIntent::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.reasoning_effort(), Some(ReasoningEffort::Medium));
     }
 
     #[test]
-    fn test_effective_model_reasoning_effort_preserves_legacy_budget_behavior() {
+    fn test_request_control_resolver_preserves_legacy_budget_behavior() {
         let mut config = Config::for_openai_responses("sk-test", None, Some("gpt-5.4"));
         config.thinking_budget_tokens = Some(2048);
 
-        assert_eq!(config.effective_model_reasoning_effort(), None);
+        let resolved = crate::resolve_session_request_controls(
+            &config,
+            crate::provider_capabilities_for_config(&config),
+            crate::RequestControlIntent::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.reasoning_effort(), None);
+        assert_eq!(resolved.budget_tokens(), Some(2048));
     }
 
     #[test]
@@ -2516,7 +2483,13 @@ supports_reasoning = true
         let overlaid = config.with_agent_root_overlays(&[overlay_path]).unwrap();
 
         assert_eq!(
-            overlaid.effective_model_reasoning_effort(),
+            crate::resolve_session_request_controls(
+                &overlaid,
+                crate::provider_capabilities_for_config(&overlaid),
+                crate::RequestControlIntent::default(),
+            )
+            .unwrap()
+            .reasoning_effort(),
             Some(ReasoningEffort::High)
         );
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,6 +19,7 @@ mod llm;
 mod models;
 mod paths;
 mod policy;
+mod request_controls;
 mod retry;
 mod rollout;
 mod session;
@@ -59,6 +60,11 @@ pub use models::{ModelCatalog, ModelInfo};
 pub use paths::AlanHomePaths;
 pub use policy::{PolicyAction, PolicyDecision, PolicyEngine, PolicyProfile, PolicyRule};
 pub use prompts::PromptLoader;
+pub use request_controls::{
+    RequestControlDiagnostic, RequestControlIntent, RequestControlResolutionInput,
+    RequestControlSource, ResolvedRequestControls, provider_capabilities_for_config,
+    resolve_request_controls, resolve_session_request_controls, resolve_turn_request_controls,
+};
 pub use rollout::{
     CheckpointRecord, EventRecord, MessageRecord, RolloutItem, RolloutRecorder, SessionMeta,
     ToolCallRecord, session_storage_key,

--- a/crates/runtime/src/models.rs
+++ b/crates/runtime/src/models.rs
@@ -156,7 +156,7 @@ impl ModelCatalog {
             .collect()
     }
 
-    fn load_with_overlay_paths(
+    pub(crate) fn load_with_overlay_paths(
         global_overlay: Option<&Path>,
         workspace_overlay: Option<&Path>,
     ) -> anyhow::Result<Self> {

--- a/crates/runtime/src/request_controls.rs
+++ b/crates/runtime/src/request_controls.rs
@@ -1,0 +1,465 @@
+//! Runtime-owned provider request-control resolution.
+//!
+//! This module owns Alan-level precedence and validation for model request
+//! controls. Provider adapters remain responsible for wire projection only.
+
+use crate::config::{Config, LlmProvider};
+use crate::llm::{ProviderCapabilities, factory::ProviderType};
+use alan_protocol::{ReasoningControls, ReasoningEffort};
+use serde::{Deserialize, Serialize};
+
+/// Raw request-control intent from config, session launch, or a single turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RequestControlIntent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_budget_tokens: Option<u32>,
+}
+
+impl RequestControlIntent {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            reasoning_effort: config.model_reasoning_effort,
+            thinking_budget_tokens: config.thinking_budget_tokens,
+        }
+    }
+
+    pub fn reasoning_effort(reasoning_effort: Option<ReasoningEffort>) -> Self {
+        Self {
+            reasoning_effort,
+            thinking_budget_tokens: None,
+        }
+    }
+
+    pub fn thinking_budget_tokens(thinking_budget_tokens: Option<u32>) -> Self {
+        Self {
+            reasoning_effort: None,
+            thinking_budget_tokens,
+        }
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.reasoning_effort.is_none() && self.thinking_budget_tokens.is_none()
+    }
+
+    pub fn apply_to_config(self, config: &mut Config) {
+        config.model_reasoning_effort = self.reasoning_effort;
+        config.thinking_budget_tokens = self.thinking_budget_tokens;
+    }
+}
+
+/// Source of the resolved request controls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestControlSource {
+    TurnOverride,
+    SessionOverride,
+    AgentConfig,
+    LegacyBudget,
+    ModelDefault,
+    ProviderDefault,
+}
+
+/// Diagnostic produced during request-control resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestControlDiagnostic {
+    pub message: String,
+}
+
+/// Normalized request controls plus their source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedRequestControls {
+    pub reasoning: ReasoningControls,
+    pub source: RequestControlSource,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<RequestControlDiagnostic>,
+}
+
+impl Default for ResolvedRequestControls {
+    fn default() -> Self {
+        Self {
+            reasoning: ReasoningControls::default(),
+            source: RequestControlSource::ProviderDefault,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+impl ResolvedRequestControls {
+    pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.reasoning.effort
+    }
+
+    pub fn budget_tokens(&self) -> Option<u32> {
+        self.reasoning.budget_tokens
+    }
+}
+
+/// Inputs for resolving request controls.
+#[derive(Debug, Clone, Copy)]
+pub struct RequestControlResolutionInput<'a> {
+    pub config: &'a Config,
+    pub provider_capabilities: ProviderCapabilities,
+    pub session_intent: RequestControlIntent,
+    pub turn_intent: RequestControlIntent,
+}
+
+/// Resolve session-scoped request controls.
+pub fn resolve_session_request_controls(
+    config: &Config,
+    provider_capabilities: ProviderCapabilities,
+    session_intent: RequestControlIntent,
+) -> anyhow::Result<ResolvedRequestControls> {
+    resolve_request_controls(RequestControlResolutionInput {
+        config,
+        provider_capabilities,
+        session_intent,
+        turn_intent: RequestControlIntent::default(),
+    })
+}
+
+/// Resolve request controls for a single turn.
+pub fn resolve_turn_request_controls(
+    config: &Config,
+    provider_capabilities: ProviderCapabilities,
+    session_intent: RequestControlIntent,
+    turn_intent: RequestControlIntent,
+) -> anyhow::Result<ResolvedRequestControls> {
+    resolve_request_controls(RequestControlResolutionInput {
+        config,
+        provider_capabilities,
+        session_intent,
+        turn_intent,
+    })
+}
+
+/// Resolve effective request controls from turn/session/config/model/provider inputs.
+pub fn resolve_request_controls(
+    input: RequestControlResolutionInput<'_>,
+) -> anyhow::Result<ResolvedRequestControls> {
+    if let Some(effort) = input.turn_intent.reasoning_effort {
+        validate_reasoning_effort(input.config, input.provider_capabilities, effort)?;
+        return Ok(effort_controls(effort, RequestControlSource::TurnOverride));
+    }
+
+    if let Some(effort) = input.session_intent.reasoning_effort {
+        validate_reasoning_effort(input.config, input.provider_capabilities, effort)?;
+        return Ok(effort_controls(
+            effort,
+            RequestControlSource::SessionOverride,
+        ));
+    }
+
+    let config_intent = RequestControlIntent::from_config(input.config);
+    if let Some(effort) = config_intent.reasoning_effort {
+        validate_reasoning_effort(input.config, input.provider_capabilities, effort)?;
+        return Ok(effort_controls(effort, RequestControlSource::AgentConfig));
+    }
+
+    if let Some(tokens) = input.turn_intent.thinking_budget_tokens {
+        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
+    }
+
+    if let Some(tokens) = input.session_intent.thinking_budget_tokens {
+        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
+    }
+
+    if let Some(tokens) = config_intent.thinking_budget_tokens {
+        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
+    }
+
+    if let Some(effort) = input
+        .config
+        .effective_model_info()
+        .and_then(|model_info| model_info.default_reasoning_effort)
+    {
+        validate_reasoning_effort(input.config, input.provider_capabilities, effort)?;
+        return Ok(effort_controls(effort, RequestControlSource::ModelDefault));
+    }
+
+    Ok(ResolvedRequestControls::default())
+}
+
+/// Return the static capability matrix for the provider selected by config.
+pub fn provider_capabilities_for_config(config: &Config) -> ProviderCapabilities {
+    provider_type_for_llm_provider(config.llm_provider).capabilities()
+}
+
+fn effort_controls(
+    effort: ReasoningEffort,
+    source: RequestControlSource,
+) -> ResolvedRequestControls {
+    ResolvedRequestControls {
+        reasoning: ReasoningControls {
+            effort: Some(effort),
+            budget_tokens: None,
+        },
+        source,
+        diagnostics: Vec::new(),
+    }
+}
+
+fn budget_controls(tokens: u32, source: RequestControlSource) -> ResolvedRequestControls {
+    ResolvedRequestControls {
+        reasoning: ReasoningControls {
+            effort: None,
+            budget_tokens: Some(tokens),
+        },
+        source,
+        diagnostics: Vec::new(),
+    }
+}
+
+fn validate_reasoning_effort(
+    config: &Config,
+    provider_capabilities: ProviderCapabilities,
+    effort: ReasoningEffort,
+) -> anyhow::Result<()> {
+    if !provider_capabilities.supports_reasoning_effort_control {
+        anyhow::bail!(
+            "provider `{}` does not support reasoning effort controls",
+            config.llm_provider.as_str()
+        );
+    }
+
+    let Some(model_info) = config.effective_model_info() else {
+        return Ok(());
+    };
+
+    if model_info.supported_reasoning_efforts.contains(&effort) {
+        return Ok(());
+    }
+
+    let supported = if model_info.supported_reasoning_efforts.is_empty() {
+        "none declared".to_string()
+    } else {
+        model_info
+            .supported_reasoning_efforts
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    anyhow::bail!(
+        "model `{}` does not support reasoning effort `{}`; supported efforts: {}",
+        model_info.slug,
+        effort,
+        supported
+    );
+}
+
+fn provider_type_for_llm_provider(provider: LlmProvider) -> ProviderType {
+    match provider {
+        LlmProvider::GoogleGeminiGenerateContent => ProviderType::GoogleGeminiGenerateContent,
+        LlmProvider::Chatgpt => ProviderType::ChatgptResponses,
+        LlmProvider::OpenAiResponses => ProviderType::OpenAiResponses,
+        LlmProvider::OpenAiChatCompletions => ProviderType::OpenAiChatCompletions,
+        LlmProvider::OpenAiChatCompletionsCompatible => {
+            ProviderType::OpenAiChatCompletionsCompatible
+        }
+        LlmProvider::OpenRouter => ProviderType::OpenRouter,
+        LlmProvider::AnthropicMessages => ProviderType::AnthropicMessages,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ModelCatalogProvider;
+
+    fn openai_config() -> Config {
+        Config::default()
+    }
+
+    fn openai_caps() -> ProviderCapabilities {
+        provider_capabilities_for_config(&openai_config())
+    }
+
+    #[test]
+    fn turn_override_has_highest_precedence() {
+        let mut config = openai_config();
+        config.model_reasoning_effort = Some(ReasoningEffort::Medium);
+        let resolved = resolve_turn_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::reasoning_effort(Some(ReasoningEffort::High)),
+            RequestControlIntent::reasoning_effort(Some(ReasoningEffort::Low)),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning.effort, Some(ReasoningEffort::Low));
+        assert_eq!(resolved.source, RequestControlSource::TurnOverride);
+    }
+
+    #[test]
+    fn session_override_precedes_agent_config() {
+        let mut config = openai_config();
+        config.model_reasoning_effort = Some(ReasoningEffort::High);
+        let resolved = resolve_session_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::reasoning_effort(Some(ReasoningEffort::Low)),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning.effort, Some(ReasoningEffort::Low));
+        assert_eq!(resolved.source, RequestControlSource::SessionOverride);
+    }
+
+    #[test]
+    fn agent_config_effort_precedes_model_default() {
+        let mut config = openai_config();
+        config.model_reasoning_effort = Some(ReasoningEffort::High);
+        let resolved = resolve_session_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::default(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning.effort, Some(ReasoningEffort::High));
+        assert_eq!(resolved.source, RequestControlSource::AgentConfig);
+    }
+
+    #[test]
+    fn legacy_budget_precedes_model_default() {
+        let mut config = openai_config();
+        config.thinking_budget_tokens = Some(2048);
+        let resolved = resolve_session_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::default(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning.effort, None);
+        assert_eq!(resolved.reasoning.budget_tokens, Some(2048));
+        assert_eq!(resolved.source, RequestControlSource::LegacyBudget);
+    }
+
+    #[test]
+    fn model_default_applies_when_no_intent_or_budget() {
+        let config = openai_config();
+        let resolved = resolve_session_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::default(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning.effort, Some(ReasoningEffort::Medium));
+        assert_eq!(resolved.source, RequestControlSource::ModelDefault);
+    }
+
+    #[test]
+    fn unknown_model_metadata_uses_provider_default() {
+        let mut config = openai_config();
+        config.llm_provider = LlmProvider::OpenRouter;
+        let resolved = resolve_session_request_controls(
+            &config,
+            provider_capabilities_for_config(&config),
+            RequestControlIntent::default(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.reasoning, ReasoningControls::default());
+        assert_eq!(resolved.source, RequestControlSource::ProviderDefault);
+    }
+
+    #[test]
+    fn provider_without_effort_support_rejects_explicit_effort() {
+        let config = openai_config();
+        let mut caps = openai_caps();
+        caps.supports_reasoning_effort_control = false;
+        let err = resolve_session_request_controls(
+            &config,
+            caps,
+            RequestControlIntent::reasoning_effort(Some(ReasoningEffort::High)),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("does not support reasoning effort controls")
+        );
+    }
+
+    #[test]
+    fn model_rejects_unsupported_explicit_effort() {
+        let mut config = openai_config();
+        config.llm_provider = LlmProvider::OpenAiChatCompletionsCompatible;
+        config.openai_chat_completions_compatible_model = "qwen3.5-plus".to_string();
+        let overlay = r#"
+[[openai_chat_completions_compatible.models]]
+slug = "qwen3.5-plus"
+family = "qwen3.5"
+context_window_tokens = 1_000_000
+supports_reasoning = true
+supported_reasoning_efforts = ["low", "high"]
+default_reasoning_effort = "high"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let overlay_path = dir.path().join("models.toml");
+        std::fs::write(&overlay_path, overlay).unwrap();
+        let catalog =
+            crate::ModelCatalog::load_with_overlay_paths(None, Some(&overlay_path)).unwrap();
+        config.set_model_catalog(std::sync::Arc::new(catalog));
+
+        let err = resolve_session_request_controls(
+            &config,
+            provider_capabilities_for_config(&config),
+            RequestControlIntent::reasoning_effort(Some(ReasoningEffort::XHigh)),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("supported efforts: low, high"));
+    }
+
+    #[test]
+    fn model_catalog_defaults_are_exposed_as_model_default_source() {
+        let config = openai_config();
+        let model_info = config
+            .effective_model_info()
+            .expect("default OpenAI Responses model should be cataloged");
+        assert_eq!(model_info.provider, ModelCatalogProvider::OpenAiResponses);
+
+        let resolved = resolve_session_request_controls(
+            &config,
+            openai_caps(),
+            RequestControlIntent::default(),
+        )
+        .unwrap();
+        assert_eq!(resolved.source, RequestControlSource::ModelDefault);
+    }
+
+    #[test]
+    fn layering_contract_keeps_effective_resolution_out_of_call_sites() {
+        let turn_executor = include_str!("runtime/turn_executor.rs");
+        for forbidden in [
+            "effective_model_reasoning_effort",
+            "validate_reasoning_effort_for_resolved_model",
+            "active_turn_reasoning_effort",
+            "runtime_config.model_reasoning_effort",
+            "runtime_config.thinking_budget_tokens",
+        ] {
+            assert!(
+                !turn_executor.contains(forbidden),
+                "`turn_executor` must consume request-control resolver output, found `{forbidden}`"
+            );
+        }
+
+        let daemon_routes = include_str!("../../alan/src/daemon/routes.rs");
+        for forbidden in [
+            "source_reasoning_effort",
+            "reasoning_effort.or(",
+            "effective_model_reasoning_effort",
+            "validate_reasoning_effort_for_resolved_model",
+        ] {
+            assert!(
+                !daemon_routes.contains(forbidden),
+                "daemon routes must mirror runtime resolver metadata, found `{forbidden}`"
+            );
+        }
+    }
+}

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -1463,6 +1463,24 @@ mod tests {
         tokio::sync::broadcast::channel(8).0.subscribe()
     }
 
+    fn test_startup_metadata(
+        session_id: impl Into<String>,
+        rollout_path: Option<PathBuf>,
+        durable: bool,
+    ) -> RuntimeStartupMetadata {
+        RuntimeStartupMetadata {
+            session_id: session_id.into(),
+            rollout_path,
+            durability: super::super::engine::SessionDurabilityState {
+                durable,
+                required: false,
+            },
+            execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
+            request_controls: crate::ResolvedRequestControls::default(),
+            warnings: Vec::new(),
+        }
+    }
+
     #[derive(Clone, Default)]
     struct RecordedRequests(Arc<Mutex<Vec<GenerationRequest>>>);
 
@@ -2389,7 +2407,13 @@ model_reasoning_effort = "high"
         assert_eq!(result.status, ChildRuntimeStatus::Completed);
         let seen_config = seen_config.lock().unwrap().clone().unwrap();
         assert_eq!(
-            seen_config.effective_model_reasoning_effort(),
+            crate::resolve_session_request_controls(
+                &seen_config,
+                crate::provider_capabilities_for_config(&seen_config),
+                crate::RequestControlIntent::default(),
+            )
+            .unwrap()
+            .reasoning_effort(),
             Some(alan_protocol::ReasoningEffort::Low)
         );
 
@@ -2641,16 +2665,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2682,16 +2697,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2733,16 +2739,11 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: Some(rollout.path().to_path_buf()),
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: true,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata(
+                "child-session",
+                Some(rollout.path().to_path_buf()),
+                true,
+            ),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2804,16 +2805,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2855,16 +2847,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2916,16 +2899,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -2969,16 +2943,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx: test_liveness_rx(),
             submission_id,
@@ -3088,16 +3053,7 @@ model_reasoning_effort = "high"
 
         let controller = ChildRuntimeController {
             runtime: None,
-            startup_metadata: RuntimeStartupMetadata {
-                session_id: "child-session".to_string(),
-                rollout_path: None,
-                durability: super::super::engine::SessionDurabilityState {
-                    durable: false,
-                    required: false,
-                },
-                execution_backend: crate::tools::Sandbox::backend_name_static().to_string(),
-                warnings: Vec::new(),
-            },
+            startup_metadata: test_startup_metadata("child-session", None, false),
             event_rx: rx,
             liveness_rx,
             submission_id,

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -178,6 +178,7 @@ pub struct RuntimeStartupMetadata {
     pub rollout_path: Option<PathBuf>,
     pub durability: SessionDurabilityState,
     pub execution_backend: String,
+    pub request_controls: crate::ResolvedRequestControls,
     pub warnings: Vec<String>,
 }
 
@@ -244,9 +245,10 @@ async fn initialize_session(
     desired_session_id: Option<&str>,
     durability_required: bool,
     rollout_cwd: Option<&std::path::Path>,
-    reasoning_effort: Option<alan_protocol::ReasoningEffort>,
+    request_controls: crate::ResolvedRequestControls,
 ) -> anyhow::Result<SessionStartupOutcome> {
     let mut warnings = Vec::new();
+    let reasoning_effort = request_controls.reasoning_effort();
 
     let session = if let Some(path) = resume_rollout_path {
         let load_result = Session::load_from_rollout_with_recorder_cwd(
@@ -331,6 +333,7 @@ async fn initialize_session(
                 required: durability_required,
             },
             execution_backend: current_execution_backend(),
+            request_controls,
             warnings,
         },
         session,
@@ -382,8 +385,7 @@ struct ExplicitRuntimeOverrides {
     compaction_trigger_ratio: bool,
     compaction_soft_trigger_ratio: bool,
     compaction_hard_trigger_ratio: bool,
-    thinking_budget_tokens: bool,
-    model_reasoning_effort: bool,
+    request_control_intent: bool,
     streaming_mode: bool,
     partial_stream_recovery_mode: bool,
     durability_required: bool,
@@ -416,7 +418,7 @@ impl AgentConfig {
     pub fn set_model_override(&mut self, model: impl Into<String>) {
         self.core_config.set_effective_model(model);
         sync_runtime_context_window_budget(&self.core_config, &mut self.runtime_config);
-        sync_runtime_model_reasoning_effort(&self.core_config, &mut self.runtime_config);
+        sync_runtime_request_control_intent(&self.core_config, &mut self.runtime_config);
         self.explicit_runtime_overrides.model = true;
     }
 
@@ -424,10 +426,9 @@ impl AgentConfig {
     pub fn set_thinking_budget_override(&mut self, thinking_budget_tokens: Option<u32>) {
         self.core_config.thinking_budget_tokens = thinking_budget_tokens;
         self.core_config.model_reasoning_effort = None;
-        self.runtime_config.thinking_budget_tokens = thinking_budget_tokens;
-        self.runtime_config.model_reasoning_effort = None;
-        self.explicit_runtime_overrides.thinking_budget_tokens = true;
-        self.explicit_runtime_overrides.model_reasoning_effort = true;
+        self.runtime_config.request_control_intent =
+            crate::RequestControlIntent::thinking_budget_tokens(thinking_budget_tokens);
+        self.explicit_runtime_overrides.request_control_intent = true;
     }
 
     /// Override named model reasoning effort for this launch across overlays.
@@ -437,10 +438,9 @@ impl AgentConfig {
     ) {
         self.core_config.model_reasoning_effort = model_reasoning_effort;
         self.core_config.thinking_budget_tokens = None;
-        self.runtime_config.model_reasoning_effort = model_reasoning_effort;
-        self.runtime_config.thinking_budget_tokens = None;
-        self.explicit_runtime_overrides.model_reasoning_effort = true;
-        self.explicit_runtime_overrides.thinking_budget_tokens = true;
+        self.runtime_config.request_control_intent =
+            crate::RequestControlIntent::reasoning_effort(model_reasoning_effort);
+        self.explicit_runtime_overrides.request_control_intent = true;
     }
 
     /// Override streaming mode for this runtime launch, preserving it across agent-root overlays.
@@ -469,7 +469,7 @@ impl AgentConfig {
 
     pub fn refresh_runtime_derived_fields(&mut self) {
         sync_runtime_context_window_budget(&self.core_config, &mut self.runtime_config);
-        sync_runtime_model_reasoning_effort(&self.core_config, &mut self.runtime_config);
+        sync_runtime_request_control_intent(&self.core_config, &mut self.runtime_config);
     }
 
     pub fn with_agent_root_overlays(
@@ -477,10 +477,8 @@ impl AgentConfig {
         overlay_paths: &[std::path::PathBuf],
     ) -> anyhow::Result<Self> {
         let mut merge_base_core_config = self.core_config.clone();
-        if self.explicit_runtime_overrides.model_reasoning_effort {
+        if self.explicit_runtime_overrides.request_control_intent {
             merge_base_core_config.model_reasoning_effort = None;
-        }
-        if self.explicit_runtime_overrides.thinking_budget_tokens {
             merge_base_core_config.thinking_budget_tokens = None;
         }
 
@@ -508,15 +506,13 @@ impl AgentConfig {
         if self.explicit_runtime_overrides.model {
             core_config.set_effective_model(self.core_config.effective_model().to_string());
             sync_runtime_context_window_budget(core_config, runtime_config);
-            sync_runtime_model_reasoning_effort(core_config, runtime_config);
+            sync_runtime_request_control_intent(core_config, runtime_config);
         }
-        if self.explicit_runtime_overrides.thinking_budget_tokens {
-            core_config.thinking_budget_tokens = self.runtime_config.thinking_budget_tokens;
-            runtime_config.thinking_budget_tokens = self.runtime_config.thinking_budget_tokens;
-        }
-        if self.explicit_runtime_overrides.model_reasoning_effort {
-            core_config.model_reasoning_effort = self.runtime_config.model_reasoning_effort;
-            runtime_config.model_reasoning_effort = self.runtime_config.model_reasoning_effort;
+        if self.explicit_runtime_overrides.request_control_intent {
+            self.runtime_config
+                .request_control_intent
+                .apply_to_config(core_config);
+            runtime_config.request_control_intent = self.runtime_config.request_control_intent;
         }
         if self.explicit_runtime_overrides.streaming_mode {
             core_config.streaming_mode = self.runtime_config.streaming_mode;
@@ -653,12 +649,11 @@ fn sync_runtime_context_window_budget(
     runtime_config.context_window_tokens = core_config.effective_context_window_tokens();
 }
 
-fn sync_runtime_model_reasoning_effort(
+fn sync_runtime_request_control_intent(
     core_config: &crate::config::Config,
     runtime_config: &mut RuntimeConfig,
 ) {
-    runtime_config.model_reasoning_effort = core_config.effective_model_reasoning_effort();
-    runtime_config.thinking_budget_tokens = core_config.thinking_budget_tokens;
+    runtime_config.request_control_intent = crate::RequestControlIntent::from_config(core_config);
 }
 
 fn merge_runtime_config_from_core_overlay(
@@ -688,8 +683,7 @@ fn merge_runtime_config_from_core_overlay(
     sync_if_unmodified!(compaction_trigger_ratio);
     sync_if_unmodified!(compaction_soft_trigger_ratio);
     sync_if_unmodified!(compaction_hard_trigger_ratio);
-    sync_if_unmodified!(thinking_budget_tokens);
-    sync_if_unmodified!(model_reasoning_effort);
+    sync_if_unmodified!(request_control_intent);
     sync_if_unmodified!(streaming_mode);
     sync_if_unmodified!(partial_stream_recovery_mode);
     sync_if_unmodified!(durability_required);
@@ -837,6 +831,7 @@ impl RuntimeController {
                     required: false,
                 },
                 execution_backend: current_execution_backend(),
+                request_controls: crate::ResolvedRequestControls::default(),
                 warnings: Vec::new(),
             });
         };
@@ -1010,9 +1005,11 @@ pub fn effective_core_config_for_runtime(
         core_config.memory.workspace_dir =
             Some(crate::workspace_memory_dir_from_alan_dir(alan_dir));
     }
-    if let Some(effort) = core_config.effective_model_reasoning_effort() {
-        core_config.validate_reasoning_effort_for_resolved_model(effort)?;
-    }
+    crate::resolve_session_request_controls(
+        &core_config,
+        crate::provider_capabilities_for_config(&core_config),
+        agent_config.runtime_config.request_control_intent,
+    )?;
 
     Ok(core_config)
 }
@@ -1124,7 +1121,17 @@ pub fn spawn_with_llm_client_and_tools(
     // Spawn the main runtime task
     let task_handle = tokio::spawn(async move {
         let model = core_config.effective_model().to_string();
-        let reasoning_effort = core_config.effective_model_reasoning_effort();
+        let session_request_controls = match crate::resolve_session_request_controls(
+            &core_config,
+            llm_client.capabilities(),
+            runtime_config.request_control_intent,
+        ) {
+            Ok(controls) => controls,
+            Err(err) => {
+                let _ = ready_tx.send(Err(format!("{:#}", err)));
+                return;
+            }
+        };
         let startup = match initialize_session(
             &model,
             resume_rollout_path.as_ref(),
@@ -1132,7 +1139,7 @@ pub fn spawn_with_llm_client_and_tools(
             desired_session_id.as_deref(),
             runtime_config.durability_required,
             rollout_cwd.as_deref(),
-            reasoning_effort,
+            session_request_controls,
         )
         .await
         {
@@ -1911,7 +1918,13 @@ prompt_snapshot_enabled = true
         assert_eq!(merged.core_config.thinking_budget_tokens, Some(1024));
         assert!(merged.core_config.prompt_snapshot_enabled);
         assert_eq!(merged.runtime_config.tool_repeat_limit, 9);
-        assert_eq!(merged.runtime_config.thinking_budget_tokens, Some(1024));
+        assert_eq!(
+            merged
+                .runtime_config
+                .request_control_intent
+                .thinking_budget_tokens,
+            Some(1024)
+        );
         assert!(merged.runtime_config.prompt_snapshot_enabled);
     }
 
@@ -1934,7 +1947,10 @@ model_reasoning_effort = "high"
             Some(alan_protocol::ReasoningEffort::High)
         );
         assert_eq!(
-            merged.runtime_config.model_reasoning_effort,
+            merged
+                .runtime_config
+                .request_control_intent
+                .reasoning_effort,
             Some(alan_protocol::ReasoningEffort::High)
         );
     }
@@ -1987,10 +2003,19 @@ thinking_budget_tokens = 1024
             merged.runtime_config.streaming_mode,
             crate::config::StreamingMode::On
         );
-        assert_eq!(merged.runtime_config.thinking_budget_tokens, None);
         assert_eq!(
-            merged.runtime_config.model_reasoning_effort,
+            merged
+                .runtime_config
+                .request_control_intent
+                .reasoning_effort,
             Some(alan_protocol::ReasoningEffort::Low)
+        );
+        assert_eq!(
+            merged
+                .runtime_config
+                .request_control_intent
+                .thinking_budget_tokens,
+            None
         );
     }
 
@@ -2766,7 +2791,14 @@ thinking_budget_tokens = 1024
             Some(desired_session_id.as_str()),
             true,
             Some(resumed_cwd.as_path()),
-            Some(alan_protocol::ReasoningEffort::Medium),
+            crate::ResolvedRequestControls {
+                reasoning: alan_protocol::ReasoningControls {
+                    effort: Some(alan_protocol::ReasoningEffort::Medium),
+                    budget_tokens: None,
+                },
+                source: crate::RequestControlSource::SessionOverride,
+                diagnostics: Vec::new(),
+            },
         )
         .await
         .unwrap();

--- a/crates/runtime/src/runtime/mod.rs
+++ b/crates/runtime/src/runtime/mod.rs
@@ -70,10 +70,8 @@ pub struct RuntimeConfig {
     pub governance: alan_protocol::GovernanceConfig,
     /// Loaded policy engine for this runtime/session.
     pub policy_engine: crate::policy::PolicyEngine,
-    /// Budget tokens for provider-specific thinking/reasoning. None = disabled.
-    pub thinking_budget_tokens: Option<u32>,
-    /// Named cross-provider reasoning effort. None = use provider default or legacy budget.
-    pub model_reasoning_effort: Option<alan_protocol::ReasoningEffort>,
+    /// Request-control intent carried by runtime/session launch.
+    pub request_control_intent: crate::RequestControlIntent,
     /// Streaming strategy (`auto`/`on`/`off`).
     pub streaming_mode: crate::config::StreamingMode,
     /// Recovery strategy when streaming is interrupted after visible output.
@@ -108,8 +106,7 @@ impl Default for RuntimeConfig {
             policy_engine: crate::policy::PolicyEngine::for_profile(
                 crate::policy::PolicyProfile::Autonomous,
             ),
-            thinking_budget_tokens: None,
-            model_reasoning_effort: None,
+            request_control_intent: crate::RequestControlIntent::default(),
             streaming_mode: crate::config::StreamingMode::Auto,
             partial_stream_recovery_mode: crate::config::PartialStreamRecoveryMode::ContinueOnce,
             durability_required: false,
@@ -138,8 +135,7 @@ impl From<&crate::config::Config> for RuntimeConfig {
             policy_engine: crate::policy::PolicyEngine::for_profile(
                 crate::policy::PolicyProfile::Autonomous,
             ),
-            thinking_budget_tokens: config.thinking_budget_tokens,
-            model_reasoning_effort: config.effective_model_reasoning_effort(),
+            request_control_intent: crate::RequestControlIntent::from_config(config),
             streaming_mode: config.streaming_mode,
             partial_stream_recovery_mode: config.partial_stream_recovery_mode,
             durability_required: config.durability.required,

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -1692,9 +1692,11 @@ Use this skill when asked.
     #[tokio::test]
     async fn test_handle_follow_up_without_active_turn_starts_new_turn() {
         let mut state = create_test_state();
-        state
-            .turn_state
-            .set_active_turn_reasoning_effort(Some(alan_protocol::ReasoningEffort::High));
+        state.turn_state.set_active_turn_request_control_intent(
+            crate::RequestControlIntent::reasoning_effort(Some(
+                alan_protocol::ReasoningEffort::High,
+            )),
+        );
         let cancel = CancellationToken::new();
         let mut events = vec![];
         let mut emit = |event: Event| {
@@ -1722,7 +1724,12 @@ Use this skill when asked.
                     Some(vec![ContentPart::text("run after current")])
                 );
                 assert!(activate_task);
-                assert_eq!(state.turn_state.active_turn_reasoning_effort(), None);
+                assert!(
+                    state
+                        .turn_state
+                        .active_turn_request_control_intent()
+                        .is_empty()
+                );
             }
             _ => panic!("Expected RunTurn"),
         }

--- a/crates/runtime/src/runtime/submission_handlers.rs
+++ b/crates/runtime/src/runtime/submission_handlers.rs
@@ -169,9 +169,9 @@ where
             merged_parts.extend(parts);
 
             state.turn_state.clear();
-            state
-                .turn_state
-                .set_active_turn_reasoning_effort(reasoning_effort);
+            state.turn_state.set_active_turn_request_control_intent(
+                crate::RequestControlIntent::reasoning_effort(reasoning_effort),
+            );
 
             if queued_next_turn_count > 0 {
                 emit(Event::Warning {
@@ -661,7 +661,10 @@ mod tests {
                     "existing message"
                 );
                 assert_eq!(
-                    state.turn_state.active_turn_reasoning_effort(),
+                    state
+                        .turn_state
+                        .active_turn_request_control_intent()
+                        .reasoning_effort,
                     Some(alan_protocol::ReasoningEffort::High)
                 );
             }

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -859,17 +859,19 @@ where
         .iter()
         .map(|tool| tool.name.clone())
         .collect::<Vec<_>>();
-    let reasoning_effort = state
-        .turn_state
-        .active_turn_reasoning_effort()
-        .or(state.runtime_config.model_reasoning_effort);
+    let turn_request_controls = crate::resolve_turn_request_controls(
+        &state.core_config,
+        state.llm_client.capabilities(),
+        state.runtime_config.request_control_intent,
+        state.turn_state.active_turn_request_control_intent(),
+    )?;
     let model = state.core_config.effective_model().to_string();
     let memory_enabled = state.core_config.memory.enabled;
     let context_items = state.session.tape.context_items().to_vec();
     let context_delta = state.session.tape.last_context_delta().clone();
     state.session.record_turn_context_if_changed(
         &model,
-        reasoning_effort,
+        turn_request_controls.reasoning_effort(),
         &system_prompt,
         &context_items,
         &tool_names,
@@ -1005,23 +1007,13 @@ where
                 .with_previous_response_id(previous_response_id)
                 .with_store(true);
         }
-        if let Some(effort) = reasoning_effort {
-            if !provider_capabilities.supports_reasoning_effort_control {
-                anyhow::bail!(
-                    "provider `{}` does not support reasoning effort controls",
-                    provider
-                );
-            }
-            state
-                .core_config
-                .validate_reasoning_effort_for_resolved_model(effort)?;
-            request.reasoning.effort = Some(effort);
-        } else if let Some(thinking_budget_tokens) = state.runtime_config.thinking_budget_tokens {
-            request = request.with_thinking_budget_tokens(thinking_budget_tokens);
-        }
+        let request_controls = turn_request_controls.clone();
+        request = request.with_reasoning_controls(request_controls.reasoning);
 
         let request_start = Instant::now();
-        let reasoning_effort_log = reasoning_effort.map(|effort| effort.to_string());
+        let reasoning_effort_log = request_controls
+            .reasoning_effort()
+            .map(|effort| effort.to_string());
         info!(
             messages = messages.len(),
             estimated_prompt_tokens,
@@ -1029,7 +1021,8 @@ where
             tools = tools.len(),
             provider,
             reasoning_effort = reasoning_effort_log.as_deref(),
-            reasoning_budget_tokens = request.reasoning.budget_tokens,
+            reasoning_budget_tokens = request_controls.budget_tokens(),
+            request_control_source = ?request_controls.source,
             "LLM request"
         );
 
@@ -3077,7 +3070,9 @@ description: {description}
         };
         let mut state = create_test_state_with_provider(provider);
         state.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
-        state.runtime_config.model_reasoning_effort = Some(alan_protocol::ReasoningEffort::High);
+        state.runtime_config.request_control_intent = crate::RequestControlIntent::reasoning_effort(
+            Some(alan_protocol::ReasoningEffort::High),
+        );
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -3126,10 +3121,14 @@ description: {description}
             .await
             .unwrap();
         state.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
-        state.runtime_config.model_reasoning_effort = Some(alan_protocol::ReasoningEffort::High);
-        state
-            .turn_state
-            .set_active_turn_reasoning_effort(Some(alan_protocol::ReasoningEffort::Low));
+        state.runtime_config.request_control_intent = crate::RequestControlIntent::reasoning_effort(
+            Some(alan_protocol::ReasoningEffort::High),
+        );
+        state.turn_state.set_active_turn_request_control_intent(
+            crate::RequestControlIntent::reasoning_effort(Some(
+                alan_protocol::ReasoningEffort::Low,
+            )),
+        );
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -3188,7 +3187,8 @@ description: {description}
         };
         let mut state = create_test_state_with_provider(provider);
         state.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
-        state.runtime_config.thinking_budget_tokens = Some(2048);
+        state.runtime_config.request_control_intent =
+            crate::RequestControlIntent::thinking_budget_tokens(Some(2048));
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -3230,6 +3230,7 @@ description: {description}
             provider_name: "openai_responses",
         };
         let mut state = create_test_state_with_provider(provider);
+        state.core_config.llm_provider = crate::config::LlmProvider::OpenRouter;
         state.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
         let cancel = CancellationToken::new();
 

--- a/crates/runtime/src/runtime/turn_state.rs
+++ b/crates/runtime/src/runtime/turn_state.rs
@@ -4,7 +4,7 @@ use super::agent_loop::{DeferredRuntimeAction, NormalizedToolCall};
 use crate::approval::{PendingConfirmation, PendingDynamicToolCall, PendingStructuredInputRequest};
 use crate::skills::ActiveSkillEnvelope;
 use crate::tape::ContentPart;
-use alan_protocol::{PlanItem, ReasoningEffort, Submission};
+use alan_protocol::{PlanItem, Submission};
 
 const MAX_QUEUED_NEXT_TURN_INPUTS: usize = 16;
 const AUTO_MID_TURN_COMPACTION_LIMIT: u32 = 2;
@@ -60,8 +60,8 @@ pub(crate) struct TurnState {
     active_turn_message_start: Option<usize>,
     /// Active skills resolved for the current turn.
     active_skills: Vec<ActiveSkillEnvelope>,
-    /// Optional reasoning effort override scoped to the active logical turn.
-    active_turn_reasoning_effort: Option<ReasoningEffort>,
+    /// Optional request-control intent scoped to the active logical turn.
+    active_turn_request_control_intent: crate::RequestControlIntent,
     /// Latest explicit plan/progress state published during the current session.
     plan_snapshot: Option<PlanSnapshot>,
     /// Best-effort follow-up work queued after a turn completes.
@@ -81,7 +81,7 @@ impl TurnState {
         self.buffered_inband_submissions.clear();
         self.active_turn_message_start = None;
         self.active_skills.clear();
-        self.active_turn_reasoning_effort = None;
+        self.active_turn_request_control_intent = crate::RequestControlIntent::default();
         self.reset_auto_mid_turn_compaction_state();
     }
 
@@ -171,12 +171,15 @@ impl TurnState {
         self.active_turn_message_start
     }
 
-    pub(crate) fn set_active_turn_reasoning_effort(&mut self, effort: Option<ReasoningEffort>) {
-        self.active_turn_reasoning_effort = effort;
+    pub(crate) fn set_active_turn_request_control_intent(
+        &mut self,
+        intent: crate::RequestControlIntent,
+    ) {
+        self.active_turn_request_control_intent = intent;
     }
 
-    pub(crate) fn active_turn_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        self.active_turn_reasoning_effort
+    pub(crate) fn active_turn_request_control_intent(&self) -> crate::RequestControlIntent {
+        self.active_turn_request_control_intent
     }
 
     pub(crate) fn note_tape_compaction(&mut self, retention_start: usize) {

--- a/docs/spec/provider_capability_contract.md
+++ b/docs/spec/provider_capability_contract.md
@@ -238,34 +238,40 @@ apply" and is distinct from explicit `none`.
 
 Normative rules:
 
-1. Alan must resolve effective effort before provider dispatch from turn
-   override, session/runtime override, agent config, model catalog default, then
-   provider default.
-2. If a resolved model catalog entry declares supported efforts, Alan must
+1. `alan-runtime` owns effective request-control resolution. Config, daemon
+   routes, clients, and provider adapters may carry request-control intent or
+   metadata, but they must not independently decide the final effective value.
+2. Alan must resolve effective controls before provider dispatch from turn
+   override, session/runtime override, agent config, legacy budget intent, model
+   catalog default, then provider default.
+3. If a resolved model catalog entry declares supported efforts, Alan must
    reject explicit unsupported effort before making the provider request.
-3. `thinking_budget_tokens` is a provider-specific compatibility control, not
+4. `thinking_budget_tokens` is a provider-specific compatibility control, not
    Alan's canonical cross-provider reasoning API.
-4. A configuration that explicitly sets both `model_reasoning_effort` and
+5. A configuration that explicitly sets both `model_reasoning_effort` and
    `thinking_budget_tokens` is ambiguous and must be rejected.
-5. Compatibility providers must not silently drop explicit effort. They may
+6. Compatibility providers must not silently drop explicit effort. They may
    receive effort only when Alan has model/provider metadata declaring support;
    otherwise the request must fail before dispatch.
-6. Reasoning-effort metadata may be logged or persisted as request/session
+7. Reasoning-effort metadata may be logged or persisted as request/session
    metadata, but Alan must not expose hidden reasoning content as a side effect
    of enabling effort controls.
 
 Provider projection rules:
 
-1. OpenAI Responses maps effort to `reasoning.effort`.
-2. OpenAI Chat Completions maps effort to `reasoning_effort`.
-3. Managed ChatGPT Responses may use the Responses-shaped field only when the
+1. Provider adapters consume normalized `GenerationRequest.reasoning` controls
+   and project them to provider-specific wire fields. They must not re-run
+   Alan-level precedence, model default, or config conflict logic.
+2. OpenAI Responses maps effort to `reasoning.effort`.
+3. OpenAI Chat Completions maps effort to `reasoning_effort`.
+4. Managed ChatGPT Responses may use the Responses-shaped field only when the
    live capability matrix says effort control is supported.
-4. Anthropic Messages maps effort to extended-thinking budget presets unless an
+5. Anthropic Messages maps effort to extended-thinking budget presets unless an
    explicit legacy budget is the only configured control, and the adapter must
    keep Anthropic minimum-budget and `max_tokens` constraints explicit.
-5. Gemini 3 maps effort to `thinkingConfig.thinkingLevel`; Gemini 2.5 maps
+6. Gemini 3 maps effort to `thinkingConfig.thinkingLevel`; Gemini 2.5 maps
    effort to `thinkingConfig.thinkingBudget`.
-6. OpenRouter and OpenAI-compatible endpoints use explicit extension fields
+7. OpenRouter and OpenAI-compatible endpoints use explicit extension fields
    only for verified model/provider combinations.
 
 Migration guidance:

--- a/docs/spec/provider_reasoning_effort_migration.md
+++ b/docs/spec/provider_reasoning_effort_migration.md
@@ -46,6 +46,11 @@ Keep `thinking_budget_tokens` when the target provider is budget-native, such
 as Anthropic extended thinking or Gemini 2.5 thinking budgets, and you need a
 specific provider token budget rather than Alan's named effort presets.
 
+Alan normalizes the selected named effort or legacy budget in the runtime before
+provider dispatch. Provider-specific `extra_params` may still carry temporary
+compatibility fields when no canonical control is set, but they must not
+override a resolved runtime effort or budget.
+
 If a provider/model supports both in the future, prefer named effort in shared
 agent configuration and reserve raw budgets for provider-specific profiles or
 temporary experiments.

--- a/openspec/changes/centralize-provider-request-controls/.openspec.yaml
+++ b/openspec/changes/centralize-provider-request-controls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/centralize-provider-request-controls/design.md
+++ b/openspec/changes/centralize-provider-request-controls/design.md
@@ -1,0 +1,217 @@
+## Context
+
+The `model_reasoning_effort` change is cross-cutting because the control is
+visible at multiple layers:
+
+- `alan_protocol` defines `ReasoningEffort` and turn-scoped override fields.
+- `alan_runtime::Config` parses user config, resolves model metadata, validates
+  config conflicts, and currently derives effective model defaults.
+- `RuntimeConfig` copies effective reasoning state from `Config`, while
+  `AgentConfig` has explicit override bookkeeping for both effort and legacy
+  thinking budget.
+- `turn_executor` chooses between turn override, runtime effort, and legacy
+  budget immediately before building `GenerationRequest`.
+- `alan_llm::GenerationRequest` carries both `thinking_budget_tokens` and
+  `ReasoningControls`, and provider adapters contain additional precedence and
+  budget-to-effort mapping logic.
+- The daemon/session stores and clients carry `reasoning_effort` as metadata,
+  but they should not own the rules that decide what is effective.
+
+That shape is understandable for an incremental feature, but it mixes intent,
+effective value, provider capability validation, and provider-wire projection.
+In Rust terms, several crates now know too much about the same state machine.
+The owner should be the crate that has all required inputs and controls runtime
+semantics: `alan-runtime`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish `alan-runtime` as the single owner for effective request-control
+  resolution.
+- Separate four concepts in types: user intent, override precedence, resolved
+  runtime controls, and provider-wire projection.
+- Preserve the current external config and daemon API for reasoning effort.
+- Keep provider adapters responsible for provider-specific payload shape, not
+  Alan-level defaults or precedence.
+- Make the next request control require changes in predictable locations:
+  protocol DTO if it is externally visible, runtime resolver, provider
+  projection, tests/docs.
+
+**Non-Goals:**
+
+- Do not remove `model_reasoning_effort`.
+- Do not remove `thinking_budget_tokens` in this change; it remains a
+  compatibility input.
+- Do not redesign the model catalog wholesale.
+- Do not generate OpenAPI/client bindings in this change, although the design
+  should leave room for that later.
+- Do not change provider behavior except where the current behavior relies on
+  duplicated or inconsistent resolution.
+
+## Decisions
+
+### Decision: Add a Runtime Request-Control Resolver
+
+Add a new runtime module, tentatively `crates/runtime/src/request_controls.rs`,
+with types similar to:
+
+```rust
+pub struct RequestControlIntent {
+    pub reasoning_effort: Option<ReasoningEffort>,
+    pub thinking_budget_tokens: Option<u32>,
+}
+
+pub struct RequestControlOverrides {
+    pub session: RequestControlIntent,
+    pub turn: RequestControlIntent,
+}
+
+pub struct ResolvedRequestControls {
+    pub reasoning: ReasoningControls,
+    pub reasoning_source: Option<RequestControlSource>,
+    pub diagnostics: Vec<RequestControlDiagnostic>,
+}
+
+pub enum RequestControlSource {
+    TurnOverride,
+    SessionOverride,
+    AgentConfig,
+    ModelDefault,
+    LegacyBudget,
+    ProviderDefault,
+}
+```
+
+The resolver takes `Config`, resolved provider type/capabilities, model catalog
+metadata, session override, and turn override. It returns a single normalized
+`ResolvedRequestControls` value used by runtime startup metadata, per-turn
+`GenerationRequest`, logging, rollout/session metadata, and daemon responses.
+
+Alternative considered: keep the logic on `Config`.
+That keeps code local to config parsing, but `Config` does not own turn-scoped
+overrides, provider capabilities, or dispatch-time validation. It would keep
+request semantics in a type whose job should be loading configuration.
+
+### Decision: Treat `Config` as Input, Not Resolver
+
+`Config` should keep user-facing fields and local config validation, including
+rejecting explicit `model_reasoning_effort` plus `thinking_budget_tokens` in
+the same config file. It should not expose methods that look like final runtime
+truth for request controls, such as `effective_model_reasoning_effort`.
+
+The replacement shape should be:
+
+- `Config` exposes raw intent fields.
+- Model catalog exposes model capability/default metadata.
+- The resolver combines raw config, model metadata, provider capabilities, and
+  overrides into effective controls.
+
+Alternative considered: rename the existing `effective_*` methods and keep
+them as helper methods.
+That still invites daemon/runtime code to recompute final values from partial
+inputs. The resolver should be the only path for effective request controls.
+
+### Decision: RuntimeConfig Stores Intent or Snapshot, Not Independent Truth
+
+`RuntimeConfig` currently carries `model_reasoning_effort` and
+`thinking_budget_tokens` as mutable effective values. That creates a second
+truth beside `Config` and requires explicit sync helpers.
+
+The target shape is:
+
+- `RuntimeConfig` may store launch/session override intent.
+- Runtime startup computes a `ResolvedRequestControls` snapshot for metadata.
+- Turn execution recomputes or derives a turn snapshot through the resolver
+  when turn overrides are present.
+- Any persisted metadata stores the resolver output with source information,
+  not another independent effective field.
+
+Alternative considered: store only the resolved session value and mutate it for
+turns.
+That makes turn overrides hard to reason about and loses the reason why a value
+was selected. A small immutable snapshot per request is easier to test.
+
+### Decision: Provider Adapters Project, They Do Not Decide Precedence
+
+`alan_llm::GenerationRequest` should carry normalized controls. Provider
+adapters may map those controls to provider payloads:
+
+- OpenAI Responses: `reasoning.effort`
+- OpenAI Chat Completions: `reasoning_effort`
+- Anthropic: effort-to-budget presets or explicit budget when budget is the
+  normalized control
+- Gemini: effort-to-`thinkingLevel`/`thinkingBudget` based on model family
+- OpenRouter/compatible: extension fields when enabled by runtime metadata
+
+Adapters should not infer Alan-level defaults from legacy budgets or consume
+`extra_params.reasoning_effort` as a competing source when canonical controls
+are present. Compatibility parsing can remain temporarily, but it should feed
+the same normalized control path or be removed in a follow-up.
+
+Alternative considered: move all provider projection into runtime.
+That would make runtime depend on provider payload details and weaken the LLM
+crate boundary. The adapter owns wire shape; runtime owns Alan semantics.
+
+### Decision: Keep Protocol Narrow
+
+`alan_protocol` should continue to own portable wire enums and client-visible
+DTOs such as `ReasoningEffort`. It should not own model catalog logic or
+provider capability resolution. If a broader request-control DTO becomes
+necessary for turns, it should represent user intent only, not an effective
+runtime value.
+
+### Decision: Make Contract Tests Guard the Layering
+
+Add focused tests that fail when effective request-control rules leak back into
+the wrong layer:
+
+- resolver unit tests for precedence, config conflict, model default,
+  unsupported explicit effort, provider unsupported effort, and legacy budget.
+- turn-executor tests proving it consumes `ResolvedRequestControls`.
+- provider adapter tests proving canonical controls override provider-specific
+  extra params and that adapters do not synthesize Alan defaults.
+- daemon contract tests proving responses mirror resolver metadata.
+
+## Risks / Trade-offs
+
+- Resolver becomes a central module with several inputs -> Keep the API small,
+  immutable, and heavily unit-tested.
+- Temporary duplication may exist during migration -> Do the refactor in
+  phases, first introducing the resolver and then deleting old helpers.
+- Provider-specific behavior can be over-centralized accidentally -> Keep only
+  precedence and validation in runtime; wire payload mapping stays in
+  `alan-llm`.
+- Existing tests may need broad updates -> Prefer helper constructors for
+  runtime/session test fixtures so future request controls do not require
+  editing dozens of `reasoning_effort: None` literals.
+- Model catalog does not cover every provider/model -> Resolver must support
+  "unknown model metadata" explicitly and distinguish provider default from
+  model-catalog default.
+
+## Migration Plan
+
+1. Add `request_controls` module and resolver tests without changing behavior.
+2. Route runtime startup metadata and turn execution through the resolver.
+3. Replace `Config::effective_model_reasoning_effort` and
+   `validate_reasoning_effort_for_resolved_model` call sites with resolver
+   calls, then make old helpers private or remove them.
+4. Collapse `RuntimeConfig` request-control fields into intent/snapshot fields
+   and remove sync helper duplication.
+5. Normalize `GenerationRequest` so adapters read `ReasoningControls` as the
+   canonical input; retain compatibility builder methods while they populate
+   the normalized field.
+6. Update daemon/session metadata to use resolver output.
+7. Update docs and add contract tests.
+
+Rollback is straightforward because the external config/API shape is preserved:
+revert the internal resolver changes and restore direct field plumbing.
+
+## Open Questions
+
+- Should `ResolvedRequestControls` live in `alan-runtime` only, or be exported
+  for daemon metadata construction?
+- Should provider capability metadata evolve from booleans to typed projection
+  modes in this change, or remain a follow-up?
+- Should `thinking_budget_tokens` be removed from `GenerationRequest` now or
+  deprecated in place for one release?

--- a/openspec/changes/centralize-provider-request-controls/proposal.md
+++ b/openspec/changes/centralize-provider-request-controls/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Adding `model_reasoning_effort` showed that provider request controls currently
+do not have a single runtime owner: config parsing, model metadata, runtime
+overrides, turn-scoped overrides, daemon metadata, and provider adapters each
+perform part of the same resolution. That works for one control, but it makes
+the next control expensive and easy to implement inconsistently.
+
+This change creates a clearer layering for request controls so Alan can add
+future provider knobs without duplicating effective-value logic across runtime,
+daemon, clients, and provider adapters.
+
+## What Changes
+
+- Introduce a runtime-owned request-control resolution layer that produces a
+  single effective control set for a runtime session and each turn.
+- Move reasoning-effort/model-default/legacy-budget precedence and validation
+  out of `Config`, `RuntimeConfig`, and `turn_executor` call sites into that
+  resolver.
+- Keep `model_reasoning_effort` as the canonical user-facing config key and
+  retain `thinking_budget_tokens` as a provider-specific compatibility input.
+- Make provider adapters consume normalized request controls and only perform
+  provider-wire projection.
+- Make daemon/session metadata report the resolver output rather than
+  independently reconstructing reasoning effort.
+- Add contract tests that prevent reintroducing per-layer reasoning-effort
+  resolution.
+- No external API breaking change is intended.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-request-controls`: Runtime-owned resolution and provider projection
+  contract for model/request controls such as reasoning effort and thinking
+  budget.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `crates/protocol`: canonical wire/control enums remain here; may gain a
+  stable request-controls DTO if needed for turn-scoped overrides.
+- `crates/runtime`: add the resolver/owner module; simplify `Config`,
+  `RuntimeConfig`, runtime startup, turn execution, child-agent override merge,
+  rollout/session metadata plumbing.
+- `crates/llm`: provider adapters project normalized controls to provider
+  payloads; they should not infer Alan-level defaults or precedence.
+- `crates/alan`: daemon session create/fork/read responses use runtime resolver
+  metadata instead of duplicating effective reasoning-effort rules.
+- `clients/tui` and `clients/apple`: remain presentation and request DTO layers;
+  no independent request-control semantics.
+- Tests/docs: add focused resolver tests, provider projection tests, daemon
+  payload contract tests, and update provider capability documentation.

--- a/openspec/changes/centralize-provider-request-controls/specs/provider-request-controls/spec.md
+++ b/openspec/changes/centralize-provider-request-controls/specs/provider-request-controls/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Runtime-Owned Request Control Resolution
+Alan MUST resolve effective provider request controls through a runtime-owned
+resolver before dispatching a model request. The resolver MUST combine turn
+override, session/runtime override, agent config intent, model catalog default,
+legacy provider budget intent, provider capabilities, and provider default in a
+single typed result.
+
+#### Scenario: Turn override has highest precedence
+- **WHEN** a session has `model_reasoning_effort = "high"` and a turn requests `reasoning_effort = "low"`
+- **THEN** the resolved request controls use `low` for that turn
+- **AND** the session-level resolved controls remain unchanged for later turns
+
+#### Scenario: Model default is applied once by the resolver
+- **WHEN** no explicit reasoning effort or thinking budget is configured and the resolved model catalog entry declares default effort `medium`
+- **THEN** the resolver returns reasoning effort `medium` with source `model_default`
+- **AND** no other runtime, daemon, or provider-adapter layer recomputes that default independently
+
+#### Scenario: Unknown model metadata uses provider default
+- **WHEN** the selected provider/model has no model catalog metadata and no explicit request control is configured
+- **THEN** the resolver returns no explicit reasoning effort or budget
+- **AND** the source records that provider defaults will apply
+
+### Requirement: Request Control Intent Is Separate From Resolved Controls
+Alan MUST represent user/session/turn request-control intent separately from
+resolved request controls. `Config` and transport DTOs MAY contain user intent,
+but they MUST NOT be the authority for final effective request-control values.
+
+#### Scenario: Config conflict remains local validation
+- **WHEN** an agent config explicitly sets both `model_reasoning_effort` and `thinking_budget_tokens`
+- **THEN** config loading rejects the config as ambiguous
+- **AND** the resolver is not required to guess precedence between the two config fields
+
+#### Scenario: RuntimeConfig does not duplicate independent effective truth
+- **WHEN** a workspace overlay changes model metadata or a runtime launch applies a session override
+- **THEN** Alan resolves request controls through the resolver
+- **AND** `RuntimeConfig` does not require a separate sync helper to keep a duplicated effective reasoning field aligned with `Config`
+
+### Requirement: Explicit Request Controls Are Validated Before Dispatch
+Alan MUST validate explicit request controls against provider capability and
+resolved model metadata before making a provider request. Explicit unsupported
+controls MUST fail before dispatch instead of being silently dropped.
+
+#### Scenario: Provider does not support effort control
+- **WHEN** a turn explicitly requests reasoning effort and the selected provider declares no effort-control support
+- **THEN** Alan rejects the turn before provider dispatch
+- **AND** the error identifies the unsupported request control
+
+#### Scenario: Model rejects unsupported effort
+- **WHEN** the resolved model catalog entry supports only `low` and `high`
+- **AND** a session or turn explicitly requests `xhigh`
+- **THEN** Alan rejects the request before provider dispatch
+- **AND** the error lists the supported efforts from the model metadata
+
+### Requirement: Provider Adapters Only Project Normalized Controls
+Provider adapters MUST consume normalized request controls from
+`GenerationRequest` and project them to provider-specific payload fields.
+Provider adapters MUST NOT own Alan-level override precedence, model default
+selection, or config conflict resolution.
+
+#### Scenario: Canonical effort overrides provider extra params
+- **WHEN** a generation request contains normalized reasoning effort `low` and provider-specific extra params include `reasoning_effort = "high"`
+- **THEN** the provider adapter sends `low`
+- **AND** the provider-specific extra param does not create a competing effective value
+
+#### Scenario: Legacy budget is normalized before projection
+- **WHEN** `thinking_budget_tokens` is the only configured compatibility input
+- **THEN** the runtime resolver produces a normalized budget control
+- **AND** provider adapters project that budget according to provider rules without inferring Alan-level defaults
+
+### Requirement: Daemon And Clients Mirror Resolver Metadata
+Daemon session metadata, fork metadata, read responses, and client DTOs MUST
+report request-control metadata produced by the runtime resolver. They MUST NOT
+reconstruct reasoning-effort precedence independently.
+
+#### Scenario: Create session response uses resolver output
+- **WHEN** a session is created without explicit reasoning effort and the selected model default resolves to `medium`
+- **THEN** the create-session response reports `reasoning_effort = "medium"`
+- **AND** the value comes from runtime startup metadata
+
+#### Scenario: Fork override uses resolver output
+- **WHEN** a fork request explicitly overrides source-session reasoning effort
+- **THEN** the forked session metadata reports the newly resolved effort
+- **AND** daemon code does not merge source and override reasoning fields outside the runtime resolver
+
+### Requirement: Request Control Tests Guard Layer Boundaries
+Alan MUST include tests that cover resolver precedence, validation, provider
+projection, and daemon metadata mirroring. Tests MUST make it hard to re-add
+effective request-control logic in clients, daemon routes, provider adapters, or
+runtime execution call sites.
+
+#### Scenario: Resolver precedence matrix is tested
+- **WHEN** resolver tests run
+- **THEN** they cover turn override, session override, agent config, model default, legacy budget, and provider default cases
+
+#### Scenario: Layering contract rejects duplicate resolution
+- **WHEN** contract tests inspect request-control plumbing
+- **THEN** they fail if `turn_executor` or daemon routes directly recompute effective reasoning effort instead of consuming resolver output

--- a/openspec/changes/centralize-provider-request-controls/tasks.md
+++ b/openspec/changes/centralize-provider-request-controls/tasks.md
@@ -1,0 +1,40 @@
+## 1. Resolver Foundation
+
+- [x] 1.1 Add `crates/runtime/src/request_controls.rs` with intent, source, diagnostics, and resolved-control types.
+- [x] 1.2 Implement resolver precedence for turn override, session override, agent config, model default, legacy budget, and provider default.
+- [x] 1.3 Move explicit effort support validation into the resolver using provider capabilities and resolved model metadata.
+- [x] 1.4 Add resolver unit tests covering the full precedence matrix and unsupported provider/model cases.
+
+## 2. Runtime Integration
+
+- [x] 2.1 Replace `Config::effective_model_reasoning_effort` call sites with resolver calls.
+- [x] 2.2 Replace `Config::validate_reasoning_effort_for_resolved_model` call sites with resolver validation.
+- [x] 2.3 Refactor `RuntimeConfig` and `AgentConfig` so request controls are stored as intent or resolver snapshot, not duplicated effective truth.
+- [x] 2.4 Update workspace overlay and explicit runtime override merge tests for the new request-control intent model.
+- [x] 2.5 Update `turn_executor` to consume `ResolvedRequestControls` when building `GenerationRequest`.
+- [x] 2.6 Update turn-scoped reasoning override handling to feed resolver input without recomputing effective controls in `turn_executor`.
+
+## 3. Provider Projection
+
+- [x] 3.1 Normalize `GenerationRequest` so `ReasoningControls` is the canonical request-control carrier.
+- [x] 3.2 Keep compatibility builder methods while ensuring legacy budget setters populate normalized controls.
+- [x] 3.3 Update OpenAI Responses and Chat Completions adapters to project normalized controls only.
+- [x] 3.4 Update Gemini, Anthropic, OpenRouter, and compatible adapters to avoid Alan-level default or precedence decisions.
+- [x] 3.5 Add provider projection tests for canonical effort, legacy budget, and extra-param precedence.
+
+## 4. Daemon, Session, And Client Metadata
+
+- [x] 4.1 Route runtime startup metadata through resolver output.
+- [x] 4.2 Update daemon create/read/fork/session-store code to mirror resolver metadata rather than recomputing effective effort.
+- [x] 4.3 Reduce repeated `reasoning_effort: None` fixture churn with helper constructors where practical.
+- [x] 4.4 Confirm TUI and Apple clients remain DTO/presentation-only and do not encode request-control semantics.
+- [x] 4.5 Add daemon payload contract tests for create session and fork override metadata.
+
+## 5. Documentation And Contract Guardrails
+
+- [x] 5.1 Update `docs/spec/provider_capability_contract.md` with the runtime resolver ownership boundary.
+- [x] 5.2 Update `docs/spec/provider_reasoning_effort_migration.md` if compatibility behavior changes during refactor.
+- [x] 5.3 Add lightweight contract checks or focused tests that fail when daemon routes or `turn_executor` recompute effective reasoning controls directly.
+- [x] 5.4 Run `cargo fmt --all`.
+- [x] 5.5 Run focused runtime, LLM, daemon payload, and protocol tests.
+- [x] 5.6 Run `openspec validate centralize-provider-request-controls`.


### PR DESCRIPTION
## Summary
- Add a runtime-owned request-control resolver for reasoning effort and legacy thinking budget intent.
- Route runtime startup, turn execution, child-agent overrides, and daemon metadata through resolver output instead of duplicated effective-value helpers.
- Make provider adapters project normalized ReasoningControls and prevent provider extra_params from overriding canonical runtime controls.
- Add OpenSpec artifacts, docs, resolver/layering/provider projection tests, and daemon payload contract coverage.

## Stack
- Base: #330 / codex/stabilize-macos-shell-terminal

## Tests
- cargo check -p alan-runtime -p alan-llm -p alan --all-targets
- cargo test -p alan-runtime request_controls
- cargo test -p alan-runtime reasoning_effort
- cargo test -p alan-runtime thinking_budget
- cargo test -p alan-runtime test_run_turn_omits_reasoning_controls_when_unset
- cargo test -p alan-runtime agent_config
- cargo test -p alan-llm reasoning_effort
- cargo test -p alan-llm projects_messages_tools_and_reasoning_budget
- cargo test -p alan --test daemon_payload_contract_test
- cargo test -p alan-protocol reasoning
- openspec validate centralize-provider-request-controls