### PR TITLE
Clarify OpenSpec specs and propose removing legacy budget control

### DIFF
--- a/openspec/changes/remove-legacy-thinking-budget-control/.openspec.yaml
+++ b/openspec/changes/remove-legacy-thinking-budget-control/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/remove-legacy-thinking-budget-control/design.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`provider-request-controls` centralized request-control ownership around
+canonical reasoning effort, but it intentionally kept `thinking_budget_tokens` as
+a public compatibility input. That compatibility now works against the desired
+architecture: clients, configs, runtime launch paths, and provider adapters must
+continue to preserve a second reasoning-control vocabulary that can drift from
+`model_reasoning_effort`.
+
+Some providers still require budget-shaped wire fields. This change removes the
+public compatibility control, not provider-internal budget projection.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `model_reasoning_effort` the only user-facing reasoning control.
+- Reject legacy `thinking_budget_tokens` config and request payloads with clear
+  migration guidance.
+- Remove public `GenerationRequest.thinking_budget_tokens` compatibility paths.
+- Keep provider adapters able to derive provider-native budgets from canonical
+  effort where the provider API requires budgets.
+- Keep request-control precedence owned by the runtime resolver.
+
+**Non-Goals:**
+
+- Do not remove canonical reasoning effort.
+- Do not remove provider-native budget wire fields where Anthropic, Gemini, or
+  another provider requires them.
+- Do not add automatic migration or alias behavior for old configs.
+- Do not change unrelated provider settings or OpenRouter provider identity.
+
+## Decisions
+
+1. Public legacy budget inputs are rejected, not ignored.
+
+   Rejecting old `thinking_budget_tokens` values makes stale configuration
+   visible and avoids silent reasoning behavior changes. Ignoring the field would
+   be easier to deploy but would make debugging model behavior harder.
+
+2. Provider-internal budget projection remains behind normalized controls.
+
+   Anthropic extended thinking and Gemini 2.5 thinking may require budget-shaped
+   payloads. Those budgets should be derived from `ReasoningEffort`, model
+   metadata, and provider rules inside adapter projection, not accepted as a
+   separate public control.
+
+3. The resolver remains the single request-control owner.
+
+   Config parsing can reject obsolete fields, and provider adapters can validate
+   provider-specific wire constraints, but no daemon, client, or adapter should
+   recompute Alan-level effort precedence.
+
+4. Migration is explicit and breaking.
+
+   Existing users must replace `thinking_budget_tokens` with
+   `model_reasoning_effort`. Alan should return an actionable error instead of
+   rewriting old configuration automatically.
+
+## Risks / Trade-offs
+
+- Existing local configs may fail to load. -> Error messages and migration docs
+  must identify `model_reasoning_effort` as the replacement.
+- Provider-specific behavior may change for users who tuned exact budgets. -> The
+  model catalog and provider mapping tests must document effort-to-budget presets.
+- Removing public fields can create broad fixture churn. -> Use helper builders
+  and DTO constructors to keep tests focused on behavior.
+
+## Migration Plan
+
+1. Update specs and docs to define `model_reasoning_effort` as the only public
+   reasoning control.
+2. Remove or reject `thinking_budget_tokens` from config, protocol DTOs, daemon
+   payloads, client DTOs, and public LLM request builders.
+3. Preserve provider-native budget projection derived from canonical effort.
+4. Add negative tests for legacy field rejection and positive tests for
+   effort-derived provider budgets.
+5. Release with a breaking migration note: replace `thinking_budget_tokens` with
+   the closest supported `model_reasoning_effort` value.
+
+## Open Questions
+
+- Which effort preset should replace common legacy budget examples in docs?
+- Should the error include provider-specific advice when the old budget was close
+  to a known effort preset?

--- a/openspec/changes/remove-legacy-thinking-budget-control/proposal.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Alan now has a canonical reasoning-effort control and a runtime-owned
+request-control resolver. Keeping `thinking_budget_tokens` as a legacy public
+fallback leaves two user-facing ways to request reasoning behavior, which weakens
+the single-owner boundary and keeps compatibility semantics that Alan no longer
+needs.
+
+## What Changes
+
+- **BREAKING** Remove `thinking_budget_tokens` as a supported user-facing
+  request-control field in agent config, session/turn API payloads, client DTOs,
+  and public `GenerationRequest` construction.
+- **BREAKING** Reject old `thinking_budget_tokens` configuration or request
+  payloads with a clear error instead of mapping them to effort or provider
+  budgets.
+- Keep `model_reasoning_effort` as the only public reasoning control.
+- Keep provider-internal budget projection where a provider requires budgets,
+  but derive those budgets only from canonical reasoning effort and model/provider
+  metadata.
+- Remove OpenRouter-specific legacy `thinking_budget_tokens` projection behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `provider-request-controls`: Remove legacy thinking-budget compatibility from
+  the canonical request-control contract.
+- `openrouter-provider-adapter`: Remove OpenRouter request projection for public
+  `thinking_budget_tokens` fallback.
+
+## Impact
+
+- `crates/runtime`: config parsing, request-control intent, resolver inputs,
+  child-agent overrides, rollout/session metadata, and validation errors.
+- `crates/protocol`: session or turn request DTOs if they expose
+  `thinking_budget_tokens`.
+- `crates/llm`: `GenerationRequest` public fields/builders and provider adapter
+  tests that currently accept legacy budget input.
+- `crates/alan`: daemon create/fork/read payloads and error behavior for old
+  request fields.
+- `clients/tui` and `clients/apple`: remove any DTO field or UI affordance for
+  legacy thinking budgets.
+- Documentation and tests: update examples to use `model_reasoning_effort` only
+  and add negative coverage for rejected legacy fields.

--- a/openspec/changes/remove-legacy-thinking-budget-control/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/specs/openrouter-provider-adapter/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: OpenRouter request projection
+Alan SHALL map Alan generation requests to OpenRouter SDK chat requests without
+requiring runtime code to depend on OpenRouter SDK types. Reasoning control
+precedence and validation are owned by `provider-request-controls`; this
+capability covers the OpenRouter-specific wire projection. Normalized request
+controls, including effective reasoning effort, are supplied on
+`GenerationRequest` by `provider-request-controls`; the OpenRouter adapter only
+translates those controls to supported OpenRouter SDK fields and does not accept
+legacy `thinking_budget_tokens` fallback input.
+
+#### Scenario: Basic message projection
+- **WHEN** a request contains a system prompt and user, assistant, context, and tool messages
+- **THEN** the OpenRouter adapter maps them to the SDK chat message roles and content fields expected by OpenRouter
+
+#### Scenario: Tool definition projection
+- **WHEN** a request contains Alan tool definitions
+- **THEN** the OpenRouter adapter maps them to OpenRouter chat tool definitions and enables automatic tool choice behavior
+
+#### Scenario: Tool result projection
+- **WHEN** a request contains a tool-result message with a tool call id
+- **THEN** the OpenRouter adapter preserves the tool call id in the projected OpenRouter message
+
+#### Scenario: Reasoning effort projection
+- **WHEN** a request contains normalized effective reasoning effort
+- **THEN** the OpenRouter adapter maps the effort to OpenRouter reasoning request fields supported by the SDK without recomputing Alan-level precedence or defaults
+
+#### Scenario: Unsupported provider extra parameter
+- **WHEN** a request contains an OpenRouter `extra_params` key that the adapter does not support
+- **THEN** the adapter fails before dispatching the request or returns an explicit provider warning rather than silently dropping the parameter

--- a/openspec/changes/remove-legacy-thinking-budget-control/specs/provider-request-controls/spec.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/specs/provider-request-controls/spec.md
@@ -1,0 +1,204 @@
+## MODIFIED Requirements
+
+### Requirement: Request control intent is separate from resolved controls
+Alan SHALL represent user, session, and turn request-control intent separately
+from resolved request controls. `Config` and transport DTOs MAY contain
+canonical reasoning-effort intent, but they MUST NOT expose legacy
+thinking-budget intent and MUST NOT be the authority for final effective
+request-control values.
+
+#### Scenario: Agent config sets effort
+- **WHEN** `agent.toml` sets `model_reasoning_effort = "high"`
+- **THEN** the resolved runtime config carries reasoning-effort intent for `high`
+
+#### Scenario: Legacy budget config is rejected
+- **WHEN** `agent.toml` sets `thinking_budget_tokens`
+- **THEN** Alan rejects the configuration with a breaking-change error that names `model_reasoning_effort` as the replacement
+- **AND** Alan does not preserve the budget as request-control intent
+
+#### Scenario: RuntimeConfig does not duplicate independent effective truth
+- **WHEN** a workspace overlay changes model metadata or a runtime launch applies a session override
+- **THEN** Alan resolves request controls through the resolver
+- **AND** `RuntimeConfig` does not require a separate effective reasoning field that can drift from `Config`
+
+### Requirement: Runtime-owned request control resolution
+Alan SHALL resolve effective provider request controls through a runtime-owned
+resolver before dispatching a model request. The resolver SHALL combine turn
+override, session/runtime override, agent config intent, model catalog default,
+provider capabilities, and provider default in a single typed result.
+
+#### Scenario: Turn override has highest precedence
+- **WHEN** a session has `model_reasoning_effort = "high"` and a turn requests `reasoning_effort = "low"`
+- **THEN** the resolved request controls use `low` for that turn
+- **AND** the session-level resolved controls remain unchanged for later turns
+
+#### Scenario: Session override wins over agent config
+- **WHEN** a session is created with a reasoning effort override and the resolved agent config has a different effort
+- **THEN** Alan uses the session override for that runtime
+
+#### Scenario: Child agent override
+- **WHEN** a child-agent spawn spec includes a reasoning effort runtime override
+- **THEN** Alan applies that effort to the child runtime after validating it against the child model
+
+#### Scenario: Model default is applied once by the resolver
+- **WHEN** no explicit reasoning effort is configured and the resolved model catalog entry declares default effort `medium`
+- **THEN** the resolver returns reasoning effort `medium` with source `model_default`
+- **AND** no other runtime, daemon, or provider-adapter layer recomputes that default independently
+
+#### Scenario: Unknown model metadata uses provider default
+- **WHEN** the selected provider/model has no model catalog metadata and no explicit request control is configured
+- **THEN** the resolver returns no explicit reasoning effort
+- **AND** the source records that provider defaults will apply
+
+### Requirement: Explicit request controls are validated before dispatch
+Alan SHALL validate explicit request controls against provider capability and
+resolved model metadata before making a provider request. Explicit unsupported
+controls SHALL fail before dispatch instead of being silently dropped.
+
+#### Scenario: Provider does not support effort control
+- **WHEN** a turn explicitly requests reasoning effort and the selected provider declares no effort-control support
+- **THEN** Alan rejects the turn before provider dispatch
+- **AND** the error identifies the unsupported request control
+
+#### Scenario: Model rejects unsupported effort
+- **WHEN** the resolved model catalog entry supports only `low` and `high`
+- **AND** a session or turn explicitly requests `xhigh`
+- **THEN** Alan rejects the request before provider dispatch
+- **AND** the error lists the supported efforts from the model metadata
+
+#### Scenario: Legacy budget request is rejected
+- **WHEN** config, protocol, API, or client payloads contain `thinking_budget_tokens`
+- **THEN** Alan rejects the request before provider dispatch
+- **AND** the error identifies `model_reasoning_effort` as the supported reasoning control
+
+### Requirement: Generation requests carry normalized controls
+Alan SHALL carry canonical reasoning controls on `GenerationRequest` rather than
+requiring provider adapters to infer them from ad hoc `extra_params` or legacy
+budget fields.
+
+#### Scenario: Turn request includes resolved effort
+- **WHEN** runtime constructs a generation request for a reasoning-capable model
+- **THEN** the request includes the validated effective reasoning effort
+
+#### Scenario: No reasoning control
+- **WHEN** neither explicit effort nor model default applies
+- **THEN** the request omits reasoning controls and lets the provider use its default behavior
+
+#### Scenario: Legacy public budget field is unavailable
+- **WHEN** a caller tries to construct or mutate a generation request with `thinking_budget_tokens`
+- **THEN** Alan provides no supported public request-control path for that field
+- **AND** provider projection cannot use a legacy budget fallback
+
+### Requirement: Provider adapters only project normalized controls
+Provider adapters SHALL consume normalized request controls from
+`GenerationRequest` and project them to provider-specific payload fields.
+Provider adapters SHALL NOT own Alan-level override precedence, model default
+selection, config conflict resolution, or legacy budget compatibility.
+
+#### Scenario: Canonical effort overrides provider extra params
+- **WHEN** a generation request contains normalized reasoning effort `low` and provider-specific extra params include `reasoning_effort = "high"`
+- **THEN** the provider adapter sends `low`
+- **AND** the provider-specific extra param does not create a competing effective value
+
+#### Scenario: Provider-native budget is derived internally
+- **WHEN** a provider requires a budget-shaped wire field for the effective reasoning effort
+- **THEN** the provider adapter derives that budget from normalized effort, model metadata, and provider rules
+- **AND** the adapter does not accept public `thinking_budget_tokens` as an alternate effective value
+
+### Requirement: OpenAI provider mapping
+Alan SHALL map canonical reasoning effort to OpenAI-native request fields for
+OpenAI Responses and OpenAI Chat Completions providers.
+
+#### Scenario: OpenAI Responses effort
+- **WHEN** `openai_responses` receives a generation request with effective effort
+- **THEN** Alan sends it as `reasoning.effort`
+
+#### Scenario: OpenAI Chat Completions effort
+- **WHEN** `openai_chat_completions` receives a generation request with effective effort
+- **THEN** Alan sends it as `reasoning_effort`
+
+#### Scenario: OpenAI unsupported effort
+- **WHEN** a selected OpenAI model does not support the effective effort
+- **THEN** Alan rejects the request before provider dispatch
+
+### Requirement: Anthropic provider mapping
+Alan SHALL map canonical reasoning effort to Anthropic extended-thinking budget
+configuration when the selected Anthropic model supports extended thinking.
+
+#### Scenario: Anthropic effort maps to budget
+- **WHEN** `anthropic_messages` receives a generation request with effective effort
+- **THEN** Alan maps the effort to the configured Anthropic `thinking.budget_tokens` preset for the selected model
+
+#### Scenario: Anthropic minimum budget
+- **WHEN** the mapped Anthropic budget is below the provider minimum
+- **THEN** Alan rejects the request before dispatch
+
+#### Scenario: Anthropic max tokens relationship
+- **WHEN** Anthropic thinking is enabled
+- **THEN** Alan ensures `max_tokens` is greater than `budget_tokens` or rejects/adjusts according to the provider adapter contract
+
+### Requirement: Gemini provider mapping
+Alan SHALL map canonical reasoning effort to Gemini thinking controls according
+to model family.
+
+#### Scenario: Gemini 3 thinking level
+- **WHEN** `google_gemini_generate_content` uses a Gemini 3 model and receives effective effort
+- **THEN** Alan maps supported efforts to `thinkingConfig.thinkingLevel`
+
+#### Scenario: Gemini 2.5 thinking budget
+- **WHEN** `google_gemini_generate_content` uses a Gemini 2.5 model and receives effective effort
+- **THEN** Alan maps the effort to a catalog-defined `thinkingBudget`
+
+#### Scenario: Gemini disable thinking
+- **WHEN** a Gemini model does not support disabling thinking and the effective effort is `none`
+- **THEN** Alan rejects the request before dispatch
+
+### Requirement: Compatible-provider and OpenRouter mapping
+Alan SHALL only send reasoning-effort extension fields to compatibility
+providers when the provider/model explicitly declares support.
+
+#### Scenario: Compatible provider supports effort extension
+- **WHEN** `openai_chat_completions_compatible` receives effective effort for a model that declares `reasoning_effort` support
+- **THEN** Alan sends the compatible extension field
+
+#### Scenario: Compatible provider does not support effort extension
+- **WHEN** a compatibility provider/model lacks declared effort support
+- **THEN** Alan rejects explicit reasoning effort rather than silently dropping it
+
+#### Scenario: OpenRouter SDK-backed provider
+- **WHEN** the SDK-backed `openrouter` provider receives effective effort
+- **THEN** Alan maps the effort to the OpenRouter SDK/provider-native reasoning field supported by the selected endpoint and model
+
+### Requirement: Documentation and migration
+Alan SHALL document effort-first reasoning controls and the breaking removal of
+legacy `thinking_budget_tokens` public configuration.
+
+#### Scenario: Agent config example
+- **WHEN** documentation shows reasoning configuration
+- **THEN** it uses `model_reasoning_effort = "medium"` as the primary example
+
+#### Scenario: Budget documentation
+- **WHEN** documentation mentions `thinking_budget_tokens`
+- **THEN** it describes the field as removed legacy configuration and directs users to `model_reasoning_effort`
+
+#### Scenario: Migration from budget to effort
+- **WHEN** users have existing `thinking_budget_tokens` config
+- **THEN** documentation explains that the field is rejected and must be replaced with a named reasoning effort when the selected provider/model supports effort
+
+### Requirement: Request control tests guard layer boundaries
+Alan SHALL include tests that cover resolver precedence, validation, provider
+projection, and daemon metadata mirroring. Tests SHALL make it hard to re-add
+effective request-control logic in clients, daemon routes, provider adapters, or
+runtime execution call sites.
+
+#### Scenario: Resolver precedence matrix is tested
+- **WHEN** resolver tests run
+- **THEN** they cover turn override, session override, agent config, model default, and provider default cases
+
+#### Scenario: Legacy budget rejection is tested
+- **WHEN** config, protocol, API, client DTO, or generation-request construction paths are tested
+- **THEN** they reject or do not expose `thinking_budget_tokens` as a supported public request-control input
+
+#### Scenario: Layering contract rejects duplicate resolution
+- **WHEN** contract tests inspect request-control plumbing
+- **THEN** they fail if `turn_executor` or daemon routes directly recompute effective reasoning effort instead of consuming resolver output

--- a/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
@@ -1,0 +1,33 @@
+## 1. Public Contract Removal
+
+- [ ] 1.1 Remove `thinking_budget_tokens` from user-facing agent config examples and parsing, or convert remaining parser support into an explicit rejection path.
+- [ ] 1.2 Remove `thinking_budget_tokens` from daemon session/fork/turn DTOs and client DTOs where exposed.
+- [ ] 1.3 Remove public `GenerationRequest.thinking_budget_tokens` compatibility fields/builders and update call sites to use normalized reasoning controls.
+- [ ] 1.4 Add clear errors that direct users from `thinking_budget_tokens` to `model_reasoning_effort`.
+
+## 2. Resolver And Runtime
+
+- [ ] 2.1 Remove legacy budget intent from request-control resolver inputs and precedence tests.
+- [ ] 2.2 Keep resolver output centered on canonical reasoning effort plus provider-default/no-control states.
+- [ ] 2.3 Confirm child-agent runtime overrides accept reasoning effort only.
+- [ ] 2.4 Update rollout/session metadata so it never reports legacy budget as an effective public control.
+
+## 3. Provider Projection
+
+- [ ] 3.1 Keep provider-native budget projection where required, derived only from canonical reasoning effort and model/provider metadata.
+- [ ] 3.2 Remove OpenAI legacy budget-to-effort mapping.
+- [ ] 3.3 Remove Anthropic, Gemini, OpenRouter, and compatible-provider public budget fallback projection paths.
+- [ ] 3.4 Add provider projection tests for effort-derived budgets and rejected legacy budget inputs.
+
+## 4. Documentation And Migration
+
+- [ ] 4.1 Update provider reasoning documentation to make `model_reasoning_effort` the only public reasoning control.
+- [ ] 4.2 Add a breaking migration note for replacing `thinking_budget_tokens`.
+- [ ] 4.3 Remove examples that show `thinking_budget_tokens` as valid configuration.
+
+## 5. Verification
+
+- [ ] 5.1 Run `cargo fmt --all`.
+- [ ] 5.2 Run focused runtime, LLM provider, daemon payload, and client DTO tests.
+- [ ] 5.3 Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+- [ ] 5.4 Run `openspec validate remove-legacy-thinking-budget-control --strict`.

--- a/openspec/specs/agent-root-layout-contract/spec.md
+++ b/openspec/specs/agent-root-layout-contract/spec.md
@@ -1,7 +1,11 @@
 # agent-root-layout-contract Specification
 
 ## Purpose
-TBD - created by archiving change centralize-agent-root-layout-contract. Update Purpose after archive.
+Define the implementation boundary that keeps production code using
+runtime-owned typed agent-root layout APIs instead of duplicating canonical path
+construction. This capability depends on `agent-root-layout` for external path
+semantics and owns code-level centralization, non-Rust mirror constraints, and
+guardrails.
 ## Requirements
 ### Requirement: Runtime-owned agent-root layout
 Alan SHALL expose a runtime-owned typed API for canonical agent-root layout
@@ -75,4 +79,3 @@ layout strings in Rust production code outside approved layout-owner locations.
 - **WHEN** tests, documentation, or OpenSpec artifacts use literal canonical paths to describe the external contract
 - **THEN** the guardrail allows those paths through an explicit scope or allowlist
 - **AND** the allowed usage does not become a production-code layout owner
-

--- a/openspec/specs/agent-root-layout/spec.md
+++ b/openspec/specs/agent-root-layout/spec.md
@@ -1,7 +1,11 @@
 # agent-root-layout Specification
 
 ## Purpose
-TBD - created by archiving change unify-agent-root-paths. Update Purpose after archive.
+Define Alan's durable external agent-root layout contract: canonical default and
+named root paths, default agent semantics, overlay order, asset loading and
+writing, singular `.alan/agent/` removal, and repository hygiene. This
+capability owns user-visible layout behavior; implementation guardrails for how
+code constructs these paths live in `agent-root-layout-contract`.
 ## Requirements
 ### Requirement: Canonical agent root directories
 Alan SHALL store every default and named agent definition root under an `agents`
@@ -124,4 +128,3 @@ state from authored agent definitions using the canonical `.alan/agents/` layout
 - **WHEN** a workspace contains files under `.alan/agent/`
 - **THEN** repository ignore rules do not allowlist that path as an authored agent root
 - **AND** documentation instructs users to move authored files to `.alan/agents/default/`
-

--- a/openspec/specs/child-run-lifecycle/spec.md
+++ b/openspec/specs/child-run-lifecycle/spec.md
@@ -1,7 +1,9 @@
 # child-run-lifecycle Specification
 
 ## Purpose
-TBD - created by archiving change sub-agent-lifecycle-control. Update Purpose after archive.
+Define delegated child-run lifecycle behavior: registration before first
+submission, liveness and timeout classification, progress metadata, daemon and
+TUI control surfaces, and governed parent-initiated termination.
 ## Requirements
 ### Requirement: Child Run Registration
 The system SHALL create a child-run record before submitting the first operation to a delegated child runtime.
@@ -84,4 +86,3 @@ The parent runtime SHALL expose a governed virtual tool for terminating a known 
 #### Scenario: Parent terminates terminal child
 - **WHEN** the parent runtime invokes child termination for a child run that is already terminal
 - **THEN** the tool returns the existing terminal state and records no duplicate termination transition
-

--- a/openspec/specs/daemon-api-contract/spec.md
+++ b/openspec/specs/daemon-api-contract/spec.md
@@ -1,7 +1,10 @@
 # daemon-api-contract Specification
 
 ## Purpose
-TBD - created by archiving change centralize-daemon-api-contract. Update Purpose after archive.
+Define Alan daemon API route contract requirements: endpoint metadata, shared URL
+construction, remote access scope, relay policy, generated client helpers,
+payload drift checks, public route compatibility, and raw route-string
+guardrails.
 ## Requirements
 ### Requirement: Canonical Endpoint Registry
 The daemon SHALL define a canonical endpoint registry that lists every supported
@@ -111,4 +114,3 @@ construction code outside the approved contract or generated files.
   a new raw `/api/v1/...` route string
 - **THEN** the route string guardrail fails and points to the endpoint contract
   helper surface
-

--- a/openspec/specs/delegated-result-handoff/spec.md
+++ b/openspec/specs/delegated-result-handoff/spec.md
@@ -1,7 +1,9 @@
 # delegated-result-handoff Specification
 
 ## Purpose
-TBD - created by archiving change sub-agent-lifecycle-control. Update Purpose after archive.
+Define how delegated child results are handed back to the parent runtime,
+including completed output fidelity, structured result shape, truncation
+metadata, child-run references, and failure or termination metadata.
 ## Requirements
 ### Requirement: Completed Child Output Fidelity
 The system SHALL preserve completed delegated child output as full inline text or an inspectable output reference instead of silently replacing it with an unlabeled short preview.
@@ -39,4 +41,3 @@ The system SHALL include child-run metadata and latest progress information when
 #### Scenario: Child is explicitly terminated
 - **WHEN** a delegated child is terminated by operator or parent request
 - **THEN** the delegated result distinguishes `terminated` from `timed_out` and includes termination actor, reason, and mode when available
-

--- a/openspec/specs/openrouter-provider-adapter/spec.md
+++ b/openspec/specs/openrouter-provider-adapter/spec.md
@@ -92,7 +92,10 @@ compatible client.
 Alan SHALL map Alan generation requests to OpenRouter SDK chat requests without
 requiring runtime code to depend on OpenRouter SDK types. Reasoning control
 precedence and validation are owned by `provider-request-controls`; this
-capability covers the OpenRouter-specific wire projection.
+capability covers the OpenRouter-specific wire projection. Normalized request
+controls, including effective reasoning effort, are supplied on
+`GenerationRequest` by `provider-request-controls`; the OpenRouter adapter only
+translates those controls to supported OpenRouter SDK fields.
 
 #### Scenario: Basic message projection
 - **WHEN** a request contains a system prompt and user, assistant, context, and tool messages
@@ -109,6 +112,10 @@ capability covers the OpenRouter-specific wire projection.
 #### Scenario: Reasoning budget projection
 - **WHEN** a request contains `thinking_budget_tokens`
 - **THEN** the OpenRouter adapter maps the budget to OpenRouter reasoning request fields supported by the SDK
+
+#### Scenario: Reasoning effort projection
+- **WHEN** a request contains normalized effective reasoning effort
+- **THEN** the OpenRouter adapter maps the effort to OpenRouter reasoning request fields supported by the SDK without recomputing Alan-level precedence or defaults
 
 #### Scenario: Unsupported provider extra parameter
 - **WHEN** a request contains an OpenRouter `extra_params` key that the adapter does not support

--- a/openspec/specs/runtime-memory-surfaces/spec.md
+++ b/openspec/specs/runtime-memory-surfaces/spec.md
@@ -1,7 +1,9 @@
 # runtime-memory-surfaces Specification
 
 ## Purpose
-TBD - created by archiving change sub-agent-lifecycle-control. Update Purpose after archive.
+Define runtime memory and handoff surface behavior: agent-authored semantic
+continuation summaries, coherent fallback truncation, terminal turn-state
+refresh, and rollout references when compact surfaces omit detail.
 ## Requirements
 ### Requirement: Skill-Authored Semantic Memory Surfaces
 Memory and handoff surfaces SHALL prefer semantic summaries authored by the active agent through the memory skill or another explicit agent-visible memory workflow.
@@ -42,4 +44,3 @@ Memory surfaces SHALL stay compact continuation aids and point to rollouts when 
 #### Scenario: Detail exceeds memory budget
 - **WHEN** recent conversation detail exceeds the memory surface budget
 - **THEN** the memory surface keeps a coherent summary and identifies where to inspect the raw rollout for full detail
-

--- a/openspec/specs/workspace-runtime-state-hygiene/spec.md
+++ b/openspec/specs/workspace-runtime-state-hygiene/spec.md
@@ -1,7 +1,11 @@
 # workspace-runtime-state-hygiene Specification
 
 ## Purpose
-TBD - created by archiving change sub-agent-lifecycle-control. Update Purpose after archive.
+Define workspace runtime-state hygiene requirements: generated `.alan` session
+and memory state should stay out of normal source control, authored agent
+definitions should remain trackable, Alan home should not become a nested
+workspace, and workspace identity comparisons should use canonical paths where
+available.
 ## Requirements
 ### Requirement: Generated Workspace State Ignore Rules
 Repository ignore rules SHALL ignore generated workspace `.alan` runtime state by default while allowing authored agent definitions to remain trackable.
@@ -43,4 +47,3 @@ The documentation SHALL explain which `.alan` paths are generated runtime state 
 #### Scenario: Developer reads workspace state docs
 - **WHEN** a developer checks the repository documentation for `.alan` workspace state
 - **THEN** the docs identify generated sessions/memory paths separately from authored agent roots, policies, and skills
-


### PR DESCRIPTION
## Summary
- clarify long-lived OpenSpec purposes and capability ownership boundaries
- clarify OpenRouter request-control projection ownership
- add active OpenSpec change remove-legacy-thinking-budget-control for the breaking removal of public thinking_budget_tokens support

## Notes
- This PR does not implement the breaking removal; it only records the proposed change, design, delta specs, and tasks.
- The change keeps provider-internal budget projection possible when derived from canonical model_reasoning_effort.

## Validation
- openspec validate remove-legacy-thinking-budget-control --strict
- openspec validate --all --strict
- git diff --check

Rust tests were not run because this PR only updates OpenSpec documents and proposal artifacts.