### PR TITLE
Remove legacy thinking budget controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,9 +508,6 @@ prompt_snapshot_max_chars = 8000
 # Optional canonical reasoning effort. If omitted and the selected model is in
 # Alan's model catalog, Alan uses the model's catalog default.
 model_reasoning_effort = "medium"
-# Provider-specific compatibility escape hatch for budget-native providers.
-# Do not set this together with model_reasoning_effort.
-# thinking_budget_tokens = 2048
 
 [memory]
 enabled = true

--- a/README.md
+++ b/README.md
@@ -131,31 +131,31 @@ Alan/
 - **WebSocket + HTTP API**: Real-time bidirectional communication
 - **Context Compaction**: Automatic summarization when context grows large
 - **One-Shot Ask**: `alan ask` for non-interactive queries with text/json/quiet output modes
-- **Thinking Support**: Optional reasoning/thinking display with named effort control and provider-specific token budgets
+- **Thinking Support**: Optional reasoning/thinking display with canonical named effort control
 - **Session Rollback**: Undo last N turns within a session
 
 ---
 
 ## Thinking / Reasoning Support
 
-Alan exposes `model_reasoning_effort` as the canonical runtime config control,
-with `thinking_budget_tokens` retained as a provider-specific compatibility
-budget. Current provider behavior:
+Alan exposes `model_reasoning_effort` as the canonical runtime config control.
+The old public `thinking_budget_tokens` field has been removed; provider-native
+budgets are derived internally from named effort presets when a provider requires
+budget-shaped wire fields. Current provider behavior:
 
-- **Anthropic Messages API**: native thinking blocks, thinking signature, and redacted thinking blocks; named effort maps to budget presets and explicit budgets require `budget_tokens >= 1024`
+- **Anthropic Messages API**: native thinking blocks, thinking signature, and redacted thinking blocks; named effort maps to provider budget presets
 - **OpenAI Responses API**: preserves thinking metadata when available and maps named effort to `reasoning.effort`
 - **OpenAI Chat Completions API**: preserves thinking metadata when available and maps named effort to `reasoning_effort`
 - **OpenAI Chat Completions API-compatible**: chat-completions-compatible path with reasoning field support (for example `reasoning_content` and reasoning metadata)
 - **OpenRouter**: SDK-backed chat adapter that preserves OpenRouter reasoning and reasoning-detail metadata when available and maps named effort to provider-native reasoning controls
-- **Google Gemini GenerateContent API**: maps Gemini 3 effort to `thinkingLevel` and Gemini 2.5 effort/budget to `thinkingBudget`
+- **Google Gemini GenerateContent API**: maps Gemini 3 effort to `thinkingLevel` and Gemini 2.5 effort to `thinkingBudget`
 
 Notes:
 
 - `model_reasoning_effort = "medium"` is the preferred config shape when the
   selected model supports named effort.
-- `thinking_budget_tokens = null` (default) means no provider-specific raw
-  budget is configured.
-- Do not set `model_reasoning_effort` and `thinking_budget_tokens` together.
+- Existing `thinking_budget_tokens` config is rejected; replace it with the
+  closest supported `model_reasoning_effort` value.
 - `alan ask --thinking` controls whether thinking deltas are shown in text-mode CLI output.
 
 ---
@@ -240,8 +240,6 @@ enabled = false
 
 # Thinking / reasoning (optional)
 model_reasoning_effort = "medium"
-# Provider-specific budget compatibility; do not set with model_reasoning_effort.
-# thinking_budget_tokens = 2048
 ```
 
 Host-facing daemon/client settings live in `~/.alan/host.toml`. You can also set

--- a/crates/alan/src/daemon/routes.rs
+++ b/crates/alan/src/daemon/routes.rs
@@ -549,27 +549,107 @@ fn request_has_json_content_type(headers: &HeaderMap) -> bool {
 fn parse_optional_json_body<T: DeserializeOwned>(
     headers: &HeaderMap,
     body: &Bytes,
-) -> Result<Option<T>, StatusCode> {
+) -> Result<Option<T>, JsonBodyError> {
     if body.is_empty() || body.iter().all(|byte| byte.is_ascii_whitespace()) {
         return Ok(None);
     }
 
     if !request_has_json_content_type(headers) {
-        return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        return Err(JsonBodyError::UnsupportedMediaType);
     }
 
-    serde_json::from_slice(body)
+    let value =
+        serde_json::from_slice::<serde_json::Value>(body).map_err(|_| JsonBodyError::BadRequest)?;
+    if object_has_removed_thinking_budget(&value) {
+        return Err(JsonBodyError::RemovedThinkingBudget);
+    }
+
+    serde_json::from_value(value)
         .map(Some)
-        .map_err(|_| StatusCode::BAD_REQUEST)
+        .map_err(|_| JsonBodyError::BadRequest)
 }
 
-fn json_body_error_response(status: StatusCode) -> (StatusCode, Json<serde_json::Value>) {
-    let message = match status {
-        StatusCode::BAD_REQUEST => "Invalid JSON request body",
-        StatusCode::UNSUPPORTED_MEDIA_TYPE => "Expected application/json request body",
-        _ => "Invalid request body",
+fn parse_required_json_body<T, F>(
+    headers: &HeaderMap,
+    body: &Bytes,
+    contains_removed_thinking_budget: F,
+) -> Result<T, JsonBodyError>
+where
+    T: DeserializeOwned,
+    F: FnOnce(&serde_json::Value) -> bool,
+{
+    if body.is_empty() || body.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Err(JsonBodyError::BadRequest);
+    }
+
+    if !request_has_json_content_type(headers) {
+        return Err(JsonBodyError::UnsupportedMediaType);
+    }
+
+    let value =
+        serde_json::from_slice::<serde_json::Value>(body).map_err(|_| JsonBodyError::BadRequest)?;
+    if contains_removed_thinking_budget(&value) {
+        return Err(JsonBodyError::RemovedThinkingBudget);
+    }
+
+    serde_json::from_value(value).map_err(|_| JsonBodyError::BadRequest)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonBodyError {
+    BadRequest,
+    UnsupportedMediaType,
+    RemovedThinkingBudget,
+}
+
+impl JsonBodyError {
+    fn status(self) -> StatusCode {
+        match self {
+            Self::BadRequest | Self::RemovedThinkingBudget => StatusCode::BAD_REQUEST,
+            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::BadRequest => "Invalid JSON request body",
+            Self::UnsupportedMediaType => "Expected application/json request body",
+            Self::RemovedThinkingBudget => {
+                "Removed request field `thinking_budget_tokens`; use `model_reasoning_effort` in agent config or `reasoning_effort` on session/turn requests"
+            }
+        }
+    }
+}
+
+fn object_has_removed_thinking_budget(value: &serde_json::Value) -> bool {
+    value
+        .as_object()
+        .is_some_and(|object| object.contains_key("thinking_budget_tokens"))
+}
+
+fn submit_request_has_removed_thinking_budget(value: &serde_json::Value) -> bool {
+    if object_has_removed_thinking_budget(value) {
+        return true;
+    }
+
+    let Some(op) = value.get("op") else {
+        return false;
     };
-    (status, Json(serde_json::json!({ "error": message })))
+    object_has_removed_thinking_budget(op)
+        || op
+            .get("context")
+            .is_some_and(object_has_removed_thinking_budget)
+}
+
+fn json_body_error_status(error: JsonBodyError) -> StatusCode {
+    error.status()
+}
+
+fn json_body_error_response(error: JsonBodyError) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        error.status(),
+        Json(serde_json::json!({ "error": error.message() })),
+    )
 }
 
 fn skill_catalog_error_response(err: anyhow::Error) -> (StatusCode, Json<serde_json::Value>) {
@@ -1108,11 +1188,12 @@ pub async fn fork_session(
     Path(session_id): Path<String>,
     headers: HeaderMap,
     body: Bytes,
-) -> Result<Json<ForkSessionResponse>, StatusCode> {
-    let payload = parse_optional_json_body::<ForkSessionRequest>(&headers, &body)?;
+) -> Result<Json<ForkSessionResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let payload = parse_optional_json_body::<ForkSessionRequest>(&headers, &body)
+        .map_err(json_body_error_response)?;
     state.ensure_sessions_recovered().await.map_err(|err| {
         warn!(%session_id, error = %err, "Failed to recover sessions before fork");
-        StatusCode::INTERNAL_SERVER_ERROR
+        status_error_response(StatusCode::INTERNAL_SERVER_ERROR)
     })?;
     let (
         source_workspace_id,
@@ -1126,7 +1207,7 @@ pub async fn fork_session(
     ) = {
         let sessions = state.sessions.read().await;
         let Some(entry) = sessions.get(&session_id) else {
-            return Err(StatusCode::NOT_FOUND);
+            return Err(status_error_response(StatusCode::NOT_FOUND));
         };
         (
             entry.workspace_id.clone(),
@@ -1145,7 +1226,7 @@ pub async fn fork_session(
         .await
         .map_err(|err| {
             warn!(%session_id, error = %err, "Failed to update inbound activity before fork");
-            StatusCode::INTERNAL_SERVER_ERROR
+            status_error_response(StatusCode::INTERNAL_SERVER_ERROR)
         })?;
 
     let JsonLikeFork {
@@ -1172,14 +1253,18 @@ pub async fn fork_session(
         if path.exists() {
             Some(path)
         } else {
-            latest_rollout_path_for_workspace(&state, &session_id, &source_workspace_id).await?
+            latest_rollout_path_for_workspace(&state, &session_id, &source_workspace_id)
+                .await
+                .map_err(status_error_response)?
         }
     } else {
-        latest_rollout_path_for_workspace(&state, &session_id, &source_workspace_id).await?
+        latest_rollout_path_for_workspace(&state, &session_id, &source_workspace_id)
+            .await
+            .map_err(status_error_response)?
     };
 
     let Some(rollout_path) = rollout_path else {
-        return Err(StatusCode::CONFLICT);
+        return Err(status_error_response(StatusCode::CONFLICT));
     };
 
     let new_session_id = state
@@ -1196,13 +1281,13 @@ pub async fn fork_session(
         .await
         .map_err(|err| {
             warn!(%session_id, error = %err, "Failed to fork session");
-            status_for_session_creation_error(&err)
+            status_error_response(status_for_session_creation_error(&err))
         })?;
 
     let (agent_name, profile_id, provider, resolved_model, reasoning_effort, durability) = {
         let sessions = state.sessions.read().await;
         let Some(entry) = sessions.get(&new_session_id) else {
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            return Err(status_error_response(StatusCode::INTERNAL_SERVER_ERROR));
         };
         (
             entry.agent_name.clone(),
@@ -1486,6 +1571,30 @@ pub struct SubmitResponse {
     pub accepted: bool,
 }
 
+/// HTTP route wrapper for submitting an operation to a session.
+pub async fn submit_operation_route(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    remote_context: Option<Extension<RemoteRequestContext>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<SubmitResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let request = parse_required_json_body::<SubmitRequest, _>(
+        &headers,
+        &body,
+        submit_request_has_removed_thinking_budget,
+    )
+    .map_err(json_body_error_response)?;
+    submit_operation(
+        State(state),
+        Path(session_id),
+        remote_context,
+        Json(request),
+    )
+    .await
+    .map_err(status_error_response)
+}
+
 /// Submit an operation to a session
 pub async fn submit_operation(
     State(state): State<AppState>,
@@ -1559,6 +1668,15 @@ pub async fn submit_operation(
     }
 }
 
+fn status_error_response(status: StatusCode) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        status,
+        Json(serde_json::json!({
+            "error": status.canonical_reason().unwrap_or("Request failed")
+        })),
+    )
+}
+
 /// Request manual context compaction for a session.
 pub async fn compact_session(
     State(state): State<AppState>,
@@ -1566,7 +1684,8 @@ pub async fn compact_session(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<CompactSessionResponse>, StatusCode> {
-    let payload = parse_optional_json_body::<CompactSessionRequest>(&headers, &body)?;
+    let payload = parse_optional_json_body::<CompactSessionRequest>(&headers, &body)
+        .map_err(json_body_error_status)?;
     let focus = payload
         .and_then(|req| req.focus)
         .map(|focus| focus.trim().to_string())
@@ -2826,6 +2945,33 @@ Body
             resp.reasoning_effort,
             Some(alan_protocol::ReasoningEffort::High)
         );
+    }
+
+    #[tokio::test]
+    async fn create_session_rejects_legacy_thinking_budget_control() {
+        let state = test_state();
+
+        let (status, body) = match create_session(
+            State(state),
+            json_headers(),
+            Bytes::from(
+                serde_json::json!({
+                    "thinking_budget_tokens": 2048
+                })
+                .to_string(),
+            ),
+        )
+        .await
+        {
+            Ok(_) => panic!("legacy thinking budget control should be rejected"),
+            Err(err) => err,
+        };
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body.0["error"].as_str().unwrap_or_default();
+        assert!(message.contains("thinking_budget_tokens"));
+        assert!(message.contains("model_reasoning_effort"));
+        assert!(message.contains("reasoning_effort"));
     }
 
     #[tokio::test]
@@ -4213,6 +4359,63 @@ Body
     }
 
     #[tokio::test]
+    async fn submit_operation_route_rejects_legacy_thinking_budget_control() {
+        let state = test_state();
+        let temp = tempfile::TempDir::new().unwrap();
+        let (entry, mut submission_rx) = session_entry(temp.path());
+        state
+            .sessions
+            .write()
+            .await
+            .insert("sess-submit-legacy".to_string(), entry);
+
+        let app = Router::new()
+            .route("/api/v1/sessions/{id}/submit", post(submit_operation_route))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions/sess-submit-legacy/submit")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "op": {
+                                "type": "turn",
+                                "parts": [
+                                    { "type": "text", "text": "hello" }
+                                ],
+                                "context": {
+                                    "thinking_budget_tokens": 2048
+                                }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let message = value["error"].as_str().unwrap_or_default();
+        assert!(message.contains("thinking_budget_tokens"));
+        assert!(message.contains("model_reasoning_effort"));
+        assert!(message.contains("reasoning_effort"));
+        match tokio::time::timeout(std::time::Duration::from_millis(100), submission_rx.recv())
+            .await
+        {
+            Err(_) | Ok(None) => {}
+            Ok(Some(_)) => {
+                panic!("legacy request-control payload should not be forwarded to runtime")
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn compact_session_submits_compact_with_options_without_focus() {
         let state = test_state();
         let temp = tempfile::TempDir::new().unwrap();
@@ -4411,6 +4614,34 @@ Body
     }
 
     #[tokio::test]
+    async fn fork_session_rejects_legacy_thinking_budget_control() {
+        let state = test_state();
+
+        let (status, body) = match fork_session(
+            State(state),
+            Path("sess-fork-legacy".to_string()),
+            json_headers(),
+            Bytes::from(
+                serde_json::json!({
+                    "thinking_budget_tokens": 2048
+                })
+                .to_string(),
+            ),
+        )
+        .await
+        {
+            Ok(_) => panic!("legacy thinking budget control should be rejected"),
+            Err(err) => err,
+        };
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body.0["error"].as_str().unwrap_or_default();
+        assert!(message.contains("thinking_budget_tokens"));
+        assert!(message.contains("model_reasoning_effort"));
+        assert!(message.contains("reasoning_effort"));
+    }
+
+    #[tokio::test]
     async fn fork_session_without_reasoning_override_preserves_source_metadata() {
         let state = test_state();
         let temp = tempfile::TempDir::new().unwrap();
@@ -4512,7 +4743,7 @@ Body
         .await
         .err()
         .unwrap();
-        assert_eq!(fork_err, StatusCode::NOT_FOUND);
+        assert_eq!(fork_err.0, StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/alan/src/daemon/server.rs
+++ b/crates/alan/src/daemon/server.rs
@@ -191,7 +191,7 @@ pub async fn run_server_with_loaded_config(loaded_config: LoadedConfig) -> Resul
             paths::SESSION_SLEEP_UNTIL,
             post(routes::sleep_session_until),
         )
-        .route(paths::SESSION_SUBMIT, post(routes::submit_operation))
+        .route(paths::SESSION_SUBMIT, post(routes::submit_operation_route))
         .route(paths::SESSION_EVENTS, get(routes::stream_events))
         .route(paths::SESSION_WS, get(websocket::ws_handler))
         .with_state(state);

--- a/crates/alan/tests/agent_root_overlay_integration_test.rs
+++ b/crates/alan/tests/agent_root_overlay_integration_test.rs
@@ -158,7 +158,7 @@ description: Overlay verification skill
 
 fn write_agent_root(
     root: &Path,
-    thinking_budget_tokens: u32,
+    model_reasoning_effort: &str,
     soul_text: &str,
     skill_body: &str,
     policy_yaml: Option<&str>,
@@ -166,7 +166,7 @@ fn write_agent_root(
     std::fs::create_dir_all(root.join("persona")).unwrap();
     std::fs::write(
         root.join("agent.toml"),
-        format!("thinking_budget_tokens = {thinking_budget_tokens}\n"),
+        format!("model_reasoning_effort = \"{model_reasoning_effort}\"\n"),
     )
     .unwrap();
     std::fs::write(root.join("persona/SOUL.md"), soul_text).unwrap();
@@ -187,28 +187,28 @@ fn prepare_overlay_chain(temp: &TempDir) -> (AlanHomePaths, PathBuf, PathBuf, Pa
 
     write_agent_root(
         &home_paths.global_agent_root_dir,
-        128,
+        "minimal",
         "global default soul",
         "global default skill body",
         None,
     );
     write_agent_root(
         &workspace_root.join(".alan/agents/default"),
-        256,
+        "low",
         "workspace default soul",
         "workspace default skill body",
         None,
     );
     write_agent_root(
         &home_paths.global_named_agents_dir.join(AGENT_NAME),
-        512,
+        "medium",
         "global named soul",
         "global named skill body",
         None,
     );
     write_agent_root(
         &workspace_root.join(".alan/agents").join(AGENT_NAME),
-        1024,
+        "high",
         "workspace named soul",
         "workspace named skill body",
         Some(
@@ -338,7 +338,10 @@ fn assert_overlay_request(request: &GenerationRequest) {
     assert!(system_prompt.contains("workspace named skill body"));
     assert!(!system_prompt.contains("global named skill body"));
     assert!(!system_prompt.contains("workspace default skill body"));
-    assert_eq!(request.thinking_budget_tokens, Some(1024));
+    assert_eq!(
+        request.reasoning.effort,
+        Some(alan_protocol::ReasoningEffort::High)
+    );
 }
 
 fn is_memory_promotion_request(request: &GenerationRequest) -> bool {

--- a/crates/llm/src/anthropic_messages.rs
+++ b/crates/llm/src/anthropic_messages.rs
@@ -596,14 +596,13 @@ fn take_anthropic_messages_extra_param(
 /// When thinking is enabled: temperature must be 1.0, max_tokens must > budget_tokens.
 fn build_thinking_params(
     reasoning_effort: Option<ReasoningEffort>,
-    thinking_budget_tokens: &Option<u32>,
     temperature: Option<f32>,
     max_tokens: i32,
 ) -> Result<(Option<ThinkingConfig>, Option<f32>, i32)> {
     let resolved_budget = match reasoning_effort {
         Some(ReasoningEffort::None) => None,
         Some(effort) => Some(anthropic_budget_for_effort(effort)),
-        None => *thinking_budget_tokens,
+        None => None,
     };
 
     match resolved_budget {
@@ -936,12 +935,9 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
-        let thinking_budget_tokens =
-            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let messages =
             take_anthropic_messages_extra_param("anthropic_messages", &mut extra_params)?
@@ -955,12 +951,8 @@ impl LlmProvider for AnthropicMessagesClient {
             );
         }
 
-        let (thinking, temperature, max_tokens) = build_thinking_params(
-            reasoning.effort,
-            &thinking_budget_tokens,
-            temperature,
-            max_tokens.unwrap_or(4096),
-        )?;
+        let (thinking, temperature, max_tokens) =
+            build_thinking_params(reasoning.effort, temperature, max_tokens.unwrap_or(4096))?;
 
         let anthropic_request = AnthropicMessagesRequest {
             model: self.model.clone(),
@@ -993,12 +985,9 @@ impl LlmProvider for AnthropicMessagesClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
-        let thinking_budget_tokens =
-            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let messages =
             take_anthropic_messages_extra_param("anthropic_messages", &mut extra_params)?
@@ -1012,12 +1001,8 @@ impl LlmProvider for AnthropicMessagesClient {
             );
         }
 
-        let (thinking, temperature, max_tokens) = build_thinking_params(
-            reasoning.effort,
-            &thinking_budget_tokens,
-            temperature,
-            max_tokens.unwrap_or(4096),
-        )?;
+        let (thinking, temperature, max_tokens) =
+            build_thinking_params(reasoning.effort, temperature, max_tokens.unwrap_or(4096))?;
 
         let anthropic_request = AnthropicMessagesRequest {
             model: self.model.clone(),
@@ -1796,15 +1781,18 @@ mod tests {
     }
 
     #[test]
-    fn test_build_thinking_params_enforces_min_budget() {
-        let err = build_thinking_params(None, &Some(512), Some(0.7), 2048).unwrap_err();
-        assert!(err.to_string().contains("budget_tokens >="));
+    fn test_build_thinking_params_omits_thinking_when_effort_unset() {
+        let (thinking, temperature, max_tokens) =
+            build_thinking_params(None, Some(0.7), 2048).unwrap();
+        assert!(thinking.is_none());
+        assert_eq!(temperature, Some(0.7));
+        assert_eq!(max_tokens, 2048);
     }
 
     #[test]
     fn test_build_thinking_params_adjusts_max_tokens_and_temperature() {
         let (thinking, temperature, max_tokens) =
-            build_thinking_params(None, &Some(1024), Some(0.2), 1000).unwrap();
+            build_thinking_params(Some(ReasoningEffort::Low), Some(0.2), 1000).unwrap();
 
         assert!(thinking.is_some());
         assert_eq!(temperature, Some(1.0));
@@ -1814,7 +1802,7 @@ mod tests {
     #[test]
     fn test_build_thinking_params_maps_reasoning_effort_to_budget() {
         let (thinking, temperature, max_tokens) =
-            build_thinking_params(Some(ReasoningEffort::High), &None, Some(0.2), 4096).unwrap();
+            build_thinking_params(Some(ReasoningEffort::High), Some(0.2), 4096).unwrap();
 
         assert_eq!(thinking.unwrap().budget_tokens, 8192);
         assert_eq!(temperature, Some(1.0));

--- a/crates/llm/src/google_gemini_generate_content.rs
+++ b/crates/llm/src/google_gemini_generate_content.rs
@@ -620,7 +620,6 @@ fn normalize_stream_finish_reason(finish_reason: String) -> String {
 fn build_gemini_thinking_config(
     model: &str,
     reasoning_effort: Option<ReasoningEffort>,
-    thinking_budget_tokens: Option<u32>,
 ) -> Result<Option<ThinkingConfig>> {
     let model = model.to_ascii_lowercase();
     if model.contains("gemini-3") {
@@ -658,11 +657,7 @@ fn build_gemini_thinking_config(
             }
             Some(ReasoningEffort::None) => Some(0),
             Some(effort) => Some(gemini_budget_for_effort(effort)),
-            None => thinking_budget_tokens
-                .map(|tokens| {
-                    i32::try_from(tokens).context("Gemini thinkingBudget exceeds supported range")
-                })
-                .transpose()?,
+            None => None,
         };
         return Ok(budget.map(|thinking_budget| ThinkingConfig {
             thinking_level: None,
@@ -694,14 +689,7 @@ fn gemini_budget_for_effort(effort: ReasoningEffort) -> i32 {
 #[async_trait::async_trait]
 impl LlmProvider for GoogleGeminiGenerateContentClient {
     async fn generate(&mut self, request: GenerationRequest) -> anyhow::Result<GenerationResponse> {
-        let thinking_config = build_gemini_thinking_config(
-            &self.model,
-            request.reasoning.effort,
-            crate::effective_thinking_budget_tokens(
-                request.reasoning,
-                request.thinking_budget_tokens,
-            ),
-        )?;
+        let thinking_config = build_gemini_thinking_config(&self.model, request.reasoning.effort)?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request
             .messages
@@ -862,14 +850,7 @@ impl LlmProvider for GoogleGeminiGenerateContentClient {
         &mut self,
         request: GenerationRequest,
     ) -> anyhow::Result<tokio::sync::mpsc::Receiver<UnifiedStreamChunk>> {
-        let thinking_config = build_gemini_thinking_config(
-            &self.model,
-            request.reasoning.effort,
-            crate::effective_thinking_budget_tokens(
-                request.reasoning,
-                request.thinking_budget_tokens,
-            ),
-        )?;
+        let thinking_config = build_gemini_thinking_config(&self.model, request.reasoning.effort)?;
         // Convert messages to Gemini format
         let contents: Vec<Content> = request
             .messages
@@ -1191,13 +1172,10 @@ mod tests {
 
     #[test]
     fn test_build_gemini_thinking_config_maps_gemini_3_effort_to_level() {
-        let config = build_gemini_thinking_config(
-            "gemini-3-flash-preview",
-            Some(ReasoningEffort::Medium),
-            None,
-        )
-        .unwrap()
-        .unwrap();
+        let config =
+            build_gemini_thinking_config("gemini-3-flash-preview", Some(ReasoningEffort::Medium))
+                .unwrap()
+                .unwrap();
 
         assert_eq!(config.thinking_level.as_deref(), Some("medium"));
         assert_eq!(config.thinking_budget, None);
@@ -1205,22 +1183,19 @@ mod tests {
 
     #[test]
     fn test_build_gemini_thinking_config_maps_gemini_25_effort_to_budget() {
-        let config =
-            build_gemini_thinking_config("gemini-2.5-flash", Some(ReasoningEffort::High), None)
-                .unwrap()
-                .unwrap();
+        let config = build_gemini_thinking_config("gemini-2.5-flash", Some(ReasoningEffort::High))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(config.thinking_level, None);
         assert_eq!(config.thinking_budget, Some(8192));
     }
 
     #[test]
-    fn test_build_gemini_thinking_config_preserves_gemini_25_explicit_budget() {
-        let config = build_gemini_thinking_config("gemini-2.5-flash", None, Some(1234))
-            .unwrap()
-            .unwrap();
+    fn test_build_gemini_thinking_config_omits_budget_when_effort_unset() {
+        let config = build_gemini_thinking_config("gemini-2.5-flash", None).unwrap();
 
-        assert_eq!(config.thinking_budget, Some(1234));
+        assert!(config.is_none());
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -166,8 +166,6 @@ pub struct GenerationRequest {
     pub tools: Vec<ToolDefinition>,
     pub temperature: Option<f32>,
     pub max_tokens: Option<i32>,
-    /// Thinking budget in tokens (provider-specific; e.g. Anthropic budget or OpenAI effort hint)
-    pub thinking_budget_tokens: Option<u32>,
     /// Canonical cross-provider reasoning controls.
     pub reasoning: ReasoningControls,
     /// Provider-specific extra parameters
@@ -243,7 +241,6 @@ impl GenerationRequest {
             tools: Vec::new(),
             temperature: None,
             max_tokens: None,
-            thinking_budget_tokens: None,
             reasoning: ReasoningControls::default(),
             extra_params: HashMap::new(),
         }
@@ -315,13 +312,6 @@ impl GenerationRequest {
         self
     }
 
-    /// Set provider-specific thinking/reasoning budget tokens.
-    pub fn with_thinking_budget_tokens(mut self, tokens: u32) -> Self {
-        self.thinking_budget_tokens = Some(tokens);
-        self.reasoning.budget_tokens = Some(tokens);
-        self
-    }
-
     /// Set canonical named reasoning effort.
     pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
         self.reasoning.effort = Some(effort);
@@ -331,7 +321,6 @@ impl GenerationRequest {
     /// Set canonical reasoning controls.
     pub fn with_reasoning_controls(mut self, controls: ReasoningControls) -> Self {
         self.reasoning = controls;
-        self.thinking_budget_tokens = controls.budget_tokens;
         self
     }
 
@@ -399,13 +388,6 @@ impl GenerationRequest {
         );
         self
     }
-}
-
-pub(crate) fn effective_thinking_budget_tokens(
-    reasoning: ReasoningControls,
-    thinking_budget_tokens: Option<u32>,
-) -> Option<u32> {
-    reasoning.budget_tokens.or(thinking_budget_tokens)
 }
 
 impl Default for GenerationRequest {
@@ -1376,13 +1358,11 @@ mod tests {
     }
 
     #[test]
-    fn test_generation_request_reasoning_controls_sync_legacy_budget() {
-        let cleared = GenerationRequest::new()
-            .with_thinking_budget_tokens(2048)
-            .with_reasoning_controls(ReasoningControls::default());
+    fn test_generation_request_reasoning_controls_set_canonical_controls() {
+        let cleared =
+            GenerationRequest::new().with_reasoning_controls(ReasoningControls::default());
 
         assert_eq!(cleared.reasoning, ReasoningControls::default());
-        assert_eq!(cleared.thinking_budget_tokens, None);
 
         let budgeted = GenerationRequest::new().with_reasoning_controls(ReasoningControls {
             effort: None,
@@ -1390,23 +1370,6 @@ mod tests {
         });
 
         assert_eq!(budgeted.reasoning.budget_tokens, Some(512));
-        assert_eq!(budgeted.thinking_budget_tokens, Some(512));
-    }
-
-    #[test]
-    fn test_effective_thinking_budget_tokens_preserves_legacy_field() {
-        let mut request = GenerationRequest::new();
-        request.thinking_budget_tokens = Some(2048);
-        assert_eq!(
-            effective_thinking_budget_tokens(request.reasoning, request.thinking_budget_tokens),
-            Some(2048)
-        );
-
-        request.reasoning.budget_tokens = Some(512);
-        assert_eq!(
-            effective_thinking_budget_tokens(request.reasoning, request.thinking_budget_tokens),
-            Some(512)
-        );
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1364,12 +1364,11 @@ mod tests {
 
         assert_eq!(cleared.reasoning, ReasoningControls::default());
 
-        let budgeted = GenerationRequest::new().with_reasoning_controls(ReasoningControls {
-            effort: None,
-            budget_tokens: Some(512),
+        let efforted = GenerationRequest::new().with_reasoning_controls(ReasoningControls {
+            effort: Some(ReasoningEffort::High),
         });
 
-        assert_eq!(budgeted.reasoning.budget_tokens, Some(512));
+        assert_eq!(efforted.reasoning.effort, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/crates/llm/src/openai_chat_completions.rs
+++ b/crates/llm/src/openai_chat_completions.rs
@@ -1479,12 +1479,9 @@ pub(crate) fn build_responses_request_for_model(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
-    let thinking_budget_tokens =
-        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let previous_response_id = take_string_extra_param("previous_response_id", &mut extra_params);
     let background = take_bool_extra_param("background", &mut extra_params);
@@ -1493,11 +1490,7 @@ pub(crate) fn build_responses_request_for_model(
         store = Some(true);
     }
 
-    let reasoning = build_openai_responses_reasoning(
-        reasoning.effort,
-        thinking_budget_tokens,
-        &mut extra_params,
-    );
+    let reasoning = build_openai_responses_reasoning(reasoning.effort, &mut extra_params);
     let include = normalize_responses_include(
         take_string_array_extra_param("include", &mut extra_params),
         should_include_reasoning_encrypted_content(&messages, &tools, reasoning.is_some()),
@@ -1535,18 +1528,11 @@ pub(crate) fn build_responses_input_tokens_request_for_model(
         tools,
         temperature: _,
         max_tokens: _,
-        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
-    let thinking_budget_tokens =
-        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
-    let reasoning = build_openai_responses_reasoning(
-        reasoning.effort,
-        thinking_budget_tokens,
-        &mut extra_params,
-    );
+    let reasoning = build_openai_responses_reasoning(reasoning.effort, &mut extra_params);
     let (response_tools, tool_choice) = convert_tools_for_openai_responses(tools);
     let input = take_responses_input_items_extra_param("responses_input_items", &mut extra_params)
         .unwrap_or_else(|| convert_messages_for_openai_responses(messages));
@@ -1666,12 +1652,9 @@ fn build_chat_completions_request_for_model(
         tools: request_tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
-    let thinking_budget_tokens =
-        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let mut messages: Vec<serde_json::Value> = Vec::new();
     if let Some(system) = system_prompt {
@@ -1690,8 +1673,7 @@ fn build_chat_completions_request_for_model(
     );
 
     let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-    let reasoning_effort =
-        build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
+    let reasoning_effort = build_reasoning_effort(reasoning.effort, &mut extra_params);
     let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
     OpenAiChatCompletionsRequest {
@@ -1710,10 +1692,9 @@ fn build_chat_completions_request_for_model(
 
 fn build_openai_responses_reasoning(
     reasoning_effort: Option<ReasoningEffort>,
-    thinking_budget_tokens: Option<u32>,
     extra_params: &mut HashMap<String, serde_json::Value>,
 ) -> Option<OpenAiResponsesReasoning> {
-    build_reasoning_effort(reasoning_effort, thinking_budget_tokens, extra_params)
+    build_reasoning_effort(reasoning_effort, extra_params)
         .map(|effort| OpenAiResponsesReasoning { effort })
 }
 
@@ -1964,20 +1945,6 @@ fn responses_stream_sequence_number(event: &serde_json::Value) -> Option<u64> {
         .and_then(serde_json::Value::as_u64)
 }
 
-fn map_thinking_budget_to_effort(thinking_budget_tokens: u32) -> &'static str {
-    if thinking_budget_tokens <= 256 {
-        "minimal"
-    } else if thinking_budget_tokens <= 1_024 {
-        "low"
-    } else if thinking_budget_tokens <= 4_096 {
-        "medium"
-    } else if thinking_budget_tokens <= 8_192 {
-        "high"
-    } else {
-        "xhigh"
-    }
-}
-
 fn is_valid_reasoning_effort(effort: &str) -> bool {
     matches!(
         effort,
@@ -2187,17 +2154,11 @@ fn extract_reasoning_fields(
 
 pub(crate) fn build_reasoning_effort(
     reasoning_effort: Option<ReasoningEffort>,
-    thinking_budget_tokens: Option<u32>,
     extra_params: &mut HashMap<String, serde_json::Value>,
 ) -> Option<String> {
     if let Some(effort) = reasoning_effort {
         extra_params.remove("reasoning_effort");
         return Some(effort.as_str().to_string());
-    }
-
-    if let Some(tokens) = thinking_budget_tokens {
-        extra_params.remove("reasoning_effort");
-        return Some(map_thinking_budget_to_effort(tokens).to_string());
     }
 
     if let Some(value) = extra_params.remove("reasoning_effort") {
@@ -2335,12 +2296,9 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
-        let thinking_budget_tokens =
-            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if let Some(system) = system_prompt {
@@ -2362,8 +2320,7 @@ impl OpenAiChatCompletionsClient {
         );
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-        let reasoning_effort =
-            build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
+        let reasoning_effort = build_reasoning_effort(reasoning.effort, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -2393,12 +2350,9 @@ impl OpenAiChatCompletionsClient {
             tools: request_tools,
             temperature,
             max_tokens,
-            thinking_budget_tokens,
             reasoning,
             mut extra_params,
         } = request;
-        let thinking_budget_tokens =
-            crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         if let Some(system) = system_prompt {
@@ -2420,8 +2374,7 @@ impl OpenAiChatCompletionsClient {
         );
 
         let (tools, tool_choice) = convert_tools_for_openai_chat_completions(request_tools);
-        let reasoning_effort =
-            build_reasoning_effort(reasoning.effort, thinking_budget_tokens, &mut extra_params);
+        let reasoning_effort = build_reasoning_effort(reasoning.effort, &mut extra_params);
         let max_completion_tokens = build_max_completion_tokens(max_tokens, &mut extra_params);
 
         let chat_request = OpenAiChatCompletionsRequest {
@@ -3062,8 +3015,7 @@ mod tests {
             serde_json::Value::String("high".to_string()),
         )]);
 
-        let effort =
-            build_reasoning_effort(Some(ReasoningEffort::Low), Some(256), &mut extra_params);
+        let effort = build_reasoning_effort(Some(ReasoningEffort::Low), &mut extra_params);
         assert_eq!(effort.as_deref(), Some("low"));
         assert!(!extra_params.contains_key("reasoning_effort"));
     }
@@ -3075,47 +3027,8 @@ mod tests {
             serde_json::Value::String("high".to_string()),
         )]);
 
-        let effort = build_reasoning_effort(None, None, &mut extra_params);
+        let effort = build_reasoning_effort(None, &mut extra_params);
         assert_eq!(effort.as_deref(), Some("high"));
-        assert!(!extra_params.contains_key("reasoning_effort"));
-    }
-
-    #[test]
-    fn test_build_reasoning_effort_maps_budget() {
-        let mut extra_params = HashMap::new();
-
-        assert_eq!(
-            build_reasoning_effort(None, Some(64), &mut extra_params).as_deref(),
-            Some("minimal")
-        );
-        assert_eq!(
-            build_reasoning_effort(None, Some(512), &mut extra_params).as_deref(),
-            Some("low")
-        );
-        assert_eq!(
-            build_reasoning_effort(None, Some(2048), &mut extra_params).as_deref(),
-            Some("medium")
-        );
-        assert_eq!(
-            build_reasoning_effort(None, Some(7000), &mut extra_params).as_deref(),
-            Some("high")
-        );
-        assert_eq!(
-            build_reasoning_effort(None, Some(10000), &mut extra_params).as_deref(),
-            Some("xhigh")
-        );
-    }
-
-    #[test]
-    fn test_build_reasoning_effort_prefers_canonical_budget_over_extra_params() {
-        let mut extra_params = HashMap::from([(
-            "reasoning_effort".to_string(),
-            serde_json::Value::String("high".to_string()),
-        )]);
-
-        let effort = build_reasoning_effort(None, Some(512), &mut extra_params);
-
-        assert_eq!(effort.as_deref(), Some("low"));
         assert!(!extra_params.contains_key("reasoning_effort"));
     }
 
@@ -3125,7 +3038,7 @@ mod tests {
             "reasoning_effort".to_string(),
             serde_json::Value::String("xhigh".to_string()),
         )]);
-        let effort = build_reasoning_effort(None, None, &mut extra_params);
+        let effort = build_reasoning_effort(None, &mut extra_params);
         assert_eq!(effort.as_deref(), Some("xhigh"));
         assert!(!extra_params.contains_key("reasoning_effort"));
     }
@@ -3157,29 +3070,6 @@ mod tests {
 
         assert_eq!(built.reasoning_effort.as_deref(), Some("low"));
         assert!(!built.extra_params.contains_key("reasoning_effort"));
-    }
-
-    #[test]
-    fn test_build_responses_request_preserves_legacy_thinking_budget_field() {
-        let mut request = GenerationRequest::new().with_user_message("Hello");
-        request.thinking_budget_tokens = Some(512);
-
-        let built = build_responses_request_for_model("gpt-5.4".to_string(), request, false);
-
-        assert_eq!(
-            built.reasoning.map(|reasoning| reasoning.effort),
-            Some("low".to_string())
-        );
-    }
-
-    #[test]
-    fn test_build_chat_completions_request_preserves_legacy_thinking_budget_field() {
-        let mut request = GenerationRequest::new().with_user_message("Hello");
-        request.thinking_budget_tokens = Some(512);
-
-        let built = build_chat_completions_request_for_model("gpt-5.4".to_string(), request);
-
-        assert_eq!(built.reasoning_effort.as_deref(), Some("low"));
     }
 
     #[test]

--- a/crates/llm/src/openrouter.rs
+++ b/crates/llm/src/openrouter.rs
@@ -188,12 +188,9 @@ pub(crate) fn build_openrouter_chat_request(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens,
         reasoning,
         mut extra_params,
     } = request;
-    let thinking_budget_tokens =
-        crate::effective_thinking_budget_tokens(reasoning, thinking_budget_tokens);
 
     let mut projected_messages = Vec::new();
     if let Some(system_prompt) = system_prompt.filter(|value| !value.is_empty()) {
@@ -213,9 +210,6 @@ pub(crate) fn build_openrouter_chat_request(
     if let Some(effort) = reasoning.effort {
         extra_params.remove("reasoning_effort");
         builder.reasoning_effort(openrouter_effort(effort));
-    } else if let Some(thinking_budget_tokens) = thinking_budget_tokens {
-        extra_params.remove("reasoning_effort");
-        builder.reasoning(ReasoningConfig::with_max_tokens(thinking_budget_tokens));
     }
 
     let tools = convert_tools_for_openrouter(tools);
@@ -925,13 +919,13 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn projects_messages_tools_and_reasoning_budget() {
+    fn projects_messages_tools_and_reasoning_effort() {
         let mut request = GenerationRequest::new()
             .with_system_prompt("system")
             .with_user_message("hello")
             .with_assistant_message("thinking done")
             .with_tool(ToolDefinition::new("lookup", "Lookup data"))
-            .with_thinking_budget_tokens(512);
+            .with_reasoning_effort(ReasoningEffort::Low);
         request.messages.push(Message {
             role: MessageRole::Assistant,
             content: String::new(),
@@ -958,7 +952,7 @@ mod tests {
         assert_eq!(value["messages"][4]["tool_call_id"], "call-1");
         assert_eq!(value["tools"][0]["function"]["name"], "lookup");
         assert_eq!(value["tool_choice"], "auto");
-        assert_eq!(value["reasoning"]["max_tokens"], 512);
+        assert_eq!(value["reasoning"]["effort"], "low");
     }
 
     #[test]
@@ -1040,28 +1034,17 @@ mod tests {
     }
 
     #[test]
-    fn canonical_budget_overrides_reasoning_effort_extra_parameter() {
+    fn canonical_effort_overrides_reasoning_effort_extra_parameter() {
         let request = GenerationRequest::new()
             .with_user_message("hello")
-            .with_thinking_budget_tokens(512)
+            .with_reasoning_effort(ReasoningEffort::Low)
             .with_extra_param("reasoning_effort", json!("high"));
 
         let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
         let value = serde_json::to_value(projected).unwrap();
 
-        assert_eq!(value["reasoning"]["max_tokens"], 512);
-        assert!(value["reasoning"].get("effort").is_none());
-    }
-
-    #[test]
-    fn legacy_budget_field_projects_reasoning_budget() {
-        let mut request = GenerationRequest::new().with_user_message("hello");
-        request.thinking_budget_tokens = Some(512);
-
-        let projected = build_openrouter_chat_request("openrouter/model", request).unwrap();
-        let value = serde_json::to_value(projected).unwrap();
-
-        assert_eq!(value["reasoning"]["max_tokens"], 512);
+        assert_eq!(value["reasoning"]["effort"], "low");
+        assert!(value["reasoning"].get("max_tokens").is_none());
     }
 
     #[test]

--- a/crates/llm/tests/live_provider_harness.rs
+++ b/crates/llm/tests/live_provider_harness.rs
@@ -1,5 +1,5 @@
 use alan_llm::factory::{self, ProviderConfig};
-use alan_llm::{GenerationRequest, LlmProvider, StreamChunk, ToolDefinition};
+use alan_llm::{GenerationRequest, LlmProvider, ReasoningEffort, StreamChunk, ToolDefinition};
 use anyhow::{Context, Result, ensure};
 use std::env;
 use std::path::PathBuf;
@@ -430,7 +430,7 @@ async fn run_openrouter_reasoning_if_supported(harness: &LiveProviderHarness) ->
         REQUEST_TIMEOUT,
         provider.generate(
             exact_reply_request(token)
-                .with_thinking_budget_tokens(256)
+                .with_reasoning_effort(ReasoningEffort::Minimal)
                 .with_extra_param("include_reasoning", serde_json::json!(true)),
         ),
     )

--- a/crates/protocol/src/op.rs
+++ b/crates/protocol/src/op.rs
@@ -81,7 +81,7 @@ pub struct DynamicToolSpec {
 
 /// User-submitted operations
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Op {
     // ========================================================================
     // New unified operations (Phase 2)
@@ -147,6 +147,7 @@ pub enum Op {
 
 /// Turn context metadata — attached to Turn ops.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct TurnContext {
     /// Optional workspace ID to route this turn to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -461,6 +462,22 @@ mod tests {
             }
             _ => panic!("Expected Turn variant"),
         }
+    }
+
+    #[test]
+    fn test_op_rejects_legacy_thinking_budget_in_turn_context() {
+        let payload = json!({
+            "type": "turn",
+            "parts": [
+                { "type": "text", "text": "Hi" }
+            ],
+            "context": {
+                "thinking_budget_tokens": 2048
+            }
+        });
+
+        let err = serde_json::from_value::<Op>(payload).unwrap_err();
+        assert!(err.to_string().contains("thinking_budget_tokens"));
     }
 
     #[test]

--- a/crates/protocol/src/reasoning.rs
+++ b/crates/protocol/src/reasoning.rs
@@ -48,16 +48,15 @@ impl fmt::Display for ReasoningEffort {
 
 /// Canonical reasoning controls carried through runtime and provider requests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReasoningControls {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub budget_tokens: Option<u32>,
 }
 
 impl ReasoningControls {
     pub fn is_empty(&self) -> bool {
-        self.effort.is_none() && self.budget_tokens.is_none()
+        self.effort.is_none()
     }
 }
 
@@ -93,5 +92,12 @@ mod tests {
         let explicit_none: ReasoningControls =
             serde_json::from_value(json!({ "effort": "none" })).unwrap();
         assert_eq!(explicit_none.effort, Some(ReasoningEffort::None));
+    }
+
+    #[test]
+    fn reasoning_controls_reject_raw_budget_tokens() {
+        let err = serde_json::from_value::<ReasoningControls>(json!({ "budget_tokens": 512 }))
+            .unwrap_err();
+        assert!(err.to_string().contains("budget_tokens"));
     }
 }

--- a/crates/protocol/src/spawn.rs
+++ b/crates/protocol/src/spawn.rs
@@ -30,6 +30,7 @@ pub enum SpawnHandle {
 
 /// Launch inputs supplied for a child runtime.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SpawnLaunchInputs {
     pub task: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -38,8 +39,6 @@ pub struct SpawnLaunchInputs {
     pub workspace_root: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_secs: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub budget_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_dir: Option<PathBuf>,
 }
@@ -120,7 +119,6 @@ mod tests {
                 cwd: Some(PathBuf::from("/tmp/workspace")),
                 workspace_root: Some(PathBuf::from("/tmp/workspace")),
                 timeout_secs: Some(120),
-                budget_tokens: Some(2048),
                 output_dir: Some(PathBuf::from("/tmp/workspace/out")),
             },
             handles: vec![
@@ -181,5 +179,16 @@ mod tests {
                 export_name: "reviewer".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn spawn_launch_inputs_reject_legacy_budget_tokens() {
+        let payload = serde_json::json!({
+            "task": "Review the repository",
+            "budget_tokens": 2048
+        });
+
+        let err = serde_json::from_value::<SpawnLaunchInputs>(payload).unwrap_err();
+        assert!(err.to_string().contains("budget_tokens"));
     }
 }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -352,9 +352,8 @@ pub struct Config {
     // ========================================================================
     // Thinking / Reasoning Controls
     // ========================================================================
-    /// Budget tokens for provider-specific thinking/reasoning. None = disabled.
-    #[serde(default)]
-    pub thinking_budget_tokens: Option<u32>,
+    #[serde(default, rename = "thinking_budget_tokens", skip_serializing)]
+    pub(crate) deprecated_thinking_budget_tokens: Option<u32>,
 
     /// Named cross-provider model reasoning effort. None = use model/provider default.
     #[serde(default)]
@@ -523,7 +522,7 @@ impl Default for Config {
             compaction_hard_trigger_ratio: None,
             prompt_snapshot_enabled: false,
             prompt_snapshot_max_chars: default_prompt_snapshot_max_chars(),
-            thinking_budget_tokens: None,
+            deprecated_thinking_budget_tokens: None,
             model_reasoning_effort: None,
             streaming_mode: default_streaming_mode(),
             partial_stream_recovery_mode: default_partial_stream_recovery_mode(),
@@ -1243,9 +1242,9 @@ impl Config {
     }
 
     fn validate_reasoning_controls(&self, source: String) -> anyhow::Result<()> {
-        if self.model_reasoning_effort.is_some() && self.thinking_budget_tokens.is_some() {
+        if self.deprecated_thinking_budget_tokens.is_some() {
             anyhow::bail!(
-                "configuration file {} sets both `model_reasoning_effort` and `thinking_budget_tokens`; remove one because named effort and token budget controls are ambiguous together",
+                "configuration file {} uses removed `thinking_budget_tokens`; replace it with `model_reasoning_effort`",
                 source
             );
         }
@@ -1792,7 +1791,7 @@ model_reasoning_effort = "high"
     }
 
     #[test]
-    fn test_config_from_file_rejects_reasoning_effort_and_budget_conflict() {
+    fn test_config_from_file_rejects_legacy_thinking_budget() {
         let temp = TempDir::new().unwrap();
         let config_path = temp.path().join("test_config.toml");
         std::fs::write(
@@ -1807,8 +1806,9 @@ thinking_budget_tokens = 2048
         let err = Config::from_file(&config_path).unwrap_err();
         assert!(
             err.to_string()
-                .contains("sets both `model_reasoning_effort`")
+                .contains("uses removed `thinking_budget_tokens`")
         );
+        assert!(err.to_string().contains("model_reasoning_effort"));
     }
 
     #[test]
@@ -1821,21 +1821,6 @@ thinking_budget_tokens = 2048
         )
         .unwrap();
         assert_eq!(resolved.reasoning_effort(), Some(ReasoningEffort::Medium));
-    }
-
-    #[test]
-    fn test_request_control_resolver_preserves_legacy_budget_behavior() {
-        let mut config = Config::for_openai_responses("sk-test", None, Some("gpt-5.4"));
-        config.thinking_budget_tokens = Some(2048);
-
-        let resolved = crate::resolve_session_request_controls(
-            &config,
-            crate::provider_capabilities_for_config(&config),
-            crate::RequestControlIntent::default(),
-        )
-        .unwrap();
-        assert_eq!(resolved.reasoning_effort(), None);
-        assert_eq!(resolved.budget_tokens(), Some(2048));
     }
 
     #[test]
@@ -2459,7 +2444,7 @@ supports_reasoning = true
         .unwrap();
 
         let overlay_path = temp.path().join("agent.toml");
-        std::fs::write(&overlay_path, "thinking_budget_tokens = 1024\n").unwrap();
+        std::fs::write(&overlay_path, "model_reasoning_effort = \"high\"\n").unwrap();
 
         let catalog = crate::ModelCatalog::load_with_overlays(Some(temp.path())).unwrap();
         let mut config =
@@ -2468,7 +2453,7 @@ supports_reasoning = true
 
         let overlaid = config.with_agent_root_overlays(&[overlay_path]).unwrap();
 
-        assert_eq!(overlaid.thinking_budget_tokens, Some(1024));
+        assert_eq!(overlaid.model_reasoning_effort, Some(ReasoningEffort::High));
         assert_eq!(overlaid.effective_model_info().unwrap().slug, "custom-kimi");
         assert_eq!(overlaid.effective_context_window_tokens(), 654_321);
     }

--- a/crates/runtime/src/llm.rs
+++ b/crates/runtime/src/llm.rs
@@ -516,7 +516,6 @@ pub fn build_generation_request(
         tools,
         temperature,
         max_tokens,
-        thinking_budget_tokens: None,
         reasoning: alan_llm::ReasoningControls::default(),
         extra_params: std::collections::HashMap::new(),
     }

--- a/crates/runtime/src/request_controls.rs
+++ b/crates/runtime/src/request_controls.rs
@@ -13,39 +13,25 @@ use serde::{Deserialize, Serialize};
 pub struct RequestControlIntent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub thinking_budget_tokens: Option<u32>,
 }
 
 impl RequestControlIntent {
     pub fn from_config(config: &Config) -> Self {
         Self {
             reasoning_effort: config.model_reasoning_effort,
-            thinking_budget_tokens: config.thinking_budget_tokens,
         }
     }
 
     pub fn reasoning_effort(reasoning_effort: Option<ReasoningEffort>) -> Self {
-        Self {
-            reasoning_effort,
-            thinking_budget_tokens: None,
-        }
-    }
-
-    pub fn thinking_budget_tokens(thinking_budget_tokens: Option<u32>) -> Self {
-        Self {
-            reasoning_effort: None,
-            thinking_budget_tokens,
-        }
+        Self { reasoning_effort }
     }
 
     pub fn is_empty(self) -> bool {
-        self.reasoning_effort.is_none() && self.thinking_budget_tokens.is_none()
+        self.reasoning_effort.is_none()
     }
 
     pub fn apply_to_config(self, config: &mut Config) {
         config.model_reasoning_effort = self.reasoning_effort;
-        config.thinking_budget_tokens = self.thinking_budget_tokens;
     }
 }
 
@@ -56,7 +42,6 @@ pub enum RequestControlSource {
     TurnOverride,
     SessionOverride,
     AgentConfig,
-    LegacyBudget,
     ModelDefault,
     ProviderDefault,
 }
@@ -89,10 +74,6 @@ impl Default for ResolvedRequestControls {
 impl ResolvedRequestControls {
     pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
         self.reasoning.effort
-    }
-
-    pub fn budget_tokens(&self) -> Option<u32> {
-        self.reasoning.budget_tokens
     }
 }
 
@@ -157,18 +138,6 @@ pub fn resolve_request_controls(
         return Ok(effort_controls(effort, RequestControlSource::AgentConfig));
     }
 
-    if let Some(tokens) = input.turn_intent.thinking_budget_tokens {
-        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
-    }
-
-    if let Some(tokens) = input.session_intent.thinking_budget_tokens {
-        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
-    }
-
-    if let Some(tokens) = config_intent.thinking_budget_tokens {
-        return Ok(budget_controls(tokens, RequestControlSource::LegacyBudget));
-    }
-
     if let Some(effort) = input
         .config
         .effective_model_info()
@@ -194,17 +163,6 @@ fn effort_controls(
         reasoning: ReasoningControls {
             effort: Some(effort),
             budget_tokens: None,
-        },
-        source,
-        diagnostics: Vec::new(),
-    }
-}
-
-fn budget_controls(tokens: u32, source: RequestControlSource) -> ResolvedRequestControls {
-    ResolvedRequestControls {
-        reasoning: ReasoningControls {
-            effort: None,
-            budget_tokens: Some(tokens),
         },
         source,
         diagnostics: Vec::new(),
@@ -323,23 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_budget_precedes_model_default() {
-        let mut config = openai_config();
-        config.thinking_budget_tokens = Some(2048);
-        let resolved = resolve_session_request_controls(
-            &config,
-            openai_caps(),
-            RequestControlIntent::default(),
-        )
-        .unwrap();
-
-        assert_eq!(resolved.reasoning.effort, None);
-        assert_eq!(resolved.reasoning.budget_tokens, Some(2048));
-        assert_eq!(resolved.source, RequestControlSource::LegacyBudget);
-    }
-
-    #[test]
-    fn model_default_applies_when_no_intent_or_budget() {
+    fn model_default_applies_when_no_explicit_intent() {
         let config = openai_config();
         let resolved = resolve_session_request_controls(
             &config,
@@ -441,7 +383,6 @@ default_reasoning_effort = "high"
             "validate_reasoning_effort_for_resolved_model",
             "active_turn_reasoning_effort",
             "runtime_config.model_reasoning_effort",
-            "runtime_config.thinking_budget_tokens",
         ] {
             assert!(
                 !turn_executor.contains(forbidden),

--- a/crates/runtime/src/request_controls.rs
+++ b/crates/runtime/src/request_controls.rs
@@ -162,7 +162,6 @@ fn effort_controls(
     ResolvedRequestControls {
         reasoning: ReasoningControls {
             effort: Some(effort),
-            budget_tokens: None,
         },
         source,
         diagnostics: Vec::new(),

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -2375,7 +2375,6 @@ model_reasoning_effort = "high"
             recorded[0].reasoning.effort,
             Some(alan_protocol::ReasoningEffort::Low)
         );
-        assert_eq!(recorded[0].reasoning.budget_tokens, None);
     }
 
     #[test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -1335,9 +1335,6 @@ fn render_launch_metadata(spec: &SpawnSpec) -> Option<String> {
     if let Some(output_dir) = spec.launch.output_dir.as_ref() {
         lines.push(format!("output_dir: {}", output_dir.display()));
     }
-    if let Some(budget_tokens) = spec.launch.budget_tokens {
-        lines.push(format!("budget_tokens: {budget_tokens}"));
-    }
 
     (!lines.is_empty()).then(|| format!("Execution Context\n{}", lines.join("\n")))
 }
@@ -1783,7 +1780,6 @@ mod tests {
                 cwd: None,
                 workspace_root: None,
                 timeout_secs: Some(30),
-                budget_tokens: None,
                 output_dir: None,
             },
             handles: Vec::new(),
@@ -2329,59 +2325,6 @@ tool_repeat_limit = 9
         let seen_config = seen_config.lock().unwrap().clone().unwrap();
         assert_eq!(seen_config.effective_model(), "gpt-5.4");
         assert_eq!(seen_config.tool_repeat_limit, 9);
-    }
-
-    #[tokio::test]
-    async fn spawn_child_runtime_ignores_launch_budget_for_reasoning_controls() {
-        let temp = TempDir::new().unwrap();
-        let requests = RecordedRequests::default();
-        let response = completed_response("Child finished cleanly.");
-        let parent = make_parent_state(&temp, requests.clone(), response.clone());
-        let root_dir = temp.path().join("repo/.alan/agents/grader");
-        std::fs::write(
-            root_dir.join("agent.toml"),
-            r#"
-	model_reasoning_effort = "high"
-	"#,
-        )
-        .unwrap();
-        let seen_config = Arc::new(Mutex::new(None::<crate::Config>));
-        let seen_config_for_factory = seen_config.clone();
-        let mut spec = launch_spec(root_dir);
-        spec.runtime_overrides.model = Some("gpt-5-mini".to_string());
-        spec.launch.budget_tokens = Some(512);
-
-        let child = spawn_child_runtime_with_client_factory(&parent, spec, |config| {
-            *seen_config_for_factory.lock().unwrap() = Some(config.clone());
-            Ok(LlmClient::new(RecordingProvider::new(
-                requests.clone(),
-                response.clone(),
-            )))
-        })
-        .await
-        .unwrap();
-        let result = child.join().await.unwrap();
-
-        assert_eq!(result.status, ChildRuntimeStatus::Completed);
-        let seen_config = seen_config.lock().unwrap().clone().unwrap();
-        assert_eq!(seen_config.effective_model(), "gpt-5-mini");
-        assert_eq!(
-            crate::resolve_session_request_controls(
-                &seen_config,
-                crate::provider_capabilities_for_config(&seen_config),
-                crate::RequestControlIntent::default(),
-            )
-            .unwrap()
-            .reasoning_effort(),
-            Some(alan_protocol::ReasoningEffort::High)
-        );
-
-        let recorded = requests.0.lock().unwrap();
-        assert_eq!(
-            recorded[0].reasoning.effort,
-            Some(alan_protocol::ReasoningEffort::High)
-        );
-        assert_eq!(recorded[0].reasoning.budget_tokens, None);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/child_agents.rs
+++ b/crates/runtime/src/runtime/child_agents.rs
@@ -1131,9 +1131,6 @@ fn build_child_agent_config(parent: &RuntimeLoopState, spec: &SpawnSpec) -> Agen
     if let Some(model) = spec.runtime_overrides.model.as_deref() {
         child_agent_config.set_model_override(model);
     }
-    if let Some(budget_tokens) = spec.launch.budget_tokens {
-        child_agent_config.set_thinking_budget_override(Some(budget_tokens));
-    }
     if let Some(effort) = spec.runtime_overrides.model_reasoning_effort {
         child_agent_config.set_model_reasoning_effort_override(Some(effort));
     }
@@ -2335,7 +2332,7 @@ tool_repeat_limit = 9
     }
 
     #[tokio::test]
-    async fn spawn_child_runtime_reapplies_model_and_budget_overrides_after_overlay() {
+    async fn spawn_child_runtime_ignores_launch_budget_for_reasoning_controls() {
         let temp = TempDir::new().unwrap();
         let requests = RecordedRequests::default();
         let response = completed_response("Child finished cleanly.");
@@ -2344,8 +2341,8 @@ tool_repeat_limit = 9
         std::fs::write(
             root_dir.join("agent.toml"),
             r#"
-thinking_budget_tokens = 1024
-"#,
+	model_reasoning_effort = "high"
+	"#,
         )
         .unwrap();
         let seen_config = Arc::new(Mutex::new(None::<crate::Config>));
@@ -2368,10 +2365,23 @@ thinking_budget_tokens = 1024
         assert_eq!(result.status, ChildRuntimeStatus::Completed);
         let seen_config = seen_config.lock().unwrap().clone().unwrap();
         assert_eq!(seen_config.effective_model(), "gpt-5-mini");
-        assert_eq!(seen_config.thinking_budget_tokens, Some(512));
+        assert_eq!(
+            crate::resolve_session_request_controls(
+                &seen_config,
+                crate::provider_capabilities_for_config(&seen_config),
+                crate::RequestControlIntent::default(),
+            )
+            .unwrap()
+            .reasoning_effort(),
+            Some(alan_protocol::ReasoningEffort::High)
+        );
 
         let recorded = requests.0.lock().unwrap();
-        assert_eq!(recorded[0].thinking_budget_tokens, Some(512));
+        assert_eq!(
+            recorded[0].reasoning.effort,
+            Some(alan_protocol::ReasoningEffort::High)
+        );
+        assert_eq!(recorded[0].reasoning.budget_tokens, None);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -422,22 +422,12 @@ impl AgentConfig {
         self.explicit_runtime_overrides.model = true;
     }
 
-    /// Override provider-specific thinking budget for this launch across overlays.
-    pub fn set_thinking_budget_override(&mut self, thinking_budget_tokens: Option<u32>) {
-        self.core_config.thinking_budget_tokens = thinking_budget_tokens;
-        self.core_config.model_reasoning_effort = None;
-        self.runtime_config.request_control_intent =
-            crate::RequestControlIntent::thinking_budget_tokens(thinking_budget_tokens);
-        self.explicit_runtime_overrides.request_control_intent = true;
-    }
-
     /// Override named model reasoning effort for this launch across overlays.
     pub fn set_model_reasoning_effort_override(
         &mut self,
         model_reasoning_effort: Option<alan_protocol::ReasoningEffort>,
     ) {
         self.core_config.model_reasoning_effort = model_reasoning_effort;
-        self.core_config.thinking_budget_tokens = None;
         self.runtime_config.request_control_intent =
             crate::RequestControlIntent::reasoning_effort(model_reasoning_effort);
         self.explicit_runtime_overrides.request_control_intent = true;
@@ -479,7 +469,6 @@ impl AgentConfig {
         let mut merge_base_core_config = self.core_config.clone();
         if self.explicit_runtime_overrides.request_control_intent {
             merge_base_core_config.model_reasoning_effort = None;
-            merge_base_core_config.thinking_budget_tokens = None;
         }
 
         let mut core_config = merge_base_core_config.with_agent_root_overlays(overlay_paths)?;
@@ -1905,26 +1894,17 @@ mod tests {
         write_agent_overlay(
             &overlay_path,
             r#"
-tool_repeat_limit = 9
-thinking_budget_tokens = 1024
-prompt_snapshot_enabled = true
-"#,
+	tool_repeat_limit = 9
+	prompt_snapshot_enabled = true
+	"#,
         );
 
         let base = AgentConfig::from(crate::Config::default());
         let merged = base.with_agent_root_overlays(&[overlay_path]).unwrap();
 
         assert_eq!(merged.core_config.tool_repeat_limit, 9);
-        assert_eq!(merged.core_config.thinking_budget_tokens, Some(1024));
         assert!(merged.core_config.prompt_snapshot_enabled);
         assert_eq!(merged.runtime_config.tool_repeat_limit, 9);
-        assert_eq!(
-            merged
-                .runtime_config
-                .request_control_intent
-                .thinking_budget_tokens,
-            Some(1024)
-        );
         assert!(merged.runtime_config.prompt_snapshot_enabled);
     }
 
@@ -1962,17 +1942,16 @@ model_reasoning_effort = "high"
         write_agent_overlay(
             &overlay_path,
             r#"
-tool_repeat_limit = 9
-streaming_mode = "off"
-thinking_budget_tokens = 1024
-"#,
+	tool_repeat_limit = 9
+	streaming_mode = "off"
+	model_reasoning_effort = "high"
+	"#,
         );
 
         let mut base = AgentConfig::from(crate::Config::default());
         base.runtime_config.tool_repeat_limit = 42;
         base.set_model_override("gpt-5-mini");
         base.set_streaming_mode_override(crate::config::StreamingMode::On);
-        base.set_thinking_budget_override(Some(2048));
         base.set_model_reasoning_effort_override(Some(alan_protocol::ReasoningEffort::Low));
 
         let merged = base.with_agent_root_overlays(&[overlay_path]).unwrap();
@@ -1983,7 +1962,6 @@ thinking_budget_tokens = 1024
             merged.core_config.streaming_mode,
             crate::config::StreamingMode::On
         );
-        assert_eq!(merged.core_config.thinking_budget_tokens, None);
         assert_eq!(
             merged.core_config.model_reasoning_effort,
             Some(alan_protocol::ReasoningEffort::Low)
@@ -2009,13 +1987,6 @@ thinking_budget_tokens = 1024
                 .request_control_intent
                 .reasoning_effort,
             Some(alan_protocol::ReasoningEffort::Low)
-        );
-        assert_eq!(
-            merged
-                .runtime_config
-                .request_control_intent
-                .thinking_budget_tokens,
-            None
         );
     }
 
@@ -2045,8 +2016,8 @@ thinking_budget_tokens = 1024
         std::fs::write(
             &overlay_path,
             r#"
-thinking_budget_tokens = 1024
-"#,
+	model_reasoning_effort = "high"
+	"#,
         )
         .unwrap();
 
@@ -2060,12 +2031,17 @@ thinking_budget_tokens = 1024
             ..WorkspaceRuntimeConfig::default()
         };
         config.agent_config.set_model_override("override-model");
-        config.agent_config.set_thinking_budget_override(Some(2048));
+        config
+            .agent_config
+            .set_model_reasoning_effort_override(Some(alan_protocol::ReasoningEffort::Low));
 
         let core_config = effective_core_config_for_runtime(&config).unwrap();
 
         assert_eq!(core_config.openai_responses_model, "override-model");
-        assert_eq!(core_config.thinking_budget_tokens, Some(2048));
+        assert_eq!(
+            core_config.model_reasoning_effort,
+            Some(alan_protocol::ReasoningEffort::Low)
+        );
         assert_eq!(
             core_config.memory.workspace_dir,
             Some(crate::workspace_memory_dir_from_alan_dir(
@@ -2624,9 +2600,9 @@ required = true
         std::fs::write(
             &overlay_path,
             r#"
-tool_repeat_limit = 9
-thinking_budget_tokens = 1024
-"#,
+	tool_repeat_limit = 9
+	model_reasoning_effort = "high"
+	"#,
         )
         .unwrap();
 
@@ -2648,7 +2624,10 @@ thinking_budget_tokens = 1024
             crate::config::LlmProvider::OpenAiResponses
         ));
         assert_eq!(core_config.tool_repeat_limit, 9);
-        assert_eq!(core_config.thinking_budget_tokens, Some(1024));
+        assert_eq!(
+            core_config.model_reasoning_effort,
+            Some(alan_protocol::ReasoningEffort::High)
+        );
         assert_eq!(
             core_config.memory.workspace_dir,
             Some(workspace_alan_dir.join("memory"))

--- a/crates/runtime/src/runtime/engine.rs
+++ b/crates/runtime/src/runtime/engine.rs
@@ -2773,7 +2773,6 @@ required = true
             crate::ResolvedRequestControls {
                 reasoning: alan_protocol::ReasoningControls {
                     effort: Some(alan_protocol::ReasoningEffort::Medium),
-                    budget_tokens: None,
                 },
                 source: crate::RequestControlSource::SessionOverride,
                 diagnostics: Vec::new(),

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -3092,7 +3092,6 @@ description: {description}
             request.reasoning.effort,
             Some(alan_protocol::ReasoningEffort::High)
         );
-        assert_eq!(request.reasoning.budget_tokens, None);
     }
 
     #[tokio::test]
@@ -3149,7 +3148,6 @@ description: {description}
                 request.reasoning.effort,
                 Some(alan_protocol::ReasoningEffort::Low)
             );
-            assert_eq!(request.reasoning.budget_tokens, None);
         }
 
         state.session.flush().await;
@@ -3209,7 +3207,6 @@ description: {description}
             request.reasoning.effort,
             Some(alan_protocol::ReasoningEffort::High)
         );
-        assert_eq!(request.reasoning.budget_tokens, None);
     }
 
     #[tokio::test]
@@ -3251,7 +3248,6 @@ description: {description}
         let requests = requests.lock().unwrap();
         let request = requests.last().expect("captured request");
         assert_eq!(request.reasoning.effort, None);
-        assert_eq!(request.reasoning.budget_tokens, None);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/turn_executor.rs
+++ b/crates/runtime/src/runtime/turn_executor.rs
@@ -1021,7 +1021,6 @@ where
             tools = tools.len(),
             provider,
             reasoning_effort = reasoning_effort_log.as_deref(),
-            reasoning_budget_tokens = request_controls.budget_tokens(),
             request_control_source = ?request_controls.source,
             "LLM request"
         );
@@ -3167,7 +3166,7 @@ description: {description}
     }
 
     #[tokio::test]
-    async fn test_run_turn_preserves_legacy_thinking_budget_without_effort() {
+    async fn test_run_turn_uses_session_reasoning_effort_without_budget_fallback() {
         let requests = Arc::new(Mutex::new(Vec::new()));
         let provider = CapturingResponsesProvider {
             requests: Arc::clone(&requests),
@@ -3187,8 +3186,9 @@ description: {description}
         };
         let mut state = create_test_state_with_provider(provider);
         state.runtime_config.streaming_mode = crate::config::StreamingMode::Off;
-        state.runtime_config.request_control_intent =
-            crate::RequestControlIntent::thinking_budget_tokens(Some(2048));
+        state.runtime_config.request_control_intent = crate::RequestControlIntent::reasoning_effort(
+            Some(alan_protocol::ReasoningEffort::High),
+        );
         let cancel = CancellationToken::new();
 
         let mut emit = |_event: Event| async {};
@@ -3205,9 +3205,11 @@ description: {description}
 
         let requests = requests.lock().unwrap();
         let request = requests.last().expect("captured request");
-        assert_eq!(request.reasoning.effort, None);
-        assert_eq!(request.reasoning.budget_tokens, Some(2048));
-        assert_eq!(request.thinking_budget_tokens, Some(2048));
+        assert_eq!(
+            request.reasoning.effort,
+            Some(alan_protocol::ReasoningEffort::High)
+        );
+        assert_eq!(request.reasoning.budget_tokens, None);
     }
 
     #[tokio::test]
@@ -3250,7 +3252,6 @@ description: {description}
         let request = requests.last().expect("captured request");
         assert_eq!(request.reasoning.effort, None);
         assert_eq!(request.reasoning.budget_tokens, None);
-        assert_eq!(request.thinking_budget_tokens, None);
     }
 
     #[tokio::test]

--- a/crates/runtime/src/runtime/virtual_tools.rs
+++ b/crates/runtime/src/runtime/virtual_tools.rs
@@ -941,7 +941,6 @@ fn build_delegated_spawn_spec(
                     .timeout_secs
                     .unwrap_or(DEFAULT_DELEGATED_TIMEOUT_SECS),
             ),
-            budget_tokens: None,
             output_dir: None,
         },
         handles: vec![SpawnHandle::Workspace, SpawnHandle::ApprovalScope],

--- a/docs/spec/alan_coding_steward_contract.md
+++ b/docs/spec/alan_coding_steward_contract.md
@@ -174,8 +174,10 @@ For coding workloads:
 4. `launch.timeout_secs` should default to a bounded value so the child cannot
    hold the parent hostage indefinitely; productized coding paths should only
    omit it intentionally.
-5. `launch.budget_tokens` is optional and should be used when the parent needs
-   a bounded reasoning budget for the worker.
+5. `runtime_overrides.model_reasoning_effort` should be used when the parent
+   needs a bounded reasoning level for the worker. The removed
+   `launch.budget_tokens` shortcut is rejected instead of being interpreted as a
+   reasoning control.
 
 ### Recommended Handle Profiles
 

--- a/docs/spec/kernel_contract.md
+++ b/docs/spec/kernel_contract.md
@@ -72,7 +72,7 @@ This document has higher priority than philosophy docs. Protocol details remain 
   inheritance.
 - Current V1 transport shape includes:
   - launch inputs such as `task`, `cwd`, `workspace_root`, `timeout_secs`,
-    `budget_tokens`, and `output_dir`
+    and `output_dir`
   - explicit bound handles such as `workspace`, `artifacts`, `memory`, `plan`,
     `conversation_snapshot`, `tool_results`, and `approval_scope`
   - small runtime overrides such as model, policy path, and a strict tool
@@ -80,6 +80,9 @@ This document has higher priority than philosophy docs. Protocol details remain 
 - `artifacts` / `output_dir` remain reserved transport fields until runtime
   artifact routing is implemented; current child-runtime launches reject them
   instead of treating them as prompt-only hints.
+- The removed `launch.budget_tokens` reasoning shortcut is not accepted; callers
+  must use `runtime_overrides.model_reasoning_effort` for child reasoning
+  control.
 - A child launch is an `exec`-like runtime action: it starts a fresh
   `AgentInstance`, binds only the requested handles, and returns result/cancel
   state through explicit runtime lifecycle APIs rather than implicit parent

--- a/docs/spec/provider_capability_contract.md
+++ b/docs/spec/provider_capability_contract.md
@@ -242,14 +242,14 @@ Normative rules:
    routes, clients, and provider adapters may carry request-control intent or
    metadata, but they must not independently decide the final effective value.
 2. Alan must resolve effective controls before provider dispatch from turn
-   override, session/runtime override, agent config, legacy budget intent, model
-   catalog default, then provider default.
+   override, session/runtime override, agent config, model catalog default, then
+   provider default.
 3. If a resolved model catalog entry declares supported efforts, Alan must
    reject explicit unsupported effort before making the provider request.
-4. `thinking_budget_tokens` is a provider-specific compatibility control, not
-   Alan's canonical cross-provider reasoning API.
-5. A configuration that explicitly sets both `model_reasoning_effort` and
-   `thinking_budget_tokens` is ambiguous and must be rejected.
+4. `thinking_budget_tokens` is a removed legacy public control. Config and API
+   payloads that still contain it must be rejected with migration guidance.
+5. `model_reasoning_effort` is the only user-facing cross-provider reasoning
+   control.
 6. Compatibility providers must not silently drop explicit effort. They may
    receive effort only when Alan has model/provider metadata declaring support;
    otherwise the request must fail before dispatch.
@@ -266,9 +266,9 @@ Provider projection rules:
 3. OpenAI Chat Completions maps effort to `reasoning_effort`.
 4. Managed ChatGPT Responses may use the Responses-shaped field only when the
    live capability matrix says effort control is supported.
-5. Anthropic Messages maps effort to extended-thinking budget presets unless an
-   explicit legacy budget is the only configured control, and the adapter must
-   keep Anthropic minimum-budget and `max_tokens` constraints explicit.
+5. Anthropic Messages maps effort to extended-thinking budget presets, and the
+   adapter must keep Anthropic minimum-budget and `max_tokens` constraints
+   explicit.
 6. Gemini 3 maps effort to `thinkingConfig.thinkingLevel`; Gemini 2.5 maps
    effort to `thinkingConfig.thinkingBudget`.
 7. OpenRouter and OpenAI-compatible endpoints use explicit extension fields
@@ -277,12 +277,10 @@ Provider projection rules:
 Migration guidance:
 
 1. New config examples should prefer `model_reasoning_effort = "medium"`.
-2. Existing OpenAI configs that used `thinking_budget_tokens` only to influence
-   reasoning depth should migrate to a named effort supported by the selected
-   model.
-3. Keep `thinking_budget_tokens` only for budget-native provider behavior or
-   temporary compatibility with a provider/model that does not yet expose named
-   effort metadata.
+2. Existing configs that used `thinking_budget_tokens` must migrate to a named
+   effort supported by the selected model.
+3. Provider-native budgets remain an adapter detail derived from named effort and
+   model/provider metadata.
 
 ## Rich Content Contract
 

--- a/docs/spec/provider_reasoning_effort_migration.md
+++ b/docs/spec/provider_reasoning_effort_migration.md
@@ -11,17 +11,9 @@ selected model declares support for that effort. Omit the field to use Alan's
 model-catalog default or, when Alan has no catalog metadata for the provider,
 the provider default.
 
-`thinking_budget_tokens` remains available, but it is a provider-specific
-compatibility setting rather than Alan's canonical reasoning control:
-
-```toml
-# Keep only for budget-native providers or temporary compatibility.
-thinking_budget_tokens = 2048
-```
-
-Do not set `model_reasoning_effort` and `thinking_budget_tokens` in the same
-agent config. Alan rejects that combination because a named effort and a raw
-budget are two different control models.
+`thinking_budget_tokens` has been removed as a public config and request field.
+If an agent config or API payload still contains it, Alan rejects the input with
+guidance to use `model_reasoning_effort`.
 
 ## OpenAI Migration
 
@@ -40,17 +32,13 @@ named effort:
 For OpenAI Responses Alan sends the selected effort as `reasoning.effort`. For
 OpenAI Chat Completions Alan sends it as `reasoning_effort`.
 
-## When To Keep Budgets
+## Provider-Native Budgets
 
-Keep `thinking_budget_tokens` when the target provider is budget-native, such
-as Anthropic extended thinking or Gemini 2.5 thinking budgets, and you need a
-specific provider token budget rather than Alan's named effort presets.
+Some provider APIs still require budget-shaped wire fields, such as Anthropic
+extended thinking or Gemini 2.5 thinking budgets. Those budgets are now derived
+inside Alan from named effort presets and model/provider metadata. They are not a
+public config or API control.
 
-Alan normalizes the selected named effort or legacy budget in the runtime before
-provider dispatch. Provider-specific `extra_params` may still carry temporary
-compatibility fields when no canonical control is set, but they must not
-override a resolved runtime effort or budget.
-
-If a provider/model supports both in the future, prefer named effort in shared
-agent configuration and reserve raw budgets for provider-specific profiles or
-temporary experiments.
+If a provider/model needs a new budget mapping, add it to Alan's provider
+projection logic and tests rather than reintroducing a user-facing raw budget
+field.

--- a/openspec/changes/remove-legacy-thinking-budget-control/specs/provider-request-controls/spec.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/specs/provider-request-controls/spec.md
@@ -89,6 +89,11 @@ budget fields.
 - **THEN** Alan provides no supported public request-control path for that field
 - **AND** provider projection cannot use a legacy budget fallback
 
+#### Scenario: Canonical controls reject raw budget-only input
+- **WHEN** protocol or generation-request code attempts to set `reasoning.budget_tokens`
+- **THEN** Alan rejects or cannot represent that raw budget-only control
+- **AND** callers must use named reasoning effort instead
+
 ### Requirement: Provider adapters only project normalized controls
 Provider adapters SHALL consume normalized request controls from
 `GenerationRequest` and project them to provider-specific payload fields.

--- a/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
@@ -4,6 +4,7 @@
 - [x] 1.2 Remove `thinking_budget_tokens` from daemon session/fork/turn DTOs and client DTOs where exposed.
 - [x] 1.3 Remove public `GenerationRequest.thinking_budget_tokens` compatibility fields/builders and update call sites to use normalized reasoning controls.
 - [x] 1.4 Add clear errors that direct users from `thinking_budget_tokens` to `model_reasoning_effort`.
+- [x] 1.5 Remove raw `reasoning.budget_tokens` from canonical request controls so budget-only inputs cannot be accepted and ignored.
 
 ## 2. Resolver And Runtime
 

--- a/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
+++ b/openspec/changes/remove-legacy-thinking-budget-control/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Public Contract Removal
 
-- [ ] 1.1 Remove `thinking_budget_tokens` from user-facing agent config examples and parsing, or convert remaining parser support into an explicit rejection path.
-- [ ] 1.2 Remove `thinking_budget_tokens` from daemon session/fork/turn DTOs and client DTOs where exposed.
-- [ ] 1.3 Remove public `GenerationRequest.thinking_budget_tokens` compatibility fields/builders and update call sites to use normalized reasoning controls.
-- [ ] 1.4 Add clear errors that direct users from `thinking_budget_tokens` to `model_reasoning_effort`.
+- [x] 1.1 Remove `thinking_budget_tokens` from user-facing agent config examples and parsing, or convert remaining parser support into an explicit rejection path.
+- [x] 1.2 Remove `thinking_budget_tokens` from daemon session/fork/turn DTOs and client DTOs where exposed.
+- [x] 1.3 Remove public `GenerationRequest.thinking_budget_tokens` compatibility fields/builders and update call sites to use normalized reasoning controls.
+- [x] 1.4 Add clear errors that direct users from `thinking_budget_tokens` to `model_reasoning_effort`.
 
 ## 2. Resolver And Runtime
 
-- [ ] 2.1 Remove legacy budget intent from request-control resolver inputs and precedence tests.
-- [ ] 2.2 Keep resolver output centered on canonical reasoning effort plus provider-default/no-control states.
-- [ ] 2.3 Confirm child-agent runtime overrides accept reasoning effort only.
-- [ ] 2.4 Update rollout/session metadata so it never reports legacy budget as an effective public control.
+- [x] 2.1 Remove legacy budget intent from request-control resolver inputs and precedence tests.
+- [x] 2.2 Keep resolver output centered on canonical reasoning effort plus provider-default/no-control states.
+- [x] 2.3 Confirm child-agent runtime overrides accept reasoning effort only.
+- [x] 2.4 Update rollout/session metadata so it never reports legacy budget as an effective public control.
 
 ## 3. Provider Projection
 
-- [ ] 3.1 Keep provider-native budget projection where required, derived only from canonical reasoning effort and model/provider metadata.
-- [ ] 3.2 Remove OpenAI legacy budget-to-effort mapping.
-- [ ] 3.3 Remove Anthropic, Gemini, OpenRouter, and compatible-provider public budget fallback projection paths.
-- [ ] 3.4 Add provider projection tests for effort-derived budgets and rejected legacy budget inputs.
+- [x] 3.1 Keep provider-native budget projection where required, derived only from canonical reasoning effort and model/provider metadata.
+- [x] 3.2 Remove OpenAI legacy budget-to-effort mapping.
+- [x] 3.3 Remove Anthropic, Gemini, OpenRouter, and compatible-provider public budget fallback projection paths.
+- [x] 3.4 Add provider projection tests for effort-derived budgets and rejected legacy budget inputs.
 
 ## 4. Documentation And Migration
 
-- [ ] 4.1 Update provider reasoning documentation to make `model_reasoning_effort` the only public reasoning control.
-- [ ] 4.2 Add a breaking migration note for replacing `thinking_budget_tokens`.
-- [ ] 4.3 Remove examples that show `thinking_budget_tokens` as valid configuration.
+- [x] 4.1 Update provider reasoning documentation to make `model_reasoning_effort` the only public reasoning control.
+- [x] 4.2 Add a breaking migration note for replacing `thinking_budget_tokens`.
+- [x] 4.3 Remove examples that show `thinking_budget_tokens` as valid configuration.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `cargo fmt --all`.
-- [ ] 5.2 Run focused runtime, LLM provider, daemon payload, and client DTO tests.
-- [ ] 5.3 Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
-- [ ] 5.4 Run `openspec validate remove-legacy-thinking-budget-control --strict`.
+- [x] 5.1 Run `cargo fmt --all`.
+- [x] 5.2 Run focused runtime, LLM provider, daemon payload, and client DTO tests.
+- [x] 5.3 Run `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
+- [x] 5.4 Run `openspec validate remove-legacy-thinking-budget-control --strict`.


### PR DESCRIPTION
Summary:
- Remove public thinking_budget_tokens config, request resolver, GenerationRequest, and provider fallback paths.
- Reject legacy config/API payloads with model_reasoning_effort/reasoning_effort guidance.
- Keep provider-native budgets derived from canonical reasoning effort and update docs/OpenSpec tasks.

Validation:
- cargo fmt --all
- cargo test -p alan-protocol
- cargo test -p alan-runtime
- cargo test -p alan-runtime --doc
- cargo test -p alan-llm
- cargo test -p alan --test daemon_payload_contract_test
- cargo test -p alan --test agent_root_overlay_integration_test
- cargo test -p alan legacy_thinking_budget_control
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- openspec validate remove-legacy-thinking-budget-control --strict
- openspec validate --all --strict
- git diff --check