### PR TITLE
Polish macOS shell terminal chrome

### DIFF
--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -23,6 +23,8 @@ final class AlanGhosttyLiveHost: NSObject {
     private var surface: ghostty_surface_t?
     private var bootProfile: AlanShellBootProfile?
     private var envStorage: [(UnsafeMutablePointer<CChar>, UnsafeMutablePointer<CChar>)] = []
+    private let tickScheduleLock = NSLock()
+    private var tickScheduled = false
     private var appObservers: [NSObjectProtocol] = []
     private var didEmitFirstRefresh = false
     private var diagnostics = TerminalRendererSnapshot.placeholder
@@ -535,8 +537,11 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func scheduleTick() {
+        guard markTickScheduledIfNeeded() else { return }
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            self.clearScheduledTick()
             if let app = self.app {
                 ghostty_app_tick(app)
             }
@@ -544,6 +549,20 @@ final class AlanGhosttyLiveHost: NSObject {
                 ghostty_surface_refresh(surface)
             }
         }
+    }
+
+    private func markTickScheduledIfNeeded() -> Bool {
+        tickScheduleLock.lock()
+        defer { tickScheduleLock.unlock() }
+        guard !tickScheduled else { return false }
+        tickScheduled = true
+        return true
+    }
+
+    private func clearScheduledTick() {
+        tickScheduleLock.lock()
+        tickScheduled = false
+        tickScheduleLock.unlock()
     }
 
     private func teardownSurface() {

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -540,6 +540,9 @@ final class AlanGhosttyLiveHost: NSObject {
             if let app = self.app {
                 ghostty_app_tick(app)
             }
+            if let surface = self.surface {
+                ghostty_surface_refresh(surface)
+            }
         }
     }
 

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -77,8 +77,8 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let canvasView, let surface else { return }
         synchronizeDrawableMetrics(for: canvasView)
         ghostty_surface_set_focus(surface, focused)
-        let isOccluded = !(canvasView.window?.occlusionState.contains(.visible) ?? false)
-        ghostty_surface_set_occlusion(surface, isOccluded)
+        let visible = canvasView.window?.occlusionState.contains(.visible) ?? false
+        ghostty_surface_set_occlusion(surface, visible)
         ghostty_surface_refresh(surface)
         markFirstRefreshIfNeeded(on: canvasView)
     }

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -3,7 +3,6 @@ import Foundation
 #if os(macOS) && canImport(GhosttyKit)
 import AppKit
 import GhosttyKit
-import Metal
 import OSLog
 import QuartzCore
 
@@ -24,7 +23,6 @@ final class AlanGhosttyLiveHost: NSObject {
     private var surface: ghostty_surface_t?
     private var bootProfile: AlanShellBootProfile?
     private var envStorage: [(UnsafeMutablePointer<CChar>, UnsafeMutablePointer<CChar>)] = []
-    private var tickScheduled = false
     private var appObservers: [NSObjectProtocol] = []
     private var didEmitFirstRefresh = false
     private var diagnostics = TerminalRendererSnapshot.placeholder
@@ -79,7 +77,8 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let canvasView, let surface else { return }
         synchronizeDrawableMetrics(for: canvasView)
         ghostty_surface_set_focus(surface, focused)
-        ghostty_surface_set_occlusion(surface, false)
+        let visible = canvasView.window?.occlusionState.contains(.visible) ?? true
+        ghostty_surface_set_occlusion(surface, visible)
         ghostty_surface_refresh(surface)
         markFirstRefreshIfNeeded(on: canvasView)
     }
@@ -99,7 +98,9 @@ final class AlanGhosttyLiveHost: NSObject {
 
     func sendKey(_ keyEvent: ghostty_input_key_s) -> Bool {
         guard let surface else { return false }
-        return ghostty_surface_key(surface, keyEvent)
+        let handled = ghostty_surface_key(surface, keyEvent)
+        ghostty_surface_refresh(surface)
+        return handled
     }
 
     func keyIsBinding(_ keyEvent: ghostty_input_key_s, flags: UnsafeMutablePointer<ghostty_binding_flags_e>?) -> Bool {
@@ -112,6 +113,7 @@ final class AlanGhosttyLiveHost: NSObject {
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
         }
+        ghostty_surface_refresh(surface)
         updateMetadata(summary: "input committed", attention: .active)
     }
 
@@ -214,6 +216,8 @@ final class AlanGhosttyLiveHost: NSObject {
         if getenv("NO_COLOR") != nil {
             unsetenv("NO_COLOR")
         }
+        scrubInheritedTerminalEnvironment()
+        configureGhosttyProcessEnvironment()
 
         let result = ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv)
         guard result == GHOSTTY_SUCCESS else {
@@ -236,6 +240,49 @@ final class AlanGhosttyLiveHost: NSObject {
             detail: "libghostty runtime is ready."
         )
         return true
+    }
+
+    private func configureGhosttyProcessEnvironment() {
+        let integration = GhosttyIntegrationStatus.discover()
+        if let resourcesPath = integration.resourcesPath {
+            let shouldOverride = getenv("ALAN_GHOSTTY_RESOURCES_DIR") != nil
+                || getenv("GHOSTTY_RESOURCES_DIR") == nil
+            if shouldOverride {
+                _ = resourcesPath.withCString { path in
+                    setenv("GHOSTTY_RESOURCES_DIR", path, 1)
+                }
+                logger.info("Using Ghostty resources directory: \(resourcesPath)")
+            }
+        }
+    }
+
+    private func scrubInheritedTerminalEnvironment() {
+        let exactKeys = [
+            "TERM",
+            "TERM_PROGRAM",
+            "TERM_PROGRAM_VERSION",
+            "COLORTERM",
+            "TERMINFO",
+            "TERMINFO_DIRS",
+            "VTE_VERSION",
+            "PWD",
+            "SHLVL",
+            "_",
+            "STARSHIP_SHELL",
+            "STARSHIP_SESSION_KEY",
+            "RBENV_SHELL",
+            "GHOSTTY_SURFACE_ID",
+            "GHOSTTY_SHELL_FEATURES",
+            "GHOSTTY_SHELL_INTEGRATION_XDG_DIR",
+            "GHOSTTY_BIN_DIR",
+        ]
+        exactKeys.forEach { unsetenv($0) }
+
+        for key in ProcessInfo.processInfo.environment.keys {
+            if key.hasPrefix("WARP_") || key.hasPrefix("CODEX_") {
+                unsetenv(key)
+            }
+        }
     }
 
     private func ensureApp() -> Bool {
@@ -403,8 +450,13 @@ final class AlanGhosttyLiveHost: NSObject {
 
         bootProfile.workingDirectory.withCString { cwdCString in
             surfaceConfig.working_directory = cwdCString
-            bootProfile.bootCommand.withCString { commandCString in
-                surfaceConfig.command = commandCString
+            if let surfaceCommand = bootProfile.surfaceCommand, !surfaceCommand.isEmpty {
+                surfaceCommand.withCString { commandCString in
+                    surfaceConfig.command = commandCString
+                    createSurface()
+                }
+            } else {
+                surfaceConfig.command = nil
                 createSurface()
             }
         }
@@ -455,9 +507,6 @@ final class AlanGhosttyLiveHost: NSObject {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         canvasView.layer?.contentsScale = layerScale
-        if let metalLayer = canvasView.layer as? CAMetalLayer {
-            metalLayer.drawableSize = CGSize(width: floor(backingSize.width), height: floor(backingSize.height))
-        }
         CATransaction.commit()
 
         ghostty_surface_set_content_scale(surface, xScale, yScale)
@@ -486,17 +535,10 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func scheduleTick() {
-        guard !tickScheduled else { return }
-        tickScheduled = true
-
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.tickScheduled = false
             if let app = self.app {
                 ghostty_app_tick(app)
-            }
-            if let surface = self.surface {
-                ghostty_surface_refresh(surface)
             }
         }
     }
@@ -821,19 +863,10 @@ final class AlanGhosttyLiveHost: NSObject {
 final class AlanGhosttyCanvasView: NSView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        wantsLayer = true
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
-    }
-
-    override func makeBackingLayer() -> CALayer {
-        let metalLayer = CAMetalLayer()
-        metalLayer.pixelFormat = .bgra8Unorm
-        metalLayer.isOpaque = false
-        metalLayer.framebufferOnly = false
-        return metalLayer
     }
 }
 

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -864,6 +864,8 @@ final class AlanGhosttyLiveHost: NSObject {
 }
 
 final class AlanGhosttyCanvasView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
     }

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -77,8 +77,8 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let canvasView, let surface else { return }
         synchronizeDrawableMetrics(for: canvasView)
         ghostty_surface_set_focus(surface, focused)
-        let visible = canvasView.window?.occlusionState.contains(.visible) ?? true
-        ghostty_surface_set_occlusion(surface, visible)
+        let isOccluded = !(canvasView.window?.occlusionState.contains(.visible) ?? false)
+        ghostty_surface_set_occlusion(surface, isOccluded)
         ghostty_surface_refresh(surface)
         markFirstRefreshIfNeeded(on: canvasView)
     }

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -299,6 +299,21 @@ private struct ShellWindowChromeMetrics: Equatable {
     var trafficLightsTopInset: CGFloat = 0
 }
 
+private struct ShellWindowDragRegion<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .contentShape(Rectangle())
+            .gesture(WindowDragGesture())
+            .allowsWindowActivationEvents(true)
+    }
+}
+
 private final class ShellWindowPlacementNSView: NSView {
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
@@ -495,27 +510,34 @@ private struct ShellSidebarView: View {
 
     private var sidebarHeader: some View {
         HStack(alignment: .center, spacing: 10) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 11, style: .continuous)
-                    .fill(ShellPalette.sidebarControlStrong)
-                Text("A")
-                    .font(.system(size: 12.5, weight: .bold, design: .rounded))
-                    .foregroundStyle(ShellPalette.accent)
-            }
-            .frame(width: 28, height: 28)
+            ShellWindowDragRegion {
+                HStack(alignment: .center, spacing: 10) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .fill(ShellPalette.sidebarControlStrong)
+                        Text("A")
+                            .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                            .foregroundStyle(ShellPalette.accent)
+                    }
+                    .frame(width: 28, height: 28)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(host.selectedSpace?.title ?? "Alan")
-                    .font(.system(size: 15.5, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                Text(spaceSubtitle)
-                    .font(.system(size: 10.5, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(host.selectedSpace?.title ?? "Alan")
+                            .font(.system(size: 15.5, weight: .semibold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                        Text(spaceSubtitle)
+                            .font(.system(size: 10.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .layoutPriority(1)
 
-            Spacer(minLength: 8)
+                    Color.clear
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Button {
                 withAnimation(.easeOut(duration: 0.18)) {

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -216,7 +216,11 @@ struct MacShellRootView: View {
                 .ignoresSafeArea()
 
             HStack(spacing: 0) {
-                ShellSidebarView(host: host, chromeMetrics: windowChromeMetrics) {
+                ShellSidebarView(
+                    host: host,
+                    chromeMetrics: windowChromeMetrics,
+                    showsInspector: $showsInspector
+                ) {
                     withAnimation(.easeOut(duration: 0.18)) {
                         isCommandTabPresented = true
                     }
@@ -224,12 +228,12 @@ struct MacShellRootView: View {
                     .frame(width: 286)
 
                 ShellWorkspaceView(host: host)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea(edges: .top)
-                .background {
-                    ShellMaterialBackgroundView()
-                        .ignoresSafeArea(edges: .top)
-                }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .ignoresSafeArea(edges: .top)
+                    .background {
+                        ShellMaterialBackgroundView()
+                            .ignoresSafeArea(edges: .top)
+                    }
 
                 if showsInspector {
                     ShellInspectorView(host: host)
@@ -251,7 +255,8 @@ struct MacShellRootView: View {
 
                 ShellCommandTabView(
                     host: host,
-                    isPresented: $isCommandTabPresented
+                    isPresented: $isCommandTabPresented,
+                    showsInspector: $showsInspector
                 )
                 .frame(width: 520)
                 .transition(.move(edge: .top).combined(with: .opacity))
@@ -466,6 +471,7 @@ private enum AlanShellWindowPlacement {
 private struct ShellSidebarView: View {
     @ObservedObject var host: ShellHostController
     let chromeMetrics: ShellWindowChromeMetrics
+    @Binding var showsInspector: Bool
     let openCommandTab: () -> Void
     @State private var hoveredTabID: String?
     @State private var hoveredSpaceID: String?
@@ -483,7 +489,7 @@ private struct ShellSidebarView: View {
         .frame(maxHeight: .infinity, alignment: .top)
         .background {
             ShellMaterialBackgroundView()
-            .ignoresSafeArea(edges: .top)
+                .ignoresSafeArea(edges: .top)
         }
     }
 
@@ -510,6 +516,24 @@ private struct ShellSidebarView: View {
             }
 
             Spacer(minLength: 8)
+
+            Button {
+                withAnimation(.easeOut(duration: 0.18)) {
+                    showsInspector.toggle()
+                }
+            } label: {
+                Image(systemName: showsInspector ? "sidebar.trailing" : "sidebar.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(ShellPalette.sidebarControl)
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(showsInspector ? "Hide Inspector" : "Show Inspector")
+            .accessibilityLabel(Text(showsInspector ? "Hide Inspector" : "Show Inspector"))
 
             Menu {
                 Button("New Tab") {
@@ -808,149 +832,6 @@ private struct ShellWorkspaceView: View {
     var body: some View {
         TerminalPaneView(host: host)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
-private struct ShellTopBarView: View {
-    @ObservedObject var host: ShellHostController
-    @Binding var isCommandTabPresented: Bool
-    @Binding var showsInspector: Bool
-
-    private var title: String {
-        if let selectedTab = host.selectedTab {
-            let tabPanes = host.shellState.panes.filter { $0.tabID == selectedTab.tabID }
-            return shellTabDisplayTitle(
-                tab: selectedTab,
-                panes: tabPanes,
-                fallback: host.selectedSpace?.title ?? "Alan"
-            )
-        }
-
-        return shellDisplayTitle(
-            rawTitle: host.selectedTab?.title ?? host.selectedSpace?.title,
-            workingDirectoryName: nil,
-            cwd: nil,
-            program: nil,
-            launchTarget: .shell,
-            fallback: host.selectedSpace?.title ?? "Alan"
-        )
-    }
-
-    private var subtitle: String? {
-        var parts: [String] = []
-
-        if let selectedSpace = host.selectedSpace?.title, selectedSpace != title {
-            parts.append(selectedSpace)
-        }
-
-        if let branch = host.selectedPane?.context?.gitBranch {
-            parts.append(branch)
-        }
-
-        if host.panesForSelectedTab.count > 1 {
-            parts.append("\(host.panesForSelectedTab.count) panes")
-        }
-
-        if host.selectedPane?.resolvedLaunchTarget == .alan {
-            parts.append("Alan tab")
-        }
-
-        return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
-    }
-
-    var body: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 16.5, weight: .semibold))
-                    .tracking(-0.2)
-                    .foregroundStyle(ShellPalette.ink)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 10.5, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                }
-            }
-
-            ShellTopBarDragRegion()
-
-            ShellToolbarButton(
-                symbol: "magnifyingglass",
-                label: "Go to or Command..."
-            ) {
-                isCommandTabPresented = true
-            }
-            .keyboardShortcut("k", modifiers: [.command])
-
-            if host.awaitingAttentionCount > 0,
-               let firstAttention = host.attentionItems.first
-            {
-                Button {
-                    host.focusAttentionItem(firstAttention)
-                } label: {
-                    ShellToolbarBadgeButton(symbol: "bell", count: host.awaitingAttentionCount)
-                }
-                .buttonStyle(.plain)
-            }
-
-            Menu {
-                Button("New Tab") {
-                    _ = host.openTerminalTab()
-                }
-                Button("Open in Alan") {
-                    _ = host.openAlanTab()
-                }
-                Divider()
-                Button("New Space") {
-                    _ = host.createTerminalSpace()
-                }
-                Button("New Space with Alan") {
-                    _ = host.createAlanSpace()
-                }
-            } label: {
-                ShellToolbarGlyph(symbol: "plus")
-            }
-            .menuStyle(.borderlessButton)
-            .buttonStyle(.plain)
-            .menuIndicator(.hidden)
-
-            Menu {
-                Button("Split Horizontally") {
-                    _ = host.splitFocusedPane(direction: .horizontal)
-                }
-                Button("Split Vertically") {
-                    _ = host.splitFocusedPane(direction: .vertical)
-                }
-                Divider()
-                Button("Jump to attention") {
-                    _ = host.focusTopRoutingCandidate(preferredPaneID: host.selectedPane?.paneID)
-                }
-            } label: {
-                ShellToolbarGlyph(symbol: "square.split.2x1")
-            }
-            .menuStyle(.borderlessButton)
-            .buttonStyle(.plain)
-            .menuIndicator(.hidden)
-
-            ShellToolbarButton(
-                symbol: showsInspector ? "sidebar.trailing" : "sidebar.right",
-                label: showsInspector ? "Hide Inspector" : "Show Inspector"
-            ) {
-                showsInspector.toggle()
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 11)
-    }
-}
-
-private struct ShellTopBarDragRegion: View {
-    var body: some View {
-        Color.clear
-            .frame(maxWidth: .infinity, minHeight: 34)
-            .contentShape(Rectangle())
-            .gesture(WindowDragGesture())
-            .allowsWindowActivationEvents(true)
     }
 }
 
@@ -1574,6 +1455,7 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
     case openAlanTab
     case jumpToAttention
     case focusBestPane
+    case toggleInspector
     case splitHorizontal
     case splitVertical
     case liftPane
@@ -1597,6 +1479,8 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Jump To Attention"
         case .focusBestPane:
             return "Focus Best Routing Pane"
+        case .toggleInspector:
+            return "Toggle Inspector"
         case .splitHorizontal:
             return "Split Focused Pane Horizontally"
         case .splitVertical:
@@ -1626,6 +1510,8 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Jump to the strongest pane that currently needs approval or attention."
         case .focusBestPane:
             return "Use shell routing signals to jump to the strongest candidate pane."
+        case .toggleInspector:
+            return "Show or hide the right-side shell inspector."
         case .splitHorizontal:
             return "Create a stacked split beneath the focused pane."
         case .splitVertical:
@@ -1668,6 +1554,16 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return ["jump to attention", "jump attention", "focus waiting pane", "approval", "waiting pane"]
         case .focusBestPane:
             return ["best pane", "route", "routing", "focus best", "jump pane"]
+        case .toggleInspector:
+            return [
+                "inspector",
+                "show inspector",
+                "hide inspector",
+                "open inspector",
+                "close inspector",
+                "toggle inspector",
+                "right sidebar",
+            ]
         case .splitHorizontal:
             return ["split horizontal", "split below", "stack split"]
         case .splitVertical:
@@ -1702,6 +1598,7 @@ private struct ShellCommandTabIntent: Identifiable {
 private struct ShellCommandTabView: View {
     @ObservedObject var host: ShellHostController
     @Binding var isPresented: Bool
+    @Binding var showsInspector: Bool
     @State private var query = ""
     @FocusState private var isQueryFocused: Bool
     @StateObject private var voiceController = ShellVoiceCommandController()
@@ -1718,6 +1615,7 @@ private struct ShellCommandTabView: View {
             .openAlanTab,
             .splitVertical,
             .splitHorizontal,
+            .toggleInspector,
             .jumpToAttention,
             .newSpace,
         ]
@@ -1786,8 +1684,8 @@ private struct ShellCommandTabView: View {
 
         if let action = matchingActions.first {
             return ShellCommandTabIntent(
-                title: action.title,
-                detail: action.detail,
+                title: title(for: action),
+                detail: detail(for: action),
                 accent: ShellPalette.accent,
                 route: .action(action)
             )
@@ -1910,8 +1808,8 @@ private struct ShellCommandTabView: View {
                                 perform(action)
                             } label: {
                                 ShellCommandRow(
-                                    title: action.title,
-                                    detail: action.detail,
+                                    title: title(for: action),
+                                    detail: detail(for: action),
                                     accent: ShellPalette.accent
                                 )
                             }
@@ -2005,6 +1903,14 @@ private struct ShellCommandTabView: View {
             }
         case .focusBestPane:
             _ = host.focusTopRoutingCandidate()
+        case .toggleInspector:
+            withAnimation(.easeOut(duration: 0.18)) {
+                if let requestedInspectorVisibility {
+                    showsInspector = requestedInspectorVisibility
+                } else {
+                    showsInspector.toggle()
+                }
+            }
         case .splitHorizontal:
             _ = host.splitFocusedPane(direction: .horizontal)
         case .splitVertical:
@@ -2047,6 +1953,29 @@ private struct ShellCommandTabView: View {
         return "\(title) • \(detail)"
     }
 
+    private var requestedInspectorVisibility: Bool? {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized.contains("show") || normalized.contains("open") {
+            return true
+        }
+        if normalized.contains("hide") || normalized.contains("close") {
+            return false
+        }
+        return nil
+    }
+
+    private func title(for action: ShellCommandTabAction) -> String {
+        guard action == .toggleInspector else { return action.title }
+        let shouldShow = requestedInspectorVisibility ?? !showsInspector
+        return shouldShow ? "Show Inspector" : "Hide Inspector"
+    }
+
+    private func detail(for action: ShellCommandTabAction) -> String {
+        guard action == .toggleInspector else { return action.detail }
+        let shouldShow = requestedInspectorVisibility ?? !showsInspector
+        return shouldShow ? "Open the right-side shell inspector." : "Close the right-side shell inspector."
+    }
+
     private func sectionLabel(_ value: String) -> some View {
         Text(value)
             .font(.system(size: 10, weight: .semibold, design: .rounded))
@@ -2081,6 +2010,11 @@ private final class ShellVoiceCommandController: NSObject, ObservableObject, NSS
             "close tab",
             "jump to attention",
             "focus waiting pane",
+            "show inspector",
+            "hide inspector",
+            "open inspector",
+            "close inspector",
+            "toggle inspector",
             "copy snapshot",
         ]
     }
@@ -2147,95 +2081,6 @@ private struct ShellCommandRow: View {
         .shadow(color: isHovered ? Color.black.opacity(0.022) : .clear, radius: 6, y: 3)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .onHover { isHovered = $0 }
-    }
-}
-
-private struct ShellToolbarButton: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isHovered = false
-    let symbol: String
-    let label: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: symbol)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(ShellPalette.ink)
-                .frame(width: 30, height: 30)
-                .background(
-                    RoundedRectangle(cornerRadius: 9, style: .continuous)
-                        .fill(isHovered ? Color.white.opacity(0.92) : ShellPalette.panel)
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: 9, style: .continuous)
-                        .stroke(ShellPalette.line.opacity(isHovered ? 0.32 : 0.16), lineWidth: 1)
-                }
-        }
-        .buttonStyle(.plain)
-        .scaleEffect(isHovered ? 1.03 : 1)
-        .shadow(color: isHovered ? Color.black.opacity(0.032) : .clear, radius: 6, y: 3)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovered)
-        .onHover { isHovered = $0 }
-        .help(label)
-    }
-}
-
-private struct ShellToolbarGlyph: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isHovered = false
-    let symbol: String
-
-    var body: some View {
-        Image(systemName: symbol)
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(ShellPalette.ink)
-            .frame(width: 30, height: 30)
-            .background(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(isHovered ? Color.white.opacity(0.92) : ShellPalette.panel)
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .stroke(ShellPalette.line.opacity(isHovered ? 0.32 : 0.16), lineWidth: 1)
-            }
-            .scaleEffect(isHovered ? 1.03 : 1)
-            .shadow(color: isHovered ? Color.black.opacity(0.032) : .clear, radius: 6, y: 3)
-            .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovered)
-            .onHover { isHovered = $0 }
-    }
-}
-
-private struct ShellToolbarBadgeButton: View {
-    let symbol: String
-    let count: Int
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            ShellToolbarGlyph(symbol: symbol)
-
-            if count > 1 {
-                Text("\(min(count, 9))")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(
-                        Capsule(style: .continuous)
-                            .fill(ShellPalette.attention)
-                    )
-                    .offset(x: 7, y: -6)
-            } else {
-                Circle()
-                    .fill(ShellPalette.attention)
-                    .frame(width: 8, height: 8)
-                    .overlay {
-                        Circle()
-                            .stroke(Color.white.opacity(0.95), lineWidth: 1.5)
-                    }
-                    .offset(x: 6, y: -5)
-            }
-        }
     }
 }
 

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -3,23 +3,163 @@ import SwiftUI
 #if os(macOS)
 import AppKit
 
+private extension Color {
+    static func shellAdaptive(
+        light: (Double, Double, Double),
+        dark: (Double, Double, Double),
+        alpha: Double = 1
+    ) -> Color {
+        shellAdaptive(light: light, lightAlpha: alpha, dark: dark, darkAlpha: alpha)
+    }
+
+    static func shellAdaptive(
+        light: (Double, Double, Double),
+        lightAlpha: Double,
+        dark: (Double, Double, Double),
+        darkAlpha: Double
+    ) -> Color {
+        Color(
+            NSColor(name: nil) { appearance in
+                let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                let rgb = isDark ? dark : light
+                let alpha = isDark ? darkAlpha : lightAlpha
+                return NSColor(red: rgb.0, green: rgb.1, blue: rgb.2, alpha: alpha)
+            }
+        )
+    }
+}
+
 enum ShellPalette {
-    static let canvas = Color(red: 0.94, green: 0.94, blue: 0.965)
-    static let window = Color(red: 0.972, green: 0.973, blue: 0.985)
-    static let sidebar = Color(red: 0.922, green: 0.924, blue: 0.953)
-    static let sidebarRail = Color(red: 0.902, green: 0.907, blue: 0.941)
-    static let sidebarCard = Color(red: 0.98, green: 0.98, blue: 0.995)
-    static let workspace = Color(red: 0.979, green: 0.98, blue: 0.989)
-    static let terminal = Color(red: 0.10, green: 0.12, blue: 0.16)
-    static let terminalSoft = Color(red: 0.16, green: 0.18, blue: 0.24)
-    static let accent = Color(red: 0.31, green: 0.39, blue: 0.71)
-    static let accentSoft = Color(red: 0.90, green: 0.92, blue: 0.98)
-    static let ink = Color(red: 0.16, green: 0.18, blue: 0.24)
-    static let mutedInk = Color(red: 0.43, green: 0.45, blue: 0.54)
-    static let line = Color(red: 0.82, green: 0.83, blue: 0.89)
-    static let panel = Color.white.opacity(0.74)
-    static let panelSoft = Color.white.opacity(0.6)
-    static let attention = Color(red: 0.82, green: 0.55, blue: 0.24)
+    static let canvas = Color.shellAdaptive(
+        light: (0.94, 0.94, 0.965),
+        dark: (0.045, 0.050, 0.062)
+    )
+    static let window = Color.shellAdaptive(
+        light: (0.972, 0.973, 0.985),
+        dark: (0.055, 0.061, 0.074)
+    )
+    static let sidebar = Color.shellAdaptive(
+        light: (0.922, 0.924, 0.953),
+        dark: (0.071, 0.079, 0.096)
+    )
+    static let sidebarRail = Color.shellAdaptive(
+        light: (0.902, 0.907, 0.941),
+        dark: (0.083, 0.092, 0.112)
+    )
+    static let sidebarCard = Color.shellAdaptive(
+        light: (0.98, 0.98, 0.995),
+        lightAlpha: 1.0,
+        dark: (0.172, 0.188, 0.224),
+        darkAlpha: 0.92
+    )
+    static let sidebarSelection = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.15,
+        dark: (0.205, 0.225, 0.270),
+        darkAlpha: 0.72
+    )
+    static let sidebarHover = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.08,
+        dark: (0.185, 0.205, 0.245),
+        darkAlpha: 0.46
+    )
+    static let sidebarControl = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.12,
+        dark: (0.190, 0.210, 0.252),
+        darkAlpha: 0.54
+    )
+    static let sidebarControlStrong = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.18,
+        dark: (0.215, 0.235, 0.282),
+        darkAlpha: 0.72
+    )
+    static let railBase = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.08,
+        dark: (0.155, 0.172, 0.210),
+        darkAlpha: 0.58
+    )
+    static let railHover = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.14,
+        dark: (0.190, 0.210, 0.252),
+        darkAlpha: 0.66
+    )
+    static let railSelection = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.22,
+        dark: (0.235, 0.255, 0.310),
+        darkAlpha: 0.78
+    )
+    static let workspace = Color.shellAdaptive(
+        light: (0.979, 0.98, 0.989),
+        dark: (0.050, 0.056, 0.070)
+    )
+    static let terminal = Color.shellAdaptive(
+        light: (0.10, 0.12, 0.16),
+        dark: (0.050, 0.061, 0.076)
+    )
+    static let terminalSoft = Color.shellAdaptive(
+        light: (0.16, 0.18, 0.24),
+        dark: (0.100, 0.116, 0.145)
+    )
+    static let accent = Color.shellAdaptive(
+        light: (0.31, 0.39, 0.71),
+        dark: (0.50, 0.60, 0.94)
+    )
+    static let accentSoft = Color.shellAdaptive(
+        light: (0.90, 0.92, 0.98),
+        dark: (0.18, 0.22, 0.34)
+    )
+    static let ink = Color.shellAdaptive(
+        light: (0.16, 0.18, 0.24),
+        dark: (0.90, 0.92, 0.96)
+    )
+    static let mutedInk = Color.shellAdaptive(
+        light: (0.43, 0.45, 0.54),
+        dark: (0.64, 0.68, 0.75)
+    )
+    static let line = Color.shellAdaptive(
+        light: (0.82, 0.83, 0.89),
+        dark: (0.255, 0.285, 0.345)
+    )
+    static let panel = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.74,
+        dark: (0.135, 0.150, 0.180),
+        darkAlpha: 0.78
+    )
+    static let panelSoft = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.60,
+        dark: (0.125, 0.140, 0.170),
+        darkAlpha: 0.64
+    )
+    static let materialScrim = Color.shellAdaptive(
+        light: (0.922, 0.924, 0.953),
+        lightAlpha: 0.35,
+        dark: (0.030, 0.037, 0.050),
+        darkAlpha: 0.78
+    )
+    static let materialTopWash = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.06,
+        dark: (0.130, 0.150, 0.205),
+        darkAlpha: 0.18
+    )
+    static let materialBottomShade = Color.shellAdaptive(
+        light: (0.84, 0.86, 0.92),
+        lightAlpha: 0.04,
+        dark: (0.012, 0.016, 0.024),
+        darkAlpha: 0.34
+    )
+    static let attention = Color.shellAdaptive(
+        light: (0.82, 0.55, 0.24),
+        dark: (0.94, 0.68, 0.34)
+    )
 }
 
 private struct SidebarMaterialView: NSViewRepresentable {
@@ -32,6 +172,23 @@ private struct SidebarMaterialView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
+struct ShellMaterialBackgroundView: View {
+    var body: some View {
+        ZStack {
+            SidebarMaterialView()
+            ShellPalette.materialScrim
+            LinearGradient(
+                colors: [
+                    ShellPalette.materialTopWash,
+                    ShellPalette.materialBottomShade,
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
+    }
 }
 
 struct MacShellRootView: View {
@@ -66,17 +223,11 @@ struct MacShellRootView: View {
                 }
                     .frame(width: 286)
 
-                VStack(spacing: 0) {
-                    ShellTopBarView(
-                        host: host,
-                        isCommandTabPresented: $isCommandTabPresented,
-                        showsInspector: $showsInspector
-                    )
-                    ShellWorkspaceView(host: host)
-                }
+                ShellWorkspaceView(host: host)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .ignoresSafeArea(edges: .top)
                 .background {
-                    ShellPalette.workspace
+                    ShellMaterialBackgroundView()
                         .ignoresSafeArea(edges: .top)
                 }
 
@@ -331,10 +482,7 @@ private struct ShellSidebarView: View {
         .padding(.bottom, 15)
         .frame(maxHeight: .infinity, alignment: .top)
         .background {
-            ZStack {
-                SidebarMaterialView()
-                ShellPalette.sidebar.opacity(0.35)
-            }
+            ShellMaterialBackgroundView()
             .ignoresSafeArea(edges: .top)
         }
     }
@@ -343,7 +491,7 @@ private struct ShellSidebarView: View {
         HStack(alignment: .center, spacing: 10) {
             ZStack {
                 RoundedRectangle(cornerRadius: 11, style: .continuous)
-                    .fill(Color.white.opacity(0.18))
+                    .fill(ShellPalette.sidebarControlStrong)
                 Text("A")
                     .font(.system(size: 12.5, weight: .bold, design: .rounded))
                     .foregroundStyle(ShellPalette.accent)
@@ -377,7 +525,7 @@ private struct ShellSidebarView: View {
                     .frame(width: 26, height: 26)
                     .background(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .fill(Color.white.opacity(0.12))
+                            .fill(ShellPalette.sidebarControl)
                     )
             }
             .menuStyle(.borderlessButton)
@@ -405,7 +553,7 @@ private struct ShellSidebarView: View {
             .padding(.vertical, 10)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.white.opacity(0.10))
+                    .fill(ShellPalette.sidebarControl)
             )
         }
         .buttonStyle(.plain)
@@ -485,7 +633,7 @@ private struct ShellSidebarView: View {
                         .frame(width: 30, height: 30)
                         .background(
                             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .fill(Color.white.opacity(0.10))
+                                .fill(ShellPalette.sidebarControl)
                         )
                 }
                 .menuStyle(.borderlessButton)
@@ -658,11 +806,8 @@ private struct ShellWorkspaceView: View {
     @ObservedObject var host: ShellHostController
 
     var body: some View {
-        VStack(spacing: 0) {
-            TerminalPaneView(host: host)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .padding(16)
+        TerminalPaneView(host: host)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -857,8 +1002,8 @@ private struct ShellSpaceRailItem: View {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(
                         isSelected
-                            ? Color.white.opacity(0.22)
-                            : (isHovered ? Color.white.opacity(0.14) : Color.white.opacity(0.08))
+                            ? ShellPalette.railSelection
+                            : (isHovered ? ShellPalette.railHover : ShellPalette.railBase)
                     )
                 Image(systemName: symbolName)
                     .font(.system(size: 11, weight: .semibold))
@@ -872,7 +1017,7 @@ private struct ShellSpaceRailItem: View {
                     .frame(width: 9, height: 9)
                     .overlay {
                         Circle()
-                            .stroke(Color.white.opacity(0.9), lineWidth: 1.5)
+                            .stroke(ShellPalette.sidebarCard, lineWidth: 1.5)
                     }
                     .offset(x: 2, y: -2)
             }
@@ -959,13 +1104,13 @@ private struct ShellTabSidebarRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(
-            RoundedRectangle(cornerRadius: 11, style: .continuous)
-                .fill(
-                    isSelected
-                        ? Color.white.opacity(0.15)
-                        : (isHovered ? Color.white.opacity(0.08) : Color.clear)
-                )
-        )
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .fill(
+                        isSelected
+                            ? ShellPalette.sidebarSelection
+                            : (isHovered ? ShellPalette.sidebarHover : Color.clear)
+                    )
+            )
         .scaleEffect(isHovered && !isSelected ? 1.005 : 1)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
@@ -1008,7 +1153,7 @@ private struct ShellTabRailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .fill(host.selectedTab?.tabID == tab.tabID ? Color.white.opacity(0.78) : Color.white.opacity(0.38))
+                            .fill(host.selectedTab?.tabID == tab.tabID ? ShellPalette.sidebarCard : ShellPalette.sidebarHover)
                     )
                     .overlay {
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -1333,7 +1478,7 @@ private struct ShellTabRow: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(isSelected ? Color.white.opacity(0.95) : Color.clear)
+                .fill(isSelected ? ShellPalette.sidebarCard : Color.clear)
         )
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -1379,7 +1524,7 @@ private struct ShellAttentionRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.82))
+                .fill(ShellPalette.panel)
         )
     }
 }
@@ -1401,7 +1546,7 @@ private struct ShellEmptyStateRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.72))
+                .fill(ShellPalette.panelSoft)
         )
     }
 }

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -299,21 +299,6 @@ private struct ShellWindowChromeMetrics: Equatable {
     var trafficLightsTopInset: CGFloat = 0
 }
 
-private struct ShellWindowDragRegion<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        content
-            .contentShape(Rectangle())
-            .gesture(WindowDragGesture())
-            .allowsWindowActivationEvents(true)
-    }
-}
-
 private final class ShellWindowPlacementNSView: NSView {
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
@@ -359,7 +344,7 @@ private enum AlanShellWindowPlacement {
 
     static func apply(to window: NSWindow) {
         window.title = "Alan"
-        window.isMovableByWindowBackground = false
+        window.isMovableByWindowBackground = true
         window.minSize = NSSize(width: 1180, height: 760)
         window.tabbingMode = .disallowed
 
@@ -510,34 +495,28 @@ private struct ShellSidebarView: View {
 
     private var sidebarHeader: some View {
         HStack(alignment: .center, spacing: 10) {
-            ShellWindowDragRegion {
-                HStack(alignment: .center, spacing: 10) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 11, style: .continuous)
-                            .fill(ShellPalette.sidebarControlStrong)
-                        Text("A")
-                            .font(.system(size: 12.5, weight: .bold, design: .rounded))
-                            .foregroundStyle(ShellPalette.accent)
-                    }
-                    .frame(width: 28, height: 28)
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(host.selectedSpace?.title ?? "Alan")
-                            .font(.system(size: 15.5, weight: .semibold))
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                        Text(spaceSubtitle)
-                            .font(.system(size: 10.5, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    .layoutPriority(1)
-
-                    Color.clear
-                        .frame(maxWidth: .infinity, minHeight: 34)
-                }
+            ZStack {
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .fill(ShellPalette.sidebarControlStrong)
+                Text("A")
+                    .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                    .foregroundStyle(ShellPalette.accent)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(host.selectedSpace?.title ?? "Alan")
+                    .font(.system(size: 15.5, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(spaceSubtitle)
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 8)
 
             Button {
                 withAnimation(.easeOut(duration: 0.18)) {

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -536,9 +536,13 @@ extension ShellStateSnapshot {
 }
 
 extension ShellStateSnapshot {
+    private static func defaultShellWorkingDirectory() -> String {
+        FileManager.default.homeDirectoryForCurrentUser.path
+    }
+
     static func bootstrapDefault(
         windowID: String = "window_main",
-        workingDirectory: String = FileManager.default.currentDirectoryPath
+        workingDirectory: String = defaultShellWorkingDirectory()
     ) -> ShellStateSnapshot {
         let spaceID = "space_main"
         let tabID = "tab_main"
@@ -646,7 +650,7 @@ extension ShellStateSnapshot {
         launchTarget: ShellLaunchTarget,
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
         let spaceIndex = spaces.count + 1
@@ -698,7 +702,7 @@ extension ShellStateSnapshot {
     func creatingAlanSpace(
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
         creatingSpace(
@@ -713,7 +717,7 @@ extension ShellStateSnapshot {
     func creatingTerminalSpace(
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
         creatingSpace(
@@ -730,7 +734,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
         let targetSpaceID = requestedSpaceID ?? focusedSpaceID ?? spaces.first?.spaceID
@@ -790,7 +794,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
         try openingTab(
@@ -807,7 +811,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
         try openingTab(
@@ -823,7 +827,7 @@ extension ShellStateSnapshot {
     func splittingPane(
         _ paneID: String,
         direction: ShellSplitDirection,
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
         guard let pane = pane(paneID: paneID),
@@ -1323,7 +1327,7 @@ extension ShellStateSnapshot {
     }
 
     func migratingLegacyAlanBootstrapIfNeeded(
-        defaultWorkingDirectory: String = FileManager.default.currentDirectoryPath
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory()
     ) -> ShellStateSnapshot {
         guard spaces.count == 1,
               panes.count == 1,

--- a/clients/apple/AlanNative/TerminalHostRuntime.swift
+++ b/clients/apple/AlanNative/TerminalHostRuntime.swift
@@ -45,6 +45,7 @@ struct AlanCommandResolution: Equatable {
     let launchPath: String
     let arguments: [String]
     let bootCommand: String
+    let surfaceCommand: String?
     let summary: String
     let detail: String?
     let repoRoot: String?
@@ -117,6 +118,7 @@ struct AlanCommandResolution: Equatable {
                 launchPath: "/bin/zsh",
                 arguments: ["-lc", customCommand],
                 bootCommand: customCommand,
+                surfaceCommand: customCommand,
                 summary: "Launching pane from ALAN_SHELL_BOOT_COMMAND",
                 detail: customCommand,
                 repoRoot: repoRoot,
@@ -131,7 +133,8 @@ struct AlanCommandResolution: Equatable {
                 summary: "Launching pane from ALAN_SHELL_LOGIN_SHELL",
                 detail: shellOverride,
                 repoRoot: repoRoot,
-                candidates: candidates
+                candidates: candidates,
+                inheritGhosttyCommand: false
             )
         }
 
@@ -272,6 +275,7 @@ struct AlanCommandResolution: Equatable {
             launchPath: "/bin/zsh",
             arguments: ["-lc", "alan chat"],
             bootCommand: "alan chat",
+            surfaceCommand: "alan chat",
             summary: "No direct Alan binary found; falling back to shell PATH lookup",
             detail: "Make sure `alan` is in PATH or set ALAN_SHELL_ALAN_PATH.",
             repoRoot: repoRoot,
@@ -285,7 +289,8 @@ struct AlanCommandResolution: Equatable {
         summary: String,
         detail: String?,
         repoRoot: String?,
-        candidates: [AlanCommandCandidate]
+        candidates: [AlanCommandCandidate],
+        inheritGhosttyCommand: Bool = true
     ) -> AlanCommandResolution {
         let arguments = ["-l"]
         let bootCommand = ([executablePath] + arguments)
@@ -298,6 +303,7 @@ struct AlanCommandResolution: Equatable {
             launchPath: executablePath,
             arguments: arguments,
             bootCommand: bootCommand,
+            surfaceCommand: inheritGhosttyCommand ? nil : bootCommand,
             summary: summary,
             detail: detail,
             repoRoot: repoRoot,
@@ -324,6 +330,7 @@ struct AlanCommandResolution: Equatable {
             launchPath: executablePath,
             arguments: arguments,
             bootCommand: bootCommand,
+            surfaceCommand: bootCommand,
             summary: summary,
             detail: detail,
             repoRoot: repoRoot,
@@ -471,6 +478,10 @@ struct AlanShellBootProfile: Equatable {
         command.bootCommand
     }
 
+    var surfaceCommand: String? {
+        command.surfaceCommand
+    }
+
     var environmentPreview: [(key: String, value: String)] {
         environment.keys.sorted().map { ($0, environment[$0] ?? "") }
     }
@@ -486,9 +497,6 @@ struct AlanShellBootProfile: Equatable {
         let bindingFile = alanShellBindingFileURL(windowID: shellState.windowID, paneID: pane.paneID)
 
         var environment: [String: String] = [
-            "TERM": "xterm-ghostty",
-            "TERM_PROGRAM": "alan-shell",
-            "COLORTERM": "truecolor",
             "ALAN_SHELL_SOCKET": controlPlaneSocket.path,
             "ALAN_SHELL_WINDOW_ID": shellState.windowID,
             "ALAN_SHELL_SPACE_ID": pane.spaceID,
@@ -503,14 +511,6 @@ struct AlanShellBootProfile: Equatable {
             "ALAN_SHELL_COMMANDS_DIR": controlPlaneRoot.appendingPathComponent("commands").path,
             "ALAN_SHELL_RESULTS_DIR": controlPlaneRoot.appendingPathComponent("results").path,
         ]
-
-        if let resourcesPath = ghostty.resourcesPath {
-            environment["GHOSTTY_RESOURCES_DIR"] = resourcesPath
-        }
-
-        if let terminfoPath = ghostty.terminfoPath {
-            environment["TERMINFO_DIRS"] = terminfoPath
-        }
 
         if let executablePath = command.executablePath {
             environment["ALAN_SHELL_EXECUTABLE"] = executablePath

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -109,7 +109,26 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         super.viewDidMoveToWindow()
         installWindowObservers()
         window?.acceptsMouseMovedEvents = true
+        focusTerminalSoon()
         publishRuntimeSnapshot()
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result {
+            synchronizeLiveHost()
+            publishRuntimeSnapshot()
+        }
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result {
+            synchronizeLiveHost()
+            publishRuntimeSnapshot()
+        }
+        return result
     }
 
     override func viewDidChangeBackingProperties() {
@@ -163,6 +182,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         syncStatusBadge()
         syncOverlayVisibility()
         synchronizeLiveHost()
+        focusTerminalSoon()
         reportMetadataIfNeeded(paneMetadata)
         publishRuntimeSnapshot()
     }
@@ -170,7 +190,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func reportMetadataIfNeeded(_ snapshot: TerminalPaneMetadataSnapshot) {
         guard lastReportedMetadata != snapshot else { return }
         lastReportedMetadata = snapshot
-        metadataObserver?(snapshot)
+        guard let metadataObserver else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.lastReportedMetadata == snapshot else { return }
+            metadataObserver(snapshot)
+        }
     }
 
     private func configureView() {
@@ -339,6 +363,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
                 object: window,
                 queue: .main
             ) { [weak self] _ in
+                self?.synchronizeLiveHost()
+                self?.publishRuntimeSnapshot()
+            },
+            center.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.synchronizeLiveHost()
                 self?.publishRuntimeSnapshot()
             },
         ]
@@ -383,7 +416,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     private func reportRuntimeIfNeeded(
         _ snapshot: TerminalHostRuntimeSnapshot,
-        runtimeObserver: (TerminalHostRuntimeSnapshot) -> Void
+        runtimeObserver: @escaping (TerminalHostRuntimeSnapshot) -> Void
     ) {
         if let lastReportedRuntime,
            runtimeSnapshotEqualsIgnoringTimestamp(lastReportedRuntime, snapshot)
@@ -392,7 +425,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         }
 
         lastReportedRuntime = snapshot
-        runtimeObserver(snapshot)
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let lastReportedRuntime = self.lastReportedRuntime,
+                  self.runtimeSnapshotEqualsIgnoringTimestamp(lastReportedRuntime, snapshot)
+            else {
+                return
+            }
+            runtimeObserver(snapshot)
+        }
     }
 
     private func runtimeSnapshotEqualsIgnoringTimestamp(
@@ -476,8 +517,16 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         window?.firstResponder === self
     }
 
+    private func focusTerminalSoon() {
+        guard pane != nil else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.requestTerminalFocus()
+        }
+    }
+
     private func requestTerminalFocus() {
         window?.makeFirstResponder(self)
+        synchronizeLiveHost()
         publishRuntimeSnapshot()
     }
 
@@ -836,6 +885,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func unshiftedCodepointFromEvent(_ event: NSEvent) -> UInt32 {
+        guard event.type != .flagsChanged else {
+            return 0
+        }
         guard let chars = event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers ?? event.characters,
               let scalar = chars.unicodeScalars.first else {
             return 0

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -62,6 +62,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var keyTextAccumulator: [String]?
     private var previousPressureStage = 0
     private var hasTornDownRuntime = false
+    private var pendingFocusRequest = false
+    private var needsWindowAttachmentFocus = false
 
 #if canImport(GhosttyKit)
     private let liveHost = AlanGhosttyLiveHost()
@@ -115,7 +117,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         super.viewDidMoveToWindow()
         installWindowObservers()
         window?.acceptsMouseMovedEvents = true
-        focusTerminalSoon()
+        if window != nil, needsWindowAttachmentFocus {
+            needsWindowAttachmentFocus = false
+            focusTerminalSoon()
+        } else if window == nil {
+            needsWindowAttachmentFocus = false
+            pendingFocusRequest = false
+        }
         publishRuntimeSnapshot()
     }
 
@@ -155,6 +163,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
+        let previousPaneID = self.pane?.paneID
+        let wasSelected = self.isSelected
+
         self.pane = pane
         self.bootProfile = bootProfile
         self.isSelected = isSelected
@@ -190,7 +201,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         syncStatusBadge()
         syncOverlayVisibility()
         synchronizeLiveHost()
-        focusTerminalSoon()
+        if shouldAutoFocusAfterConfigure(
+            previousPaneID: previousPaneID,
+            paneID: pane?.paneID,
+            wasSelected: wasSelected
+        ) {
+            focusTerminalSoon()
+        }
         reportMetadataIfNeeded(paneMetadata)
         publishRuntimeSnapshot()
     }
@@ -527,9 +544,27 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     private func focusTerminalSoon() {
         guard isSelected, pane != nil else { return }
-        DispatchQueue.main.async { [weak self] in
-            self?.requestTerminalFocus()
+        guard window != nil else {
+            needsWindowAttachmentFocus = true
+            return
         }
+        guard !pendingFocusRequest else { return }
+        pendingFocusRequest = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            pendingFocusRequest = false
+            guard isSelected, pane != nil, window != nil else { return }
+            requestTerminalFocus()
+        }
+    }
+
+    private func shouldAutoFocusAfterConfigure(
+        previousPaneID: String?,
+        paneID: String?,
+        wasSelected: Bool
+    ) -> Bool {
+        guard isSelected, paneID != nil else { return false }
+        return previousPaneID != paneID || !wasSelected
     }
 
     private func requestTerminalFocus() {

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -176,13 +176,14 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func configureView() {
         wantsLayer = true
         layer?.backgroundColor = NSColor(calibratedRed: 0.06, green: 0.08, blue: 0.10, alpha: 1).cgColor
-        layer?.cornerRadius = 16
-        layer?.borderWidth = 1
-        layer?.borderColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        layer?.cornerRadius = 12
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = true
+        layer?.borderWidth = 0
         layer?.shadowColor = NSColor.black.cgColor
-        layer?.shadowOpacity = 0.12
-        layer?.shadowRadius = 16
-        layer?.shadowOffset = CGSize(width: 0, height: -4)
+        layer?.shadowOpacity = 0
+        layer?.shadowRadius = 0
+        layer?.shadowOffset = .zero
 
         translatesAutoresizingMaskIntoConstraints = false
 

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -11,6 +11,7 @@ import GhosttyKit
 struct TerminalHostView: NSViewRepresentable {
     let pane: ShellPane?
     let bootProfile: AlanShellBootProfile?
+    let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
@@ -19,6 +20,7 @@ struct TerminalHostView: NSViewRepresentable {
         runtimeRegistry.hostView(
             for: pane,
             bootProfile: bootProfile,
+            isSelected: isSelected,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -28,6 +30,7 @@ struct TerminalHostView: NSViewRepresentable {
         nsView.configure(
             pane: pane,
             bootProfile: bootProfile,
+            isSelected: isSelected,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -46,6 +49,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     private var pane: ShellPane?
     private var bootProfile: AlanShellBootProfile?
+    private var isSelected = false
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var windowObservers: [NSObjectProtocol] = []
@@ -145,11 +149,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     func configure(
         pane: ShellPane?,
         bootProfile: AlanShellBootProfile?,
+        isSelected: Bool,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
         self.pane = pane
         self.bootProfile = bootProfile
+        self.isSelected = isSelected
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
@@ -518,7 +524,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func focusTerminalSoon() {
-        guard pane != nil else { return }
+        guard isSelected, pane != nil else { return }
         DispatchQueue.main.async { [weak self] in
             self?.requestTerminalFocus()
         }

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -691,6 +691,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
 #if canImport(GhosttyKit)
+        guard !isApplicationReservedKeyEquivalent(event) else { return false }
         guard event.type == .keyDown, isFocused, liveHost.isSurfaceReady else { return false }
 
         var keyEvent = ghosttyKeyEvent(for: event, action: GHOSTTY_ACTION_PRESS)
@@ -711,6 +712,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override func keyDown(with event: NSEvent) {
 #if canImport(GhosttyKit)
+        if isApplicationReservedKeyEquivalent(event) {
+            NSApp.terminate(nil)
+            return
+        }
+
         guard liveHost.isSurfaceReady else {
             interpretKeyEvents([event])
             return
@@ -921,6 +927,17 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return !isControlCharacter(scalar)
         }
         return true
+    }
+
+    private func isApplicationReservedKeyEquivalent(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .numericPad, .function])
+        guard flags == .command else { return false }
+
+        return event.charactersIgnoringModifiers?.lowercased() == "q"
     }
 
     private func syncPreedit(clearIfNeeded: Bool = true) {

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -84,6 +84,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         true
     }
 
+    override var mouseDownCanMoveWindow: Bool { false }
+
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         true
     }
@@ -1060,11 +1062,15 @@ private func makeCanvasView() -> NSView {
 #if canImport(GhosttyKit)
     let view = AlanGhosttyCanvasView(frame: .zero)
 #else
-    let view = NSView(frame: .zero)
+    let view = AlanTerminalFallbackCanvasView(frame: .zero)
     view.wantsLayer = true
     view.layer?.backgroundColor = NSColor.clear.cgColor
 #endif
     view.translatesAutoresizingMaskIntoConstraints = false
     return view
+}
+
+final class AlanTerminalFallbackCanvasView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
 }
 #endif

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -408,6 +408,7 @@ private struct ShellPaneTreeLayoutView: View {
                 ShellTerminalLeafView(
                     pane: pane,
                     bootProfile: host.bootProfile(for: pane),
+                    isSelected: host.selectedPane?.paneID == pane.paneID,
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     onSelect: { host.focus(paneID: pane.paneID) },
                     onRuntimeUpdate: host.updateTerminalRuntime,
@@ -440,6 +441,7 @@ private struct ShellPaneTreeLayoutView: View {
 private struct ShellTerminalLeafView: View {
     let pane: ShellPane
     let bootProfile: AlanShellBootProfile?
+    let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let onSelect: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
@@ -449,6 +451,7 @@ private struct ShellTerminalLeafView: View {
         TerminalHostView(
             pane: pane,
             bootProfile: bootProfile,
+            isSelected: isSelected,
             runtimeRegistry: runtimeRegistry,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -5,19 +5,17 @@ struct TerminalPaneView: View {
     @ObservedObject var host: ShellHostController
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if showsMetadataStrip {
-                paneMetadataStrip
-            }
+        VStack(alignment: .leading, spacing: 10) {
             paneCanvas
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             if host.panesForSelectedTab.count > 1 {
                 paneSelectorStrip
             }
         }
-        .padding(.horizontal, 4)
-        .padding(.top, 4)
-        .padding(.bottom, 2)
+        .padding(.top, 12)
+        .padding(.trailing, 12)
+        .padding(.bottom, 12)
     }
 
     private var paneMetadataStrip: some View {
@@ -409,10 +407,8 @@ private struct ShellPaneTreeLayoutView: View {
                let pane = host.shellState.panes.first(where: { $0.paneID == paneID }) {
                 ShellTerminalLeafView(
                     pane: pane,
-                    runtime: host.runtime(for: pane.paneID),
                     bootProfile: host.bootProfile(for: pane),
                     runtimeRegistry: host.terminalRuntimeRegistry,
-                    isFocused: host.shellState.focusedPaneID == pane.paneID,
                     onSelect: { host.focus(paneID: pane.paneID) },
                     onRuntimeUpdate: host.updateTerminalRuntime,
                     onMetadataUpdate: { metadata in
@@ -442,127 +438,39 @@ private struct ShellPaneTreeLayoutView: View {
 }
 
 private struct ShellTerminalLeafView: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let pane: ShellPane
-    let runtime: TerminalHostRuntimeSnapshot
     let bootProfile: AlanShellBootProfile?
     let runtimeRegistry: TerminalRuntimeRegistry
-    let isFocused: Bool
     let onSelect: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(isFocused ? ShellPalette.accent : Color.white.opacity(0.28))
-                    .frame(width: 5, height: 5)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(paneTitle)
-                        .font(.system(size: 11.5, weight: .semibold))
-                        .tracking(-0.1)
-                        .foregroundStyle(.white.opacity(0.96))
-                    if let summary = paneSubtitle {
-                        Text(summary)
-                            .font(.system(size: 9.5, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.52))
-                            .lineLimit(1)
-                    }
-                }
-
-                Spacer(minLength: 8)
-
-                if pane.resolvedLaunchTarget == .alan {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 8.5, weight: .bold))
-                        .foregroundStyle(ShellPalette.accentSoft)
-                }
-
-                if pane.attention == .awaitingUser || pane.attention == .notable {
-                    HStack(spacing: 4) {
-                        Circle()
-                            .fill(pane.attention == .awaitingUser ? ShellPalette.attention : Color.white.opacity(0.68))
-                            .frame(width: 4.5, height: 4.5)
-                        Text(pane.attention == .awaitingUser ? "Waiting" : "Notice")
-                            .font(.system(size: 9.5, weight: .semibold))
-                            .foregroundStyle(pane.attention == .awaitingUser ? ShellPalette.attention : .white.opacity(0.68))
-                    }
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
-            .padding(.bottom, 6)
-            .contentShape(Rectangle())
-            .onTapGesture(perform: onSelect)
-
-            TerminalHostView(
-                pane: pane,
-                bootProfile: bootProfile,
-                runtimeRegistry: runtimeRegistry,
-                onRuntimeUpdate: onRuntimeUpdate,
-                onMetadataUpdate: onMetadataUpdate
-            )
-            .id(pane.paneID)
-            .frame(minHeight: 260, maxHeight: .infinity)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(ShellPalette.terminal)
+        TerminalHostView(
+            pane: pane,
+            bootProfile: bootProfile,
+            runtimeRegistry: runtimeRegistry,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
         )
+        .id(pane.paneID)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(ShellPalette.terminal)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(
-                    isFocused ? ShellPalette.accent.opacity(0.55) : ShellPalette.line.opacity(0.18),
-                    lineWidth: isFocused ? 1.25 : 1
+                    ShellPalette.accent.opacity(0.32),
+                    lineWidth: 1
                 )
         }
         .shadow(
-            color: isFocused ? ShellPalette.accent.opacity(0.12) : Color.black.opacity(0.035),
-            radius: isFocused ? 14 : 8,
-            y: isFocused ? 8 : 4
+            color: Color.black.opacity(0.10),
+            radius: 18,
+            y: 8
         )
-        .scaleEffect(isFocused ? 1 : 0.998)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isFocused)
-    }
-
-    private var paneTitle: String {
-        shellDisplayTitle(
-            rawTitle: pane.viewport?.title,
-            workingDirectoryName: pane.context?.workingDirectoryName,
-            cwd: pane.cwd,
-            program: pane.process?.program,
-            launchTarget: pane.resolvedLaunchTarget,
-            fallback: pane.resolvedLaunchTarget == .alan ? "Alan" : "Shell"
-        )
-    }
-
-    private var paneSubtitle: String? {
-        if let branch = pane.context?.gitBranch {
-            return branch
-        }
-
-        if let folder = shellVisibleLabel(pane.context?.workingDirectoryName) ?? shellPathLeaf(pane.cwd),
-           folder != paneTitle
-        {
-            return folder
-        }
-
-        if let summary = shellUserFacingSummary(pane.viewport?.summary),
-           summary != paneTitle
-        {
-            return summary
-        }
-
-        if let program = shellVisibleLabel(pane.process?.program),
-           program.localizedCaseInsensitiveCompare(paneTitle) != .orderedSame
-        {
-            return program
-        }
-
-        return nil
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -13,9 +13,9 @@ struct TerminalPaneView: View {
                 paneSelectorStrip
             }
         }
-        .padding(.top, 12)
-        .padding(.trailing, 12)
-        .padding(.bottom, 12)
+        .padding(.top, 8)
+        .padding(.trailing, 8)
+        .padding(.bottom, 8)
     }
 
     private var paneMetadataStrip: some View {

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -97,6 +97,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     func hostView(
         for pane: ShellPane?,
         bootProfile: AlanShellBootProfile?,
+        isSelected: Bool,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
@@ -116,6 +117,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         hostView.configure(
             pane: pane,
             bootProfile: bootProfile,
+            isSelected: isSelected,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -86,6 +86,11 @@ require_pattern \
     "Ghostty occlusion bridge must pass visible=true for visible windows"
 
 require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "if let surface = self\\.surface" \
+    "Ghostty wakeup ticks must look up the current surface before refreshing"
+
+require_pattern \
     "clients/apple/AlanNative/ShellHostController.swift" \
     "struct ShellWindowContext" \
     "shell host must expose a per-window context"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -77,18 +77,28 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
-    "struct ShellWindowDragRegion" \
-    "hidden-titlebar shell windows must expose a replacement drag region"
+    "window\\.isMovableByWindowBackground = true" \
+    "hidden-titlebar shell windows must make non-interactive background regions draggable"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "override var mouseDownCanMoveWindow: Bool \\{ false \\}" \
+    "terminal host views must not allow terminal pane clicks to drag the shell window"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "final class AlanTerminalFallbackCanvasView" \
+    "fallback terminal canvas views must explicitly opt out of background window dragging"
+
+require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "override var mouseDownCanMoveWindow: Bool \\{ false \\}" \
+    "Ghostty canvas views must not allow terminal pane clicks to drag the shell window"
+
+reject_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
     "WindowDragGesture\\(\\)" \
-    "hidden-titlebar shell windows must use WindowDragGesture for custom chrome"
-
-require_pattern \
-    "clients/apple/AlanNative/MacShellRootView.swift" \
-    "allowsWindowActivationEvents\\(true\\)" \
-    "custom shell window drag regions must support click-then-drag activation"
+    "shell window dragging should rely on movable background regions, not transparent SwiftUI drag overlays"
 
 require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \
@@ -98,7 +108,12 @@ require_pattern \
 require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \
     "ghostty_surface_set_occlusion\\(surface, visible\\)" \
-    "Ghostty occlusion bridge must pass visible=true for visible windows"
+    "GhosttyKit bridge must pass the observed visible state used by this linked Ghostty build"
+
+reject_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "let isOccluded =|isSurfaceOccluded|!isVisible" \
+    "GhosttyKit bridge must not invert NSWindow visible state for this linked Ghostty build"
 
 require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -121,6 +121,21 @@ require_pattern \
     "Ghostty wakeup ticks must look up the current surface before refreshing"
 
 require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "private var tickScheduled = false" \
+    "Ghostty wakeup ticks must be coalesced so repeated wakeups do not flood the main queue"
+
+require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "guard markTickScheduledIfNeeded\\(\\) else \\{ return \\}" \
+    "Ghostty wakeup ticks must skip scheduling when a tick is already pending"
+
+require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "clearScheduledTick\\(\\)" \
+    "Ghostty wakeup ticks must clear their pending marker when the scheduled tick begins"
+
+require_pattern \
     "clients/apple/AlanNative/ShellHostController.swift" \
     "struct ShellWindowContext" \
     "shell host must expose a per-window context"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -76,6 +76,21 @@ require_pattern \
     "terminal auto-focus must be gated to the selected pane"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "shouldAutoFocusAfterConfigure" \
+    "terminal auto-focus must only be requested on initial attachment or selected-pane transitions"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "previousPaneID != paneID \\|\\| !wasSelected" \
+    "terminal auto-focus must not refocus the same selected pane on every SwiftUI update"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "guard !pendingFocusRequest else \\{ return \\}" \
+    "terminal auto-focus must coalesce pending first-responder requests"
+
+require_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
     "window\\.isMovableByWindowBackground = true" \
     "hidden-titlebar shell windows must make non-interactive background regions draggable"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -76,6 +76,21 @@ require_pattern \
     "terminal auto-focus must be gated to the selected pane"
 
 require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "struct ShellWindowDragRegion" \
+    "hidden-titlebar shell windows must expose a replacement drag region"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "WindowDragGesture\\(\\)" \
+    "hidden-titlebar shell windows must use WindowDragGesture for custom chrome"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "allowsWindowActivationEvents\\(true\\)" \
+    "custom shell window drag regions must support click-then-drag activation"
+
+require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \
     "let visible = .*occlusionState\\.contains\\(\\.visible\\) \\?\\? false" \
     "Ghostty occlusion bridge must derive the visible flag from NSWindow occlusion state"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -66,6 +66,16 @@ require_pattern \
     "terminal teardown must be idempotent"
 
 require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "let visible = .*occlusionState\\.contains\\(\\.visible\\) \\?\\? false" \
+    "Ghostty occlusion bridge must derive the visible flag from NSWindow occlusion state"
+
+require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "ghostty_surface_set_occlusion\\(surface, visible\\)" \
+    "Ghostty occlusion bridge must pass visible=true for visible windows"
+
+require_pattern \
     "clients/apple/AlanNative/ShellHostController.swift" \
     "struct ShellWindowContext" \
     "shell host must expose a per-window context"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -66,6 +66,16 @@ require_pattern \
     "terminal teardown must be idempotent"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "let isSelected: Bool" \
+    "terminal hosts must know whether their pane is selected"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "guard isSelected, pane != nil else \\{ return \\}" \
+    "terminal auto-focus must be gated to the selected pane"
+
+require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \
     "let visible = .*occlusionState\\.contains\\(\\.visible\\) \\?\\? false" \
     "Ghostty occlusion bridge must derive the visible flag from NSWindow occlusion state"

--- a/justfile
+++ b/justfile
@@ -52,6 +52,11 @@ serve:
 build:
     cargo build --release
 
+# Build and launch the native macOS app
+app:
+    xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
+    /usr/bin/open -n target/xcode-derived/Build/Products/Debug/Alan.app
+
 # Install alan to ~/.alan/bin
 install:
     ./scripts/install.sh


### PR DESCRIPTION
## Summary
- remove the macOS shell top bar and make the terminal pane the primary workspace surface
- align the floating terminal pane with 12px continuous corners and balanced margins
- add adaptive shell colors for dark mode and replace fixed white sidebar surfaces with semantic palette tokens
- keep app-level Cmd+Q out of the embedded terminal key-binding path so Alan can quit normally
- add a `just app` recipe to build and launch the native macOS app
- pass Ghostty the visible window state for occlusion updates so fish remains interactive after startup
- gate terminal auto-focus to the selected pane so split background panes cannot steal first responder
- refresh the Ghostty surface after wakeup ticks so PTY output is presented promptly
- restore a sidebar header drag region for hidden-titlebar shell windows

## Verification
- git diff --check
- bash clients/apple/scripts/check-shell-contracts.sh
- just --list
- just --dry-run app
- just app
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/AlanDerivedData build
- launched /private/tmp/AlanDerivedData/Build/Products/Debug/Alan.app and verified Cmd+Q quits Alan
- manual: verified fish terminal interaction after the Ghostty occlusion fix