### PR TITLE
Add OpenSpec for terminal event ownership

### DIFF
--- a/openspec/changes/converge-terminal-event-ownership/.openspec.yaml
+++ b/openspec/changes/converge-terminal-event-ownership/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/converge-terminal-event-ownership/design.md
+++ b/openspec/changes/converge-terminal-event-ownership/design.md
@@ -1,0 +1,173 @@
+## Context
+
+The current macOS terminal pane has one physical interaction area but several
+logical event owners:
+
+- SwiftUI `ShellTerminalLeafView` wraps the native terminal view with
+  `.onTapGesture(perform: onSelect)` for pane selection.
+- `AlanTerminalHostNSView` owns terminal focus, key input, IME, mouse forwarding,
+  scroll, paste, selection readback, and Ghostty synchronization.
+- The full-size Ghostty or fallback canvas is a child view of the host and
+  participates in AppKit hit-testing even though the host is the object that
+  forwards terminal input.
+- The hidden-titlebar shell window uses background dragging, while terminal
+  host/canvas views opt out through `mouseDownCanMoveWindow`.
+
+That layering makes terminal interaction fragile. A pane click is selection in
+SwiftUI, terminal input in AppKit, and potentially a window drag depending on
+which layer receives the event. The code should converge on one owner for
+terminal-area events without changing the broader shell state model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `AlanTerminalHostNSView` the single owner of mouse events that occur
+  inside terminal pixels.
+- Keep SwiftUI responsible for rendering layout, reading shell state, and
+  owning explicit controls such as pane selector buttons.
+- Ensure a terminal click selects the pane, focuses the terminal host, and
+  forwards the same event to Ghostty without requiring a second click.
+- Keep drawing subviews, including Ghostty canvas and fallback canvas, from
+  stealing terminal events from the host.
+- Keep non-interactive shell background draggable while terminal panes remain
+  non-draggable.
+- Avoid retain cycles caused by registry-owned AppKit views storing strong
+  SwiftUI/controller closures.
+
+**Non-Goals:**
+
+- Do not change Ghostty API semantics, occlusion handling, or renderer startup.
+- Do not redesign split-pane layout, sidebar layout, or the visual treatment of
+  terminal corners.
+- Do not change control-plane protocol payloads or shell persistence format.
+- Do not implement a new terminal emulator or replace Ghostty selection logic.
+
+## Decisions
+
+### Decision: Terminal host owns terminal-area events
+
+Remove the SwiftUI `.onTapGesture(perform: onSelect)` wrapper from the terminal
+leaf. The native host should activate its pane from AppKit mouse handlers before
+it forwards terminal input to Ghostty.
+
+Rationale: terminal mouse events already need AppKit for first responder,
+selection, scroll, IME, paste, and Ghostty coordinate conversion. Keeping
+selection in SwiftUI creates a competing recognizer outside the terminal input
+pipeline.
+
+Alternative considered: keep the SwiftUI tap gesture and tune gesture priority.
+That would preserve two event owners and still risk stealing the first terminal
+click from Ghostty or fighting AppKit responder behavior.
+
+### Decision: Use a weak activation delegate instead of stored closures
+
+Introduce a narrow main-actor delegate:
+
+```swift
+@MainActor
+protocol TerminalHostActivationDelegate: AnyObject {
+    func terminalHostDidRequestActivation(paneID: String)
+}
+```
+
+`ShellHostController` should conform and call `focus(paneID:)`. `TerminalHostView`
+passes the delegate through `TerminalRuntimeRegistry` into
+`AlanTerminalHostNSView`. The host stores it as `weak`.
+
+Rationale: terminal host views are pane-keyed and registry-owned. Storing a
+strong `onSelect` closure on those views can create a long-lived cycle from the
+controller to the registry to the host view back to the controller. A weak
+delegate keeps the imperative AppKit bridge explicit and bounded.
+
+Alternative considered: pass `onSelect` closures through `NSViewRepresentable`.
+That is convenient for transient SwiftUI views but wrong for registry-owned
+AppKit objects with longer lifetimes.
+
+### Decision: Make canvases drawing-only in hit-testing
+
+`AlanGhosttyCanvasView` and `AlanTerminalFallbackCanvasView` should return `nil`
+from `hitTest(_:)` so AppKit delivers terminal mouse events to
+`AlanTerminalHostNSView`. Passive placeholder/diagnostic overlay views inside
+the host should also be non-interactive unless they intentionally contain real
+controls.
+
+Rationale: the canvas is the rendering attachment passed to Ghostty; the host is
+the event adapter. This keeps coordinate conversion, pane activation, focus, and
+Ghostty forwarding in one class.
+
+Alternative considered: override `hitTest(_:)` on the host and forcibly return
+the host for all descendants. That is stronger than necessary and would make it
+harder to add future interactive controls inside the terminal host.
+
+### Decision: Activate before forwarding mouse-down events
+
+For primary, secondary, and other mouse-down events, the host should request
+activation for its pane, make itself first responder, then forward position and
+button state to Ghostty. Mouse-up, drag, motion, scroll, pressure, and key paths
+remain host-owned and should not depend on SwiftUI tap state.
+
+Rationale: selecting a non-focused pane and sending the first click to the
+terminal are one user action. Activation must not consume the event that starts
+terminal selection or clicks a terminal application.
+
+Alternative considered: activate only on mouse-up. That delays focus and can
+misroute the down/up pair that terminal applications expect.
+
+### Decision: Encode the boundary in shell contract checks
+
+Extend `check-shell-contracts.sh` to reject the SwiftUI terminal leaf
+`.onTapGesture(perform: onSelect)` path and require the weak delegate plus
+drawing-only canvas hit-testing.
+
+Rationale: this class of regression is easy to reintroduce during visual chrome
+changes. A lightweight textual contract check is appropriate because the
+boundary is structural.
+
+Alternative considered: rely only on manual app testing. Manual testing remains
+necessary for terminal interaction, but it should not be the first place this
+architectural boundary is noticed.
+
+## Risks / Trade-offs
+
+- Weak delegate is missing or stale -> the terminal still receives input but a
+  non-selected pane may not update shell selection; mitigate by configuring the
+  delegate every `updateNSView` and adding a contract check.
+- Drawing-only canvas hit-testing hides future canvas controls -> only use
+  transparent hit-testing for rendering/passive views; future real controls must
+  be separate AppKit or SwiftUI controls with explicit ownership.
+- Activation changes event ordering -> activate before Ghostty mouse-down and
+  verify first click, drag selection, right click, scroll, and typing after pane
+  switching in the running app.
+- Contract checks become too implementation-specific -> check only durable
+  boundary markers: no SwiftUI terminal tap wrapper, weak delegate, and
+  transparent rendering canvases.
+
+## Migration Plan
+
+1. Add the activation delegate protocol and `ShellHostController` conformance.
+2. Thread the weak delegate through `TerminalHostView`,
+   `TerminalRuntimeRegistry.hostView(...)`, and
+   `AlanTerminalHostNSView.configure(...)`.
+3. Move terminal-pane activation into host mouse-down handling and remove
+   `onSelect` from `ShellTerminalLeafView`.
+4. Make Ghostty, fallback, and passive overlay rendering views transparent to
+   hit-testing while preserving `mouseDownCanMoveWindow == false`.
+5. Add shell contract checks for the event ownership boundary.
+6. Verify with `check-shell-contracts.sh`, the macOS Xcode build, and manual app
+   interaction covering pane click-to-focus, immediate typing, text selection,
+   right click, scroll, and background window dragging.
+
+Rollback is straightforward: keep the delegate path isolated to terminal
+activation, so it can be reverted without changing runtime ownership,
+control-plane delivery, or Ghostty lifecycle code.
+
+## Open Questions
+
+- Should scroll on a non-selected pane activate that pane, or should it continue
+  to scroll without changing selection? The first implementation should preserve
+  the current scroll semantics unless manual testing shows a native expectation
+  mismatch.
+- Should the fallback diagnostic overlay ever contain interactive setup actions?
+  If so, those controls need explicit ownership rather than inheriting the
+  drawing-only overlay behavior.

--- a/openspec/changes/converge-terminal-event-ownership/proposal.md
+++ b/openspec/changes/converge-terminal-event-ownership/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The macOS terminal pane currently splits ownership of the same mouse event
+across SwiftUI selection gestures, AppKit terminal input handling, Ghostty canvas
+rendering, and NSWindow background dragging. That makes small chrome changes
+fragile: a pane click can accidentally become selection-only, terminal input,
+or window dragging depending on which layer wins hit-testing.
+
+## What Changes
+
+- Move terminal-pane activation from the SwiftUI `.onTapGesture` wrapper into
+  the AppKit terminal host that already owns terminal mouse, keyboard, IME,
+  selection, scroll, paste, and Ghostty forwarding.
+- Keep SwiftUI responsible for layout, shell selection state, and explicit
+  controls such as pane selector buttons.
+- Make Ghostty and fallback canvas subviews drawing surfaces rather than event
+  owners, so terminal mouse events are handled consistently by the host view.
+- Add a narrow weak activation delegate from the AppKit host back to the shell
+  controller instead of storing long-lived strong SwiftUI closures in
+  registry-owned host views.
+- Preserve the existing background-window-dragging contract: non-interactive
+  shell background remains draggable, while terminal pane clicks never drag the
+  window.
+- Add contract checks and focused verification notes so future changes cannot
+  reintroduce SwiftUI tap ownership over the terminal pane.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-terminal-lifecycle`: terminal focus and pane selection must follow
+  stable pane identity while terminal-area events are owned by the terminal host
+  rather than transient SwiftUI gesture wrappers.
+- `macos-shell-ui-ux-conformance`: terminal content remains the center of
+  gravity, with terminal clicks behaving as terminal activation/input and
+  background dragging limited to non-terminal, non-interactive chrome.
+- `macos-shell-build-test-contract`: shell contract checks must cover the
+  terminal event boundary so regressions are caught without relying only on
+  manual visual testing.
+
+## Impact
+
+- Apple client files: `TerminalPaneView.swift`, `TerminalHostView.swift`,
+  `TerminalRuntimeRegistry.swift`, `ShellHostController.swift`,
+  `GhosttyLiveHost.swift`, and `check-shell-contracts.sh`.
+- Runtime behavior: terminal pane clicks select/focus the pane and continue to
+  forward mouse input to Ghostty through a single AppKit path.
+- UI behavior: pane selector buttons and other explicit SwiftUI controls keep
+  their existing action ownership; only terminal-canvas selection is moved.
+- No external API, daemon protocol, persistence format, or Ghostty dependency
+  changes are intended.

--- a/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Terminal event ownership is contract-checked
+The Apple client SHALL include focused shell contract checks that preserve the
+terminal event ownership boundary between SwiftUI layout, AppKit terminal host
+input, rendering canvases, and native window background dragging.
+
+#### Scenario: SwiftUI terminal tap wrapper is reintroduced
+- **WHEN** a code change wraps the terminal native view in a SwiftUI tap gesture for pane selection
+- **THEN** the shell contract check fails with an error explaining that terminal-area selection belongs to the terminal host
+
+#### Scenario: Activation delegate strongly retains controller state
+- **WHEN** a code change stores terminal activation as a strong registry-owned closure
+- **THEN** the shell contract check fails or the focused review checklist requires replacing it with the weak activation boundary
+
+#### Scenario: Rendering canvas becomes interactive owner
+- **WHEN** a code change lets Ghostty or fallback rendering canvas views receive terminal mouse-down hit tests as independent owners
+- **THEN** the shell contract check fails or the focused review checklist requires routing those events through the terminal host
+
+#### Scenario: Focused manual verification is performed
+- **WHEN** event ownership implementation is ready for review
+- **THEN** verification covers click-to-select, immediate typing, drag selection, right click, scrolling, and background window dragging in the running macOS app

--- a/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Terminal-area events are owned by the terminal host
+The macOS shell host SHALL route mouse events that occur inside terminal pixels
+through the pane's AppKit terminal host rather than through SwiftUI tap gesture
+wrappers around the terminal view.
+
+#### Scenario: First click activates and reaches the terminal
+- **WHEN** a user clicks a visible terminal pane that is not currently selected
+- **THEN** the shell selects that pane, makes its terminal host first responder, and forwards the same mouse-down event to the terminal renderer
+
+#### Scenario: Terminal text selection starts on first drag
+- **WHEN** a user begins a drag inside a visible terminal pane
+- **THEN** the drag is handled by the terminal host and can start terminal text selection without requiring a prior selection-only click
+
+#### Scenario: Terminal host lifetime remains pane-keyed
+- **WHEN** SwiftUI recreates the terminal leaf view for an existing pane
+- **THEN** the registry reuses the pane-keyed terminal host and refreshes its weak activation boundary without transferring terminal event ownership to the SwiftUI view
+
+### Requirement: Terminal activation does not retain shell controllers
+Registry-owned terminal host views SHALL use a weak activation boundary when
+requesting pane selection from the shell controller.
+
+#### Scenario: Host requests activation
+- **WHEN** a terminal host receives a mouse-down event for a pane with a stable pane ID
+- **THEN** it calls the weak activation boundary for that pane before requesting terminal focus
+
+#### Scenario: Activation boundary is unavailable
+- **WHEN** a terminal host has no activation delegate available
+- **THEN** terminal input handling remains local to the host and the host does not keep a strong closure that can retain the shell controller

--- a/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/converge-terminal-event-ownership/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Terminal panes have unambiguous hit-testing boundaries
+The macOS shell UI SHALL keep terminal-rendering surfaces from intercepting
+mouse events that must be handled by the terminal host, while preserving
+explicit SwiftUI/AppKit controls outside the terminal pane.
+
+#### Scenario: Rendering canvas is clicked
+- **WHEN** a user clicks the Ghostty or fallback rendering canvas inside a terminal pane
+- **THEN** AppKit hit-testing delivers the event to the terminal host rather than treating the canvas as a separate interactive owner
+
+#### Scenario: Passive terminal overlay is visible
+- **WHEN** a non-interactive terminal placeholder or diagnostic overlay is visible over the terminal canvas
+- **THEN** the overlay does not prevent the terminal host from receiving pane activation clicks
+
+#### Scenario: Pane selector button is clicked
+- **WHEN** a user clicks an explicit pane selector button outside the terminal canvas
+- **THEN** that SwiftUI control handles selection through its own action without routing the click through the terminal host
+
+### Requirement: Window dragging excludes terminal panes
+The macOS shell UI SHALL allow non-interactive window background regions to drag
+the hidden-titlebar shell window and SHALL prevent terminal-pane interactions
+from initiating window dragging.
+
+#### Scenario: Background chrome is dragged
+- **WHEN** a user drags a non-interactive shell background area outside terminal panes and controls
+- **THEN** the window moves according to the native movable-background behavior
+
+#### Scenario: Terminal pane is dragged
+- **WHEN** a user drags inside a terminal pane
+- **THEN** the drag is handled as terminal input or terminal selection and does not move the window

--- a/openspec/changes/converge-terminal-event-ownership/tasks.md
+++ b/openspec/changes/converge-terminal-event-ownership/tasks.md
@@ -1,0 +1,43 @@
+## 1. Activation Boundary
+
+- [ ] 1.1 Add `TerminalHostActivationDelegate` as a main-actor class-bound protocol with a pane activation method.
+- [ ] 1.2 Make `ShellHostController` conform to the activation delegate and route requests to `focus(paneID:)`.
+- [ ] 1.3 Thread the delegate through `TerminalHostView`, `TerminalRuntimeRegistry.hostView(...)`, and `AlanTerminalHostNSView.configure(...)`.
+- [ ] 1.4 Store the activation delegate weakly on `AlanTerminalHostNSView` and refresh it whenever the host is configured.
+
+## 2. Terminal Event Ownership
+
+- [ ] 2.1 Remove terminal-pane selection ownership from `ShellTerminalLeafView` by deleting the terminal `.onTapGesture(perform: onSelect)` path and any now-unused terminal-leaf `onSelect` plumbing.
+- [ ] 2.2 Add a host-owned activation helper that validates the current pane ID, asks the weak delegate to activate it, and requests terminal focus.
+- [ ] 2.3 Call the activation helper before forwarding primary, secondary, and other mouse-down events to Ghostty.
+- [ ] 2.4 Preserve existing mouse-up, drag, movement, scroll, pressure, key, IME, copy, paste, and command-key behavior through the AppKit terminal host.
+- [ ] 2.5 Keep explicit SwiftUI controls, including pane selector buttons, on their existing selection actions.
+
+## 3. Hit-Testing And Dragging Boundaries
+
+- [ ] 3.1 Make `AlanGhosttyCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
+- [ ] 3.2 Make `AlanTerminalFallbackCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
+- [ ] 3.3 Make passive terminal placeholder/diagnostic overlay views non-interactive unless they contain explicit controls.
+- [ ] 3.4 Confirm terminal pane clicks and drags still opt out of native background window dragging.
+
+## 4. Contract Checks
+
+- [ ] 4.1 Extend `clients/apple/scripts/check-shell-contracts.sh` to require the weak activation delegate boundary.
+- [ ] 4.2 Extend the contract check to reject SwiftUI terminal leaf `.onTapGesture(perform: onSelect)`.
+- [ ] 4.3 Extend the contract check to require transparent hit-testing for Ghostty and fallback rendering canvases.
+- [ ] 4.4 Keep the existing occlusion and background-dragging checks intact.
+
+## 5. Verification
+
+- [ ] 5.1 Run `git diff --check`.
+- [ ] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 5.3 Build the macOS app with the documented Xcode command for `AlanNative`.
+- [ ] 5.4 Manually verify click-to-select, immediate typing after selecting a pane, drag selection, right click, scroll, and background window dragging in the running app.
+- [ ] 5.5 Review the diff for retain cycles, especially registry-owned host views retaining shell controller state.
+
+## 6. PR And Archive Readiness
+
+- [ ] 6.1 Update the PR with the implementation summary and verification results.
+- [ ] 6.2 Resolve any review comments tied to terminal event ownership after confirming the running app behavior.
+- [ ] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
+- [ ] 6.4 Archive the OpenSpec change after implementation is merged.


### PR DESCRIPTION
## Summary
- add the converge-terminal-event-ownership OpenSpec change referenced by the macOS Ghostty parity plan
- define the AppKit terminal-host activation boundary and hit-testing/window-dragging contracts
- add task breakdown for implementation, verification, PR review, and archive readiness

## Validation
- openspec validate converge-terminal-event-ownership --type change --strict --json
- git diff --check --cached