### PR TITLE
Converge terminal event ownership

### DIFF
--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -885,6 +885,8 @@ final class AlanGhosttyLiveHost: NSObject {
 final class AlanGhosttyCanvasView: NSView {
     override var mouseDownCanMoveWindow: Bool { false }
 
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
     }

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -72,7 +72,7 @@ struct ShellWindowContext {
 }
 
 @MainActor
-final class ShellHostController: ObservableObject {
+final class ShellHostController: ObservableObject, TerminalHostActivationDelegate {
     enum StartupMode {
         case fresh
         case restorePrevious
@@ -323,6 +323,10 @@ final class ShellHostController: ObservableObject {
     func focus(paneID: String) {
         guard let result = try? shellState.focusingPane(paneID) else { return }
         applyMutationResult(result)
+    }
+
+    func terminalHostDidRequestActivation(paneID: String) {
+        focus(paneID: paneID)
     }
 
     @discardableResult

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -13,6 +13,7 @@ struct TerminalHostView: NSViewRepresentable {
     let bootProfile: AlanShellBootProfile?
     let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
+    let activationDelegate: TerminalHostActivationDelegate?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -21,6 +22,7 @@ struct TerminalHostView: NSViewRepresentable {
             for: pane,
             bootProfile: bootProfile,
             isSelected: isSelected,
+            activationDelegate: activationDelegate,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -31,15 +33,21 @@ struct TerminalHostView: NSViewRepresentable {
             pane: pane,
             bootProfile: bootProfile,
             isSelected: isSelected,
+            activationDelegate: activationDelegate,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
     }
 }
 
+@MainActor
+protocol TerminalHostActivationDelegate: AnyObject {
+    func terminalHostDidRequestActivation(paneID: String)
+}
+
 final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHandle {
     private let canvasView = makeCanvasView()
-    private let overlayCard = NSVisualEffectView()
+    private let overlayCard = AlanTerminalPassiveOverlayView()
     private let bodyStack = NSStackView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let subtitleLabel = NSTextField(wrappingLabelWithString: "")
@@ -50,6 +58,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var pane: ShellPane?
     private var bootProfile: AlanShellBootProfile?
     private var isSelected = false
+    private weak var activationDelegate: TerminalHostActivationDelegate?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var windowObservers: [NSObjectProtocol] = []
@@ -160,6 +169,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         pane: ShellPane?,
         bootProfile: AlanShellBootProfile?,
         isSelected: Bool,
+        activationDelegate: TerminalHostActivationDelegate?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
@@ -169,6 +179,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         self.pane = pane
         self.bootProfile = bootProfile
         self.isSelected = isSelected
+        self.activationDelegate = activationDelegate
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
@@ -573,6 +584,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         publishRuntimeSnapshot()
     }
 
+    private func activateTerminalHostForMouseEvent() {
+        if let paneID = pane?.paneID {
+            activationDelegate?.terminalHostDidRequestActivation(paneID: paneID)
+        }
+        requestTerminalFocus()
+    }
+
     private func localPoint(for event: NSEvent) -> CGPoint {
         convert(event.locationInWindow, from: nil)
     }
@@ -590,7 +608,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func mouseDown(with event: NSEvent) {
-        requestTerminalFocus()
+        activateTerminalHostForMouseEvent()
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
         _ = liveHost.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT, mods: modsFromEvent(event))
@@ -606,7 +624,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        requestTerminalFocus()
+        activateTerminalHostForMouseEvent()
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
         _ = liveHost.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_RIGHT, mods: modsFromEvent(event))
@@ -624,7 +642,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func otherMouseDown(with event: NSEvent) {
-        requestTerminalFocus()
+        activateTerminalHostForMouseEvent()
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
         let button = event.buttonNumber == 2 ? GHOSTTY_MOUSE_MIDDLE : GHOSTTY_MOUSE_MIDDLE
@@ -1107,5 +1125,13 @@ private func makeCanvasView() -> NSView {
 
 final class AlanTerminalFallbackCanvasView: NSView {
     override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+final class AlanTerminalPassiveOverlayView: NSVisualEffectView {
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
 }
 #endif

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -410,7 +410,7 @@ private struct ShellPaneTreeLayoutView: View {
                     bootProfile: host.bootProfile(for: pane),
                     isSelected: host.selectedPane?.paneID == pane.paneID,
                     runtimeRegistry: host.terminalRuntimeRegistry,
-                    onSelect: { host.focus(paneID: pane.paneID) },
+                    activationDelegate: host,
                     onRuntimeUpdate: host.updateTerminalRuntime,
                     onMetadataUpdate: { metadata in
                         host.updateTerminalMetadata(metadata, for: pane.paneID)
@@ -443,7 +443,7 @@ private struct ShellTerminalLeafView: View {
     let bootProfile: AlanShellBootProfile?
     let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
-    let onSelect: () -> Void
+    let activationDelegate: TerminalHostActivationDelegate?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -453,6 +453,7 @@ private struct ShellTerminalLeafView: View {
             bootProfile: bootProfile,
             isSelected: isSelected,
             runtimeRegistry: runtimeRegistry,
+            activationDelegate: activationDelegate,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -472,8 +473,6 @@ private struct ShellTerminalLeafView: View {
             radius: 18,
             y: 8
         )
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onSelect)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -98,6 +98,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         for pane: ShellPane?,
         bootProfile: AlanShellBootProfile?,
         isSelected: Bool,
+        activationDelegate: TerminalHostActivationDelegate?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
@@ -118,6 +119,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             pane: pane,
             bootProfile: bootProfile,
             isSelected: isSelected,
+            activationDelegate: activationDelegate,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -91,6 +91,41 @@ require_pattern \
     "terminal auto-focus must coalesce pending first-responder requests"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "protocol TerminalHostActivationDelegate: AnyObject" \
+    "terminal activation must use a narrow class-bound delegate"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "TerminalHostActivationDelegate" \
+    "shell host controller must own terminal activation requests"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "activationDelegate: TerminalHostActivationDelegate\\?" \
+    "terminal runtime registry must thread the weak activation boundary"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "weak var activationDelegate" \
+    "registry-owned terminal host views must not strongly retain activation owners"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "terminalHostDidRequestActivation\\(paneID:" \
+    "terminal host mouse events must request pane activation through the delegate"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "private let overlayCard = AlanTerminalPassiveOverlayView\\(\\)" \
+    "passive terminal overlays must use a non-interactive overlay view"
+
+reject_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "onTapGesture\\(perform: onSelect\\)" \
+    "terminal leaf selection must not be owned by a SwiftUI tap wrapper"
+
+require_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
     "window\\.isMovableByWindowBackground = true" \
     "hidden-titlebar shell windows must make non-interactive background regions draggable"
@@ -106,9 +141,19 @@ require_pattern \
     "fallback terminal canvas views must explicitly opt out of background window dragging"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "override func hitTest\\(_ point: NSPoint\\) -> NSView\\? \\{ nil \\}" \
+    "fallback terminal canvas views must be transparent to AppKit hit-testing"
+
+require_pattern \
     "clients/apple/AlanNative/GhosttyLiveHost.swift" \
     "override var mouseDownCanMoveWindow: Bool \\{ false \\}" \
     "Ghostty canvas views must not allow terminal pane clicks to drag the shell window"
+
+require_pattern \
+    "clients/apple/AlanNative/GhosttyLiveHost.swift" \
+    "override func hitTest\\(_ point: NSPoint\\) -> NSView\\? \\{ nil \\}" \
+    "Ghostty canvas views must be transparent to AppKit hit-testing"
 
 reject_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \

--- a/openspec/changes/converge-terminal-event-ownership/tasks.md
+++ b/openspec/changes/converge-terminal-event-ownership/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Activation Boundary
 
-- [ ] 1.1 Add `TerminalHostActivationDelegate` as a main-actor class-bound protocol with a pane activation method.
-- [ ] 1.2 Make `ShellHostController` conform to the activation delegate and route requests to `focus(paneID:)`.
-- [ ] 1.3 Thread the delegate through `TerminalHostView`, `TerminalRuntimeRegistry.hostView(...)`, and `AlanTerminalHostNSView.configure(...)`.
-- [ ] 1.4 Store the activation delegate weakly on `AlanTerminalHostNSView` and refresh it whenever the host is configured.
+- [x] 1.1 Add `TerminalHostActivationDelegate` as a main-actor class-bound protocol with a pane activation method.
+- [x] 1.2 Make `ShellHostController` conform to the activation delegate and route requests to `focus(paneID:)`.
+- [x] 1.3 Thread the delegate through `TerminalHostView`, `TerminalRuntimeRegistry.hostView(...)`, and `AlanTerminalHostNSView.configure(...)`.
+- [x] 1.4 Store the activation delegate weakly on `AlanTerminalHostNSView` and refresh it whenever the host is configured.
 
 ## 2. Terminal Event Ownership
 
-- [ ] 2.1 Remove terminal-pane selection ownership from `ShellTerminalLeafView` by deleting the terminal `.onTapGesture(perform: onSelect)` path and any now-unused terminal-leaf `onSelect` plumbing.
-- [ ] 2.2 Add a host-owned activation helper that validates the current pane ID, asks the weak delegate to activate it, and requests terminal focus.
-- [ ] 2.3 Call the activation helper before forwarding primary, secondary, and other mouse-down events to Ghostty.
-- [ ] 2.4 Preserve existing mouse-up, drag, movement, scroll, pressure, key, IME, copy, paste, and command-key behavior through the AppKit terminal host.
-- [ ] 2.5 Keep explicit SwiftUI controls, including pane selector buttons, on their existing selection actions.
+- [x] 2.1 Remove terminal-pane selection ownership from `ShellTerminalLeafView` by deleting the terminal `.onTapGesture(perform: onSelect)` path and any now-unused terminal-leaf `onSelect` plumbing.
+- [x] 2.2 Add a host-owned activation helper that validates the current pane ID, asks the weak delegate to activate it, and requests terminal focus.
+- [x] 2.3 Call the activation helper before forwarding primary, secondary, and other mouse-down events to Ghostty.
+- [x] 2.4 Preserve existing mouse-up, drag, movement, scroll, pressure, key, IME, copy, paste, and command-key behavior through the AppKit terminal host.
+- [x] 2.5 Keep explicit SwiftUI controls, including pane selector buttons, on their existing selection actions.
 
 ## 3. Hit-Testing And Dragging Boundaries
 
-- [ ] 3.1 Make `AlanGhosttyCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
-- [ ] 3.2 Make `AlanTerminalFallbackCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
-- [ ] 3.3 Make passive terminal placeholder/diagnostic overlay views non-interactive unless they contain explicit controls.
-- [ ] 3.4 Confirm terminal pane clicks and drags still opt out of native background window dragging.
+- [x] 3.1 Make `AlanGhosttyCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
+- [x] 3.2 Make `AlanTerminalFallbackCanvasView` transparent to AppKit hit-testing while preserving `mouseDownCanMoveWindow == false`.
+- [x] 3.3 Make passive terminal placeholder/diagnostic overlay views non-interactive unless they contain explicit controls.
+- [x] 3.4 Confirm terminal pane clicks and drags still opt out of native background window dragging.
 
 ## 4. Contract Checks
 
-- [ ] 4.1 Extend `clients/apple/scripts/check-shell-contracts.sh` to require the weak activation delegate boundary.
-- [ ] 4.2 Extend the contract check to reject SwiftUI terminal leaf `.onTapGesture(perform: onSelect)`.
-- [ ] 4.3 Extend the contract check to require transparent hit-testing for Ghostty and fallback rendering canvases.
-- [ ] 4.4 Keep the existing occlusion and background-dragging checks intact.
+- [x] 4.1 Extend `clients/apple/scripts/check-shell-contracts.sh` to require the weak activation delegate boundary.
+- [x] 4.2 Extend the contract check to reject SwiftUI terminal leaf `.onTapGesture(perform: onSelect)`.
+- [x] 4.3 Extend the contract check to require transparent hit-testing for Ghostty and fallback rendering canvases.
+- [x] 4.4 Keep the existing occlusion and background-dragging checks intact.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `git diff --check`.
-- [ ] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.3 Build the macOS app with the documented Xcode command for `AlanNative`.
-- [ ] 5.4 Manually verify click-to-select, immediate typing after selecting a pane, drag selection, right click, scroll, and background window dragging in the running app.
-- [ ] 5.5 Review the diff for retain cycles, especially registry-owned host views retaining shell controller state.
+- [x] 5.1 Run `git diff --check`.
+- [x] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.3 Build the macOS app with the documented Xcode command for `AlanNative`.
+- [x] 5.4 Manually verify click-to-select, immediate typing after selecting a pane, drag selection, right click, scroll, and background window dragging in the running app.
+- [x] 5.5 Review the diff for retain cycles, especially registry-owned host views retaining shell controller state.
 
 ## 6. PR And Archive Readiness
 
-- [ ] 6.1 Update the PR with the implementation summary and verification results.
+- [x] 6.1 Update the PR with the implementation summary and verification results.
 - [ ] 6.2 Resolve any review comments tied to terminal event ownership after confirming the running app behavior.
 - [ ] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
 - [ ] 6.4 Archive the OpenSpec change after implementation is merged.


### PR DESCRIPTION
## Summary
- Move terminal pane activation from SwiftUI leaf taps into a narrow AppKit host delegate owned by ShellHostController.
- Make Ghostty/fallback canvas and passive overlay hit-testing transparent while preserving terminal drag opt-out.
- Extend shell contract checks and mark the OpenSpec implementation/verification tasks complete.

## Verification
- git diff --check
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate converge-terminal-event-ownership --type change --strict --json
- openspec status --change converge-terminal-event-ownership --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
- Manual Alan app smoke: split panes, click-to-select both panes, immediate typing, right click, drag selection, terminal scroll, and non-terminal background drag path