### PR TITLE
Add macOS terminal surface controller

### DIFF
--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		00000000000000000000000E /* ShellControlPlane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010E /* ShellControlPlane.swift */; };
 		00000000000000000000000F /* TerminalRuntimeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000010F /* TerminalRuntimeRegistry.swift */; };
 		000000000000000000000010 /* TerminalRuntimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000110 /* TerminalRuntimeService.swift */; };
+		000000000000000000000011 /* TerminalSurfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000111 /* TerminalSurfaceController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +44,7 @@
 		00000000000000000000010E /* ShellControlPlane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellControlPlane.swift; sourceTree = "<group>"; };
 		00000000000000000000010F /* TerminalRuntimeRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeRegistry.swift; sourceTree = "<group>"; };
 		000000000000000000000110 /* TerminalRuntimeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeService.swift; sourceTree = "<group>"; };
+		000000000000000000000111 /* TerminalSurfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 				000000000000000000000107 /* TerminalPaneView.swift */,
 				000000000000000000000108 /* TerminalHostRuntime.swift */,
 				000000000000000000000110 /* TerminalRuntimeService.swift */,
+				000000000000000000000111 /* TerminalSurfaceController.swift */,
 				000000000000000000000109 /* TerminalHostView.swift */,
 				00000000000000000000010F /* TerminalRuntimeRegistry.swift */,
 				00000000000000000000010A /* GhosttyLiveHost.swift */,
@@ -199,6 +202,7 @@
 				000000000000000000000009 /* TerminalHostView.swift in Sources */,
 				00000000000000000000000A /* GhosttyLiveHost.swift in Sources */,
 				000000000000000000000010 /* TerminalRuntimeService.swift in Sources */,
+				000000000000000000000011 /* TerminalSurfaceController.swift in Sources */,
 				00000000000000000000000E /* ShellControlPlane.swift in Sources */,
 				00000000000000000000000F /* TerminalRuntimeRegistry.swift in Sources */,
 			);

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -9,6 +9,7 @@ import QuartzCore
 final class AlanGhosttyLiveHost: NSObject {
     var onDiagnosticsChange: ((TerminalRendererSnapshot) -> Void)?
     var onMetadataChange: ((TerminalPaneMetadataSnapshot) -> Void)?
+    var onSearchUpdate: ((AlanTerminalSearchEngineUpdate) -> Void)?
 
     private let logger = Logger(
         subsystem: "com.realmorrisliu.AlanNative",
@@ -163,6 +164,21 @@ final class AlanGhosttyLiveHost: NSObject {
     func hasSelection() -> Bool {
         guard let surface else { return false }
         return ghostty_surface_has_selection(surface)
+    }
+
+    func performBindingAction(_ action: String) -> Bool {
+        guard let surface, !action.isEmpty else { return false }
+        let handled = action.withCString { cString in
+            ghostty_surface_binding_action(
+                surface,
+                cString,
+                UInt(action.lengthOfBytes(using: .utf8))
+            )
+        }
+        if handled {
+            ghostty_surface_refresh(surface)
+        }
+        return handled
     }
 
     func imeRect(in view: NSView) -> NSRect? {
@@ -657,6 +673,35 @@ final class AlanGhosttyLiveHost: NSObject {
             let summary = progressSummary(progress)
             performOnMain {
                 self.updateMetadata(summary: summary, attention: .active)
+            }
+            return true
+
+        case GHOSTTY_ACTION_START_SEARCH:
+            let query = action.action.start_search.needle.flatMap { String(cString: $0) } ?? ""
+            performOnMain {
+                self.onSearchUpdate?(.started(query: query))
+            }
+            return true
+
+        case GHOSTTY_ACTION_END_SEARCH:
+            performOnMain {
+                self.onSearchUpdate?(.ended)
+            }
+            return true
+
+        case GHOSTTY_ACTION_SEARCH_TOTAL:
+            let rawTotal = action.action.search_total.total
+            let total = rawTotal >= 0 ? Int(rawTotal) : nil
+            performOnMain {
+                self.onSearchUpdate?(.matches(total: total))
+            }
+            return true
+
+        case GHOSTTY_ACTION_SEARCH_SELECTED:
+            let rawSelected = action.action.search_selected.selected
+            let selected = rawSelected >= 0 ? Int(rawSelected) : nil
+            performOnMain {
+                self.onSearchUpdate?(.selected(index: selected))
             }
             return true
 

--- a/clients/apple/AlanNative/TerminalHostRuntime.swift
+++ b/clients/apple/AlanNative/TerminalHostRuntime.swift
@@ -610,6 +610,7 @@ struct TerminalHostRuntimeSnapshot: Equatable {
     let isFocused: Bool
     let renderer: TerminalRendererSnapshot
     let paneMetadata: TerminalPaneMetadataSnapshot
+    let surfaceState: AlanTerminalSurfaceStateSnapshot
     let lastUpdatedAt: Date
 
     var stageLabel: String {
@@ -628,6 +629,7 @@ struct TerminalHostRuntimeSnapshot: Equatable {
         isFocused: false,
         renderer: .placeholder,
         paneMetadata: .placeholder,
+        surfaceState: .placeholder,
         lastUpdatedAt: .now
     )
 }

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -55,16 +55,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private let commandLabel = NSTextField(wrappingLabelWithString: "")
     private let footerLabel = NSTextField(wrappingLabelWithString: "")
     private let statusBadge = NSTextField(labelWithString: "")
+    private let surfaceController = AlanTerminalSurfaceController()
 
     private var pane: ShellPane?
     private var bootProfile: AlanShellBootProfile?
     private var isSelected = false
-    private var surfaceHandle: AlanTerminalSurfaceHandle?
-#if canImport(GhosttyKit)
-    private var ghosttySurfaceHandle: AlanGhosttyEventSurfaceHandle? {
-        surfaceHandle as? AlanGhosttyEventSurfaceHandle
-    }
-#endif
     private weak var activationDelegate: TerminalHostActivationDelegate?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
@@ -183,10 +178,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         self.pane = pane
         self.bootProfile = bootProfile
         self.isSelected = isSelected
-        if self.surfaceHandle !== surfaceHandle {
-            self.surfaceHandle?.detach()
-            self.surfaceHandle = surfaceHandle
-        }
+        surfaceController.bind(surfaceHandle: surfaceHandle, paneID: pane?.paneID)
         self.activationDelegate = activationDelegate
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
@@ -335,21 +327,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             )
         }
 
-        guard let surfaceHandle else {
-            return .rejected(
-                errorCode: "terminal_runtime_unavailable",
-                errorMessage: "No service-owned terminal surface is attached to this host."
-            )
-        }
-
-        guard surfaceHandle.isSurfaceReady else {
-            return .rejected(
-                errorCode: "terminal_runtime_unavailable",
-                errorMessage: "The requested pane is not ready to receive terminal input."
-            )
-        }
-
-        return surfaceHandle.sendControlText(text)
+        return surfaceController.sendControlText(text)
     }
 
     func teardownTerminalRuntime() {
@@ -360,8 +338,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         guard !hasTornDownRuntime else { return }
         hasTornDownRuntime = true
         removeWindowObservers()
-        surfaceHandle?.detach()
-        surfaceHandle = nil
+        surfaceController.detach()
     }
 
     private func installWindowObservers() {
@@ -434,6 +411,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             isFocused: isFocused,
             renderer: rendererSnapshot,
             paneMetadata: paneMetadata,
+            surfaceState: surfaceController.surfaceStateSnapshot,
             lastUpdatedAt: .now
         )
         reportRuntimeIfNeeded(snapshot, runtimeObserver: runtimeObserver)
@@ -476,17 +454,20 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             && lhs.isFocused == rhs.isFocused
             && lhs.renderer == rhs.renderer
             && lhs.paneMetadata == rhs.paneMetadata
+            && lhs.surfaceState.equalsIgnoringTimestamp(rhs.surfaceState)
     }
 
     private func synchronizeLiveHost() {
 #if canImport(GhosttyKit)
         guard let canvasView = canvasView as? AlanGhosttyCanvasView else { return }
-        surfaceHandle?.attach(
+        surfaceController.attach(
             to: canvasView,
+            bootProfile: bootProfile,
             focused: isFocused,
             onDiagnosticsChange: { [weak self] snapshot in
                 guard let self else { return }
                 rendererSnapshot = snapshot
+                surfaceController.updateRenderer(snapshot)
                 syncStatusBadge()
                 syncOverlayVisibility()
                 publishRuntimeSnapshot()
@@ -494,8 +475,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             onMetadataChange: { [weak self] snapshot in
                 guard let self else { return }
                 paneMetadata = snapshot
+                surfaceController.updateMetadata(snapshot)
                 subtitleLabel.stringValue = snapshot.summary ?? subtitleLabel.stringValue
                 reportMetadataIfNeeded(snapshot)
+                syncOverlayVisibility()
                 publishRuntimeSnapshot()
             }
         )
@@ -547,12 +530,24 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func syncOverlayVisibility() {
-        let shouldHideOverlay =
-            bootProfile?.ghostty.isReady == true
-            && rendererSnapshot.kind == .ghosttyLive
-            && (rendererSnapshot.phase == .surfaceReady || rendererSnapshot.phase == .firstRefresh)
+        if let overlayState = surfaceController.overlayState(
+            renderer: rendererSnapshot,
+            metadata: paneMetadata,
+            bootProfile: bootProfile
+        ) {
+            statusBadge.stringValue = overlayState.badge
+            titleLabel.stringValue = overlayState.title
+            subtitleLabel.stringValue = overlayState.message
+            if let action = overlayState.action {
+                commandLabel.stringValue = action
+            }
+            footerLabel.stringValue = bootProfile.map { "launch: \($0.command.strategy.rawValue)\ncwd: \($0.workingDirectory)" }
+                ?? "Select a pane to prepare a terminal boot profile."
+            overlayCard.isHidden = false
+            return
+        }
 
-        overlayCard.isHidden = shouldHideOverlay
+        overlayCard.isHidden = true
     }
 
     private var isFocused: Bool {
@@ -609,7 +604,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func sendMousePosition(for event: NSEvent) {
 #if canImport(GhosttyKit)
         let point = ghosttyPoint(for: event)
-        ghosttySurfaceHandle?.sendMousePosition(x: point.x, y: point.y, mods: modsFromEvent(event))
+        surfaceController.sendMousePosition(x: point.x, y: point.y, mods: modsFromEvent(event))
 #endif
     }
 
@@ -617,15 +612,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         activateTerminalHostForMouseEvent()
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT, mods: modsFromEvent(event))
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_LEFT, mods: modsFromEvent(event))
 #endif
     }
 
     override func mouseUp(with event: NSEvent) {
         previousPressureStage = 0
 #if canImport(GhosttyKit)
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT, mods: modsFromEvent(event))
-        ghosttySurfaceHandle?.sendMousePressure(stage: 0, pressure: 0)
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_LEFT, mods: modsFromEvent(event))
+        surfaceController.sendMousePressure(stage: 0, pressure: 0)
 #endif
     }
 
@@ -633,7 +628,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         activateTerminalHostForMouseEvent()
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_RIGHT, mods: modsFromEvent(event))
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: GHOSTTY_MOUSE_RIGHT, mods: modsFromEvent(event))
 #else
         super.rightMouseDown(with: event)
 #endif
@@ -641,7 +636,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override func rightMouseUp(with event: NSEvent) {
 #if canImport(GhosttyKit)
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_RIGHT, mods: modsFromEvent(event))
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: GHOSTTY_MOUSE_RIGHT, mods: modsFromEvent(event))
 #else
         super.rightMouseUp(with: event)
 #endif
@@ -652,7 +647,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 #if canImport(GhosttyKit)
         sendMousePosition(for: event)
         let button = event.buttonNumber == 2 ? GHOSTTY_MOUSE_MIDDLE : GHOSTTY_MOUSE_MIDDLE
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: button, mods: modsFromEvent(event))
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_PRESS, button: button, mods: modsFromEvent(event))
 #else
         super.otherMouseDown(with: event)
 #endif
@@ -661,7 +656,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     override func otherMouseUp(with event: NSEvent) {
 #if canImport(GhosttyKit)
         let button = event.buttonNumber == 2 ? GHOSTTY_MOUSE_MIDDLE : GHOSTTY_MOUSE_MIDDLE
-        _ = ghosttySurfaceHandle?.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: button, mods: modsFromEvent(event))
+        _ = surfaceController.sendMouseButton(state: GHOSTTY_MOUSE_RELEASE, button: button, mods: modsFromEvent(event))
 #else
         super.otherMouseUp(with: event)
 #endif
@@ -701,13 +696,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
 #if canImport(GhosttyKit)
-        ghosttySurfaceHandle?.sendMousePosition(x: -1, y: -1, mods: modsFromEvent(event))
+        surfaceController.sendMousePosition(x: -1, y: -1, mods: modsFromEvent(event))
 #endif
     }
 
     override func scrollWheel(with event: NSEvent) {
 #if canImport(GhosttyKit)
-        guard ghosttySurfaceHandle?.isSurfaceReady == true else { return super.scrollWheel(with: event) }
+        guard surfaceController.isSurfaceReady == true else { return super.scrollWheel(with: event) }
 
         var x = event.scrollingDeltaX
         var y = event.scrollingDeltaY
@@ -741,7 +736,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         }
         scrollMods |= momentum << 1
 
-        ghosttySurfaceHandle?.sendMouseScroll(x: x, y: y, mods: ghostty_input_scroll_mods_t(scrollMods))
+        surfaceController.sendMouseScroll(x: x, y: y, mods: ghostty_input_scroll_mods_t(scrollMods))
 #else
         super.scrollWheel(with: event)
 #endif
@@ -750,23 +745,27 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     override func pressureChange(with event: NSEvent) {
         super.pressureChange(with: event)
 #if canImport(GhosttyKit)
-        guard ghosttySurfaceHandle?.isSurfaceReady == true else { return }
-        ghosttySurfaceHandle?.sendMousePressure(stage: UInt32(event.stage), pressure: Double(event.pressure))
+        guard surfaceController.isSurfaceReady == true else { return }
+        surfaceController.sendMousePressure(stage: UInt32(event.stage), pressure: Double(event.pressure))
         previousPressureStage = event.stage
 #endif
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if routeNativeKeyCommandIfNeeded(event) {
+            return true
+        }
+
 #if canImport(GhosttyKit)
         guard !isApplicationReservedKeyEquivalent(event) else { return false }
-        guard event.type == .keyDown, isFocused, ghosttySurfaceHandle?.isSurfaceReady == true else { return false }
+        guard event.type == .keyDown, isFocused, surfaceController.isSurfaceReady == true else { return false }
 
         var keyEvent = ghosttyKeyEvent(for: event, action: GHOSTTY_ACTION_PRESS)
         var flags = ghostty_binding_flags_e(0)
         let text = textForKeyEvent(event) ?? ""
         let isBinding = text.withCString { cString in
             keyEvent.text = cString
-            return ghosttySurfaceHandle?.keyIsBinding(keyEvent, flags: &flags) ?? false
+            return surfaceController.keyIsBinding(keyEvent, flags: &flags)
         }
 
         if isBinding {
@@ -778,13 +777,20 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func keyDown(with event: NSEvent) {
+        if routeNativeKeyCommandIfNeeded(event) {
+            return
+        }
+        if handleSearchKeyIfNeeded(event) {
+            return
+        }
+
 #if canImport(GhosttyKit)
         if isApplicationReservedKeyEquivalent(event) {
             NSApp.terminate(nil)
             return
         }
 
-        guard ghosttySurfaceHandle?.isSurfaceReady == true else {
+        guard surfaceController.isSurfaceReady == true else {
             interpretKeyEvents([event])
             return
         }
@@ -792,7 +798,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         requestTerminalFocus()
 
         let translationModsGhostty =
-            ghosttySurfaceHandle?.keyTranslationMods(for: modsFromEvent(event)) ?? modsFromEvent(event)
+            surfaceController.keyTranslationMods(for: modsFromEvent(event))
         var translationMods = event.modifierFlags
         for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
             let shouldInclude: Bool
@@ -842,7 +848,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         syncPreedit(clearIfNeeded: markedTextBefore)
 
         if let keyTextAccumulator, !keyTextAccumulator.isEmpty {
-            keyTextAccumulator.forEach { ghosttySurfaceHandle?.sendText($0) }
+            keyTextAccumulator.forEach { surfaceController.sendText($0) }
             return
         }
 
@@ -856,10 +862,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         if let text = textForKeyEvent(translationEvent), shouldSendText(text) {
             text.withCString { cString in
                 keyEvent.text = cString
-                _ = ghosttySurfaceHandle?.sendKey(keyEvent)
+                _ = surfaceController.sendKey(keyEvent)
             }
         } else {
-            _ = ghosttySurfaceHandle?.sendKey(keyEvent)
+            _ = surfaceController.sendKey(keyEvent)
         }
 #else
         super.keyDown(with: event)
@@ -868,9 +874,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override func keyUp(with event: NSEvent) {
 #if canImport(GhosttyKit)
-        guard ghosttySurfaceHandle?.isSurfaceReady == true else { return super.keyUp(with: event) }
+        guard surfaceController.isSurfaceReady == true else { return super.keyUp(with: event) }
         let keyEvent = ghosttyKeyEvent(for: event, action: GHOSTTY_ACTION_RELEASE)
-        _ = ghosttySurfaceHandle?.sendKey(keyEvent)
+        _ = surfaceController.sendKey(keyEvent)
 #else
         super.keyUp(with: event)
 #endif
@@ -878,7 +884,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override func flagsChanged(with event: NSEvent) {
 #if canImport(GhosttyKit)
-        guard ghosttySurfaceHandle?.isSurfaceReady == true else { return super.flagsChanged(with: event) }
+        guard surfaceController.isSurfaceReady == true else { return super.flagsChanged(with: event) }
 
         let modifier: UInt32
         switch event.keyCode {
@@ -897,7 +903,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         }
 
         let keyEvent = ghosttyKeyEvent(for: event, action: action)
-        _ = ghosttySurfaceHandle?.sendKey(keyEvent)
+        _ = surfaceController.sendKey(keyEvent)
         sendMousePosition(for: event)
 #else
         super.flagsChanged(with: event)
@@ -906,7 +912,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     @objc func copy(_ sender: Any?) {
 #if canImport(GhosttyKit)
-        guard let text = ghosttySurfaceHandle?.readSelectionText(), !text.isEmpty else { return }
+        guard let text = surfaceController.readSelectionText(), !text.isEmpty else { return }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
@@ -920,7 +926,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     @objc func paste(_ sender: Any?) {
 #if canImport(GhosttyKit)
         guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else { return }
-        ghosttySurfaceHandle?.sendText(text)
+        surfaceController.sendText(text)
 #endif
     }
 
@@ -997,6 +1003,77 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         return true
     }
 
+    private func routeNativeKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
+        switch surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event)) {
+        case .nativeCommand("find"):
+            surfaceController.beginSearch()
+            syncOverlayVisibility()
+            publishRuntimeSnapshot()
+            return true
+        case .nativeCommand("quit"):
+            return false
+        case .nativeCommand, .terminalText, .terminalKey, .ignored:
+            return false
+        }
+    }
+
+    private func handleSearchKeyIfNeeded(_ event: NSEvent) -> Bool {
+        guard surfaceController.searchAdapter?.state.isActive == true else { return false }
+        guard event.type == .keyDown else { return true }
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) {
+            return false
+        }
+
+        switch event.keyCode {
+        case 0x35:
+            surfaceController.dismissSearch()
+        case 0x24:
+            surfaceController.nextSearchMatch()
+        case 0x33:
+            let current = surfaceController.searchAdapter?.state.query ?? ""
+            surfaceController.updateSearchQuery(String(current.dropLast()))
+        default:
+            if let characters = textForKeyEvent(event), shouldSendText(characters) {
+                let current = surfaceController.searchAdapter?.state.query ?? ""
+                surfaceController.updateSearchQuery(current + characters)
+            }
+        }
+
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+        return true
+    }
+
+    private func terminalKeyInput(for event: NSEvent) -> AlanTerminalKeyInput {
+        let phase: AlanTerminalKeyPhase
+        switch event.type {
+        case .keyDown:
+            phase = .down
+        case .keyUp:
+            phase = .up
+        case .flagsChanged:
+            phase = .flagsChanged
+        default:
+            phase = .down
+        }
+        return AlanTerminalKeyInput(
+            characters: event.charactersIgnoringModifiers ?? event.characters,
+            keyCode: event.keyCode,
+            modifiers: terminalKeyModifiers(from: event.modifierFlags),
+            phase: phase,
+            isRepeat: event.isARepeat
+        )
+    }
+
+    private func terminalKeyModifiers(from flags: NSEvent.ModifierFlags) -> AlanTerminalKeyModifiers {
+        var modifiers: AlanTerminalKeyModifiers = []
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.command) { modifiers.insert(.command) }
+        return modifiers
+    }
+
     private func isApplicationReservedKeyEquivalent(_ event: NSEvent) -> Bool {
         guard event.type == .keyDown else { return false }
 
@@ -1011,9 +1088,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func syncPreedit(clearIfNeeded: Bool = true) {
 #if canImport(GhosttyKit)
         if markedText.length > 0 {
-            ghosttySurfaceHandle?.sendPreedit(markedText.string)
+            surfaceController.sendPreedit(markedText.string)
         } else if clearIfNeeded {
-            ghosttySurfaceHandle?.sendPreedit(nil)
+            surfaceController.sendPreedit(nil)
         }
 #endif
     }
@@ -1038,7 +1115,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             self.keyTextAccumulator = keyTextAccumulator
         } else {
 #if canImport(GhosttyKit)
-            ghosttySurfaceHandle?.sendText(characters)
+            surfaceController.sendText(characters)
 #endif
         }
     }
@@ -1072,7 +1149,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     func selectedRange() -> NSRange {
 #if canImport(GhosttyKit)
-        if let selection = ghosttySurfaceHandle?.readSelectionText() {
+        if let selection = surfaceController.readSelectionText() {
             return NSRange(location: 0, length: selection.utf16.count)
         }
 #endif
@@ -1091,7 +1168,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
 #if canImport(GhosttyKit)
-        guard let selection = ghosttySurfaceHandle?.readSelectionText(), !selection.isEmpty else { return nil }
+        guard let selection = surfaceController.readSelectionText(), !selection.isEmpty else { return nil }
         actualRange?.pointee = NSRange(location: 0, length: selection.utf16.count)
         return NSAttributedString(string: selection)
 #else
@@ -1105,7 +1182,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
 #if canImport(GhosttyKit)
-        if let imeRect = ghosttySurfaceHandle?.imeRect(in: self) {
+        if let imeRect = surfaceController.imeRect(in: self) {
             return imeRect
         }
 #endif

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -78,6 +78,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
+        surfaceController.onSearchStateChange = { [weak self] in
+            self?.syncOverlayVisibility()
+            self?.publishRuntimeSnapshot()
+        }
         configureView()
     }
 
@@ -1006,7 +1010,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func routeNativeKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
         switch surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event)) {
         case .nativeCommand("find"):
-            surfaceController.beginSearch()
+            guard surfaceController.beginSearch() else { return false }
             syncOverlayVisibility()
             publishRuntimeSnapshot()
             return true

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -182,6 +182,22 @@ struct TerminalPaneView: View {
                 value: runtime.renderer.summary
             )
             TerminalInfoRow(
+                label: "Surface",
+                value: surfaceReadinessLabel(runtime.surfaceState.readiness)
+            )
+            TerminalInfoRow(
+                label: "Input",
+                value: runtime.surfaceState.inputReady ? "ready" : "not ready"
+            )
+            TerminalInfoRow(
+                label: "Mode",
+                value: runtime.surfaceState.terminalMode.rawValue.replacingOccurrences(of: "_", with: " ")
+            )
+            TerminalInfoRow(
+                label: "Renderer Health",
+                value: runtime.surfaceState.rendererHealth
+            )
+            TerminalInfoRow(
                 label: "cwd",
                 value: runtime.paneMetadata.workingDirectory ?? "pending"
             )
@@ -393,6 +409,15 @@ struct TerminalPaneView: View {
 
     private func rendererKindLabel(for kind: TerminalRendererKind) -> String {
         kind.rawValue.replacingOccurrences(of: "_", with: " ")
+    }
+
+    private func surfaceReadinessLabel(_ readiness: AlanTerminalSurfaceReadiness) -> String {
+        switch readiness {
+        case .ready:
+            return "ready"
+        case .unready(let reason):
+            return reason.rawValue.replacingOccurrences(of: "_", with: " ")
+        }
     }
 }
 

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -162,6 +162,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             isFocused: false,
             renderer: surfaceSnapshot.renderer,
             paneMetadata: surfaceSnapshot.metadata,
+            surfaceState: .placeholder,
             lastUpdatedAt: surfaceSnapshot.lastUpdatedAt
         )
     }

--- a/clients/apple/AlanNative/TerminalRuntimeService.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeService.swift
@@ -308,7 +308,7 @@ protocol AlanTerminalSurfaceHandle: AnyObject {
 
 #if canImport(GhosttyKit)
 @MainActor
-protocol AlanGhosttyEventSurfaceHandle: AlanTerminalSurfaceHandle {
+protocol AlanGhosttyEventSurfaceHandle: AlanTerminalSurfaceHandle, AlanTerminalSearchEngine {
     func keyTranslationMods(for mods: ghostty_input_mods_e) -> ghostty_input_mods_e
     func sendKey(_ keyEvent: ghostty_input_key_s) -> Bool
     func keyIsBinding(
@@ -636,6 +636,31 @@ extension AlanGhosttySurfaceHandle: AlanGhosttyEventSurfaceHandle {
     func imeRect(in view: NSView) -> NSRect? {
         liveHost.imeRect(in: view)
     }
+
+    func setSearchUpdateHandler(_ handler: ((AlanTerminalSearchEngineUpdate) -> Void)?) {
+        liveHost.onSearchUpdate = handler
+    }
+
+    func startSearch() -> Bool {
+        liveHost.performBindingAction("start_search")
+    }
+
+    func updateSearchQuery(_ query: String) -> Bool {
+        liveHost.performBindingAction("search:\(query)")
+    }
+
+    func navigateSearch(_ direction: AlanTerminalSearchNavigationDirection) -> Bool {
+        switch direction {
+        case .next:
+            return liveHost.performBindingAction("navigate_search:next")
+        case .previous:
+            return liveHost.performBindingAction("navigate_search:previous")
+        }
+    }
+
+    func endSearch() -> Bool {
+        liveHost.performBindingAction("end_search")
+    }
 }
 #endif
 
@@ -782,8 +807,11 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private(set) var detachCount = 0
     private(set) var teardownCount = 0
     private(set) var deliveredText: [String] = []
+    private(set) var searchActions: [String] = []
     var deliveryResult: TerminalRuntimeDeliveryResult?
+    var searchActionsShouldSucceed = true
     var ready = true
+    private var searchUpdateHandler: ((AlanTerminalSearchEngineUpdate) -> Void)?
     private var currentSnapshot: AlanTerminalSurfaceSnapshot
 
     init(paneID: String) {
@@ -862,6 +890,51 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             attachedViewCount: attachedViewCount ?? currentSnapshot.attachedViewCount,
             lastUpdatedAt: .now
         )
+    }
+}
+
+extension FakeAlanTerminalSurfaceHandle: AlanTerminalSearchEngine {
+    func setSearchUpdateHandler(_ handler: ((AlanTerminalSearchEngineUpdate) -> Void)?) {
+        searchUpdateHandler = handler
+    }
+
+    func startSearch() -> Bool {
+        recordSearchAction("start_search")
+        guard searchActionsShouldSucceed else { return false }
+        searchUpdateHandler?(.started(query: ""))
+        return true
+    }
+
+    func updateSearchQuery(_ query: String) -> Bool {
+        recordSearchAction("search:\(query)")
+        guard searchActionsShouldSucceed else { return false }
+        searchUpdateHandler?(.started(query: query))
+        return true
+    }
+
+    func navigateSearch(_ direction: AlanTerminalSearchNavigationDirection) -> Bool {
+        switch direction {
+        case .next:
+            recordSearchAction("navigate_search:next")
+        case .previous:
+            recordSearchAction("navigate_search:previous")
+        }
+        return searchActionsShouldSucceed
+    }
+
+    func endSearch() -> Bool {
+        recordSearchAction("end_search")
+        guard searchActionsShouldSucceed else { return false }
+        searchUpdateHandler?(.ended)
+        return true
+    }
+
+    func emitSearchUpdate(_ update: AlanTerminalSearchEngineUpdate) {
+        searchUpdateHandler?(update)
+    }
+
+    private func recordSearchAction(_ action: String) {
+        searchActions.append(action)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalRuntimeService.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeService.swift
@@ -467,6 +467,24 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
                 )
             )
         }
+        guard !currentSnapshot.metadata.processExited else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_child_exited",
+                    errorMessage: "The terminal process has exited.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        guard currentSnapshot.renderer.phase != .failed else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_renderer_failed",
+                    errorMessage: "The terminal renderer is not available.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
         guard bootstrap.ensureReady().isReady else {
             return recordDelivery(
                 .unavailable(

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -1,0 +1,626 @@
+import Foundation
+
+#if os(macOS)
+import AppKit
+#if canImport(GhosttyKit)
+import GhosttyKit
+#endif
+
+enum AlanTerminalMode: String, Equatable {
+    case normalBuffer = "normal_buffer"
+    case alternateScreen = "alternate_screen"
+    case mouseReporting = "mouse_reporting"
+}
+
+struct AlanTerminalScrollbackMetrics: Equatable {
+    let totalRows: Int
+    let visibleRows: Int
+    let firstVisibleRow: Int
+    let mode: AlanTerminalMode
+
+    static let empty = AlanTerminalScrollbackMetrics(
+        totalRows: 0,
+        visibleRows: 0,
+        firstVisibleRow: 0,
+        mode: .normalBuffer
+    )
+}
+
+struct AlanTerminalScrollbackState: Equatable {
+    let metrics: AlanTerminalScrollbackMetrics
+    let nativeScrollbarVisible: Bool
+    let thumbRange: Range<Int>
+
+    static let empty = AlanTerminalScrollbackState(
+        metrics: .empty,
+        nativeScrollbarVisible: false,
+        thumbRange: 0..<0
+    )
+}
+
+@MainActor
+final class AlanTerminalScrollbackAdapter {
+    private(set) var state = AlanTerminalScrollbackState.empty
+
+    @discardableResult
+    func updateMetrics(_ metrics: AlanTerminalScrollbackMetrics) -> AlanTerminalScrollbackState {
+        let totalRows = max(0, metrics.totalRows)
+        let visibleRows = max(0, min(metrics.visibleRows, totalRows))
+        let firstVisibleRow = max(0, min(metrics.firstVisibleRow, max(totalRows - visibleRows, 0)))
+        let hasScrollableNormalBuffer = metrics.mode == .normalBuffer && totalRows > visibleRows
+        let nextMetrics = AlanTerminalScrollbackMetrics(
+            totalRows: totalRows,
+            visibleRows: visibleRows,
+            firstVisibleRow: firstVisibleRow,
+            mode: metrics.mode
+        )
+        state = AlanTerminalScrollbackState(
+            metrics: nextMetrics,
+            nativeScrollbarVisible: hasScrollableNormalBuffer,
+            thumbRange: firstVisibleRow..<(firstVisibleRow + visibleRows)
+        )
+        return state
+    }
+
+    func shouldForwardScrollToTerminal() -> Bool {
+        state.metrics.mode == .alternateScreen || state.metrics.mode == .mouseReporting
+    }
+}
+
+struct AlanTerminalKeyModifiers: OptionSet, Equatable {
+    let rawValue: Int
+
+    static let shift = AlanTerminalKeyModifiers(rawValue: 1 << 0)
+    static let control = AlanTerminalKeyModifiers(rawValue: 1 << 1)
+    static let option = AlanTerminalKeyModifiers(rawValue: 1 << 2)
+    static let command = AlanTerminalKeyModifiers(rawValue: 1 << 3)
+}
+
+enum AlanTerminalKeyPhase: Equatable {
+    case down
+    case up
+    case flagsChanged
+}
+
+struct AlanTerminalKeyInput: Equatable {
+    let characters: String?
+    let keyCode: UInt16
+    let modifiers: AlanTerminalKeyModifiers
+    let phase: AlanTerminalKeyPhase
+    let isRepeat: Bool
+}
+
+enum AlanTerminalInputRoutingDecision: Equatable {
+    case nativeCommand(String)
+    case terminalText(String)
+    case terminalKey
+    case ignored
+}
+
+@MainActor
+final class AlanTerminalInputAdapter {
+    func routeKey(_ input: AlanTerminalKeyInput) -> AlanTerminalInputRoutingDecision {
+        if input.phase == .down,
+           input.modifiers == .command,
+           input.characters?.lowercased() == "q"
+        {
+            return .nativeCommand("quit")
+        }
+
+        if input.phase == .down,
+           input.modifiers == .command,
+           input.characters?.lowercased() == "f"
+        {
+            return .nativeCommand("find")
+        }
+
+        guard input.phase == .down else { return .terminalKey }
+        guard input.modifiers.subtracting([.shift, .option]).isEmpty else {
+            return .terminalKey
+        }
+        guard let characters = input.characters, !characters.isEmpty else { return .terminalKey }
+        if characters.count == 1, let scalar = characters.unicodeScalars.first {
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                return .terminalKey
+            }
+            if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
+                return .terminalKey
+            }
+        }
+        return .terminalText(characters)
+    }
+}
+
+struct AlanTerminalSearchState: Equatable {
+    let paneID: String
+    let query: String
+    let isActive: Bool
+    let totalMatches: Int?
+    let selectedIndex: Int?
+
+    static func inactive(paneID: String) -> AlanTerminalSearchState {
+        AlanTerminalSearchState(
+            paneID: paneID,
+            query: "",
+            isActive: false,
+            totalMatches: nil,
+            selectedIndex: nil
+        )
+    }
+}
+
+@MainActor
+final class AlanTerminalSearchAdapter {
+    private(set) var state: AlanTerminalSearchState
+
+    init(paneID: String) {
+        self.state = .inactive(paneID: paneID)
+    }
+
+    func updateQuery(_ query: String) {
+        state = AlanTerminalSearchState(
+            paneID: state.paneID,
+            query: query,
+            isActive: true,
+            totalMatches: state.totalMatches,
+            selectedIndex: state.selectedIndex
+        )
+    }
+
+    func updateMatches(total: Int?, selectedIndex: Int?) {
+        let boundedIndex: Int?
+        if let total, total > 0, let selectedIndex {
+            boundedIndex = max(0, min(selectedIndex, total - 1))
+        } else {
+            boundedIndex = nil
+        }
+        state = AlanTerminalSearchState(
+            paneID: state.paneID,
+            query: state.query,
+            isActive: state.isActive,
+            totalMatches: total,
+            selectedIndex: boundedIndex
+        )
+    }
+
+    func next() {
+        guard let total = state.totalMatches, total > 0 else { return }
+        let current = state.selectedIndex ?? -1
+        updateMatches(total: total, selectedIndex: (current + 1) % total)
+    }
+
+    func previous() {
+        guard let total = state.totalMatches, total > 0 else { return }
+        let current = state.selectedIndex ?? 0
+        updateMatches(total: total, selectedIndex: (current - 1 + total) % total)
+    }
+
+    func dismiss() {
+        state = .inactive(paneID: state.paneID)
+    }
+}
+
+@MainActor
+final class AlanTerminalSelectionClipboardAdapter {
+    private weak var surfaceHandle: AlanTerminalSurfaceHandle?
+
+    init(surfaceHandle: AlanTerminalSurfaceHandle?) {
+        self.surfaceHandle = surfaceHandle
+    }
+
+    func updateSurfaceHandle(_ surfaceHandle: AlanTerminalSurfaceHandle?) {
+        self.surfaceHandle = surfaceHandle
+    }
+
+    func paste(_ text: String) -> TerminalRuntimeDeliveryResult {
+        guard !text.isEmpty else {
+            return .accepted(byteCount: 0)
+        }
+        guard let surfaceHandle,
+              surfaceHandle.isSurfaceReady,
+              surfaceHandle.snapshot.teardownStatus != .completed
+        else {
+            return .rejected(
+                errorCode: "terminal_clipboard_unavailable",
+                errorMessage: "Paste cannot be delivered because the terminal is not ready.",
+                runtimePhase: surfaceHandle?.snapshot.runtimePhase
+            )
+        }
+        return surfaceHandle.sendControlText(text)
+    }
+
+    func writeSelectionToPasteboard(_ text: String?, pasteboard: NSPasteboard = .general) -> Bool {
+        guard let text, !text.isEmpty else { return false }
+        pasteboard.clearContents()
+        return pasteboard.setString(text, forType: .string)
+    }
+}
+
+enum AlanTerminalSurfaceUnreadyReason: String, Equatable {
+    case missingSurface = "missing_surface"
+    case inputNotReady = "input_not_ready"
+    case rendererFailed = "renderer_failed"
+    case childExited = "child_exited"
+    case readonly
+}
+
+enum AlanTerminalSurfaceReadiness: Equatable {
+    case ready
+    case unready(reason: AlanTerminalSurfaceUnreadyReason)
+}
+
+struct AlanTerminalOverlayState: Equatable {
+    let title: String
+    let message: String
+    let badge: String
+    let action: String?
+    let debugDetail: String?
+}
+
+struct AlanTerminalSurfaceStateSnapshot: Equatable {
+    let readiness: AlanTerminalSurfaceReadiness
+    let terminalMode: AlanTerminalMode
+    let scrollback: AlanTerminalScrollbackState
+    let search: AlanTerminalSearchState?
+    let readonly: Bool
+    let secureInput: Bool
+    let inputReady: Bool
+    let rendererHealth: String
+    let childExited: Bool
+    let lastUpdatedAt: Date
+
+    static let placeholder = AlanTerminalSurfaceStateSnapshot(
+        readiness: .unready(reason: .missingSurface),
+        terminalMode: .normalBuffer,
+        scrollback: .empty,
+        search: nil,
+        readonly: false,
+        secureInput: false,
+        inputReady: false,
+        rendererHealth: "pending",
+        childExited: false,
+        lastUpdatedAt: .now
+    )
+
+    func equalsIgnoringTimestamp(_ other: AlanTerminalSurfaceStateSnapshot) -> Bool {
+        readiness == other.readiness
+            && terminalMode == other.terminalMode
+            && scrollback == other.scrollback
+            && search == other.search
+            && readonly == other.readonly
+            && secureInput == other.secureInput
+            && inputReady == other.inputReady
+            && rendererHealth == other.rendererHealth
+            && childExited == other.childExited
+    }
+}
+
+@MainActor
+final class AlanTerminalMetadataAdapter {
+    func overlayState(
+        renderer: TerminalRendererSnapshot,
+        metadata: TerminalPaneMetadataSnapshot,
+        surface: AlanTerminalSurfaceReadiness
+    ) -> AlanTerminalOverlayState? {
+        if metadata.processExited {
+            let status = metadata.lastCommandExitCode.map { "Exit status \($0)." }
+                ?? "The shell process ended."
+            return AlanTerminalOverlayState(
+                title: "Process exited",
+                message: status,
+                badge: "Exited",
+                action: "Open a new pane or tab to continue.",
+                debugDetail: metadata.summary
+            )
+        }
+
+        if renderer.phase == .failed || surface == .unready(reason: .rendererFailed) {
+            return AlanTerminalOverlayState(
+                title: "Terminal cannot draw",
+                message: "The terminal renderer is not available for this pane.",
+                badge: "Renderer failed",
+                action: "Close and reopen the pane if it does not recover.",
+                debugDetail: renderer.failureReason ?? renderer.detail ?? renderer.summary
+            )
+        }
+
+        switch surface {
+        case .ready:
+            return nil
+        case .unready(reason: .missingSurface):
+            return AlanTerminalOverlayState(
+                title: "Terminal surface missing",
+                message: "This pane does not currently have a terminal surface.",
+                badge: "Missing",
+                action: "Select the pane again or open a new terminal.",
+                debugDetail: nil
+            )
+        case .unready(reason: .inputNotReady):
+            return AlanTerminalOverlayState(
+                title: "Terminal is starting",
+                message: "Input will be available after the terminal finishes attaching.",
+                badge: "Starting",
+                action: nil,
+                debugDetail: renderer.detail
+            )
+        case .unready(reason: .rendererFailed):
+            return AlanTerminalOverlayState(
+                title: "Terminal cannot draw",
+                message: "The terminal renderer is not available for this pane.",
+                badge: "Renderer failed",
+                action: "Close and reopen the pane if it does not recover.",
+                debugDetail: renderer.failureReason ?? renderer.detail ?? renderer.summary
+            )
+        case .unready(reason: .childExited):
+            return AlanTerminalOverlayState(
+                title: "Process exited",
+                message: "The shell process ended.",
+                badge: "Exited",
+                action: "Open a new pane or tab to continue.",
+                debugDetail: metadata.summary
+            )
+        case .unready(reason: .readonly):
+            return AlanTerminalOverlayState(
+                title: "Terminal is read-only",
+                message: "This pane is not accepting input right now.",
+                badge: "Read-only",
+                action: nil,
+                debugDetail: nil
+            )
+        }
+    }
+}
+
+@MainActor
+final class AlanTerminalSurfaceController {
+    let inputAdapter = AlanTerminalInputAdapter()
+    let scrollbackAdapter = AlanTerminalScrollbackAdapter()
+    let metadataAdapter = AlanTerminalMetadataAdapter()
+
+    private(set) var searchAdapter: AlanTerminalSearchAdapter?
+    private(set) var clipboardAdapter = AlanTerminalSelectionClipboardAdapter(surfaceHandle: nil)
+    private weak var surfaceHandle: AlanTerminalSurfaceHandle?
+    private var latestRenderer = TerminalRendererSnapshot.placeholder
+    private var latestMetadata = TerminalPaneMetadataSnapshot.placeholder
+    private var readonly = false
+    private var secureInput = false
+
+    var isSurfaceReady: Bool {
+        surfaceReadiness == .ready
+    }
+
+    var surfaceStateSnapshot: AlanTerminalSurfaceStateSnapshot {
+        AlanTerminalSurfaceStateSnapshot(
+            readiness: surfaceReadiness,
+            terminalMode: scrollbackAdapter.state.metrics.mode,
+            scrollback: scrollbackAdapter.state,
+            search: searchAdapter?.state,
+            readonly: readonly,
+            secureInput: secureInput,
+            inputReady: isSurfaceReady,
+            rendererHealth: latestRenderer.phase == .failed ? "failed" : latestRenderer.phase.rawValue,
+            childExited: latestMetadata.processExited,
+            lastUpdatedAt: .now
+        )
+    }
+
+    func bind(surfaceHandle: AlanTerminalSurfaceHandle?, paneID: String?) {
+        if self.surfaceHandle !== surfaceHandle {
+            self.surfaceHandle?.detach()
+            self.surfaceHandle = surfaceHandle
+        }
+        clipboardAdapter.updateSurfaceHandle(surfaceHandle)
+        if let paneID, searchAdapter?.state.paneID != paneID {
+            searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
+        } else if paneID == nil {
+            searchAdapter = nil
+        }
+    }
+
+    func attach(
+        to canvasView: NSView,
+        bootProfile: AlanShellBootProfile?,
+        focused: Bool,
+        onDiagnosticsChange: @escaping (TerminalRendererSnapshot) -> Void,
+        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void
+    ) {
+        surfaceHandle?.configure(bootProfile: bootProfile)
+        surfaceHandle?.attach(
+            to: canvasView,
+            focused: focused,
+            onDiagnosticsChange: { [weak self] snapshot in
+                guard let self else { return }
+                latestRenderer = snapshot
+                onDiagnosticsChange(snapshot)
+            },
+            onMetadataChange: { [weak self] metadata in
+                guard let self else { return }
+                latestMetadata = metadata
+                onMetadataChange(metadata)
+            }
+        )
+    }
+
+    func detach() {
+        surfaceHandle?.detach()
+        surfaceHandle = nil
+        clipboardAdapter.updateSurfaceHandle(nil)
+    }
+
+    func updateRenderer(_ renderer: TerminalRendererSnapshot) {
+        latestRenderer = renderer
+    }
+
+    func updateMetadata(_ metadata: TerminalPaneMetadataSnapshot) {
+        latestMetadata = metadata
+    }
+
+    func overlayState(
+        renderer: TerminalRendererSnapshot,
+        metadata: TerminalPaneMetadataSnapshot,
+        bootProfile: AlanShellBootProfile?
+    ) -> AlanTerminalOverlayState? {
+        if let searchState = searchAdapter?.state,
+           searchState.isActive
+        {
+            let status: String
+            if let totalMatches = searchState.totalMatches,
+               let selectedIndex = searchState.selectedIndex
+            {
+                status = "\(selectedIndex + 1) of \(totalMatches)"
+            } else if searchState.query.isEmpty {
+                status = "Type to search this pane."
+            } else {
+                status = "Searching this pane."
+            }
+            return AlanTerminalOverlayState(
+                title: "Search terminal",
+                message: searchState.query.isEmpty ? "Find text in this pane." : searchState.query,
+                badge: "Search",
+                action: status,
+                debugDetail: "pane=\(searchState.paneID)"
+            )
+        }
+
+        let readiness: AlanTerminalSurfaceReadiness
+        if bootProfile == nil || surfaceHandle == nil {
+            readiness = .unready(reason: .missingSurface)
+        } else {
+            readiness = surfaceReadiness
+        }
+        return metadataAdapter.overlayState(renderer: renderer, metadata: metadata, surface: readiness)
+    }
+
+    func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        guard !text.isEmpty else {
+            return .accepted(byteCount: 0, runtimePhase: surfaceHandle?.snapshot.runtimePhase)
+        }
+        guard let surfaceHandle else {
+            return .rejected(
+                errorCode: "terminal_runtime_unavailable",
+                errorMessage: "No service-owned terminal surface is attached to this host."
+            )
+        }
+        guard !surfaceHandle.snapshot.metadata.processExited else {
+            return .rejected(
+                errorCode: "terminal_child_exited",
+                errorMessage: "The terminal process has exited.",
+                runtimePhase: surfaceHandle.snapshot.runtimePhase
+            )
+        }
+        guard surfaceHandle.isSurfaceReady else {
+            return .rejected(
+                errorCode: "terminal_runtime_unavailable",
+                errorMessage: "The requested pane is not ready to receive terminal input.",
+                runtimePhase: surfaceHandle.snapshot.runtimePhase
+            )
+        }
+        return surfaceHandle.sendControlText(text)
+    }
+
+    func beginSearch() {
+        guard let paneID = searchAdapter?.state.paneID ?? surfaceHandle?.paneID else { return }
+        if searchAdapter == nil {
+            searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
+        }
+        searchAdapter?.updateQuery(searchAdapter?.state.query ?? "")
+    }
+
+    func updateSearchQuery(_ query: String) {
+        beginSearch()
+        searchAdapter?.updateQuery(query)
+    }
+
+    func nextSearchMatch() {
+        searchAdapter?.next()
+    }
+
+    func previousSearchMatch() {
+        searchAdapter?.previous()
+    }
+
+    func dismissSearch() {
+        searchAdapter?.dismiss()
+    }
+
+    private var surfaceReadiness: AlanTerminalSurfaceReadiness {
+        guard let surfaceHandle else { return .unready(reason: .missingSurface) }
+        if latestMetadata.processExited || surfaceHandle.snapshot.metadata.processExited {
+            return .unready(reason: .childExited)
+        }
+        if latestRenderer.phase == .failed || surfaceHandle.snapshot.renderer.phase == .failed {
+            return .unready(reason: .rendererFailed)
+        }
+        if readonly {
+            return .unready(reason: .readonly)
+        }
+        guard surfaceHandle.isSurfaceReady else {
+            return .unready(reason: .inputNotReady)
+        }
+        return .ready
+    }
+}
+
+#if canImport(GhosttyKit)
+extension AlanTerminalSurfaceController {
+    var ghosttySurfaceHandle: AlanGhosttyEventSurfaceHandle? {
+        surfaceHandle as? AlanGhosttyEventSurfaceHandle
+    }
+
+    func keyTranslationMods(for mods: ghostty_input_mods_e) -> ghostty_input_mods_e {
+        ghosttySurfaceHandle?.keyTranslationMods(for: mods) ?? mods
+    }
+
+    func sendKey(_ keyEvent: ghostty_input_key_s) -> Bool {
+        ghosttySurfaceHandle?.sendKey(keyEvent) ?? false
+    }
+
+    func keyIsBinding(
+        _ keyEvent: ghostty_input_key_s,
+        flags: UnsafeMutablePointer<ghostty_binding_flags_e>?
+    ) -> Bool {
+        ghosttySurfaceHandle?.keyIsBinding(keyEvent, flags: flags) ?? false
+    }
+
+    func sendText(_ text: String) {
+        ghosttySurfaceHandle?.sendText(text)
+    }
+
+    func sendPreedit(_ text: String?) {
+        ghosttySurfaceHandle?.sendPreedit(text)
+    }
+
+    func sendMousePosition(x: Double, y: Double, mods: ghostty_input_mods_e) {
+        ghosttySurfaceHandle?.sendMousePosition(x: x, y: y, mods: mods)
+    }
+
+    func sendMouseButton(
+        state: ghostty_input_mouse_state_e,
+        button: ghostty_input_mouse_button_e,
+        mods: ghostty_input_mods_e
+    ) -> Bool {
+        ghosttySurfaceHandle?.sendMouseButton(state: state, button: button, mods: mods) ?? false
+    }
+
+    func sendMouseScroll(x: Double, y: Double, mods: ghostty_input_scroll_mods_t) {
+        ghosttySurfaceHandle?.sendMouseScroll(x: x, y: y, mods: mods)
+    }
+
+    func sendMousePressure(stage: UInt32, pressure: Double) {
+        ghosttySurfaceHandle?.sendMousePressure(stage: stage, pressure: pressure)
+    }
+
+    func readSelectionText() -> String? {
+        ghosttySurfaceHandle?.readSelectionText()
+    }
+
+    func hasSelection() -> Bool {
+        ghosttySurfaceHandle?.hasSelection() ?? false
+    }
+
+    func imeRect(in view: NSView) -> NSRect? {
+        ghosttySurfaceHandle?.imeRect(in: view)
+    }
+}
+#endif
+#endif

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -149,6 +149,27 @@ struct AlanTerminalSearchState: Equatable {
     }
 }
 
+enum AlanTerminalSearchNavigationDirection: Equatable {
+    case next
+    case previous
+}
+
+enum AlanTerminalSearchEngineUpdate: Equatable {
+    case started(query: String)
+    case ended
+    case matches(total: Int?)
+    case selected(index: Int?)
+}
+
+@MainActor
+protocol AlanTerminalSearchEngine: AnyObject {
+    func setSearchUpdateHandler(_ handler: ((AlanTerminalSearchEngineUpdate) -> Void)?)
+    func startSearch() -> Bool
+    func updateSearchQuery(_ query: String) -> Bool
+    func navigateSearch(_ direction: AlanTerminalSearchNavigationDirection) -> Bool
+    func endSearch() -> Bool
+}
+
 @MainActor
 final class AlanTerminalSearchAdapter {
     private(set) var state: AlanTerminalSearchState
@@ -376,10 +397,12 @@ final class AlanTerminalSurfaceController {
     let inputAdapter = AlanTerminalInputAdapter()
     let scrollbackAdapter = AlanTerminalScrollbackAdapter()
     let metadataAdapter = AlanTerminalMetadataAdapter()
+    var onSearchStateChange: (() -> Void)?
 
     private(set) var searchAdapter: AlanTerminalSearchAdapter?
     private(set) var clipboardAdapter = AlanTerminalSelectionClipboardAdapter(surfaceHandle: nil)
     private weak var surfaceHandle: AlanTerminalSurfaceHandle?
+    private weak var searchEngine: AlanTerminalSearchEngine?
     private var latestRenderer = TerminalRendererSnapshot.placeholder
     private var latestMetadata = TerminalPaneMetadataSnapshot.placeholder
     private var readonly = false
@@ -408,6 +431,14 @@ final class AlanTerminalSurfaceController {
         if self.surfaceHandle !== surfaceHandle {
             self.surfaceHandle?.detach()
             self.surfaceHandle = surfaceHandle
+        }
+        let nextSearchEngine = surfaceHandle as? AlanTerminalSearchEngine
+        if searchEngine !== nextSearchEngine {
+            searchEngine?.setSearchUpdateHandler(nil)
+            searchEngine = nextSearchEngine
+            searchEngine?.setSearchUpdateHandler { [weak self] update in
+                self?.applySearchEngineUpdate(update)
+            }
         }
         clipboardAdapter.updateSurfaceHandle(surfaceHandle)
         if let paneID, searchAdapter?.state.paneID != paneID {
@@ -444,6 +475,8 @@ final class AlanTerminalSurfaceController {
     func detach() {
         surfaceHandle?.detach()
         surfaceHandle = nil
+        searchEngine?.setSearchUpdateHandler(nil)
+        searchEngine = nil
         clipboardAdapter.updateSurfaceHandle(nil)
     }
 
@@ -518,29 +551,67 @@ final class AlanTerminalSurfaceController {
         return surfaceHandle.sendControlText(text)
     }
 
-    func beginSearch() {
-        guard let paneID = searchAdapter?.state.paneID ?? surfaceHandle?.paneID else { return }
+    @discardableResult
+    func beginSearch() -> Bool {
+        guard let paneID = searchAdapter?.state.paneID ?? surfaceHandle?.paneID else { return false }
         if searchAdapter == nil {
             searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
         }
+        if searchAdapter?.state.isActive == true {
+            return true
+        }
+        guard searchEngine?.startSearch() == true else { return false }
         searchAdapter?.updateQuery(searchAdapter?.state.query ?? "")
+        return true
     }
 
-    func updateSearchQuery(_ query: String) {
-        beginSearch()
+    @discardableResult
+    func updateSearchQuery(_ query: String) -> Bool {
+        guard beginSearch() else { return false }
+        guard searchEngine?.updateSearchQuery(query) == true else { return false }
         searchAdapter?.updateQuery(query)
+        return true
     }
 
     func nextSearchMatch() {
-        searchAdapter?.next()
+        if searchEngine?.navigateSearch(.next) != true {
+            searchAdapter?.next()
+        }
     }
 
     func previousSearchMatch() {
-        searchAdapter?.previous()
+        if searchEngine?.navigateSearch(.previous) != true {
+            searchAdapter?.previous()
+        }
     }
 
     func dismissSearch() {
+        _ = searchEngine?.endSearch()
         searchAdapter?.dismiss()
+    }
+
+    private func applySearchEngineUpdate(_ update: AlanTerminalSearchEngineUpdate) {
+        switch update {
+        case .started(let query):
+            guard let paneID = searchAdapter?.state.paneID ?? surfaceHandle?.paneID else { return }
+            if searchAdapter == nil {
+                searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
+            }
+            searchAdapter?.updateQuery(query)
+        case .ended:
+            searchAdapter?.dismiss()
+        case .matches(let total):
+            searchAdapter?.updateMatches(
+                total: total,
+                selectedIndex: searchAdapter?.state.selectedIndex
+            )
+        case .selected(let index):
+            searchAdapter?.updateMatches(
+                total: searchAdapter?.state.totalMatches,
+                selectedIndex: index
+            )
+        }
+        onSearchStateChange?()
     }
 
     private var surfaceReadiness: AlanTerminalSurfaceReadiness {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -91,6 +91,16 @@ require_pattern \
     "terminal search state must be pane scoped and adapter-owned"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "protocol AlanTerminalSearchEngine" \
+    "terminal search queries must be delegated to a real surface search engine"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-surface-controller.swift" \
+    "verifiesSearchActionsReachSurfaceEngine" \
+    "surface controller tests must prove search actions reach the surface engine"
+
+require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.sh" \
     "TerminalSurfaceController.swift" \
     "surface controller behavior tests must compile the controller boundary"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -71,6 +71,31 @@ require_pattern \
     "terminal runtime registry must delegate runtime authority to the service"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "final class AlanTerminalSurfaceController" \
+    "terminal surface behavior must be owned by a controller boundary"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "final class AlanTerminalInputAdapter" \
+    "terminal keyboard and IME behavior must be normalized through an input adapter"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "final class AlanTerminalScrollbackAdapter" \
+    "terminal scrollback behavior must be normalized through a scrollback adapter"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "final class AlanTerminalSearchAdapter" \
+    "terminal search state must be pane scoped and adapter-owned"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-surface-controller.sh" \
+    "TerminalSurfaceController.swift" \
+    "surface controller behavior tests must compile the controller boundary"
+
+require_pattern \
     "clients/apple/AlanNative/ShellControlPlane.swift" \
     "deliveryCode: String?" \
     "pane.send_text responses must expose service delivery state"

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-BUILD_DIR="${TMPDIR:-/tmp}/alan-terminal-runtime-service-tests"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-terminal-surface-controller-tests"
 MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
-TEST_BINARY="${BUILD_DIR}/terminal-runtime-service-tests"
+TEST_BINARY="${BUILD_DIR}/terminal-surface-controller-tests"
 
 mkdir -p "$MODULE_CACHE_DIR"
 
@@ -13,9 +13,9 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellControlPlane.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalHostRuntime.swift" \
-    "$REPO_ROOT/clients/apple/AlanNative/TerminalSurfaceController.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalRuntimeService.swift" \
-    "$REPO_ROOT/clients/apple/scripts/test-terminal-runtime-service.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-terminal-surface-controller.swift" \
     -o "$TEST_BINARY"
 
 "$TEST_BINARY"

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -17,6 +17,7 @@ private enum TerminalSurfaceControllerTests {
         verifiesScrollbackMetricsAndTerminalModes()
         verifiesInputCommandRouting()
         verifiesPaneScopedSearchState()
+        verifiesSearchActionsReachSurfaceEngine()
         verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
         verifiesClipboardDeliveryStates()
         verifiesMetadataOverlayProjection()
@@ -97,6 +98,56 @@ private enum TerminalSurfaceControllerTests {
         search.dismiss()
         expect(search.state.isActive == false, "dismissed search must be inactive")
         expect(search.state.paneID == "pane_1", "search state must remain pane scoped")
+    }
+
+    private static func verifiesSearchActionsReachSurfaceEngine() {
+        let handle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        let controller = AlanTerminalSurfaceController()
+        var searchStateChangeCount = 0
+        controller.onSearchStateChange = {
+            searchStateChangeCount += 1
+        }
+        controller.bind(surfaceHandle: handle, paneID: "pane_1")
+
+        expect(controller.beginSearch(), "controller must start search through the surface engine")
+        expect(handle.searchActions == ["start_search"], "begin search must invoke Ghostty search action")
+        expect(controller.searchAdapter?.state.isActive == true, "started search must become active")
+
+        expect(
+            controller.updateSearchQuery("alan"),
+            "query changes must be accepted by the surface search engine"
+        )
+        expect(
+            handle.searchActions.suffix(1) == ["search:alan"],
+            "query changes must reach the terminal search action"
+        )
+
+        let countBeforeEngineUpdates = searchStateChangeCount
+        handle.emitSearchUpdate(.matches(total: 3))
+        handle.emitSearchUpdate(.selected(index: 1))
+        expect(controller.searchAdapter?.state.totalMatches == 3, "search totals must update from engine callbacks")
+        expect(controller.searchAdapter?.state.selectedIndex == 1, "selected match must update from engine callbacks")
+        expect(
+            searchStateChangeCount == countBeforeEngineUpdates + 2,
+            "engine search callbacks must notify host UI refresh"
+        )
+
+        controller.nextSearchMatch()
+        controller.previousSearchMatch()
+        expect(
+            handle.searchActions.suffix(2) == ["navigate_search:next", "navigate_search:previous"],
+            "search navigation must be delegated to the terminal search engine"
+        )
+
+        controller.dismissSearch()
+        expect(handle.searchActions.last == "end_search", "dismissed search must end the terminal search")
+        expect(controller.searchAdapter?.state.isActive == false, "dismissed search must deactivate local state")
+
+        handle.searchActionsShouldSucceed = false
+        expect(
+            controller.beginSearch() == false,
+            "failed engine start must not pretend search is available"
+        )
     }
 
     private static func verifiesSurfaceSnapshotEqualityIgnoresTimestamp() {

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -1,0 +1,179 @@
+import Darwin
+import Foundation
+
+#if os(macOS)
+@main
+struct TerminalSurfaceControllerTestRunner {
+    static func main() async {
+        await MainActor.run {
+            TerminalSurfaceControllerTests.run()
+        }
+    }
+}
+
+@MainActor
+private enum TerminalSurfaceControllerTests {
+    static func run() {
+        verifiesScrollbackMetricsAndTerminalModes()
+        verifiesInputCommandRouting()
+        verifiesPaneScopedSearchState()
+        verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
+        verifiesClipboardDeliveryStates()
+        verifiesMetadataOverlayProjection()
+        print("Terminal surface controller tests passed.")
+    }
+
+    private static func verifiesScrollbackMetricsAndTerminalModes() {
+        let adapter = AlanTerminalScrollbackAdapter()
+        let normal = adapter.updateMetrics(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 140,
+                visibleRows: 40,
+                firstVisibleRow: 90,
+                mode: .normalBuffer
+            )
+        )
+
+        expect(normal.nativeScrollbarVisible, "normal-buffer scrollback must expose native scrollbar")
+        expect(normal.thumbRange.lowerBound == 90, "scrollbar must track first visible row")
+        expect(normal.thumbRange.upperBound == 130, "scrollbar must track visible row range")
+
+        let alternate = adapter.updateMetrics(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 140,
+                visibleRows: 40,
+                firstVisibleRow: 90,
+                mode: .alternateScreen
+            )
+        )
+
+        expect(alternate.nativeScrollbarVisible == false, "alternate-screen scrollback must not expose stale normal-buffer scrollbar")
+    }
+
+    private static func verifiesInputCommandRouting() {
+        let adapter = AlanTerminalInputAdapter()
+        let command = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "q",
+                keyCode: 12,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(command == .nativeCommand("quit"), "command-q must route to the native app command")
+
+        let findCommand = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "f",
+                keyCode: 3,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(findCommand == .nativeCommand("find"), "command-f must route to pane search")
+
+        let printable = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "a",
+                keyCode: 0,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(printable == .terminalText("a"), "printable key input must become terminal text")
+    }
+
+    private static func verifiesPaneScopedSearchState() {
+        let search = AlanTerminalSearchAdapter(paneID: "pane_1")
+        search.updateQuery("runtime")
+        search.updateMatches(total: 3, selectedIndex: 0)
+        search.next()
+        expect(search.state.selectedIndex == 1, "next search result must advance inside the pane")
+        search.previous()
+        expect(search.state.selectedIndex == 0, "previous search result must move backward inside the pane")
+        search.dismiss()
+        expect(search.state.isActive == false, "dismissed search must be inactive")
+        expect(search.state.paneID == "pane_1", "search state must remain pane scoped")
+    }
+
+    private static func verifiesSurfaceSnapshotEqualityIgnoresTimestamp() {
+        let older = AlanTerminalSurfaceStateSnapshot.placeholder
+        let newer = AlanTerminalSurfaceStateSnapshot(
+            readiness: older.readiness,
+            terminalMode: older.terminalMode,
+            scrollback: older.scrollback,
+            search: older.search,
+            readonly: older.readonly,
+            secureInput: older.secureInput,
+            inputReady: older.inputReady,
+            rendererHealth: older.rendererHealth,
+            childExited: older.childExited,
+            lastUpdatedAt: older.lastUpdatedAt.addingTimeInterval(60)
+        )
+        expect(older != newer, "regular surface snapshot equality must keep timestamp changes visible")
+        expect(
+            older.equalsIgnoringTimestamp(newer),
+            "runtime snapshot diffing must ignore surface timestamp churn"
+        )
+    }
+
+    private static func verifiesClipboardDeliveryStates() {
+        let handle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        let clipboard = AlanTerminalSelectionClipboardAdapter(surfaceHandle: handle)
+        let accepted = clipboard.paste("hello")
+        expect(accepted.applied, "ready paste must be delivered")
+        expect(handle.deliveredText == ["hello"], "ready paste must reach the surface handle")
+
+        _ = handle.teardown()
+        let rejected = clipboard.paste("again")
+        expect(rejected.applied == false, "closed paste must not report success")
+        expect(rejected.errorCode == "terminal_clipboard_unavailable", "closed paste must use a stable clipboard error")
+    }
+
+    private static func verifiesMetadataOverlayProjection() {
+        let adapter = AlanTerminalMetadataAdapter()
+        let failed = adapter.overlayState(
+            renderer: TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .failed,
+                summary: "internal callback failed",
+                detail: nil,
+                failureReason: "renderer lost device",
+                recentEvents: ["raw callback name"]
+            ),
+            metadata: .placeholder,
+            surface: .unready(reason: .rendererFailed)
+        )
+        expect(failed?.title == "Terminal cannot draw", "renderer failure overlay must use user-facing language")
+        expect(failed?.debugDetail?.contains("renderer lost device") == true, "debug detail must preserve raw failure context")
+
+        let exited = adapter.overlayState(
+            renderer: .placeholder,
+            metadata: TerminalPaneMetadataSnapshot(
+                title: nil,
+                workingDirectory: nil,
+                summary: nil,
+                attention: .idle,
+                processExited: true,
+                lastCommandExitCode: 2,
+                lastUpdatedAt: .now
+            ),
+            surface: .ready
+        )
+        expect(exited?.title == "Process exited", "child exit overlay must be terminal-specific")
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        guard condition() else {
+            fputs("error: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+#endif

--- a/openspec/changes/complete-macos-terminal-surface/design.md
+++ b/openspec/changes/complete-macos-terminal-surface/design.md
@@ -120,6 +120,9 @@ surface adapter after runtime ownership is moved behind a stable service.
   state without exposing those details in the default terminal canvas.
 - Added compact user-facing overlays for search, missing surface, startup,
   renderer failure, child exit, and read-only states.
+- Wired terminal search to Ghostty binding actions so query changes and
+  next/previous navigation reach the terminal search engine, with total and
+  selected-match state flowing back through Ghostty action callbacks.
 - Added control-plane delivery rejection for child-exit and renderer-failure
   states so remote text delivery does not report false success.
 
@@ -130,8 +133,6 @@ Remaining unsupported Ghostty parity after this pass:
 - Alternate-screen and application mouse-mode detection are not yet sourced from
   live Ghostty callbacks; scroll/mouse events are centralized but still forward
   through the existing Ghostty event API.
-- Search is pane-scoped with native command routing and overlay state, but it
-  does not yet drive Ghostty search highlights or real match counts.
 - Selection and paste continue to use the existing Ghostty text forwarding path;
   bracketed-paste-aware delivery is not exposed separately yet.
 - URL hover, secure input, and terminal application mode diagnostics remain

--- a/openspec/changes/complete-macos-terminal-surface/design.md
+++ b/openspec/changes/complete-macos-terminal-surface/design.md
@@ -106,6 +106,48 @@ surface adapter after runtime ownership is moved behind a stable service.
 5. Add unit tests and manual verification notes for IME, scrollback, mouse apps,
    search, paste, and failure states.
 
+## Implementation Notes
+
+### 2026-05-06 Surface Controller Pass
+
+- Added `AlanTerminalSurfaceController` plus input, scrollback metrics,
+  selection/clipboard, search-state, and metadata/overlay adapters.
+- Moved the existing AppKit key, mouse, scroll, selection, clipboard, and IME
+  forwarding paths through the controller while preserving the Ghostty host as
+  the renderer owner.
+- Added surface readiness state to host runtime snapshots so the inspector can
+  distinguish renderer health, input readiness, terminal mode, and process
+  state without exposing those details in the default terminal canvas.
+- Added compact user-facing overlays for search, missing surface, startup,
+  renderer failure, child exit, and read-only states.
+- Added control-plane delivery rejection for child-exit and renderer-failure
+  states so remote text delivery does not report false success.
+
+Remaining unsupported Ghostty parity after this pass:
+
+- There is no AppKit `NSScrollView` bridge yet; scrollback metrics are modeled
+  and tested, but live scrollbar synchronization is not wired to Ghostty.
+- Alternate-screen and application mouse-mode detection are not yet sourced from
+  live Ghostty callbacks; scroll/mouse events are centralized but still forward
+  through the existing Ghostty event API.
+- Search is pane-scoped with native command routing and overlay state, but it
+  does not yet drive Ghostty search highlights or real match counts.
+- Selection and paste continue to use the existing Ghostty text forwarding path;
+  bracketed-paste-aware delivery is not exposed separately yet.
+- URL hover, secure input, and terminal application mode diagnostics remain
+  placeholders until the needed Ghostty surface callbacks are available.
+
+Manual verification notes:
+
+- Built and launched the Debug `Alan.app`.
+- Verified a real shell prompt accepts input and prints command output.
+- Verified `Command-F` opens the terminal search overlay.
+- Verified typing while search is active updates the overlay instead of sending
+  text into the shell.
+- Verified `Escape` dismisses search and terminal input resumes.
+- Verified the inspector Debug view remains the place for raw shell/runtime
+  JSON, while the search overlay uses user-facing terminal language.
+
 ## Open Questions
 
 - Which Ghostty surface APIs expose search, URL hover, and renderer health

--- a/openspec/changes/complete-macos-terminal-surface/tasks.md
+++ b/openspec/changes/complete-macos-terminal-surface/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Surface Controller Structure
 
-- [ ] 1.1 Add `AlanTerminalSurfaceController` to bind runtime surface handles to AppKit terminal views.
-- [ ] 1.2 Add dedicated input, scrollback, selection/clipboard, search, and metadata adapter types.
-- [ ] 1.3 Move existing terminal event forwarding into the controller without changing behavior.
-- [ ] 1.4 Expose fake surface handles and fake terminal events for controller tests.
+- [x] 1.1 Add `AlanTerminalSurfaceController` to bind runtime surface handles to AppKit terminal views.
+- [x] 1.2 Add dedicated input, scrollback, selection/clipboard, search, and metadata adapter types.
+- [x] 1.3 Move existing terminal event forwarding into the controller without changing behavior.
+- [x] 1.4 Expose fake surface handles and fake terminal events for controller tests.
 
 ## 2. Scrollback And Rendering State
 
 - [ ] 2.1 Add an AppKit scroll view adapter for terminal scrollback and native scrollbar synchronization.
 - [ ] 2.2 Handle alternate-screen and terminal mouse-mode interactions with scroll input.
 - [ ] 2.3 Project renderer health, input readiness, readonly state, and child-exit state into pane metadata.
-- [ ] 2.4 Add truthful fallback UI for renderer failure, missing surface, input-not-ready, and child-exit states.
+- [x] 2.4 Add truthful fallback UI for renderer failure, missing surface, input-not-ready, and child-exit states.
 
 ## 3. Input, Selection, Clipboard, And Search
 
-- [ ] 3.1 Normalize keyDown, keyUp, flagsChanged, performKeyEquivalent, marked text, preedit, commit, and cancellation paths.
+- [x] 3.1 Normalize keyDown, keyUp, flagsChanged, performKeyEquivalent, marked text, preedit, commit, and cancellation paths.
 - [ ] 3.2 Normalize primary, secondary, other-button, drag, movement, hover, pressure, and scroll events against terminal mouse modes.
 - [ ] 3.3 Implement native selection, copy, paste, bracketed-paste-aware delivery when available, and paste failure reporting.
-- [ ] 3.4 Add pane-scoped terminal search with find, next, previous, match status, and dismissal behavior.
-- [ ] 3.5 Add compact user-facing terminal overlays while keeping raw surface diagnostics in the inspector debug layer.
+- [x] 3.4 Add pane-scoped terminal search with find, next, previous, match status, and dismissal behavior.
+- [x] 3.5 Add compact user-facing terminal overlays while keeping raw surface diagnostics in the inspector debug layer.
 
 ## 4. Shell Integration
 
-- [ ] 4.1 Update `TerminalPaneView` and host wrappers to compose the surface controller without adding decorative terminal chrome.
+- [x] 4.1 Update `TerminalPaneView` and host wrappers to compose the surface controller without adding decorative terminal chrome.
 - [ ] 4.2 Update sidebar/status metadata for title, cwd, bell, attention, process exit, and renderer health.
-- [ ] 4.3 Update control-plane text delivery and pane summaries to account for input readiness, child exit, readonly state, and renderer failure.
-- [ ] 4.4 Document any Ghostty surface behavior that remains unsupported after this pass.
+- [x] 4.3 Update control-plane text delivery and pane summaries to account for input readiness, child exit, readonly state, and renderer failure.
+- [x] 4.4 Document any Ghostty surface behavior that remains unsupported after this pass.
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for scrollback metrics, input normalization, search state, clipboard failure states, and metadata projection with fake surfaces.
-- [ ] 5.2 Run `git diff --check`.
-- [ ] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.4 Build the macOS app with the documented `AlanNative` command.
+- [x] 5.1 Add unit tests for scrollback metrics, input normalization, search state, clipboard failure states, and metadata projection with fake surfaces.
+- [x] 5.2 Run `git diff --check`.
+- [x] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.4 Build the macOS app with the documented `AlanNative` command.
 - [ ] 5.5 Manually verify shell scrollback, alternate-screen scrolling, selection/copy, paste, right-click, IME composition, terminal mouse apps, search, child exit, and renderer/fallback state.
 
 ## 6. PR And Archive Readiness
 
-- [ ] 6.1 Attach screenshot or manual verification notes for terminal overlays and inspector debug separation.
-- [ ] 6.2 Review the diff for duplicate event forwarding or conflicting responder-chain ownership.
+- [x] 6.1 Attach screenshot or manual verification notes for terminal overlays and inspector debug separation.
+- [x] 6.2 Review the diff for duplicate event forwarding or conflicting responder-chain ownership.
 - [ ] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
 - [ ] 6.4 Archive the OpenSpec change after implementation is merged.


### PR DESCRIPTION
## Summary
- add AlanTerminalSurfaceController plus input, scrollback, search, clipboard, and metadata adapters
- route terminal host key/mouse/IME/selection forwarding through the controller and expose surface readiness in runtime snapshots
- add user-facing terminal overlays and reject control-plane text delivery after child exit or renderer failure
- document remaining Ghostty parity gaps in the active OpenSpec change

Stacked on #342.

## Verification
- clients/apple/scripts/test-terminal-surface-controller.sh
- clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate complete-macos-terminal-surface --type change --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
- manual Debug Alan.app smoke: shell input, Command-F search overlay, search text capture, Escape dismissal, input resume, inspector/debug separation