### PR TITLE
Complete native terminal scrollback and clipboard routing

### DIFF
--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -29,6 +29,7 @@ final class AlanGhosttyLiveHost: NSObject {
     private var didEmitFirstRefresh = false
     private var diagnostics = TerminalRendererSnapshot.placeholder
     private var metadata = TerminalPaneMetadataSnapshot.placeholder
+    private let terminalModeTracker = AlanTerminalModeTracker()
 
     func attach(
         to canvasView: AlanGhosttyCanvasView,
@@ -339,6 +340,7 @@ final class AlanGhosttyLiveHost: NSObject {
 
         teardownSurface()
         didEmitFirstRefresh = false
+        terminalModeTracker.reset()
 
         transition(
             kind: .ghosttyLive,
@@ -512,6 +514,7 @@ final class AlanGhosttyLiveHost: NSObject {
             free($0.1)
         }
         envStorage.removeAll()
+        terminalModeTracker.reset()
 
         if app != nil {
             transition(
@@ -679,11 +682,18 @@ final class AlanGhosttyLiveHost: NSObject {
 
         case GHOSTTY_ACTION_SCROLLBAR:
             let scrollbar = action.action.scrollbar
+            let totalRows = clampedInt(scrollbar.total)
+            let visibleRows = clampedInt(scrollbar.len)
+            let mode = terminalModeTracker.resolveMode(
+                totalRows: totalRows,
+                visibleRows: visibleRows,
+                mouseCaptured: surface.map { ghostty_surface_mouse_captured($0) } ?? false
+            )
             let metrics = AlanTerminalScrollbackMetrics(
-                totalRows: clampedInt(scrollbar.total),
-                visibleRows: clampedInt(scrollbar.len),
+                totalRows: totalRows,
+                visibleRows: visibleRows,
                 firstVisibleRow: clampedInt(scrollbar.offset),
-                mode: .normalBuffer
+                mode: mode
             )
             performOnMain {
                 self.onScrollbackUpdate?(metrics)

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -10,6 +10,7 @@ final class AlanGhosttyLiveHost: NSObject {
     var onDiagnosticsChange: ((TerminalRendererSnapshot) -> Void)?
     var onMetadataChange: ((TerminalPaneMetadataSnapshot) -> Void)?
     var onSearchUpdate: ((AlanTerminalSearchEngineUpdate) -> Void)?
+    var onScrollbackUpdate: ((AlanTerminalScrollbackMetrics) -> Void)?
 
     private let logger = Logger(
         subsystem: "com.realmorrisliu.AlanNative",
@@ -676,6 +677,19 @@ final class AlanGhosttyLiveHost: NSObject {
             }
             return true
 
+        case GHOSTTY_ACTION_SCROLLBAR:
+            let scrollbar = action.action.scrollbar
+            let metrics = AlanTerminalScrollbackMetrics(
+                totalRows: clampedInt(scrollbar.total),
+                visibleRows: clampedInt(scrollbar.len),
+                firstVisibleRow: clampedInt(scrollbar.offset),
+                mode: .normalBuffer
+            )
+            performOnMain {
+                self.onScrollbackUpdate?(metrics)
+            }
+            return true
+
         case GHOSTTY_ACTION_START_SEARCH:
             let query = action.action.start_search.needle.flatMap { String(cString: $0) } ?? ""
             performOnMain {
@@ -725,6 +739,10 @@ final class AlanGhosttyLiveHost: NSObject {
         default:
             return nil
         }
+    }
+
+    private func clampedInt(_ value: UInt64) -> Int {
+        value > UInt64(Int.max) ? Int.max : Int(value)
     }
 
     private func updateMetadata(

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -300,6 +300,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         [statusBadge, titleLabel, subtitleLabel, commandLabel, footerLabel].forEach(bodyStack.addArrangedSubview)
 
         let nativeScrollView = surfaceController.nativeScrollViewAdapter.scrollView
+        surfaceController.nativeScrollViewAdapter.onScrollWheel = { [weak self] event in
+            self?.routeScrollWheel(event) ?? false
+        }
         surfaceController.nativeScrollViewAdapter.attachCanvasView(canvasView)
         addSubview(nativeScrollView)
         addSubview(overlayCard)
@@ -714,8 +717,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func scrollWheel(with event: NSEvent) {
+        if routeScrollWheel(event) {
+            return
+        }
+        super.scrollWheel(with: event)
+    }
+
+    private func routeScrollWheel(_ event: NSEvent) -> Bool {
 #if canImport(GhosttyKit)
-        guard surfaceController.isSurfaceReady == true else { return super.scrollWheel(with: event) }
+        guard surfaceController.isSurfaceReady == true else { return false }
 
         let scrollRoute = surfaceController.routeScroll(
             AlanTerminalScrollInput(
@@ -728,9 +738,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         case .nativeScroll:
             syncNativeScrollback()
             publishRuntimeSnapshot()
-            return
+            return true
         case .ignored:
-            return
+            return true
         case .terminalScroll:
             break
         }
@@ -768,8 +778,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         scrollMods |= momentum << 1
 
         surfaceController.sendMouseScroll(x: x, y: y, mods: ghostty_input_scroll_mods_t(scrollMods))
+        return true
 #else
-        super.scrollWheel(with: event)
+        return false
 #endif
     }
 

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -78,7 +78,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        surfaceController.onSearchStateChange = { [weak self] in
+        surfaceController.onSurfaceStateChange = { [weak self] in
+            self?.syncNativeScrollback()
             self?.syncOverlayVisibility()
             self?.publishRuntimeSnapshot()
         }
@@ -164,6 +165,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     override func layout() {
         super.layout()
         synchronizeLiveHost()
+        syncNativeScrollback()
         publishRuntimeSnapshot()
     }
 
@@ -216,6 +218,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         syncStatusBadge()
         syncOverlayVisibility()
         synchronizeLiveHost()
+        syncNativeScrollback()
         if shouldAutoFocusAfterConfigure(
             previousPaneID: previousPaneID,
             paneID: pane?.paneID,
@@ -296,15 +299,17 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         [statusBadge, titleLabel, subtitleLabel, commandLabel, footerLabel].forEach(bodyStack.addArrangedSubview)
 
-        addSubview(canvasView)
+        let nativeScrollView = surfaceController.nativeScrollViewAdapter.scrollView
+        surfaceController.nativeScrollViewAdapter.attachCanvasView(canvasView)
+        addSubview(nativeScrollView)
         addSubview(overlayCard)
         overlayCard.addSubview(bodyStack)
 
         NSLayoutConstraint.activate([
-            canvasView.topAnchor.constraint(equalTo: topAnchor),
-            canvasView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            canvasView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            canvasView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            nativeScrollView.topAnchor.constraint(equalTo: topAnchor),
+            nativeScrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            nativeScrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            nativeScrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             overlayCard.centerXAnchor.constraint(equalTo: centerXAnchor),
             overlayCard.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -487,6 +492,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             }
         )
 #endif
+    }
+
+    private func syncNativeScrollback() {
+        surfaceController.syncNativeScrollView(viewportSize: bounds.size)
     }
 
     private func synchronizeRendererSnapshot(with bootProfile: AlanShellBootProfile?) {
@@ -708,6 +717,24 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 #if canImport(GhosttyKit)
         guard surfaceController.isSurfaceReady == true else { return super.scrollWheel(with: event) }
 
+        let scrollRoute = surfaceController.routeScroll(
+            AlanTerminalScrollInput(
+                deltaX: event.scrollingDeltaX,
+                deltaY: event.scrollingDeltaY,
+                precise: event.hasPreciseScrollingDeltas
+            )
+        )
+        switch scrollRoute {
+        case .nativeScroll:
+            syncNativeScrollback()
+            publishRuntimeSnapshot()
+            return
+        case .ignored:
+            return
+        case .terminalScroll:
+            break
+        }
+
         var x = event.scrollingDeltaX
         var y = event.scrollingDeltaY
         let precision = event.hasPreciseScrollingDeltas
@@ -915,12 +942,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     @objc func copy(_ sender: Any?) {
-#if canImport(GhosttyKit)
-        guard let text = surfaceController.readSelectionText(), !text.isEmpty else { return }
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-#endif
+        _ = surfaceController.copySelection(to: .general)
     }
 
     @objc func cut(_ sender: Any?) {
@@ -928,10 +950,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     @objc func paste(_ sender: Any?) {
-#if canImport(GhosttyKit)
         guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else { return }
-        surfaceController.sendText(text)
-#endif
+        _ = surfaceController.paste(text)
+        publishRuntimeSnapshot()
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -303,6 +303,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         surfaceController.nativeScrollViewAdapter.onScrollWheel = { [weak self] event in
             self?.routeScrollWheel(event) ?? false
         }
+        surfaceController.nativeScrollViewAdapter.onMouseEvent = { [weak self] routedEvent, event in
+            self?.routeWrappedMouseEvent(routedEvent, event) ?? false
+        }
         surfaceController.nativeScrollViewAdapter.attachCanvasView(canvasView)
         addSubview(nativeScrollView)
         addSubview(overlayCard)
@@ -714,6 +717,39 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 #if canImport(GhosttyKit)
         surfaceController.sendMousePosition(x: -1, y: -1, mods: modsFromEvent(event))
 #endif
+    }
+
+    @discardableResult
+    private func routeWrappedMouseEvent(_ routedEvent: AlanTerminalRoutedMouseEvent, _ event: NSEvent) -> Bool {
+        switch routedEvent {
+        case .mouseDown:
+            mouseDown(with: event)
+        case .mouseUp:
+            mouseUp(with: event)
+        case .rightMouseDown:
+            rightMouseDown(with: event)
+        case .rightMouseUp:
+            rightMouseUp(with: event)
+        case .otherMouseDown:
+            otherMouseDown(with: event)
+        case .otherMouseUp:
+            otherMouseUp(with: event)
+        case .mouseEntered:
+            mouseEntered(with: event)
+        case .mouseMoved:
+            mouseMoved(with: event)
+        case .mouseDragged:
+            mouseDragged(with: event)
+        case .rightMouseDragged:
+            rightMouseDragged(with: event)
+        case .otherMouseDragged:
+            otherMouseDragged(with: event)
+        case .mouseExited:
+            mouseExited(with: event)
+        case .pressureChange:
+            pressureChange(with: event)
+        }
+        return true
     }
 
     override func scrollWheel(with event: NSEvent) {

--- a/clients/apple/AlanNative/TerminalRuntimeService.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeService.swift
@@ -308,7 +308,12 @@ protocol AlanTerminalSurfaceHandle: AnyObject {
 
 #if canImport(GhosttyKit)
 @MainActor
-protocol AlanGhosttyEventSurfaceHandle: AlanTerminalSurfaceHandle, AlanTerminalSearchEngine {
+protocol AlanGhosttyEventSurfaceHandle:
+    AlanTerminalSurfaceHandle,
+    AlanTerminalSearchEngine,
+    AlanTerminalScrollbackEngine,
+    AlanTerminalSelectionEngine
+{
     func keyTranslationMods(for mods: ghostty_input_mods_e) -> ghostty_input_mods_e
     func sendKey(_ keyEvent: ghostty_input_key_s) -> Bool
     func keyIsBinding(
@@ -641,6 +646,10 @@ extension AlanGhosttySurfaceHandle: AlanGhosttyEventSurfaceHandle {
         liveHost.onSearchUpdate = handler
     }
 
+    func setScrollbackUpdateHandler(_ handler: ((AlanTerminalScrollbackMetrics) -> Void)?) {
+        liveHost.onScrollbackUpdate = handler
+    }
+
     func startSearch() -> Bool {
         liveHost.performBindingAction("start_search")
     }
@@ -660,6 +669,10 @@ extension AlanGhosttySurfaceHandle: AlanGhosttyEventSurfaceHandle {
 
     func endSearch() -> Bool {
         liveHost.performBindingAction("end_search")
+    }
+
+    func scrollTo(row: Int) -> Bool {
+        liveHost.performBindingAction("scroll_to_row:\(row)")
     }
 }
 #endif
@@ -808,10 +821,14 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private(set) var teardownCount = 0
     private(set) var deliveredText: [String] = []
     private(set) var searchActions: [String] = []
+    private(set) var scrollActions: [String] = []
     var deliveryResult: TerminalRuntimeDeliveryResult?
     var searchActionsShouldSucceed = true
+    var scrollActionsShouldSucceed = true
+    var selectedText: String?
     var ready = true
     private var searchUpdateHandler: ((AlanTerminalSearchEngineUpdate) -> Void)?
+    private var scrollbackUpdateHandler: ((AlanTerminalScrollbackMetrics) -> Void)?
     private var currentSnapshot: AlanTerminalSurfaceSnapshot
 
     init(paneID: String) {
@@ -935,6 +952,31 @@ extension FakeAlanTerminalSurfaceHandle: AlanTerminalSearchEngine {
 
     private func recordSearchAction(_ action: String) {
         searchActions.append(action)
+    }
+}
+
+extension FakeAlanTerminalSurfaceHandle: AlanTerminalScrollbackEngine {
+    func setScrollbackUpdateHandler(_ handler: ((AlanTerminalScrollbackMetrics) -> Void)?) {
+        scrollbackUpdateHandler = handler
+    }
+
+    func scrollTo(row: Int) -> Bool {
+        scrollActions.append("scroll_to_row:\(row)")
+        return scrollActionsShouldSucceed
+    }
+
+    func emitScrollbackUpdate(_ metrics: AlanTerminalScrollbackMetrics) {
+        scrollbackUpdateHandler?(metrics)
+    }
+}
+
+extension FakeAlanTerminalSurfaceHandle: AlanTerminalSelectionEngine {
+    func readSelectionText() -> String? {
+        selectedText
+    }
+
+    func hasSelection() -> Bool {
+        selectedText?.isEmpty == false
     }
 }
 

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -160,8 +160,13 @@ final class AlanTerminalScrollbackAdapter {
 
 @MainActor
 final class AlanTerminalNativeScrollViewAdapter {
-    let scrollView = NSScrollView()
+    let scrollView = AlanTerminalRoutingScrollView()
     var onVisibleRowChange: ((Int) -> Void)?
+    var onScrollWheel: ((NSEvent) -> Bool)? {
+        didSet {
+            scrollView.onScrollWheel = onScrollWheel
+        }
+    }
 
     private let documentView = NSView(frame: .zero)
     private weak var canvasView: NSView?
@@ -270,6 +275,20 @@ final class AlanTerminalNativeScrollViewAdapter {
     private func synchronizeCanvasView() {
         let visibleRect = scrollView.contentView.documentVisibleRect
         canvasView?.frame = NSRect(origin: visibleRect.origin, size: scrollView.contentView.bounds.size)
+    }
+}
+
+@MainActor
+final class AlanTerminalRoutingScrollView: NSScrollView {
+    var onScrollWheel: ((NSEvent) -> Bool)?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func scrollWheel(with event: NSEvent) {
+        if onScrollWheel?(event) == true {
+            return
+        }
+        super.scrollWheel(with: event)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -38,6 +38,50 @@ struct AlanTerminalScrollbackState: Equatable {
     )
 }
 
+struct AlanTerminalScrollInput: Equatable {
+    let deltaX: Double
+    let deltaY: Double
+    let precise: Bool
+}
+
+enum AlanTerminalScrollRoutingDecision: Equatable {
+    case nativeScroll(row: Int)
+    case terminalScroll
+    case ignored
+}
+
+@MainActor
+protocol AlanTerminalScrollbackEngine: AnyObject {
+    func setScrollbackUpdateHandler(_ handler: ((AlanTerminalScrollbackMetrics) -> Void)?)
+    func scrollTo(row: Int) -> Bool
+}
+
+@MainActor
+protocol AlanTerminalSelectionEngine: AnyObject {
+    func readSelectionText() -> String?
+    func hasSelection() -> Bool
+}
+
+@MainActor
+protocol AlanTerminalPasteboardWriting: AnyObject {
+    func writeString(_ text: String) -> Bool
+}
+
+@MainActor
+final class AlanTerminalSystemPasteboardWriter: AlanTerminalPasteboardWriting {
+    private let pasteboard: NSPasteboard
+
+    init(pasteboard: NSPasteboard = .general) {
+        self.pasteboard = pasteboard
+    }
+
+    func writeString(_ text: String) -> Bool {
+        pasteboard.clearContents()
+        pasteboard.declareTypes([.string], owner: nil)
+        return pasteboard.setString(text, forType: .string)
+    }
+}
+
 @MainActor
 final class AlanTerminalScrollbackAdapter {
     private(set) var state = AlanTerminalScrollbackState.empty
@@ -62,8 +106,144 @@ final class AlanTerminalScrollbackAdapter {
         return state
     }
 
+    @discardableResult
+    func scrollTo(firstVisibleRow: Int) -> AlanTerminalScrollbackState {
+        updateMetrics(
+            AlanTerminalScrollbackMetrics(
+                totalRows: state.metrics.totalRows,
+                visibleRows: state.metrics.visibleRows,
+                firstVisibleRow: firstVisibleRow,
+                mode: state.metrics.mode
+            )
+        )
+    }
+
+    func targetFirstVisibleRow(for input: AlanTerminalScrollInput) -> Int? {
+        guard state.nativeScrollbarVisible else { return nil }
+        guard abs(input.deltaY) >= abs(input.deltaX) else { return nil }
+        let rowDelta = Int((-input.deltaY).rounded(.toNearestOrAwayFromZero))
+        guard rowDelta != 0 else { return nil }
+        let maxFirstVisibleRow = max(state.metrics.totalRows - state.metrics.visibleRows, 0)
+        return max(0, min(state.metrics.firstVisibleRow + rowDelta, maxFirstVisibleRow))
+    }
+
     func shouldForwardScrollToTerminal() -> Bool {
         state.metrics.mode == .alternateScreen || state.metrics.mode == .mouseReporting
+    }
+}
+
+@MainActor
+final class AlanTerminalNativeScrollViewAdapter {
+    let scrollView = NSScrollView()
+    var onVisibleRowChange: ((Int) -> Void)?
+
+    private let documentView = NSView(frame: .zero)
+    private weak var canvasView: NSView?
+    private var observers: [NSObjectProtocol] = []
+    private var state = AlanTerminalScrollbackState.empty
+    private var rowHeight: CGFloat = 1
+    private var isProgrammaticSync = false
+    private var lastSentRow: Int?
+
+    init() {
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = false
+        scrollView.usesPredominantAxisScrolling = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.drawsBackground = false
+        scrollView.contentView.clipsToBounds = false
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        scrollView.documentView = documentView
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleBoundsChange()
+                }
+            }
+        )
+    }
+
+    deinit {
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    func attachCanvasView(_ canvasView: NSView) {
+        guard self.canvasView !== canvasView else { return }
+        self.canvasView?.removeFromSuperview()
+        self.canvasView = canvasView
+        canvasView.removeFromSuperview()
+        canvasView.translatesAutoresizingMaskIntoConstraints = true
+        canvasView.autoresizingMask = [.width, .height]
+        canvasView.frame = scrollView.contentView.bounds
+        scrollView.contentView.addSubview(canvasView)
+    }
+
+    func sync(
+        state: AlanTerminalScrollbackState,
+        viewportSize: CGSize,
+        rowHeight: CGFloat = 1
+    ) {
+        self.state = state
+        self.rowHeight = max(rowHeight, 1)
+        let viewportWidth = max(viewportSize.width, 0)
+        let viewportHeight = max(viewportSize.height, 0)
+        documentView.frame.size.width = viewportWidth
+        scrollView.hasVerticalScroller = state.nativeScrollbarVisible
+        scrollView.verticalScrollElasticity = state.nativeScrollbarVisible ? .allowed : .none
+
+        guard viewportWidth > 0, viewportHeight > 0, state.nativeScrollbarVisible else {
+            documentView.frame.size.height = viewportHeight
+            scrollView.contentView.scroll(to: .zero)
+            synchronizeCanvasView()
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            return
+        }
+
+        let contentHeight = max(CGFloat(state.metrics.totalRows) * self.rowHeight, viewportHeight)
+        documentView.frame.size.height = contentHeight
+        let offsetY = CGFloat(
+            state.metrics.totalRows
+                - state.metrics.firstVisibleRow
+                - state.metrics.visibleRows
+        ) * self.rowHeight
+        isProgrammaticSync = true
+        scrollView.contentView.scroll(to: CGPoint(x: 0, y: max(offsetY, 0)))
+        synchronizeCanvasView()
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        lastSentRow = state.metrics.firstVisibleRow
+        isProgrammaticSync = false
+    }
+
+    private func handleBoundsChange() {
+        synchronizeCanvasView()
+        guard !isProgrammaticSync else { return }
+        guard state.nativeScrollbarVisible else { return }
+        let visibleRect = scrollView.contentView.documentVisibleRect
+        let documentHeight = documentView.frame.height
+        guard rowHeight > 0, visibleRect.height > 0, documentHeight > visibleRect.height else {
+            return
+        }
+
+        let scrollOffset = documentHeight - visibleRect.origin.y - visibleRect.height
+        let row = max(0, min(Int((scrollOffset / rowHeight).rounded()), maxFirstVisibleRow))
+        guard row != lastSentRow else { return }
+        lastSentRow = row
+        onVisibleRowChange?(row)
+    }
+
+    private var maxFirstVisibleRow: Int {
+        max(state.metrics.totalRows - state.metrics.visibleRows, 0)
+    }
+
+    private func synchronizeCanvasView() {
+        let visibleRect = scrollView.contentView.documentVisibleRect
+        canvasView?.frame = NSRect(origin: visibleRect.origin, size: scrollView.contentView.bounds.size)
     }
 }
 
@@ -250,10 +430,13 @@ final class AlanTerminalSelectionClipboardAdapter {
         return surfaceHandle.sendControlText(text)
     }
 
-    func writeSelectionToPasteboard(_ text: String?, pasteboard: NSPasteboard = .general) -> Bool {
+    func writeSelection(_ text: String?, to writer: AlanTerminalPasteboardWriting) -> Bool {
         guard let text, !text.isEmpty else { return false }
-        pasteboard.clearContents()
-        return pasteboard.setString(text, forType: .string)
+        return writer.writeString(text)
+    }
+
+    func writeSelectionToPasteboard(_ text: String?, pasteboard: NSPasteboard = .general) -> Bool {
+        writeSelection(text, to: AlanTerminalSystemPasteboardWriter(pasteboard: pasteboard))
     }
 }
 
@@ -396,17 +579,27 @@ final class AlanTerminalMetadataAdapter {
 final class AlanTerminalSurfaceController {
     let inputAdapter = AlanTerminalInputAdapter()
     let scrollbackAdapter = AlanTerminalScrollbackAdapter()
+    let nativeScrollViewAdapter = AlanTerminalNativeScrollViewAdapter()
     let metadataAdapter = AlanTerminalMetadataAdapter()
     var onSearchStateChange: (() -> Void)?
+    var onSurfaceStateChange: (() -> Void)?
 
     private(set) var searchAdapter: AlanTerminalSearchAdapter?
     private(set) var clipboardAdapter = AlanTerminalSelectionClipboardAdapter(surfaceHandle: nil)
     private weak var surfaceHandle: AlanTerminalSurfaceHandle?
     private weak var searchEngine: AlanTerminalSearchEngine?
+    private weak var scrollbackEngine: AlanTerminalScrollbackEngine?
+    private weak var selectionEngine: AlanTerminalSelectionEngine?
     private var latestRenderer = TerminalRendererSnapshot.placeholder
     private var latestMetadata = TerminalPaneMetadataSnapshot.placeholder
     private var readonly = false
     private var secureInput = false
+
+    init() {
+        nativeScrollViewAdapter.onVisibleRowChange = { [weak self] row in
+            self?.scrollToNativeRow(row)
+        }
+    }
 
     var isSurfaceReady: Bool {
         surfaceReadiness == .ready
@@ -440,6 +633,15 @@ final class AlanTerminalSurfaceController {
                 self?.applySearchEngineUpdate(update)
             }
         }
+        let nextScrollbackEngine = surfaceHandle as? AlanTerminalScrollbackEngine
+        if scrollbackEngine !== nextScrollbackEngine {
+            scrollbackEngine?.setScrollbackUpdateHandler(nil)
+            scrollbackEngine = nextScrollbackEngine
+            scrollbackEngine?.setScrollbackUpdateHandler { [weak self] metrics in
+                self?.applyScrollbackMetrics(metrics)
+            }
+        }
+        selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine
         clipboardAdapter.updateSurfaceHandle(surfaceHandle)
         if let paneID, searchAdapter?.state.paneID != paneID {
             searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
@@ -477,6 +679,9 @@ final class AlanTerminalSurfaceController {
         surfaceHandle = nil
         searchEngine?.setSearchUpdateHandler(nil)
         searchEngine = nil
+        scrollbackEngine?.setScrollbackUpdateHandler(nil)
+        scrollbackEngine = nil
+        selectionEngine = nil
         clipboardAdapter.updateSurfaceHandle(nil)
     }
 
@@ -551,6 +756,54 @@ final class AlanTerminalSurfaceController {
         return surfaceHandle.sendControlText(text)
     }
 
+    func syncNativeScrollView(viewportSize: CGSize) {
+        let visibleRows = max(scrollbackAdapter.state.metrics.visibleRows, 1)
+        let rowHeight = viewportSize.height / CGFloat(visibleRows)
+        nativeScrollViewAdapter.sync(
+            state: scrollbackAdapter.state,
+            viewportSize: viewportSize,
+            rowHeight: rowHeight
+        )
+    }
+
+    func routeScroll(_ input: AlanTerminalScrollInput) -> AlanTerminalScrollRoutingDecision {
+        guard isSurfaceReady else { return .ignored }
+        guard !scrollbackAdapter.shouldForwardScrollToTerminal() else { return .terminalScroll }
+        guard let row = scrollbackAdapter.targetFirstVisibleRow(for: input) else {
+            return .terminalScroll
+        }
+        guard scrollToNativeRow(row) else { return .terminalScroll }
+        return .nativeScroll(row: row)
+    }
+
+    @discardableResult
+    private func scrollToNativeRow(_ row: Int) -> Bool {
+        guard scrollbackEngine?.scrollTo(row: row) == true else { return false }
+        scrollbackAdapter.scrollTo(firstVisibleRow: row)
+        notifySurfaceStateChanged()
+        return true
+    }
+
+    func copySelection(to pasteboard: NSPasteboard = .general) -> Bool {
+        clipboardAdapter.writeSelectionToPasteboard(selectionEngine?.readSelectionText(), pasteboard: pasteboard)
+    }
+
+    func copySelection(to writer: AlanTerminalPasteboardWriting) -> Bool {
+        clipboardAdapter.writeSelection(selectionEngine?.readSelectionText(), to: writer)
+    }
+
+    func paste(_ text: String) -> TerminalRuntimeDeliveryResult {
+        clipboardAdapter.paste(text)
+    }
+
+    func readSelectionText() -> String? {
+        selectionEngine?.readSelectionText()
+    }
+
+    func hasSelection() -> Bool {
+        selectionEngine?.hasSelection() ?? false
+    }
+
     @discardableResult
     func beginSearch() -> Bool {
         guard let paneID = searchAdapter?.state.paneID ?? surfaceHandle?.paneID else { return false }
@@ -611,7 +864,21 @@ final class AlanTerminalSurfaceController {
                 selectedIndex: index
             )
         }
+        notifySearchStateChanged()
+    }
+
+    private func applyScrollbackMetrics(_ metrics: AlanTerminalScrollbackMetrics) {
+        scrollbackAdapter.updateMetrics(metrics)
+        notifySurfaceStateChanged()
+    }
+
+    private func notifySearchStateChanged() {
         onSearchStateChange?()
+        notifySurfaceStateChanged()
+    }
+
+    private func notifySurfaceStateChanged() {
+        onSurfaceStateChange?()
     }
 
     private var surfaceReadiness: AlanTerminalSurfaceReadiness {
@@ -679,14 +946,6 @@ extension AlanTerminalSurfaceController {
 
     func sendMousePressure(stage: UInt32, pressure: Double) {
         ghosttySurfaceHandle?.sendMousePressure(stage: stage, pressure: pressure)
-    }
-
-    func readSelectionText() -> String? {
-        ghosttySurfaceHandle?.readSelectionText()
-    }
-
-    func hasSelection() -> Bool {
-        ghosttySurfaceHandle?.hasSelection() ?? false
     }
 
     func imeRect(in view: NSView) -> NSRect? {

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -12,6 +12,32 @@ enum AlanTerminalMode: String, Equatable {
     case mouseReporting = "mouse_reporting"
 }
 
+final class AlanTerminalModeTracker {
+    private var hasSeenScrollableNormalBuffer = false
+
+    func reset() {
+        hasSeenScrollableNormalBuffer = false
+    }
+
+    func resolveMode(totalRows: Int, visibleRows: Int, mouseCaptured: Bool) -> AlanTerminalMode {
+        if mouseCaptured {
+            return .mouseReporting
+        }
+
+        let hasScrollableRows = max(0, totalRows) > max(0, visibleRows)
+        if hasScrollableRows {
+            hasSeenScrollableNormalBuffer = true
+            return .normalBuffer
+        }
+
+        if hasSeenScrollableNormalBuffer {
+            return .alternateScreen
+        }
+
+        return .normalBuffer
+    }
+}
+
 struct AlanTerminalScrollbackMetrics: Equatable {
     let totalRows: Int
     let visibleRows: Int

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -110,6 +110,7 @@ final class AlanTerminalSystemPasteboardWriter: AlanTerminalPasteboardWriting {
 
 @MainActor
 final class AlanTerminalScrollbackAdapter {
+    private var preciseScrollRemainder = 0.0
     private(set) var state = AlanTerminalScrollbackState.empty
 
     @discardableResult
@@ -129,6 +130,9 @@ final class AlanTerminalScrollbackAdapter {
             nativeScrollbarVisible: hasScrollableNormalBuffer,
             thumbRange: firstVisibleRow..<(firstVisibleRow + visibleRows)
         )
+        if !hasScrollableNormalBuffer {
+            preciseScrollRemainder = 0
+        }
         return state
     }
 
@@ -144,18 +148,56 @@ final class AlanTerminalScrollbackAdapter {
         )
     }
 
-    func targetFirstVisibleRow(for input: AlanTerminalScrollInput) -> Int? {
-        guard state.nativeScrollbarVisible else { return nil }
-        guard abs(input.deltaY) >= abs(input.deltaX) else { return nil }
-        let rowDelta = Int((-input.deltaY).rounded(.toNearestOrAwayFromZero))
+    func shouldConsumeNativeScrollInput(_ input: AlanTerminalScrollInput) -> Bool {
+        guard state.nativeScrollbarVisible else { return false }
+        guard abs(input.deltaY) >= abs(input.deltaX) else { return false }
+        return input.deltaY != 0 || preciseScrollRemainder != 0
+    }
+
+    func resetPreciseScrollAccumulator() {
+        preciseScrollRemainder = 0
+    }
+
+    func targetFirstVisibleRow(for input: AlanTerminalScrollInput, rowHeight: CGFloat = 1) -> Int? {
+        guard shouldConsumeNativeScrollInput(input) else { return nil }
+        let rowDelta: Int
+        if input.precise {
+            let rows = (-input.deltaY / max(Double(rowHeight), 1)) + preciseScrollRemainder
+            rowDelta = Int(rows.rounded(.towardZero))
+            preciseScrollRemainder = rows - Double(rowDelta)
+        } else {
+            preciseScrollRemainder = 0
+            rowDelta = Int((-input.deltaY).rounded(.toNearestOrAwayFromZero))
+        }
         guard rowDelta != 0 else { return nil }
         let maxFirstVisibleRow = max(state.metrics.totalRows - state.metrics.visibleRows, 0)
-        return max(0, min(state.metrics.firstVisibleRow + rowDelta, maxFirstVisibleRow))
+        let targetRow = max(0, min(state.metrics.firstVisibleRow + rowDelta, maxFirstVisibleRow))
+        guard targetRow != state.metrics.firstVisibleRow else {
+            preciseScrollRemainder = 0
+            return nil
+        }
+        return targetRow
     }
 
     func shouldForwardScrollToTerminal() -> Bool {
         state.metrics.mode == .alternateScreen || state.metrics.mode == .mouseReporting
     }
+}
+
+enum AlanTerminalRoutedMouseEvent: Equatable {
+    case mouseDown
+    case mouseUp
+    case rightMouseDown
+    case rightMouseUp
+    case otherMouseDown
+    case otherMouseUp
+    case mouseEntered
+    case mouseMoved
+    case mouseDragged
+    case rightMouseDragged
+    case otherMouseDragged
+    case mouseExited
+    case pressureChange
 }
 
 @MainActor
@@ -165,6 +207,11 @@ final class AlanTerminalNativeScrollViewAdapter {
     var onScrollWheel: ((NSEvent) -> Bool)? {
         didSet {
             scrollView.onScrollWheel = onScrollWheel
+        }
+    }
+    var onMouseEvent: ((AlanTerminalRoutedMouseEvent, NSEvent) -> Bool)? {
+        didSet {
+            scrollView.onMouseEvent = onMouseEvent
         }
     }
 
@@ -281,14 +328,110 @@ final class AlanTerminalNativeScrollViewAdapter {
 @MainActor
 final class AlanTerminalRoutingScrollView: NSScrollView {
     var onScrollWheel: ((NSEvent) -> Bool)?
+    var onMouseEvent: ((AlanTerminalRoutedMouseEvent, NSEvent) -> Bool)?
 
     override var mouseDownCanMoveWindow: Bool { false }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if onMouseEvent?(.mouseDown, event) == true {
+            return
+        }
+        super.mouseDown(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if onMouseEvent?(.mouseUp, event) == true {
+            return
+        }
+        super.mouseUp(with: event)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        if onMouseEvent?(.rightMouseDown, event) == true {
+            return
+        }
+        super.rightMouseDown(with: event)
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        if onMouseEvent?(.rightMouseUp, event) == true {
+            return
+        }
+        super.rightMouseUp(with: event)
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        if onMouseEvent?(.otherMouseDown, event) == true {
+            return
+        }
+        super.otherMouseDown(with: event)
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        if onMouseEvent?(.otherMouseUp, event) == true {
+            return
+        }
+        super.otherMouseUp(with: event)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        if onMouseEvent?(.mouseEntered, event) == true {
+            return
+        }
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        if onMouseEvent?(.mouseMoved, event) == true {
+            return
+        }
+        super.mouseMoved(with: event)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        if onMouseEvent?(.mouseDragged, event) == true {
+            return
+        }
+        super.mouseDragged(with: event)
+    }
+
+    override func rightMouseDragged(with event: NSEvent) {
+        if onMouseEvent?(.rightMouseDragged, event) == true {
+            return
+        }
+        super.rightMouseDragged(with: event)
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        if onMouseEvent?(.otherMouseDragged, event) == true {
+            return
+        }
+        super.otherMouseDragged(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if onMouseEvent?(.mouseExited, event) == true {
+            return
+        }
+        super.mouseExited(with: event)
+    }
 
     override func scrollWheel(with event: NSEvent) {
         if onScrollWheel?(event) == true {
             return
         }
         super.scrollWheel(with: event)
+    }
+
+    override func pressureChange(with event: NSEvent) {
+        if onMouseEvent?(.pressureChange, event) == true {
+            return
+        }
+        super.pressureChange(with: event)
     }
 }
 
@@ -639,6 +782,7 @@ final class AlanTerminalSurfaceController {
     private var latestMetadata = TerminalPaneMetadataSnapshot.placeholder
     private var readonly = false
     private var secureInput = false
+    private var nativeScrollRowHeight: CGFloat = 1
 
     init() {
         nativeScrollViewAdapter.onVisibleRowChange = { [weak self] row in
@@ -804,19 +948,25 @@ final class AlanTerminalSurfaceController {
     func syncNativeScrollView(viewportSize: CGSize) {
         let visibleRows = max(scrollbackAdapter.state.metrics.visibleRows, 1)
         let rowHeight = viewportSize.height / CGFloat(visibleRows)
+        nativeScrollRowHeight = max(rowHeight, 1)
         nativeScrollViewAdapter.sync(
             state: scrollbackAdapter.state,
             viewportSize: viewportSize,
-            rowHeight: rowHeight
+            rowHeight: nativeScrollRowHeight
         )
     }
 
     func routeScroll(_ input: AlanTerminalScrollInput) -> AlanTerminalScrollRoutingDecision {
         guard isSurfaceReady else { return .ignored }
         guard !scrollbackAdapter.shouldForwardScrollToTerminal() else { return .terminalScroll }
-        guard let row = scrollbackAdapter.targetFirstVisibleRow(for: input) else {
+        guard scrollbackAdapter.shouldConsumeNativeScrollInput(input) else {
+            scrollbackAdapter.resetPreciseScrollAccumulator()
             return .terminalScroll
         }
+        guard let row = scrollbackAdapter.targetFirstVisibleRow(
+            for: input,
+            rowHeight: nativeScrollRowHeight
+        ) else { return .ignored }
         guard scrollToNativeRow(row) else { return .terminalScroll }
         return .nativeScroll(row: row)
     }

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -114,6 +114,13 @@ final class AlanTerminalScrollbackAdapter {
     private(set) var state = AlanTerminalScrollbackState.empty
 
     @discardableResult
+    func reset() -> AlanTerminalScrollbackState {
+        state = .empty
+        preciseScrollRemainder = 0
+        return state
+    }
+
+    @discardableResult
     func updateMetrics(_ metrics: AlanTerminalScrollbackMetrics) -> AlanTerminalScrollbackState {
         let totalRows = max(0, metrics.totalRows)
         let visibleRows = max(0, min(metrics.visibleRows, totalRows))
@@ -810,7 +817,8 @@ final class AlanTerminalSurfaceController {
     }
 
     func bind(surfaceHandle: AlanTerminalSurfaceHandle?, paneID: String?) {
-        if self.surfaceHandle !== surfaceHandle {
+        let surfaceChanged = self.surfaceHandle !== surfaceHandle
+        if surfaceChanged {
             self.surfaceHandle?.detach()
             self.surfaceHandle = surfaceHandle
         }
@@ -826,9 +834,12 @@ final class AlanTerminalSurfaceController {
         if scrollbackEngine !== nextScrollbackEngine {
             scrollbackEngine?.setScrollbackUpdateHandler(nil)
             scrollbackEngine = nextScrollbackEngine
+            resetPerSurfaceStateForSurfaceChange()
             scrollbackEngine?.setScrollbackUpdateHandler { [weak self] metrics in
                 self?.applyScrollbackMetrics(metrics)
             }
+        } else if surfaceChanged {
+            resetPerSurfaceStateForSurfaceChange()
         }
         selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine
         clipboardAdapter.updateSurfaceHandle(surfaceHandle)
@@ -871,6 +882,7 @@ final class AlanTerminalSurfaceController {
         scrollbackEngine?.setScrollbackUpdateHandler(nil)
         scrollbackEngine = nil
         selectionEngine = nil
+        resetPerSurfaceStateForSurfaceChange()
         clipboardAdapter.updateSurfaceHandle(nil)
     }
 
@@ -1065,6 +1077,28 @@ final class AlanTerminalSurfaceController {
     private func applyScrollbackMetrics(_ metrics: AlanTerminalScrollbackMetrics) {
         scrollbackAdapter.updateMetrics(metrics)
         notifySurfaceStateChanged()
+    }
+
+    private func resetPerSurfaceStateForSurfaceChange() {
+        let previousState = scrollbackAdapter.state
+        let previousRenderer = latestRenderer
+        let previousMetadata = latestMetadata
+        let previousReadonly = readonly
+        let previousSecureInput = secureInput
+        scrollbackAdapter.reset()
+        nativeScrollRowHeight = 1
+        latestRenderer = .placeholder
+        latestMetadata = .placeholder
+        readonly = false
+        secureInput = false
+        if previousState != .empty
+            || previousRenderer != .placeholder
+            || previousMetadata != .placeholder
+            || previousReadonly
+            || previousSecureInput
+        {
+            notifySurfaceStateChanged()
+        }
     }
 
     private func notifySearchStateChanged() {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -87,6 +87,16 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "final class AlanTerminalNativeScrollViewAdapter" \
+    "terminal scrollback must have an AppKit scroll view adapter"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "protocol AlanTerminalScrollbackEngine" \
+    "terminal scrollback must delegate native row scrolls to a surface engine"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
     "final class AlanTerminalSearchAdapter" \
     "terminal search state must be pane scoped and adapter-owned"
 
@@ -99,6 +109,16 @@ require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.swift" \
     "verifiesSearchActionsReachSurfaceEngine" \
     "surface controller tests must prove search actions reach the surface engine"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-surface-controller.swift" \
+    "verifiesScrollbackActionsReachSurfaceEngine" \
+    "surface controller tests must prove scrollback actions reach the surface engine"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-surface-controller.swift" \
+    "verifiesSelectionCopyAndPasteUseController" \
+    "surface controller tests must prove copy and paste use controller-owned clipboard paths"
 
 require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.sh" \

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -17,6 +17,7 @@ private enum TerminalSurfaceControllerTests {
     static func run() {
         verifiesScrollbackMetricsAndTerminalModes()
         verifiesModeTrackerPreservesTerminalScrollRouting()
+        verifiesNativeScrollViewForwardsWheelEvents()
         verifiesInputCommandRouting()
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
@@ -99,6 +100,19 @@ private enum TerminalSurfaceControllerTests {
             mouseCaptured: false
         )
         expect(resetMode == .normalBuffer, "new surfaces must not inherit prior alternate-screen state")
+    }
+
+    private static func verifiesNativeScrollViewForwardsWheelEvents() {
+        let adapter = AlanTerminalNativeScrollViewAdapter()
+        var routedDeltaY: Double?
+        adapter.onScrollWheel = { event in
+            routedDeltaY = event.scrollingDeltaY
+            return true
+        }
+
+        let event = RecordingTerminalScrollWheelEvent(deltaX: 0, deltaY: -7)
+        adapter.scrollView.scrollWheel(with: event)
+        expect(routedDeltaY == -7, "native scroll view must forward wheel events to terminal routing")
     }
 
     private static func verifiesInputCommandRouting() {
@@ -385,5 +399,25 @@ private final class RecordingTerminalPasteboardWriter: AlanTerminalPasteboardWri
         string = text
         return true
     }
+}
+
+private final class RecordingTerminalScrollWheelEvent: NSEvent {
+    private let recordedDeltaX: CGFloat
+    private let recordedDeltaY: CGFloat
+
+    init(deltaX: CGFloat, deltaY: CGFloat) {
+        recordedDeltaX = deltaX
+        recordedDeltaY = deltaY
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override var scrollingDeltaX: CGFloat { recordedDeltaX }
+    override var scrollingDeltaY: CGFloat { recordedDeltaY }
+    override var hasPreciseScrollingDeltas: Bool { true }
+    override var momentumPhase: NSEvent.Phase { [] }
 }
 #endif

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import AppKit
 
 #if os(macOS)
 @main
@@ -18,8 +19,10 @@ private enum TerminalSurfaceControllerTests {
         verifiesInputCommandRouting()
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
+        verifiesScrollbackActionsReachSurfaceEngine()
         verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
         verifiesClipboardDeliveryStates()
+        verifiesSelectionCopyAndPasteUseController()
         verifiesMetadataOverlayProjection()
         print("Terminal surface controller tests passed.")
     }
@@ -150,6 +153,60 @@ private enum TerminalSurfaceControllerTests {
         )
     }
 
+    private static func verifiesScrollbackActionsReachSurfaceEngine() {
+        let handle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        let controller = AlanTerminalSurfaceController()
+        var stateChangeCount = 0
+        controller.onSurfaceStateChange = {
+            stateChangeCount += 1
+        }
+        controller.bind(surfaceHandle: handle, paneID: "pane_1")
+
+        handle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 220,
+                visibleRows: 40,
+                firstVisibleRow: 120,
+                mode: .normalBuffer
+            )
+        )
+
+        expect(controller.scrollbackAdapter.state.nativeScrollbarVisible, "Ghostty scrollbar updates must expose native scrollbar state")
+        expect(
+            controller.scrollbackAdapter.state.thumbRange == 120..<160,
+            "Ghostty scrollbar updates must set the visible terminal row range"
+        )
+        expect(stateChangeCount == 1, "scrollbar updates must notify host UI/runtime refresh")
+
+        let normalRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+        )
+        expect(
+            normalRoute == .nativeScroll(row: 128),
+            "normal-buffer scroll input must become a native row scroll"
+        )
+        expect(
+            handle.scrollActions == ["scroll_to_row:128"],
+            "native row scroll must reach the terminal surface"
+        )
+
+        handle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 220,
+                visibleRows: 40,
+                firstVisibleRow: 120,
+                mode: .alternateScreen
+            )
+        )
+        let alternateRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+        )
+        expect(
+            alternateRoute == .terminalScroll,
+            "alternate-screen scroll input must stay routed to the terminal app"
+        )
+    }
+
     private static func verifiesSurfaceSnapshotEqualityIgnoresTimestamp() {
         let older = AlanTerminalSurfaceStateSnapshot.placeholder
         let newer = AlanTerminalSurfaceStateSnapshot(
@@ -182,6 +239,35 @@ private enum TerminalSurfaceControllerTests {
         let rejected = clipboard.paste("again")
         expect(rejected.applied == false, "closed paste must not report success")
         expect(rejected.errorCode == "terminal_clipboard_unavailable", "closed paste must use a stable clipboard error")
+    }
+
+    private static func verifiesSelectionCopyAndPasteUseController() {
+        let handle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        handle.selectedText = "selected terminal text"
+        let controller = AlanTerminalSurfaceController()
+        controller.bind(surfaceHandle: handle, paneID: "pane_1")
+
+        let pasteboard = RecordingTerminalPasteboardWriter()
+        expect(
+            controller.copySelection(to: pasteboard),
+            "controller copy must write selected terminal text to the pasteboard"
+        )
+        expect(
+            pasteboard.string == "selected terminal text",
+            "copied terminal selection must be available as pasteboard text"
+        )
+
+        let pasteResult = controller.paste("pasted text")
+        expect(pasteResult.applied, "controller paste must use failure-aware delivery")
+        expect(handle.deliveredText.last == "pasted text", "controller paste must reach the surface handle")
+
+        _ = handle.teardown()
+        let rejected = controller.paste("after close")
+        expect(rejected.applied == false, "closed controller paste must not report success")
+        expect(
+            rejected.errorCode == "terminal_clipboard_unavailable",
+            "closed controller paste must use the stable clipboard error"
+        )
     }
 
     private static func verifiesMetadataOverlayProjection() {
@@ -225,6 +311,16 @@ private enum TerminalSurfaceControllerTests {
             fputs("error: \(message)\n", stderr)
             exit(1)
         }
+    }
+}
+
+@MainActor
+private final class RecordingTerminalPasteboardWriter: AlanTerminalPasteboardWriting {
+    private(set) var string: String?
+
+    func writeString(_ text: String) -> Bool {
+        string = text
+        return true
     }
 }
 #endif

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -23,6 +23,7 @@ private enum TerminalSurfaceControllerTests {
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
         verifiesScrollbackActionsReachSurfaceEngine()
+        verifiesBindClearsStaleScrollbackState()
         verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
         verifiesClipboardDeliveryStates()
         verifiesSelectionCopyAndPasteUseController()
@@ -320,6 +321,86 @@ private enum TerminalSurfaceControllerTests {
         expect(
             mouseReportingRoute == .terminalScroll,
             "terminal mouse-reporting scroll input must stay routed to the terminal app"
+        )
+    }
+
+    private static func verifiesBindClearsStaleScrollbackState() {
+        let firstHandle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        let secondHandle = FakeAlanTerminalSurfaceHandle(paneID: "pane_2")
+        let controller = AlanTerminalSurfaceController()
+        var stateChangeCount = 0
+        controller.onSurfaceStateChange = {
+            stateChangeCount += 1
+        }
+        controller.bind(surfaceHandle: firstHandle, paneID: "pane_1")
+        firstHandle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 220,
+                visibleRows: 40,
+                firstVisibleRow: 120,
+                mode: .normalBuffer
+            )
+        )
+
+        expect(controller.scrollbackAdapter.state.nativeScrollbarVisible, "first surface must expose scrollback")
+        expect(stateChangeCount == 1, "first surface scrollback update must notify once")
+        controller.updateMetadata(
+            TerminalPaneMetadataSnapshot(
+                title: "old pane",
+                workingDirectory: "/tmp/old",
+                summary: "exited",
+                attention: .idle,
+                processExited: true,
+                lastCommandExitCode: 1,
+                lastUpdatedAt: .now
+            )
+        )
+        controller.updateRenderer(
+            TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .failed,
+                summary: "old renderer failed",
+                detail: nil,
+                failureReason: "old surface failed",
+                recentEvents: []
+            )
+        )
+
+        controller.bind(surfaceHandle: secondHandle, paneID: "pane_2")
+        expect(
+            controller.scrollbackAdapter.state == .empty,
+            "rebinding to a new surface must clear stale scrollback"
+        )
+        expect(stateChangeCount == 2, "clearing stale scrollback must notify host UI refresh")
+
+        let staleRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: false)
+        )
+        expect(
+            staleRoute == .terminalScroll,
+            "new surfaces without scrollback metrics must not issue stale native row scrolls"
+        )
+        expect(secondHandle.scrollActions.isEmpty, "stale scrollback must not reach the new surface")
+
+        firstHandle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 400,
+                visibleRows: 50,
+                firstVisibleRow: 200,
+                mode: .normalBuffer
+            )
+        )
+        expect(
+            controller.scrollbackAdapter.state == .empty,
+            "old surface scrollback callbacks must be detached after rebind"
+        )
+        expect(
+            controller.surfaceStateSnapshot.childExited == false,
+            "rebinding to a new surface must clear stale child-exit metadata"
+        )
+        expect(
+            controller.surfaceStateSnapshot.rendererHealth != "failed",
+            "rebinding to a new surface must clear stale renderer failure state"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -16,6 +16,7 @@ struct TerminalSurfaceControllerTestRunner {
 private enum TerminalSurfaceControllerTests {
     static func run() {
         verifiesScrollbackMetricsAndTerminalModes()
+        verifiesModeTrackerPreservesTerminalScrollRouting()
         verifiesInputCommandRouting()
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
@@ -51,7 +52,53 @@ private enum TerminalSurfaceControllerTests {
             )
         )
 
-        expect(alternate.nativeScrollbarVisible == false, "alternate-screen scrollback must not expose stale normal-buffer scrollbar")
+        expect(
+            alternate.nativeScrollbarVisible == false,
+            "alternate-screen scrollback must not expose stale normal-buffer scrollbar"
+        )
+    }
+
+    private static func verifiesModeTrackerPreservesTerminalScrollRouting() {
+        let tracker = AlanTerminalModeTracker()
+
+        let initialMode = tracker.resolveMode(
+            totalRows: 40,
+            visibleRows: 40,
+            mouseCaptured: false
+        )
+        expect(initialMode == .normalBuffer, "initial unscrollable terminal state must stay normal")
+
+        let scrollbackMode = tracker.resolveMode(
+            totalRows: 220,
+            visibleRows: 40,
+            mouseCaptured: false
+        )
+        expect(scrollbackMode == .normalBuffer, "scrollable primary screen must use normal mode")
+
+        let alternateMode = tracker.resolveMode(
+            totalRows: 40,
+            visibleRows: 40,
+            mouseCaptured: false
+        )
+        expect(
+            alternateMode == .alternateScreen,
+            "collapsed scrollbar after scrollback must preserve alternate-screen terminal routing"
+        )
+
+        let mouseMode = tracker.resolveMode(
+            totalRows: 220,
+            visibleRows: 40,
+            mouseCaptured: true
+        )
+        expect(mouseMode == .mouseReporting, "mouse-captured surfaces must route scroll to terminal")
+
+        tracker.reset()
+        let resetMode = tracker.resolveMode(
+            totalRows: 40,
+            visibleRows: 40,
+            mouseCaptured: false
+        )
+        expect(resetMode == .normalBuffer, "new surfaces must not inherit prior alternate-screen state")
     }
 
     private static func verifiesInputCommandRouting() {
@@ -204,6 +251,22 @@ private enum TerminalSurfaceControllerTests {
         expect(
             alternateRoute == .terminalScroll,
             "alternate-screen scroll input must stay routed to the terminal app"
+        )
+
+        handle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 220,
+                visibleRows: 40,
+                firstVisibleRow: 120,
+                mode: .mouseReporting
+            )
+        )
+        let mouseReportingRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+        )
+        expect(
+            mouseReportingRoute == .terminalScroll,
+            "terminal mouse-reporting scroll input must stay routed to the terminal app"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -18,6 +18,7 @@ private enum TerminalSurfaceControllerTests {
         verifiesScrollbackMetricsAndTerminalModes()
         verifiesModeTrackerPreservesTerminalScrollRouting()
         verifiesNativeScrollViewForwardsWheelEvents()
+        verifiesNativeScrollViewForwardsMouseEvents()
         verifiesInputCommandRouting()
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
@@ -113,6 +114,24 @@ private enum TerminalSurfaceControllerTests {
         let event = RecordingTerminalScrollWheelEvent(deltaX: 0, deltaY: -7)
         adapter.scrollView.scrollWheel(with: event)
         expect(routedDeltaY == -7, "native scroll view must forward wheel events to terminal routing")
+    }
+
+    private static func verifiesNativeScrollViewForwardsMouseEvents() {
+        let adapter = AlanTerminalNativeScrollViewAdapter()
+        var routedEvents: [AlanTerminalRoutedMouseEvent] = []
+        adapter.onMouseEvent = { routedEvent, _ in
+            routedEvents.append(routedEvent)
+            return true
+        }
+
+        let event = RecordingTerminalMouseEvent()
+        adapter.scrollView.mouseDown(with: event)
+        adapter.scrollView.mouseDragged(with: event)
+        adapter.scrollView.mouseUp(with: event)
+        expect(
+            routedEvents == [.mouseDown, .mouseDragged, .mouseUp],
+            "native scroll view must forward mouse events to terminal routing"
+        )
     }
 
     private static func verifiesInputCommandRouting() {
@@ -240,15 +259,35 @@ private enum TerminalSurfaceControllerTests {
         expect(stateChangeCount == 1, "scrollbar updates must notify host UI/runtime refresh")
 
         let normalRoute = controller.routeScroll(
-            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: false)
         )
         expect(
             normalRoute == .nativeScroll(row: 128),
-            "normal-buffer scroll input must become a native row scroll"
+            "normal-buffer non-precise scroll input must become a native row scroll"
         )
         expect(
             handle.scrollActions == ["scroll_to_row:128"],
             "native row scroll must reach the terminal surface"
+        )
+
+        controller.syncNativeScrollView(viewportSize: CGSize(width: 800, height: 640))
+        let firstPreciseRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+        )
+        expect(
+            firstPreciseRoute == .ignored,
+            "sub-row precise scroll input must be consumed while accumulating native row movement"
+        )
+        let secondPreciseRoute = controller.routeScroll(
+            AlanTerminalScrollInput(deltaX: 0, deltaY: -8, precise: true)
+        )
+        expect(
+            secondPreciseRoute == .nativeScroll(row: 129),
+            "precise scroll input must scale point deltas by row height before native row scroll"
+        )
+        expect(
+            handle.scrollActions.suffix(1) == ["scroll_to_row:129"],
+            "accumulated precise scroll must move by one row at a 16-point row height"
         )
 
         handle.emitScrollbackUpdate(
@@ -419,5 +458,15 @@ private final class RecordingTerminalScrollWheelEvent: NSEvent {
     override var scrollingDeltaY: CGFloat { recordedDeltaY }
     override var hasPreciseScrollingDeltas: Bool { true }
     override var momentumPhase: NSEvent.Phase { [] }
+}
+
+private final class RecordingTerminalMouseEvent: NSEvent {
+    override init() {
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
 }
 #endif

--- a/openspec/changes/complete-macos-terminal-surface/design.md
+++ b/openspec/changes/complete-macos-terminal-surface/design.md
@@ -126,15 +126,35 @@ surface adapter after runtime ownership is moved behind a stable service.
 - Added control-plane delivery rejection for child-exit and renderer-failure
   states so remote text delivery does not report false success.
 
+### 2026-05-06 Native Scroll And Clipboard Pass
+
+- Added `AlanTerminalNativeScrollViewAdapter`, modeled after Ghostty's
+  `SurfaceScrollView` shape: an `NSScrollView` owns native scrollbar behavior
+  while the terminal canvas remains the visible renderer.
+- Wired Ghostty `GHOSTTY_ACTION_SCROLLBAR` callbacks into pane-scoped
+  `AlanTerminalScrollbackMetrics`, and route normal-buffer native scrolls back
+  to Ghostty with `scroll_to_row:<row>`.
+- Kept alternate-screen and terminal mouse-reporting scroll input routed to the
+  terminal surface instead of exposing stale normal-buffer scrollbar state.
+- Added controller-owned copy and paste paths. Copy reads terminal selection
+  through a selection engine and writes through a pasteboard writer seam; paste
+  uses the existing failure-aware surface delivery path so closed or not-ready
+  panes do not report success.
+- Added focused fake-surface tests for scrollback callback routing, native row
+  scroll action dispatch, alternate-screen scroll routing, selection copy, and
+  paste non-delivery.
+
 Remaining unsupported Ghostty parity after this pass:
 
-- There is no AppKit `NSScrollView` bridge yet; scrollback metrics are modeled
-  and tested, but live scrollbar synchronization is not wired to Ghostty.
 - Alternate-screen and application mouse-mode detection are not yet sourced from
-  live Ghostty callbacks; scroll/mouse events are centralized but still forward
-  through the existing Ghostty event API.
-- Selection and paste continue to use the existing Ghostty text forwarding path;
-  bracketed-paste-aware delivery is not exposed separately yet.
+  live Ghostty callbacks; the controller honors the modeled mode, but production
+  mode updates still need a Ghostty callback source.
+- Primary, secondary, other-button, drag, movement, hover, and pressure events
+  are still forwarded through the existing Ghostty event API; a fuller mouse
+  adapter pass remains.
+- Paste uses the service-owned control-text delivery path, which Ghostty treats
+  as paste-like input, but a dedicated bracketed-paste API is not exposed
+  separately yet.
 - URL hover, secure input, and terminal application mode diagnostics remain
   placeholders until the needed Ghostty surface callbacks are available.
 

--- a/openspec/changes/complete-macos-terminal-surface/tasks.md
+++ b/openspec/changes/complete-macos-terminal-surface/tasks.md
@@ -7,8 +7,8 @@
 
 ## 2. Scrollback And Rendering State
 
-- [ ] 2.1 Add an AppKit scroll view adapter for terminal scrollback and native scrollbar synchronization.
-- [ ] 2.2 Handle alternate-screen and terminal mouse-mode interactions with scroll input.
+- [x] 2.1 Add an AppKit scroll view adapter for terminal scrollback and native scrollbar synchronization.
+- [x] 2.2 Handle alternate-screen and terminal mouse-mode interactions with scroll input.
 - [ ] 2.3 Project renderer health, input readiness, readonly state, and child-exit state into pane metadata.
 - [x] 2.4 Add truthful fallback UI for renderer failure, missing surface, input-not-ready, and child-exit states.
 
@@ -16,7 +16,7 @@
 
 - [x] 3.1 Normalize keyDown, keyUp, flagsChanged, performKeyEquivalent, marked text, preedit, commit, and cancellation paths.
 - [ ] 3.2 Normalize primary, secondary, other-button, drag, movement, hover, pressure, and scroll events against terminal mouse modes.
-- [ ] 3.3 Implement native selection, copy, paste, bracketed-paste-aware delivery when available, and paste failure reporting.
+- [x] 3.3 Implement native selection, copy, paste, bracketed-paste-aware delivery when available, and paste failure reporting.
 - [x] 3.4 Add pane-scoped terminal search with find, next, previous, match status, and dismissal behavior.
 - [x] 3.5 Add compact user-facing terminal overlays while keeping raw surface diagnostics in the inspector debug layer.
 


### PR DESCRIPTION
## Summary
- Adds an AppKit NSScrollView-backed terminal scrollback adapter and routes Ghostty scrollbar callbacks into AlanTerminalScrollbackMetrics.
- Routes normal-buffer scrolls to Ghostty row scroll actions while preserving alternate-screen and terminal mouse-mode scroll forwarding.
- Moves selection copy and paste through controller-owned, failure-aware clipboard paths with fake-surface coverage.

## OpenSpec
- complete-macos-terminal-surface: completed tasks 2.1, 2.2, and 3.3 in this slice.
- Remaining tasks stay pending for follow-up stacked PRs: metadata projection/status, full pointer mouse normalization, broader manual matrix, spec sync, and archive.

## Verification
- clients/apple/scripts/test-terminal-surface-controller.sh
- clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate complete-macos-terminal-surface --type change --strict --json
- git diff --check
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
- Manual smoke: launched Alan.app, ran seq 1 80, verified native scrollback top/bottom rendering without blank canvas.