### PR TITLE
Propose Alan Remote Workspace MVP

### DIFF
--- a/openspec/changes/add-remote-workspace-mvp/.openspec.yaml
+++ b/openspec/changes/add-remote-workspace-mvp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/add-remote-workspace-mvp/design.md
+++ b/openspec/changes/add-remote-workspace-mvp/design.md
@@ -1,0 +1,171 @@
+## Context
+
+The current remote-control architecture already separates Agent Node, Relay,
+and Remote Client responsibilities. It also has a relay MVP, node routing
+metadata, sticky session-to-node binding, reconnect snapshots, and scoped
+remote-control checks. That foundation is intentionally technical: operators
+enable relay mode with environment variables, pass node IDs and tokens, and
+clients address relay nodes directly.
+
+Alan Remote Workspace changes the product boundary. The user should experience
+their Mac as an available Alan device that can continue work from iPhone. The
+system can still use an outbound relay under the hood, but the product must not
+ask the user to understand tunnels, daemon URLs, VPNs, public IPs, SSH, router
+configuration, or port forwarding.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a signed-in Alan Desktop automatically become remotely reachable from
+  the user's own iPhone without inbound network exposure.
+- Let the iPhone app discover the user's online Macs and connect to a selected
+  workspace/session using the same Alan account.
+- Preserve Mac-authoritative runtime execution, tool execution, governance,
+  session state, and event ordering.
+- Support realtime message submission, streamed output, interrupt, yield
+  resume, and reconnect recovery over the remote path.
+- Bind remote access to account identity, device identity, scoped short-lived
+  credentials, revocation, and encrypted transport.
+- Keep existing direct/relay architecture as the lower-level transport
+  foundation while replacing operator-facing setup with product-managed
+  enrollment and presence.
+
+**Non-Goals:**
+
+- Remote desktop, screen sharing, terminal screen mirroring, or arbitrary
+  desktop control.
+- P2P hole punching, LAN discovery, router configuration, user-managed VPNs,
+  SSH setup, or Cloudflare-style user-managed tunnels.
+- Multi-user collaboration or shared workspaces.
+- Complex enterprise networking, MDM, organization policy, or delegated
+  account administration.
+- Moving agent execution, workspace reads, tool execution, or governance
+  authority to Alan Cloud.
+- Building a full push-notification system as a blocker for foreground iPhone
+  realtime use.
+
+## Decisions
+
+1. Use Alan Cloud as an account/device directory plus relay broker, not as a
+   runtime authority.
+
+   Alan Cloud owns user authentication, device enrollment, presence, relay
+   routing, short-lived token issuance, revocation, and audit metadata. It does
+   not execute tools, read local workspace files, decide governance outcomes,
+   author session events, or advance runtime state.
+
+   Alternative considered: expose `alan-agentd` directly from the Mac. That
+   conflicts with zero configuration and would require public IP, router, or
+   tunnel knowledge for many users.
+
+2. Treat the Mac as the authoritative execution device.
+
+   The Mac owns the local daemon/runtime, session store, workspace identity,
+   event ordering, reconnect snapshot, tool execution, and policy decisions.
+   Relay and iPhone requests are remote inputs to the Mac, not remote execution
+   contexts.
+
+   Alternative considered: proxy workspace state through Alan Cloud and allow
+   cloud-side execution for continuity. That would break the security and
+   product requirement that user tasks execute on the user's own device.
+
+3. Add product-managed device enrollment above the existing relay tunnel.
+
+   A signed-in Desktop creates or refreshes a stable local device identity,
+   stores device credentials in Keychain, requests short-lived relay tickets,
+   and starts the outbound relay connection automatically. The user sees
+   device availability, not relay configuration.
+
+   Alternative considered: continue using `ALAN_RELAY_URL`,
+   `ALAN_RELAY_NODE_ID`, and `ALAN_RELAY_NODE_TOKEN` as the primary path.
+   Those remain useful for development/operator modes but cannot be the MVP
+   product path.
+
+4. Model the user-facing surface as devices, workspaces, and sessions.
+
+   The iPhone app should list the user's online Macs and connectable
+   workspaces/sessions. It should not display relay node IDs, daemon base URLs,
+   tunnel status, or raw routing headers unless a debug surface is explicitly
+   opened.
+
+   Alternative considered: reuse the existing relay node list directly in the
+   mobile UI. That leaks implementation details and makes the product feel like
+   remote infrastructure instead of workspace continuation.
+
+5. Provide realtime relay subscriptions with cursor recovery.
+
+   Remote Workspace needs realtime streamed output while preserving
+   reconnect-safe recovery. The transport should support a realtime event
+   subscription through the relay path, and clients must still use node-authored
+   `events/read` and `reconnect_snapshot` after reconnect or gap detection.
+
+   Alternative considered: use high-frequency polling only. Polling is a useful
+   fallback, but it does not satisfy the product expectation of streamed output
+   and responsive interrupt/approval flows.
+
+6. Use device-bound, scoped, short-lived credentials.
+
+   Account login proves user identity. Device enrollment binds a Mac/iPhone app
+   installation to that account. Each remote connection uses short-lived access
+   tokens scoped to the account, device, target Mac, workspace/session, and
+   permitted operations. The Mac re-validates state-changing requests before
+   applying them.
+
+   Alternative considered: one long-lived bearer token per node. That matches
+   the current technical MVP but is too hard to revoke safely and too weak for
+   an account-driven consumer product.
+
+## Risks / Trade-offs
+
+- Relay compromise exposes routing metadata -> Keep relay non-authoritative,
+  issue short-lived scoped credentials, minimize stored metadata, and require
+  Mac-side revalidation for state-changing operations.
+- Mac goes offline during iPhone use -> Keep session state on the Mac, mark the
+  device offline/stale in presence, and allow the iPhone to show the last known
+  state without pretending execution can continue.
+- Realtime relay stream drops under mobile network churn -> Require cursor
+  recovery through `events/read` and `reconnect_snapshot`; never re-drive a turn
+  due to reconnect.
+- Device list becomes noisy or confusing -> Show only user-owned devices with
+  product labels, last activity, current workspace status, and clear offline
+  state; keep relay diagnostics debug-only.
+- Workspace path disclosure on mobile -> Show friendly workspace identity and
+  status by default; avoid exposing full local paths unless the Mac authorizes
+  that metadata for the signed-in user.
+- Existing environment-configured relay paths diverge from product-managed
+  remote workspace -> Keep environment configuration as development/operator
+  compatibility but make the account/device path the default in Desktop and
+  iPhone builds.
+
+## Migration Plan
+
+1. Add the OpenSpec requirements and GitHub tracking issue for Remote Workspace
+   MVP; mark the old architecture issue as superseded by this product contract.
+2. Introduce account/device data models and local device identity storage
+   without changing existing relay behavior.
+3. Implement Desktop device enrollment and automatic outbound relay connection
+   behind a feature flag or development cloud endpoint.
+4. Add Cloud device/presence/workspace directory endpoints and short-lived
+   relay ticket issuance.
+5. Add realtime relay event subscription while preserving polling fallback and
+   reconnect snapshot recovery.
+6. Update iPhone to use account device discovery and remote workspace/session
+   selection instead of manual daemon connection.
+7. Harden revocation, audit, and offline/reconnect behavior before making the
+   feature default.
+8. Keep rollback simple: Desktop can stop advertising remote availability and
+   iPhone can fall back to existing manual/local daemon connection paths during
+   development.
+
+## Open Questions
+
+- Which Alan account provider is authoritative for MVP login: Alan-hosted auth,
+  Sign in with Apple, GitHub, or an existing managed account surface?
+- Should remote event payloads be end-to-end encrypted between iPhone and Mac
+  in MVP, or is TLS plus node-authoritative execution acceptable for the first
+  product slice?
+- What is the minimum workspace metadata that iPhone may display without
+  exposing sensitive local paths?
+- Should APNs pending-approval notifications be included in this MVP or tracked
+  as a follow-up after foreground realtime remote workspace works?

--- a/openspec/changes/add-remote-workspace-mvp/issue-triage.md
+++ b/openspec/changes/add-remote-workspace-mvp/issue-triage.md
@@ -1,0 +1,65 @@
+## OpenSpec
+
+- Tracking issue: `#349`
+- Change: `add-remote-workspace-mvp`
+- Proposal: `openspec/changes/add-remote-workspace-mvp/proposal.md`
+- Design: `openspec/changes/add-remote-workspace-mvp/design.md`
+- Requirements:
+  - `openspec/changes/add-remote-workspace-mvp/specs/remote-workspace-access/spec.md`
+  - `openspec/changes/add-remote-workspace-mvp/specs/daemon-api-contract/spec.md`
+- Tasks: `openspec/changes/add-remote-workspace-mvp/tasks.md`
+
+## Summary
+
+Define and implement Alan Remote Workspace MVP: a signed-in Mac automatically
+becomes remotely connectable, and a signed-in iPhone using the same account can
+discover that Mac, choose a workspace/session, stream events, send messages,
+interrupt execution, resume pending yields, and recover after reconnect without
+requiring public IPs, router setup, VPNs, tunnels, SSH, daemon URLs, or port
+forwarding.
+
+The user-facing product framing is:
+
+> Your Alan is continuing work on another device.
+
+Not:
+
+> Remote desktop, LAN tunnel, or network configuration.
+
+## Scope
+
+- Account-bound Mac/iPhone device enrollment.
+- Automatic Desktop remote availability over outbound encrypted relay.
+- iPhone device/workspace/session discovery.
+- Realtime remote event streaming plus `events/read` and reconnect snapshot
+  recovery.
+- Remote message submit, interrupt, and yield resume.
+- Device-bound, scoped, short-lived credentials and revocation.
+- Mac-authoritative execution, workspace access, governance, and event
+  ordering.
+
+## Non-goals
+
+- Remote desktop or screen sharing.
+- P2P hole punching.
+- LAN discovery.
+- Multi-user collaboration.
+- Enterprise networking/MDM policy.
+- Cloud-side agent/tool execution.
+
+## Issue Cleanup
+
+- Close `#9` as superseded by `#349`, this OpenSpec-backed Remote Workspace MVP issue.
+  The lower-level Agent Node / Relay / Client architecture remains the
+  transport foundation, but this issue becomes the product contract.
+- Keep `#75` open as the iOS task-manager/product IA follow-up. It should
+  depend on this MVP rather than replace it.
+- Leave `#305` unchanged; it is unrelated to remote access.
+- Leave closed phase issues `#32`, `#33`, `#34`, and `#35` closed; their
+  completed direct/relay/multi-node/reliability work becomes prior foundation.
+
+## Verification
+
+- `openspec validate add-remote-workspace-mvp --type change --strict --json`
+- `openspec validate --all --strict --json`
+- `git diff --check`

--- a/openspec/changes/add-remote-workspace-mvp/proposal.md
+++ b/openspec/changes/add-remote-workspace-mvp/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Alan already has a technical remote-control foundation, but it still feels like
+an operator-configured relay/tunnel system. The MVP should turn that foundation
+into a product experience where a user opens Alan on their Mac, opens Alan on
+iPhone with the same account, and continues the Mac workspace without learning
+VPN, tunnels, public IPs, router configuration, SSH, or port forwarding.
+
+## What Changes
+
+- Add Alan Remote Workspace as an account-bound, zero-configuration remote
+  access experience for a user's own Mac and iPhone.
+- Have Alan Desktop automatically register and advertise the Mac as an online,
+  trusted execution device after account login.
+- Have Alan iPhone automatically discover the user's online Macs, connect to a
+  selected Mac, continue a workspace/session, stream events, send messages,
+  interrupt execution, resume pending yields, and recover after reconnect.
+- Introduce product-level device/workspace/session status instead of exposing
+  relay nodes, tunnel URLs, daemon URLs, public IPs, or router concepts.
+- Preserve the existing invariant that agent execution, tool execution,
+  governance checks, workspace access, and event ordering remain authoritative
+  on the user's Mac.
+- Add device binding, scoped authorization, revocation, and encrypted transport
+  requirements for remote workspace access.
+- Fold the current open remote-control architecture issue into this product
+  contract while keeping the iOS task-manager issue as a follow-up UI framing
+  track.
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-workspace-access`: Defines Alan account-bound device discovery,
+  automatic Mac availability, iPhone remote workspace continuation, realtime
+  control/event flow, reconnect recovery, and security boundaries for the MVP.
+
+### Modified Capabilities
+
+- `daemon-api-contract`: Extends relay/API endpoint metadata so remote
+  workspace clients can subscribe to realtime session events through the relay
+  path while preserving cursor replay and node-authoritative execution.
+
+## Impact
+
+- Alan Desktop/macOS account login, device enrollment, Keychain-backed device
+  credentials, and automatic outbound relay connection.
+- Alan iPhone account login, device/workspace discovery, connection selection,
+  realtime session view, message submission, interrupt, and yield resume.
+- Alan Cloud/App Server account, device registry, presence, relay broker, token
+  issuance, revocation, and audit surfaces.
+- Daemon/relay session event routing, reconnect snapshot usage, and endpoint
+  contract metadata for realtime remote workspace flows.
+- Existing GitHub issue tracking for remote access: close or supersede `#9`
+  with this OpenSpec-backed product issue; keep `#75` open as iOS IA follow-up
+  unless it is rewritten to depend on this change.

--- a/openspec/changes/add-remote-workspace-mvp/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-remote-workspace-mvp/specs/daemon-api-contract/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Relay Policy Metadata
+The daemon SHALL derive relay forwarding, realtime streaming support,
+WebSocket/subscription support, streaming exclusion, WebSocket exclusion,
+session binding extraction, and response URL rewriting from endpoint contract
+metadata.
+
+#### Scenario: relay forwarding allows only contract-approved endpoints
+- **WHEN** a relay request attempts to forward a daemon API path
+- **THEN** the relay layer allows forwarding only when the matched endpoint
+  metadata permits relay forwarding
+
+#### Scenario: relay realtime event subscriptions allow only contract-approved endpoints
+- **WHEN** a remote workspace client attempts to subscribe to realtime session
+  events through the relay path
+- **THEN** the relay layer allows the subscription only when the matched
+  endpoint metadata permits relay realtime event delivery
+- **AND** relay event delivery preserves node-authored event IDs and sequence
+  metadata
+
+#### Scenario: relay URL rewriting uses response URL metadata
+- **WHEN** a relayed session lifecycle response contains daemon-relative URL
+  fields
+- **THEN** the relay layer rewrites only the response fields identified by the
+  endpoint contract

--- a/openspec/changes/add-remote-workspace-mvp/specs/remote-workspace-access/spec.md
+++ b/openspec/changes/add-remote-workspace-mvp/specs/remote-workspace-access/spec.md
@@ -157,7 +157,7 @@ scoped short-lived authorization, and revocation.
 - **WHEN** iPhone connects to a Mac through Alan Remote Workspace
 - **THEN** the connection uses encrypted transport
 - **AND** access tokens are scoped to the signed-in account, client device,
-  target Mac device, and permitted operations
+  target Mac device, selected workspace/session, and permitted operations
 
 #### Scenario: Device is revoked
 - **WHEN** a user revokes a Mac or iPhone device

--- a/openspec/changes/add-remote-workspace-mvp/specs/remote-workspace-access/spec.md
+++ b/openspec/changes/add-remote-workspace-mvp/specs/remote-workspace-access/spec.md
@@ -1,0 +1,182 @@
+## ADDED Requirements
+
+### Requirement: Account-bound device enrollment
+Alan SHALL bind each remote-capable Mac and iPhone app installation to an Alan
+account and a stable device identity before allowing Remote Workspace access.
+
+#### Scenario: Mac enrolls after account login
+- **WHEN** a user signs in to Alan Desktop on macOS
+- **THEN** the Mac is registered as a device owned by that account
+- **AND** the Mac receives device-bound credentials suitable for remote
+  availability
+- **AND** those credentials are stored in the platform secure store rather than
+  in workspace files
+
+#### Scenario: iPhone signs in to the same account
+- **WHEN** a user signs in to Alan on iPhone with the same account as the Mac
+- **THEN** the iPhone is registered as a device owned by that account
+- **AND** the iPhone can request access only to devices associated with that
+  account
+
+### Requirement: Automatic Mac remote availability
+Alan Desktop SHALL automatically keep the signed-in Mac remotely connectable
+while the app is running and the user has not disabled Remote Workspace.
+
+#### Scenario: Desktop starts while signed in
+- **WHEN** Alan Desktop starts with a valid signed-in account and device binding
+- **THEN** it establishes an outbound encrypted connection to the Alan remote
+  service without requiring inbound network configuration
+- **AND** the user is not asked for public IP, router, VPN, tunnel, SSH, or port
+  forwarding settings
+
+#### Scenario: Desktop loses remote connectivity
+- **WHEN** the Mac loses network connectivity or its outbound remote connection
+  drops
+- **THEN** Alan Desktop retries connection in the background
+- **AND** Alan Cloud marks the device stale or offline without changing local
+  runtime state
+
+### Requirement: User-owned device discovery
+Alan SHALL let a signed-in iPhone discover the user's own online Alan Desktop
+devices without exposing relay or tunnel implementation details.
+
+#### Scenario: iPhone lists available Macs
+- **WHEN** the iPhone app requests Remote Workspace devices for the signed-in
+  account
+- **THEN** the response includes only devices owned by that account
+- **AND** each device includes product-facing status such as online/offline,
+  last seen, and connectability
+- **AND** the response does not require the iPhone user to provide a daemon URL,
+  public IP, tunnel URL, or relay node token
+
+#### Scenario: Device is offline
+- **WHEN** a previously enrolled Mac is not connected to Alan Cloud
+- **THEN** the iPhone may show the Mac as offline or unavailable
+- **AND** the iPhone MUST NOT offer state-advancing actions against that Mac
+  until it reconnects
+
+### Requirement: Workspace and agent status discovery
+Alan SHALL expose enough Mac-authored workspace and session status for iPhone
+users to choose what to continue remotely.
+
+#### Scenario: Mac publishes connectable workspace status
+- **WHEN** Alan Desktop is online
+- **THEN** it publishes connectable workspace status for the signed-in user
+- **AND** status includes whether a workspace is connectable and whether an
+  agent/session is currently active
+- **AND** the Mac remains the authority for workspace identity and session
+  liveness
+
+#### Scenario: iPhone chooses a workspace
+- **WHEN** the iPhone user selects an online Mac
+- **THEN** the iPhone can list or select the Mac-authored connectable
+  workspaces/sessions
+- **AND** the UI presents the action as continuing work on another Alan device
+  rather than connecting to infrastructure
+
+### Requirement: Remote session control
+Alan SHALL allow iPhone to continue a Mac workspace/session by sending normal
+Alan control operations to the Mac through the remote service.
+
+#### Scenario: iPhone sends a message
+- **WHEN** the iPhone user sends a message to a remote workspace/session
+- **THEN** the request is routed to the selected Mac
+- **AND** the Mac validates authorization and applies the operation through the
+  same session/runtime path used by local clients
+
+#### Scenario: iPhone interrupts an active run
+- **WHEN** the iPhone user interrupts a running remote session
+- **THEN** the interrupt is routed to the selected Mac
+- **AND** the Mac remains responsible for applying or rejecting the interrupt
+  according to runtime state
+
+#### Scenario: iPhone resumes a pending yield
+- **WHEN** a remote session is waiting for confirmation or structured input
+- **THEN** the iPhone can submit a resume response if its token has the required
+  resume scope
+- **AND** the Mac validates the pending request before advancing execution
+
+### Requirement: Realtime remote event flow
+Alan SHALL support realtime remote delivery of session events and streamed
+assistant output from the Mac to the iPhone.
+
+#### Scenario: Session streams output remotely
+- **WHEN** a Mac-authored remote session emits text, thinking, tool, warning,
+  error, yield, or turn-boundary events
+- **THEN** the iPhone receives those events in near real time over the remote
+  transport
+- **AND** event IDs, sequence, session IDs, submission IDs, turn IDs, and item
+  IDs remain authored by the Mac
+
+#### Scenario: Relay transports events
+- **WHEN** realtime events are delivered through Alan Cloud relay
+- **THEN** the relay forwards event transport without becoming the authority for
+  event ordering or runtime state
+- **AND** the iPhone can still recover missed events with the Mac-authored
+  cursor replay APIs
+
+### Requirement: Reconnect and gap recovery
+Alan SHALL recover remote iPhone sessions after app backgrounding, network
+changes, and relay reconnects without duplicating execution.
+
+#### Scenario: iPhone reconnects with a valid cursor
+- **WHEN** the iPhone reconnects with its latest observed event cursor
+- **THEN** Alan returns events after that cursor
+- **AND** runtime execution is not restarted or re-driven by reconnect
+
+#### Scenario: iPhone cursor has a gap
+- **WHEN** the iPhone reconnects after its cursor is no longer in the replay
+  buffer
+- **THEN** Alan returns a gap indication
+- **AND** the iPhone can rebuild actionable state from the reconnect snapshot
+  before continuing event consumption
+
+### Requirement: Node-authoritative execution boundary
+Alan SHALL keep remote workspace execution, tool access, governance, and local
+workspace reads authoritative on the user's Mac.
+
+#### Scenario: Cloud receives a state-changing remote request
+- **WHEN** Alan Cloud receives a request to submit, interrupt, resume, fork,
+  compact, roll back, or delete a remote session
+- **THEN** Alan Cloud routes the request to the selected Mac
+- **AND** Alan Cloud MUST NOT execute tools, read local workspace files, decide
+  policy outcomes, or mutate runtime state on behalf of the Mac
+
+#### Scenario: Mac rejects unauthorized request
+- **WHEN** a remote request lacks the required account, device, session, or
+  operation scope
+- **THEN** the Mac or Cloud rejects the request with a machine-readable
+  authorization error
+- **AND** no runtime state is advanced
+
+### Requirement: Remote access security and revocation
+Alan SHALL protect Remote Workspace with encrypted transport, device binding,
+scoped short-lived authorization, and revocation.
+
+#### Scenario: Remote connection is established
+- **WHEN** iPhone connects to a Mac through Alan Remote Workspace
+- **THEN** the connection uses encrypted transport
+- **AND** access tokens are scoped to the signed-in account, client device,
+  target Mac device, and permitted operations
+
+#### Scenario: Device is revoked
+- **WHEN** a user revokes a Mac or iPhone device
+- **THEN** Alan invalidates future remote access for that device
+- **AND** active remote connections using that device credential are closed or
+  rejected before additional state-changing operations are accepted
+
+### Requirement: Zero-configuration product language
+Alan SHALL present Remote Workspace as device-to-device workspace continuation,
+not as remote desktop or user-managed networking.
+
+#### Scenario: User opens Remote Workspace on iPhone
+- **WHEN** the iPhone user opens the remote workspace surface
+- **THEN** the primary UI language describes online Alan devices, workspaces,
+  sessions, runs, messages, and approvals
+- **AND** it does not require or foreground VPN, tunnel, Cloudflare, SSH, port
+  mapping, router configuration, public IP, or daemon URL concepts
+
+#### Scenario: Debug details are needed
+- **WHEN** a developer opens an explicit debug or diagnostics surface
+- **THEN** Alan may expose relay, node, routing, and connection diagnostics
+- **AND** those diagnostics remain outside the default user workflow

--- a/openspec/changes/add-remote-workspace-mvp/tasks.md
+++ b/openspec/changes/add-remote-workspace-mvp/tasks.md
@@ -1,0 +1,60 @@
+## 1. Tracking And Product Boundary
+
+- [x] 1.1 Create the GitHub tracking issue for `add-remote-workspace-mvp` and link it to this OpenSpec change.
+- [x] 1.2 Close or mark issue `#9` as superseded by the Remote Workspace MVP issue.
+- [x] 1.3 Keep issue `#75` open as the iOS task-manager IA follow-up and link it to the Remote Workspace MVP issue.
+- [ ] 1.4 Decide the MVP account provider and document any remaining auth-provider assumptions before implementation starts.
+
+## 2. Account And Device Model
+
+- [ ] 2.1 Define account-owned device records for Mac and iPhone, including `device_id`, display name, platform, owner account, enrollment state, last seen, and revocation state.
+- [ ] 2.2 Add Mac device enrollment after Desktop account login with Keychain-backed device credentials.
+- [ ] 2.3 Add iPhone device enrollment after mobile account login with platform secure credential storage.
+- [ ] 2.4 Add device revocation handling that prevents future remote access and terminates or rejects active state-changing requests.
+
+## 3. Cloud Presence And Relay Broker
+
+- [ ] 3.1 Add Cloud service endpoints for listing account-owned devices and their online/offline/connectable status.
+- [ ] 3.2 Add short-lived relay ticket issuance scoped to account, client device, target Mac device, workspace/session, and operation class.
+- [ ] 3.3 Add Mac presence heartbeats that publish online/stale/offline status without moving runtime authority from the Mac.
+- [ ] 3.4 Add audit records for enrollment, connection, revocation, and state-changing remote control attempts.
+
+## 4. Mac Desktop Remote Availability
+
+- [ ] 4.1 Start product-managed outbound relay connection automatically when Desktop is signed in and Remote Workspace is enabled.
+- [ ] 4.2 Keep environment-configured relay mode as development/operator compatibility while making account/device relay the Desktop default path.
+- [ ] 4.3 Publish Mac-authored workspace/session status, including connectable workspace state and active agent/session state.
+- [ ] 4.4 Ensure Mac remains the final authority for workspace identity, session liveness, governance, tool execution, and event ordering.
+
+## 5. Realtime Relay And Daemon Contract
+
+- [ ] 5.1 Extend daemon endpoint metadata for relay-approved realtime session event subscriptions.
+- [ ] 5.2 Implement relay realtime event transport without making relay the author of event IDs, sequence, or runtime state.
+- [ ] 5.3 Preserve `events/read` and `reconnect_snapshot` as the required recovery path after reconnect or event gaps.
+- [ ] 5.4 Add tests that reject realtime relay subscription attempts for endpoints not approved by daemon endpoint metadata.
+
+## 6. iPhone Remote Workspace Experience
+
+- [ ] 6.1 Replace manual daemon/relay connection as the primary iPhone path with account device discovery.
+- [ ] 6.2 Show online Macs and connectable workspaces/sessions using product-facing labels, not relay node IDs or tunnel URLs.
+- [ ] 6.3 Allow iPhone to send messages, interrupt runs, and resume pending yields against the selected Mac workspace/session.
+- [ ] 6.4 Ensure iPhone reconnects with its latest event cursor and rebuilds state from reconnect snapshots when gaps are reported.
+- [ ] 6.5 Keep relay, node, routing, and daemon diagnostics behind explicit debug surfaces.
+
+## 7. Security Verification
+
+- [ ] 7.1 Add tests for account/device scope checks on read, write, resume, and admin remote operations.
+- [ ] 7.2 Add tests showing Cloud cannot advance runtime state without routing to and receiving authorization from the Mac.
+- [ ] 7.3 Add tests for revoked Mac and iPhone devices denying new state-changing operations.
+- [ ] 7.4 Add tests or harness scenarios for dropped mobile connections, cursor replay, gap recovery, and no duplicate execution.
+
+## 8. Documentation And OpenSpec Closure
+
+- [ ] 8.1 Update product and maintainer docs to describe Remote Workspace as device-to-device workspace continuation.
+- [ ] 8.2 Update remote-control architecture/security docs to reference Remote Workspace as the product layer above direct/relay transport.
+- [ ] 8.3 Run focused Rust/Swift tests for changed daemon, relay, Desktop, and iPhone surfaces.
+- [ ] 8.4 Run `openspec validate add-remote-workspace-mvp --type change --strict --json`.
+- [ ] 8.5 Run `openspec validate --all --strict --json`.
+- [ ] 8.6 Run `git diff --check`.
+- [ ] 8.7 Before archive, sync accepted delta requirements into `openspec/specs/`.
+- [ ] 8.8 Archive the OpenSpec change after implementation is merged.


### PR DESCRIPTION
## Summary
- Add the add-remote-workspace-mvp OpenSpec change.
- Define the new remote-workspace-access capability for account-bound Mac/iPhone device discovery, zero-config remote availability, realtime remote workspace continuation, reconnect recovery, and Mac-authoritative execution.
- Extend daemon-api-contract requirements for relay-approved realtime session event subscriptions.

## Tracking
- Issue: #349
- Supersedes: #9
- Leaves #75 as the iOS task-manager IA follow-up.

## Verification
- openspec validate add-remote-workspace-mvp --type change --strict --json
- openspec validate --all --strict --json
- git diff --check