### PR TITLE
Add ratio-based split dividers

### DIFF
--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -809,6 +809,16 @@ private enum AlanShellLocalCommandExecutor {
                 errorCode: error.rawValue,
                 errorMessage: "The requested pane does not exist."
             )
+        case .splitNotFound:
+            return response(
+                for: command,
+                state: state,
+                applied: false,
+                tabID: command.tabID,
+                paneID: command.paneID,
+                errorCode: error.rawValue,
+                errorMessage: "The requested split does not exist."
+            )
         case .lastTab:
             return response(
                 for: command,

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -435,6 +435,30 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
+    func resizeSplit(splitNodeID: String, ratio: Double) -> Bool {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.resizingSplit(splitNodeID, ratio: ratio)
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
+    }
+
+    @discardableResult
+    func equalizeSelectedTabSplits() -> Bool {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.equalizingSplits(in: selectedTabID)
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
+    }
+
+    @discardableResult
     func closeSelectedTab() -> Bool {
         guard let selectedTabID else { return false }
         return closeTab(tabID: selectedTabID) == .closed

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -435,14 +435,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
-    func resizeSplit(splitNodeID: String, ratio: Double) -> Bool {
+    func resizeSplit(splitNodeID: String, ratio: Double, persist: Bool = true) -> Bool {
         let result: ShellStateMutationResult
         do {
             result = try shellState.resizingSplit(splitNodeID, ratio: ratio)
         } catch {
             return false
         }
-        applyMutationResult(result)
+        applyMutationResult(result, publish: persist)
         return true
     }
 
@@ -824,11 +824,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         publishControlPlaneState()
     }
 
-    private func applyMutationResult(_ result: ShellStateMutationResult) {
-        adoptStateFromControlPlane(result.state)
+    private func applyMutationResult(
+        _ result: ShellStateMutationResult,
+        publish: Bool = true
+    ) {
+        adoptStateFromControlPlane(result.state, publish: publish)
     }
 
-    private func adoptStateFromControlPlane(_ state: ShellStateSnapshot) {
+    private func adoptStateFromControlPlane(
+        _ state: ShellStateSnapshot,
+        publish: Bool = true
+    ) {
         let paneIDs = Set(state.panes.map(\.paneID))
         terminalRuntimeRegistry.releaseRuntimes(excluding: paneIDs)
 
@@ -878,7 +884,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             panes: hydratedPanes
         )
         synchronizeSelection()
-        publishControlPlaneState()
+        if publish {
+            publishControlPlaneState()
+        }
     }
 
     private func recordControlPlaneDiagnostic(_ message: String) {

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -302,9 +302,13 @@ extension ShellPane {
 }
 
 struct ShellPaneTreeNode: Identifiable, Codable, Equatable {
+    static let minimumSplitRatio = 0.15
+    static let maximumSplitRatio = 0.85
+
     let nodeID: String
     let kind: ShellPaneTreeKind
     let direction: ShellSplitDirection?
+    let ratio: Double?
     let paneID: String?
     let children: [ShellPaneTreeNode]?
 
@@ -314,8 +318,63 @@ struct ShellPaneTreeNode: Identifiable, Codable, Equatable {
         case nodeID = "node_id"
         case kind
         case direction
+        case ratio
         case paneID = "pane_id"
         case children
+    }
+
+    init(
+        nodeID: String,
+        kind: ShellPaneTreeKind,
+        direction: ShellSplitDirection?,
+        ratio: Double? = nil,
+        paneID: String?,
+        children: [ShellPaneTreeNode]?
+    ) {
+        self.nodeID = nodeID
+        self.kind = kind
+        self.direction = direction
+        self.ratio = kind == .split
+            ? Self.clampedSplitRatio(ratio ?? 0.5)
+            : nil
+        self.paneID = paneID
+        self.children = children
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(ShellPaneTreeKind.self, forKey: .kind)
+        let decodedRatio = try container.decodeIfPresent(Double.self, forKey: .ratio)
+
+        self.init(
+            nodeID: try container.decode(String.self, forKey: .nodeID),
+            kind: kind,
+            direction: try container.decodeIfPresent(ShellSplitDirection.self, forKey: .direction),
+            ratio: kind == .split ? decodedRatio : nil,
+            paneID: try container.decodeIfPresent(String.self, forKey: .paneID),
+            children: try container.decodeIfPresent([ShellPaneTreeNode].self, forKey: .children)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(nodeID, forKey: .nodeID)
+        try container.encode(kind, forKey: .kind)
+        try container.encodeIfPresent(direction, forKey: .direction)
+        if kind == .split {
+            try container.encode(ratio ?? 0.5, forKey: .ratio)
+        }
+        try container.encodeIfPresent(paneID, forKey: .paneID)
+        try container.encodeIfPresent(children, forKey: .children)
+    }
+
+    static func clampedSplitRatio(_ ratio: Double) -> Double {
+        guard ratio.isFinite else { return 0.5 }
+        return min(max(ratio, minimumSplitRatio), maximumSplitRatio)
+    }
+
+    var splitRatio: Double {
+        Self.clampedSplitRatio(ratio ?? 0.5)
     }
 }
 
@@ -339,6 +398,67 @@ extension ShellPaneTreeNode {
             return paneID == targetPaneID
         case .split:
             return (children ?? []).contains { $0.contains(paneID: targetPaneID) }
+        }
+    }
+
+    func contains(nodeID targetNodeID: String) -> Bool {
+        if nodeID == targetNodeID { return true }
+        return (children ?? []).contains { $0.contains(nodeID: targetNodeID) }
+    }
+
+    func resizingSplit(
+        _ targetNodeID: String,
+        ratio targetRatio: Double
+    ) -> (node: ShellPaneTreeNode, changed: Bool) {
+        if kind == .split, nodeID == targetNodeID {
+            return (
+                ShellPaneTreeNode(
+                    nodeID: nodeID,
+                    kind: kind,
+                    direction: direction,
+                    ratio: targetRatio,
+                    paneID: paneID,
+                    children: children
+                ),
+                true
+            )
+        }
+
+        guard let children, !children.isEmpty else { return (self, false) }
+        var didChange = false
+        let nextChildren = children.map { child in
+            let result = child.resizingSplit(targetNodeID, ratio: targetRatio)
+            didChange = didChange || result.changed
+            return result.node
+        }
+
+        guard didChange else { return (self, false) }
+        return (
+            ShellPaneTreeNode(
+                nodeID: nodeID,
+                kind: kind,
+                direction: direction,
+                ratio: ratio,
+                paneID: paneID,
+                children: nextChildren
+            ),
+            true
+        )
+    }
+
+    func equalizedSplits() -> ShellPaneTreeNode {
+        switch kind {
+        case .pane:
+            return self
+        case .split:
+            return ShellPaneTreeNode(
+                nodeID: nodeID,
+                kind: kind,
+                direction: direction,
+                ratio: 0.5,
+                paneID: paneID,
+                children: children?.map { $0.equalizedSplits() }
+            )
         }
     }
 
@@ -370,6 +490,7 @@ extension ShellPaneTreeNode {
                 nodeID: splitNodeID,
                 kind: .split,
                 direction: direction,
+                ratio: 0.5,
                 paneID: nil,
                 children: [currentLeaf, newLeaf]
             )
@@ -378,6 +499,7 @@ extension ShellPaneTreeNode {
                 nodeID: nodeID,
                 kind: .split,
                 direction: self.direction,
+                ratio: ratio,
                 paneID: nil,
                 children: (children ?? []).map {
                     $0.splittingPane(
@@ -408,6 +530,7 @@ extension ShellPaneTreeNode {
                 nodeID: nodeID,
                 kind: .split,
                 direction: direction,
+                ratio: ratio,
                 paneID: nil,
                 children: remainingChildren
             )
@@ -434,6 +557,7 @@ extension ShellPaneTreeNode {
                 nodeID: nodeID,
                 kind: .split,
                 direction: direction,
+                ratio: ratio,
                 paneID: nil,
                 children: (children ?? []) + [newLeaf]
             )
@@ -443,6 +567,7 @@ extension ShellPaneTreeNode {
             nodeID: splitNodeID,
             kind: .split,
             direction: direction,
+            ratio: 0.5,
             paneID: nil,
             children: [self, newLeaf]
         )
@@ -453,6 +578,7 @@ enum ShellStateMutationError: String, Error {
     case spaceNotFound = "space_not_found"
     case tabNotFound = "tab_not_found"
     case paneNotFound = "pane_not_found"
+    case splitNotFound = "split_not_found"
     case lastTab = "last_tab"
     case lastPane = "last_pane"
     case invalidMoveTarget = "invalid_move_target"
@@ -965,6 +1091,42 @@ extension ShellStateSnapshot {
         )
     }
 
+    func resizingSplit(
+        _ splitNodeID: String,
+        ratio: Double
+    ) throws -> ShellStateMutationResult {
+        guard let tab = spaces.lazy
+            .flatMap(\.tabs)
+            .first(where: { $0.paneTree.contains(nodeID: splitNodeID) })
+        else {
+            throw ShellStateMutationError.splitNotFound
+        }
+
+        let resizeResult = tab.paneTree.resizingSplit(splitNodeID, ratio: ratio)
+        guard resizeResult.changed else {
+            throw ShellStateMutationError.splitNotFound
+        }
+
+        return try replacingTabTree(
+            tabID: tab.tabID,
+            paneTree: resizeResult.node
+        )
+    }
+
+    func equalizingSplits(in requestedTabID: String?) throws -> ShellStateMutationResult {
+        let tabID = requestedTabID ?? focusedTabID
+        guard let tabID,
+              let tab = tab(tabID: tabID)
+        else {
+            throw ShellStateMutationError.tabNotFound
+        }
+
+        return try replacingTabTree(
+            tabID: tab.tabID,
+            paneTree: tab.paneTree.equalizedSplits()
+        )
+    }
+
     func closingPane(_ paneID: String) throws -> ShellStateMutationResult {
         guard let pane = pane(paneID: paneID),
               let tab = tab(tabID: pane.tabID)
@@ -1260,6 +1422,48 @@ extension ShellStateSnapshot {
             spaceID: pane(paneID: paneID)?.spaceID,
             tabID: pane(paneID: paneID)?.tabID,
             paneID: paneID
+        )
+    }
+
+    private func replacingTabTree(
+        tabID: String,
+        paneTree: ShellPaneTreeNode
+    ) throws -> ShellStateMutationResult {
+        guard let targetSpace = spaces.first(where: { space in
+            space.tabs.contains(where: { $0.tabID == tabID })
+        }),
+        let targetTab = targetSpace.tabs.first(where: { $0.tabID == tabID })
+        else {
+            throw ShellStateMutationError.tabNotFound
+        }
+
+        let updatedTab = ShellTab(
+            tabID: targetTab.tabID,
+            kind: targetTab.kind,
+            title: targetTab.title,
+            paneTree: paneTree
+        )
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == targetSpace.spaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs.map { tab in
+                    tab.tabID == updatedTab.tabID ? updatedTab : tab
+                }
+            )
+        }
+
+        return ShellStateMutationResult(
+            state: replacing(
+                spaces: nextSpaces,
+                panes: panes,
+                focusedPaneID: focusedPaneID
+            ),
+            spaceID: targetSpace.spaceID,
+            tabID: updatedTab.tabID,
+            paneID: focusedPaneID
         )
     }
 

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -552,14 +552,25 @@ extension ShellPaneTreeNode {
         )
 
         if kind == .split,
-           self.direction == direction {
+           self.direction == direction,
+           let existingChildren = children,
+           let lastChild = existingChildren.last {
+            let nestedSplit = ShellPaneTreeNode(
+                nodeID: splitNodeID,
+                kind: .split,
+                direction: direction,
+                ratio: 0.5,
+                paneID: nil,
+                children: [lastChild, newLeaf]
+            )
+
             return ShellPaneTreeNode(
                 nodeID: nodeID,
                 kind: .split,
                 direction: direction,
                 ratio: ratio,
                 paneID: nil,
-                children: (children ?? []) + [newLeaf]
+                children: Array(existingChildren.dropLast()) + [nestedSplit]
             )
         }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -490,23 +490,105 @@ private struct ShellPaneTreeLayoutView: View {
                 )
             }
         case .split:
-            if node.direction == .vertical {
-                HStack(spacing: 10) {
-                    splitChildren
+            ShellSplitLayoutView(node: node, host: host)
+        }
+    }
+}
+
+private struct ShellSplitLayoutView: View {
+    let node: ShellPaneTreeNode
+    @ObservedObject var host: ShellHostController
+    @State private var dragStartRatio: Double?
+
+    private var children: [ShellPaneTreeNode] {
+        node.children ?? []
+    }
+
+    var body: some View {
+        if children.count == 2 {
+            GeometryReader { proxy in
+                if node.direction == .vertical {
+                    HStack(spacing: 0) {
+                        ShellPaneTreeLayoutView(node: children[0], host: host)
+                            .frame(width: primaryLength(total: proxy.size.width))
+                        ShellSplitDividerView(direction: .vertical)
+                            .gesture(resizeGesture(totalLength: proxy.size.width))
+                        ShellPaneTreeLayoutView(node: children[1], host: host)
+                            .frame(width: secondaryLength(total: proxy.size.width))
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        ShellPaneTreeLayoutView(node: children[0], host: host)
+                            .frame(height: primaryLength(total: proxy.size.height))
+                        ShellSplitDividerView(direction: .horizontal)
+                            .gesture(resizeGesture(totalLength: proxy.size.height))
+                        ShellPaneTreeLayoutView(node: children[1], host: host)
+                            .frame(height: secondaryLength(total: proxy.size.height))
+                    }
                 }
-            } else {
-                VStack(spacing: 10) {
-                    splitChildren
-                }
+            }
+        } else if node.direction == .vertical {
+            HStack(spacing: 0) {
+                indexedChildrenWithDividers
+            }
+        } else {
+            VStack(spacing: 0) {
+                indexedChildrenWithDividers
             }
         }
     }
 
     @ViewBuilder
-    private var splitChildren: some View {
-        ForEach(node.children ?? []) { child in
+    private var indexedChildrenWithDividers: some View {
+        ForEach(Array(children.enumerated()), id: \.element.id) { index, child in
+            if index > 0 {
+                ShellSplitDividerView(direction: node.direction ?? .vertical)
+            }
             ShellPaneTreeLayoutView(node: child, host: host)
         }
+    }
+
+    private var dividerThickness: CGFloat { 1 }
+
+    private func primaryLength(total: CGFloat) -> CGFloat {
+        max((total - dividerThickness) * node.splitRatio, 0)
+    }
+
+    private func secondaryLength(total: CGFloat) -> CGFloat {
+        max(total - dividerThickness - primaryLength(total: total), 0)
+    }
+
+    private func resizeGesture(totalLength: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                if dragStartRatio == nil {
+                    dragStartRatio = node.splitRatio
+                }
+                let delta = node.direction == .vertical
+                    ? value.translation.width
+                    : value.translation.height
+                let usableLength = max(totalLength - dividerThickness, 1)
+                let nextRatio = (dragStartRatio ?? node.splitRatio) + Double(delta / usableLength)
+                _ = host.resizeSplit(splitNodeID: node.nodeID, ratio: nextRatio)
+            }
+            .onEnded { _ in
+                dragStartRatio = nil
+            }
+    }
+}
+
+private struct ShellSplitDividerView: View {
+    let direction: ShellSplitDirection
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.16))
+            .frame(
+                width: direction == .vertical ? 1 : nil,
+                height: direction == .horizontal ? 1 : nil
+            )
+            .contentShape(Rectangle())
+            .help("Resize split")
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -175,6 +175,7 @@ struct TerminalPaneView: View {
                 .padding(28)
             }
         }
+        .modifier(ShellTerminalSurfaceFrame())
     }
 
     private var runtimeCard: some View {
@@ -448,6 +449,27 @@ struct TerminalPaneView: View {
     }
 }
 
+private struct ShellTerminalSurfaceFrame: ViewModifier {
+    private let shape = RoundedRectangle(cornerRadius: 12, style: .continuous)
+
+    func body(content: Content) -> some View {
+        content
+            .background(ShellPalette.terminal)
+            .clipShape(shape)
+            .overlay {
+                shape.stroke(
+                    ShellPalette.line.opacity(0.18),
+                    lineWidth: 1
+                )
+            }
+            .shadow(
+                color: Color.black.opacity(0.10),
+                radius: 18,
+                y: 8
+            )
+    }
+}
+
 private struct ShellPaneTreeLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
@@ -558,17 +580,25 @@ private struct ShellSplitLayoutView: View {
 }
 
 private struct ShellSplitDividerView: View {
+    @State private var isHovered = false
     let direction: ShellSplitDirection
 
     var body: some View {
         Rectangle()
-            .fill(Color.primary.opacity(0.16))
+            .fill(ShellSplitDividerTint.color(isHovered: isHovered))
             .frame(
                 width: direction == .vertical ? 1 : nil,
                 height: direction == .horizontal ? 1 : nil
             )
             .contentShape(Rectangle())
+            .onHover { isHovered = $0 }
             .help("Resize split")
+    }
+}
+
+private enum ShellSplitDividerTint {
+    static func color(isHovered: Bool) -> Color {
+        ShellPalette.terminalSoft.opacity(isHovered ? 0.38 : 0.18)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -550,7 +550,7 @@ private struct ShellSplitLayoutView: View {
         }
     }
 
-    private var dividerThickness: CGFloat { 1 }
+    private var dividerThickness: CGFloat { ShellSplitDividerMetrics.thickness }
 
     private func primaryLength(total: CGFloat) -> CGFloat {
         max((total - dividerThickness) * node.splitRatio, 0)
@@ -584,25 +584,49 @@ private struct ShellSplitDividerView: View {
     let direction: ShellSplitDirection
 
     var body: some View {
-        Rectangle()
-            .fill(ShellSplitDividerTint.color(isHovered: isHovered))
+        seam
             .frame(
-                width: direction == .vertical ? 1 : nil,
-                height: direction == .horizontal ? 1 : nil
+                width: direction == .vertical ? ShellSplitDividerMetrics.thickness : nil,
+                height: direction == .horizontal ? ShellSplitDividerMetrics.thickness : nil
             )
             .contentShape(Rectangle())
             .onHover { isHovered = $0 }
             .help("Resize split")
     }
+
+    @ViewBuilder
+    private var seam: some View {
+        if direction == .vertical {
+            HStack(spacing: 0) {
+                Rectangle().fill(ShellSplitDividerTint.shadow(isHovered: isHovered))
+                Rectangle().fill(ShellSplitDividerTint.highlight(isHovered: isHovered))
+            }
+        } else {
+            VStack(spacing: 0) {
+                Rectangle().fill(ShellSplitDividerTint.shadow(isHovered: isHovered))
+                Rectangle().fill(ShellSplitDividerTint.highlight(isHovered: isHovered))
+            }
+        }
+    }
+}
+
+private enum ShellSplitDividerMetrics {
+    static let thickness: CGFloat = 2
 }
 
 private enum ShellSplitDividerTint {
-    static func color(isHovered: Bool) -> Color {
-        ShellPalette.terminalSoft.opacity(isHovered ? 0.38 : 0.18)
+    static func shadow(isHovered: Bool) -> Color {
+        Color.black.opacity(isHovered ? 0.22 : 0.14)
+    }
+
+    static func highlight(isHovered: Bool) -> Color {
+        ShellPalette.terminalSoft.opacity(isHovered ? 0.48 : 0.34)
     }
 }
 
 private struct ShellTerminalLeafView: View {
+    @AppStorage("alanShellDimsInactiveSplitPanes") private var dimsInactiveSplitPanes = true
+
     let pane: ShellPane
     let bootProfile: AlanShellBootProfile?
     let isSelected: Bool
@@ -624,6 +648,23 @@ private struct ShellTerminalLeafView: View {
         .id(pane.paneID)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(ShellPalette.terminal)
+        .overlay {
+            ShellInactivePaneDim(
+                isSelected: isSelected,
+                isEnabled: dimsInactiveSplitPanes
+            )
+        }
+    }
+}
+
+private struct ShellInactivePaneDim: View {
+    let isSelected: Bool
+    let isEnabled: Bool
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.black.opacity(isSelected || !isEnabled ? 0 : 0.14))
+            .allowsHitTesting(false)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -501,6 +501,7 @@ private struct ShellSplitLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     @State private var dragStartRatio: Double?
+    @State private var dragPreviewRatio: Double?
 
     private var children: [ShellPaneTreeNode] {
         node.children ?? []
@@ -571,10 +572,16 @@ private struct ShellSplitLayoutView: View {
                     : value.translation.height
                 let usableLength = max(totalLength - dividerThickness, 1)
                 let nextRatio = (dragStartRatio ?? node.splitRatio) + Double(delta / usableLength)
-                _ = host.resizeSplit(splitNodeID: node.nodeID, ratio: nextRatio)
+                if host.resizeSplit(splitNodeID: node.nodeID, ratio: nextRatio, persist: false) {
+                    dragPreviewRatio = nextRatio
+                }
             }
             .onEnded { _ in
+                if let finalRatio = dragPreviewRatio {
+                    _ = host.resizeSplit(splitNodeID: node.nodeID, ratio: finalRatio, persist: true)
+                }
                 dragStartRatio = nil
+                dragPreviewRatio = nil
             }
     }
 }

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -13,9 +13,6 @@ struct TerminalPaneView: View {
                 paneMetadataStrip
             }
 
-            if host.panesForSelectedTab.count > 1 {
-                paneSelectorStrip
-            }
         }
         .padding(.top, 8)
         .padding(.trailing, 8)
@@ -178,23 +175,6 @@ struct TerminalPaneView: View {
                 .padding(28)
             }
         }
-    }
-
-    private var paneSelectorStrip: some View {
-        HStack(spacing: 0) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(Array(host.panesForSelectedTab.enumerated()), id: \.element.paneID) { _, pane in
-                        TerminalPaneSelectorButton(
-                            pane: pane,
-                            isFocused: host.selectedPane?.paneID == pane.paneID,
-                            onSelect: { host.focus(paneID: pane.paneID) }
-                        )
-                    }
-                }
-            }
-        }
-        .padding(.top, 2)
     }
 
     private var runtimeCard: some View {
@@ -614,100 +594,6 @@ private struct ShellTerminalLeafView: View {
         .id(pane.paneID)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(ShellPalette.terminal)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(
-                    ShellPalette.accent.opacity(0.32),
-                    lineWidth: 1
-                )
-        }
-        .shadow(
-            color: Color.black.opacity(0.10),
-            radius: 18,
-            y: 8
-        )
-    }
-}
-
-private struct TerminalPaneSelectorButton: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isHovered = false
-    let pane: ShellPane
-    let isFocused: Bool
-    let onSelect: () -> Void
-
-    private var titleText: String {
-        shellDisplayTitle(
-            rawTitle: pane.viewport?.title,
-            workingDirectoryName: pane.context?.workingDirectoryName,
-            cwd: pane.cwd,
-            program: pane.process?.program,
-            launchTarget: pane.resolvedLaunchTarget,
-            fallback: pane.resolvedLaunchTarget == .alan ? "Alan" : "Shell"
-        )
-    }
-
-    private var summaryText: String? {
-        if let branch = pane.context?.gitBranch {
-            return branch
-        }
-
-        if let folder = shellVisibleLabel(pane.context?.workingDirectoryName) ?? shellPathLeaf(pane.cwd),
-           folder != titleText
-        {
-            return folder
-        }
-
-        if let summary = shellUserFacingSummary(pane.viewport?.summary),
-           summary != titleText
-        {
-            return summary
-        }
-
-        if let program = shellVisibleLabel(pane.process?.program),
-           program.localizedCaseInsensitiveCompare(titleText) != .orderedSame
-        {
-            return program
-        }
-
-        return nil
-    }
-
-    var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(isFocused ? ShellPalette.accent : ShellPalette.line.opacity(0.9))
-                    .frame(width: 6, height: 6)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(titleText)
-                        .font(.system(size: 12, weight: .semibold))
-                    if let summaryText {
-                        Text(summaryText)
-                            .font(.system(size: 11, weight: .medium))
-                            .lineLimit(1)
-                    }
-                }
-            }
-            .foregroundStyle(isFocused ? ShellPalette.ink : ShellPalette.mutedInk)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(minWidth: 108, alignment: .leading)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(isFocused ? Color.white.opacity(0.74) : (isHovered ? Color.white.opacity(0.36) : Color.white.opacity(0.24)))
-            )
-            .overlay {
-                Capsule(style: .continuous)
-                    .stroke(ShellPalette.line.opacity(isFocused ? 0.34 : (isHovered ? 0.2 : 0.12)), lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .scaleEffect(isHovered && !isFocused ? 1.01 : 1)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovered)
-        .onHover { isHovered = $0 }
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -190,6 +190,16 @@ reject_pattern \
     "splitChildren" \
     "split panes must not leave a fixed gap between adjacent terminal panes"
 
+reject_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "clipShape\\(RoundedRectangle\\(cornerRadius: 12" \
+    "terminal panes must not render as separate rounded cards inside a split surface"
+
+reject_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "paneSelectorStrip" \
+    "split panes must not show a bottom pane tab strip by default"
+
 require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
     "hasTornDownRuntime" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -185,6 +185,16 @@ require_pattern \
     "ShellSplitDividerView" \
     "split panes must use an explicit divider instead of visual spacing gaps"
 
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellSplitDividerTint" \
+    "split divider tint must stay subtle instead of rendering as a hard line"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellTerminalSurfaceFrame" \
+    "terminal panes must share one outer rounded terminal surface frame"
+
 reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "splitChildren" \
@@ -192,13 +202,13 @@ reject_pattern \
 
 reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
-    "clipShape\\(RoundedRectangle\\(cornerRadius: 12" \
-    "terminal panes must not render as separate rounded cards inside a split surface"
+    "paneSelectorStrip" \
+    "split panes must not show a bottom pane tab strip by default"
 
 reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
-    "paneSelectorStrip" \
-    "split panes must not show a bottom pane tab strip by default"
+    "Color\\.primary\\.opacity\\(0\\.16\\)" \
+    "split divider must not render as a high-contrast primary-color line"
 
 require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -181,6 +181,16 @@ require_pattern \
     "terminal host views must be keyed by stable pane identity"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellSplitDividerView" \
+    "split panes must use an explicit divider instead of visual spacing gaps"
+
+reject_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "splitChildren" \
+    "split panes must not leave a fixed gap between adjacent terminal panes"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
     "hasTornDownRuntime" \
     "terminal teardown must be idempotent"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -202,6 +202,31 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "dragPreviewRatio" \
+    "split divider drag must track the live preview ratio until drag end"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "resizeSplit\\(splitNodeID: node\\.nodeID, ratio: nextRatio, persist: false\\)" \
+    "split divider drag previews must not persist every pointer sample"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "resizeSplit\\(splitNodeID: node\\.nodeID, ratio: finalRatio, persist: true\\)" \
+    "split divider drag end must persist the final ratio"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "func resizeSplit\\(splitNodeID: String, ratio: Double, persist: Bool = true\\)" \
+    "shell split resize must expose a non-persisting preview path"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "applyMutationResult\\(result, publish: persist\\)" \
+    "split resize preview persistence must be controlled at mutation application"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -192,8 +192,33 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellSplitDividerMetrics\\.thickness" \
+    "split divider must use an intentional seam thickness instead of a hard 1px line"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellSplitDividerTint\\.shadow" \
+    "split divider must use a subtle bevel seam rather than a single flat line"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellInactivePaneDim" \
+    "inactive split panes must use a lightweight dim treatment"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "allowsHitTesting\\(false\\)" \
+    "inactive pane dimming must not intercept terminal pointer input"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "@AppStorage\\(\"alanShellDimsInactiveSplitPanes\"\\)" \
+    "inactive pane dimming must be backed by a user-default preference"
 
 reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \

--- a/clients/apple/scripts/test-shell-split-model.sh
+++ b/clients/apple/scripts/test-shell-split-model.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-split-model-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-split-model-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-split-model.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+@main
+struct ShellSplitModelTestRunner {
+    static func main() throws {
+        try ShellSplitModelTests.run()
+    }
+}
+
+private enum ShellSplitModelTests {
+    static func run() throws {
+        try verifiesNewSplitsStoreEqualRatio()
+        try verifiesSplitRatiosClampWhenResized()
+        try verifiesEqualizeRestoresEverySplitRatio()
+        try verifiesLegacySplitDecodeDefaultsToEqualRatio()
+        print("Shell split model tests passed.")
+    }
+
+    private static func verifiesNewSplitsStoreEqualRatio() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        let result = try state.splittingPane("pane_1", direction: .vertical)
+        let tree = try requireFocusedTabTree(result.state)
+
+        expect(tree.kind == .split, "splitting a pane must create a split branch")
+        expect(tree.ratio == 0.5, "new split branches must persist an equal divider ratio")
+        expect(tree.children?.count == 2, "a split branch must keep two structural children")
+    }
+
+    private static func verifiesSplitRatiosClampWhenResized() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        let split = try state.splittingPane("pane_1", direction: .vertical).state
+        let splitID = try requireFocusedTabTree(split).nodeID
+
+        let tooSmall = try split.resizingSplit(splitID, ratio: 0.01).state
+        let tooSmallRatio = try requireFocusedTabTree(tooSmall).ratio
+        expect(
+            tooSmallRatio == ShellPaneTreeNode.minimumSplitRatio,
+            "resize must clamp tiny split ratios to the minimum usable ratio"
+        )
+
+        let tooLarge = try split.resizingSplit(splitID, ratio: 0.99).state
+        let tooLargeRatio = try requireFocusedTabTree(tooLarge).ratio
+        expect(
+            tooLargeRatio == ShellPaneTreeNode.maximumSplitRatio,
+            "resize must clamp large split ratios to the maximum usable ratio"
+        )
+    }
+
+    private static func verifiesEqualizeRestoresEverySplitRatio() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", direction: .vertical).state
+        let rootID = try requireFocusedTabTree(state).nodeID
+        state = try state.resizingSplit(rootID, ratio: 0.72).state
+        state = try state.equalizingSplits(in: state.focusedTabID).state
+        let equalizedRatio = try requireFocusedTabTree(state).ratio
+
+        expect(
+            equalizedRatio == 0.5,
+            "equalize must restore the tab's root split ratio"
+        )
+    }
+
+    private static func verifiesLegacySplitDecodeDefaultsToEqualRatio() throws {
+        let legacyJSON = """
+        {
+          "contract_version": "0.1",
+          "window_id": "window_test",
+          "focused_space_id": "space_main",
+          "focused_tab_id": "tab_main",
+          "focused_pane_id": "pane_1",
+          "spaces": [
+            {
+              "space_id": "space_main",
+              "title": "Terminal",
+              "attention": "active",
+              "tabs": [
+                {
+                  "tab_id": "tab_main",
+                  "kind": "terminal",
+                  "title": "Shell",
+                  "pane_tree": {
+                    "node_id": "node_split",
+                    "kind": "split",
+                    "direction": "vertical",
+                    "children": [
+                      {"node_id": "node_pane_1", "kind": "pane", "pane_id": "pane_1"},
+                      {"node_id": "node_pane_2", "kind": "pane", "pane_id": "pane_2"}
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "panes": [
+            {"pane_id": "pane_1", "tab_id": "tab_main", "space_id": "space_main", "launch_target": "shell", "attention": "active"},
+            {"pane_id": "pane_2", "tab_id": "tab_main", "space_id": "space_main", "launch_target": "shell", "attention": "idle"}
+          ]
+        }
+        """
+        let data = Data(legacyJSON.utf8)
+        let state = try JSONDecoder().decode(ShellStateSnapshot.self, from: data)
+        let tree = try requireFocusedTabTree(state)
+
+        expect(tree.ratio == 0.5, "legacy split trees without ratio must decode as equal splits")
+
+        let encoded = try JSONEncoder().encode(state)
+        let encodedString = String(decoding: encoded, as: UTF8.self)
+        expect(encodedString.contains("\"ratio\""), "decoded legacy split ratios must persist when re-encoded")
+    }
+
+    private static func requireFocusedTabTree(_ state: ShellStateSnapshot) throws -> ShellPaneTreeNode {
+        guard let tabID = state.focusedTabID,
+              let tab = state.tab(tabID: tabID)
+        else {
+            throw TestFailure("focused tab missing")
+        }
+        return tab.paneTree
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        guard condition() else {
+            fputs("error: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -12,6 +12,7 @@ private enum ShellSplitModelTests {
         try verifiesNewSplitsStoreEqualRatio()
         try verifiesSplitRatiosClampWhenResized()
         try verifiesEqualizeRestoresEverySplitRatio()
+        try verifiesSameDirectionAttachKeepsBinarySplitTree()
         try verifiesLegacySplitDecodeDefaultsToEqualRatio()
         print("Shell split model tests passed.")
     }
@@ -57,6 +58,32 @@ private enum ShellSplitModelTests {
         expect(
             equalizedRatio == 0.5,
             "equalize must restore the tab's root split ratio"
+        )
+    }
+
+    private static func verifiesSameDirectionAttachKeepsBinarySplitTree() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        let split = try state.splittingPane("pane_1", direction: .vertical).state
+        let attached = try requireFocusedTabTree(split).attachingPane(
+            "pane_3",
+            direction: .vertical,
+            splitNodeID: "node_nested_split",
+            newLeafNodeID: "node_pane_3"
+        )
+
+        expect(
+            attached.children?.count == 2,
+            "same-direction pane attachment must keep split branches binary"
+        )
+        guard let nestedSplit = attached.children?.last else {
+            throw TestFailure("nested split missing")
+        }
+        expect(nestedSplit.kind == .split, "same-direction attachment must nest the final child")
+        expect(nestedSplit.direction == .vertical, "nested split must keep the requested direction")
+        expect(nestedSplit.children?.count == 2, "nested split must own exactly two children")
+        expect(
+            attached.paneIDs == ["pane_1", "pane_2", "pane_3"],
+            "same-direction attachment must preserve pane ordering"
         )
     }
 

--- a/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
@@ -11,7 +11,7 @@ card grid or debug layout.
 
 #### Scenario: Split panes share one terminal surface
 - **WHEN** a tab contains adjacent visible terminal panes
-- **THEN** panes are rendered as one continuous terminal surface with no per-pane rounded cards, shadows, bottom pane tab strip, or fixed gaps; only the split divider separates neighboring panes
+- **THEN** panes are rendered inside one continuous terminal surface whose outer four corners are rounded, with no per-pane rounded cards, shadows, bottom pane tab strip, or fixed gaps; only a subtle low-contrast split seam separates neighboring panes
 
 #### Scenario: Divider hover
 - **WHEN** the user hovers or drags a split divider

--- a/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
@@ -9,6 +9,10 @@ card grid or debug layout.
 - **WHEN** a tab contains multiple visible terminal panes
 - **THEN** dividers and focus treatment are compact and do not show raw pane IDs, runtime phases, or redundant labels by default
 
+#### Scenario: Split panes share one terminal surface
+- **WHEN** a tab contains adjacent visible terminal panes
+- **THEN** panes are rendered as one continuous terminal surface with no per-pane rounded cards, shadows, bottom pane tab strip, or fixed gaps; only the split divider separates neighboring panes
+
 #### Scenario: Divider hover
 - **WHEN** the user hovers or drags a split divider
 - **THEN** the divider provides a clear native resize affordance without resizing unrelated sidebar or toolbar elements

--- a/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/upgrade-macos-shell-splits-commands/specs/macos-shell-ui-ux-conformance/spec.md
@@ -11,11 +11,15 @@ card grid or debug layout.
 
 #### Scenario: Split panes share one terminal surface
 - **WHEN** a tab contains adjacent visible terminal panes
-- **THEN** panes are rendered inside one continuous terminal surface whose outer four corners are rounded, with no per-pane rounded cards, shadows, bottom pane tab strip, or fixed gaps; only a subtle low-contrast split seam separates neighboring panes
+- **THEN** panes are rendered inside one continuous terminal surface whose outer four corners are rounded, with no per-pane rounded cards, shadows, bottom pane tab strip, or fixed gaps; only a subtle low-contrast beveled split seam separates neighboring panes
 
 #### Scenario: Divider hover
 - **WHEN** the user hovers or drags a split divider
 - **THEN** the divider provides a clear native resize affordance without resizing unrelated sidebar or toolbar elements
+
+#### Scenario: Inactive split pane
+- **WHEN** a split pane is not the active terminal pane
+- **THEN** Alan may apply a preference-backed lightweight dim treatment that preserves terminal readability and pointer input while making the active pane and split boundary easier to scan
 
 ### Requirement: Command UI owns navigation and actions
 The default command entry SHALL present tabs, panes, spaces, and workspace

--- a/openspec/changes/upgrade-macos-shell-splits-commands/tasks.md
+++ b/openspec/changes/upgrade-macos-shell-splits-commands/tasks.md
@@ -11,6 +11,7 @@
 - [x] 2.2 Add native divider resize affordances with stable minimum pane sizes.
 - [ ] 2.3 Add split zoom and unzoom UI that preserves sibling runtime handles.
 - [ ] 2.4 Add visual treatment for focused panes that stays lightweight and hides debug identifiers.
+- [x] 2.5 Keep adjacent split panes as one continuous terminal surface without per-pane rounded cards or a bottom pane tab strip.
 
 ## 3. Native Commands And Menus
 

--- a/openspec/changes/upgrade-macos-shell-splits-commands/tasks.md
+++ b/openspec/changes/upgrade-macos-shell-splits-commands/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Split Model
 
-- [ ] 1.1 Add split branch ratio, structural identity, and validation/clamping to the shell model.
-- [ ] 1.2 Add migration/loading behavior for existing equal split trees.
+- [x] 1.1 Add split branch ratio, structural identity, and validation/clamping to the shell model.
+- [x] 1.2 Add migration/loading behavior for existing equal split trees.
 - [ ] 1.3 Add model operations for split directional creation, resize, equalize, zoom, unzoom, close, focus, and move.
 - [ ] 1.4 Add focused model tests for ratio persistence, invalid ratios, tree repair, and empty-container handling.
 
 ## 2. Split Layout UI
 
-- [ ] 2.1 Replace equal `HStack`/`VStack` recursion with a ratio-aware split layout view.
-- [ ] 2.2 Add native divider resize affordances with stable minimum pane sizes.
+- [x] 2.1 Replace equal `HStack`/`VStack` recursion with a ratio-aware split layout view.
+- [x] 2.2 Add native divider resize affordances with stable minimum pane sizes.
 - [ ] 2.3 Add split zoom and unzoom UI that preserves sibling runtime handles.
 - [ ] 2.4 Add visual treatment for focused panes that stays lightweight and hides debug identifiers.
 


### PR DESCRIPTION
## Summary
- Persist split branch ratios with clamping and legacy equal-split migration.
- Replace fixed split pane spacing and independent pane cards with one rounded outer terminal surface; internal split panes stay square and share the same clipped surface.
- Remove the bottom pane selector strip, replace the hard divider with a subtle 2px beveled seam, and add preference-backed inactive-pane dimming for split scanability.
- Add focused shell split model/contract coverage and update OpenSpec task/spec progress for this splits slice.

## Test Plan
- ./clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- git diff --check
- openspec validate upgrade-macos-shell-splits-commands --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build