### PR TITLE
Add macOS shell split commands

### DIFF
--- a/clients/apple/AlanNative/AlanNativeApp.swift
+++ b/clients/apple/AlanNative/AlanNativeApp.swift
@@ -65,6 +65,7 @@ private final class AlanMacAppDelegate: NSObject, NSApplicationDelegate {
 }
 
 private struct AlanMacShellCommands: Commands {
+    @ObservedObject var host: ShellHostController
     @Environment(\.openWindow) private var openWindow
 
     var body: some Commands {
@@ -74,6 +75,79 @@ private struct AlanMacShellCommands: Commands {
                 AlanMacPrimaryWindowPresenter.focusExistingWindowSoon()
             }
             .keyboardShortcut("n", modifiers: .command)
+        }
+
+        CommandMenu("Shell") {
+            Button("New Terminal Tab") {
+                host.performShellWorkspaceCommand(.newTerminalTab)
+            }
+            .keyboardShortcut("t", modifiers: .command)
+
+            Button("New Alan Tab") {
+                host.performShellWorkspaceCommand(.newAlanTab)
+            }
+            .keyboardShortcut("t", modifiers: [.command, .option])
+
+            Divider()
+
+            Button("Split Right") {
+                host.performShellWorkspaceCommand(.splitRight)
+            }
+            .keyboardShortcut("d", modifiers: .command)
+
+            Button("Split Down") {
+                host.performShellWorkspaceCommand(.splitDown)
+            }
+            .keyboardShortcut("d", modifiers: [.command, .shift])
+
+            Button("Split Left") {
+                host.performShellWorkspaceCommand(.splitLeft)
+            }
+            .keyboardShortcut("d", modifiers: [.command, .option])
+
+            Button("Split Up") {
+                host.performShellWorkspaceCommand(.splitUp)
+            }
+            .keyboardShortcut("d", modifiers: [.command, .option, .shift])
+
+            Button("Equalize Splits") {
+                host.performShellWorkspaceCommand(.equalizeSplits)
+            }
+            .keyboardShortcut("=", modifiers: [.command, .option])
+
+            Divider()
+
+            Button("Focus Pane Left") {
+                host.performShellWorkspaceCommand(.focusLeft)
+            }
+            .keyboardShortcut(.leftArrow, modifiers: [.command, .control])
+
+            Button("Focus Pane Right") {
+                host.performShellWorkspaceCommand(.focusRight)
+            }
+            .keyboardShortcut(.rightArrow, modifiers: [.command, .control])
+
+            Button("Focus Pane Up") {
+                host.performShellWorkspaceCommand(.focusUp)
+            }
+            .keyboardShortcut(.upArrow, modifiers: [.command, .control])
+
+            Button("Focus Pane Down") {
+                host.performShellWorkspaceCommand(.focusDown)
+            }
+            .keyboardShortcut(.downArrow, modifiers: [.command, .control])
+
+            Divider()
+
+            Button("Close Pane") {
+                host.performShellWorkspaceCommand(.closePane)
+            }
+            .keyboardShortcut("w", modifiers: [.command, .shift])
+
+            Button("Close Tab") {
+                host.performShellWorkspaceCommand(.closeTab)
+            }
+            .keyboardShortcut("w", modifiers: .command)
         }
     }
 }
@@ -100,7 +174,7 @@ struct AlanNativeApp: App {
                 .toolbar(removing: .title)
         }
         .commands {
-            AlanMacShellCommands()
+            AlanMacShellCommands(host: primaryShellOwner.host)
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 1360, height: 860)

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -559,7 +559,7 @@ private struct ShellSidebarView: View {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.secondary)
-                Text("Go to tab or command")
+                Text("Go to or Command...")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -1457,8 +1457,15 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
     case jumpToAttention
     case focusBestPane
     case toggleInspector
-    case splitHorizontal
-    case splitVertical
+    case splitRight
+    case splitDown
+    case splitLeft
+    case splitUp
+    case focusLeft
+    case focusRight
+    case focusUp
+    case focusDown
+    case equalizeSplits
     case liftPane
     case closePane
     case closeTab
@@ -1482,10 +1489,24 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Focus Best Routing Pane"
         case .toggleInspector:
             return "Toggle Inspector"
-        case .splitHorizontal:
-            return "Split Focused Pane Horizontally"
-        case .splitVertical:
-            return "Split Focused Pane Vertically"
+        case .splitRight:
+            return "Split Pane Right"
+        case .splitDown:
+            return "Split Pane Down"
+        case .splitLeft:
+            return "Split Pane Left"
+        case .splitUp:
+            return "Split Pane Up"
+        case .focusLeft:
+            return "Focus Pane Left"
+        case .focusRight:
+            return "Focus Pane Right"
+        case .focusUp:
+            return "Focus Pane Up"
+        case .focusDown:
+            return "Focus Pane Down"
+        case .equalizeSplits:
+            return "Equalize Splits"
         case .liftPane:
             return "Lift Focused Pane To Tab"
         case .closePane:
@@ -1513,10 +1534,24 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Use shell routing signals to jump to the strongest candidate pane."
         case .toggleInspector:
             return "Show or hide the right-side shell inspector."
-        case .splitHorizontal:
+        case .splitRight:
+            return "Create a side-by-side split to the right of the focused pane."
+        case .splitDown:
             return "Create a stacked split beneath the focused pane."
-        case .splitVertical:
-            return "Create a side-by-side split next to the focused pane."
+        case .splitLeft:
+            return "Create a side-by-side split to the left of the focused pane."
+        case .splitUp:
+            return "Create a stacked split above the focused pane."
+        case .focusLeft:
+            return "Move terminal focus to the pane on the left."
+        case .focusRight:
+            return "Move terminal focus to the pane on the right."
+        case .focusUp:
+            return "Move terminal focus to the pane above."
+        case .focusDown:
+            return "Move terminal focus to the pane below."
+        case .equalizeSplits:
+            return "Return the current tab's split dividers to equal ratios."
         case .liftPane:
             return "Move the focused pane into its own tab without losing shell identity."
         case .closePane:
@@ -1565,10 +1600,24 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
                 "toggle inspector",
                 "right sidebar",
             ]
-        case .splitHorizontal:
-            return ["split horizontal", "split below", "stack split"]
-        case .splitVertical:
-            return ["split vertical", "split right", "side by side"]
+        case .splitRight:
+            return ["split right", "split vertical", "side by side"]
+        case .splitDown:
+            return ["split down", "split horizontal", "split below", "stack split"]
+        case .splitLeft:
+            return ["split left"]
+        case .splitUp:
+            return ["split up", "split above"]
+        case .focusLeft:
+            return ["focus left", "pane left"]
+        case .focusRight:
+            return ["focus right", "pane right"]
+        case .focusUp:
+            return ["focus up", "pane up"]
+        case .focusDown:
+            return ["focus down", "pane down"]
+        case .equalizeSplits:
+            return ["equalize", "balance splits", "reset split ratios"]
         case .liftPane:
             return ["lift pane", "move pane", "extract pane"]
         case .closePane:
@@ -1614,8 +1663,9 @@ private struct ShellCommandTabView: View {
         let defaultActions: [ShellCommandTabAction] = [
             .openTab,
             .openAlanTab,
-            .splitVertical,
-            .splitHorizontal,
+            .splitRight,
+            .splitDown,
+            .equalizeSplits,
             .toggleInspector,
             .jumpToAttention,
             .newSpace,
@@ -1664,7 +1714,7 @@ private struct ShellCommandTabView: View {
         {
             if let candidate = matchingRoutingCandidates.first {
                 return ShellCommandTabIntent(
-                    title: "Focus \(candidate.paneID)",
+                    title: "Focus \(routingTitle(for: candidate))",
                     detail: routingDetail(for: candidate),
                     accent: ShellPalette.accent,
                     route: .candidate(candidate)
@@ -1706,7 +1756,7 @@ private struct ShellCommandTabView: View {
                     TextField(
                         "",
                         text: $query,
-                        prompt: Text("Go to tab or run command")
+                        prompt: Text("Go to or Command...")
                             .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
                     )
                         .textFieldStyle(.plain)
@@ -1828,7 +1878,7 @@ private struct ShellCommandTabView: View {
                                     execute(.candidate(candidate))
                                 } label: {
                                     ShellCommandRow(
-                                        title: "Focus \(candidate.paneID)",
+                                        title: "Focus \(routingTitle(for: candidate))",
                                         detail: routingDetail(for: candidate),
                                         accent: ShellPalette.accent
                                     )
@@ -1895,9 +1945,9 @@ private struct ShellCommandTabView: View {
         case .newAlanSpace:
             _ = host.createAlanSpace()
         case .openTab:
-            _ = host.openTerminalTab()
+            host.performShellWorkspaceCommand(.newTerminalTab)
         case .openAlanTab:
-            _ = host.openAlanTab()
+            host.performShellWorkspaceCommand(.newAlanTab)
         case .jumpToAttention:
             if let firstAttention = host.attentionItems.first {
                 host.focusAttentionItem(firstAttention)
@@ -1912,16 +1962,30 @@ private struct ShellCommandTabView: View {
                     showsInspector.toggle()
                 }
             }
-        case .splitHorizontal:
-            _ = host.splitFocusedPane(direction: .horizontal)
-        case .splitVertical:
-            _ = host.splitFocusedPane(direction: .vertical)
+        case .splitRight:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitRight)
+        case .splitDown:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitDown)
+        case .splitLeft:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitLeft)
+        case .splitUp:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitUp)
+        case .focusLeft:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusLeft)
+        case .focusRight:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusRight)
+        case .focusUp:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusUp)
+        case .focusDown:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusDown)
+        case .equalizeSplits:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.equalizeSplits)
         case .liftPane:
             _ = host.liftSelectedPaneToTab()
         case .closePane:
-            _ = host.closeSelectedPane()
+            host.performShellWorkspaceCommand(.closePane)
         case .closeTab:
-            _ = host.closeSelectedTab()
+            host.performShellWorkspaceCommand(.closeTab)
         case .copySnapshot:
             host.copySnapshotJSON()
         }
@@ -1947,11 +2011,25 @@ private struct ShellCommandTabView: View {
     }
 
     private func routingDetail(for candidate: AlanShellRoutingCandidate) -> String {
-        let pane = host.shellState.panes.first(where: { $0.paneID == candidate.paneID })
-        let title = pane?.viewport?.title ?? pane?.process?.program ?? candidate.paneID
+        let title = routingTitle(for: candidate)
         let reasons = candidate.reasons.prefix(3).joined(separator: " • ")
         let detail = reasons.isEmpty ? "score \(Int(candidate.score * 100))" : reasons
         return "\(title) • \(detail)"
+    }
+
+    private func routingTitle(for candidate: AlanShellRoutingCandidate) -> String {
+        guard let pane = host.shellState.panes.first(where: { $0.paneID == candidate.paneID }) else {
+            return "Terminal Pane"
+        }
+
+        return shellDisplayTitle(
+            rawTitle: pane.viewport?.title,
+            workingDirectoryName: pane.context?.workingDirectoryName,
+            cwd: pane.cwd,
+            program: pane.process?.program,
+            launchTarget: pane.resolvedLaunchTarget,
+            fallback: pane.viewport?.summary
+        )
     }
 
     private var requestedInspectorVisibility: Bool? {
@@ -2004,8 +2082,15 @@ private final class ShellVoiceCommandController: NSObject, ObservableObject, NSS
             "open in alan",
             "focus best pane",
             "route to best pane",
-            "split horizontal",
-            "split vertical",
+            "split right",
+            "split down",
+            "split left",
+            "split up",
+            "focus left",
+            "focus right",
+            "focus up",
+            "focus down",
+            "equalize splits",
             "lift pane",
             "close pane",
             "close tab",

--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -819,6 +819,16 @@ private enum AlanShellLocalCommandExecutor {
                 errorCode: error.rawValue,
                 errorMessage: "The requested split does not exist."
             )
+        case .spatialFocusTargetNotFound:
+            return response(
+                for: command,
+                state: state,
+                applied: false,
+                tabID: command.tabID,
+                paneID: command.paneID,
+                errorCode: error.rawValue,
+                errorMessage: "There is no pane in that direction."
+            )
         case .lastTab:
             return response(
                 for: command,

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -415,23 +415,77 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func splitFocusedPane(direction: ShellSplitDirection) -> String? {
+        splitFocusedPane(placement: .defaultPlacement(for: direction))
+    }
+
+    @discardableResult
+    func splitFocusedPane(placement: ShellPaneSplitDirection) -> String? {
         guard let focusedPaneID = shellState.focusedPaneID else { return nil }
-        return splitPane(paneID: focusedPaneID, direction: direction)
+        return splitPane(paneID: focusedPaneID, placement: placement)
     }
 
     @discardableResult
     func splitPane(paneID: String, direction: ShellSplitDirection) -> String? {
+        splitPane(paneID: paneID, placement: .defaultPlacement(for: direction))
+    }
+
+    @discardableResult
+    func splitPane(paneID: String, placement: ShellPaneSplitDirection) -> String? {
         let result: ShellStateMutationResult
         do {
             result = try shellState.splittingPane(
                 paneID,
-                direction: direction
+                placement: placement
             )
         } catch {
             return nil
         }
         applyMutationResult(result)
         return result.paneID
+    }
+
+    @discardableResult
+    func focusAdjacentPane(direction: ShellSpatialFocusDirection) -> Bool {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.focusingAdjacentPane(direction)
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
+    }
+
+    @discardableResult
+    func performShellWorkspaceCommand(_ command: ShellWorkspaceCommand) -> Bool {
+        switch command {
+        case .newTerminalTab:
+            return openTerminalTab() != nil
+        case .newAlanTab:
+            return openAlanTab() != nil
+        case .splitLeft:
+            return splitFocusedPane(placement: .left) != nil
+        case .splitRight:
+            return splitFocusedPane(placement: .right) != nil
+        case .splitUp:
+            return splitFocusedPane(placement: .up) != nil
+        case .splitDown:
+            return splitFocusedPane(placement: .down) != nil
+        case .focusLeft:
+            return focusAdjacentPane(direction: .left)
+        case .focusRight:
+            return focusAdjacentPane(direction: .right)
+        case .focusUp:
+            return focusAdjacentPane(direction: .up)
+        case .focusDown:
+            return focusAdjacentPane(direction: .down)
+        case .equalizeSplits:
+            return equalizeSelectedTabSplits()
+        case .closePane:
+            return closeSelectedPane()
+        case .closeTab:
+            return closeSelectedTab()
+        }
     }
 
     @discardableResult

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -23,6 +23,83 @@ enum ShellSplitDirection: String, Codable {
     case vertical
 }
 
+enum ShellPaneSplitDirection: String, Codable, CaseIterable {
+    case left
+    case right
+    case up
+    case down
+
+    var splitDirection: ShellSplitDirection {
+        switch self {
+        case .left, .right:
+            return .vertical
+        case .up, .down:
+            return .horizontal
+        }
+    }
+
+    var placesNewPaneBeforeTarget: Bool {
+        switch self {
+        case .left, .up:
+            return true
+        case .right, .down:
+            return false
+        }
+    }
+
+    static func defaultPlacement(for splitDirection: ShellSplitDirection) -> ShellPaneSplitDirection {
+        switch splitDirection {
+        case .horizontal:
+            return .down
+        case .vertical:
+            return .right
+        }
+    }
+}
+
+enum ShellSpatialFocusDirection: String, Codable, CaseIterable {
+    case left
+    case right
+    case up
+    case down
+
+    var splitDirection: ShellSplitDirection {
+        switch self {
+        case .left, .right:
+            return .vertical
+        case .up, .down:
+            return .horizontal
+        }
+    }
+
+    var movesForward: Bool {
+        switch self {
+        case .right, .down:
+            return true
+        case .left, .up:
+            return false
+        }
+    }
+}
+
+enum ShellWorkspaceCommand: String, CaseIterable, Identifiable {
+    case newTerminalTab
+    case newAlanTab
+    case splitLeft
+    case splitRight
+    case splitUp
+    case splitDown
+    case focusLeft
+    case focusRight
+    case focusUp
+    case focusDown
+    case equalizeSplits
+    case closePane
+    case closeTab
+
+    var id: String { rawValue }
+}
+
 enum ShellLaunchTarget: String, Codable, CaseIterable {
     case shell
     case alan
@@ -469,6 +546,22 @@ extension ShellPaneTreeNode {
         newLeafNodeID: String,
         newPaneID: String
     ) -> ShellPaneTreeNode {
+        splittingPane(
+            targetPaneID,
+            placement: .defaultPlacement(for: direction),
+            splitNodeID: splitNodeID,
+            newLeafNodeID: newLeafNodeID,
+            newPaneID: newPaneID
+        )
+    }
+
+    func splittingPane(
+        _ targetPaneID: String,
+        placement: ShellPaneSplitDirection,
+        splitNodeID: String,
+        newLeafNodeID: String,
+        newPaneID: String
+    ) -> ShellPaneTreeNode {
         switch kind {
         case .pane:
             guard paneID == targetPaneID else { return self }
@@ -489,10 +582,12 @@ extension ShellPaneTreeNode {
             return ShellPaneTreeNode(
                 nodeID: splitNodeID,
                 kind: .split,
-                direction: direction,
+                direction: placement.splitDirection,
                 ratio: 0.5,
                 paneID: nil,
-                children: [currentLeaf, newLeaf]
+                children: placement.placesNewPaneBeforeTarget
+                    ? [newLeaf, currentLeaf]
+                    : [currentLeaf, newLeaf]
             )
         case .split:
             return ShellPaneTreeNode(
@@ -504,7 +599,7 @@ extension ShellPaneTreeNode {
                 children: (children ?? []).map {
                     $0.splittingPane(
                         targetPaneID,
-                        direction: direction,
+                        placement: placement,
                         splitNodeID: splitNodeID,
                         newLeafNodeID: newLeafNodeID,
                         newPaneID: newPaneID
@@ -583,6 +678,229 @@ extension ShellPaneTreeNode {
             children: [self, newLeaf]
         )
     }
+
+    func adjacentPaneID(
+        from targetPaneID: String,
+        direction: ShellSpatialFocusDirection
+    ) -> String? {
+        let frames = leafFrames(in: .unit)
+        guard let targetFrame = frames.first(where: { $0.paneID == targetPaneID }) else {
+            return nil
+        }
+
+        return frames
+            .filter { $0.paneID != targetPaneID && targetFrame.isAdjacentCandidate($0, direction: direction) }
+            .min { lhs, rhs in
+                targetFrame.sortsBefore(lhs, rhs, direction: direction)
+            }?
+            .paneID
+    }
+
+    private struct PaneFrame {
+        static let unit = PaneFrame(
+            paneID: "",
+            minX: 0,
+            maxX: 1,
+            minY: 0,
+            maxY: 1
+        )
+
+        let paneID: String
+        let minX: Double
+        let maxX: Double
+        let minY: Double
+        let maxY: Double
+
+        var width: Double { max(maxX - minX, 0) }
+        var height: Double { max(maxY - minY, 0) }
+        var midX: Double { (minX + maxX) / 2 }
+        var midY: Double { (minY + maxY) / 2 }
+
+        func replacingPaneID(_ paneID: String) -> PaneFrame {
+            PaneFrame(
+                paneID: paneID,
+                minX: minX,
+                maxX: maxX,
+                minY: minY,
+                maxY: maxY
+            )
+        }
+
+        func isAdjacentCandidate(
+            _ candidate: PaneFrame,
+            direction: ShellSpatialFocusDirection
+        ) -> Bool {
+            let epsilon = 0.000_001
+            guard perpendicularOverlap(with: candidate, direction: direction) > epsilon else {
+                return false
+            }
+
+            switch direction {
+            case .left:
+                return candidate.maxX <= minX + epsilon
+            case .right:
+                return candidate.minX >= maxX - epsilon
+            case .up:
+                return candidate.maxY <= minY + epsilon
+            case .down:
+                return candidate.minY >= maxY - epsilon
+            }
+        }
+
+        func sortsBefore(
+            _ lhs: PaneFrame,
+            _ rhs: PaneFrame,
+            direction: ShellSpatialFocusDirection
+        ) -> Bool {
+            let epsilon = 0.000_001
+            let lhsDistance = primaryDistance(to: lhs, direction: direction)
+            let rhsDistance = primaryDistance(to: rhs, direction: direction)
+            if abs(lhsDistance - rhsDistance) > epsilon {
+                return lhsDistance < rhsDistance
+            }
+
+            let lhsOverlap = perpendicularOverlap(with: lhs, direction: direction)
+            let rhsOverlap = perpendicularOverlap(with: rhs, direction: direction)
+            if abs(lhsOverlap - rhsOverlap) > epsilon {
+                return lhsOverlap > rhsOverlap
+            }
+
+            let lhsCenterDistance = perpendicularCenterDistance(to: lhs, direction: direction)
+            let rhsCenterDistance = perpendicularCenterDistance(to: rhs, direction: direction)
+            if abs(lhsCenterDistance - rhsCenterDistance) > epsilon {
+                return lhsCenterDistance < rhsCenterDistance
+            }
+
+            return lhs.paneID < rhs.paneID
+        }
+
+        private func primaryDistance(
+            to candidate: PaneFrame,
+            direction: ShellSpatialFocusDirection
+        ) -> Double {
+            switch direction {
+            case .left:
+                return max(minX - candidate.maxX, 0)
+            case .right:
+                return max(candidate.minX - maxX, 0)
+            case .up:
+                return max(minY - candidate.maxY, 0)
+            case .down:
+                return max(candidate.minY - maxY, 0)
+            }
+        }
+
+        private func perpendicularOverlap(
+            with candidate: PaneFrame,
+            direction: ShellSpatialFocusDirection
+        ) -> Double {
+            switch direction {
+            case .left, .right:
+                return max(0, min(maxY, candidate.maxY) - max(minY, candidate.minY))
+            case .up, .down:
+                return max(0, min(maxX, candidate.maxX) - max(minX, candidate.minX))
+            }
+        }
+
+        private func perpendicularCenterDistance(
+            to candidate: PaneFrame,
+            direction: ShellSpatialFocusDirection
+        ) -> Double {
+            switch direction {
+            case .left, .right:
+                return abs(midY - candidate.midY)
+            case .up, .down:
+                return abs(midX - candidate.midX)
+            }
+        }
+    }
+
+    private func leafFrames(in frame: PaneFrame) -> [PaneFrame] {
+        switch kind {
+        case .pane:
+            guard let paneID else { return [] }
+            return [frame.replacingPaneID(paneID)]
+        case .split:
+            let childNodes = children ?? []
+            guard !childNodes.isEmpty else { return [] }
+
+            if childNodes.count == 2 {
+                let ratio = splitRatio
+                switch direction ?? .horizontal {
+                case .vertical:
+                    let splitX = frame.minX + frame.width * ratio
+                    return childNodes[0].leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: frame.minX,
+                            maxX: splitX,
+                            minY: frame.minY,
+                            maxY: frame.maxY
+                        )
+                    ) + childNodes[1].leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: splitX,
+                            maxX: frame.maxX,
+                            minY: frame.minY,
+                            maxY: frame.maxY
+                        )
+                    )
+                case .horizontal:
+                    let splitY = frame.minY + frame.height * ratio
+                    return childNodes[0].leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: frame.minX,
+                            maxX: frame.maxX,
+                            minY: frame.minY,
+                            maxY: splitY
+                        )
+                    ) + childNodes[1].leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: frame.minX,
+                            maxX: frame.maxX,
+                            minY: splitY,
+                            maxY: frame.maxY
+                        )
+                    )
+                }
+            }
+
+            let childCount = Double(childNodes.count)
+            return childNodes.enumerated().flatMap { index, child in
+                let start = Double(index) / childCount
+                let end = Double(index + 1) / childCount
+                switch direction ?? .horizontal {
+                case .vertical:
+                    let minX = frame.minX + frame.width * start
+                    let maxX = frame.minX + frame.width * end
+                    return child.leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: minX,
+                            maxX: maxX,
+                            minY: frame.minY,
+                            maxY: frame.maxY
+                        )
+                    )
+                case .horizontal:
+                    let minY = frame.minY + frame.height * start
+                    let maxY = frame.minY + frame.height * end
+                    return child.leafFrames(
+                        in: PaneFrame(
+                            paneID: "",
+                            minX: frame.minX,
+                            maxX: frame.maxX,
+                            minY: minY,
+                            maxY: maxY
+                        )
+                    )
+                }
+            }
+        }
+    }
 }
 
 enum ShellStateMutationError: String, Error {
@@ -590,6 +908,7 @@ enum ShellStateMutationError: String, Error {
     case tabNotFound = "tab_not_found"
     case paneNotFound = "pane_not_found"
     case splitNotFound = "split_not_found"
+    case spatialFocusTargetNotFound = "spatial_focus_target_not_found"
     case lastTab = "last_tab"
     case lastPane = "last_pane"
     case invalidMoveTarget = "invalid_move_target"
@@ -860,6 +1179,24 @@ extension ShellStateSnapshot {
         )
     }
 
+    func focusingAdjacentPane(_ direction: ShellSpatialFocusDirection) throws -> ShellStateMutationResult {
+        guard let focusedPaneID,
+              let focusedPane = pane(paneID: focusedPaneID),
+              let focusedTab = tab(tabID: focusedPane.tabID)
+        else {
+            throw ShellStateMutationError.paneNotFound
+        }
+
+        guard let targetPaneID = focusedTab.paneTree.adjacentPaneID(
+            from: focusedPaneID,
+            direction: direction
+        ) else {
+            throw ShellStateMutationError.spatialFocusTargetNotFound
+        }
+
+        return try focusingPane(targetPaneID)
+    }
+
     func creatingSpace(
         launchTarget: ShellLaunchTarget,
         title: String?,
@@ -1044,6 +1381,20 @@ extension ShellStateSnapshot {
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
+        try splittingPane(
+            paneID,
+            placement: .defaultPlacement(for: direction),
+            defaultWorkingDirectory: defaultWorkingDirectory,
+            now: now
+        )
+    }
+
+    func splittingPane(
+        _ paneID: String,
+        placement: ShellPaneSplitDirection,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
+        now: Date = .now
+    ) throws -> ShellStateMutationResult {
         guard let pane = pane(paneID: paneID),
               let tab = tab(tabID: pane.tabID)
         else {
@@ -1070,7 +1421,7 @@ extension ShellStateSnapshot {
             title: tab.title,
             paneTree: tab.paneTree.splittingPane(
                 paneID,
-                direction: direction,
+                placement: placement,
                 splitNodeID: splitNodeID,
                 newLeafNodeID: "node_\(newPaneID)",
                 newPaneID: newPaneID

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -14,6 +14,7 @@ struct TerminalHostView: NSViewRepresentable {
     let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
+    let onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -23,6 +24,7 @@ struct TerminalHostView: NSViewRepresentable {
             bootProfile: bootProfile,
             isSelected: isSelected,
             activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -35,6 +37,7 @@ struct TerminalHostView: NSViewRepresentable {
             isSelected: isSelected,
             surfaceHandle: runtimeRegistry.surfaceHandle(for: pane, bootProfile: bootProfile),
             activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -61,6 +64,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var bootProfile: AlanShellBootProfile?
     private var isSelected = false
     private weak var activationDelegate: TerminalHostActivationDelegate?
+    private var workspaceCommandHandler: ((ShellWorkspaceCommand) -> Void)?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var windowObservers: [NSObjectProtocol] = []
@@ -175,6 +179,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         isSelected: Bool,
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
+        onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
@@ -186,6 +191,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         self.isSelected = isSelected
         surfaceController.bind(surfaceHandle: surfaceHandle, paneID: pane?.paneID)
         self.activationDelegate = activationDelegate
+        workspaceCommandHandler = onWorkspaceCommand
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
@@ -957,6 +963,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 #endif
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if routeWorkspaceKeyCommandIfNeeded(event) {
+            return true
+        }
         if routeNativeKeyCommandIfNeeded(event) {
             return true
         }
@@ -982,6 +991,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func keyDown(with event: NSEvent) {
+        if routeWorkspaceKeyCommandIfNeeded(event) {
+            return
+        }
         if routeNativeKeyCommandIfNeeded(event) {
             return
         }
@@ -1214,6 +1226,16 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         case .nativeCommand, .terminalText, .terminalKey, .ignored:
             return false
         }
+    }
+
+    private func routeWorkspaceKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
+        guard let command = surfaceController.inputAdapter.routeWorkspaceCommand(
+            terminalKeyInput(for: event)
+        ) else {
+            return false
+        }
+        workspaceCommandHandler?(command)
+        return true
     }
 
     private func handleSearchKeyIfNeeded(_ event: NSEvent) -> Bool {

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -485,6 +485,9 @@ private struct ShellPaneTreeLayoutView: View {
                     isSelected: host.selectedPane?.paneID == pane.paneID,
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     activationDelegate: host,
+                    onWorkspaceCommand: { command in
+                        host.performShellWorkspaceCommand(command)
+                    },
                     onRuntimeUpdate: host.updateTerminalRuntime,
                     onMetadataUpdate: { metadata in
                         host.updateTerminalMetadata(metadata, for: pane.paneID)
@@ -639,6 +642,7 @@ private struct ShellTerminalLeafView: View {
     let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
+    let onWorkspaceCommand: (ShellWorkspaceCommand) -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -649,6 +653,7 @@ private struct ShellTerminalLeafView: View {
             isSelected: isSelected,
             runtimeRegistry: runtimeRegistry,
             activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -57,6 +57,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         bootProfile: AlanShellBootProfile?,
         isSelected: Bool,
         activationDelegate: TerminalHostActivationDelegate?,
+        onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
@@ -86,6 +87,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             isSelected: isSelected,
             surfaceHandle: surfaceHandle,
             activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -474,6 +474,62 @@ enum AlanTerminalInputRoutingDecision: Equatable {
 
 @MainActor
 final class AlanTerminalInputAdapter {
+    func routeWorkspaceCommand(_ input: AlanTerminalKeyInput) -> ShellWorkspaceCommand? {
+        guard input.phase == .down, !input.isRepeat else { return nil }
+
+        let characters = input.characters?.lowercased()
+        switch input.modifiers {
+        case [.command]:
+            switch characters {
+            case "d":
+                return .splitRight
+            case "t":
+                return .newTerminalTab
+            case "w":
+                return .closeTab
+            default:
+                return nil
+            }
+        case [.command, .shift]:
+            switch characters {
+            case "d":
+                return .splitDown
+            case "w":
+                return .closePane
+            default:
+                return nil
+            }
+        case [.command, .option]:
+            switch characters {
+            case "d":
+                return .splitLeft
+            case "t":
+                return .newAlanTab
+            case "=" where input.keyCode == 0x18:
+                return .equalizeSplits
+            default:
+                return nil
+            }
+        case [.command, .option, .shift]:
+            return characters == "d" ? .splitUp : nil
+        case [.command, .control]:
+            switch input.keyCode {
+            case 0x7B:
+                return .focusLeft
+            case 0x7C:
+                return .focusRight
+            case 0x7E:
+                return .focusUp
+            case 0x7D:
+                return .focusDown
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+
     func routeKey(_ input: AlanTerminalKeyInput) -> AlanTerminalInputRoutingDecision {
         if input.phase == .down,
            input.modifiers == .command,

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -226,6 +226,61 @@ require_pattern \
     "split resize preview persistence must be controlled at mutation application"
 
 require_pattern \
+    "clients/apple/AlanNative/ShellModel.swift" \
+    "enum ShellPaneSplitDirection" \
+    "split commands must model left/right/up/down placement separately from split axis"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellModel.swift" \
+    "enum ShellSpatialFocusDirection" \
+    "spatial focus commands must use explicit left/right/up/down directions"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "func performShellWorkspaceCommand\\(_ command: ShellWorkspaceCommand\\)" \
+    "menu, keyboard, and command UI actions must route through one shell command entry point"
+
+require_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "AlanMacShellCommands\\(host: primaryShellOwner\\.host\\)" \
+    "native menu commands must receive the primary shell host"
+
+require_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "CommandMenu\\(\"Shell\"\\)" \
+    "split workspace actions must be exposed through a native Shell menu"
+
+require_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "\\.keyboardShortcut\\(\"d\", modifiers: \\.command\\)" \
+    "split right must have a native command-key shortcut"
+
+require_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "\\.keyboardShortcut\\(\"d\", modifiers: \\[\\.command, \\.shift\\]\\)" \
+    "split down must have a native command-shift shortcut"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "ShellWorkspaceCommand\\.splitRight" \
+    "command UI split actions must call the same shell command router as native menus"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "Go to or Command\\.\\.\\." \
+    "command entry copy must match the accepted shell command UI label"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "func routeWorkspaceCommand\\(_ input: AlanTerminalKeyInput\\) -> ShellWorkspaceCommand\\?" \
+    "terminal input routing must recognize Alan workspace shortcuts before terminal bindings"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "routeWorkspaceKeyCommandIfNeeded\\(event\\)" \
+    "terminal host key equivalents must give Alan workspace shortcuts priority over Ghostty bindings"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -17,6 +17,7 @@ final class AlanTerminalHostNSView: NSView {
         isSelected: Bool,
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
+        onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {}

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -10,9 +10,12 @@ struct ShellSplitModelTestRunner {
 private enum ShellSplitModelTests {
     static func run() throws {
         try verifiesNewSplitsStoreEqualRatio()
+        try verifiesDirectionalSplitsPlaceNewPaneOnRequestedSide()
         try verifiesSplitRatiosClampWhenResized()
         try verifiesEqualizeRestoresEverySplitRatio()
         try verifiesSameDirectionAttachKeepsBinarySplitTree()
+        try verifiesSpatialFocusFollowsSplitTree()
+        try verifiesSpatialFocusPreservesPerpendicularPosition()
         try verifiesLegacySplitDecodeDefaultsToEqualRatio()
         print("Shell split model tests passed.")
     }
@@ -25,6 +28,26 @@ private enum ShellSplitModelTests {
         expect(tree.kind == .split, "splitting a pane must create a split branch")
         expect(tree.ratio == 0.5, "new split branches must persist an equal divider ratio")
         expect(tree.children?.count == 2, "a split branch must keep two structural children")
+    }
+
+    private static func verifiesDirectionalSplitsPlaceNewPaneOnRequestedSide() throws {
+        let base = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+
+        let rightTree = try requireFocusedTabTree(try base.splittingPane("pane_1", placement: .right).state)
+        expect(rightTree.direction == .vertical, "split right must create a vertical split branch")
+        expect(rightTree.paneIDs == ["pane_1", "pane_2"], "split right must place the new pane after the focused pane")
+
+        let leftTree = try requireFocusedTabTree(try base.splittingPane("pane_1", placement: .left).state)
+        expect(leftTree.direction == .vertical, "split left must create a vertical split branch")
+        expect(leftTree.paneIDs == ["pane_2", "pane_1"], "split left must place the new pane before the focused pane")
+
+        let downTree = try requireFocusedTabTree(try base.splittingPane("pane_1", placement: .down).state)
+        expect(downTree.direction == .horizontal, "split down must create a horizontal split branch")
+        expect(downTree.paneIDs == ["pane_1", "pane_2"], "split down must place the new pane after the focused pane")
+
+        let upTree = try requireFocusedTabTree(try base.splittingPane("pane_1", placement: .up).state)
+        expect(upTree.direction == .horizontal, "split up must create a horizontal split branch")
+        expect(upTree.paneIDs == ["pane_2", "pane_1"], "split up must place the new pane before the focused pane")
     }
 
     private static func verifiesSplitRatiosClampWhenResized() throws {
@@ -84,6 +107,64 @@ private enum ShellSplitModelTests {
         expect(
             attached.paneIDs == ["pane_1", "pane_2", "pane_3"],
             "same-direction attachment must preserve pane ordering"
+        )
+    }
+
+    private static func verifiesSpatialFocusFollowsSplitTree() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+        let pane2 = state.focusedPaneID ?? "pane_2"
+        let pane1Focused = try state.focusingPane("pane_1").state
+
+        let rightResult = try pane1Focused.focusingAdjacentPane(.right)
+        expect(rightResult.paneID == pane2, "focus right must move to the right sibling pane")
+
+        let leftResult = try rightResult.state.focusingAdjacentPane(.left)
+        expect(leftResult.paneID == "pane_1", "focus left must return to the left sibling pane")
+
+        do {
+            _ = try pane1Focused.focusingAdjacentPane(.left)
+            expect(false, "focus left without a neighbor must throw")
+        } catch ShellStateMutationError.spatialFocusTargetNotFound {
+            // Expected.
+        }
+    }
+
+    private static func verifiesSpatialFocusPreservesPerpendicularPosition() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+        state = try state.splittingPane("pane_1", placement: .down).state
+        state = try state.splittingPane("pane_2", placement: .down).state
+
+        let lowerLeftFocused = try state.focusingPane("pane_3").state
+        let rightResult = try lowerLeftFocused.focusingAdjacentPane(.right)
+        expect(
+            rightResult.paneID == "pane_4",
+            "focus right from the lower-left pane must land on the lower-right pane"
+        )
+
+        let leftResult = try rightResult.state.focusingAdjacentPane(.left)
+        expect(
+            leftResult.paneID == "pane_3",
+            "focus left from the lower-right pane must return to the lower-left pane"
+        )
+
+        var rowState = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        rowState = try rowState.splittingPane("pane_1", placement: .down).state
+        rowState = try rowState.splittingPane("pane_1", placement: .right).state
+        rowState = try rowState.splittingPane("pane_2", placement: .right).state
+
+        let upperRightFocused = try rowState.focusingPane("pane_3").state
+        let downResult = try upperRightFocused.focusingAdjacentPane(.down)
+        expect(
+            downResult.paneID == "pane_4",
+            "focus down from the upper-right pane must land on the lower-right pane"
+        )
+
+        let upResult = try downResult.state.focusingAdjacentPane(.up)
+        expect(
+            upResult.paneID == "pane_3",
+            "focus up from the lower-right pane must return to the upper-right pane"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -171,6 +171,39 @@ private enum TerminalSurfaceControllerTests {
             )
         )
         expect(printable == .terminalText("a"), "printable key input must become terminal text")
+
+        let splitDown = adapter.routeWorkspaceCommand(
+            AlanTerminalKeyInput(
+                characters: "d",
+                keyCode: 2,
+                modifiers: [.command, .shift],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(splitDown == .splitDown, "command-shift-d must route to shell split down before terminal bindings")
+
+        let splitRight = adapter.routeWorkspaceCommand(
+            AlanTerminalKeyInput(
+                characters: "d",
+                keyCode: 2,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(splitRight == .splitRight, "command-d must route to shell split right before terminal bindings")
+
+        let focusRight = adapter.routeWorkspaceCommand(
+            AlanTerminalKeyInput(
+                characters: nil,
+                keyCode: 0x7C,
+                modifiers: [.command, .control],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(focusRight == .focusRight, "command-control-right must route to shell focus right")
     }
 
     private static func verifiesPointerRoutingFollowsTerminalMouseModes() {


### PR DESCRIPTION
Summary:
- Add ShellWorkspaceCommand routing for terminal tabs, Alan tabs, directional splits, spatial focus, equalize, and close actions.
- Wire native Shell menu shortcuts and command UI actions through the same shell host command entry point.
- Add split placement and spatial focus model coverage plus contract checks for the new command surface.

Verification:
- clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- clients/apple/scripts/test-terminal-surface-controller.sh
- clients/apple/scripts/test-terminal-runtime-service.sh
- clients/apple/scripts/test-shell-runtime-metadata.sh
- git diff --check
- openspec validate upgrade-macos-shell-splits-commands --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Scope note:
- This PR intentionally covers the split command/shortcut slice only. Remote workspace, zoom, resize command results, and pane movement remain in the broader OpenSpec change.