### PR TITLE
Propose macOS pane title bars and radius specs

### DIFF
--- a/openspec/changes/add-macos-pane-title-bars/.openspec.yaml
+++ b/openspec/changes/add-macos-pane-title-bars/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/add-macos-pane-title-bars/design.md
+++ b/openspec/changes/add-macos-pane-title-bars/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`TerminalPaneView` currently renders the selected tab's `ShellPaneTreeNode` into
+`ShellTerminalLeafView` leaves. Each leaf owns a `TerminalHostView`, stable
+`.id(pane.paneID)`, inactive-pane dimming, and split dividers, but there is no
+per-pane visible title or close affordance. The only lightweight metadata strip
+is global to the selected pane, so split panes can be hard to identify at a
+glance.
+
+The title data already exists in the model and is already owned by the terminal
+lifecycle contract. `TerminalHostRuntimeSnapshot` projects terminal metadata
+into `ShellPane.viewport?.title`, and the UI already has normalization helpers
+such as `shellNormalizedTitle(...)` and `shellDisplayTitle(...)`. This change
+only decides how the pane title bar consumes that metadata. Close behavior also
+already exists in the model and controller: `ShellStateSnapshot.closingPane(...)`
+repairs split trees, falls back to tab close when a tab has one pane, and
+preserves remaining pane runtimes through the shared mutation path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a narrow title bar to every visible terminal pane, including single-pane
+  and split-pane tabs.
+- Prefer the current terminal title from `ShellViewportSnapshot.title`, with
+  cwd, working-directory, launch-target, and process fallbacks only when the
+  terminal title is unavailable.
+- Close the exact pane whose title-bar button was clicked, without depending on
+  whatever pane was selected before the click.
+- Keep the chrome visually quiet and compatible with the existing Arc-like,
+  terminal-first macOS shell contract.
+- Preserve terminal hit-testing, text selection, mouse reporting, and scroll
+  behavior by keeping the title bar outside the terminal host surface.
+
+**Non-Goals:**
+
+- Add a general pane-management toolbar, pane tab strip, breadcrumbs, badges, or
+  debug metadata to the pane header.
+- Change spaces/tabs IA, split-tree persistence, pane runtime ownership, or
+  terminal renderer internals.
+- Add drag-to-move, zoom, search, or command palette changes; those remain owned
+  by the advanced split/workspace changes.
+
+## Decisions
+
+1. Render pane title bars in `ShellTerminalLeafView`.
+
+   Each leaf already has the pane model, selected state, runtime registry, and
+   workspace command hooks. Placing the header there makes the title bar
+   per-pane by construction and keeps split branches agnostic to leaf chrome.
+
+   Alternative considered: render one header above `TerminalPaneView`. That
+   keeps the layout simple but fails the core requirement because only the
+   selected pane would be identified. Alternative considered: overlay the header
+   directly on top of `TerminalHostView`. That preserves terminal area but risks
+   occluding the first terminal row and reintroducing hit-testing ambiguity.
+
+2. Add a pane-specific title helper that reuses existing normalization but
+   changes the priority order.
+
+   The pane title bar should describe the current terminal surface first, so it
+   should prefer `shellNormalizedTitle(pane.viewport?.title)`. Working directory
+   and process labels remain useful fallbacks. This avoids changing
+   `shellDisplayTitle(...)`, whose cwd-first ordering is still appropriate for
+   tab/sidebar contexts.
+
+   Alternative considered: use `shellDisplayTitle(...)` unchanged. That would be
+   low-risk mechanically, but it can show cwd instead of the actual terminal
+   title when both are present.
+
+3. Target close by pane ID, not by selected pane.
+
+   The title-bar close button should call a controller-owned targeted close path
+   for the pane represented by that leaf. The implementation can expose the
+   existing private `closePane(paneID:)` mutation as a focused controller method
+   or add an equivalent wrapper, but it must keep the existing model semantics:
+   repair split trees, close a single-pane tab through tab-close semantics, and
+   leave the only remaining tab unchanged.
+
+   Alternative considered: focus the pane and then call `closeSelectedPane()`.
+   That couples a destructive action to selection order and can close the wrong
+   pane if focus changes are coalesced or rejected.
+
+4. Keep title-bar chrome fixed-height and non-invasive.
+
+   The first implementation should use a compact native row: truncated title,
+   optional subtle active/inactive treatment, and one icon-only close button with
+   tooltip/accessibility label. The title bar should not add cards, large
+   padding, shadows, or extra metadata chips. Long titles must truncate without
+   resizing panes or split dividers.
+
+5. Verify UI consumption with focused tests plus one visual/manual pass.
+
+   The existing terminal metadata tests already cover title projection into pane
+   metadata. This change should only add coverage for the title-bar helper's
+   consumption order and targeted close semantics. Hit-testing and visual polish
+   still need a running-app screenshot or manual note because the quality bar is
+   about terminal input behavior and native layout feel, not just model
+   mutation.
+
+## Risks / Trade-offs
+
+- Header height reduces terminal rows -> Keep the row narrow and stable, and
+  verify single-pane and split-pane screenshots before marking UI work complete.
+- Close button steals terminal input focus -> Keep the button outside the
+  terminal host surface and return focus to the next selected terminal after
+  successful close.
+- Inactive-pane close targets the wrong pane -> Route by pane ID and add a
+  focused test for closing a non-selected visible pane.
+- Terminal titles can be empty, noisy, or cwd-like -> Normalize and fallback
+  consistently, but do not expose raw pane IDs or runtime metadata in default
+  UI.
+- Existing advanced-splits work may touch the same files -> Keep this change
+  narrow: pane header, title derivation, close routing, and verification only.
+
+## Migration Plan
+
+No persisted state or external API migration is required. The change is a local
+macOS UI/controller polish pass. If implementation needs to roll back, remove
+the leaf title-bar wrapper and targeted close UI while leaving the existing
+split model and runtime service intact.
+
+## Open Questions
+
+- Should the title bar remain visible when there is only one total pane in the
+  app, or should the close button be disabled while the title remains visible?
+  Default decision for implementation: keep the title visible and disable or
+  no-op the close control when the existing model reports `lastTab`.

--- a/openspec/changes/add-macos-pane-title-bars/proposal.md
+++ b/openspec/changes/add-macos-pane-title-bars/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Split panes currently show terminal content with only subtle focus treatment and
+optional global metadata, so users cannot quickly identify or close a specific
+visible pane from the pane itself. A narrow per-pane title bar gives every pane a
+stable native affordance while keeping the terminal canvas dominant.
+
+## What Changes
+
+- Add a narrow title bar to each visible terminal pane.
+- Show the pane's current terminal display title by consuming the existing
+  pane metadata/title-normalization path; do not introduce a second terminal
+  title collection contract.
+- Add a close button in the pane title bar that closes that pane through the
+  shared shell workspace command path.
+- Keep the title bar lightweight: no raw pane IDs, runtime phases, debug labels,
+  dense toolbar controls, cards, shadows, or redundant metadata.
+- Preserve terminal hit-testing: the title bar owns only its explicit controls,
+  while terminal text selection, mouse input, and scroll remain inside the
+  terminal host surface.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Adds the default per-pane title bar contract,
+  including title content, close affordance, visual weight, and terminal-first
+  hit-testing boundaries.
+- `macos-shell-build-test-contract`: Adds focused verification for pane title
+  display, close routing, and terminal input preservation.
+
+## Impact
+
+- Apple client UI: `clients/apple/AlanNative/TerminalPaneView.swift` and
+  adjacent view helpers for the pane leaf wrapper.
+- Apple client model/controller: existing `ShellPane`,
+  `ShellViewportSnapshot.title`, title normalization helpers,
+  `ShellWorkspaceCommand.closePane`, and `ShellHostController` close paths.
+- Apple client tests/scripts: focused shell model, runtime metadata, shell
+  contract checks, and manual screenshot/interaction verification.

--- a/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Pane title bars have focused verification
+The Apple client SHALL include focused automated or documented verification for
+pane title-bar consumption, pane-scoped close routing, and terminal input
+ownership when pane title bars are changed.
+
+#### Scenario: Pane title-bar consumption tested
+- **WHEN** pane title-bar helpers receive existing terminal title, working-directory, cwd, launch-target, and process metadata combinations
+- **THEN** focused tests verify title-bar priority, fallback ordering, long-title handling, and suppression of raw pane IDs or debug terms without retesting terminal title capture itself
+
+#### Scenario: Pane close routing tested
+- **WHEN** a title-bar close action targets a selected pane, an inactive split pane, a single-pane tab with other tabs, or the final remaining pane
+- **THEN** focused tests verify the shell mutation result, selected pane after close, split tree repair, and final-pane protection
+
+#### Scenario: Terminal input preservation reviewed
+- **WHEN** pane title-bar implementation is ready for review
+- **THEN** maintainers can inspect automated shell contract checks or manual notes covering terminal click-to-focus, typing, selection drag, right click, scrolling, and close-button interaction
+
+#### Scenario: Visual evidence captured
+- **WHEN** pane title-bar UI polish is marked complete
+- **THEN** maintainers can inspect a running-app screenshot or manual note showing light-mode single-pane and split-pane tabs with compact pane title bars, readable titles, restrained close buttons, and no default debug labels

--- a/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Terminal panes expose narrow title bars
+Each visible macOS terminal pane SHALL include a compact title bar at the top of
+the pane that identifies the terminal and provides a pane-scoped close
+affordance while keeping terminal content visually dominant.
+
+#### Scenario: Single pane title visible
+- **WHEN** a terminal tab contains one visible pane
+- **THEN** the pane shows a narrow title bar above the terminal canvas with a user-facing terminal title and one close button
+
+#### Scenario: Split pane titles visible
+- **WHEN** a terminal tab contains multiple visible panes
+- **THEN** every pane leaf shows its own title bar and close button without adding a pane selector strip, card grid, or debug labels
+
+#### Scenario: Long title fits
+- **WHEN** a pane title is long or changes while the pane is visible
+- **THEN** the title truncates within a stable fixed-height title bar without resizing split dividers, sidebar rows, toolbar content, or sibling panes
+
+### Requirement: Pane title bars consume terminal metadata
+Pane title bars SHALL consume the current terminal title already projected into
+pane metadata, and SHALL use existing user-facing fallback labels only when the
+terminal title is unavailable.
+
+#### Scenario: Terminal title exists
+- **WHEN** a pane has a non-empty `viewport.title`
+- **THEN** the title bar shows the normalized terminal title rather than raw pane IDs, cwd-first labels, runtime phases, or debug event text
+
+#### Scenario: Terminal title missing
+- **WHEN** a pane has no usable terminal title
+- **THEN** the title bar falls back to working-directory name, cwd leaf, launch target, process name, or `Terminal` using user-facing copy
+
+#### Scenario: Debug terms suppressed
+- **WHEN** terminal metadata contains implementation-oriented summaries such as `title updated`, `window attached`, or raw runtime state
+- **THEN** the title bar does not expose those terms outside the explicit inspector debug surface
+
+### Requirement: Pane close button targets its pane
+The pane title bar close button SHALL close the pane represented by that title
+bar through the shared shell controller mutation path.
+
+#### Scenario: Inactive split pane closed
+- **WHEN** a user clicks the close button on a non-selected visible split pane
+- **THEN** Alan closes that pane, repairs the split tree, and keeps the remaining pane runtimes alive without closing a different selected pane
+
+#### Scenario: Single pane tab closed
+- **WHEN** a user clicks the close button for the only pane in a tab and other tabs remain
+- **THEN** Alan applies the existing tab-close semantics for that tab and focuses a remaining terminal pane
+
+#### Scenario: Last remaining pane protected
+- **WHEN** a close button targets the only pane in the only remaining tab
+- **THEN** Alan keeps the shell state valid and does not remove the final workspace surface
+
+### Requirement: Pane title bars preserve terminal input ownership
+Pane title bars SHALL own only their explicit title and button controls, and
+SHALL not intercept terminal input, selection, mouse reporting, scrollback, or
+renderer hit-testing inside the terminal canvas.
+
+#### Scenario: Terminal canvas clicked below title bar
+- **WHEN** a user clicks, drags, scrolls, or right-clicks inside the terminal canvas below a pane title bar
+- **THEN** the terminal host receives the event according to the terminal event ownership contract
+
+#### Scenario: Close button clicked
+- **WHEN** a user clicks the close button in the pane title bar
+- **THEN** the button handles the pane close action without routing that click through terminal text input
+
+#### Scenario: Title area clicked
+- **WHEN** a user clicks the non-button title area
+- **THEN** Alan may focus the pane, but it does not send text, mouse reports, or scroll events to the terminal application

--- a/openspec/changes/add-macos-pane-title-bars/tasks.md
+++ b/openspec/changes/add-macos-pane-title-bars/tasks.md
@@ -1,0 +1,35 @@
+## 1. Title Derivation
+
+- [ ] 1.1 Add a pane-title helper that consumes existing `ShellViewportSnapshot.title` before cwd, working-directory, launch-target, process, or `Terminal` fallbacks.
+- [ ] 1.2 Add focused tests for title-bar consumption priority, fallback ordering, long title truncation readiness, and debug/raw-ID suppression without retesting terminal title capture itself.
+
+## 2. Pane Leaf UI
+
+- [ ] 2.1 Wrap each `ShellTerminalLeafView` terminal host in a compact fixed-height title bar plus terminal canvas layout.
+- [ ] 2.2 Render a single-line truncated pane title with active/inactive styling that stays visually lighter than terminal content.
+- [ ] 2.3 Add an icon-only pane close button with tooltip/accessibility label and stable dimensions.
+- [ ] 2.4 Keep the title bar outside the terminal host surface so terminal clicks, drags, right clicks, and scroll events stay owned by the terminal host.
+
+## 3. Pane-Scoped Close Routing
+
+- [ ] 3.1 Expose a controller-owned targeted pane close path that routes by pane ID and reuses existing `ShellStateSnapshot.closingPane(...)` semantics.
+- [ ] 3.2 Wire the title-bar close button to close the pane represented by that leaf, including inactive split panes.
+- [ ] 3.3 Keep final-pane protection aligned with the existing `lastTab` model behavior and avoid leaving the shell without a valid surface.
+- [ ] 3.4 Add focused tests for selected-pane close, inactive split-pane close, single-pane tab close, and final-pane protection.
+
+## 4. Verification
+
+- [ ] 4.1 Run `clients/apple/scripts/test-shell-split-model.sh`.
+- [ ] 4.2 Run `clients/apple/scripts/test-shell-runtime-metadata.sh`.
+- [ ] 4.3 Run `clients/apple/scripts/test-terminal-surface-controller.sh` if terminal input or host wrapper behavior changes.
+- [ ] 4.4 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 4.5 Run `git diff --check`.
+- [ ] 4.6 Run `openspec validate add-macos-pane-title-bars --type change --strict --json`.
+- [ ] 4.7 Run `openspec validate --all --strict --json`.
+- [ ] 4.8 Build the macOS app with the documented `AlanNative` Debug command.
+- [ ] 4.9 Capture or document light-mode single-pane and split-pane screenshots plus manual terminal interaction notes.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 Sync accepted delta requirements into `openspec/specs/` before archiving after implementation merges.
+- [ ] 5.2 Record implementation verification evidence in the change before archive.

--- a/openspec/changes/normalize-macos-shell-corner-radii/.openspec.yaml
+++ b/openspec/changes/normalize-macos-shell-corner-radii/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/normalize-macos-shell-corner-radii/design.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The active macOS shell surface uses `MacShellRootView.swift`,
+`TerminalPaneView.swift`, and `TerminalHostView.swift` for the default
+terminal-first app. A quick inventory shows the active shell uses hard-coded
+rounded rectangles at 8, 10, 11, 12, 13, 14, 16, 18, 20, 22, and 24 points,
+plus `Capsule` shapes for chips and keycap-like controls. The largest values
+show up in the command palette outer shell (`24`), inspector cards (`20`),
+command search field (`18`), tab rail cards (`18`), and terminal info cards
+(`22`).
+
+This conflicts with the current product direction: Arc-like native material,
+compact rows, terminal-first focus, and calm precision. The UI should feel
+native and deliberate, not pill-heavy or card-heavy. The goal is not to remove
+all curvature; it is to make radius choices scarce, named, smaller, and tied to
+component roles.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a small radius scale for the active Alan macOS shell.
+- Reduce large rounded rectangles and pill/capsule shapes in the default shell
+  UI.
+- Make future pane title bars, command rows, sidebar rows, inspector cards, and
+  terminal surrounds use the same scale.
+- Keep true circular elements only where the shape is semantic: status dots,
+  traffic-light-like indicators, or icon-only circular affordances that are
+  intentionally system-like.
+- Add verification so new ad hoc large radii do not reappear immediately.
+
+**Non-Goals:**
+
+- Redesign spacing, typography, colors, shadows, or information architecture
+  except where radius changes make them visibly inconsistent.
+- Rewrite legacy/non-primary `ContentView.swift` surfaces in this pass.
+- Remove all rounded corners or make Alan feel boxy.
+- Change split behavior, terminal runtime ownership, AppKit hit-testing, or
+  shell model state.
+
+## Decisions
+
+1. Introduce a role-based radius scale, not a free numeric palette.
+
+   Proposed active-shell scale:
+
+   - `none = 0`: full-height material panels, continuous sidebars, separators,
+     and background bands.
+   - `control = 6`: icon buttons, compact keycaps, small title-bar controls,
+     small inline controls.
+   - `row = 8`: sidebar rows, command rows, attention rows, chips, inspector
+     sub-rows, and pane title bars.
+   - `surface = 10`: terminal surround, search fields, inline panels, and
+     small grouped tool surfaces.
+   - `overlay = 12`: command palette outer shell, inspector cards, fallback
+     overlay cards, and rare modal-like surfaces.
+
+   Values above `12` are not part of the default shell scale. They require a
+   documented exception in code or a spec update. This keeps Alan precise while
+   leaving enough curvature for native material surfaces.
+
+   Alternative considered: make everything `8`. That would be simple but too
+   blunt; overlays and terminal surrounds need slightly different optical
+   treatment from small rows. Alternative considered: preserve Apple's very soft
+   continuous style at `18+`. That keeps current feel but does not answer the
+   user's concern that the app is too round and under-specified.
+
+2. Add central radius tokens near `ShellPalette`.
+
+   A small `ShellRadii` enum or similar helper should live with the shell visual
+   tokens, and active-shell SwiftUI views should reference it instead of
+   hard-coded radius values. AppKit-only surfaces can mirror those constants
+   explicitly where Swift types cannot be shared cleanly.
+
+   Alternative considered: leave numeric values inline but document the scale.
+   That is easy to drift from and makes review harder.
+
+3. Replace decorative `Capsule` use with modest rounded rectangles.
+
+   `Capsule` makes compact controls read as pills. In Alan's default shell,
+   text chips, keycap hints, metadata chips, and command badges should usually
+   use `control` or `row` radii instead. Keep `Circle` for status dots and
+   system-like round indicators.
+
+   Alternative considered: allow capsules for every chip because they are common
+   in SwiftUI. That is exactly what makes the UI feel soft and inconsistent.
+
+4. Scope the implementation to the primary macOS shell first.
+
+   The first pass should update `MacShellRootView.swift`,
+   `TerminalPaneView.swift`, and normal-flow AppKit fallback cards in
+   `TerminalHostView.swift`. `ContentView.swift` appears to contain older or
+   separate console surfaces; it should be inventoried but not rewritten unless
+   it is confirmed to be part of the active default shell.
+
+5. Verify visually and mechanically.
+
+   The useful mechanical guard is a focused script or check-shell-contract rule
+   that flags new active-shell `RoundedRectangle(cornerRadius: 14+)`,
+   `layer?.cornerRadius = 14+`, and default-shell `Capsule` usage except for an
+   allowlist. Visual review must still compare single-pane, split-pane,
+   command-palette, and inspector screenshots because small radius changes can
+   affect the perceived density and hierarchy.
+
+## Risks / Trade-offs
+
+- Smaller radii can make the app feel too austere -> Keep material, opacity,
+  spacing, and selected-state subtleties intact; do not pair the radius pass
+  with a broad flattening pass.
+- Hard caps can block legitimate modal styling -> Allow `overlay = 12` and make
+  larger radii require explicit documentation rather than silently banning all
+  exceptions.
+- Replacing capsules may reduce affordance clarity -> Preserve padding,
+  contrast, hover/focus state, and icon alignment when changing shapes.
+- Existing pane-title-bar work may introduce new radii -> Make that change use
+  the same `ShellRadii` scale before implementation.
+- Mechanical grep checks can be brittle -> Keep them focused on active shell
+  files and allowlisted semantic circles/capsules.
+
+## Migration Plan
+
+No state migration is required. Implement the scale behind shared shell visual
+tokens, replace active-shell hard-coded radii in small batches, then run visual
+verification. Archive should sync the accepted radius requirements into
+`openspec/specs/` after implementation lands.

--- a/openspec/changes/normalize-macos-shell-corner-radii/proposal.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The macOS shell UI currently mixes many one-off corner radii across the default
+surface: 8, 10, 11, 12, 13, 14, 16, 18, 20, 22, 24, plus several `Capsule`
+shapes. This makes Alan feel softer and less precise than the intended calm,
+Arc-like native shell.
+
+## What Changes
+
+- Introduce a small Alan shell corner-radius scale for active macOS shell UI.
+- Reduce large rounded rectangles in sidebar, command UI, inspector, terminal
+  surrounds, and debug/info surfaces.
+- Replace decorative `Capsule` usage in text controls and chips with modest
+  rounded rectangles unless the shape is a true status dot or system-like
+  circular control.
+- Keep terminal panes visually continuous: split panes still share one terminal
+  surround, but the outer terminal corners become smaller and more precise.
+- Treat legacy/non-primary Apple surfaces separately; do not expand this pass
+  into unrelated UI rewrites.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Adds the default shell corner-radius scale,
+  shape exceptions, and visual-review requirements for smaller, more precise
+  radius usage.
+- `macos-shell-build-test-contract`: Adds focused verification that UI changes
+  do not reintroduce large ad hoc radii or capsule-heavy default shell chrome.
+
+## Impact
+
+- Apple client UI: primarily `clients/apple/AlanNative/MacShellRootView.swift`
+  and `clients/apple/AlanNative/TerminalPaneView.swift`.
+- Apple client AppKit host fallback: `TerminalHostView.swift` only where its
+  placeholder/fallback panels remain visible in normal shell flows.
+- Active OpenSpec UI polish: coordinate with
+  `add-macos-pane-title-bars` so pane title bars use the same radius scale.
+- Visual QA: running-app screenshots for sidebar, terminal, command UI, and
+  inspector in light mode.

--- a/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Corner-radius conformance is verified
+The Apple client SHALL include focused verification for active-shell
+corner-radius normalization when default macOS shell chrome is changed.
+
+#### Scenario: Active shell radius check runs
+- **WHEN** a change updates active shell visual chrome in `MacShellRootView.swift`, `TerminalPaneView.swift`, or normal-flow `TerminalHostView.swift` fallback surfaces
+- **THEN** a focused check or review step verifies that rounded rectangles use the Alan shell radius scale and do not introduce large ad hoc radii
+
+#### Scenario: Capsule usage reviewed
+- **WHEN** a change adds `Capsule` usage to active default shell chrome
+- **THEN** the change documents why the component is a semantic pill or replaces it with a radius-scale rounded rectangle
+
+#### Scenario: Visual comparison captured
+- **WHEN** radius normalization implementation is marked complete
+- **THEN** maintainers can inspect running-app screenshots or notes for sidebar, terminal, command palette, and inspector states confirming that the UI is smaller-radius, still native, and not visually flat
+
+#### Scenario: Legacy surfaces scoped
+- **WHEN** radius inventory finds older or non-primary Apple client surfaces
+- **THEN** implementation records whether they are active default shell UI before changing them, instead of silently broadening the polish pass

--- a/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Corner radii are restrained and tokenized
+The default Alan macOS shell UI SHALL use a small role-based corner-radius scale
+for rounded rectangular surfaces and controls. It SHALL avoid large ad hoc
+radii and capsule-heavy default chrome.
+
+#### Scenario: Radius scale applied
+- **WHEN** the active macOS shell renders sidebar rows, command rows, pane title bars, inspector cards, terminal surrounds, inline panels, or overlay surfaces
+- **THEN** those rounded rectangular elements use the Alan shell radius scale rather than one-off numeric radii
+
+#### Scenario: Default shell avoids large radii
+- **WHEN** a default shell surface is visible in normal light-mode use
+- **THEN** rounded rectangular chrome does not use radii larger than the overlay radius unless a specific exception is documented in the UI contract
+
+#### Scenario: Capsule use is limited
+- **WHEN** the default shell shows text chips, keycap hints, metadata chips, command badges, sidebar controls, or pane title controls
+- **THEN** those controls use restrained rounded rectangles rather than `Capsule` shapes unless the component is explicitly defined as a semantic pill
+
+#### Scenario: True circles remain semantic
+- **WHEN** the shell shows attention dots, status indicators, traffic-light-like indicators, or intentionally round icon-only controls
+- **THEN** those elements may remain circular because the circle communicates state or system-like control behavior
+
+#### Scenario: Terminal surface remains precise
+- **WHEN** a single pane or split-pane tab is visible
+- **THEN** terminal panes keep a shared continuous terminal surround with smaller outer corners and no per-pane rounded card treatment
+
+### Requirement: Radius normalization preserves shell hierarchy
+Radius normalization SHALL make Alan feel calmer and more precise without
+turning the UI into a flat grid or weakening control affordances.
+
+#### Scenario: Sidebar remains skimmable
+- **WHEN** sidebar spaces, tabs, command entry, and creation controls are visible
+- **THEN** smaller radii preserve row scanning, hover states, selected states, and stable dimensions
+
+#### Scenario: Command UI remains readable
+- **WHEN** the command palette is open
+- **THEN** the outer overlay, search field, and result rows use distinct but restrained radii so hierarchy is visible without large bubble-like cards
+
+#### Scenario: Inspector remains secondary
+- **WHEN** the inspector is visible
+- **THEN** overview and debug surfaces use restrained radii and do not read as large decorative cards competing with the terminal

--- a/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
@@ -1,0 +1,34 @@
+## 1. Radius Inventory And Tokens
+
+- [ ] 1.1 Confirm which Apple client surfaces are active default macOS shell UI versus legacy or non-primary surfaces.
+- [ ] 1.2 Add a shared active-shell radius token surface near `ShellPalette` with `control = 6`, `row = 8`, `surface = 10`, and `overlay = 12`.
+- [ ] 1.3 Document allowed shape exceptions for semantic circles and any rare semantic pills.
+
+## 2. Active Shell UI Normalization
+
+- [ ] 2.1 Replace hard-coded active-shell rounded rectangle radii in `MacShellRootView.swift` with the shared radius tokens.
+- [ ] 2.2 Replace hard-coded active-shell rounded rectangle radii in `TerminalPaneView.swift` with the shared radius tokens.
+- [ ] 2.3 Align normal-flow AppKit fallback radii in `TerminalHostView.swift` with the shared radius scale where those surfaces are visible in default shell flows.
+- [ ] 2.4 Replace decorative `Capsule` usage in default shell text chips, keycap hints, metadata chips, and command badges with restrained rounded rectangles unless documented as semantic pills.
+- [ ] 2.5 Ensure `add-macos-pane-title-bars` implementation uses the same radius tokens for pane title bars and close controls.
+
+## 3. Guardrails
+
+- [ ] 3.1 Add or extend a focused shell contract check that flags active-shell `RoundedRectangle(cornerRadius: 14+)` and AppKit `cornerRadius >= 14` unless allowlisted.
+- [ ] 3.2 Add or extend a focused shell contract check or review checklist for new default-shell `Capsule` usage.
+- [ ] 3.3 Keep the check scoped to active shell files so legacy/non-primary surfaces are not rewritten implicitly.
+
+## 4. Verification
+
+- [ ] 4.1 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 4.2 Run `git diff --check`.
+- [ ] 4.3 Run `openspec validate normalize-macos-shell-corner-radii --type change --strict --json`.
+- [ ] 4.4 Run `openspec validate --all --strict --json`.
+- [ ] 4.5 Build the macOS app with the documented `AlanNative` Debug command.
+- [ ] 4.6 Capture or document light-mode screenshots for sidebar, single/split terminal, command palette, and inspector after normalization.
+- [ ] 4.7 Manually verify the shell still feels native, readable, and not visually flat after reducing radii.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 Sync accepted radius requirements into `openspec/specs/` before archive.
+- [ ] 5.2 Record radius inventory, exceptions, validation commands, and visual evidence in the change before archive.


### PR DESCRIPTION
## Summary
- Add the OpenSpec change for per-pane macOS terminal title bars, title sourcing, close routing, and terminal hit-testing boundaries.
- Add the OpenSpec change for normalizing macOS shell corner radii and reducing capsule-heavy default chrome.
- Coordinate both changes through the macOS shell UI/UX conformance and build/test contracts.

## Validation
- openspec validate add-macos-pane-title-bars --type change --strict --json
- openspec validate normalize-macos-shell-corner-radii --type change --strict --json
- openspec validate --all --strict --json
- git diff --cached --check