### PR TITLE
Propose macOS search polish and inspector removal

### DIFF
--- a/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-pane-title-bars/specs/macos-shell-ui-ux-conformance/spec.md
@@ -32,7 +32,7 @@ terminal title is unavailable.
 
 #### Scenario: Debug terms suppressed
 - **WHEN** terminal metadata contains implementation-oriented summaries such as `title updated`, `window attached`, or raw runtime state
-- **THEN** the title bar does not expose those terms outside the explicit inspector debug surface
+- **THEN** the title bar does not expose those terms outside explicit developer/debug-only surfaces
 
 ### Requirement: Pane close button targets its pane
 The pane title bar close button SHALL close the pane represented by that title

--- a/openspec/changes/add-macos-shell-automation-tests/design.md
+++ b/openspec/changes/add-macos-shell-automation-tests/design.md
@@ -66,8 +66,8 @@ future macOS surfaces.
 
    Tests do not need to assert every pixel, but they must launch the app and
    exercise representative workflows: launch, switch space/tab, create split,
-   open command UI, show inspector overview/debug, and type basic terminal input
-   when Ghostty is available.
+   open command UI, open pane-scoped Find for the focused pane, and type basic
+   terminal input when Ghostty is available.
 
    Alternative considered: keep screenshot review purely manual. Manual review
    remains useful but should not be the only repeatable signal.

--- a/openspec/changes/add-macos-shell-automation-tests/proposal.md
+++ b/openspec/changes/add-macos-shell-automation-tests/proposal.md
@@ -17,8 +17,8 @@ and UI smoke flows.
 - Add Apple-client unit tests for shell model mutations, runtime registry/service
   behavior, boot profile resolution, and local control-plane command execution.
 - Add UI smoke tests or scripted screenshot checks for launch, space/tab
-  switching, split creation, command UI, inspector disclosure, and basic terminal
-  input.
+  switching, split creation, command UI, pane-scoped Find behavior, and basic
+  terminal input.
 - Extend build/test documentation and `just`/script entry points so the focused
   Apple checks are discoverable and repeatable.
 - Keep tests layered so most run without real Ghostty artifacts, while a smaller

--- a/openspec/changes/add-macos-shell-automation-tests/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-shell-automation-tests/specs/macos-shell-build-test-contract/spec.md
@@ -19,20 +19,20 @@ execution, App Intent routing, and UI smoke flows.
 
 ### Requirement: UI smoke coverage is repeatable
 The Apple client SHALL provide a repeatable UI smoke or screenshot flow for
-launch, space/tab switching, split creation, command UI, inspector disclosure,
-and basic terminal input when terminal runtime is available.
+launch, space/tab switching, split creation, command UI, pane-scoped Find
+behavior, and basic terminal input when terminal runtime is available.
 
 #### Scenario: Launch smoke
 - **WHEN** the UI smoke flow starts the macOS app
-- **THEN** it verifies that the default light-mode window shows the space rail, active tab list, terminal content area, and inspector-off state
+- **THEN** it verifies that the default light-mode window shows the space rail, active tab list, terminal content area, and no persistent inspector pane or toggle
 
 #### Scenario: Split smoke
 - **WHEN** the UI smoke flow creates a split
 - **THEN** it verifies that multiple panes are visible and no raw pane IDs or debug labels dominate the default UI
 
-#### Scenario: Inspector smoke
-- **WHEN** the UI smoke flow opens inspector overview and debug layers
-- **THEN** it verifies that user-facing summary appears in Overview and raw diagnostics are restricted to Debug
+#### Scenario: Find smoke
+- **WHEN** the UI smoke flow opens pane-scoped Find for the focused terminal pane
+- **THEN** it verifies that a focused text field appears in pane chrome, result feedback is visible without raw debug labels, and dismissing Find returns focus to the owning terminal surface
 
 ### Requirement: Test fixtures share production command paths
 Apple tests SHALL exercise shell mutations through the same controller command

--- a/openspec/changes/add-macos-shell-automation-tests/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-shell-automation-tests/specs/macos-shell-ui-ux-conformance/spec.md
@@ -2,8 +2,8 @@
 
 ### Requirement: UI conformance has repeatable smoke evidence
 Mac shell UI conformance work SHALL include repeatable smoke or screenshot
-evidence for launch, space/tab switching, split creation, command UI, inspector
-overview, and inspector debug states.
+evidence for launch, space/tab switching, split creation, command UI, and
+pane-scoped Find behavior.
 
 #### Scenario: Default launch evidence
 - **WHEN** a UI conformance implementation is ready
@@ -13,9 +13,9 @@ overview, and inspector debug states.
 - **WHEN** command UI behavior changes
 - **THEN** maintainers can run or inspect evidence showing `Go to or Command...` results with user-facing labels
 
-#### Scenario: Inspector evidence
-- **WHEN** inspector behavior changes
-- **THEN** maintainers can run or inspect evidence confirming Overview stays user-facing and Debug contains raw diagnostics
+#### Scenario: Find evidence
+- **WHEN** pane-scoped Find behavior changes
+- **THEN** maintainers can run or inspect evidence confirming the active pane shows a native-feeling Find surface without restoring inspector chrome or debug-first panels
 
 ### Requirement: Automation surfaces do not add default chrome
 Adding App Intents and automation support SHALL not add visible default UI chrome

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -23,7 +23,7 @@
 
 ## 4. UI Smoke And Documentation
 
-- [ ] 4.1 Add a repeatable UI smoke or screenshot script for launch, space/tab switching, split creation, command UI, inspector overview/debug, and basic terminal input when available.
+- [ ] 4.1 Add a repeatable UI smoke or screenshot script for launch, space/tab switching, split creation, command UI, pane-scoped Find behavior for the focused pane, and basic terminal input when available.
 - [ ] 4.2 Add focused Apple test and UI smoke commands to `justfile` or Apple helper scripts.
 - [ ] 4.3 Update `clients/apple/README.md` with dependency setup, focused tests, UI smoke, and Ghostty integration commands.
 - [ ] 4.4 Ensure smoke artifacts avoid exposing private terminal content.

--- a/openspec/changes/normalize-macos-shell-corner-radii/design.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/design.md
@@ -5,9 +5,11 @@ The active macOS shell surface uses `MacShellRootView.swift`,
 terminal-first app. A quick inventory shows the active shell uses hard-coded
 rounded rectangles at 8, 10, 11, 12, 13, 14, 16, 18, 20, 22, and 24 points,
 plus `Capsule` shapes for chips and keycap-like controls. The largest values
-show up in the command palette outer shell (`24`), inspector cards (`20`),
-command search field (`18`), tab rail cards (`18`), and terminal info cards
-(`22`).
+show up in the command palette outer shell (`24`), command search field (`18`),
+tab rail cards (`18`), and terminal info cards (`22`). The separate inspector
+surfaces that previously used `20`-point cards are being removed by
+`polish-macos-search-remove-inspector`, so this normalization pass should not
+keep them alive as a target surface.
 
 This conflicts with the current product direction: Arc-like native material,
 compact rows, terminal-first focus, and calm precision. The UI should feel
@@ -22,7 +24,7 @@ component roles.
 - Define a small radius scale for the active Alan macOS shell.
 - Reduce large rounded rectangles and pill/capsule shapes in the default shell
   UI.
-- Make future pane title bars, command rows, sidebar rows, inspector cards, and
+- Make future pane title bars, command rows, sidebar rows, command overlays, and
   terminal surrounds use the same scale.
 - Keep true circular elements only where the shape is semantic: status dots,
   traffic-light-like indicators, or icon-only circular affordances that are
@@ -48,12 +50,12 @@ component roles.
      and background bands.
    - `control = 6`: icon buttons, compact keycaps, small title-bar controls,
      small inline controls.
-   - `row = 8`: sidebar rows, command rows, attention rows, chips, inspector
-     sub-rows, and pane title bars.
+   - `row = 8`: sidebar rows, command rows, attention rows, chips, and pane
+     title bars.
    - `surface = 10`: terminal surround, search fields, inline panels, and
      small grouped tool surfaces.
-   - `overlay = 12`: command palette outer shell, inspector cards, fallback
-     overlay cards, and rare modal-like surfaces.
+   - `overlay = 12`: command palette outer shell, fallback overlay cards, and
+     rare modal-like surfaces.
 
    Values above `12` are not part of the default shell scale. They require a
    documented exception in code or a spec update. This keeps Alan precise while
@@ -99,8 +101,9 @@ component roles.
    that flags new active-shell `RoundedRectangle(cornerRadius: 14+)`,
    `layer?.cornerRadius = 14+`, and default-shell `Capsule` usage except for an
    allowlist. Visual review must still compare single-pane, split-pane,
-   command-palette, and inspector screenshots because small radius changes can
-   affect the perceived density and hierarchy.
+   command-palette, and remaining default-shell overlay screenshots because
+   small radius changes can affect the perceived density and hierarchy. Deleted
+   inspector surfaces do not need radius review in this change.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/normalize-macos-shell-corner-radii/proposal.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/proposal.md
@@ -8,8 +8,8 @@ Arc-like native shell.
 ## What Changes
 
 - Introduce a small Alan shell corner-radius scale for active macOS shell UI.
-- Reduce large rounded rectangles in sidebar, command UI, inspector, terminal
-  surrounds, and debug/info surfaces.
+- Reduce large rounded rectangles in sidebar, command UI, terminal surrounds,
+  pane title bars, and remaining default-shell fallback/debug surfaces.
 - Replace decorative `Capsule` usage in text controls and chips with modest
   rounded rectangles unless the shape is a true status dot or system-like
   circular control.
@@ -41,4 +41,4 @@ None.
 - Active OpenSpec UI polish: coordinate with
   `add-macos-pane-title-bars` so pane title bars use the same radius scale.
 - Visual QA: running-app screenshots for sidebar, terminal, command UI, and
-  inspector in light mode.
+  remaining default-shell overlays in light mode.

--- a/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-build-test-contract/spec.md
@@ -14,7 +14,7 @@ corner-radius normalization when default macOS shell chrome is changed.
 
 #### Scenario: Visual comparison captured
 - **WHEN** radius normalization implementation is marked complete
-- **THEN** maintainers can inspect running-app screenshots or notes for sidebar, terminal, command palette, and inspector states confirming that the UI is smaller-radius, still native, and not visually flat
+- **THEN** maintainers can inspect running-app screenshots or notes for sidebar, terminal, command palette, and remaining default-shell overlay states confirming that the UI is smaller-radius, still native, and not visually flat
 
 #### Scenario: Legacy surfaces scoped
 - **WHEN** radius inventory finds older or non-primary Apple client surfaces

--- a/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/specs/macos-shell-ui-ux-conformance/spec.md
@@ -6,7 +6,7 @@ for rounded rectangular surfaces and controls. It SHALL avoid large ad hoc
 radii and capsule-heavy default chrome.
 
 #### Scenario: Radius scale applied
-- **WHEN** the active macOS shell renders sidebar rows, command rows, pane title bars, inspector cards, terminal surrounds, inline panels, or overlay surfaces
+- **WHEN** the active macOS shell renders sidebar rows, command rows, pane title bars, terminal surrounds, inline panels, or overlay surfaces
 - **THEN** those rounded rectangular elements use the Alan shell radius scale rather than one-off numeric radii
 
 #### Scenario: Default shell avoids large radii
@@ -37,6 +37,6 @@ turning the UI into a flat grid or weakening control affordances.
 - **WHEN** the command palette is open
 - **THEN** the outer overlay, search field, and result rows use distinct but restrained radii so hierarchy is visible without large bubble-like cards
 
-#### Scenario: Inspector remains secondary
-- **WHEN** the inspector is visible
-- **THEN** overview and debug surfaces use restrained radii and do not read as large decorative cards competing with the terminal
+#### Scenario: Overlays remain secondary
+- **WHEN** the command palette or another remaining default-shell overlay is visible
+- **THEN** that surface uses restrained radii and does not read as a large decorative card competing with the terminal

--- a/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
@@ -25,7 +25,7 @@
 - [ ] 4.3 Run `openspec validate normalize-macos-shell-corner-radii --type change --strict --json`.
 - [ ] 4.4 Run `openspec validate --all --strict --json`.
 - [ ] 4.5 Build the macOS app with the documented `AlanNative` Debug command.
-- [ ] 4.6 Capture or document light-mode screenshots for sidebar, single/split terminal, command palette, and inspector after normalization.
+- [ ] 4.6 Capture or document light-mode screenshots for sidebar, single/split terminal, command palette, and remaining default-shell overlays after normalization.
 - [ ] 4.7 Manually verify the shell still feels native, readable, and not visually flat after reducing radii.
 
 ## 5. Archive Readiness

--- a/openspec/changes/polish-macos-search-remove-inspector/.openspec.yaml
+++ b/openspec/changes/polish-macos-search-remove-inspector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/polish-macos-search-remove-inspector/design.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/design.md
@@ -1,0 +1,150 @@
+## Context
+
+The active macOS shell UI is centered in `MacShellRootView.swift`, with
+`TerminalPaneView.swift` and `TerminalHostView.swift` owning terminal rendering
+and input. The current shell still treats the inspector as a product surface:
+`MacShellRootView` stores `alanShellShowsInspector`, renders a right-side
+`ShellInspectorView`, exposes a sidebar toggle, includes a command-palette
+`toggleInspector` action, and teaches speech recognition inspector commands.
+
+That inspector duplicates information already available in shell snapshots,
+runtime metadata, logs, and focused test/debug scripts. It also works against
+the current visual direction: terminal first, fewer controls, native material,
+and progressive disclosure through explicit debug tools rather than a permanent
+secondary pane.
+
+Terminal search already has a useful backend boundary. `Command-F` routes to the
+focused pane, `TerminalSurfaceController` owns an `AlanTerminalSearchAdapter`,
+and Ghostty-backed surfaces receive `start_search`, `search:<query>`,
+`navigate_search:*`, and `end_search` actions. The weak part is the user
+experience: search text is entered by intercepting terminal key events and
+presented as a generic terminal overlay, so it does not behave like a normal
+macOS Find control.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove inspector from the default macOS shell product surface and interaction
+  model.
+- Keep terminal/runtime diagnostics available outside the default UI through
+  existing developer surfaces.
+- Make `Command-F` open a focused, native-feeling Find bar for the focused pane.
+- Route query edits, match navigation, and dismissal through the existing
+  pane-scoped terminal search engine.
+- Keep sidebar, split layout, and terminal geometry stable while Find is open.
+- Update tests and contract checks so inspector does not drift back in as a
+  default affordance.
+
+**Non-Goals:**
+
+- Remove shell snapshots, runtime metadata, logging, or debugging capability.
+- Add global workspace search, transcript search, semantic search, or search
+  across multiple panes/tabs.
+- Replace Ghostty's search backend or redefine search-result computation.
+- Redesign the command palette beyond removing inspector actions and stale copy.
+- Implement a dark-mode pass.
+
+## Decisions
+
+1. Remove inspector completely from user-facing shell UI.
+
+   Delete the right-side `ShellInspectorView`, `ShellInspectorSection`,
+   `InspectorCard`, sidebar toggle, command-palette `toggleInspector` action,
+   inspector speech commands, and `alanShellShowsInspector` storage. The default
+   shell should have two structural regions: material sidebar and terminal
+   workspace.
+
+   Alternative considered: keep a hidden debug inspector behind a menu item.
+   That preserves current code but keeps a product concept that the user has
+   judged low-value. Debug needs should use explicit developer surfaces instead
+   of keeping default IA alive for a rarely used pane.
+
+2. Preserve diagnostics through developer/debug surfaces, not product chrome.
+
+   Any data currently visible only in the inspector should be checked against
+   existing alternatives before deletion: `alan shell state`, copy-snapshot
+   command paths, runtime logs, focused scripts, and test fixtures. If an
+   inspector-only datum is still needed, add it to one of those explicit debug
+   paths rather than creating another in-app panel.
+
+   Alternative considered: move inspector content into the command palette.
+   That would clutter the command UI and keep debug state too close to normal
+   navigation.
+
+3. Introduce a real SwiftUI/AppKit Find bar instead of printable-key capture.
+
+   `Command-F` should show a compact pane-scoped Find bar with a focused text
+   field. While the field is focused, normal text editing keys belong to the
+   text field, not to `TerminalHostView`'s terminal key interception. Query
+   changes call `updateSearchQuery(_:)`, and the existing
+   `AlanTerminalSearchAdapter` remains the state bridge for query, total
+   matches, selected match, and active/inactive state.
+
+   Alternative considered: improve the existing terminal overlay copy only.
+   That would still feel unlike standard macOS Find because there is no real
+   editable field, selection, cursor, or native focus model.
+
+4. Anchor Find to the focused terminal pane without resizing the workspace.
+
+   The first implementation should render the Find bar as a compact overlay or
+   leaf-level tool surface inside the focused pane's chrome layer. It should not
+   open a command-palette sheet, add a sidebar section, or change split ratios.
+   In split mode, only the focused pane shows the active Find bar; switching pane
+   focus either moves the bar to that pane's active search state or dismisses the
+   previous visual affordance according to the pane-owned search state.
+
+   Alternative considered: add a full-width window find bar below the toolbar.
+   That is common in document apps, but Alan's search target is a terminal pane;
+   a window-wide bar makes split-pane targeting ambiguous.
+
+5. Match macOS Find keyboard expectations.
+
+   Required shortcuts:
+
+   - `Command-F`: open Find for the focused pane and focus/select the query
+     field.
+   - `Return` or `Command-G`: next match.
+   - `Shift-Return` or `Shift-Command-G`: previous match.
+   - `Escape`: close Find and return focus to the owning terminal pane.
+
+   Optional controls should be icon-first: previous, next, close, and a match
+   count such as `2 of 9` or `No results`. The UI must avoid raw pane IDs,
+   Ghostty action names, and debug routing details.
+
+6. Keep backend search lifecycle pane-owned.
+
+   Search start/update/navigation/end continues through the focused pane's
+   `TerminalSurfaceController` and `AlanTerminalSearchEngine`. View rebuilds
+   should not lose active search state for the pane runtime. Closing Find calls
+   `endSearch()` and returns first responder to the terminal host when possible.
+
+## Risks / Trade-offs
+
+- Removing inspector can hide a useful debug datum -> Before deleting each
+  section, confirm the data is available from shell snapshot, logs, tests, or an
+  explicit debug command; move only truly needed data.
+- Stale active OpenSpec changes mention inspector -> Update or rebase those
+  changes so this removal remains the source of truth.
+- Find bar focus can steal terminal input unexpectedly -> Confine typed query
+  input to the focused text field and make Escape reliably restore terminal
+  focus.
+- Search state can target the wrong pane after focus changes -> Keep all search
+  actions pane-scoped and add focused tests for split-pane search ownership.
+- Overlay placement can occlude terminal content -> Keep the bar compact,
+  material-backed, and anchored where it does not resize or obscure split chrome;
+  verify with screenshots.
+
+## Migration Plan
+
+No persisted data migration is required beyond removing or ignoring
+`alanShellShowsInspector`. Implementation should remove inspector UI and command
+surface references first, then introduce the Find bar on top of the existing
+search adapter/engine. Visual verification should cover the default light-mode
+window, split panes, `Command-F`, search navigation, and dismissal back to the
+terminal.
+
+## Open Questions
+
+None. Default decision: delete inspector as a product feature now, and use
+explicit debug commands/scripts if later work needs deeper shell diagnostics.

--- a/openspec/changes/polish-macos-search-remove-inspector/design.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/design.md
@@ -104,8 +104,10 @@ macOS Find control.
 
    - `Command-F`: open Find for the focused pane and focus/select the query
      field.
-   - `Return` or `Command-G`: next match.
-   - `Shift-Return` or `Shift-Command-G`: previous match.
+   - `Return` or `Command-G`: next match for the pane that owns the active Find
+     interaction.
+   - `Shift-Return` or `Shift-Command-G`: previous match for the pane that owns
+     the active Find interaction.
    - `Escape`: close Find and return focus to the owning terminal pane.
 
    Optional controls should be icon-first: previous, next, close, and a match
@@ -114,10 +116,12 @@ macOS Find control.
 
 6. Keep backend search lifecycle pane-owned.
 
-   Search start/update/navigation/end continues through the focused pane's
-   `TerminalSurfaceController` and `AlanTerminalSearchEngine`. View rebuilds
-   should not lose active search state for the pane runtime. Closing Find calls
-   `endSearch()` and returns first responder to the terminal host when possible.
+   Search starts through the focused pane's `TerminalSurfaceController` and
+   `AlanTerminalSearchEngine`. Once Find is active, query
+   update/navigation/end continues through the pane that owns that Find
+   interaction even if split-pane focus changes. View rebuilds should not lose
+   active search state for the pane runtime. Closing Find calls `endSearch()`
+   and returns first responder to the terminal host when possible.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/polish-macos-search-remove-inspector/proposal.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/proposal.md
@@ -56,6 +56,8 @@ None.
   `clients/apple/scripts/test-terminal-surface-controller.swift`,
   `clients/apple/scripts/check-shell-contracts.sh`, and visual/manual
   verification notes for the default light-mode shell and `Command-F` flow.
-- Active UI polish OpenSpec work may mention inspector screenshots or inspector
-  radii; those changes should be rebased or adjusted so inspector removal is the
-  source of truth.
+- Active UI polish OpenSpec work such as
+  `normalize-macos-shell-corner-radii` and `add-macos-pane-title-bars` must
+  treat inspector-specific screenshots, radii targets, and debug-surface wording
+  as removed or rerouted to explicit developer/debug-only surfaces so inspector
+  removal remains the source of truth.

--- a/openspec/changes/polish-macos-search-remove-inspector/proposal.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The macOS shell is moving into a UI polish phase, and the right-side inspector no
+longer earns its visual and interaction cost. At the same time, `Command-F`
+currently routes to pane search but does not feel like the standard macOS Find
+experience users expect in a terminal app.
+
+## What Changes
+
+- **BREAKING**: Remove the inspector as a user-facing macOS shell feature,
+  including the sidebar toggle, command-palette action, persisted visibility
+  preference, right-side pane, voice commands, and UI/spec references that make
+  inspector part of the default product surface.
+- Keep diagnostic data available through developer/debug-only mechanisms such as
+  existing shell snapshots, logs, scripts, or future explicit debug commands
+  rather than a persistent in-app inspector.
+- Refine terminal search so `Command-F` opens a native-feeling, pane-scoped Find
+  bar with a real focused text field, visible result count, next/previous
+  controls, close behavior, and predictable keyboard shortcuts.
+- Preserve terminal-first layout: opening or closing Find must not resize the
+  sidebar, toolbar, split layout, or terminal canvas in a disruptive way.
+- Preserve the existing pane-scoped terminal search engine contract; this is a UI
+  polish and interaction pass, not a new search backend.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Removes the inspector contract and adds the
+  polished pane-scoped Find bar UX contract for `Command-F`.
+- `macos-shell-terminal-lifecycle`: Tightens terminal search lifecycle behavior
+  around focus, query updates, result navigation, dismissal, and pane identity.
+- `macos-shell-workspace-interactions`: Removes inspector from command and
+  toolbar interaction expectations and clarifies search keyboard routing.
+- `macos-shell-build-test-contract`: Updates verification requirements so UI
+  polish is checked through inspector-removal assertions and Find bar behavior
+  instead of inspector screenshots.
+
+## Impact
+
+- Apple client UI: primarily
+  `clients/apple/AlanNative/MacShellRootView.swift`,
+  `clients/apple/AlanNative/TerminalPaneView.swift`, and
+  `clients/apple/AlanNative/TerminalHostView.swift`.
+- Apple client search ownership: existing `AlanTerminalSearchAdapter`,
+  `AlanTerminalSearchEngine`, `TerminalSurfaceController`, and Ghostty search
+  action routing remain the backend contract.
+- Apple client commands and affordances: `AlanMacShellCommands`, sidebar command
+  launcher/header actions, command palette actions, speech command vocabulary,
+  and persisted app storage keys that mention inspector.
+- Tests and scripts:
+  `clients/apple/scripts/test-terminal-surface-controller.swift`,
+  `clients/apple/scripts/check-shell-contracts.sh`, and visual/manual
+  verification notes for the default light-mode shell and `Command-F` flow.
+- Active UI polish OpenSpec work may mention inspector screenshots or inspector
+  radii; those changes should be rebased or adjusted so inspector removal is the
+  source of truth.

--- a/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Surface behavior has focused verification
+The Apple client SHALL add focused tests or documented manual verification for
+terminal scrollback, input translation, IME/preedit, selection, clipboard,
+search, terminal mode changes, renderer health, and child-exit behavior.
+
+#### Scenario: Scrollback verification
+- **WHEN** terminal surface work changes scrollback or scrollbar behavior
+- **THEN** tests or manual notes verify normal-buffer scrolling, alternate-screen behavior, and scrollbar synchronization
+
+#### Scenario: Input verification
+- **WHEN** terminal input adapter behavior changes
+- **THEN** tests or manual notes verify printable input, command-key routing, modifiers, IME composition, paste, and terminal mouse mode
+
+#### Scenario: Search verification
+- **WHEN** terminal search UI, routing, or adapter behavior changes
+- **THEN** tests or manual notes verify `Command-F`, typed query editing, next/previous navigation, no-result feedback, Escape dismissal, and return of focus to the owning terminal pane
+
+#### Scenario: Failure-state verification
+- **WHEN** renderer health, child-exit, or fallback UI changes
+- **THEN** tests or manual notes verify that the default UI is truthful and raw diagnostics remain restricted to explicit developer debug surfaces
+
+## ADDED Requirements
+
+### Requirement: UI polish verifies inspector removal
+The Apple client SHALL include focused checks or review evidence that inspector
+UI and command affordances are absent from the default macOS shell.
+
+#### Scenario: Inspector controls removed
+- **WHEN** macOS shell UI polish is ready for review
+- **THEN** checks or review notes verify that the sidebar, toolbar, command UI, speech vocabulary, and app storage no longer expose an inspector toggle or inspector pane
+
+#### Scenario: Inspector screenshots retired
+- **WHEN** UI smoke or screenshot documentation is updated
+- **THEN** it verifies the default light-mode window without inspector and does not require inspector overview or debug screenshots
+
+### Requirement: Find bar has focused verification
+The Apple client SHALL verify the polished terminal Find bar through automated
+adapter tests where practical and manual or screenshot evidence for visual
+behavior.
+
+#### Scenario: Find state test
+- **WHEN** a focused test starts search, edits a query, receives match updates, navigates, and dismisses search
+- **THEN** it verifies the fake search engine receives start, query, navigation, and end actions in order for the owning pane
+
+#### Scenario: Find visual review
+- **WHEN** the running app is inspected in light mode
+- **THEN** maintainers can confirm the Find bar is compact, pane scoped, has a real text field, shows match feedback, and does not resize the sidebar, toolbar, split layout, or terminal canvas

--- a/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal mode changes survive view changes
+The macOS shell host SHALL keep terminal mode metadata such as alternate screen,
+mouse reporting, search state, and readonly state with the runtime identity
+rather than with transient host views.
+
+#### Scenario: View recreated during alternate screen
+- **WHEN** a pane view is recreated while an alternate-screen application is active
+- **THEN** the replacement view reflects the current terminal mode rather than reverting to normal-buffer assumptions
+
+#### Scenario: Background pane exits readonly mode
+- **WHEN** a background pane changes readonly or input readiness state
+- **THEN** the pane metadata updates without selecting that tab
+
+#### Scenario: View recreated during terminal search
+- **WHEN** a pane view is recreated while terminal search is active for that pane
+- **THEN** the replacement view reflects the pane's current search query, active state, and match metadata without routing search to another pane
+
+## ADDED Requirements
+
+### Requirement: Terminal search lifecycle is pane owned
+Terminal search SHALL start, update, navigate, and end through the focused
+pane's terminal surface controller and search engine, preserving pane runtime
+identity across SwiftUI/AppKit view reconstruction.
+
+#### Scenario: Search starts for focused pane
+- **WHEN** `Command-F` is invoked while a terminal pane is focused
+- **THEN** Alan starts search through that pane's `AlanTerminalSearchEngine` and records active search state against that pane identity
+
+#### Scenario: Query updates target owning pane
+- **WHEN** the user edits the Find query while search is active
+- **THEN** Alan sends the query update to the search engine for the pane that owns the Find interaction and does not treat the query text as terminal input
+
+#### Scenario: Navigation targets owning pane
+- **WHEN** the user requests next or previous search result
+- **THEN** Alan navigates results through the owning pane's search engine and updates the owning pane's selected-match state
+
+#### Scenario: Search ends for owning pane
+- **WHEN** the user dismisses Find
+- **THEN** Alan ends search through the owning pane's search engine, clears active search UI for that pane, and leaves other pane runtimes unchanged

--- a/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: Visual system follows native material guidance
+The default macOS shell SHALL use a light-mode-first native material visual
+system that feels calm, precise, and terminal-oriented. It SHALL avoid
+card-heavy dashboard composition, decorative gradients, hard-coded dominant
+theme panels, persistent secondary inspector panes, and ornamental controls.
+
+#### Scenario: Material sidebar
+- **WHEN** the app window is visible in the default light appearance
+- **THEN** the space rail and tab list use material-backed surfaces, subtle separators, and restrained selection states rather than an opaque themed sidebar panel
+
+#### Scenario: Stable compact controls
+- **WHEN** the user hovers, selects, inserts, closes, or switches tabs and spaces
+- **THEN** rows, icon controls, counters, and status marks keep stable dimensions and do not resize the sidebar or terminal content
+
+#### Scenario: No dashboard treatment
+- **WHEN** the user views the default shell
+- **THEN** the UI does not present page-like sections, nested cards, large explanatory panels, persistent inspector panes, or marketing-style hero composition
+
+### Requirement: Default UI hides implementation jargon
+The default macOS UI SHALL avoid exposing raw pane IDs, `tab_id`, binding,
+runtime phases, `window attached`, `title updated`, and other implementation
+terms outside explicit developer debug surfaces.
+
+#### Scenario: Normal terminal workflow
+- **WHEN** a user creates, selects, splits, searches, or closes tabs and panes
+- **THEN** visible copy uses product terms such as Space, Tab, Split, Find, Go to or Command, Open in Alan, and Ask Alan
+
+#### Scenario: Command search results
+- **WHEN** the command UI shows tabs, panes, actions, routing candidates, or attention items
+- **THEN** result titles and summaries use user-facing names where available and do not expose raw pane IDs as the primary label unless the user is in an explicit debug context
+
+#### Scenario: Developer diagnostics
+- **WHEN** a developer opens an explicit debug surface such as a shell snapshot, log, test fixture, or debug command
+- **THEN** implementation details may be shown with clear debug framing outside the default product UI
+
+### Requirement: Toolbar is native and restrained
+The macOS toolbar/titlebar SHALL feel like native window chrome and contain only
+the current tab title/context, one command entry point, and a small number of
+frequent actions.
+
+#### Scenario: Toolbar default state
+- **WHEN** no urgent attention item exists
+- **THEN** the toolbar does not show attention as a large standalone primary control
+
+#### Scenario: Command entry
+- **WHEN** the user invokes the command UI
+- **THEN** the entry point is labeled and organized as `Go to or Command...`
+
+#### Scenario: Inspector absent
+- **WHEN** the user scans the toolbar, sidebar header, and default shell chrome
+- **THEN** there is no persistent inspector toggle or right-side inspector affordance
+
+### Requirement: UI conformance is verified visually
+Mac shell UI changes SHALL be reviewed against the documented UI contract before
+the UI conformance tasks are marked complete.
+
+#### Scenario: Default screenshot review
+- **WHEN** a UI conformance implementation pass is ready for review
+- **THEN** maintainers can inspect a running-app screenshot of the default light-mode window showing the space rail, active-space tab list, terminal-first content area, and no inspector pane or inspector toggle
+
+#### Scenario: Find bar screenshot review
+- **WHEN** terminal search UI tasks are marked complete
+- **THEN** maintainers can inspect screenshots or recorded notes for `Command-F`, typed search text, match navigation, no-result state, and dismissal back to terminal focus
+
+### Requirement: Terminal overlays use user-facing language
+The macOS terminal UI SHALL present terminal search, child-exit, renderer
+failure, readonly, input-not-ready, and clipboard states with concise
+terminal-user language in the canvas area or focused pane chrome, while raw
+runtime details remain developer-debug-only.
+
+#### Scenario: Renderer failure visible
+- **WHEN** a focused terminal pane cannot render
+- **THEN** the default UI explains that the terminal cannot draw and offers an actionable next step without showing raw Ghostty callback names or pane IDs
+
+#### Scenario: Child exit visible
+- **WHEN** a terminal child process exits
+- **THEN** the pane shows a compact terminal exit state rather than debug event names
+
+#### Scenario: Debug surface opened
+- **WHEN** a developer opens an explicit debug surface outside the default product UI
+- **THEN** renderer diagnostics, surface identifiers, input mode details, and raw event payloads may be inspected with debug framing
+
+### Requirement: Terminal search does not displace workspace structure
+Terminal search UI SHALL be compact, pane scoped, and presented as a
+native-feeling Find bar for the focused terminal pane without turning the shell
+into a dashboard or page layout.
+
+#### Scenario: Search opens
+- **WHEN** the user invokes `Command-F`
+- **THEN** the focused pane shows a compact Find bar with a focused editable text field, previous and next controls, close control, and result-count feedback while the sidebar, toolbar, and split layout keep stable dimensions
+
+#### Scenario: Search updates
+- **WHEN** the user types or edits text in the Find bar
+- **THEN** query changes are applied to the focused pane's terminal search engine without sending those characters as terminal input
+
+#### Scenario: Search navigates
+- **WHEN** matches exist and the user presses Return, `Command-G`, Shift-Return, Shift-`Command-G`, or the previous/next controls
+- **THEN** Alan moves between matches in the focused pane and updates visible match feedback such as `2 of 9`
+
+#### Scenario: Search closes
+- **WHEN** the user dismisses terminal search with Escape or the close control
+- **THEN** the Find bar closes, terminal search ends for the owning pane, and keyboard focus returns to the terminal pane that owned the search interaction
+
+### Requirement: Command UI owns navigation and shell actions
+The default command entry SHALL present tabs, panes, spaces, routing candidates,
+attention items, and common shell workspace actions through `Go to or Command...`
+using user-facing labels and compact rows.
+
+#### Scenario: Command results include panes
+- **WHEN** command search lists pane targets
+- **THEN** results use tab title, pane title, cwd, process context, or routing context as the primary label rather than raw pane IDs
+
+#### Scenario: Command result invokes split action
+- **WHEN** the user selects a split, focus, equalize, close, or pane lift action from command UI
+- **THEN** Alan runs the same shell controller mutation used by menu and keyboard paths where that action is shared
+
+#### Scenario: Inspector action absent
+- **WHEN** the user opens `Go to or Command...` or searches for inspector-related terms
+- **THEN** the command UI does not offer show, hide, open, close, or toggle inspector actions
+
+### Requirement: Toolbar stays restrained during split interactions
+Advanced split, focus, resize, equalize, close, and pane lift affordances SHALL
+not turn the toolbar into a dense control strip.
+
+#### Scenario: Multiple panes visible
+- **WHEN** a tab contains multiple panes
+- **THEN** the default toolbar remains focused on current tab context, command entry, and frequent actions without adding an inspector toggle or persistent pane-management strip
+
+#### Scenario: Pane lift available
+- **WHEN** pane lift is available through command UI or another explicit non-terminal affordance
+- **THEN** the default toolbar does not add a persistent pane-management strip
+
+## REMOVED Requirements
+
+### Requirement: Inspector uses progressive disclosure
+**Reason**: The inspector no longer justifies a persistent product surface in
+the terminal-first macOS shell. It duplicates developer diagnostics, consumes
+horizontal space, adds command and toolbar clutter, and weakens the Arc-like
+terminal workspace direction.
+
+**Migration**: Remove inspector UI and user-facing actions. Keep needed
+diagnostics available through explicit developer surfaces such as shell
+snapshots, logs, focused scripts, test fixtures, or future debug commands rather
+than a right-side in-app inspector.

--- a/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-ui-ux-conformance/spec.md
@@ -93,11 +93,11 @@ into a dashboard or page layout.
 
 #### Scenario: Search updates
 - **WHEN** the user types or edits text in the Find bar
-- **THEN** query changes are applied to the focused pane's terminal search engine without sending those characters as terminal input
+- **THEN** query changes are applied to the terminal search engine for the pane that owns the active Find interaction without sending those characters as terminal input
 
 #### Scenario: Search navigates
 - **WHEN** matches exist and the user presses Return, `Command-G`, Shift-Return, Shift-`Command-G`, or the previous/next controls
-- **THEN** Alan moves between matches in the focused pane and updates visible match feedback such as `2 of 9`
+- **THEN** Alan moves between matches for the pane that owns the active Find interaction and updates visible match feedback such as `2 of 9`
 
 #### Scenario: Search closes
 - **WHEN** the user dismisses terminal search with Escape or the close control

--- a/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Commands use native Mac surfaces
+Workspace actions SHALL be available through native menu/command routing,
+keyboard shortcuts, command UI, and any restrained toolbar affordances that call
+the same shell controller mutations where the action is shared.
+
+#### Scenario: Menu command
+- **WHEN** the user selects New Terminal Tab, New Alan Tab, Split, Focus Pane, Equalize Splits, Close Pane, or Close Tab from the menu bar
+- **THEN** Alan executes the same shell controller action used by keyboard and command UI paths
+
+#### Scenario: Keyboard command
+- **WHEN** the user invokes a supported command-key shortcut
+- **THEN** the responder chain routes it to Alan's workspace command handler or terminal surface command handler as appropriate
+
+#### Scenario: Command UI
+- **WHEN** the user opens `Go to or Command...`
+- **THEN** workspace actions and routing targets appear with user-facing labels and no raw pane IDs outside debug context
+
+#### Scenario: Inspector command removed
+- **WHEN** the user opens menus, command UI, or other native command surfaces
+- **THEN** Alan does not expose inspector show, hide, open, close, or toggle commands
+
+## ADDED Requirements
+
+### Requirement: Find keyboard routing follows Mac conventions
+Terminal Find keyboard handling SHALL follow common macOS search conventions
+while preserving terminal-first focus ownership.
+
+#### Scenario: Open Find
+- **WHEN** the user presses `Command-F` with a terminal pane focused
+- **THEN** Alan opens the focused pane's Find bar, focuses the Find text field, and preserves the current query where pane search state already exists
+
+#### Scenario: Next result
+- **WHEN** Find is active and the user presses Return or `Command-G`
+- **THEN** Alan navigates to the next result for the owning pane without sending Return or `g` to the terminal
+
+#### Scenario: Previous result
+- **WHEN** Find is active and the user presses Shift-Return or Shift-`Command-G`
+- **THEN** Alan navigates to the previous result for the owning pane without sending those keys to the terminal
+
+#### Scenario: Close Find
+- **WHEN** Find is active and the user presses Escape
+- **THEN** Alan closes Find for the owning pane and returns keyboard focus to that terminal pane

--- a/openspec/changes/polish-macos-search-remove-inspector/tasks.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/tasks.md
@@ -18,8 +18,8 @@
 ## 3. Find Keyboard And Focus Routing
 
 - [ ] 3.1 Keep `Command-F` routed to the focused pane's terminal search owner and open the Find bar.
-- [ ] 3.2 Route Return and `Command-G` to next search result while Find is active.
-- [ ] 3.3 Route Shift-Return and Shift-`Command-G` to previous search result while Find is active.
+- [ ] 3.2 Route Return and `Command-G` to the next search result for the pane that owns the active Find interaction.
+- [ ] 3.3 Route Shift-Return and Shift-`Command-G` to the previous search result for the pane that owns the active Find interaction.
 - [ ] 3.4 Route Escape and the close control to `dismissSearch()` for the owning pane.
 - [ ] 3.5 Return first responder/focus to the owning terminal pane after Find is dismissed.
 - [ ] 3.6 Verify split-pane focus changes cannot send query edits or navigation to the wrong pane.

--- a/openspec/changes/polish-macos-search-remove-inspector/tasks.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/tasks.md
@@ -1,0 +1,49 @@
+## 1. Inspector Removal
+
+- [ ] 1.1 Remove `alanShellShowsInspector`, `showsInspector` bindings, right-side inspector layout, and inspector animations from `MacShellRootView.swift`.
+- [ ] 1.2 Delete `ShellInspectorView`, `ShellInspectorSection`, `InspectorCard`, and inspector-only helper code after confirming any needed diagnostics remain available from shell snapshots, logs, scripts, or tests.
+- [ ] 1.3 Remove inspector sidebar/header toggle controls, accessibility labels, tooltips, and user-facing copy.
+- [ ] 1.4 Remove inspector actions and keywords from `ShellCommandTabAction`, default command-palette results, command execution, and dynamic show/hide title/detail logic.
+- [ ] 1.5 Remove inspector phrases from `ShellVoiceCommandController` vocabulary and handling.
+- [ ] 1.6 Update active UI polish changes or verification notes that still require inspector screenshots, inspector radii, or inspector smoke coverage.
+
+## 2. Native Find Bar UI
+
+- [ ] 2.1 Add a compact pane-scoped Find bar component with editable text field, previous/next icon controls, close control, and match-count/no-result feedback.
+- [ ] 2.2 Render the Find bar for the focused pane without resizing the sidebar, toolbar, split tree, or terminal canvas.
+- [ ] 2.3 Focus and select the Find query field when `Command-F` opens search.
+- [ ] 2.4 Apply query edits through the owning pane's `TerminalSurfaceController.updateSearchQuery(_:)` instead of sending printable query text as terminal input.
+- [ ] 2.5 Display search adapter state for active query, total matches, selected match, searching/no-result state, and inactive state without raw pane IDs or Ghostty action names.
+
+## 3. Find Keyboard And Focus Routing
+
+- [ ] 3.1 Keep `Command-F` routed to the focused pane's terminal search owner and open the Find bar.
+- [ ] 3.2 Route Return and `Command-G` to next search result while Find is active.
+- [ ] 3.3 Route Shift-Return and Shift-`Command-G` to previous search result while Find is active.
+- [ ] 3.4 Route Escape and the close control to `dismissSearch()` for the owning pane.
+- [ ] 3.5 Return first responder/focus to the owning terminal pane after Find is dismissed.
+- [ ] 3.6 Verify split-pane focus changes cannot send query edits or navigation to the wrong pane.
+
+## 4. Tests And Contract Checks
+
+- [ ] 4.1 Update `clients/apple/scripts/test-terminal-surface-controller.swift` to cover Find start, query update, navigation, engine callbacks, and dismissal for the owning pane.
+- [ ] 4.2 Add or update focused tests for `Command-F`, `Command-G`, Shift-`Command-G`, Return, Shift-Return, Escape, and printable query text behavior while Find is active.
+- [ ] 4.3 Update `clients/apple/scripts/check-shell-contracts.sh` so inspector UI/actions are not required and stale inspector affordances are flagged if reintroduced.
+- [ ] 4.4 Update UI smoke/manual verification expectations from inspector overview/debug coverage to default-shell-without-inspector and `Command-F` Find bar coverage.
+- [ ] 4.5 Search Apple client code, scripts, docs, and active OpenSpec changes for stale user-facing inspector references and remove or reframe them where this change owns the surface.
+
+## 5. Verification
+
+- [ ] 5.1 Run `clients/apple/scripts/test-terminal-surface-controller.sh`.
+- [ ] 5.2 Run other focused Apple shell scripts affected by command UI or shell UI changes.
+- [ ] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 5.4 Run `git diff --check`.
+- [ ] 5.5 Run `openspec validate polish-macos-search-remove-inspector --type change --strict --json`.
+- [ ] 5.6 Run `openspec validate --all --strict --json`.
+- [ ] 5.7 Build the macOS app with the documented `AlanNative` Debug command.
+- [ ] 5.8 Capture or document light-mode screenshots/manual notes for default shell without inspector, split-pane Find ownership, query editing, match navigation, no-result feedback, and Escape dismissal back to terminal.
+
+## 6. Archive Readiness
+
+- [ ] 6.1 Sync accepted inspector-removal and Find bar requirements into `openspec/specs/` before archive.
+- [ ] 6.2 Record implementation verification evidence and any adjusted active-change dependencies in this change before archive.


### PR DESCRIPTION
## Summary
- add the `polish-macos-search-remove-inspector` OpenSpec change to remove the macOS shell inspector from the default product surface and replace `Command-F` with a pane-scoped native-feeling Find bar
- update the affected macOS shell capability specs, design notes, and implementation tasks for inspector removal, Find focus/routing, and verification expectations
- align the active `add-macos-shell-automation-tests` change so its smoke-test expectations target the default no-inspector shell and pane-scoped Find instead of inspector coverage

## Validation
- openspec validate polish-macos-search-remove-inspector --type change --strict --json
- openspec validate add-macos-shell-automation-tests --type change --strict --json
- openspec validate --all --strict --json
- git diff --cached --check