### PR TITLE
Propose macOS app architecture maintainability

### DIFF
--- a/openspec/changes/improve-macos-app-architecture-maintainability/.openspec.yaml
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/improve-macos-app-architecture-maintainability/design.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/design.md
@@ -1,0 +1,169 @@
+## Context
+
+The Apple client currently has useful architectural concepts but weak physical
+organization. The macOS shell has a dedicated state model, host controller,
+terminal runtime registry/service, surface controller, control plane, and
+Ghostty bridge, but those concerns are still expressed through large flat Swift
+files:
+
+- `MacShellRootView.swift` mixes theme tokens, SwiftUI shell layout, AppKit
+  material wrappers, window placement, sidebar, inspector, command tab, and
+  voice command UI.
+- `AlanNativeApp.swift` mixes the app entry point, singleton handling, primary
+  shell owner, window focusing, app delegate, and shell commands.
+- `ContentView.swift` still combines legacy/mobile console models, daemon event
+  reduction, polling, view model state, and complete UI composition.
+- `TerminalHostView.swift` needs an AppKit `NSView`, but that view now owns
+  layout, focus, window observation, input routing, overlay copy, runtime
+  publication, and Ghostty attachment.
+- `ShellControlPlane.swift` combines protocol models, local command execution,
+  socket serving, file polling, state merging, persistence, and diagnostics.
+
+This change is a planning and contract change. It should enable later apply
+work to split source ownership without changing the shell's user-visible
+behavior or terminal/control-plane contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish a stable source-layout target for the Apple client that matches
+  README guidance and Xcode project organization.
+- Make SwiftUI scene roots readable as composition rather than view-controller
+  substitutes.
+- Keep AppKit bridges necessary for macOS terminal behavior, but narrow and name
+  their boundaries.
+- Separate terminal runtime, control-plane, model mutation, daemon API, and
+  event-reducer responsibilities into files that can be tested and reviewed
+  independently.
+- Isolate legacy/mobile console code from the primary macOS shell path.
+- Define validation so future architecture refactors can be checked without
+  requiring full visual or behavioral retesting for every file move.
+
+**Non-Goals:**
+
+- Do not redesign the macOS shell UI, change Arc-like layout goals, or alter
+  visual styling as part of this proposal.
+- Do not change daemon HTTP APIs, shell control-plane wire formats, Ghostty
+  integration behavior, terminal lifecycle semantics, or split interaction
+  behavior.
+- Do not require one giant mechanical move that rewrites every Swift file in a
+  single implementation PR.
+- Do not remove the existing iOS/mobile console; only isolate it from the
+  primary macOS shell architecture.
+
+## Decisions
+
+### Decision: Introduce architecture folders by responsibility
+
+Target source organization should use stable top-level folders under
+`clients/apple/AlanNative`:
+
+- `App/`: `AlanNativeApp`, app delegate, singleton startup, command definitions,
+  window presentation/coordinator code.
+- `Views/Shell/`: SwiftUI shell root, sidebar, workspace, command palette,
+  pane title/search UI, and other shell-specific SwiftUI components.
+- `Views/Console/` or `LegacyConsole/`: mobile/remote-control console UI and
+  view model code that is not the primary macOS shell.
+- `Models/`: API DTOs, shell snapshots, shell IDs, enums, value types, and
+  legacy decoding shims.
+- `Stores/` or `Controllers/`: observable app/shell controllers that own view
+  state and delegate domain work to services.
+- `Services/`: daemon API client, event stream reader/reducer, terminal runtime
+  service, Ghostty bootstrap, shell control plane, socket server, persistence,
+  and other process or IO code.
+- `Support/`: design tokens, formatting helpers, window placement, AppKit
+  adapters, and small utilities.
+
+Alternative considered: keep the current flat directory and only split large
+files. That lowers initial churn but leaves the same navigation and ownership
+problem for future contributors.
+
+### Decision: Split behavior-preserving slices
+
+Implementation should proceed in small, behavior-preserving slices:
+
+1. Move pure models and support utilities first.
+2. Move app startup, commands, and window coordination.
+3. Split SwiftUI shell view components by visible responsibility.
+4. Isolate mobile/legacy console code.
+5. Split terminal host bridge collaborators.
+6. Split control-plane socket, file polling, local executor, and protocol DTOs.
+7. Add or update focused structural checks after each slice.
+
+Alternative considered: perform a one-shot reorganization. That would make the
+final tree cleaner sooner, but it would conflict with active macOS shell work
+and make review risky.
+
+### Decision: Treat AppKit as a narrow bridge, not a smell
+
+The terminal host, visual effect materials, window placement, first-responder
+handling, hit testing, and local socket interactions legitimately require
+AppKit or Darwin APIs. The goal is not to remove AppKit. The goal is to prevent
+AppKit objects from becoming ambient dependencies across unrelated SwiftUI
+views.
+
+Alternative considered: force all UI into SwiftUI wrappers. That would fight the
+terminal/event ownership requirements already captured in macOS shell specs.
+
+### Decision: Keep existing specs as behavior owners
+
+This change owns maintainability policy and validation. Existing specs remain
+owners for product behavior:
+
+- `macos-shell-ui-ux-conformance` owns visual and interaction presentation.
+- `macos-shell-terminal-lifecycle` owns terminal runtime continuity and event
+  ownership.
+- `macos-shell-control-plane-reliability` owns IPC and authoritative command
+  behavior.
+- `macos-shell-build-test-contract` owns focused verification gates.
+
+Alternative considered: fold architecture requirements into the UI conformance
+spec. That would blur source-structure maintainability with user-visible UI
+quality.
+
+## Risks / Trade-offs
+
+- [Risk] File moves can create noisy diffs and Xcode project churn. →
+  Mitigation: move by responsibility in small PRs and keep behavior changes out
+  of mechanical reorganization commits.
+- [Risk] Active macOS UI changes may touch the same large files. → Mitigation:
+  sequence implementation slices after active proposal branches are merged or
+  rebase each slice before making behavior edits.
+- [Risk] Over-splitting can make simple UI changes require too many jumps. →
+  Mitigation: split by durable feature ownership, not by every private helper.
+- [Risk] Structural checks can become brittle. → Mitigation: make checks focus
+  on high-signal boundaries such as forbidden root-view ownership, file-size
+  hotspots, and README/project layout drift, while leaving local naming details
+  to review.
+- [Risk] Moving legacy/mobile console code could accidentally change iOS build
+  behavior. → Mitigation: keep iOS entry behavior intact and validate the Apple
+  project after each console isolation slice.
+
+## Migration Plan
+
+1. Add or update architecture-focused scripts/checks that report current
+   hotspots without requiring all code to be reorganized immediately.
+2. Create the target folder structure and move pure model/support files with no
+   behavior edits.
+3. Update Xcode project membership and README structure in the same slice as
+   each move.
+4. Split SwiftUI shell views and app startup code after active UI polish changes
+   are merged or rebased.
+5. Split AppKit terminal/control-plane collaborators after focused shell
+   contract tests are available for those boundaries.
+6. Tighten architecture checks from warning/report mode to required gate once
+   the largest hotspots have owners.
+
+Rollback is straightforward for each slice: revert the file move or extraction
+commit because behavior changes should be kept separate from structural moves.
+
+## Open Questions
+
+- Should the primary shell observable object continue to be named
+  `ShellHostController`, or should future code distinguish `ShellStore`,
+  `ShellCoordinator`, and `ShellRuntimeCoordinator`?
+- Should legacy/mobile console code live under `Views/Console/` or a clearer
+  `LegacyConsole/` namespace until the iOS product direction is revisited?
+- Should the architecture check be implemented as a Swift script, shell script,
+  or a small SwiftPM helper if it grows beyond simple path/size/import checks?

--- a/openspec/changes/improve-macos-app-architecture-maintainability/proposal.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The macOS app has grown from a shell spike into a real native terminal surface,
+but its source organization has not caught up with the architecture. SwiftUI
+scene roots, AppKit bridges, terminal runtime ownership, control-plane IPC,
+legacy console UI, and design tokens are still concentrated in a small number
+of large flat files, which makes routine UI and terminal work harder to review,
+test, and sequence safely.
+
+Several active macOS shell changes now touch the same files and concepts. This
+change establishes a maintainability contract before more UI polish, search,
+split, voice, and remote-workspace work increases the cost of untangling those
+boundaries.
+
+## What Changes
+
+- Introduce a native Apple client architecture contract for source layout,
+  SwiftUI scene composition, AppKit bridge ownership, service/model boundaries,
+  and legacy/mobile isolation.
+- Require the Apple client README and project structure to describe the same
+  organization developers actually edit.
+- Require large SwiftUI roots to move toward small feature views and extracted
+  command/window coordination instead of accumulating view, window, command,
+  and debug logic in one file.
+- Require AppKit escape hatches such as window placement and terminal host
+  views to be narrow, named, and separated from unrelated SwiftUI layout.
+- Require terminal runtime, control-plane, socket, model mutation, and API/event
+  reducer responsibilities to have explicit owning files or services.
+- Preserve current product behavior while making future refactors easier to
+  review and verify in focused slices.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-app-architecture-maintainability`: Defines maintainable native Apple
+  client source organization, SwiftUI/AppKit boundaries, service/model
+  ownership, and validation expectations for macOS app architecture changes.
+
+### Modified Capabilities
+
+- `macos-shell-build-test-contract`: Add a focused architecture-maintainability
+  validation gate for Apple client structure changes, separate from UI visual
+  conformance and shell behavior tests.
+
+## Impact
+
+- Affected source areas: `clients/apple/AlanNative`, `clients/apple/README.md`,
+  `clients/apple/AlanNative.xcodeproj/project.pbxproj`, and Apple-focused
+  script checks under `clients/apple/scripts`.
+- Expected future implementation areas include `App/`, `Views/`, `Models/`,
+  `Services/`, `Support/`, terminal host bridge files, control-plane service
+  files, and mobile or legacy console folders.
+- No user-facing behavior, daemon API, shell control-plane protocol, Ghostty
+  runtime behavior, or visual design change is intended by this proposal alone.

--- a/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Apple client source layout mirrors architecture ownership
+The native Apple client SHALL organize source files by durable responsibility so
+developers can distinguish app startup, SwiftUI views, models, controllers,
+services, and support code without reading every file in a flat directory.
+
+#### Scenario: Source tree is inspected
+- **WHEN** a developer inspects `clients/apple/AlanNative`
+- **THEN** app entry code, shell views, console views, protocol models,
+  observable controllers, service/IO code, and support utilities are grouped by
+  responsibility rather than mixed in one flat source directory
+
+#### Scenario: README documents source layout
+- **WHEN** the Apple client README describes the directory structure
+- **THEN** the documented folders match the source tree and Xcode project
+  organization used by the current code
+
+### Requirement: SwiftUI scene roots compose focused feature views
+SwiftUI scene and root view files SHALL primarily compose stable layout,
+selection, and feature views. They MUST NOT accumulate unrelated design tokens,
+window coordination, command routing, inspector/debug panels, service clients,
+or platform bridge implementations.
+
+#### Scenario: macOS shell root is edited
+- **WHEN** a developer changes the default macOS shell layout
+- **THEN** the root view remains a readable composition of sidebar, workspace,
+  command, and optional utility surfaces, with feature-specific UI implemented
+  in dedicated view files
+
+#### Scenario: App commands are edited
+- **WHEN** a developer changes menu or keyboard command ownership
+- **THEN** command definitions and command routing live in app or shell command
+  files rather than being buried in unrelated view body code
+
+### Requirement: AppKit bridges are narrow and named
+The Apple client SHALL isolate AppKit bridge code behind small, named wrappers
+or coordinators for the specific desktop behavior they own, while keeping
+unrelated SwiftUI views free of ambient `NSWindow`, `NSView`, `NSApp`, socket,
+or process-management details.
+
+#### Scenario: Window placement changes
+- **WHEN** hidden-titlebar placement, minimum size, traffic-light metrics, or
+  primary-window focusing behavior changes
+- **THEN** the implementation is owned by an app/window support component rather
+  than by the macOS shell root view file
+
+#### Scenario: Material background changes
+- **WHEN** a SwiftUI view needs native material rendering
+- **THEN** the `NSVisualEffectView` bridge is isolated behind a reusable material
+  wrapper or support component
+
+#### Scenario: Terminal host bridge changes
+- **WHEN** terminal first-responder, hit-testing, IME, pointer, keyboard, or
+  Ghostty attachment behavior changes
+- **THEN** the AppKit terminal host keeps those behaviors behind the terminal
+  host boundary and does not leak AppKit ownership through unrelated SwiftUI
+  views
+
+### Requirement: Terminal host collaborators have explicit ownership
+The terminal host implementation SHALL separate runtime attachment, overlay
+presentation, input routing, window observation, metadata publishing, and
+surface coordination into explicit collaborators when those responsibilities
+become non-trivial.
+
+#### Scenario: Terminal input routing changes
+- **WHEN** keyboard, IME, paste, pointer, scroll, or terminal search routing is
+  modified
+- **THEN** the change is reviewable in terminal input/surface collaborators
+  without requiring a full audit of overlay layout or window observation code
+
+#### Scenario: Runtime snapshot publication changes
+- **WHEN** terminal runtime metadata publication changes
+- **THEN** the owning component clearly distinguishes snapshot construction from
+  AppKit layout and visible overlay presentation
+
+### Requirement: Control-plane implementation separates IPC, execution, and persistence
+The shell control-plane implementation SHALL keep protocol DTOs, local command
+execution, socket serving, file polling, state merging, event persistence, and
+diagnostics in reviewable ownership units.
+
+#### Scenario: Socket transport changes
+- **WHEN** local socket request size, timeout, accept loop, or client response
+  behavior changes
+- **THEN** the change is isolated to the socket transport owner and does not
+  require reviewing shell mutation semantics
+
+#### Scenario: Local command execution changes
+- **WHEN** a shell control command changes how it mutates shell state or applies
+  side effects
+- **THEN** the local command executor owns the behavior separately from socket
+  read/write and file-polling code
+
+#### Scenario: Persistence diagnostics change
+- **WHEN** state, event, command, or binding persistence diagnostics change
+- **THEN** the persistence/event owner can be reviewed independently from IPC
+  request parsing
+
+### Requirement: API clients and event reducers are not embedded in views
+The Apple client SHALL keep daemon API clients, event polling or streaming
+loops, protocol event reduction, and view model state projection outside
+complete SwiftUI view files so each can be tested or reviewed without editing a
+complete SwiftUI screen.
+
+#### Scenario: Session event mapping changes
+- **WHEN** daemon session events are mapped into chat messages, timeline rows,
+  pending-yield state, or connection state
+- **THEN** the reducer behavior is owned outside the SwiftUI view body and can
+  be tested without rendering the full console UI
+
+#### Scenario: API endpoint support changes
+- **WHEN** daemon API request or response DTOs change
+- **THEN** the API client and protocol models own that change separately from
+  shell or console layout files
+
+### Requirement: Mobile and legacy console surfaces are isolated from the primary macOS shell
+The Apple client SHALL keep mobile or legacy remote-control console surfaces
+separate from the primary macOS shell path so contributors can identify which UI
+is active for macOS shell development.
+
+#### Scenario: macOS shell contributor opens the project
+- **WHEN** a developer needs to change the default macOS shell experience
+- **THEN** primary shell files are distinguishable from iOS/mobile console files
+  by folder, naming, or project grouping
+
+#### Scenario: iOS console behavior changes
+- **WHEN** a developer changes the mobile console layout or event handling
+- **THEN** the change does not require editing primary macOS shell root files
+  unless a shared model or service contract is intentionally changed
+
+### Requirement: Large files have planned ownership boundaries
+The Apple client SHALL avoid large multi-responsibility Swift files as the
+stable end state. When a file remains large during migration, the owning change
+SHALL document the intended split and avoid adding unrelated responsibilities to
+that file.
+
+#### Scenario: Large file receives new behavior
+- **WHEN** a developer adds behavior to an existing large Apple client file
+- **THEN** the change either places the behavior in the target owner file or
+  documents why the temporary location is still compatible with the migration
+  plan
+
+#### Scenario: Refactor slice completes
+- **WHEN** a behavior-preserving architecture refactor slice is completed
+- **THEN** the resulting file ownership makes future changes narrower to review
+  than the previous large-file organization

--- a/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Apple architecture maintainability has focused validation
+The Apple client SHALL provide focused validation for source layout,
+multi-responsibility hotspots, README/project drift, and SwiftUI/AppKit boundary
+regressions when architecture maintainability changes are implemented.
+
+#### Scenario: Architecture report is run
+- **WHEN** a developer runs the Apple architecture-maintainability check
+- **THEN** the report identifies files or project groups that violate the
+  accepted source ownership boundaries and gives actionable paths to the owning
+  files or folders
+
+#### Scenario: README and project layout drift
+- **WHEN** Apple client source folders or Xcode project groups are reorganized
+- **THEN** validation or review confirms `clients/apple/README.md`, source
+  paths, and project membership describe the same structure
+
+#### Scenario: AppKit bridge spreads into unrelated SwiftUI
+- **WHEN** a change introduces `NSWindow`, `NSView`, `NSApp`, Darwin socket, or
+  process-management ownership into a SwiftUI feature view that does not own a
+  platform bridge
+- **THEN** the architecture check fails or the review checklist requires moving
+  the behavior into an app, service, terminal host, or support boundary
+
+#### Scenario: Behavior-preserving move is reviewed
+- **WHEN** a refactor slice only moves or extracts Apple client code
+- **THEN** verification includes diff review, project membership validation, and
+  the focused Apple build or script checks needed to prove behavior was not
+  intentionally changed

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -1,0 +1,73 @@
+## 1. Architecture Inventory And Guardrails
+
+- [ ] 1.1 Inventory current Apple client Swift files by primary responsibility, line count, platform scope, AppKit imports, and Xcode project membership.
+- [ ] 1.2 Define the accepted target folder layout under `clients/apple/AlanNative` and record which current files should move to each owner.
+- [ ] 1.3 Add a focused architecture-maintainability check that reports flat-directory drift, README/source layout mismatch, oversized multi-responsibility files, and AppKit bridge leakage.
+- [ ] 1.4 Keep the first architecture check in report or narrowly failing mode so it protects new regressions without requiring the full migration in one commit.
+
+## 2. App Entry And Window Ownership
+
+- [ ] 2.1 Move macOS app singleton startup and duplicate-instance activation out of `AlanNativeApp.swift` into app-owned files.
+- [ ] 2.2 Move primary shell owner creation and stable `window_main` setup into an app or shell startup owner.
+- [ ] 2.3 Move shell menu/keyboard command definitions into a dedicated command owner that still routes through the shared shell workspace command API.
+- [ ] 2.4 Move hidden-titlebar placement, traffic-light metrics, min-size, tabbing, and primary-window focusing out of `MacShellRootView.swift` into a window support/coordinator boundary.
+
+## 3. SwiftUI Shell View Structure
+
+- [ ] 3.1 Split `MacShellRootView.swift` into focused shell root, sidebar, workspace, command palette, material/theme, and support files without changing behavior.
+- [ ] 3.2 Ensure the shell root reads as stable composition and no longer owns feature-specific sidebar rows, command search internals, inspector/debug panels, or voice command implementation.
+- [ ] 3.3 Move shell visual tokens and material wrappers into support/design-token files that can be reused without importing unrelated shell layout.
+- [ ] 3.4 Coordinate with `polish-macos-search-remove-inspector` so inspector removal and Find bar work are not buried inside the architecture split.
+
+## 4. Console, API, And Event Reduction Boundaries
+
+- [ ] 4.1 Move mobile or legacy console UI from `ContentView.swift` into a clearly named console/mobile folder while preserving the non-macOS app entry path.
+- [ ] 4.2 Move chat/timeline/pending-yield value types into model files or console-specific model files.
+- [ ] 4.3 Split daemon API DTOs and `AlanAPIClient` ownership from console view model and SwiftUI screens.
+- [ ] 4.4 Extract daemon event polling/reading and event-to-UI-state reduction from `AlanConsoleViewModel` so event mapping is testable without rendering the full console UI.
+
+## 5. Shell Model And Controller Ownership
+
+- [ ] 5.1 Split pure shell enum/value types, pane/tree/tab/space snapshots, legacy decoding, bootstrap defaults, and mutation helpers out of the current monolithic `ShellModel.swift`.
+- [ ] 5.2 Keep shell mutation behavior covered by the existing focused shell model script tests after each split.
+- [ ] 5.3 Review `ShellHostController` for controller/store/service boundaries and move persistence, boot-profile projection, attention projection, and runtime update projection where they have clear owners.
+- [ ] 5.4 Preserve `ShellWorkspaceCommand` as the shared command vocabulary used by menu, command palette, keyboard, and control-plane paths.
+
+## 6. Terminal Host And Runtime Service Boundaries
+
+- [ ] 6.1 Split `TerminalHostView.swift` so `AlanTerminalHostNSView` remains the AppKit bridge while input routing, overlay presentation, window observation, runtime snapshot publication, and Ghostty attachment have explicit collaborators.
+- [ ] 6.2 Keep terminal-area event ownership routed through the AppKit terminal host and preserve the weak activation boundary during extraction.
+- [ ] 6.3 Keep terminal runtime identity service-backed and pane-keyed while moving files or collaborators.
+- [ ] 6.4 Run focused terminal surface/runtime scripts after terminal-host or runtime-service extractions.
+
+## 7. Control Plane And IPC Boundaries
+
+- [ ] 7.1 Split shell control-plane protocol DTOs from socket server, file-polling control plane, local command executor, state merger, event persistence, and diagnostics.
+- [ ] 7.2 Keep socket transport behavior bounded by request size, request timeout, response timeout, and concurrency limits during extraction.
+- [ ] 7.3 Keep local command execution authoritative against shell/runtime state and separate from transport read/write code.
+- [ ] 7.4 Run focused shell control-plane contract scripts after IPC or local executor extraction.
+
+## 8. Documentation And Project Organization
+
+- [ ] 8.1 Update `clients/apple/README.md` so documented source layout matches the actual folders and current macOS/iOS entry paths.
+- [ ] 8.2 Update the Xcode project file to keep groups, file references, and target membership aligned with the new source layout.
+- [ ] 8.3 Document which active macOS OpenSpec changes may conflict with architecture slices and how implementation should sequence or rebase around them.
+- [ ] 8.4 Confirm no behavior-only OpenSpec requirement is moved into this architecture-maintainability capability.
+
+## 9. Verification
+
+- [ ] 9.1 Run the new Apple architecture-maintainability check and document current remaining hotspots.
+- [ ] 9.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 9.3 Run focused Apple shell scripts affected by moved model, runtime, terminal surface, or control-plane files.
+- [ ] 9.4 Run `git diff --check`.
+- [ ] 9.5 Run `openspec validate improve-macos-app-architecture-maintainability --type change --strict --json`.
+- [ ] 9.6 Run `openspec validate --all --strict --json`.
+- [ ] 9.7 Build the macOS app with `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`.
+
+## 10. PR Review And Archive Readiness
+
+- [ ] 10.1 Keep mechanical file moves separate from behavior edits in commits or PR descriptions.
+- [ ] 10.2 Ask reviewers to evaluate whether source ownership, AppKit bridge boundaries, and validation gates make future work easier to maintain.
+- [ ] 10.3 Before archive, sync the accepted `macos-app-architecture-maintainability` requirements into `openspec/specs/`.
+- [ ] 10.4 Before archive, sync the accepted build/test contract delta into `openspec/specs/macos-shell-build-test-contract/spec.md`.
+- [ ] 10.5 Record implementation verification evidence and remaining architecture debt before archiving the change.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for macOS app architecture maintainability
- capture source layout, SwiftUI/AppKit boundary, terminal host, control-plane, console/API, and validation requirements
- add implementation tasks that map the 10 identified architecture issues into staged refactor slices

## Validation
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- git diff --check