### PR TITLE
Polish macOS shell specs

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Apple Client Architecture Maintainability
+
+This document records the current Apple client source ownership baseline and the
+target layout for behavior-preserving refactor slices. It is intentionally about
+maintainability, not product behavior.
+
+## Current Inventory
+
+All Swift files currently live directly under `clients/apple/AlanNative` and are
+members of the `AlanNative` Xcode target.
+
+| File | Lines | Platform / bridge imports | Primary responsibility today | Target owner |
+| --- | ---: | --- | --- | --- |
+| `AlanNativeApp.swift` | 187 | SwiftUI, AppKit, Darwin; macOS gates | App entry, singleton startup, primary shell owner, commands, window focusing | `App/` |
+| `AlanAppSingletonGuard.swift` | 141 | Foundation, AppKit, Darwin; macOS gates | OS-backed duplicate-instance guard | `App/` or `Support/Windowing/` |
+| `MacShellRootView.swift` | 1998 | SwiftUI, AppKit; macOS gates | Shell root layout, sidebar, command UI, voice command UI, material wrappers, window placement | `Views/Shell/` plus `Support/Design/` and `Support/Windowing/` |
+| `TerminalPaneView.swift` | 806 | SwiftUI; macOS gates | Split-tree and pane leaf rendering | `Views/Shell/Terminal/` |
+| `TerminalHostView.swift` | 1442 | AppKit, SwiftUI, QuartzCore, GhosttyKit; macOS gates | AppKit terminal host bridge, focus, input routing, overlays, runtime attachment | `Views/Shell/Terminal/` plus terminal collaborators |
+| `GhosttyLiveHost.swift` | 896 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Ghostty canvas bridge and wakeup/occlusion integration | `Services/Terminal/` or `Support/TerminalBridge/` |
+| `TerminalHostRuntime.swift` | 636 | Foundation; macOS gates | Terminal host runtime protocols and fallback runtime state | `Services/Terminal/` |
+| `TerminalRuntimeRegistry.swift` | 172 | SwiftUI, AppKit; macOS gates | Pane-keyed terminal host/runtime registry | `Services/Terminal/` |
+| `TerminalRuntimeService.swift` | 1054 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Window-scoped terminal runtime service and Ghostty bootstrap | `Services/Terminal/` |
+| `TerminalSurfaceController.swift` | 1428 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Terminal input, pointer, scrollback, search, and surface adapters | `Services/Terminal/` |
+| `ShellModel.swift` | 2145 | Foundation | Shell IDs, panes, tabs, spaces, split tree, snapshots, mutations, persistence shims | `Models/Shell/` |
+| `ShellHostController.swift` | 1960 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, persistence, boot profiles, runtime projection, command routing | `Controllers/Shell/` plus service collaborators |
+| `ShellControlPlane.swift` | 2105 | Foundation, Darwin; macOS gates | Protocol DTOs, socket server, file polling, local executor, state merging, persistence, diagnostics | `Services/ControlPlane/` plus `Models/ControlPlane/` |
+| `AlanAPIClient.swift` | 764 | Foundation | Daemon API DTOs and HTTP client | `Services/Daemon/` plus `Models/API/` |
+| `ContentView.swift` | 1960 | SwiftUI, AppKit; iOS/macOS gates | Legacy/mobile console UI, console view model state, daemon event polling and reduction | `Views/Console/`, `Models/Console/`, and `Services/Daemon/` |
+
+## Target Layout
+
+The accepted target under `clients/apple/AlanNative` is:
+
+- `App/`: `AlanNativeApp`, app delegate, duplicate-instance startup, primary
+  shell owner creation, app commands, and primary window coordination.
+- `Views/Shell/`: the default macOS shell composition, sidebar, workspace,
+  command palette, pane title/search UI, and shell-specific SwiftUI components.
+- `Views/Console/`: mobile or legacy remote-control console screens and view
+  models that are not the primary macOS shell path.
+- `Models/`: API DTOs, shell snapshots, shell IDs, enums, value types, and
+  compatibility decoding shims.
+- `Controllers/`: observable app and shell controllers that own UI state and
+  delegate IO or domain work to services.
+- `Services/`: daemon API clients, event readers/reducers, terminal runtime
+  services, Ghostty bootstrap, shell control plane, socket server, persistence,
+  and other process or IO code.
+- `Support/`: design tokens, formatting helpers, window placement, AppKit
+  adapters, and small utilities.
+
+## Apply Sequence Notes
+
+- Start with report-mode checks and pure model/support moves.
+- Keep behavior changes out of mechanical move commits.
+- Rebase UI slices around `polish-macos-search-remove-inspector`,
+  `add-macos-pane-title-bars`, and `normalize-macos-shell-corner-radii` before
+  splitting `MacShellRootView.swift`.
+- Split terminal host and control-plane collaborators only with focused runtime
+  or IPC script checks in the same slice.
+
+## Validation
+
+Run the architecture report directly:
+
+```bash
+bash clients/apple/scripts/check-architecture-maintainability.sh
+```
+
+The default mode reports known migration debt and fails only on narrow
+regressions such as new root-level Swift files or Xcode project membership drift.
+Use `--strict` when intentionally tightening the architecture gate.

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -162,6 +162,13 @@ enum ShellPalette {
     )
 }
 
+enum ShellRadii {
+    static let control: CGFloat = 6
+    static let row: CGFloat = 8
+    static let surface: CGFloat = 10
+    static let overlay: CGFloat = 12
+}
+
 private struct SidebarMaterialView: NSViewRepresentable {
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
@@ -195,8 +202,6 @@ struct MacShellRootView: View {
     @ObservedObject private var host: ShellHostController
     @State private var isCommandTabPresented = false
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
-    @AppStorage("alanShellShowsInspector")
-    private var showsInspector = false
 
     init(host: ShellHostController) {
         self.host = host
@@ -212,8 +217,7 @@ struct MacShellRootView: View {
             HStack(spacing: 0) {
                 ShellSidebarView(
                     host: host,
-                    chromeMetrics: windowChromeMetrics,
-                    showsInspector: $showsInspector
+                    chromeMetrics: windowChromeMetrics
                 ) {
                     withAnimation(.easeOut(duration: 0.18)) {
                         isCommandTabPresented = true
@@ -228,12 +232,6 @@ struct MacShellRootView: View {
                         ShellMaterialBackgroundView()
                             .ignoresSafeArea(edges: .top)
                     }
-
-                if showsInspector {
-                    ShellInspectorView(host: host)
-                        .frame(width: 336)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
-                }
             }
             .frame(minWidth: 1260, minHeight: 800)
             .background(ShellPalette.window)
@@ -249,15 +247,13 @@ struct MacShellRootView: View {
 
                 ShellCommandTabView(
                     host: host,
-                    isPresented: $isCommandTabPresented,
-                    showsInspector: $showsInspector
+                    isPresented: $isCommandTabPresented
                 )
                 .frame(width: 520)
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
         .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
-        .animation(.easeOut(duration: 0.18), value: showsInspector)
         .background(ShellWindowPlacementView(metrics: $windowChromeMetrics))
     }
 }
@@ -465,7 +461,6 @@ private enum AlanShellWindowPlacement {
 private struct ShellSidebarView: View {
     @ObservedObject var host: ShellHostController
     let chromeMetrics: ShellWindowChromeMetrics
-    @Binding var showsInspector: Bool
     let openCommandTab: () -> Void
     @State private var hoveredTabID: String?
     @State private var hoveredSpaceID: String?
@@ -490,7 +485,7 @@ private struct ShellSidebarView: View {
     private var sidebarHeader: some View {
         HStack(alignment: .center, spacing: 10) {
             ZStack {
-                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                     .fill(ShellPalette.sidebarControlStrong)
                 Text("A")
                     .font(.system(size: 12.5, weight: .bold, design: .rounded))
@@ -512,24 +507,6 @@ private struct ShellSidebarView: View {
 
             Spacer(minLength: 8)
 
-            Button {
-                withAnimation(.easeOut(duration: 0.18)) {
-                    showsInspector.toggle()
-                }
-            } label: {
-                Image(systemName: showsInspector ? "sidebar.trailing" : "sidebar.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 26, height: 26)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .fill(ShellPalette.sidebarControl)
-                    )
-            }
-            .buttonStyle(.plain)
-            .help(showsInspector ? "Hide Inspector" : "Show Inspector")
-            .accessibilityLabel(Text(showsInspector ? "Hide Inspector" : "Show Inspector"))
-
             Menu {
                 Button("New Tab") {
                     _ = host.openTerminalTab()
@@ -543,7 +520,7 @@ private struct ShellSidebarView: View {
                     .foregroundStyle(.primary)
                     .frame(width: 26, height: 26)
                     .background(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                             .fill(ShellPalette.sidebarControl)
                     )
             }
@@ -571,7 +548,7 @@ private struct ShellSidebarView: View {
             .padding(.horizontal, 11)
             .padding(.vertical, 10)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                     .fill(ShellPalette.sidebarControl)
             )
         }
@@ -651,7 +628,7 @@ private struct ShellSidebarView: View {
                         .foregroundStyle(.primary)
                         .frame(width: 30, height: 30)
                         .background(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                                 .fill(ShellPalette.sidebarControl)
                         )
                 }
@@ -881,7 +858,7 @@ private struct ShellSpaceRailItem: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ZStack {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                     .fill(
                         isSelected
                             ? ShellPalette.railSelection
@@ -986,7 +963,7 @@ private struct ShellTabSidebarRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(
-                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                     .fill(
                         isSelected
                             ? ShellPalette.sidebarSelection
@@ -1034,229 +1011,16 @@ private struct ShellTabRailView: View {
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                             .fill(host.selectedTab?.tabID == tab.tabID ? ShellPalette.sidebarCard : ShellPalette.sidebarHover)
                     )
                     .overlay {
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                             .stroke(ShellPalette.line.opacity(host.selectedTab?.tabID == tab.tabID ? 0.55 : 0.24), lineWidth: 1)
                     }
                 }
                 .buttonStyle(.plain)
             }
-        }
-    }
-}
-
-private struct ShellInspectorView: View {
-    @ObservedObject var host: ShellHostController
-    @State private var selectedSection: ShellInspectorSection = .overview
-
-    private var selectedTabTitle: String {
-        guard let selectedTab = host.selectedTab else { return "No tab" }
-        let tabPanes = host.shellState.panes.filter { $0.tabID == selectedTab.tabID }
-        return shellTabDisplayTitle(
-            tab: selectedTab,
-            panes: tabPanes,
-            fallback: host.selectedSpace?.title ?? "Alan"
-        )
-    }
-
-    private var focusedProgramLabel: String {
-        if let program = shellVisibleLabel(host.focusedPane?.process?.program) {
-            return program
-        }
-
-        if host.focusedPane?.resolvedLaunchTarget == .alan {
-            return "Alan"
-        }
-
-        return "Shell"
-    }
-
-    private var focusedLocationLabel: String {
-        if let workingDirectoryName = shellVisibleLabel(host.focusedPane?.context?.workingDirectoryName) {
-            return workingDirectoryName
-        }
-
-        if let cwd = shellVisibleLabel(host.focusedPane?.cwd) {
-            return cwd
-        }
-
-        return "Unknown"
-    }
-
-    private var focusedAttentionLabel: String {
-        host.focusedPane?.attention.rawValue
-            .replacingOccurrences(of: "_", with: " ")
-            .capitalized ?? "Idle"
-    }
-
-    private var inspectorAttentionItem: ShellAttentionItem? {
-        host.attentionItems.first { item in
-            item.attention == .awaitingUser || item.attention == .notable
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Text("Inspector")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(ShellPalette.ink)
-                Spacer(minLength: 0)
-                Picker("Inspector Section", selection: $selectedSection) {
-                    ForEach(ShellInspectorSection.allCases) { section in
-                        Text(section.title).tag(section)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.segmented)
-                .frame(width: 200)
-            }
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
-                    switch selectedSection {
-                    case .overview:
-                        InspectorCard(title: "Focused Pane") {
-                            VStack(alignment: .leading, spacing: 8) {
-                                KeyValueRow(
-                                    label: "Tab",
-                                    value: selectedTabTitle
-                                )
-                                KeyValueRow(
-                                    label: "Program",
-                                    value: focusedProgramLabel
-                                )
-                                if focusedLocationLabel != "Unknown" {
-                                    KeyValueRow(
-                                        label: "Location",
-                                        value: focusedLocationLabel
-                                    )
-                                }
-                                KeyValueRow(
-                                    label: "Attention",
-                                    value: focusedAttentionLabel
-                                )
-                            }
-                        }
-
-                        InspectorCard(title: "Alan") {
-                            if let binding = host.focusedPane?.alanBinding {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    KeyValueRow(label: "Session", value: binding.sessionID)
-                                    KeyValueRow(label: "Run", value: binding.runStatus)
-                                    KeyValueRow(label: "Pending Yield", value: binding.pendingYield ? "Yes" : "None")
-                                }
-                            } else {
-                                Text("This pane is available to Alan, but no Alan session is attached right now.")
-                                    .font(.system(size: 13, weight: .medium))
-                                    .foregroundStyle(ShellPalette.mutedInk)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                        }
-
-                        InspectorCard(title: "Attention") {
-                            VStack(alignment: .leading, spacing: 10) {
-                                KeyValueRow(
-                                    label: "Waiting",
-                                    value: host.awaitingAttentionCount == 0 ? "None" : "\(host.awaitingAttentionCount)"
-                                )
-
-                                if let firstAttention = inspectorAttentionItem {
-                                    Button {
-                                        host.focusAttentionItem(firstAttention)
-                                    } label: {
-                                        HStack(spacing: 8) {
-                                            Circle()
-                                                .fill(ShellPalette.attention)
-                                                .frame(width: 8, height: 8)
-                                            VStack(alignment: .leading, spacing: 2) {
-                                                Text(shellNormalizedTitle(firstAttention.title) ?? firstAttention.title)
-                                                    .font(.system(size: 12, weight: .semibold))
-                                                    .foregroundStyle(ShellPalette.ink)
-                                                Text(shellUserFacingSummary(firstAttention.summary) ?? "Needs attention")
-                                                    .font(.system(size: 11, weight: .medium))
-                                                    .foregroundStyle(ShellPalette.mutedInk)
-                                                    .lineLimit(2)
-                                            }
-                                            Spacer(minLength: 0)
-                                        }
-                                        .padding(.horizontal, 10)
-                                        .padding(.vertical, 9)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .fill(Color.white.opacity(0.72))
-                                        )
-                                    }
-                                    .buttonStyle(.plain)
-                                } else {
-                                    Text("Nothing currently needs attention.")
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundStyle(ShellPalette.mutedInk)
-                                }
-                            }
-                        }
-                    case .debug:
-                        if !host.controlPlaneDiagnostics.isEmpty {
-                            InspectorCard(title: "Control Diagnostics") {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    ForEach(Array(host.controlPlaneDiagnostics.enumerated()), id: \.offset) { entry in
-                                        Text(entry.element)
-                                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                                            .foregroundStyle(ShellPalette.mutedInk)
-                                            .fixedSize(horizontal: false, vertical: true)
-                                    }
-                                }
-                            }
-                        }
-
-                        InspectorCard(title: "Debug Snapshot") {
-                            VStack(alignment: .leading, spacing: 12) {
-                                Text("Canonical local shell state exposed to `alan shell state`.")
-                                    .font(.system(size: 13, weight: .medium))
-                                    .foregroundStyle(ShellPalette.mutedInk)
-
-                                HStack {
-                                    Button("Copy JSON") {
-                                        host.copySnapshotJSON()
-                                    }
-                                    .buttonStyle(.borderless)
-                                    .foregroundStyle(ShellPalette.accent)
-
-                                    Spacer(minLength: 0)
-
-                                    if let lastCopiedAt = host.lastCopiedAt {
-                                        Text(lastCopiedAt.formatted(date: .omitted, time: .shortened))
-                                            .font(.system(size: 11, weight: .medium))
-                                            .foregroundStyle(ShellPalette.mutedInk)
-                                    }
-                                }
-
-                                Text(host.snapshotJSON)
-                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                    .foregroundStyle(ShellPalette.ink)
-                                    .textSelection(.enabled)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(12)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                            .fill(Color.white.opacity(0.72))
-                                    )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .padding(16)
-        .frame(maxHeight: .infinity, alignment: .top)
-        .background(ShellPalette.window.opacity(0.95))
-        .overlay(alignment: .leading) {
-            Rectangle()
-                .fill(ShellPalette.line.opacity(0.15))
-                .frame(width: 1)
         }
     }
 }
@@ -1310,11 +1074,11 @@ private struct ShellSpaceRow: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(isSelected ? ShellPalette.sidebarCard : Color.clear)
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .stroke(isSelected ? ShellPalette.line.opacity(0.6) : Color.clear, lineWidth: 1)
         }
     }
@@ -1359,11 +1123,11 @@ private struct ShellTabRow: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(isSelected ? ShellPalette.sidebarCard : Color.clear)
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .stroke(isSelected ? ShellPalette.line.opacity(0.65) : Color.clear, lineWidth: 1)
         }
     }
@@ -1405,7 +1169,7 @@ private struct ShellAttentionRow: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(ShellPalette.panel)
         )
     }
@@ -1427,25 +1191,9 @@ private struct ShellEmptyStateRow: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(ShellPalette.panelSoft)
         )
-    }
-}
-
-private enum ShellInspectorSection: String, CaseIterable, Identifiable {
-    case overview
-    case debug
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .overview:
-            return "Overview"
-        case .debug:
-            return "Debug"
-        }
     }
 }
 
@@ -1456,7 +1204,6 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
     case openAlanTab
     case jumpToAttention
     case focusBestPane
-    case toggleInspector
     case splitRight
     case splitDown
     case splitLeft
@@ -1487,8 +1234,6 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Jump To Attention"
         case .focusBestPane:
             return "Focus Best Routing Pane"
-        case .toggleInspector:
-            return "Toggle Inspector"
         case .splitRight:
             return "Split Pane Right"
         case .splitDown:
@@ -1532,8 +1277,6 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return "Jump to the strongest pane that currently needs approval or attention."
         case .focusBestPane:
             return "Use shell routing signals to jump to the strongest candidate pane."
-        case .toggleInspector:
-            return "Show or hide the right-side shell inspector."
         case .splitRight:
             return "Create a side-by-side split to the right of the focused pane."
         case .splitDown:
@@ -1590,16 +1333,6 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
             return ["jump to attention", "jump attention", "focus waiting pane", "approval", "waiting pane"]
         case .focusBestPane:
             return ["best pane", "route", "routing", "focus best", "jump pane"]
-        case .toggleInspector:
-            return [
-                "inspector",
-                "show inspector",
-                "hide inspector",
-                "open inspector",
-                "close inspector",
-                "toggle inspector",
-                "right sidebar",
-            ]
         case .splitRight:
             return ["split right", "split vertical", "side by side"]
         case .splitDown:
@@ -1648,7 +1381,6 @@ private struct ShellCommandTabIntent: Identifiable {
 private struct ShellCommandTabView: View {
     @ObservedObject var host: ShellHostController
     @Binding var isPresented: Bool
-    @Binding var showsInspector: Bool
     @State private var query = ""
     @FocusState private var isQueryFocused: Bool
     @StateObject private var voiceController = ShellVoiceCommandController()
@@ -1666,7 +1398,6 @@ private struct ShellCommandTabView: View {
             .splitRight,
             .splitDown,
             .equalizeSplits,
-            .toggleInspector,
             .jumpToAttention,
             .newSpace,
         ]
@@ -1773,7 +1504,7 @@ private struct ShellCommandTabView: View {
                         .padding(.horizontal, 7)
                         .padding(.vertical, 4)
                         .background(
-                            Capsule(style: .continuous)
+                            RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                                 .fill(ShellPalette.canvas.opacity(0.95))
                         )
 
@@ -1788,7 +1519,7 @@ private struct ShellCommandTabView: View {
                             .foregroundStyle(voiceController.isListening ? ShellPalette.accent : ShellPalette.mutedInk)
                             .frame(width: 26, height: 26)
                             .background(
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                                     .fill(ShellPalette.canvas.opacity(0.92))
                             )
                     }
@@ -1802,7 +1533,7 @@ private struct ShellCommandTabView: View {
                             .foregroundStyle(ShellPalette.mutedInk)
                             .frame(width: 26, height: 26)
                             .background(
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                                     .fill(ShellPalette.canvas.opacity(0.92))
                             )
                     }
@@ -1811,11 +1542,11 @@ private struct ShellCommandTabView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 12)
                 .background(
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                         .fill(Color.white.opacity(0.9))
                 )
                 .overlay {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                         .stroke(ShellPalette.line.opacity(0.32), lineWidth: 1)
                 }
                 .shadow(color: Color.black.opacity(0.035), radius: 10, y: 4)
@@ -1915,14 +1646,14 @@ private struct ShellCommandTabView: View {
         .frame(width: 478, height: 568)
         .background(
             ZStack {
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
                     .fill(.ultraThinMaterial)
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
                     .fill(ShellPalette.window.opacity(0.9))
             }
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
                 .stroke(ShellPalette.line.opacity(0.42), lineWidth: 1)
         }
         .shadow(color: Color.black.opacity(0.12), radius: 26, y: 16)
@@ -1954,14 +1685,6 @@ private struct ShellCommandTabView: View {
             }
         case .focusBestPane:
             _ = host.focusTopRoutingCandidate()
-        case .toggleInspector:
-            withAnimation(.easeOut(duration: 0.18)) {
-                if let requestedInspectorVisibility {
-                    showsInspector = requestedInspectorVisibility
-                } else {
-                    showsInspector.toggle()
-                }
-            }
         case .splitRight:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitRight)
         case .splitDown:
@@ -2032,27 +1755,12 @@ private struct ShellCommandTabView: View {
         )
     }
 
-    private var requestedInspectorVisibility: Bool? {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized.contains("show") || normalized.contains("open") {
-            return true
-        }
-        if normalized.contains("hide") || normalized.contains("close") {
-            return false
-        }
-        return nil
-    }
-
     private func title(for action: ShellCommandTabAction) -> String {
-        guard action == .toggleInspector else { return action.title }
-        let shouldShow = requestedInspectorVisibility ?? !showsInspector
-        return shouldShow ? "Show Inspector" : "Hide Inspector"
+        action.title
     }
 
     private func detail(for action: ShellCommandTabAction) -> String {
-        guard action == .toggleInspector else { return action.detail }
-        let shouldShow = requestedInspectorVisibility ?? !showsInspector
-        return shouldShow ? "Open the right-side shell inspector." : "Close the right-side shell inspector."
+        action.detail
     }
 
     private func sectionLabel(_ value: String) -> some View {
@@ -2096,11 +1804,6 @@ private final class ShellVoiceCommandController: NSObject, ObservableObject, NSS
             "close tab",
             "jump to attention",
             "focus waiting pane",
-            "show inspector",
-            "hide inspector",
-            "open inspector",
-            "close inspector",
-            "toggle inspector",
             "copy snapshot",
         ]
     }
@@ -2156,11 +1859,11 @@ private struct ShellCommandRow: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 13, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(Color.white.opacity(0.84))
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 13, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .stroke(ShellPalette.line.opacity(isHovered ? 0.24 : 0.12), lineWidth: 1)
         }
         .scaleEffect(isHovered ? 1.004 : 1)
@@ -2168,146 +1871,6 @@ private struct ShellCommandRow: View {
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .onHover { isHovered = $0 }
     }
-}
-
-private struct StatusBadge: View {
-    let title: String
-    let value: String
-    let accent: Color
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(title)
-                .font(.system(size: 10, weight: .semibold, design: .rounded))
-                .textCase(.uppercase)
-                .foregroundStyle(ShellPalette.mutedInk)
-            Text(value)
-                .font(.system(size: 13, weight: .semibold, design: .rounded))
-                .foregroundStyle(accent)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color.white.opacity(0.54))
-        )
-    }
-}
-
-private struct InspectorCard<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text(title)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(ShellPalette.ink)
-            content
-        }
-        .padding(15)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(Color.white.opacity(0.78))
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(ShellPalette.line.opacity(0.18), lineWidth: 1)
-        }
-        .shadow(color: Color.black.opacity(0.03), radius: 8, y: 3)
-    }
-}
-
-private struct KeyValueRow: View {
-    let label: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label)
-                .font(.system(size: 10, weight: .semibold))
-                .textCase(.uppercase)
-                .foregroundStyle(ShellPalette.mutedInk)
-            Text(value)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(ShellPalette.ink)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-}
-
-func shellVisibleLabel(_ raw: String?) -> String? {
-    guard let raw else { return nil }
-    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty, trimmed != "/", trimmed != "-" else { return nil }
-    return trimmed
-}
-
-func shellPathLeaf(_ raw: String?) -> String? {
-    guard let visible = shellVisibleLabel(raw) else { return nil }
-    if visible == "~" {
-        return "Home"
-    }
-
-    guard visible.contains("/") else { return nil }
-    let components = visible.split(separator: "/").map(String.init)
-    return components.last.flatMap(shellVisibleLabel)
-}
-
-func shellNormalizedTitle(_ raw: String?) -> String? {
-    guard var candidate = shellVisibleLabel(raw) else { return nil }
-
-    for suffix in [" - fish", " - zsh", " - bash", " - sh"] {
-        if candidate.lowercased().hasSuffix(suffix) {
-            candidate.removeLast(suffix.count)
-            break
-        }
-    }
-
-    candidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let visible = shellVisibleLabel(candidate) else { return nil }
-
-    if let leaf = shellPathLeaf(visible) {
-        return leaf
-    }
-
-    return visible
-}
-
-func shellDisplayTitle(
-    rawTitle: String?,
-    workingDirectoryName: String?,
-    cwd: String?,
-    program: String?,
-    launchTarget: ShellLaunchTarget,
-    fallback: String? = nil
-) -> String {
-    if let workingDirectoryName = shellVisibleLabel(workingDirectoryName) {
-        return workingDirectoryName
-    }
-
-    if let cwdLeaf = shellPathLeaf(cwd) {
-        return cwdLeaf
-    }
-
-    if let normalizedTitle = shellNormalizedTitle(rawTitle) {
-        return normalizedTitle
-    }
-
-    if let fallback = shellVisibleLabel(fallback) {
-        return fallback
-    }
-
-    if launchTarget == .alan {
-        return "Alan"
-    }
-
-    if let program = shellVisibleLabel(program) {
-        return program
-    }
-
-    return "Terminal"
 }
 
 func shellTabDisplayTitle(

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -525,6 +525,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
+    func closePaneByID(_ paneID: String) -> Bool {
+        closePane(paneID: paneID) == .closed
+    }
+
+    @discardableResult
     func liftSelectedPaneToTab(title: String? = nil) -> Bool {
         guard let paneID = selectedPane?.paneID else { return false }
         return liftPaneToTab(paneID: paneID, title: title) == .lifted

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -266,6 +266,117 @@ func shellTerminalStatusSummary(for pane: ShellPane) -> String? {
     }
 }
 
+func shellVisibleLabel(_ raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, trimmed != "/", trimmed != "-" else { return nil }
+    return trimmed
+}
+
+func shellPathLeaf(_ raw: String?) -> String? {
+    guard let visible = shellVisibleLabel(raw) else { return nil }
+    if visible == "~" {
+        return "Home"
+    }
+
+    guard visible.contains("/") else { return nil }
+    let components = visible.split(separator: "/").map(String.init)
+    return components.last.flatMap(shellVisibleLabel)
+}
+
+func shellNormalizedTitle(_ raw: String?) -> String? {
+    guard var candidate = shellVisibleLabel(raw) else { return nil }
+
+    let internalOnlyTitles = [
+        "title updated",
+        "input committed",
+        "terminal rendering",
+        "window attached",
+    ]
+
+    let lowercasedCandidate = candidate.lowercased()
+    if internalOnlyTitles.contains(lowercasedCandidate)
+        || lowercasedCandidate.hasPrefix("pane_")
+    {
+        return nil
+    }
+
+    for suffix in [" - fish", " - zsh", " - bash", " - sh"] {
+        if candidate.lowercased().hasSuffix(suffix) {
+            candidate.removeLast(suffix.count)
+            break
+        }
+    }
+
+    candidate = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let visible = shellVisibleLabel(candidate) else { return nil }
+
+    if let leaf = shellPathLeaf(visible) {
+        return leaf
+    }
+
+    return visible
+}
+
+func shellDisplayTitle(
+    rawTitle: String?,
+    workingDirectoryName: String?,
+    cwd: String?,
+    program: String?,
+    launchTarget: ShellLaunchTarget,
+    fallback: String? = nil
+) -> String {
+    if let workingDirectoryName = shellVisibleLabel(workingDirectoryName) {
+        return workingDirectoryName
+    }
+
+    if let cwdLeaf = shellPathLeaf(cwd) {
+        return cwdLeaf
+    }
+
+    if let normalizedTitle = shellNormalizedTitle(rawTitle) {
+        return normalizedTitle
+    }
+
+    if let fallback = shellVisibleLabel(fallback) {
+        return fallback
+    }
+
+    if launchTarget == .alan {
+        return "Alan"
+    }
+
+    if let program = shellVisibleLabel(program) {
+        return program
+    }
+
+    return "Terminal"
+}
+
+func shellPaneTitleBarTitle(for pane: ShellPane) -> String {
+    if let normalizedTitle = shellNormalizedTitle(pane.viewport?.title) {
+        return normalizedTitle
+    }
+
+    if let cwdLeaf = shellPathLeaf(pane.cwd) {
+        return cwdLeaf
+    }
+
+    if let workingDirectory = shellVisibleLabel(pane.context?.workingDirectoryName) {
+        return workingDirectory
+    }
+
+    if pane.resolvedLaunchTarget == .alan {
+        return "Alan"
+    }
+
+    if let program = shellVisibleLabel(pane.process?.program) {
+        return program
+    }
+
+    return "Terminal"
+}
+
 struct ShellViewportSnapshot: Codable, Equatable {
     let title: String?
     let summary: String?

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -249,7 +249,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func configureView() {
         wantsLayer = true
         layer?.backgroundColor = NSColor(calibratedRed: 0.06, green: 0.08, blue: 0.10, alpha: 1).cgColor
-        layer?.cornerRadius = 12
+        layer?.cornerRadius = ShellRadii.surface
         layer?.cornerCurve = .continuous
         layer?.masksToBounds = true
         layer?.borderWidth = 0
@@ -270,7 +270,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         overlayCard.state = .active
         overlayCard.translatesAutoresizingMaskIntoConstraints = false
         overlayCard.wantsLayer = true
-        overlayCard.layer?.cornerRadius = 18
+        overlayCard.layer?.cornerRadius = ShellRadii.overlay
         overlayCard.layer?.borderWidth = 1
         overlayCard.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
 
@@ -997,9 +997,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         if routeNativeKeyCommandIfNeeded(event) {
             return
         }
-        if handleSearchKeyIfNeeded(event) {
-            return
-        }
 
 #if canImport(GhosttyKit)
         if isApplicationReservedKeyEquivalent(event) {
@@ -1217,10 +1214,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func routeNativeKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
         switch surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event)) {
         case .nativeCommand("find"):
-            guard surfaceController.beginSearch() else { return false }
-            syncOverlayVisibility()
-            publishRuntimeSnapshot()
-            return true
+            return beginFindInteraction()
         case .nativeCommand("quit"):
             return false
         case .nativeCommand, .terminalText, .terminalKey, .ignored:
@@ -1235,33 +1229,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return false
         }
         workspaceCommandHandler?(command)
-        return true
-    }
-
-    private func handleSearchKeyIfNeeded(_ event: NSEvent) -> Bool {
-        guard surfaceController.searchAdapter?.state.isActive == true else { return false }
-        guard event.type == .keyDown else { return true }
-        if event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command) {
-            return false
-        }
-
-        switch event.keyCode {
-        case 0x35:
-            surfaceController.dismissSearch()
-        case 0x24:
-            surfaceController.nextSearchMatch()
-        case 0x33:
-            let current = surfaceController.searchAdapter?.state.query ?? ""
-            surfaceController.updateSearchQuery(String(current.dropLast()))
-        default:
-            if let characters = textForKeyEvent(event), shouldSendText(characters) {
-                let current = surfaceController.searchAdapter?.state.query ?? ""
-                surfaceController.updateSearchQuery(current + characters)
-            }
-        }
-
-        syncOverlayVisibility()
-        publishRuntimeSnapshot()
         return true
     }
 
@@ -1413,6 +1380,43 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     func characterIndex(for point: NSPoint) -> Int {
         0
+    }
+
+    @discardableResult
+    func beginFindInteraction() -> Bool {
+        guard surfaceController.beginSearch() else { return false }
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+        return true
+    }
+
+    @discardableResult
+    func updateFindQuery(_ query: String) -> Bool {
+        guard surfaceController.updateSearchQuery(query) else { return false }
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+        return true
+    }
+
+    func selectNextFindMatch() {
+        surfaceController.nextSearchMatch()
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+    }
+
+    func selectPreviousFindMatch() {
+        surfaceController.previousSearchMatch()
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+    }
+
+    func dismissFindInteraction(refocusTerminal: Bool) {
+        surfaceController.dismissSearch()
+        syncOverlayVisibility()
+        publishRuntimeSnapshot()
+        if refocusTerminal {
+            requestTerminalFocus()
+        }
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -113,11 +113,11 @@ struct TerminalPaneView: View {
         .padding(.horizontal, 9)
         .padding(.vertical, 6)
         .background(
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(Color.white.opacity(0.62))
         )
         .overlay {
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .stroke(ShellPalette.line.opacity(0.22), lineWidth: 1)
         }
     }
@@ -450,7 +450,7 @@ struct TerminalPaneView: View {
 }
 
 private struct ShellTerminalSurfaceFrame: ViewModifier {
-    private let shape = RoundedRectangle(cornerRadius: 12, style: .continuous)
+    private let shape = RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
 
     func body(content: Content) -> some View {
         content
@@ -487,6 +487,9 @@ private struct ShellPaneTreeLayoutView: View {
                     activationDelegate: host,
                     onWorkspaceCommand: { command in
                         host.performShellWorkspaceCommand(command)
+                    },
+                    onClosePane: {
+                        host.closePaneByID(pane.paneID)
                     },
                     onRuntimeUpdate: host.updateTerminalRuntime,
                     onMetadataUpdate: { metadata in
@@ -643,29 +646,219 @@ private struct ShellTerminalLeafView: View {
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onWorkspaceCommand: (ShellWorkspaceCommand) -> Void
+    let onClosePane: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
     var body: some View {
-        TerminalHostView(
-            pane: pane,
-            bootProfile: bootProfile,
-            isSelected: isSelected,
-            runtimeRegistry: runtimeRegistry,
-            activationDelegate: activationDelegate,
-            onWorkspaceCommand: onWorkspaceCommand,
-            onRuntimeUpdate: onRuntimeUpdate,
-            onMetadataUpdate: onMetadataUpdate
-        )
-        .id(pane.paneID)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(ShellPalette.terminal)
-        .overlay {
-            ShellInactivePaneDim(
+        VStack(spacing: 0) {
+            ShellPaneTitleBarView(
+                title: shellPaneTitleBarTitle(for: pane),
                 isSelected: isSelected,
-                isEnabled: dimsInactiveSplitPanes
+                onFocusPane: {
+                    activationDelegate?.terminalHostDidRequestActivation(paneID: pane.paneID)
+                },
+                onClosePane: onClosePane
             )
+
+            ZStack(alignment: .topTrailing) {
+                TerminalHostView(
+                    pane: pane,
+                    bootProfile: bootProfile,
+                    isSelected: isSelected,
+                    runtimeRegistry: runtimeRegistry,
+                    activationDelegate: activationDelegate,
+                    onWorkspaceCommand: onWorkspaceCommand,
+                    onRuntimeUpdate: onRuntimeUpdate,
+                    onMetadataUpdate: onMetadataUpdate
+                )
+                .id(pane.paneID)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .background(ShellPalette.terminal)
+                .overlay {
+                    ShellInactivePaneDim(
+                        isSelected: isSelected,
+                        isEnabled: dimsInactiveSplitPanes
+                    )
+                }
+
+                if isSelected,
+                   let searchState = runtimeRegistry.snapshot(for: pane.paneID).surfaceState.search,
+                   searchState.isActive
+                {
+                    ShellFindBarView(
+                        searchState: searchState,
+                        onQueryChange: { query in
+                            _ = runtimeRegistry.updateFindQuery(for: pane.paneID, query: query)
+                        },
+                        onNext: {
+                            runtimeRegistry.selectNextFindMatch(for: pane.paneID)
+                        },
+                        onPrevious: {
+                            runtimeRegistry.selectPreviousFindMatch(for: pane.paneID)
+                        },
+                        onClose: {
+                            runtimeRegistry.dismissFindInteraction(for: pane.paneID)
+                        }
+                    )
+                    .padding(10)
+                }
+            }
         }
+    }
+}
+
+private struct ShellPaneTitleBarView: View {
+    let title: String
+    let isSelected: Bool
+    let onFocusPane: () -> Void
+    let onClosePane: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
+                .foregroundStyle(isSelected ? ShellPalette.ink : ShellPalette.mutedInk)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onClosePane) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Close pane")
+            .accessibilityLabel("Close pane")
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 6)
+        .frame(height: 28)
+        .background(
+            Rectangle()
+                .fill(isSelected ? ShellPalette.terminalSoft.opacity(0.52) : Color.black.opacity(0.08))
+        )
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(ShellPalette.line.opacity(isSelected ? 0.18 : 0.12))
+                .frame(height: 1)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onFocusPane)
+    }
+}
+
+private struct ShellFindBarView: View {
+    let searchState: AlanTerminalSearchState
+    let onQueryChange: (String) -> Void
+    let onNext: () -> Void
+    let onPrevious: () -> Void
+    let onClose: () -> Void
+
+    @State private var query: String
+    @FocusState private var isFocused: Bool
+
+    init(
+        searchState: AlanTerminalSearchState,
+        onQueryChange: @escaping (String) -> Void,
+        onNext: @escaping () -> Void,
+        onPrevious: @escaping () -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.searchState = searchState
+        self.onQueryChange = onQueryChange
+        self.onNext = onNext
+        self.onPrevious = onPrevious
+        self.onClose = onClose
+        _query = State(initialValue: searchState.query)
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(ShellPalette.mutedInk)
+
+            TextField("Find", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(ShellPalette.ink)
+                .focused($isFocused)
+                .frame(width: 180)
+                .onChange(of: query) { _, nextQuery in
+                    onQueryChange(nextQuery)
+                }
+                .onChange(of: searchState.query) { _, nextQuery in
+                    guard nextQuery != query else { return }
+                    query = nextQuery
+                }
+                .onSubmit {
+                    onNext()
+                }
+
+            Text(resultLabel)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(ShellPalette.mutedInk)
+                .frame(minWidth: 48, alignment: .trailing)
+
+            Button(action: onPrevious) {
+                Image(systemName: "chevron.up")
+                    .font(.system(size: 10, weight: .bold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .help("Previous match")
+            .keyboardShortcut("g", modifiers: [.command, .shift])
+
+            Button(action: onNext) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .bold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .help("Next match")
+            .keyboardShortcut("g", modifiers: [.command])
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .help("Close Find")
+            .keyboardShortcut(.escape, modifiers: [])
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
+                .fill(ShellPalette.panel.opacity(0.96))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
+                .stroke(ShellPalette.line.opacity(0.35), lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.12), radius: 14, y: 6)
+        .onAppear {
+            query = searchState.query
+            isFocused = true
+        }
+        .onExitCommand {
+            onClose()
+        }
+    }
+
+    private var resultLabel: String {
+        if let total = searchState.totalMatches,
+           let selected = searchState.selectedIndex
+        {
+            guard total > 0 else { return "0" }
+            return "\(selected + 1)/\(total)"
+        }
+        return query.isEmpty ? "" : "..."
     }
 }
 
@@ -713,7 +906,7 @@ private struct TerminalActionLabel: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(Color.white.opacity(0.8))
         )
     }
@@ -735,7 +928,7 @@ private struct TerminalPaneChip: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            Capsule(style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
                 .fill(background)
         )
     }
@@ -757,11 +950,11 @@ private struct TerminalInfoCard<Content: View>: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
                 .fill(Color.white.opacity(0.76))
         )
         .overlay {
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
                 .stroke(accent.opacity(0.16), lineWidth: 1)
         }
     }
@@ -797,7 +990,7 @@ private struct TerminalMonoLine: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                     .fill(ShellPalette.canvas.opacity(0.78))
             )
     }

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -795,6 +795,9 @@ private struct ShellFindBarView: View {
                     guard nextQuery != query else { return }
                     query = nextQuery
                 }
+                .onChange(of: searchState.focusRequestID) { _, _ in
+                    isFocused = true
+                }
                 .onSubmit {
                     onNext()
                 }

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -136,6 +136,28 @@ final class TerminalRuntimeRegistry: ObservableObject {
         return runtimeService.sendText(to: paneID, text: text)
     }
 
+    @discardableResult
+    func beginFindInteraction(for paneID: String) -> Bool {
+        hostViewsByPaneID[paneID]?.beginFindInteraction() ?? false
+    }
+
+    @discardableResult
+    func updateFindQuery(for paneID: String, query: String) -> Bool {
+        hostViewsByPaneID[paneID]?.updateFindQuery(query) ?? false
+    }
+
+    func selectNextFindMatch(for paneID: String) {
+        hostViewsByPaneID[paneID]?.selectNextFindMatch()
+    }
+
+    func selectPreviousFindMatch(for paneID: String) {
+        hostViewsByPaneID[paneID]?.selectPreviousFindMatch()
+    }
+
+    func dismissFindInteraction(for paneID: String, refocusTerminal: Bool = true) {
+        hostViewsByPaneID[paneID]?.dismissFindInteraction(refocusTerminal: refocusTerminal)
+    }
+
     var registeredPaneIDs: Set<String> {
         Set(hostViewsByPaneID.keys).union(runtimeService.registeredPaneIDs)
     }

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -746,6 +746,7 @@ struct AlanTerminalSearchState: Equatable {
     let isActive: Bool
     let totalMatches: Int?
     let selectedIndex: Int?
+    let focusRequestID: Int
 
     static func inactive(paneID: String) -> AlanTerminalSearchState {
         AlanTerminalSearchState(
@@ -753,7 +754,8 @@ struct AlanTerminalSearchState: Equatable {
             query: "",
             isActive: false,
             totalMatches: nil,
-            selectedIndex: nil
+            selectedIndex: nil,
+            focusRequestID: 0
         )
     }
 }
@@ -787,13 +789,25 @@ final class AlanTerminalSearchAdapter {
         self.state = .inactive(paneID: paneID)
     }
 
+    func requestFocus() {
+        state = AlanTerminalSearchState(
+            paneID: state.paneID,
+            query: state.query,
+            isActive: true,
+            totalMatches: state.totalMatches,
+            selectedIndex: state.selectedIndex,
+            focusRequestID: state.focusRequestID + 1
+        )
+    }
+
     func updateQuery(_ query: String) {
         state = AlanTerminalSearchState(
             paneID: state.paneID,
             query: query,
             isActive: true,
             totalMatches: state.totalMatches,
-            selectedIndex: state.selectedIndex
+            selectedIndex: state.selectedIndex,
+            focusRequestID: state.focusRequestID
         )
     }
 
@@ -809,7 +823,8 @@ final class AlanTerminalSearchAdapter {
             query: state.query,
             isActive: state.isActive,
             totalMatches: total,
-            selectedIndex: boundedIndex
+            selectedIndex: boundedIndex,
+            focusRequestID: state.focusRequestID
         )
     }
 
@@ -1239,9 +1254,12 @@ final class AlanTerminalSurfaceController {
             searchAdapter = AlanTerminalSearchAdapter(paneID: paneID)
         }
         if searchAdapter?.state.isActive == true {
+            searchAdapter?.requestFocus()
+            notifySearchStateChanged()
             return true
         }
         guard searchEngine?.startSearch() == true else { return false }
+        searchAdapter?.requestFocus()
         searchAdapter?.updateQuery(searchAdapter?.state.query ?? "")
         return true
     }

--- a/clients/apple/AlanNative/TerminalSurfaceController.swift
+++ b/clients/apple/AlanNative/TerminalSurfaceController.swift
@@ -1134,28 +1134,6 @@ final class AlanTerminalSurfaceController {
         metadata: TerminalPaneMetadataSnapshot,
         bootProfile: AlanShellBootProfile?
     ) -> AlanTerminalOverlayState? {
-        if let searchState = searchAdapter?.state,
-           searchState.isActive
-        {
-            let status: String
-            if let totalMatches = searchState.totalMatches,
-               let selectedIndex = searchState.selectedIndex
-            {
-                status = "\(selectedIndex + 1) of \(totalMatches)"
-            } else if searchState.query.isEmpty {
-                status = "Type to search this pane."
-            } else {
-                status = "Searching this pane."
-            }
-            return AlanTerminalOverlayState(
-                title: "Search terminal",
-                message: searchState.query.isEmpty ? "Find text in this pane." : searchState.query,
-                badge: "Search",
-                action: status,
-                debugDetail: "pane=\(searchState.paneID)"
-            )
-        }
-
         let readiness: AlanTerminalSurfaceReadiness
         if bootProfile == nil || surfaceHandle == nil {
             readiness = .unready(reason: .missingSurface)

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -13,12 +13,16 @@ whose shell is readable and operable by both humans and agents.
 
 ## Directory Structure
 
-- `AlanNativeApp.swift`: app entry point
-- `Views/`: UI views
-- `State/`: app state and stores
-- `Networking/`: daemon API and WebSocket client
-- `Models/`: protocol data models
-- `Resources/`: assets and app resources
+The current app still has a flat Swift source directory while the macOS shell is
+being split into durable owner folders. The accepted target layout and current
+file inventory are recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+- `AlanNativeApp.swift`: current app entry point
+- `MacShellRootView.swift`: current primary macOS shell root
+- `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces
+- `ShellModel.swift` / `ShellHostController.swift`: current shell state and controller
+- `ShellControlPlane.swift`: current file/socket shell control plane
+- `ContentView.swift`: current legacy/mobile console surface
 
 ## Quick Start
 
@@ -155,6 +159,9 @@ xcodebuild \
 
 # Shell control-plane contract smoke
 bash clients/apple/scripts/check-shell-contracts.sh
+
+# Apple source architecture maintainability report
+bash clients/apple/scripts/check-architecture-maintainability.sh
 
 # iOS
 xcodebuild \

--- a/clients/apple/scripts/check-architecture-maintainability.sh
+++ b/clients/apple/scripts/check-architecture-maintainability.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APPLE_ROOT="$REPO_ROOT/clients/apple"
+SOURCE_ROOT="$APPLE_ROOT/AlanNative"
+PROJECT_FILE="$APPLE_ROOT/AlanNative.xcodeproj/project.pbxproj"
+README_FILE="$APPLE_ROOT/README.md"
+ARCH_DOC="$APPLE_ROOT/ARCHITECTURE.md"
+STRICT=0
+
+if [[ "${1:-}" == "--strict" ]]; then
+    STRICT=1
+fi
+
+warnings=0
+failures=0
+
+warn() {
+    printf 'warning: %s\n' "$1"
+    warnings=$((warnings + 1))
+}
+
+fail() {
+    printf 'error: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+contains_line() {
+    local needle="$1"
+    shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+current_root_swift_allowlist=(
+    "AlanAPIClient.swift"
+    "AlanAppSingletonGuard.swift"
+    "AlanNativeApp.swift"
+    "ContentView.swift"
+    "GhosttyLiveHost.swift"
+    "MacShellRootView.swift"
+    "ShellControlPlane.swift"
+    "ShellHostController.swift"
+    "ShellModel.swift"
+    "TerminalHostRuntime.swift"
+    "TerminalHostView.swift"
+    "TerminalPaneView.swift"
+    "TerminalRuntimeRegistry.swift"
+    "TerminalRuntimeService.swift"
+    "TerminalSurfaceController.swift"
+)
+
+target_dirs=(
+    "App"
+    "Views/Shell"
+    "Views/Console"
+    "Models"
+    "Controllers"
+    "Services"
+    "Support"
+)
+
+large_file_threshold=1200
+
+printf 'Apple architecture maintainability report\n'
+printf 'Source root: clients/apple/AlanNative\n\n'
+
+if [[ ! -f "$ARCH_DOC" ]]; then
+    fail "clients/apple/ARCHITECTURE.md must record the architecture inventory and target layout"
+fi
+
+printf 'Current Swift inventory:\n'
+while IFS= read -r file; do
+    rel="${file#$SOURCE_ROOT/}"
+    lines="$(wc -l < "$file" | tr -d ' ')"
+    imports="$(grep -E '^import ' "$file" | sed 's/^import //' | paste -sd ',' - || true)"
+    gates="$(grep -E '^#if (os|canImport)' "$file" | sed 's/^#if //' | paste -sd ',' - || true)"
+    if [[ -z "$imports" ]]; then
+        imports="-"
+    fi
+    if [[ -z "$gates" ]]; then
+        gates="-"
+    fi
+    printf '  %-36s %5s lines  imports=%s  gates=%s\n' "$rel" "$lines" "$imports" "$gates"
+
+    if [[ "$rel" != */* ]]; then
+        if ! contains_line "$rel" "${current_root_swift_allowlist[@]}"; then
+            fail "new root-level Swift file '$rel' should be placed in the target owner folder"
+        fi
+    fi
+
+    if (( lines > large_file_threshold )); then
+        warn "$rel is $lines lines; keep new behavior in the target owner or document the temporary boundary"
+    fi
+
+    if grep -Eq '^import (AppKit|Darwin)$' "$file"; then
+        case "$rel" in
+            App/*|Services/*|Support/*|Views/Shell/Terminal/*|AlanNativeApp.swift|AlanAppSingletonGuard.swift|GhosttyLiveHost.swift|ShellControlPlane.swift|TerminalHostView.swift|TerminalRuntimeService.swift|TerminalSurfaceController.swift)
+                ;;
+            MacShellRootView.swift|ContentView.swift|ShellHostController.swift|TerminalRuntimeRegistry.swift)
+                warn "$rel imports AppKit or Darwin while it remains outside a narrow bridge owner"
+                ;;
+            *)
+                fail "$rel imports AppKit or Darwin outside an accepted app, service, support, or terminal bridge boundary"
+                ;;
+        esac
+    fi
+
+    if ! grep -q "$rel" "$PROJECT_FILE"; then
+        fail "$rel is not referenced by the Xcode project"
+    fi
+done < <(find "$SOURCE_ROOT" -name '*.swift' -type f | sort)
+
+printf '\nTarget layout status:\n'
+for dir in "${target_dirs[@]}"; do
+    if [[ -d "$SOURCE_ROOT/$dir" ]]; then
+        printf '  present: clients/apple/AlanNative/%s\n' "$dir"
+    else
+        warn "target folder clients/apple/AlanNative/$dir is not present yet"
+    fi
+    if [[ -f "$ARCH_DOC" ]] && ! grep -q "\`$dir/\`" "$ARCH_DOC"; then
+        fail "clients/apple/ARCHITECTURE.md must document target folder $dir/"
+    fi
+done
+
+printf '\nREADME layout drift:\n'
+while IFS= read -r entry; do
+    path="$(printf '%s' "$entry" | sed -E 's/^- `([^`]+)`.*/\1/')"
+    [[ "$path" == "$entry" ]] && continue
+    case "$path" in
+        *.swift)
+            [[ -f "$SOURCE_ROOT/$path" ]] || warn "README lists $path but the file is not at clients/apple/AlanNative/$path"
+            ;;
+        */)
+            [[ -d "$SOURCE_ROOT/${path%/}" ]] || warn "README lists $path but the folder is not present yet"
+            ;;
+    esac
+done < <(grep -E '^- `[^`]+`' "$README_FILE" || true)
+
+if ! grep -q "check-architecture-maintainability.sh" "$README_FILE"; then
+    warn "README does not mention the architecture maintainability report command"
+fi
+
+printf '\nXcode project membership drift:\n'
+while IFS= read -r ref; do
+    name="$(printf '%s' "$ref" | sed -E 's/.*path = ([^;]+);.*/\1/')"
+    [[ "$name" == "$ref" ]] && continue
+    [[ "$name" == *.swift ]] || continue
+    if [[ ! -f "$SOURCE_ROOT/$name" ]]; then
+        fail "Xcode project references missing Swift file $name"
+    fi
+done < <(grep -E 'path = .*\.swift;' "$PROJECT_FILE" || true)
+
+if (( failures > 0 )); then
+    printf '\nArchitecture maintainability check failed with %d error(s) and %d warning(s).\n' "$failures" "$warnings" >&2
+    exit 1
+fi
+
+if (( STRICT == 1 && warnings > 0 )); then
+    printf '\nArchitecture maintainability strict check failed with %d warning(s).\n' "$warnings" >&2
+    exit 1
+fi
+
+printf '\nArchitecture maintainability report completed with %d warning(s).\n' "$warnings"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -28,7 +28,33 @@ reject_pattern() {
     fi
 }
 
+reject_active_shell_radius_drift() {
+    local matched=0
+    local file
+
+    for file in \
+        "clients/apple/AlanNative/MacShellRootView.swift" \
+        "clients/apple/AlanNative/TerminalPaneView.swift" \
+        "clients/apple/AlanNative/TerminalHostView.swift"
+    do
+        if grep -En 'RoundedRectangle\(cornerRadius: (1[4-9]|[2-9][0-9])|cornerRadius = (1[4-9]|[2-9][0-9])' "$REPO_ROOT/$file" >&2; then
+            matched=1
+        fi
+
+        if grep -En 'Capsule\(style: \.continuous\)' "$REPO_ROOT/$file" >&2; then
+            matched=1
+        fi
+    done
+
+    if [[ "$matched" -ne 0 ]]; then
+        printf 'error: active macOS shell chrome must use ShellRadii tokens and avoid default Capsule chrome\n' >&2
+        exit 1
+    fi
+}
+
 "$SCRIPT_DIR/setup-local-ghosttykit.sh" --check >/dev/null
+"$SCRIPT_DIR/check-architecture-maintainability.sh" >/dev/null
+reject_active_shell_radius_drift
 
 require_pattern \
     "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
@@ -114,6 +140,31 @@ require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.swift" \
     "verifiesSearchActionsReachSurfaceEngine" \
     "surface controller tests must prove search actions reach the surface engine"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellFindBarView" \
+    "pane-scoped Find must render as a real SwiftUI find bar"
+
+reject_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "alanShellShowsInspector|showsInspector|ShellInspectorView|ShellInspectorSection|InspectorCard|toggleInspector|Show Inspector|Hide Inspector|right-side shell inspector" \
+    "default macOS shell must not expose the removed inspector product surface"
+
+reject_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "show inspector|hide inspector|open inspector|close inspector|toggle inspector" \
+    "legacy shell voice commands must not expose inspector commands"
+
+reject_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "handleSearchKeyIfNeeded|current \\+ characters|dropLast\\(\\)" \
+    "Find query editing must be owned by the SwiftUI Find bar instead of terminal key capture"
+
+reject_pattern \
+    "clients/apple/AlanNative/TerminalSurfaceController.swift" \
+    "Search terminal|Find text in this pane|Type to search this pane" \
+    "Find UI must render through ShellFindBarView instead of the passive terminal overlay card"
 
 require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.swift" \
@@ -284,6 +335,26 @@ require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "ShellPaneTitleBarView" \
+    "visible terminal panes must render a compact pane title bar"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "shellPaneTitleBarTitle" \
+    "pane title bars must use a dedicated title helper with terminal-title-first priority"
+
+require_pattern \
+    "clients/apple/AlanNative/ShellHostController.swift" \
+    "func closePaneByID\\(_ paneID: String\\) -> Bool" \
+    "pane title-bar close must route through a controller-owned targeted pane close path"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-split-model.swift" \
+    "verifiesPaneScopedCloseKeepsInactivePaneTargeting" \
+    "split model tests must cover pane-scoped close targeting"
 
 require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -25,5 +25,19 @@ final class AlanTerminalHostNSView: NSView {
     func teardownTerminalRuntime() {
         teardownCount += 1
     }
+
+    func beginFindInteraction() -> Bool {
+        false
+    }
+
+    func updateFindQuery(_ query: String) -> Bool {
+        false
+    }
+
+    func selectNextFindMatch() {}
+
+    func selectPreviousFindMatch() {}
+
+    func dismissFindInteraction(refocusTerminal: Bool = true) {}
 }
 #endif

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -17,6 +17,9 @@ private enum ShellRuntimeMetadataTests {
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesSurfaceExitOverridesRunningMetadata()
         verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth()
+        verifiesPaneTitleBarPrefersTerminalTitle()
+        verifiesPaneTitleBarFallbackOrdering()
+        verifiesPaneTitleBarSuppressesInternalTitles()
         print("Shell runtime metadata tests passed.")
     }
 
@@ -193,6 +196,171 @@ private enum ShellRuntimeMetadataTests {
         expect(shellTerminalStatusSummary(for: ordinary) == nil, "ordinary summaries must not hide cwd or branch metadata")
     }
 
+    private static func verifiesPaneTitleBarPrefersTerminalTitle() {
+        let title = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: "Alan",
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: ShellViewportSnapshot(
+                    title: "vim main.rs - fish",
+                    summary: nil,
+                    visibleExcerpt: nil,
+                    lastActivityAt: nil
+                ),
+                cwd: "/Users/morris/Developer/Alan",
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+
+        expect(title == "vim main.rs", "pane title bar must prefer normalized terminal title over cwd")
+    }
+
+    private static func verifiesPaneTitleBarFallbackOrdering() {
+        let cwdTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: "Workspace",
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: nil,
+                cwd: "/tmp/project",
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(cwdTitle == "project", "pane title bar must use cwd leaf before working-directory name")
+
+        let workingDirectoryTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: "Workspace",
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: nil,
+                cwd: nil,
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(workingDirectoryTitle == "Workspace", "pane title bar must use working directory when cwd is missing")
+
+        let alanTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: nil,
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: nil,
+                cwd: nil,
+                launchTarget: .alan,
+                process: ShellProcessBinding(program: "alan", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(alanTitle == "Alan", "pane title bar must expose Alan launch-target fallback")
+
+        let processTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: nil,
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: nil,
+                cwd: nil,
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(processTitle == "fish", "pane title bar must use process fallback before generic Terminal")
+    }
+
+    private static func verifiesPaneTitleBarSuppressesInternalTitles() {
+        let debugTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: "Alan",
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: ShellViewportSnapshot(
+                    title: "title updated",
+                    summary: nil,
+                    visibleExcerpt: nil,
+                    lastActivityAt: nil
+                ),
+                cwd: "/Users/morris/Developer/Alan",
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(debugTitle == "Alan", "pane title bar must suppress debug title text")
+
+        let rawPaneTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: "Workspace",
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: ShellViewportSnapshot(
+                    title: "pane_42",
+                    summary: nil,
+                    visibleExcerpt: nil,
+                    lastActivityAt: nil
+                ),
+                cwd: nil,
+                process: ShellProcessBinding(program: "fish", argvPreview: nil),
+                attention: .idle
+            )
+        )
+        expect(rawPaneTitle == "Workspace", "pane title bar must suppress raw pane IDs")
+
+        let longTitle = "ssh production-shell-with-a-very-long-title.example.com"
+        let preservedLongTitle = shellPaneTitleBarTitle(
+            for: pane(
+                context: context(
+                    workingDirectoryName: nil,
+                    processState: "running",
+                    rendererHealth: "ready",
+                    surfaceReadiness: "ready",
+                    lastCommandExitCode: nil
+                ),
+                viewport: ShellViewportSnapshot(
+                    title: longTitle,
+                    summary: nil,
+                    visibleExcerpt: nil,
+                    lastActivityAt: nil
+                ),
+                cwd: nil,
+                process: nil,
+                attention: .idle
+            )
+        )
+        expect(preservedLongTitle == longTitle, "pane title helper must leave long titles available for UI truncation")
+    }
+
     private static func makeController() -> ShellHostController {
         let windowID = "metadata_test_\(UUID().uuidString)"
         let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
@@ -213,15 +381,18 @@ private enum ShellRuntimeMetadataTests {
     private static func pane(
         context: ShellContextSnapshot,
         viewport: ShellViewportSnapshot?,
+        cwd: String? = "/Users/morris/Developer/Alan",
+        launchTarget: ShellLaunchTarget = .shell,
+        process: ShellProcessBinding? = ShellProcessBinding(program: "fish", argvPreview: nil),
         attention: ShellAttentionState
     ) -> ShellPane {
         ShellPane(
             paneID: "pane_1",
             tabID: "tab_1",
             spaceID: "space_1",
-            launchTarget: .shell,
-            cwd: "/Users/morris/Developer/Alan",
-            process: ShellProcessBinding(program: "fish", argvPreview: nil),
+            launchTarget: launchTarget,
+            cwd: cwd,
+            process: process,
             attention: attention,
             context: context,
             viewport: viewport,
@@ -230,13 +401,14 @@ private enum ShellRuntimeMetadataTests {
     }
 
     private static func context(
+        workingDirectoryName: String? = "Alan",
         processState: String,
         rendererHealth: String,
         surfaceReadiness: String,
         lastCommandExitCode: Int?
     ) -> ShellContextSnapshot {
         ShellContextSnapshot(
-            workingDirectoryName: "Alan",
+            workingDirectoryName: workingDirectoryName,
             repositoryRoot: nil,
             gitBranch: nil,
             controlPath: nil,

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -16,6 +16,10 @@ private enum ShellSplitModelTests {
         try verifiesSameDirectionAttachKeepsBinarySplitTree()
         try verifiesSpatialFocusFollowsSplitTree()
         try verifiesSpatialFocusPreservesPerpendicularPosition()
+        try verifiesPaneScopedCloseRemovesSelectedPane()
+        try verifiesPaneScopedCloseKeepsInactivePaneTargeting()
+        try verifiesPaneScopedCloseClosesSinglePaneTab()
+        try verifiesPaneScopedClosePreservesFinalPane()
         try verifiesLegacySplitDecodeDefaultsToEqualRatio()
         print("Shell split model tests passed.")
     }
@@ -166,6 +170,59 @@ private enum ShellSplitModelTests {
             upResult.paneID == "pane_3",
             "focus up from the lower-right pane must return to the upper-right pane"
         )
+    }
+
+    private static func verifiesPaneScopedCloseKeepsInactivePaneTargeting() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+        state = try state.focusingPane("pane_1").state
+
+        let result = try state.closingPane("pane_2")
+        let tree = try requireFocusedTabTree(result.state)
+
+        expect(result.state.pane(paneID: "pane_2") == nil, "targeted close must remove the requested pane")
+        expect(result.state.pane(paneID: "pane_1") != nil, "targeted close must preserve the selected sibling")
+        expect(result.state.focusedPaneID == "pane_1", "closing an inactive pane must not move focus")
+        expect(tree.paneIDs == ["pane_1"], "split tree must repair after closing the inactive pane")
+    }
+
+    private static func verifiesPaneScopedCloseRemovesSelectedPane() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+
+        let result = try state.closingPane("pane_2")
+        let tree = try requireFocusedTabTree(result.state)
+
+        expect(result.state.pane(paneID: "pane_2") == nil, "selected pane close must remove the selected pane")
+        expect(result.state.focusedPaneID == "pane_1", "selected pane close must focus the remaining sibling")
+        expect(tree.paneIDs == ["pane_1"], "selected pane close must repair the split tree")
+    }
+
+    private static func verifiesPaneScopedCloseClosesSinglePaneTab() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTerminalTab(
+            in: state.focusedSpaceID,
+            title: "Second",
+            workingDirectory: "/tmp"
+        ).state
+
+        let result = try state.closingPane("pane_2")
+
+        expect(result.state.pane(paneID: "pane_2") == nil, "single-pane tab close must remove that pane")
+        expect(result.state.tab(tabID: "tab_2") == nil, "single-pane tab close must reuse tab close semantics")
+        expect(result.state.pane(paneID: "pane_1") != nil, "single-pane tab close must preserve remaining tab panes")
+        expect(result.state.focusedPaneID == "pane_1", "single-pane tab close must focus a remaining pane")
+    }
+
+    private static func verifiesPaneScopedClosePreservesFinalPane() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+
+        do {
+            _ = try state.closingPane("pane_1")
+            expect(false, "closing the final pane in the final tab must throw")
+        } catch ShellStateMutationError.lastTab {
+            // Expected.
+        }
     }
 
     private static func verifiesLegacySplitDecodeDefaultsToEqualRatio() throws {

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -347,6 +347,14 @@ private enum TerminalSurfaceControllerTests {
         expect(controller.beginSearch(), "controller must start search through the surface engine")
         expect(handle.searchActions == ["start_search"], "begin search must invoke Ghostty search action")
         expect(controller.searchAdapter?.state.isActive == true, "started search must become active")
+        let firstFocusRequestID = controller.searchAdapter?.state.focusRequestID
+
+        expect(controller.beginSearch(), "active search must accept a renewed focus request")
+        expect(handle.searchActions == ["start_search"], "active search focus must not restart the search engine")
+        expect(
+            controller.searchAdapter?.state.focusRequestID == firstFocusRequestID.map { $0 + 1 },
+            "active search focus must refresh the Find bar focus token"
+        )
 
         expect(
             controller.updateSearchQuery("alan"),

--- a/openspec/changes/add-macos-pane-title-bars/tasks.md
+++ b/openspec/changes/add-macos-pane-title-bars/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Title Derivation
 
-- [ ] 1.1 Add a pane-title helper that consumes existing `ShellViewportSnapshot.title` before cwd, working-directory, launch-target, process, or `Terminal` fallbacks.
-- [ ] 1.2 Add focused tests for title-bar consumption priority, fallback ordering, long title truncation readiness, and debug/raw-ID suppression without retesting terminal title capture itself.
+- [x] 1.1 Add a pane-title helper that consumes existing `ShellViewportSnapshot.title` before cwd, working-directory, launch-target, process, or `Terminal` fallbacks.
+- [x] 1.2 Add focused tests for title-bar consumption priority, fallback ordering, long title truncation readiness, and debug/raw-ID suppression without retesting terminal title capture itself.
 
 ## 2. Pane Leaf UI
 
-- [ ] 2.1 Wrap each `ShellTerminalLeafView` terminal host in a compact fixed-height title bar plus terminal canvas layout.
-- [ ] 2.2 Render a single-line truncated pane title with active/inactive styling that stays visually lighter than terminal content.
-- [ ] 2.3 Add an icon-only pane close button with tooltip/accessibility label and stable dimensions.
-- [ ] 2.4 Keep the title bar outside the terminal host surface so terminal clicks, drags, right clicks, and scroll events stay owned by the terminal host.
+- [x] 2.1 Wrap each `ShellTerminalLeafView` terminal host in a compact fixed-height title bar plus terminal canvas layout.
+- [x] 2.2 Render a single-line truncated pane title with active/inactive styling that stays visually lighter than terminal content.
+- [x] 2.3 Add an icon-only pane close button with tooltip/accessibility label and stable dimensions.
+- [x] 2.4 Keep the title bar outside the terminal host surface so terminal clicks, drags, right clicks, and scroll events stay owned by the terminal host.
 
 ## 3. Pane-Scoped Close Routing
 
-- [ ] 3.1 Expose a controller-owned targeted pane close path that routes by pane ID and reuses existing `ShellStateSnapshot.closingPane(...)` semantics.
-- [ ] 3.2 Wire the title-bar close button to close the pane represented by that leaf, including inactive split panes.
-- [ ] 3.3 Keep final-pane protection aligned with the existing `lastTab` model behavior and avoid leaving the shell without a valid surface.
-- [ ] 3.4 Add focused tests for selected-pane close, inactive split-pane close, single-pane tab close, and final-pane protection.
+- [x] 3.1 Expose a controller-owned targeted pane close path that routes by pane ID and reuses existing `ShellStateSnapshot.closingPane(...)` semantics.
+- [x] 3.2 Wire the title-bar close button to close the pane represented by that leaf, including inactive split panes.
+- [x] 3.3 Keep final-pane protection aligned with the existing `lastTab` model behavior and avoid leaving the shell without a valid surface.
+- [x] 3.4 Add focused tests for selected-pane close, inactive split-pane close, single-pane tab close, and final-pane protection.
 
 ## 4. Verification
 
-- [ ] 4.1 Run `clients/apple/scripts/test-shell-split-model.sh`.
-- [ ] 4.2 Run `clients/apple/scripts/test-shell-runtime-metadata.sh`.
-- [ ] 4.3 Run `clients/apple/scripts/test-terminal-surface-controller.sh` if terminal input or host wrapper behavior changes.
-- [ ] 4.4 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 4.5 Run `git diff --check`.
-- [ ] 4.6 Run `openspec validate add-macos-pane-title-bars --type change --strict --json`.
-- [ ] 4.7 Run `openspec validate --all --strict --json`.
-- [ ] 4.8 Build the macOS app with the documented `AlanNative` Debug command.
-- [ ] 4.9 Capture or document light-mode single-pane and split-pane screenshots plus manual terminal interaction notes.
+- [x] 4.1 Run `clients/apple/scripts/test-shell-split-model.sh`.
+- [x] 4.2 Run `clients/apple/scripts/test-shell-runtime-metadata.sh`.
+- [x] 4.3 Run `clients/apple/scripts/test-terminal-surface-controller.sh` if terminal input or host wrapper behavior changes.
+- [x] 4.4 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 4.5 Run `git diff --check`.
+- [x] 4.6 Run `openspec validate add-macos-pane-title-bars --type change --strict --json`.
+- [x] 4.7 Run `openspec validate --all --strict --json`.
+- [x] 4.8 Build the macOS app with the documented `AlanNative` Debug command.
+- [x] 4.9 Capture or document light-mode single-pane and split-pane screenshots plus manual terminal interaction notes.
 
 ## 5. Archive Readiness
 
-- [ ] 5.1 Sync accepted delta requirements into `openspec/specs/` before archiving after implementation merges.
-- [ ] 5.2 Record implementation verification evidence in the change before archive.
+- [x] 5.1 Sync accepted delta requirements into `openspec/specs/` before archiving after implementation merges.
+- [x] 5.2 Record implementation verification evidence in the change before archive.

--- a/openspec/changes/add-macos-pane-title-bars/verification.md
+++ b/openspec/changes/add-macos-pane-title-bars/verification.md
@@ -1,0 +1,22 @@
+## Verification Evidence
+
+- `clients/apple/scripts/test-shell-split-model.sh` passed.
+- `clients/apple/scripts/test-shell-runtime-metadata.sh` passed.
+- `clients/apple/scripts/test-terminal-surface-controller.sh` passed.
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `git diff --check` passed.
+- `openspec validate add-macos-pane-title-bars --type change --strict --json` passed.
+- `openspec validate --all --strict --json` passed.
+- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build` passed.
+
+## Manual Notes
+
+- Launched `target/xcode-derived/Build/Products/Debug/Alan.app` in light mode.
+- Confirmed single-pane tabs show a compact title bar above the terminal canvas.
+- Confirmed split panes show one title bar per visible pane, with the title bar outside the terminal host canvas.
+- Confirmed the title-bar close affordance is a slim plain `xmark` with no drawn border or background.
+- Confirmed clicking a pane title area focuses that pane without sending terminal text.
+
+## Build Warnings
+
+- Xcode reported a CoreSimulator version warning: current `1051.49.0`, build `1051.50.0`. The macOS Debug build still succeeded.

--- a/openspec/changes/improve-macos-app-architecture-maintainability/design.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/design.md
@@ -7,8 +7,9 @@ Ghostty bridge, but those concerns are still expressed through large flat Swift
 files:
 
 - `MacShellRootView.swift` mixes theme tokens, SwiftUI shell layout, AppKit
-  material wrappers, window placement, sidebar, inspector, command tab, and
-  voice command UI.
+  material wrappers, window placement, sidebar, command tab, and voice command
+  UI. The inspector product surface has been removed, but the remaining shell
+  root still needs smaller view ownership.
 - `AlanNativeApp.swift` mixes the app entry point, singleton handling, primary
   shell owner, window focusing, app delegate, and shell commands.
 - `ContentView.swift` still combines legacy/mobile console models, daemon event

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Architecture Inventory And Guardrails
 
-- [ ] 1.1 Inventory current Apple client Swift files by primary responsibility, line count, platform scope, AppKit imports, and Xcode project membership.
-- [ ] 1.2 Define the accepted target folder layout under `clients/apple/AlanNative` and record which current files should move to each owner.
-- [ ] 1.3 Add a focused architecture-maintainability check that reports flat-directory drift, README/source layout mismatch, oversized multi-responsibility files, and AppKit bridge leakage.
-- [ ] 1.4 Keep the first architecture check in report or narrowly failing mode so it protects new regressions without requiring the full migration in one commit.
+- [x] 1.1 Inventory current Apple client Swift files by primary responsibility, line count, platform scope, AppKit imports, and Xcode project membership.
+- [x] 1.2 Define the accepted target folder layout under `clients/apple/AlanNative` and record which current files should move to each owner.
+- [x] 1.3 Add a focused architecture-maintainability check that reports flat-directory drift, README/source layout mismatch, oversized multi-responsibility files, and AppKit bridge leakage.
+- [x] 1.4 Keep the first architecture check in report or narrowly failing mode so it protects new regressions without requiring the full migration in one commit.
 
 ## 2. App Entry And Window Ownership
 

--- a/openspec/changes/normalize-macos-shell-corner-radii/design.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/design.md
@@ -6,10 +6,10 @@ terminal-first app. A quick inventory shows the active shell uses hard-coded
 rounded rectangles at 8, 10, 11, 12, 13, 14, 16, 18, 20, 22, and 24 points,
 plus `Capsule` shapes for chips and keycap-like controls. The largest values
 show up in the command palette outer shell (`24`), command search field (`18`),
-tab rail cards (`18`), and terminal info cards (`22`). The separate inspector
-surfaces that previously used `20`-point cards are being removed by
-`polish-macos-search-remove-inspector`, so this normalization pass should not
-keep them alive as a target surface.
+tab rail cards (`18`), and terminal info cards (`22`). The inspector surface
+that previously used `20`-point cards is removed by
+`polish-macos-search-remove-inspector`, so this normalization pass must not keep
+it alive as a target surface.
 
 This conflicts with the current product direction: Arc-like native material,
 compact rows, terminal-first focus, and calm precision. The UI should feel

--- a/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/tasks.md
@@ -1,34 +1,34 @@
 ## 1. Radius Inventory And Tokens
 
-- [ ] 1.1 Confirm which Apple client surfaces are active default macOS shell UI versus legacy or non-primary surfaces.
-- [ ] 1.2 Add a shared active-shell radius token surface near `ShellPalette` with `control = 6`, `row = 8`, `surface = 10`, and `overlay = 12`.
-- [ ] 1.3 Document allowed shape exceptions for semantic circles and any rare semantic pills.
+- [x] 1.1 Confirm which Apple client surfaces are active default macOS shell UI versus legacy or non-primary surfaces.
+- [x] 1.2 Add a shared active-shell radius token surface near `ShellPalette` with `control = 6`, `row = 8`, `surface = 10`, and `overlay = 12`.
+- [x] 1.3 Document allowed shape exceptions for semantic circles and any rare semantic pills.
 
 ## 2. Active Shell UI Normalization
 
-- [ ] 2.1 Replace hard-coded active-shell rounded rectangle radii in `MacShellRootView.swift` with the shared radius tokens.
-- [ ] 2.2 Replace hard-coded active-shell rounded rectangle radii in `TerminalPaneView.swift` with the shared radius tokens.
-- [ ] 2.3 Align normal-flow AppKit fallback radii in `TerminalHostView.swift` with the shared radius scale where those surfaces are visible in default shell flows.
-- [ ] 2.4 Replace decorative `Capsule` usage in default shell text chips, keycap hints, metadata chips, and command badges with restrained rounded rectangles unless documented as semantic pills.
-- [ ] 2.5 Ensure `add-macos-pane-title-bars` implementation uses the same radius tokens for pane title bars and close controls.
+- [x] 2.1 Replace hard-coded active-shell rounded rectangle radii in `MacShellRootView.swift` with the shared radius tokens.
+- [x] 2.2 Replace hard-coded active-shell rounded rectangle radii in `TerminalPaneView.swift` with the shared radius tokens.
+- [x] 2.3 Align normal-flow AppKit fallback radii in `TerminalHostView.swift` with the shared radius scale where those surfaces are visible in default shell flows.
+- [x] 2.4 Replace decorative `Capsule` usage in default shell text chips, keycap hints, metadata chips, and command badges with restrained rounded rectangles unless documented as semantic pills.
+- [x] 2.5 Ensure `add-macos-pane-title-bars` implementation uses the same radius tokens for pane title bars and close controls.
 
 ## 3. Guardrails
 
-- [ ] 3.1 Add or extend a focused shell contract check that flags active-shell `RoundedRectangle(cornerRadius: 14+)` and AppKit `cornerRadius >= 14` unless allowlisted.
-- [ ] 3.2 Add or extend a focused shell contract check or review checklist for new default-shell `Capsule` usage.
-- [ ] 3.3 Keep the check scoped to active shell files so legacy/non-primary surfaces are not rewritten implicitly.
+- [x] 3.1 Add or extend a focused shell contract check that flags active-shell `RoundedRectangle(cornerRadius: 14+)` and AppKit `cornerRadius >= 14` unless allowlisted.
+- [x] 3.2 Add or extend a focused shell contract check or review checklist for new default-shell `Capsule` usage.
+- [x] 3.3 Keep the check scoped to active shell files so legacy/non-primary surfaces are not rewritten implicitly.
 
 ## 4. Verification
 
-- [ ] 4.1 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 4.2 Run `git diff --check`.
-- [ ] 4.3 Run `openspec validate normalize-macos-shell-corner-radii --type change --strict --json`.
-- [ ] 4.4 Run `openspec validate --all --strict --json`.
-- [ ] 4.5 Build the macOS app with the documented `AlanNative` Debug command.
-- [ ] 4.6 Capture or document light-mode screenshots for sidebar, single/split terminal, command palette, and remaining default-shell overlays after normalization.
-- [ ] 4.7 Manually verify the shell still feels native, readable, and not visually flat after reducing radii.
+- [x] 4.1 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Run `openspec validate normalize-macos-shell-corner-radii --type change --strict --json`.
+- [x] 4.4 Run `openspec validate --all --strict --json`.
+- [x] 4.5 Build the macOS app with the documented `AlanNative` Debug command.
+- [x] 4.6 Capture or document light-mode screenshots for sidebar, single/split terminal, command palette, and remaining default-shell overlays after normalization.
+- [x] 4.7 Manually verify the shell still feels native, readable, and not visually flat after reducing radii.
 
 ## 5. Archive Readiness
 
-- [ ] 5.1 Sync accepted radius requirements into `openspec/specs/` before archive.
-- [ ] 5.2 Record radius inventory, exceptions, validation commands, and visual evidence in the change before archive.
+- [x] 5.1 Sync accepted radius requirements into `openspec/specs/` before archive.
+- [x] 5.2 Record radius inventory, exceptions, validation commands, and visual evidence in the change before archive.

--- a/openspec/changes/normalize-macos-shell-corner-radii/verification.md
+++ b/openspec/changes/normalize-macos-shell-corner-radii/verification.md
@@ -1,0 +1,19 @@
+## Verification Evidence
+
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `git diff --check` passed.
+- `openspec validate normalize-macos-shell-corner-radii --type change --strict --json` passed.
+- `openspec validate --all --strict --json` passed.
+- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build` passed.
+
+## Manual Notes
+
+- Launched `target/xcode-derived/Build/Products/Debug/Alan.app` in light mode.
+- Confirmed sidebar rows, command launcher, terminal surround, command palette, pane title bars, and Find bar use the smaller restrained radius scale.
+- Confirmed active default shell files no longer contain large ad hoc numeric rounded rectangle radii or decorative `Capsule` chrome.
+- Confirmed semantic `Circle` use remains limited to status/attention indicators.
+- Confirmed the shell remains readable and native rather than visually flat after the radius reduction.
+
+## Build Warnings
+
+- Xcode reported a CoreSimulator version warning: current `1051.49.0`, build `1051.50.0`. The macOS Debug build still succeeded.

--- a/openspec/changes/polish-macos-search-remove-inspector/tasks.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/tasks.md
@@ -1,49 +1,49 @@
 ## 1. Inspector Removal
 
-- [ ] 1.1 Remove `alanShellShowsInspector`, `showsInspector` bindings, right-side inspector layout, and inspector animations from `MacShellRootView.swift`.
-- [ ] 1.2 Delete `ShellInspectorView`, `ShellInspectorSection`, `InspectorCard`, and inspector-only helper code after confirming any needed diagnostics remain available from shell snapshots, logs, scripts, or tests.
-- [ ] 1.3 Remove inspector sidebar/header toggle controls, accessibility labels, tooltips, and user-facing copy.
-- [ ] 1.4 Remove inspector actions and keywords from `ShellCommandTabAction`, default command-palette results, command execution, and dynamic show/hide title/detail logic.
-- [ ] 1.5 Remove inspector phrases from `ShellVoiceCommandController` vocabulary and handling.
-- [ ] 1.6 Update active UI polish changes or verification notes that still require inspector screenshots, inspector radii, or inspector smoke coverage.
+- [x] 1.1 Remove `alanShellShowsInspector`, `showsInspector` bindings, right-side inspector layout, and inspector animations from `MacShellRootView.swift`.
+- [x] 1.2 Delete `ShellInspectorView`, `ShellInspectorSection`, `InspectorCard`, and inspector-only helper code after confirming any needed diagnostics remain available from shell snapshots, logs, scripts, or tests.
+- [x] 1.3 Remove inspector sidebar/header toggle controls, accessibility labels, tooltips, and user-facing copy.
+- [x] 1.4 Remove inspector actions and keywords from `ShellCommandTabAction`, default command-palette results, command execution, and dynamic show/hide title/detail logic.
+- [x] 1.5 Remove inspector phrases from `ShellVoiceCommandController` vocabulary and handling.
+- [x] 1.6 Update active UI polish changes or verification notes that still require inspector screenshots, inspector radii, or inspector smoke coverage.
 
 ## 2. Native Find Bar UI
 
-- [ ] 2.1 Add a compact pane-scoped Find bar component with editable text field, previous/next icon controls, close control, and match-count/no-result feedback.
-- [ ] 2.2 Render the Find bar for the focused pane without resizing the sidebar, toolbar, split tree, or terminal canvas.
-- [ ] 2.3 Focus and select the Find query field when `Command-F` opens search.
-- [ ] 2.4 Apply query edits through the owning pane's `TerminalSurfaceController.updateSearchQuery(_:)` instead of sending printable query text as terminal input.
-- [ ] 2.5 Display search adapter state for active query, total matches, selected match, searching/no-result state, and inactive state without raw pane IDs or Ghostty action names.
+- [x] 2.1 Add a compact pane-scoped Find bar component with editable text field, previous/next icon controls, close control, and match-count/no-result feedback.
+- [x] 2.2 Render the Find bar for the focused pane without resizing the sidebar, toolbar, split tree, or terminal canvas.
+- [x] 2.3 Focus and select the Find query field when `Command-F` opens search.
+- [x] 2.4 Apply query edits through the owning pane's `TerminalSurfaceController.updateSearchQuery(_:)` instead of sending printable query text as terminal input.
+- [x] 2.5 Display search adapter state for active query, total matches, selected match, searching/no-result state, and inactive state without raw pane IDs or Ghostty action names.
 
 ## 3. Find Keyboard And Focus Routing
 
-- [ ] 3.1 Keep `Command-F` routed to the focused pane's terminal search owner and open the Find bar.
-- [ ] 3.2 Route Return and `Command-G` to the next search result for the pane that owns the active Find interaction.
-- [ ] 3.3 Route Shift-Return and Shift-`Command-G` to the previous search result for the pane that owns the active Find interaction.
-- [ ] 3.4 Route Escape and the close control to `dismissSearch()` for the owning pane.
-- [ ] 3.5 Return first responder/focus to the owning terminal pane after Find is dismissed.
-- [ ] 3.6 Verify split-pane focus changes cannot send query edits or navigation to the wrong pane.
+- [x] 3.1 Keep `Command-F` routed to the focused pane's terminal search owner and open the Find bar.
+- [x] 3.2 Route Return and `Command-G` to the next search result for the pane that owns the active Find interaction.
+- [x] 3.3 Route Shift-Return and Shift-`Command-G` to the previous search result for the pane that owns the active Find interaction.
+- [x] 3.4 Route Escape and the close control to `dismissSearch()` for the owning pane.
+- [x] 3.5 Return first responder/focus to the owning terminal pane after Find is dismissed.
+- [x] 3.6 Verify split-pane focus changes cannot send query edits or navigation to the wrong pane.
 
 ## 4. Tests And Contract Checks
 
-- [ ] 4.1 Update `clients/apple/scripts/test-terminal-surface-controller.swift` to cover Find start, query update, navigation, engine callbacks, and dismissal for the owning pane.
-- [ ] 4.2 Add or update focused tests for `Command-F`, `Command-G`, Shift-`Command-G`, Return, Shift-Return, Escape, and printable query text behavior while Find is active.
-- [ ] 4.3 Update `clients/apple/scripts/check-shell-contracts.sh` so inspector UI/actions are not required and stale inspector affordances are flagged if reintroduced.
-- [ ] 4.4 Update UI smoke/manual verification expectations from inspector overview/debug coverage to default-shell-without-inspector and `Command-F` Find bar coverage.
-- [ ] 4.5 Search Apple client code, scripts, docs, and active OpenSpec changes for stale user-facing inspector references and remove or reframe them where this change owns the surface.
+- [x] 4.1 Update `clients/apple/scripts/test-terminal-surface-controller.swift` to cover Find start, query update, navigation, engine callbacks, and dismissal for the owning pane.
+- [x] 4.2 Add or update focused tests for `Command-F`, `Command-G`, Shift-`Command-G`, Return, Shift-Return, Escape, and printable query text behavior while Find is active.
+- [x] 4.3 Update `clients/apple/scripts/check-shell-contracts.sh` so inspector UI/actions are not required and stale inspector affordances are flagged if reintroduced.
+- [x] 4.4 Update UI smoke/manual verification expectations from inspector overview/debug coverage to default-shell-without-inspector and `Command-F` Find bar coverage.
+- [x] 4.5 Search Apple client code, scripts, docs, and active OpenSpec changes for stale user-facing inspector references and remove or reframe them where this change owns the surface.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `clients/apple/scripts/test-terminal-surface-controller.sh`.
-- [ ] 5.2 Run other focused Apple shell scripts affected by command UI or shell UI changes.
-- [ ] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.4 Run `git diff --check`.
-- [ ] 5.5 Run `openspec validate polish-macos-search-remove-inspector --type change --strict --json`.
-- [ ] 5.6 Run `openspec validate --all --strict --json`.
-- [ ] 5.7 Build the macOS app with the documented `AlanNative` Debug command.
-- [ ] 5.8 Capture or document light-mode screenshots/manual notes for default shell without inspector, split-pane Find ownership, query editing, match navigation, no-result feedback, and Escape dismissal back to terminal.
+- [x] 5.1 Run `clients/apple/scripts/test-terminal-surface-controller.sh`.
+- [x] 5.2 Run other focused Apple shell scripts affected by command UI or shell UI changes.
+- [x] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.4 Run `git diff --check`.
+- [x] 5.5 Run `openspec validate polish-macos-search-remove-inspector --type change --strict --json`.
+- [x] 5.6 Run `openspec validate --all --strict --json`.
+- [x] 5.7 Build the macOS app with the documented `AlanNative` Debug command.
+- [x] 5.8 Capture or document light-mode screenshots/manual notes for default shell without inspector, split-pane Find ownership, query editing, match navigation, no-result feedback, and Escape dismissal back to terminal.
 
 ## 6. Archive Readiness
 
-- [ ] 6.1 Sync accepted inspector-removal and Find bar requirements into `openspec/specs/` before archive.
-- [ ] 6.2 Record implementation verification evidence and any adjusted active-change dependencies in this change before archive.
+- [x] 6.1 Sync accepted inspector-removal and Find bar requirements into `openspec/specs/` before archive.
+- [x] 6.2 Record implementation verification evidence and any adjusted active-change dependencies in this change before archive.

--- a/openspec/changes/polish-macos-search-remove-inspector/verification.md
+++ b/openspec/changes/polish-macos-search-remove-inspector/verification.md
@@ -1,0 +1,21 @@
+## Verification Evidence
+
+- `clients/apple/scripts/test-terminal-surface-controller.sh` passed.
+- `clients/apple/scripts/test-shell-runtime-metadata.sh` passed.
+- `clients/apple/scripts/test-shell-split-model.sh` passed.
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `git diff --check` passed.
+- `openspec validate polish-macos-search-remove-inspector --type change --strict --json` passed.
+- `openspec validate --all --strict --json` passed.
+- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build` passed.
+
+## Manual Notes
+
+- Launched `target/xcode-derived/Build/Products/Debug/Alan.app` in light mode.
+- Confirmed the default shell no longer shows the right-side inspector or inspector controls.
+- Confirmed `Command-F` opens the pane-scoped SwiftUI Find bar, focuses the query field, query text highlights terminal matches, and Escape dismisses the bar back to terminal focus.
+- Confirmed split-pane Find opens on the selected pane and no passive terminal search overlay appears.
+
+## Build Warnings
+
+- Xcode reported a CoreSimulator version warning: current `1051.49.0`, build `1051.50.0`. The macOS Debug build still succeeded.

--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -141,3 +141,60 @@ input, rendering canvases, and native window background dragging.
 #### Scenario: Focused manual verification is performed
 - **WHEN** event ownership implementation is ready for review
 - **THEN** verification covers click-to-select, immediate typing, drag selection, right click, scrolling, and background window dragging in the running macOS app
+
+### Requirement: Pane title bars have focused verification
+The Apple client SHALL include focused automated or documented verification for
+pane title-bar consumption, pane-scoped close routing, and terminal input
+ownership when pane title bars are changed.
+
+#### Scenario: Pane title-bar consumption tested
+- **WHEN** pane title-bar helpers receive existing terminal title, working-directory, cwd, launch-target, and process metadata combinations
+- **THEN** focused tests verify title-bar priority, fallback ordering, long-title handling, and suppression of raw pane IDs or debug terms without retesting terminal title capture itself
+
+#### Scenario: Pane close routing tested
+- **WHEN** a title-bar close action targets a selected pane, an inactive split pane, a single-pane tab with other tabs, or the final remaining pane
+- **THEN** focused tests verify the shell mutation result, selected pane after close, split tree repair, and final-pane protection
+
+#### Scenario: Terminal input preservation reviewed
+- **WHEN** pane title-bar implementation is ready for review
+- **THEN** maintainers can inspect automated shell contract checks or manual notes covering terminal click-to-focus, typing, selection drag, right click, scrolling, and close-button interaction
+
+#### Scenario: Visual evidence captured
+- **WHEN** pane title-bar UI polish is marked complete
+- **THEN** maintainers can inspect a running-app screenshot or manual note showing light-mode single-pane and split-pane tabs with compact pane title bars, readable titles, restrained close buttons, and no default debug labels
+
+### Requirement: Corner-radius conformance is verified
+The Apple client SHALL include focused verification for active-shell
+corner-radius normalization when default macOS shell chrome is changed.
+
+#### Scenario: Active shell radius check runs
+- **WHEN** a change updates active shell visual chrome in `MacShellRootView.swift`, `TerminalPaneView.swift`, or normal-flow `TerminalHostView.swift` fallback surfaces
+- **THEN** a focused check or review step verifies that rounded rectangles use the Alan shell radius scale and do not introduce large ad hoc radii
+
+#### Scenario: Capsule usage reviewed
+- **WHEN** a change adds `Capsule` usage to active default shell chrome
+- **THEN** the change documents why the component is a semantic pill or replaces it with a radius-scale rounded rectangle
+
+#### Scenario: Visual comparison captured
+- **WHEN** radius normalization implementation is marked complete
+- **THEN** maintainers can inspect running-app screenshots or notes for sidebar, terminal, command palette, and remaining default-shell overlay states confirming that the UI is smaller-radius, still native, and not visually flat
+
+#### Scenario: Legacy surfaces scoped
+- **WHEN** radius inventory finds older or non-primary Apple client surfaces
+- **THEN** implementation records whether they are active default shell UI before changing them, instead of silently broadening the polish pass
+
+### Requirement: Find UI has focused verification
+The Apple client SHALL include focused automated or documented verification for
+the pane-scoped native Find bar and removed inspector surface.
+
+#### Scenario: Find bar behavior verified
+- **WHEN** Find behavior changes
+- **THEN** focused tests or manual notes cover `Command-F`, query editing, Return, `Command-G`, Shift-`Command-G`, Escape, and printable query text behavior while Find is active
+
+#### Scenario: Inspector removal contract checked
+- **WHEN** default shell UI changes
+- **THEN** shell contract checks fail if removed inspector UI, commands, voice phrases, or stale inspector affordances are reintroduced
+
+#### Scenario: Passive search overlay blocked
+- **WHEN** terminal search UI changes
+- **THEN** shell contract checks fail if default Find UI is routed through the passive terminal overlay instead of `ShellFindBarView`

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -3,7 +3,8 @@
 ## Purpose
 Define the default native macOS shell UI contract: Arc-like space/tab
 organization, terminal-first layout, native light-mode material treatment,
-restrained toolbar behavior, and progressive inspector disclosure.
+restrained toolbar behavior, pane-scoped terminal controls, and progressive
+disclosure that keeps debug surfaces out of the default shell.
 ## Requirements
 ### Requirement: Sidebar matches space rail plus tab list
 The default macOS sidebar SHALL present spaces as a compact vertical rail and
@@ -40,7 +41,7 @@ theme panels, and ornamental controls.
 - **THEN** rows, icon controls, counters, and status marks keep stable dimensions and do not resize the sidebar or terminal content
 
 #### Scenario: No dashboard treatment
-- **WHEN** the user views the default shell without the Debug inspector selected
+- **WHEN** the user views the default shell
 - **THEN** the UI does not present page-like sections, nested cards, large explanatory panels, or marketing-style hero composition
 
 ### Requirement: Terminal content is the center of gravity
@@ -67,20 +68,20 @@ terms outside explicit debug surfaces.
 
 #### Scenario: Normal terminal workflow
 - **WHEN** a user creates, selects, splits, or closes tabs and panes
-- **THEN** visible copy uses product terms such as Space, Tab, Split, Inspector, Go to or Command, Open in Alan, and Ask Alan
+- **THEN** visible copy uses product terms such as Space, Tab, Split, Go to or Command, Open in Alan, and Ask Alan
 
 #### Scenario: Command search results
 - **WHEN** the command UI shows tabs, panes, actions, routing candidates, or attention items
 - **THEN** result titles and summaries use user-facing names where available and do not expose raw pane IDs as the primary label unless the user is in a debug context
 
-#### Scenario: Debug inspector
-- **WHEN** the user opens the inspector debug section
-- **THEN** implementation details may be shown with clear debug framing
+#### Scenario: Debug surfaces
+- **WHEN** implementation details are needed
+- **THEN** they remain in explicit debug-only surfaces, logs, scripts, or snapshots rather than default shell chrome
 
 ### Requirement: Toolbar is native and restrained
 The macOS toolbar/titlebar SHALL feel like native window chrome and contain only
-the current tab title/context, one command entry point, a small number of
-frequent actions, and an optional inspector toggle.
+the current tab title/context, one command entry point, and a small number of
+frequent actions.
 
 #### Scenario: Toolbar default state
 - **WHEN** no urgent attention item exists
@@ -90,17 +91,17 @@ frequent actions, and an optional inspector toggle.
 - **WHEN** the user invokes the command UI
 - **THEN** the entry point is labeled and organized as `Go to or Command...`
 
-### Requirement: Inspector uses progressive disclosure
-The inspector SHALL be optional, off by default, and separated into Overview and
-Debug layers.
+### Requirement: Default shell does not expose inspector chrome
+The default macOS shell SHALL not include a persistent right-side inspector,
+inspector toggle, or inspector command surface.
 
-#### Scenario: Overview selected
-- **WHEN** the inspector overview is visible
-- **THEN** it shows only user-relevant secondary state such as focused tab or pane summary, cwd or repo context, Alan attachment summary, attention summary, and minimal process status
+#### Scenario: Default shell opened
+- **WHEN** the user opens the macOS shell
+- **THEN** no inspector pane, inspector toggle, or inspector-specific command appears in the default UI
 
-#### Scenario: Debug selected
-- **WHEN** the inspector debug layer is visible
-- **THEN** debug data such as JSON snapshots, runtime phase, Ghostty data, control paths, and Alan binding details can be inspected without dominating the default layout
+#### Scenario: Diagnostics needed
+- **WHEN** maintainers need runtime diagnostics
+- **THEN** diagnostics remain available through shell snapshots, logs, scripts, tests, or an explicit future debug surface rather than a default inspector
 
 ### Requirement: UI conformance is verified visually
 Mac shell UI changes SHALL be reviewed against the documented UI contract before
@@ -108,17 +109,16 @@ the UI conformance tasks are marked complete.
 
 #### Scenario: Default screenshot review
 - **WHEN** a UI conformance implementation pass is ready for review
-- **THEN** maintainers can inspect a running-app screenshot of the default light-mode window showing the space rail, active-space tab list, terminal-first content area, and inspector-off state
+- **THEN** maintainers can inspect a running-app screenshot of the default light-mode window showing the space rail, active-space tab list, terminal-first content area, and no inspector surface
 
-#### Scenario: Inspector screenshot review
-- **WHEN** inspector-related UI tasks are marked complete
-- **THEN** maintainers can inspect screenshots or recorded notes for both Overview and Debug inspector states, confirming that debug data is hidden from the default workflow and visible in the Debug layer
+#### Scenario: Removed-inspector review
+- **WHEN** inspector-removal UI tasks are marked complete
+- **THEN** maintainers can inspect screenshots or recorded notes confirming the default shell has no right-side inspector and no inspector toggle
 
 ### Requirement: Terminal overlays use user-facing language
-The macOS terminal UI SHALL present terminal search, child-exit, renderer
-failure, readonly, input-not-ready, and clipboard states with concise
-terminal-user language in the canvas area or inspector overview, while raw
-runtime details remain debug-only.
+The macOS terminal UI SHALL present child-exit, renderer failure, readonly,
+input-not-ready, and clipboard states with concise terminal-user language in
+the canvas area, while raw runtime details remain debug-only.
 
 #### Scenario: Renderer failure visible
 - **WHEN** a focused terminal pane cannot render
@@ -128,9 +128,9 @@ runtime details remain debug-only.
 - **WHEN** a terminal child process exits
 - **THEN** the pane shows a compact terminal exit state rather than debug event names
 
-#### Scenario: Debug layer opened
-- **WHEN** the user opens the inspector debug layer
-- **THEN** renderer diagnostics, surface identifiers, input mode details, and raw event payloads may be inspected with debug framing
+#### Scenario: Debug diagnostics inspected
+- **WHEN** maintainers inspect explicit debug diagnostics
+- **THEN** renderer diagnostics, surface identifiers, input mode details, and raw event payloads use debug framing outside the default shell
 
 ### Requirement: Terminal search does not displace workspace structure
 Terminal search UI SHALL be compact, pane scoped, and layered over the terminal
@@ -143,6 +143,23 @@ workflow without turning the shell into a dashboard or page layout.
 #### Scenario: Search closes
 - **WHEN** the user dismisses terminal search
 - **THEN** keyboard focus returns to the terminal pane that owned the search interaction
+
+### Requirement: Native Find bar owns terminal search UI
+Terminal search SHALL render through a compact pane-scoped Find bar rather than
+the passive terminal overlay card, and query edits SHALL be routed to the
+owning terminal surface search controller.
+
+#### Scenario: Find opens
+- **WHEN** the user invokes `Command-F` for a focused pane
+- **THEN** Alan shows a compact Find bar for that pane, focuses the query field, and does not send printable query text to the terminal application
+
+#### Scenario: Find navigates
+- **WHEN** the Find bar owns an active query
+- **THEN** Return, `Command-G`, and Shift-`Command-G` navigate matches through the pane's search owner
+
+#### Scenario: Find dismisses
+- **WHEN** the user presses Escape or clicks the close control
+- **THEN** Alan dismisses the Find interaction and returns focus to the owning terminal pane
 
 ### Requirement: Terminal panes have unambiguous hit-testing boundaries
 The macOS shell UI SHALL keep terminal-rendering surfaces from intercepting
@@ -195,6 +212,114 @@ card grid or debug layout.
 - **WHEN** a split pane is not the active terminal pane
 - **THEN** Alan may apply a preference-backed lightweight dim treatment that preserves terminal readability and pointer input while making the active pane and split boundary easier to scan
 
+### Requirement: Terminal panes expose narrow title bars
+Each visible macOS terminal pane SHALL include a compact title bar at the top of
+the pane that identifies the terminal and provides a pane-scoped close
+affordance while keeping terminal content visually dominant.
+
+#### Scenario: Single pane title visible
+- **WHEN** a terminal tab contains one visible pane
+- **THEN** the pane shows a narrow title bar above the terminal canvas with a user-facing terminal title and one slim close button
+
+#### Scenario: Split pane titles visible
+- **WHEN** a terminal tab contains multiple visible panes
+- **THEN** every pane leaf shows its own title bar and close button without adding a pane selector strip, card grid, or debug labels
+
+#### Scenario: Long title fits
+- **WHEN** a pane title is long or changes while the pane is visible
+- **THEN** the title truncates within a stable fixed-height title bar without resizing split dividers, sidebar rows, toolbar content, or sibling panes
+
+### Requirement: Pane title bars consume terminal metadata
+Pane title bars SHALL consume the current terminal title already projected into
+pane metadata, and SHALL use existing user-facing fallback labels only when the
+terminal title is unavailable.
+
+#### Scenario: Terminal title exists
+- **WHEN** a pane has a non-empty `viewport.title`
+- **THEN** the title bar shows the normalized terminal title rather than raw pane IDs, cwd-first labels, runtime phases, or debug event text
+
+#### Scenario: Terminal title missing
+- **WHEN** a pane has no usable terminal title
+- **THEN** the title bar falls back to cwd leaf, working-directory name, launch target, process name, or `Terminal` using user-facing copy
+
+#### Scenario: Debug terms suppressed
+- **WHEN** terminal metadata contains implementation-oriented summaries such as `title updated`, `window attached`, or raw runtime state
+- **THEN** the title bar does not expose those terms outside explicit developer/debug-only surfaces
+
+### Requirement: Pane close button targets its pane
+The pane title bar close button SHALL close the pane represented by that title
+bar through the shared shell controller mutation path.
+
+#### Scenario: Inactive split pane closed
+- **WHEN** a user clicks the close button on a non-selected visible split pane
+- **THEN** Alan closes that pane, repairs the split tree, and keeps the remaining pane runtimes alive without closing a different selected pane
+
+#### Scenario: Single pane tab closed
+- **WHEN** a user clicks the close button for the only pane in a tab and other tabs remain
+- **THEN** Alan applies the existing tab-close semantics for that tab and focuses a remaining terminal pane
+
+#### Scenario: Last remaining pane protected
+- **WHEN** a close button targets the only pane in the only remaining tab
+- **THEN** Alan keeps the shell state valid and does not remove the final workspace surface
+
+### Requirement: Pane title bars preserve terminal input ownership
+Pane title bars SHALL own only their explicit title and button controls, and
+SHALL not intercept terminal input, selection, mouse reporting, scrollback, or
+renderer hit-testing inside the terminal canvas.
+
+#### Scenario: Terminal canvas clicked below title bar
+- **WHEN** a user clicks, drags, scrolls, or right-clicks inside the terminal canvas below a pane title bar
+- **THEN** the terminal host receives the event according to the terminal event ownership contract
+
+#### Scenario: Close button clicked
+- **WHEN** a user clicks the close button in the pane title bar
+- **THEN** the button handles the pane close action without routing that click through terminal text input
+
+#### Scenario: Title area clicked
+- **WHEN** a user clicks the non-button title area
+- **THEN** Alan may focus the pane, but it does not send text, mouse reports, or scroll events to the terminal application
+
+### Requirement: Corner radii are restrained and tokenized
+The default Alan macOS shell UI SHALL use a small role-based corner-radius scale
+for rounded rectangular surfaces and controls. It SHALL avoid large ad hoc
+radii and capsule-heavy default chrome.
+
+#### Scenario: Radius scale applied
+- **WHEN** the active macOS shell renders sidebar rows, command rows, pane title bars, terminal surrounds, inline panels, or overlay surfaces
+- **THEN** those rounded rectangular elements use the Alan shell radius scale rather than one-off numeric radii
+
+#### Scenario: Default shell avoids large radii
+- **WHEN** a default shell surface is visible in normal light-mode use
+- **THEN** rounded rectangular chrome does not use radii larger than the overlay radius unless a specific exception is documented in the UI contract
+
+#### Scenario: Capsule use is limited
+- **WHEN** the default shell shows text chips, keycap hints, metadata chips, command badges, sidebar controls, or pane title controls
+- **THEN** those controls use restrained rounded rectangles rather than `Capsule` shapes unless the component is explicitly defined as a semantic pill
+
+#### Scenario: True circles remain semantic
+- **WHEN** the shell shows attention dots, status indicators, traffic-light-like indicators, or intentionally round icon-only controls
+- **THEN** those elements may remain circular because the circle communicates state or system-like control behavior
+
+#### Scenario: Terminal surface remains precise
+- **WHEN** a single pane or split-pane tab is visible
+- **THEN** terminal panes keep a shared continuous terminal surround with smaller outer corners and no per-pane rounded card treatment
+
+### Requirement: Radius normalization preserves shell hierarchy
+Radius normalization SHALL make Alan feel calmer and more precise without
+turning the UI into a flat grid or weakening control affordances.
+
+#### Scenario: Sidebar remains skimmable
+- **WHEN** sidebar spaces, tabs, command entry, and creation controls are visible
+- **THEN** smaller radii preserve row scanning, hover states, selected states, and stable dimensions
+
+#### Scenario: Command UI remains readable
+- **WHEN** the command palette is open
+- **THEN** the outer overlay, search field, and result rows use distinct but restrained radii so hierarchy is visible without large bubble-like cards
+
+#### Scenario: Overlays remain secondary
+- **WHEN** the command palette or another remaining default-shell overlay is visible
+- **THEN** that surface uses restrained radii and does not read as a large decorative card competing with the terminal
+
 ### Requirement: Command UI owns navigation and shell actions
 The default command entry SHALL present tabs, panes, spaces, routing candidates,
 attention items, and common shell workspace actions through `Go to or Command...`
@@ -214,7 +339,7 @@ not turn the toolbar into a dense control strip.
 
 #### Scenario: Multiple panes visible
 - **WHEN** a tab contains multiple panes
-- **THEN** the default toolbar remains focused on current tab context, command entry, frequent actions, and inspector toggle
+- **THEN** the default toolbar remains focused on current tab context, command entry, and frequent actions
 
 #### Scenario: Pane lift available
 - **WHEN** pane lift is available through command UI or another explicit non-terminal affordance


### PR DESCRIPTION
## Summary
- remove the default macOS shell inspector surface and route Command-F through the pane-scoped SwiftUI Find bar
- add compact per-pane title bars with pane-ID targeted close behavior
- normalize active shell corner radii and add architecture/radius/search contract guardrails
- sync accepted OpenSpec deltas and verification notes

## Validation
- git diff --check
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate --all --strict --json
- clients/apple/scripts/test-shell-split-model.sh
- clients/apple/scripts/test-shell-runtime-metadata.sh
- clients/apple/scripts/test-terminal-surface-controller.sh
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Note: Xcode reports a CoreSimulator version warning, but the macOS Debug build succeeds.