### PR TITLE
Extract console event reducer

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -40,7 +40,8 @@ Xcode target.
 | `Models/API/DaemonAPIModels.swift` | 529 | Foundation | Daemon API response DTOs, operation payloads, JSON values, and API error type | `Models/API/` |
 | `Models/Console/ConsoleModels.swift` | 148 | Foundation | Console chat messages, timeline entries, structured questions, and pending-yield value state | `Models/Console/` |
 | `Services/Daemon/AlanAPIClient.swift` | 236 | Foundation | Daemon HTTP client, request construction, endpoint routing, and response validation | `Services/Daemon/` |
-| `Views/Console/ContentView.swift` | 1813 | SwiftUI, AppKit; iOS/macOS gates | Legacy/mobile console UI, console view model state, daemon event polling and reduction | `Views/Console/`, `Controllers/Console/`, and `Services/Daemon/` |
+| `Services/Daemon/ConsoleEventReducer.swift` | 195 | Foundation | Console event page reader and event-to-message/timeline/pending-yield projection reducer | `Services/Daemon/` |
+| `Views/Console/ContentView.swift` | 1708 | SwiftUI, AppKit; iOS/macOS gates | Legacy/mobile console UI, console view model state, and event pump coordination | `Views/Console/` and `Controllers/Console/` |
 
 ## Target Layout
 

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		00000000000000000000001D /* ShellVoiceCommandController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000011D /* ShellVoiceCommandController.swift */; };
 		00000000000000000000001E /* ConsoleModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000011E /* ConsoleModels.swift */; };
 		00000000000000000000001F /* DaemonAPIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000011F /* DaemonAPIModels.swift */; };
+		000000000000000000000020 /* ConsoleEventReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000120 /* ConsoleEventReducer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,6 +74,7 @@
 		00000000000000000000011D /* ShellVoiceCommandController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellVoiceCommandController.swift; sourceTree = "<group>"; };
 		00000000000000000000011E /* ConsoleModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Console/ConsoleModels.swift; sourceTree = "<group>"; };
 		00000000000000000000011F /* DaemonAPIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/API/DaemonAPIModels.swift; sourceTree = "<group>"; };
+		000000000000000000000120 /* ConsoleEventReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Daemon/ConsoleEventReducer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				000000000000000000000103 /* AlanAPIClient.swift */,
+				000000000000000000000120 /* ConsoleEventReducer.swift */,
 			);
 			name = Services/Daemon;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				00000000000000000000001D /* ShellVoiceCommandController.swift in Sources */,
 				00000000000000000000001E /* ConsoleModels.swift in Sources */,
 				00000000000000000000001F /* DaemonAPIModels.swift in Sources */,
+				000000000000000000000020 /* ConsoleEventReducer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Daemon/ConsoleEventReducer.swift
+++ b/clients/apple/AlanNative/Services/Daemon/ConsoleEventReducer.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+struct ConsoleEventReader {
+    let client: AlanAPIClient
+    let pageLimit: Int
+
+    init(client: AlanAPIClient, pageLimit: Int = 200) {
+        self.client = client
+        self.pageLimit = pageLimit
+    }
+
+    func readNextPage(sessionID: String, afterEventID: String?) async throws -> ReadEventsResponse {
+        try await client.readEvents(
+            sessionID: sessionID,
+            afterEventID: afterEventID,
+            limit: pageLimit
+        )
+    }
+}
+
+struct ConsoleEventProjection {
+    var messages: [ChatMessage]
+    var timeline: [TimelineEntry]
+    var pendingYield: PendingYieldState?
+    var confirmationModifications: String
+    var structuredAnswerDrafts: [String: String]
+    var customResumePayload: String
+
+    mutating func appendTimeline(_ title: String, detail: String?, level: TimelineEntry.Level) {
+        timeline.append(TimelineEntry(title: title, detail: detail, level: level))
+        if timeline.count > 800 {
+            timeline.removeFirst(timeline.count - 800)
+        }
+    }
+
+    mutating func appendSystemMessage(_ text: String) {
+        messages.append(ChatMessage(role: .system, text: text))
+    }
+
+    mutating func appendErrorMessage(_ text: String) {
+        messages.append(ChatMessage(role: .error, text: text))
+    }
+}
+
+struct ConsoleEventReducer {
+    private var assistantMessageByTurnID: [String: UUID] = [:]
+
+    mutating func reset() {
+        assistantMessageByTurnID.removeAll()
+    }
+
+    mutating func reduce(event: SessionEventEnvelope, into projection: inout ConsoleEventProjection) {
+        switch event.type {
+        case "turn_started":
+            projection.appendTimeline("Turn Started", detail: shortID(event.turnID), level: .info)
+
+        case "text_delta", "message_delta", "message_delta_chunk":
+            if let chunk = event.textChunk, !chunk.isEmpty {
+                appendAssistantChunk(
+                    chunk,
+                    turnID: event.turnID ?? "turn_unknown",
+                    isFinal: event.isFinal == true,
+                    messages: &projection.messages
+                )
+            }
+
+        case "thinking_delta":
+            if let chunk = event.textChunk, !chunk.isEmpty {
+                projection.appendTimeline(
+                    "Thinking",
+                    detail: summarize(chunk, maxLength: 140),
+                    level: .info
+                )
+            }
+
+        case "tool_call_started":
+            let title = "Tool Started"
+            let detail = "\(event.name ?? "tool") • \(shortID(event.toolCallID))"
+            projection.appendTimeline(title, detail: detail, level: .action)
+
+        case "tool_call_completed":
+            let preview = event.resultPreview ?? "Completed"
+            projection.appendTimeline("Tool Completed", detail: preview, level: .action)
+
+        case "yield":
+            let pending = PendingYieldState.from(event: event)
+            projection.pendingYield = pending
+            projection.confirmationModifications = ""
+            projection.structuredAnswerDrafts = Dictionary(
+                uniqueKeysWithValues: pending.questions.map { ($0.id, "") }
+            )
+            projection.customResumePayload = "{\n  \"choice\": \"approve\"\n}"
+            projection.appendTimeline("Action Required", detail: pending.kind, level: .warning)
+
+        case "warning":
+            if let message = event.message {
+                projection.appendSystemMessage("Warning: \(message)")
+                projection.appendTimeline("Warning", detail: message, level: .warning)
+            }
+
+        case "error":
+            if let message = event.message {
+                if event.recoverable == true {
+                    projection.appendSystemMessage("Recoverable: \(message)")
+                    projection.appendTimeline("Recoverable Error", detail: message, level: .warning)
+                } else {
+                    projection.appendErrorMessage(message)
+                    projection.appendTimeline("Error", detail: message, level: .error)
+                }
+            }
+
+        case "turn_completed":
+            finishAssistantMessage(for: event.turnID, messages: &projection.messages)
+            projection.appendTimeline(
+                "Turn Completed",
+                detail: event.summary,
+                level: .info
+            )
+
+        default:
+            projection.appendTimeline(
+                event.type.replacingOccurrences(of: "_", with: " ").capitalized,
+                detail: event.message ?? event.summary,
+                level: .info
+            )
+        }
+    }
+
+    private mutating func appendAssistantChunk(
+        _ chunk: String,
+        turnID: String,
+        isFinal: Bool,
+        messages: inout [ChatMessage]
+    ) {
+        let messageID: UUID
+        if let existing = assistantMessageByTurnID[turnID] {
+            messageID = existing
+        } else {
+            let id = UUID()
+            assistantMessageByTurnID[turnID] = id
+            messages.append(ChatMessage(id: id, role: .assistant, text: "", turnID: turnID, isStreaming: true))
+            messageID = id
+        }
+
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else {
+            return
+        }
+
+        messages[index].text.append(chunk)
+        messages[index].isStreaming = !isFinal
+
+        if isFinal {
+            assistantMessageByTurnID.removeValue(forKey: turnID)
+        }
+    }
+
+    private mutating func finishAssistantMessage(for turnID: String?, messages: inout [ChatMessage]) {
+        guard let turnID else {
+            return
+        }
+        guard let messageID = assistantMessageByTurnID[turnID] else {
+            return
+        }
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else {
+            assistantMessageByTurnID.removeValue(forKey: turnID)
+            return
+        }
+
+        messages[index].isStreaming = false
+        if messages[index].text.isEmpty {
+            messages[index].text = "No response text returned."
+        }
+        assistantMessageByTurnID.removeValue(forKey: turnID)
+    }
+
+    private func summarize(_ text: String, maxLength: Int) -> String {
+        let compact = text.replacingOccurrences(of: "\n", with: " ")
+        if compact.count <= maxLength {
+            return compact
+        }
+        let end = compact.index(compact.startIndex, offsetBy: maxLength)
+        return "\(compact[..<end])..."
+    }
+
+    private func shortID(_ value: String?) -> String {
+        guard let value, !value.isEmpty else {
+            return "-"
+        }
+        if value.count <= 12 {
+            return value
+        }
+        let prefix = value.prefix(8)
+        return "\(prefix)…"
+    }
+}

--- a/clients/apple/AlanNative/Views/Console/ContentView.swift
+++ b/clients/apple/AlanNative/Views/Console/ContentView.swift
@@ -80,7 +80,7 @@ final class AlanConsoleViewModel: ObservableObject {
 
     private var lastEventID: String?
     private var eventPumpTask: Task<Void, Never>?
-    private var assistantMessageByTurnID: [String: UUID] = [:]
+    private var eventReducer = ConsoleEventReducer()
     private var lastPumpErrorMessage: String?
 
     deinit {
@@ -131,7 +131,7 @@ final class AlanConsoleViewModel: ObservableObject {
                     selectedSessionID = nil
                     messages = []
                     pendingYield = nil
-                    assistantMessageByTurnID.removeAll()
+                    eventReducer.reset()
                     lastEventID = nil
                     eventPumpTask?.cancel()
                     eventPumpTask = nil
@@ -212,7 +212,7 @@ final class AlanConsoleViewModel: ObservableObject {
             selectedSessionID = nil
             messages = []
             pendingYield = nil
-            assistantMessageByTurnID.removeAll()
+            eventReducer.reset()
             lastEventID = nil
             eventPumpTask?.cancel()
             eventPumpTask = nil
@@ -381,7 +381,7 @@ final class AlanConsoleViewModel: ObservableObject {
         pendingYield = nil
         confirmationModifications = ""
         structuredAnswerDrafts = [:]
-        assistantMessageByTurnID.removeAll()
+        eventReducer.reset()
         lastEventID = nil
 
         let session = try await client().readSession(sessionID: sessionID)
@@ -427,6 +427,13 @@ final class AlanConsoleViewModel: ObservableObject {
 
     private func runEventPump(sessionID: String) async {
         connectionState = .connecting
+        let eventReader: ConsoleEventReader
+        do {
+            eventReader = try ConsoleEventReader(client: client())
+        } catch {
+            reportEventPumpError(error)
+            return
+        }
 
         while !Task.isCancelled {
             guard selectedSessionID == sessionID else {
@@ -434,10 +441,9 @@ final class AlanConsoleViewModel: ObservableObject {
             }
 
             do {
-                let page = try await client().readEvents(
+                let page = try await eventReader.readNextPage(
                     sessionID: sessionID,
-                    afterEventID: lastEventID,
-                    limit: 200
+                    afterEventID: lastEventID
                 )
 
                 connectionState = .online
@@ -465,149 +471,37 @@ final class AlanConsoleViewModel: ObservableObject {
                         return
                     }
                     lastEventID = event.eventID
-                    handle(event: event)
+                    reduce(event: event)
                 }
             } catch is CancellationError {
                 return
             } catch {
-                connectionState = .degraded
-                let message = error.localizedDescription
-                if message != lastPumpErrorMessage {
-                    lastPumpErrorMessage = message
-                    appendTimeline("Event Stream Error", detail: message, level: .warning)
-                    lastError = message
-                }
+                reportEventPumpError(error)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
     }
 
-    private func handle(event: SessionEventEnvelope) {
-        switch event.type {
-        case "turn_started":
-            appendTimeline("Turn Started", detail: shortID(event.turnID), level: .info)
-
-        case "text_delta", "message_delta", "message_delta_chunk":
-            if let chunk = event.textChunk, !chunk.isEmpty {
-                appendAssistantChunk(
-                    chunk,
-                    turnID: event.turnID ?? "turn_unknown",
-                    isFinal: event.isFinal == true
-                )
-            }
-
-        case "thinking_delta":
-            if let chunk = event.textChunk, !chunk.isEmpty {
-                appendTimeline(
-                    "Thinking",
-                    detail: summarize(chunk, maxLength: 140),
-                    level: .info
-                )
-            }
-
-        case "tool_call_started":
-            let title = "Tool Started"
-            let detail = "\(event.name ?? "tool") • \(shortID(event.toolCallID))"
-            appendTimeline(title, detail: detail, level: .action)
-
-        case "tool_call_completed":
-            let preview = event.resultPreview ?? "Completed"
-            appendTimeline("Tool Completed", detail: preview, level: .action)
-
-        case "yield":
-            let pending = PendingYieldState.from(event: event)
-            pendingYield = pending
-            confirmationModifications = ""
-            structuredAnswerDrafts = Dictionary(uniqueKeysWithValues: pending.questions.map { ($0.id, "") })
-            customResumePayload = "{\n  \"choice\": \"approve\"\n}"
-            appendTimeline("Action Required", detail: pending.kind, level: .warning)
-
-        case "warning":
-            if let message = event.message {
-                appendSystemMessage("Warning: \(message)")
-                appendTimeline("Warning", detail: message, level: .warning)
-            }
-
-        case "error":
-            if let message = event.message {
-                if event.recoverable == true {
-                    appendSystemMessage("Recoverable: \(message)")
-                    appendTimeline("Recoverable Error", detail: message, level: .warning)
-                } else {
-                    appendErrorMessage(message)
-                    appendTimeline("Error", detail: message, level: .error)
-                }
-            }
-
-        case "turn_completed":
-            finishAssistantMessage(for: event.turnID)
-            appendTimeline(
-                "Turn Completed",
-                detail: event.summary,
-                level: .info
-            )
-
-        default:
-            appendTimeline(
-                event.type.replacingOccurrences(of: "_", with: " ").capitalized,
-                detail: event.message ?? event.summary,
-                level: .info
-            )
-        }
+    private func reduce(event: SessionEventEnvelope) {
+        var projection = ConsoleEventProjection(
+            messages: messages,
+            timeline: timeline,
+            pendingYield: pendingYield,
+            confirmationModifications: confirmationModifications,
+            structuredAnswerDrafts: structuredAnswerDrafts,
+            customResumePayload: customResumePayload
+        )
+        eventReducer.reduce(event: event, into: &projection)
+        messages = projection.messages
+        timeline = projection.timeline
+        pendingYield = projection.pendingYield
+        confirmationModifications = projection.confirmationModifications
+        structuredAnswerDrafts = projection.structuredAnswerDrafts
+        customResumePayload = projection.customResumePayload
     }
 
     private func appendUserMessage(_ text: String) {
         messages.append(ChatMessage(role: .user, text: text))
-    }
-
-    private func appendSystemMessage(_ text: String) {
-        messages.append(ChatMessage(role: .system, text: text))
-    }
-
-    private func appendErrorMessage(_ text: String) {
-        messages.append(ChatMessage(role: .error, text: text))
-    }
-
-    private func appendAssistantChunk(_ chunk: String, turnID: String, isFinal: Bool) {
-        let messageID: UUID
-        if let existing = assistantMessageByTurnID[turnID] {
-            messageID = existing
-        } else {
-            let id = UUID()
-            assistantMessageByTurnID[turnID] = id
-            messages.append(ChatMessage(id: id, role: .assistant, text: "", turnID: turnID, isStreaming: true))
-            messageID = id
-        }
-
-        guard let index = messages.firstIndex(where: { $0.id == messageID }) else {
-            return
-        }
-
-        messages[index].text.append(chunk)
-        messages[index].isStreaming = !isFinal
-
-        if isFinal {
-            assistantMessageByTurnID.removeValue(forKey: turnID)
-        }
-    }
-
-    private func finishAssistantMessage(for turnID: String?) {
-        guard let turnID else {
-            return
-        }
-        guard let messageID = assistantMessageByTurnID[turnID] else {
-            return
-        }
-        guard let index = messages.firstIndex(where: { $0.id == messageID }) else {
-            assistantMessageByTurnID.removeValue(forKey: turnID)
-            return
-        }
-
-        messages[index].isStreaming = false
-        if messages[index].text.isEmpty {
-            messages[index].text = "No response text returned."
-        }
-        assistantMessageByTurnID.removeValue(forKey: turnID)
     }
 
     private func appendTimeline(_ title: String, detail: String?, level: TimelineEntry.Level) {
@@ -673,15 +567,6 @@ final class AlanConsoleViewModel: ObservableObject {
         return .string(text)
     }
 
-    private func summarize(_ text: String, maxLength: Int) -> String {
-        let compact = text.replacingOccurrences(of: "\n", with: " ")
-        if compact.count <= maxLength {
-            return compact
-        }
-        let end = compact.index(compact.startIndex, offsetBy: maxLength)
-        return "\(compact[..<end])..."
-    }
-
     private func shortID(_ value: String?) -> String {
         guard let value, !value.isEmpty else {
             return "-"
@@ -710,6 +595,16 @@ final class AlanConsoleViewModel: ObservableObject {
         let message = error.localizedDescription
         lastError = message
         appendTimeline(timelineTitle, detail: message, level: .error)
+    }
+
+    private func reportEventPumpError(_ error: Error) {
+        connectionState = .degraded
+        let message = error.localizedDescription
+        if message != lastPumpErrorMessage {
+            lastPumpErrorMessage = message
+            appendTimeline("Event Stream Error", detail: message, level: .warning)
+            lastError = message
+        }
     }
 
     private func client() throws -> AlanAPIClient {

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -28,7 +28,7 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 - `Views/Console/`: legacy/mobile remote-control console surface
 - `Models/API/`: daemon API response, operation, and JSON value models
 - `Models/Console/`: legacy/mobile console value types
-- `Services/Daemon/`: daemon HTTP client ownership
+- `Services/Daemon/`: daemon HTTP client, event page reader, and console event reducer ownership
 - `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces
 - `ShellModel.swift` / `ShellHostController.swift`: current shell state and controller
 - `ShellControlPlane.swift`: current file/socket shell control plane

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -24,7 +24,7 @@
 - [x] 4.1 Move mobile or legacy console UI from `ContentView.swift` into a clearly named console/mobile folder while preserving the non-macOS app entry path.
 - [x] 4.2 Move chat/timeline/pending-yield value types into model files or console-specific model files.
 - [x] 4.3 Split daemon API DTOs and `AlanAPIClient` ownership from console view model and SwiftUI screens.
-- [ ] 4.4 Extract daemon event polling/reading and event-to-UI-state reduction from `AlanConsoleViewModel` so event mapping is testable without rendering the full console UI.
+- [x] 4.4 Extract daemon event polling/reading and event-to-UI-state reduction from `AlanConsoleViewModel` so event mapping is testable without rendering the full console UI.
 
 ## 5. Shell Model And Controller Ownership
 


### PR DESCRIPTION
## Summary
- add a daemon console event reader/reducer owner under Services/Daemon
- move session event-to-message/timeline/pending-yield projection out of ContentView
- update Xcode project membership, Apple README, architecture inventory, and OpenSpec task 4.4

## Review focus
- Please check that this is behavior-preserving for console event handling.
- Please verify the reducer boundary is narrow enough to make event mapping reviewable without rendering the SwiftUI console screen.

## Validation
- bash clients/apple/scripts/check-architecture-maintainability.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Note: xcodebuild still prints the existing CoreSimulator out-of-date warning and AppIntents metadata warning before succeeding.