### PR TITLE
Remove shell legacy decoding

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -35,9 +35,9 @@ Xcode target.
 | `TerminalRuntimeService.swift` | 1054 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Window-scoped terminal runtime service and Ghostty bootstrap | `Services/Terminal/` |
 | `TerminalSurfaceController.swift` | 1424 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Terminal input, pointer, scrollback, search, and surface adapters | `Services/Terminal/` |
 | `Models/Shell/ShellValueTypes.swift` | 210 | Foundation | Shell command enums, launch targets, process bindings, and context snapshots | `Models/Shell/` |
-| `ShellModel.swift` | 2047 | Foundation | Shell panes, tabs, spaces, split tree, snapshots, mutations, persistence shims | `Models/Shell/` |
-| `ShellHostController.swift` | 1965 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, persistence, boot profiles, runtime projection, command routing | `Controllers/Shell/` plus service collaborators |
-| `ShellControlPlane.swift` | 2105 | Foundation, Darwin; macOS gates | Protocol DTOs, socket server, file polling, local executor, state merging, persistence, diagnostics | `Services/ControlPlane/` plus `Models/ControlPlane/` |
+| `ShellModel.swift` | 1911 | Foundation | Shell panes, tabs, spaces, split tree, snapshots, mutations, persistence shims | `Models/Shell/` |
+| `ShellHostController.swift` | 1964 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, persistence, boot profiles, runtime projection, command routing | `Controllers/Shell/` plus service collaborators |
+| `ShellControlPlane.swift` | 2075 | Foundation, Darwin; macOS gates | Protocol DTOs, socket server, file polling, local executor, state merging, persistence, diagnostics | `Services/ControlPlane/` plus `Models/ControlPlane/` |
 | `Models/API/DaemonAPIModels.swift` | 529 | Foundation | Daemon API response DTOs, operation payloads, JSON values, and API error type | `Models/API/` |
 | `Models/Console/ConsoleModels.swift` | 148 | Foundation | Console chat messages, timeline entries, structured questions, and pending-yield value state | `Models/Console/` |
 | `Services/Daemon/AlanAPIClient.swift` | 236 | Foundation | Daemon HTTP client, request construction, endpoint routing, and response validation | `Services/Daemon/` |

--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -274,36 +274,6 @@ struct AlanShellBindingProjection: Codable, Equatable {
     }
 }
 
-extension AlanShellBindingProjection {
-    private enum LegacyCodingKeys: String, CodingKey {
-        case surfaceID = "surface_id"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
-
-        let tabID: String?
-        if let decodedTabID = try container.decodeIfPresent(String.self, forKey: .tabID) {
-            tabID = decodedTabID
-        } else {
-            tabID = try legacyContainer.decodeIfPresent(String.self, forKey: .surfaceID)
-        }
-
-        self.init(
-            sessionID: try container.decode(String.self, forKey: .sessionID),
-            runStatus: try container.decode(String.self, forKey: .runStatus),
-            pendingYield: try container.decode(Bool.self, forKey: .pendingYield),
-            source: try container.decodeIfPresent(String.self, forKey: .source),
-            lastProjectedAt: try container.decodeIfPresent(String.self, forKey: .lastProjectedAt),
-            windowID: try container.decodeIfPresent(String.self, forKey: .windowID),
-            spaceID: try container.decodeIfPresent(String.self, forKey: .spaceID),
-            tabID: tabID,
-            paneID: try container.decodeIfPresent(String.self, forKey: .paneID)
-        )
-    }
-}
-
 enum AlanShellLocalCommandSideEffect {
     case sendText(paneID: String, text: String)
 }

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -81,7 +81,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private static let iso8601Formatter = ISO8601DateFormatter()
     private static let persistenceFilePrefix = "shell-state-"
     private static let persistenceFileExtension = ".json"
-    private static let legacyPersistenceFileName = "shell-state-v0.1.json"
     private static let defaultRestorationWindowID = "window_main"
 
     private let fileManager: FileManager
@@ -1925,9 +1924,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private static func isShellStatePersistenceURL(_ url: URL) -> Bool {
         let fileName = url.lastPathComponent
-        return fileName == legacyPersistenceFileName
-            || (fileName.hasPrefix(persistenceFilePrefix)
-                && fileName.hasSuffix(persistenceFileExtension))
+        return fileName.hasPrefix(persistenceFilePrefix)
+            && fileName.hasSuffix(persistenceFileExtension)
+            && fileName != "shell-state-v0.1.json"
     }
 
     private static func restoreShellState(
@@ -1942,7 +1941,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         else {
             return nil
         }
-        return state.migratingLegacyAlanBootstrapIfNeeded()
+        return state
     }
 
     private static func attentionRank(for attention: ShellAttentionState) -> Int {

--- a/clients/apple/AlanNative/ShellModel.swift
+++ b/clients/apple/AlanNative/ShellModel.swift
@@ -227,36 +227,6 @@ struct ShellPane: Identifiable, Codable, Equatable {
 }
 
 extension ShellPane {
-    // Preserve window-state compatibility while converging persisted naming on tabs.
-    private enum LegacyCodingKeys: String, CodingKey {
-        case surfaceID = "surface_id"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
-
-        let tabID: String
-        if let decodedTabID = try container.decodeIfPresent(String.self, forKey: .tabID) {
-            tabID = decodedTabID
-        } else {
-            tabID = try legacyContainer.decode(String.self, forKey: .surfaceID)
-        }
-
-        self.init(
-            paneID: try container.decode(String.self, forKey: .paneID),
-            tabID: tabID,
-            spaceID: try container.decode(String.self, forKey: .spaceID),
-            launchTarget: try container.decodeIfPresent(ShellLaunchTarget.self, forKey: .launchTarget),
-            cwd: try container.decodeIfPresent(String.self, forKey: .cwd),
-            process: try container.decodeIfPresent(ShellProcessBinding.self, forKey: .process),
-            attention: try container.decode(ShellAttentionState.self, forKey: .attention),
-            context: try container.decodeIfPresent(ShellContextSnapshot.self, forKey: .context),
-            viewport: try container.decodeIfPresent(ShellViewportSnapshot.self, forKey: .viewport),
-            alanBinding: try container.decodeIfPresent(ShellAlanBinding.self, forKey: .alanBinding)
-        )
-    }
-
     var resolvedLaunchTarget: ShellLaunchTarget {
         if let launchTarget {
             return launchTarget
@@ -323,13 +293,13 @@ struct ShellPaneTreeNode: Identifiable, Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(ShellPaneTreeKind.self, forKey: .kind)
-        let decodedRatio = try container.decodeIfPresent(Double.self, forKey: .ratio)
+        let decodedRatio = kind == .split ? try container.decode(Double.self, forKey: .ratio) : nil
 
         self.init(
             nodeID: try container.decode(String.self, forKey: .nodeID),
             kind: kind,
             direction: try container.decodeIfPresent(ShellSplitDirection.self, forKey: .direction),
-            ratio: kind == .split ? decodedRatio : nil,
+            ratio: decodedRatio,
             paneID: try container.decodeIfPresent(String.self, forKey: .paneID),
             children: try container.decodeIfPresent([ShellPaneTreeNode].self, forKey: .children)
         )
@@ -889,84 +859,8 @@ struct ShellStateSnapshot: Codable, Equatable {
 }
 
 extension ShellTab {
-    private enum LegacyCodingKeys: String, CodingKey {
-        case surfaceID = "surface_id"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
-
-        let tabID: String
-        if let decodedTabID = try container.decodeIfPresent(String.self, forKey: .tabID) {
-            tabID = decodedTabID
-        } else {
-            tabID = try legacyContainer.decode(String.self, forKey: .surfaceID)
-        }
-
-        self.init(
-            tabID: tabID,
-            kind: try container.decode(ShellTabKind.self, forKey: .kind),
-            title: try container.decodeIfPresent(String.self, forKey: .title),
-            paneTree: try container.decode(ShellPaneTreeNode.self, forKey: .paneTree)
-        )
-    }
-
     func contains(paneID: String) -> Bool {
         paneTree.contains(paneID: paneID)
-    }
-}
-
-extension ShellSpace {
-    private enum LegacyCodingKeys: String, CodingKey {
-        case surfaces
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
-
-        let tabs: [ShellTab]
-        if let decodedTabs = try container.decodeIfPresent([ShellTab].self, forKey: .tabs) {
-            tabs = decodedTabs
-        } else {
-            tabs = try legacyContainer.decode([ShellTab].self, forKey: .surfaces)
-        }
-
-        self.init(
-            spaceID: try container.decode(String.self, forKey: .spaceID),
-            title: try container.decode(String.self, forKey: .title),
-            attention: try container.decode(ShellAttentionState.self, forKey: .attention),
-            tabs: tabs
-        )
-    }
-}
-
-extension ShellStateSnapshot {
-    private enum LegacyCodingKeys: String, CodingKey {
-        case focusedSurfaceID = "focused_surface_id"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
-
-        let focusedTabID: String?
-        if let decodedTabID = try container.decodeIfPresent(String.self, forKey: .focusedTabID) {
-            focusedTabID = decodedTabID
-        } else {
-            focusedTabID = try legacyContainer.decodeIfPresent(String.self, forKey: .focusedSurfaceID)
-        }
-
-        self.init(
-            contractVersion: try container.decode(String.self, forKey: .contractVersion),
-            windowID: try container.decode(String.self, forKey: .windowID),
-            focusedSpaceID: try container.decodeIfPresent(String.self, forKey: .focusedSpaceID),
-            focusedTabID: focusedTabID,
-            focusedPaneID: try container.decodeIfPresent(String.self, forKey: .focusedPaneID),
-            spaces: try container.decode([ShellSpace].self, forKey: .spaces),
-            panes: try container.decode([ShellPane].self, forKey: .panes)
-        )
     }
 }
 
@@ -1868,36 +1762,6 @@ extension ShellStateSnapshot {
                 lastActivityAt: formatter.string(from: now)
             ),
             alanBinding: nil
-        )
-    }
-
-    func migratingLegacyAlanBootstrapIfNeeded(
-        defaultWorkingDirectory: String = defaultShellWorkingDirectory()
-    ) -> ShellStateSnapshot {
-        guard spaces.count == 1,
-              panes.count == 1,
-              let space = spaces.first,
-              let tab = space.tabs.first,
-              let pane = panes.first
-        else {
-            return self
-        }
-
-        let isLegacyBootstrap =
-            space.title == "Alan"
-            && tab.title == "Main Session"
-            && pane.process?.program == "alan-tui"
-            && pane.viewport?.title == "Alan"
-            && pane.alanBinding == nil
-            && pane.launchTarget == nil
-
-        guard isLegacyBootstrap else {
-            return self
-        }
-
-        return .bootstrapDefault(
-            windowID: windowID,
-            workingDirectory: pane.cwd ?? defaultWorkingDirectory
         )
     }
 

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -20,7 +20,7 @@ private enum ShellSplitModelTests {
         try verifiesPaneScopedCloseKeepsInactivePaneTargeting()
         try verifiesPaneScopedCloseClosesSinglePaneTab()
         try verifiesPaneScopedClosePreservesFinalPane()
-        try verifiesLegacySplitDecodeDefaultsToEqualRatio()
+        try verifiesSplitDecodeRequiresPersistedRatio()
         print("Shell split model tests passed.")
     }
 
@@ -225,8 +225,8 @@ private enum ShellSplitModelTests {
         }
     }
 
-    private static func verifiesLegacySplitDecodeDefaultsToEqualRatio() throws {
-        let legacyJSON = """
+    private static func verifiesSplitDecodeRequiresPersistedRatio() throws {
+        let missingRatioJSON = """
         {
           "contract_version": "0.1",
           "window_id": "window_test",
@@ -262,15 +262,12 @@ private enum ShellSplitModelTests {
           ]
         }
         """
-        let data = Data(legacyJSON.utf8)
-        let state = try JSONDecoder().decode(ShellStateSnapshot.self, from: data)
-        let tree = try requireFocusedTabTree(state)
-
-        expect(tree.ratio == 0.5, "legacy split trees without ratio must decode as equal splits")
-
-        let encoded = try JSONEncoder().encode(state)
-        let encodedString = String(decoding: encoded, as: UTF8.self)
-        expect(encodedString.contains("\"ratio\""), "decoded legacy split ratios must persist when re-encoded")
+        do {
+            _ = try JSONDecoder().decode(ShellStateSnapshot.self, from: Data(missingRatioJSON.utf8))
+            expect(false, "split trees without persisted ratio must fail to decode")
+        } catch DecodingError.keyNotFound(_, _) {
+            // Expected.
+        }
     }
 
     private static func requireFocusedTabTree(_ state: ShellStateSnapshot) throws -> ShellPaneTreeNode {

--- a/openspec/changes/improve-macos-app-architecture-maintainability/design.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/design.md
@@ -67,7 +67,7 @@ Target source organization should use stable top-level folders under
 - `Views/Console/` or `LegacyConsole/`: mobile/remote-control console UI and
   view model code that is not the primary macOS shell.
 - `Models/`: API DTOs, shell snapshots, shell IDs, enums, value types, and
-  legacy decoding shims.
+  current-format decoding.
 - `Stores/` or `Controllers/`: observable app/shell controllers that own view
   state and delegate domain work to services.
 - `Services/`: daemon API client, event stream reader/reducer, terminal runtime

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -28,7 +28,7 @@
 
 ## 5. Shell Model And Controller Ownership
 
-- [ ] 5.1 Split pure shell enum/value types, pane/tree/tab/space snapshots, legacy decoding, bootstrap defaults, and mutation helpers out of the current monolithic `ShellModel.swift`.
+- [ ] 5.1 Split pure shell enum/value types, pane/tree/tab/space snapshots, obsolete legacy decoding removal, bootstrap defaults, and mutation helpers out of the current monolithic `ShellModel.swift`.
 - [ ] 5.2 Keep shell mutation behavior covered by the existing focused shell model script tests after each split.
 - [ ] 5.3 Review `ShellHostController` for controller/store/service boundaries and move persistence, boot-profile projection, attention projection, and runtime update projection where they have clear owners.
 - [ ] 5.4 Preserve `ShellWorkspaceCommand` as the shared command vocabulary used by menu, command palette, keyboard, and control-plane paths.


### PR DESCRIPTION
## Summary
- Remove obsolete shell snapshot compatibility decoding for surface_id, surfaces, and focused_surface_id.
- Remove control-plane binding projection fallback from surface_id and stop restoring the old Alan bootstrap migration path.
- Require persisted split nodes to include ratio and update the focused shell model test accordingly.
- Update architecture inventory and OpenSpec wording to reflect current-format decoding rather than moving legacy shims.

## Review focus
- This is a behavior change requested after #369: old shell persistence formats are intentionally not supported.
- Please check that current-format tab/pane/space snapshot decoding remains straightforward and that no surface-named compatibility path remains.

## Validation
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/check-architecture-maintainability.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Notes: architecture check still reports the expected migration warnings; xcodebuild still reports the existing CoreSimulator/AppIntents warnings before succeeding.