### PR TITLE
Extract shell host projection services

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -39,7 +39,9 @@ Xcode target.
 | `Models/Shell/ShellTreeMutations.swift` | 198 | Foundation | Split-tree resizing, equalization, split, removal, and attachment helpers | `Models/Shell/` |
 | `Models/Shell/ShellStateMutations.swift` | 1034 | Foundation | Shell bootstrap defaults, state mutation result/error types, mutation helpers, and preview fixtures | `Models/Shell/` |
 | `ShellModel.swift` | 169 | Foundation | Shell title, label, and status presentation helpers | `Models/Shell/` or `Support/ShellPresentation/` |
-| `ShellHostController.swift` | 1964 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, persistence, boot profiles, runtime projection, command routing | `Controllers/Shell/` plus service collaborators |
+| `ShellHostController.swift` | 1632 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, runtime update intake, command routing, control-plane command handling | `Controllers/Shell/` plus service collaborators |
+| `Services/Shell/ShellPaneProjectionService.swift` | 266 | Foundation; macOS gates | Pane boot context, runtime metadata, viewport, attention, and Alan binding projection | `Services/Shell/` |
+| `Services/Shell/ShellStatePersistenceStore.swift` | 116 | Foundation; macOS gates | Shell state save/restore, persistence URL selection, and restored window context lookup | `Services/Shell/` |
 | `ShellControlPlane.swift` | 2075 | Foundation, Darwin; macOS gates | Protocol DTOs, socket server, file polling, local executor, state merging, persistence, diagnostics | `Services/ControlPlane/` plus `Models/ControlPlane/` |
 | `Models/API/DaemonAPIModels.swift` | 529 | Foundation | Daemon API response DTOs, operation payloads, JSON values, and API error type | `Models/API/` |
 | `Models/Console/ConsoleModels.swift` | 148 | Foundation | Console chat messages, timeline entries, structured questions, and pending-yield value state | `Models/Console/` |
@@ -62,8 +64,8 @@ The accepted target under `clients/apple/AlanNative` is:
 - `Controllers/`: observable app and shell controllers that own UI state and
   delegate IO or domain work to services.
 - `Services/`: daemon API clients, event readers/reducers, terminal runtime
-  services, Ghostty bootstrap, shell control plane, socket server, persistence,
-  and other process or IO code.
+  services, Ghostty bootstrap, shell projection services, shell control plane,
+  socket server, persistence, and other process or IO code.
 - `Support/`: design tokens, formatting helpers, window placement, AppKit
   adapters, and small utilities.
 

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		000000000000000000000022 /* ShellSnapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000122 /* ShellSnapshots.swift */; };
 		000000000000000000000023 /* ShellTreeMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000123 /* ShellTreeMutations.swift */; };
 		000000000000000000000024 /* ShellStateMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000124 /* ShellStateMutations.swift */; };
+		000000000000000000000025 /* ShellPaneProjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000125 /* ShellPaneProjectionService.swift */; };
+		000000000000000000000026 /* ShellStatePersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000126 /* ShellStatePersistenceStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +85,8 @@
 		000000000000000000000122 /* ShellSnapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellSnapshots.swift; sourceTree = "<group>"; };
 		000000000000000000000123 /* ShellTreeMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellTreeMutations.swift; sourceTree = "<group>"; };
 		000000000000000000000124 /* ShellStateMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellStateMutations.swift; sourceTree = "<group>"; };
+		000000000000000000000125 /* ShellPaneProjectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPaneProjectionService.swift; sourceTree = "<group>"; };
+		000000000000000000000126 /* ShellStatePersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellStatePersistenceStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +122,7 @@
 				000000000000000000000308 /* Models/Console */,
 				00000000000000000000030B /* Models/Shell */,
 				00000000000000000000030A /* Services/Daemon */,
+				00000000000000000000030C /* Services/Shell */,
 				000000000000000000000101 /* AlanNativeApp.swift */,
 				000000000000000000000112 /* AlanAppSingletonGuard.swift */,
 				000000000000000000000104 /* MacShellRootView.swift */,
@@ -210,6 +215,15 @@
 				000000000000000000000124 /* ShellStateMutations.swift */,
 			);
 			name = Models/Shell;
+			sourceTree = "<group>";
+		};
+		00000000000000000000030C /* Services/Shell */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000125 /* ShellPaneProjectionService.swift */,
+				000000000000000000000126 /* ShellStatePersistenceStore.swift */,
+			);
+			name = Services/Shell;
 			sourceTree = "<group>";
 		};
 		000000000000000000000303 /* Products */ = {
@@ -345,6 +359,8 @@
 				000000000000000000000022 /* ShellSnapshots.swift in Sources */,
 				000000000000000000000023 /* ShellTreeMutations.swift in Sources */,
 				000000000000000000000024 /* ShellStateMutations.swift in Sources */,
+				000000000000000000000025 /* ShellPaneProjectionService.swift in Sources */,
+				000000000000000000000026 /* ShellStatePersistenceStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellPaneProjectionService.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+#if os(macOS)
+struct ShellPaneProjectionService {
+    private let fileManager: FileManager
+    private let iso8601Formatter = ISO8601DateFormatter()
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func needsBootContextProjection(_ pane: ShellPane) -> Bool {
+        guard let context = pane.context else { return true }
+        return context.controlPath == nil
+            || context.alanBindingFile == nil
+            || context.launchStrategy == nil
+    }
+
+    func projectedAttention(
+        metadataAttention: ShellAttentionState,
+        processExited: Bool,
+        binding: ShellAlanBinding?,
+        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil
+    ) -> ShellAttentionState {
+        if binding?.pendingYield == true || processExited || surfaceState?.childExited == true {
+            return .awaitingUser
+        }
+
+        if surfaceState?.rendererHealth == "failed"
+            || surfaceState?.readiness == .unready(reason: .rendererFailed)
+        {
+            return .notable
+        }
+
+        return metadataAttention
+    }
+
+    func projectedViewport(
+        current: ShellPane,
+        metadata: TerminalPaneMetadataSnapshot,
+        runtime: TerminalHostRuntimeSnapshot
+    ) -> ShellViewportSnapshot {
+        ShellViewportSnapshot(
+            title: metadata.title ?? current.viewport?.title,
+            summary: projectedViewportSummary(
+                metadata: metadata,
+                runtime: runtime,
+                fallback: current.viewport?.summary
+            ),
+            visibleExcerpt: current.viewport?.visibleExcerpt,
+            lastActivityAt: metadata.lastUpdatedAt.map(iso8601Formatter.string)
+                ?? current.viewport?.lastActivityAt
+                ?? iso8601Formatter.string(from: runtime.lastUpdatedAt)
+        )
+    }
+
+    func projectedProcessExited(
+        metadataProcessExited: Bool?,
+        surfaceState: AlanTerminalSurfaceStateSnapshot?
+    ) -> Bool? {
+        if metadataProcessExited == true || surfaceState?.childExited == true {
+            return true
+        }
+
+        return metadataProcessExited ?? surfaceState?.childExited
+    }
+
+    func projectedContext(
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile,
+        workingDirectory: String?,
+        processExited: Bool?,
+        lastCommandExitCode: Int?,
+        lastMetadataAt: Date?,
+        existing: ShellContextSnapshot?,
+        runtime: TerminalHostRuntimeSnapshot? = nil
+    ) -> ShellContextSnapshot {
+        let resolvedWorkingDirectory = workingDirectory ?? pane.cwd ?? bootProfile.workingDirectory
+        let repositoryContext = repositoryContext(for: resolvedWorkingDirectory)
+        let projectedProcessExited = projectedProcessExited(
+            metadataProcessExited: processExited,
+            surfaceState: runtime?.surfaceState
+        )
+
+        return ShellContextSnapshot(
+            workingDirectoryName: workingDirectoryName(for: resolvedWorkingDirectory)
+                ?? existing?.workingDirectoryName,
+            repositoryRoot: repositoryContext.repositoryRoot ?? existing?.repositoryRoot,
+            gitBranch: repositoryContext.gitBranch ?? existing?.gitBranch,
+            controlPath: bootProfile.environment["ALAN_SHELL_CONTROL_DIR"] ?? existing?.controlPath,
+            socketPath: bootProfile.environment["ALAN_SHELL_SOCKET"] ?? existing?.socketPath,
+            alanBindingFile: bootProfile.environment["ALAN_SHELL_BINDING_FILE"]
+                ?? existing?.alanBindingFile,
+            launchCommand: bootProfile.launchCommandString,
+            launchStrategy: bootProfile.command.strategy.rawValue,
+            shellIntegrationSource: "ghostty_shell_integration",
+            processState: projectedProcessExited.map { $0 ? "exited" : "running" }
+                ?? existing?.processState,
+            rendererPhase: runtime?.renderer.phase.rawValue ?? existing?.rendererPhase,
+            rendererHealth: runtime?.surfaceState.rendererHealth
+                ?? runtime?.renderer.phase.rawValue
+                ?? existing?.rendererHealth,
+            surfaceReadiness: runtime.map { surfaceReadinessValue($0.surfaceState.readiness) }
+                ?? existing?.surfaceReadiness,
+            inputReady: runtime?.surfaceState.inputReady ?? existing?.inputReady,
+            readonly: runtime?.surfaceState.readonly ?? existing?.readonly,
+            terminalMode: runtime?.surfaceState.terminalMode.rawValue ?? existing?.terminalMode,
+            displayName: runtime?.displayName ?? existing?.displayName,
+            displayID: runtime?.displayID ?? existing?.displayID,
+            windowTitle: runtime?.attachedWindowTitle ?? existing?.windowTitle,
+            lastMetadataAt: lastMetadataAt.map(iso8601Formatter.string)
+                ?? existing?.lastMetadataAt,
+            lastCommandExitCode: lastCommandExitCode ?? existing?.lastCommandExitCode
+        )
+    }
+
+    func projectedAlanBinding(
+        for pane: ShellPane,
+        binding: ShellAlanBinding?,
+        processExited: Bool
+    ) -> ShellAlanBinding? {
+        if let binding {
+            return binding
+        }
+
+        if let existing = pane.alanBinding {
+            return existing
+        }
+
+        guard pane.resolvedLaunchTarget == .alan, !processExited else {
+            return nil
+        }
+
+        return ShellAlanBinding(
+            sessionID: "pending:\(pane.paneID)",
+            runStatus: "booting",
+            pendingYield: false,
+            source: "alan_shell_boot_projection",
+            lastProjectedAt: iso8601Formatter.string(from: .now)
+        )
+    }
+
+    private func projectedViewportSummary(
+        metadata: TerminalPaneMetadataSnapshot,
+        runtime: TerminalHostRuntimeSnapshot,
+        fallback: String?
+    ) -> String? {
+        if metadata.processExited || runtime.surfaceState.childExited {
+            if let exitCode = metadata.lastCommandExitCode {
+                return "Exited \(exitCode)"
+            }
+            return "Exited"
+        }
+
+        if runtime.surfaceState.rendererHealth == "failed"
+            || runtime.renderer.phase == .failed
+            || runtime.surfaceState.readiness == .unready(reason: .rendererFailed)
+        {
+            return "Renderer failed"
+        }
+
+        if runtime.surfaceState.readonly {
+            return "Read-only"
+        }
+
+        if runtime.surfaceState.inputReady == false,
+           runtime.surfaceState.readiness == .unready(reason: .inputNotReady)
+        {
+            return "Starting"
+        }
+
+        return metadata.summary ?? fallback
+    }
+
+    private func surfaceReadinessValue(_ readiness: AlanTerminalSurfaceReadiness) -> String {
+        switch readiness {
+        case .ready:
+            return "ready"
+        case .unready(let reason):
+            return reason.rawValue
+        }
+    }
+
+    private func workingDirectoryName(for path: String?) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        let lastComponent = URL(fileURLWithPath: path).lastPathComponent
+        return lastComponent.isEmpty ? path : lastComponent
+    }
+
+    private func repositoryContext(for workingDirectory: String?) -> (
+        repositoryRoot: String?,
+        gitBranch: String?
+    ) {
+        guard let workingDirectory, !workingDirectory.isEmpty else {
+            return (nil, nil)
+        }
+
+        var currentURL = URL(fileURLWithPath: workingDirectory, isDirectory: true).standardizedFileURL
+        var isDirectory: ObjCBool = false
+
+        if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) {
+            return (nil, nil)
+        }
+
+        if !isDirectory.boolValue {
+            currentURL.deleteLastPathComponent()
+        }
+
+        while true {
+            let gitEntryURL = currentURL.appendingPathComponent(".git")
+            if fileManager.fileExists(atPath: gitEntryURL.path) {
+                let gitDirectoryURL = resolveGitDirectory(for: gitEntryURL, repositoryRoot: currentURL)
+                let gitBranch = gitDirectoryURL.flatMap(readGitBranch(from:))
+                return (currentURL.path, gitBranch)
+            }
+
+            let parentURL = currentURL.deletingLastPathComponent()
+            if parentURL.path == currentURL.path {
+                return (nil, nil)
+            }
+            currentURL = parentURL
+        }
+    }
+
+    private func resolveGitDirectory(for gitEntryURL: URL, repositoryRoot: URL) -> URL? {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: gitEntryURL.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+
+        if isDirectory.boolValue {
+            return gitEntryURL
+        }
+
+        guard let content = try? String(contentsOf: gitEntryURL, encoding: .utf8) else {
+            return nil
+        }
+
+        let prefix = "gitdir:"
+        guard content.hasPrefix(prefix) else { return nil }
+        let rawPath = content.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawPath.isEmpty else { return nil }
+
+        let pathURL = URL(fileURLWithPath: rawPath, relativeTo: repositoryRoot)
+        return pathURL.standardizedFileURL
+    }
+
+    private func readGitBranch(from gitDirectoryURL: URL) -> String? {
+        let headURL = gitDirectoryURL.appendingPathComponent("HEAD")
+        guard let head = try? String(contentsOf: headURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !head.isEmpty
+        else {
+            return nil
+        }
+
+        let refPrefix = "ref: "
+        if head.hasPrefix(refPrefix) {
+            let reference = String(head.dropFirst(refPrefix.count))
+            return reference.split(separator: "/").last.map(String.init)
+        }
+
+        return "detached:\(String(head.prefix(12)))"
+    }
+}
+#endif

--- a/clients/apple/AlanNative/Services/Shell/ShellStatePersistenceStore.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellStatePersistenceStore.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+#if os(macOS)
+struct ShellStatePersistenceStore {
+    private static let persistenceFilePrefix = "shell-state-"
+    private static let persistenceFileExtension = ".json"
+    private static let defaultRestorationWindowID = "window_main"
+
+    private let fileManager: FileManager
+    private let persistenceURL: URL
+
+    init(fileManager: FileManager = .default, persistenceURL: URL) {
+        self.fileManager = fileManager
+        self.persistenceURL = persistenceURL
+    }
+
+    func save(_ shellState: ShellStateSnapshot) {
+        let parentURL = persistenceURL.deletingLastPathComponent()
+        try? fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(shellState) else { return }
+        try? data.write(to: persistenceURL, options: .atomic)
+    }
+
+    static func defaultPersistenceURL(windowID: String, fileManager: FileManager) -> URL {
+        let sanitizedWindowID = windowID
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+        return persistenceDirectory(fileManager: fileManager)
+            .appendingPathComponent("\(persistenceFilePrefix)\(sanitizedWindowID)\(persistenceFileExtension)")
+    }
+
+    @MainActor
+    static func restoredWindowContext(
+        fileManager: FileManager,
+        restorePrevious: Bool
+    ) -> ShellWindowContext? {
+        guard restorePrevious else { return nil }
+
+        let directory = persistenceDirectory(fileManager: fileManager)
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        let candidates = urls.compactMap { url -> (Date, ShellWindowContext)? in
+            guard isShellStatePersistenceURL(url),
+                  let state = restoreShellState(fileManager: fileManager, persistenceURL: url)
+            else {
+                return nil
+            }
+
+            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            let modifiedAt = values?.contentModificationDate ?? .distantPast
+            return (
+                modifiedAt,
+                ShellWindowContext(
+                    windowID: state.windowID,
+                    persistenceURL: url,
+                    terminalRuntimeRegistry: TerminalRuntimeRegistry()
+                )
+            )
+        }
+
+        return candidates.max { lhs, rhs in lhs.0 < rhs.0 }?.1
+    }
+
+    @MainActor
+    static func defaultWindowContext(
+        fileManager: FileManager,
+        restorePrevious: Bool
+    ) -> ShellWindowContext {
+        if restorePrevious {
+            return ShellWindowContext.make(
+                fileManager: fileManager,
+                windowID: defaultRestorationWindowID
+            )
+        }
+
+        return ShellWindowContext.make(fileManager: fileManager)
+    }
+
+    static func restoreShellState(
+        fileManager: FileManager,
+        persistenceURL: URL
+    ) -> ShellStateSnapshot? {
+        guard fileManager.fileExists(atPath: persistenceURL.path),
+              let data = try? Data(contentsOf: persistenceURL),
+              let state = try? JSONDecoder().decode(ShellStateSnapshot.self, from: data),
+              !state.spaces.isEmpty,
+              !state.panes.isEmpty
+        else {
+            return nil
+        }
+        return state
+    }
+
+    private static func persistenceDirectory(fileManager: FileManager) -> URL {
+        let appSupportURL =
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return appSupportURL.appendingPathComponent("AlanNative", isDirectory: true)
+    }
+
+    private static func isShellStatePersistenceURL(_ url: URL) -> Bool {
+        let fileName = url.lastPathComponent
+        return fileName.hasPrefix(persistenceFilePrefix)
+            && fileName.hasSuffix(persistenceFileExtension)
+            && fileName != "shell-state-v0.1.json"
+    }
+}
+#endif

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -62,7 +62,7 @@ struct ShellWindowContext {
     ) -> ShellWindowContext {
         ShellWindowContext(
             windowID: windowID,
-            persistenceURL: ShellHostController.defaultPersistenceURL(
+            persistenceURL: ShellStatePersistenceStore.defaultPersistenceURL(
                 windowID: windowID,
                 fileManager: fileManager
             ),
@@ -79,13 +79,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private static let iso8601Formatter = ISO8601DateFormatter()
-    private static let persistenceFilePrefix = "shell-state-"
-    private static let persistenceFileExtension = ".json"
-    private static let defaultRestorationWindowID = "window_main"
-
     private let fileManager: FileManager
     private let windowContext: ShellWindowContext
     private let persistenceURL: URL
+    private let persistenceStore: ShellStatePersistenceStore
+    private let paneProjection: ShellPaneProjectionService
     private lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
@@ -136,9 +134,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil
     ) {
         self.fileManager = fileManager
+        self.paneProjection = ShellPaneProjectionService(fileManager: fileManager)
         let resolvedContext = windowContext ?? ShellWindowContext.make(fileManager: fileManager)
         self.windowContext = resolvedContext
         self.persistenceURL = persistenceURL ?? resolvedContext.persistenceURL
+        self.persistenceStore = ShellStatePersistenceStore(
+            fileManager: fileManager,
+            persistenceURL: self.persistenceURL
+        )
         self.shellState = shellState
         self.terminalRuntimeRegistry =
             terminalRuntimeRegistry
@@ -168,8 +171,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     ) -> ShellHostController {
         let resolvedWindowContext =
             windowContext
-            ?? restoredWindowContext(fileManager: fileManager, startupMode: startupMode)
-            ?? defaultWindowContext(fileManager: fileManager, startupMode: startupMode)
+            ?? ShellStatePersistenceStore.restoredWindowContext(
+                fileManager: fileManager,
+                restorePrevious: startupMode == .restorePrevious
+            )
+            ?? ShellStatePersistenceStore.defaultWindowContext(
+                fileManager: fileManager,
+                restorePrevious: startupMode == .restorePrevious
+            )
         let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
         switch startupMode {
@@ -177,7 +186,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             shellState = .bootstrapDefault(windowID: resolvedWindowContext.windowID)
         case .restorePrevious:
             shellState =
-                restoreShellState(fileManager: fileManager, persistenceURL: persistenceURL)
+                ShellStatePersistenceStore.restoreShellState(
+                    fileManager: fileManager,
+                    persistenceURL: persistenceURL
+                )
                 ?? .bootstrapDefault(windowID: resolvedWindowContext.windowID)
         }
 
@@ -590,11 +602,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
            let pane = pane(paneID: paneID)
         {
             let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
-            let runtimeProcessExited = projectedProcessExited(
+            let runtimeProcessExited = paneProjection.projectedProcessExited(
                 metadataProcessExited: runtime.paneMetadata.processExited,
                 surfaceState: runtime.surfaceState
             ) ?? runtime.paneMetadata.processExited
-            let projectedContext = projectedContext(
+            let projectedContext = paneProjection.projectedContext(
                 for: pane,
                 bootProfile: bootProfile,
                 workingDirectory: runtime.paneMetadata.workingDirectory ?? pane.cwd,
@@ -606,12 +618,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             )
 
             updatePaneState(paneID: paneID) { current in
-                let projectedBinding = projectedAlanBinding(
+                let projectedBinding = paneProjection.projectedAlanBinding(
                     for: current,
                     binding: current.alanBinding,
                     processExited: runtimeProcessExited
                 )
-                let viewport = projectedViewport(
+                let viewport = paneProjection.projectedViewport(
                     current: current,
                     metadata: runtime.paneMetadata,
                     runtime: runtime
@@ -623,7 +635,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     launchTarget: current.launchTarget,
                     cwd: current.cwd ?? bootProfile.workingDirectory,
                     process: current.process,
-                    attention: projectedAttention(
+                    attention: paneProjection.projectedAttention(
                         metadataAttention: runtime.paneMetadata.attention,
                         processExited: runtimeProcessExited,
                         binding: projectedBinding,
@@ -641,11 +653,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard let pane = pane(paneID: paneID) else { return }
         let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let metadataProcessExited = projectedProcessExited(
+        let metadataProcessExited = paneProjection.projectedProcessExited(
             metadataProcessExited: metadata.processExited,
             surfaceState: runtime.surfaceState
         ) ?? metadata.processExited
-        let projectedContext = projectedContext(
+        let projectedContext = paneProjection.projectedContext(
             for: pane,
             bootProfile: bootProfile,
             workingDirectory: metadata.workingDirectory ?? pane.cwd,
@@ -660,12 +672,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             paneID: pane.paneID,
             tabTitleOverride: metadata.title
         ) { current in
-            let projectedBinding = projectedAlanBinding(
+            let projectedBinding = paneProjection.projectedAlanBinding(
                 for: current,
                 binding: current.alanBinding,
                 processExited: metadataProcessExited
             )
-            let viewport = projectedViewport(
+            let viewport = paneProjection.projectedViewport(
                 current: current,
                 metadata: metadata,
                 runtime: runtime
@@ -678,7 +690,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 launchTarget: current.launchTarget,
                 cwd: metadata.workingDirectory ?? current.cwd ?? bootProfile.workingDirectory,
                 process: current.process,
-                attention: projectedAttention(
+                attention: paneProjection.projectedAttention(
                     metadataAttention: metadata.attention,
                     processExited: metadataProcessExited,
                     binding: projectedBinding,
@@ -695,16 +707,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard let pane = pane(paneID: paneID) else { return }
         let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let runtimeProcessExited = projectedProcessExited(
+        let runtimeProcessExited = paneProjection.projectedProcessExited(
             metadataProcessExited: runtime.paneMetadata.processExited,
             surfaceState: runtime.surfaceState
         ) ?? runtime.paneMetadata.processExited
-        let projectedBinding = projectedAlanBinding(
+        let projectedBinding = paneProjection.projectedAlanBinding(
             for: pane,
             binding: binding,
             processExited: runtimeProcessExited
         )
-        let projectedContext = projectedContext(
+        let projectedContext = paneProjection.projectedContext(
             for: pane,
             bootProfile: bootProfile,
             workingDirectory: pane.cwd,
@@ -751,11 +763,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard let pane = pane(paneID: paneID) else { return }
         let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let runtimeProcessExited = projectedProcessExited(
+        let runtimeProcessExited = paneProjection.projectedProcessExited(
             metadataProcessExited: nil,
             surfaceState: runtime.surfaceState
         ) ?? false
-        let projectedContext = projectedContext(
+        let projectedContext = paneProjection.projectedContext(
             for: pane,
             bootProfile: bootProfile,
             workingDirectory: pane.cwd ?? bootProfile.workingDirectory,
@@ -767,7 +779,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         )
 
         updatePaneState(paneID: paneID) { current in
-            let projectedBinding = projectedAlanBinding(
+            let projectedBinding = paneProjection.projectedAlanBinding(
                 for: current,
                 binding: current.alanBinding,
                 processExited: runtimeProcessExited
@@ -897,9 +909,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         terminalRuntimeRegistry.releaseRuntimes(excluding: paneIDs)
 
         let hydratedPanes = state.panes.map { pane in
-            guard paneNeedsBootContextProjection(pane) else { return pane }
+            guard paneProjection.needsBootContextProjection(pane) else { return pane }
             let bootProfile = AlanShellBootProfile.forPane(pane, shellState: state)
-            let projectedContext = projectedContext(
+            let projectedContext = paneProjection.projectedContext(
                 for: pane,
                 bootProfile: bootProfile,
                 workingDirectory: pane.cwd ?? bootProfile.workingDirectory,
@@ -970,12 +982,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func persistShellState() {
-        let parentURL = persistenceURL.deletingLastPathComponent()
-        try? fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(shellState) else { return }
-        try? data.write(to: persistenceURL, options: .atomic)
+        persistenceStore.save(shellState)
     }
 
     private func pane(paneID: String) -> ShellPane? {
@@ -1192,256 +1199,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             errorCode: errorCode,
             errorMessage: errorMessage
         )
-    }
-
-    private func paneNeedsBootContextProjection(_ pane: ShellPane) -> Bool {
-        guard let context = pane.context else { return true }
-        return context.controlPath == nil
-            || context.alanBindingFile == nil
-            || context.launchStrategy == nil
-    }
-
-    private func projectedAttention(
-        metadataAttention: ShellAttentionState,
-        processExited: Bool,
-        binding: ShellAlanBinding?,
-        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil
-    ) -> ShellAttentionState {
-        if binding?.pendingYield == true || processExited || surfaceState?.childExited == true {
-            return .awaitingUser
-        }
-
-        if surfaceState?.rendererHealth == "failed"
-            || surfaceState?.readiness == .unready(reason: .rendererFailed)
-        {
-            return .notable
-        }
-
-        return metadataAttention
-    }
-
-    private func projectedViewport(
-        current: ShellPane,
-        metadata: TerminalPaneMetadataSnapshot,
-        runtime: TerminalHostRuntimeSnapshot
-    ) -> ShellViewportSnapshot {
-        ShellViewportSnapshot(
-            title: metadata.title ?? current.viewport?.title,
-            summary: projectedViewportSummary(
-                metadata: metadata,
-                runtime: runtime,
-                fallback: current.viewport?.summary
-            ),
-            visibleExcerpt: current.viewport?.visibleExcerpt,
-            lastActivityAt: metadata.lastUpdatedAt.map(Self.iso8601Formatter.string)
-                ?? current.viewport?.lastActivityAt
-                ?? Self.iso8601Formatter.string(from: runtime.lastUpdatedAt)
-        )
-    }
-
-    private func projectedViewportSummary(
-        metadata: TerminalPaneMetadataSnapshot,
-        runtime: TerminalHostRuntimeSnapshot,
-        fallback: String?
-    ) -> String? {
-        if metadata.processExited || runtime.surfaceState.childExited {
-            if let exitCode = metadata.lastCommandExitCode {
-                return "Exited \(exitCode)"
-            }
-            return "Exited"
-        }
-
-        if runtime.surfaceState.rendererHealth == "failed"
-            || runtime.renderer.phase == .failed
-            || runtime.surfaceState.readiness == .unready(reason: .rendererFailed)
-        {
-            return "Renderer failed"
-        }
-
-        if runtime.surfaceState.readonly {
-            return "Read-only"
-        }
-
-        if runtime.surfaceState.inputReady == false,
-           runtime.surfaceState.readiness == .unready(reason: .inputNotReady)
-        {
-            return "Starting"
-        }
-
-        return metadata.summary ?? fallback
-    }
-
-    private func surfaceReadinessValue(_ readiness: AlanTerminalSurfaceReadiness) -> String {
-        switch readiness {
-        case .ready:
-            return "ready"
-        case .unready(let reason):
-            return reason.rawValue
-        }
-    }
-
-    private func projectedProcessExited(
-        metadataProcessExited: Bool?,
-        surfaceState: AlanTerminalSurfaceStateSnapshot?
-    ) -> Bool? {
-        if metadataProcessExited == true || surfaceState?.childExited == true {
-            return true
-        }
-
-        return metadataProcessExited ?? surfaceState?.childExited
-    }
-
-    private func projectedContext(
-        for pane: ShellPane,
-        bootProfile: AlanShellBootProfile,
-        workingDirectory: String?,
-        processExited: Bool?,
-        lastCommandExitCode: Int?,
-        lastMetadataAt: Date?,
-        existing: ShellContextSnapshot?,
-        runtime: TerminalHostRuntimeSnapshot? = nil
-    ) -> ShellContextSnapshot {
-        let resolvedWorkingDirectory = workingDirectory ?? pane.cwd ?? bootProfile.workingDirectory
-        let repositoryContext = repositoryContext(for: resolvedWorkingDirectory)
-        let projectedProcessExited = projectedProcessExited(
-            metadataProcessExited: processExited,
-            surfaceState: runtime?.surfaceState
-        )
-
-        return ShellContextSnapshot(
-            workingDirectoryName: workingDirectoryName(for: resolvedWorkingDirectory)
-                ?? existing?.workingDirectoryName,
-            repositoryRoot: repositoryContext.repositoryRoot ?? existing?.repositoryRoot,
-            gitBranch: repositoryContext.gitBranch ?? existing?.gitBranch,
-            controlPath: bootProfile.environment["ALAN_SHELL_CONTROL_DIR"] ?? existing?.controlPath,
-            socketPath: bootProfile.environment["ALAN_SHELL_SOCKET"] ?? existing?.socketPath,
-            alanBindingFile: bootProfile.environment["ALAN_SHELL_BINDING_FILE"]
-                ?? existing?.alanBindingFile,
-            launchCommand: bootProfile.launchCommandString,
-            launchStrategy: bootProfile.command.strategy.rawValue,
-            shellIntegrationSource: "ghostty_shell_integration",
-            processState: projectedProcessExited.map { $0 ? "exited" : "running" }
-                ?? existing?.processState,
-            rendererPhase: runtime?.renderer.phase.rawValue ?? existing?.rendererPhase,
-            rendererHealth: runtime?.surfaceState.rendererHealth
-                ?? runtime?.renderer.phase.rawValue
-                ?? existing?.rendererHealth,
-            surfaceReadiness: runtime.map { surfaceReadinessValue($0.surfaceState.readiness) }
-                ?? existing?.surfaceReadiness,
-            inputReady: runtime?.surfaceState.inputReady ?? existing?.inputReady,
-            readonly: runtime?.surfaceState.readonly ?? existing?.readonly,
-            terminalMode: runtime?.surfaceState.terminalMode.rawValue ?? existing?.terminalMode,
-            displayName: runtime?.displayName ?? existing?.displayName,
-            displayID: runtime?.displayID ?? existing?.displayID,
-            windowTitle: runtime?.attachedWindowTitle ?? existing?.windowTitle,
-            lastMetadataAt: lastMetadataAt.map(Self.iso8601Formatter.string) ?? existing?.lastMetadataAt,
-            lastCommandExitCode: lastCommandExitCode ?? existing?.lastCommandExitCode
-        )
-    }
-
-    private func projectedAlanBinding(
-        for pane: ShellPane,
-        binding: ShellAlanBinding?,
-        processExited: Bool
-    ) -> ShellAlanBinding? {
-        if let binding {
-            return binding
-        }
-
-        if let existing = pane.alanBinding {
-            return existing
-        }
-
-        guard pane.resolvedLaunchTarget == .alan, !processExited else {
-            return nil
-        }
-
-        return ShellAlanBinding(
-            sessionID: "pending:\(pane.paneID)",
-            runStatus: "booting",
-            pendingYield: false,
-            source: "alan_shell_boot_projection",
-            lastProjectedAt: Self.iso8601Formatter.string(from: .now)
-        )
-    }
-
-    private func workingDirectoryName(for path: String?) -> String? {
-        guard let path, !path.isEmpty else { return nil }
-        let lastComponent = URL(fileURLWithPath: path).lastPathComponent
-        return lastComponent.isEmpty ? path : lastComponent
-    }
-
-    private func repositoryContext(for workingDirectory: String?) -> (repositoryRoot: String?, gitBranch: String?) {
-        guard let workingDirectory, !workingDirectory.isEmpty else {
-            return (nil, nil)
-        }
-
-        var currentURL = URL(fileURLWithPath: workingDirectory, isDirectory: true).standardizedFileURL
-        var isDirectory: ObjCBool = false
-
-        if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) {
-            return (nil, nil)
-        }
-
-        if !isDirectory.boolValue {
-            currentURL.deleteLastPathComponent()
-        }
-
-        while true {
-            let gitEntryURL = currentURL.appendingPathComponent(".git")
-            if fileManager.fileExists(atPath: gitEntryURL.path) {
-                let gitDirectoryURL = resolveGitDirectory(for: gitEntryURL, repositoryRoot: currentURL)
-                let gitBranch = gitDirectoryURL.flatMap(readGitBranch(from:))
-                return (currentURL.path, gitBranch)
-            }
-
-            let parentURL = currentURL.deletingLastPathComponent()
-            if parentURL.path == currentURL.path {
-                return (nil, nil)
-            }
-            currentURL = parentURL
-        }
-    }
-
-    private func resolveGitDirectory(for gitEntryURL: URL, repositoryRoot: URL) -> URL? {
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: gitEntryURL.path, isDirectory: &isDirectory) else {
-            return nil
-        }
-
-        if isDirectory.boolValue {
-            return gitEntryURL
-        }
-
-        guard let content = try? String(contentsOf: gitEntryURL, encoding: .utf8) else {
-            return nil
-        }
-
-        let prefix = "gitdir:"
-        guard content.hasPrefix(prefix) else { return nil }
-        let rawPath = content.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !rawPath.isEmpty else { return nil }
-
-        let pathURL = URL(fileURLWithPath: rawPath, relativeTo: repositoryRoot)
-        return pathURL.standardizedFileURL
-    }
-
-    private func readGitBranch(from gitDirectoryURL: URL) -> String? {
-        let headURL = gitDirectoryURL.appendingPathComponent("HEAD")
-        guard let head = try? String(contentsOf: headURL, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !head.isEmpty
-        else {
-            return nil
-        }
-
-        let refPrefix = "ref: "
-        if head.hasPrefix(refPrefix) {
-            let reference = String(head.dropFirst(refPrefix.count))
-            return reference.split(separator: "/").last.map(String.init)
-        }
-
-        return "detached:\(String(head.prefix(12)))"
     }
 
     private func strongestAttention(in panes: [ShellPane]) -> ShellAttentionState {
@@ -1853,95 +1610,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     errorMessage: "events.read is handled by the shell control plane."
                 )
         }
-    }
-
-    static func defaultPersistenceURL(windowID: String, fileManager: FileManager) -> URL {
-        let sanitizedWindowID = windowID
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: ":", with: "_")
-        return persistenceDirectory(fileManager: fileManager)
-            .appendingPathComponent("\(persistenceFilePrefix)\(sanitizedWindowID)\(persistenceFileExtension)")
-    }
-
-    private static func persistenceDirectory(fileManager: FileManager) -> URL {
-        let appSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? fileManager.temporaryDirectory
-        return appSupportURL.appendingPathComponent("AlanNative", isDirectory: true)
-    }
-
-    private static func restoredWindowContext(
-        fileManager: FileManager,
-        startupMode: StartupMode
-    ) -> ShellWindowContext? {
-        guard startupMode == .restorePrevious else { return nil }
-
-        let directory = persistenceDirectory(fileManager: fileManager)
-        guard let urls = try? fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return nil
-        }
-
-        let candidates = urls.compactMap { url -> (Date, ShellWindowContext)? in
-            guard isShellStatePersistenceURL(url),
-                  let state = restoreShellState(fileManager: fileManager, persistenceURL: url)
-            else {
-                return nil
-            }
-
-            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
-            let modifiedAt = values?.contentModificationDate ?? .distantPast
-            return (
-                modifiedAt,
-                ShellWindowContext(
-                    windowID: state.windowID,
-                    persistenceURL: url,
-                    terminalRuntimeRegistry: TerminalRuntimeRegistry()
-                )
-            )
-        }
-
-        return candidates.max { lhs, rhs in lhs.0 < rhs.0 }?.1
-    }
-
-    private static func defaultWindowContext(
-        fileManager: FileManager,
-        startupMode: StartupMode
-    ) -> ShellWindowContext {
-        switch startupMode {
-        case .fresh:
-            return ShellWindowContext.make(fileManager: fileManager)
-        case .restorePrevious:
-            return ShellWindowContext.make(
-                fileManager: fileManager,
-                windowID: defaultRestorationWindowID
-            )
-        }
-    }
-
-    private static func isShellStatePersistenceURL(_ url: URL) -> Bool {
-        let fileName = url.lastPathComponent
-        return fileName.hasPrefix(persistenceFilePrefix)
-            && fileName.hasSuffix(persistenceFileExtension)
-            && fileName != "shell-state-v0.1.json"
-    }
-
-    private static func restoreShellState(
-        fileManager: FileManager,
-        persistenceURL: URL
-    ) -> ShellStateSnapshot? {
-        guard fileManager.fileExists(atPath: persistenceURL.path),
-              let data = try? Data(contentsOf: persistenceURL),
-              let state = try? JSONDecoder().decode(ShellStateSnapshot.self, from: data),
-              !state.spaces.isEmpty,
-              !state.panes.isEmpty
-        else {
-            return nil
-        }
-        return state
     }
 
     private static func attentionRank(for attention: ShellAttentionState) -> Int {

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -30,6 +30,8 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 - `Models/Console/`: legacy/mobile console value types
 - `Models/Shell/`: shell command enums, launch targets, snapshots, and shell mutation helpers
 - `Services/Daemon/`: daemon HTTP client, event page reader, and console event reducer ownership
+- `Services/Shell/`: shell projection, persistence, and controller support
+  services that keep runtime metadata and storage out of the observable host
 - `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces
 - `ShellModel.swift` / `ShellHostController.swift`: current shell state and controller
 - `ShellControlPlane.swift`: current file/socket shell control plane

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -16,6 +16,8 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellControlPlane.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPaneProjectionService.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellStatePersistenceStore.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalSurfaceController.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalRuntimeService.swift" \

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -30,7 +30,7 @@
 
 - [x] 5.1 Split pure shell enum/value types, pane/tree/tab/space snapshots, obsolete legacy decoding removal, bootstrap defaults, and mutation helpers out of the current monolithic `ShellModel.swift`.
 - [x] 5.2 Keep shell mutation behavior covered by the existing focused shell model script tests after each split.
-- [ ] 5.3 Review `ShellHostController` for controller/store/service boundaries and move persistence, boot-profile projection, attention projection, and runtime update projection where they have clear owners.
+- [x] 5.3 Review `ShellHostController` for controller/store/service boundaries and move persistence, boot-profile projection, attention projection, and runtime update projection where they have clear owners.
 - [x] 5.4 Preserve `ShellWorkspaceCommand` as the shared command vocabulary used by menu, command palette, keyboard, and control-plane paths.
 
 ## 6. Terminal Host And Runtime Service Boundaries


### PR DESCRIPTION
## Summary
- Extract shell pane runtime/context/attention projection from ShellHostController into Services/Shell/ShellPaneProjectionService
- Extract shell state save/restore and restored-window lookup into Services/Shell/ShellStatePersistenceStore
- Update Xcode project membership, Apple architecture docs, README layout, and focused runtime metadata script inputs
- Mark OpenSpec task 5.3 complete

## Stack
- Base PR: #373

## Validation
- bash clients/apple/scripts/check-architecture-maintainability.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

## Review Focus
- This is intended to be behavior-preserving: ShellHostController still receives runtime updates and applies shell state changes, while projection and persistence are now explicit service owners.