### PR TITLE
Extract terminal runtime reporting

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -28,9 +28,11 @@ Xcode target.
 | `Views/Shell/ShellWorkspaceView.swift` | 46 | SwiftUI; macOS gates | Shell workspace composition and space keyboard shortcuts | `Views/Shell/` |
 | `Views/Shell/ShellCommandTabView.swift` | 621 | SwiftUI; macOS gates | Command palette search, routing, attention, and action presentation | `Views/Shell/` |
 | `TerminalPaneView.swift` | 1002 | SwiftUI; macOS gates | Split-tree and pane leaf rendering | `Views/Shell/Terminal/` |
-| `TerminalHostView.swift` | 1447 | AppKit, SwiftUI, QuartzCore, GhosttyKit; macOS gates | AppKit terminal host bridge, focus, input routing, overlays, runtime attachment | `Views/Shell/Terminal/` plus terminal collaborators |
+| `TerminalHostView.swift` | 1376 | AppKit, SwiftUI, QuartzCore, GhosttyKit; macOS gates | AppKit terminal host bridge, focus, overlay composition, runtime attachment, and collaborator wiring | `Views/Shell/Terminal/` plus terminal collaborators |
 | `GhosttyLiveHost.swift` | 896 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Ghostty canvas bridge and wakeup/occlusion integration | `Services/Terminal/` or `Support/TerminalBridge/` |
 | `TerminalHostRuntime.swift` | 636 | Foundation; macOS gates | Terminal host runtime protocols and fallback runtime state | `Services/Terminal/` |
+| `Services/Terminal/TerminalHostRuntimeReporter.swift` | 47 | Foundation; macOS gates | Runtime snapshot deduplication and main-queue publication for terminal host updates | `Services/Terminal/` |
+| `Services/Terminal/TerminalHostWindowObserver.swift` | 55 | AppKit; macOS gates | Terminal host window key, screen, and occlusion notification ownership | `Services/Terminal/` |
 | `TerminalRuntimeRegistry.swift` | 194 | SwiftUI, AppKit; macOS gates | Pane-keyed terminal host/runtime registry | `Services/Terminal/` |
 | `TerminalRuntimeService.swift` | 1054 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Window-scoped terminal runtime service and Ghostty bootstrap | `Services/Terminal/` |
 | `TerminalSurfaceController.swift` | 1424 | Foundation, AppKit, GhosttyKit; macOS/Ghostty gates | Terminal input, pointer, scrollback, search, and surface adapters | `Services/Terminal/` |

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		000000000000000000000024 /* ShellStateMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000124 /* ShellStateMutations.swift */; };
 		000000000000000000000025 /* ShellPaneProjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000125 /* ShellPaneProjectionService.swift */; };
 		000000000000000000000026 /* ShellStatePersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000126 /* ShellStatePersistenceStore.swift */; };
+		000000000000000000000027 /* TerminalHostRuntimeReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000127 /* TerminalHostRuntimeReporter.swift */; };
+		000000000000000000000028 /* TerminalHostWindowObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000128 /* TerminalHostWindowObserver.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -87,6 +89,8 @@
 		000000000000000000000124 /* ShellStateMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellStateMutations.swift; sourceTree = "<group>"; };
 		000000000000000000000125 /* ShellPaneProjectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPaneProjectionService.swift; sourceTree = "<group>"; };
 		000000000000000000000126 /* ShellStatePersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellStatePersistenceStore.swift; sourceTree = "<group>"; };
+		000000000000000000000127 /* TerminalHostRuntimeReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostRuntimeReporter.swift; sourceTree = "<group>"; };
+		000000000000000000000128 /* TerminalHostWindowObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostWindowObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +127,7 @@
 				00000000000000000000030B /* Models/Shell */,
 				00000000000000000000030A /* Services/Daemon */,
 				00000000000000000000030C /* Services/Shell */,
+				00000000000000000000030D /* Services/Terminal */,
 				000000000000000000000101 /* AlanNativeApp.swift */,
 				000000000000000000000112 /* AlanAppSingletonGuard.swift */,
 				000000000000000000000104 /* MacShellRootView.swift */,
@@ -224,6 +229,15 @@
 				000000000000000000000126 /* ShellStatePersistenceStore.swift */,
 			);
 			name = Services/Shell;
+			sourceTree = "<group>";
+		};
+		00000000000000000000030D /* Services/Terminal */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000127 /* TerminalHostRuntimeReporter.swift */,
+				000000000000000000000128 /* TerminalHostWindowObserver.swift */,
+			);
+			name = Services/Terminal;
 			sourceTree = "<group>";
 		};
 		000000000000000000000303 /* Products */ = {
@@ -361,6 +375,8 @@
 				000000000000000000000024 /* ShellStateMutations.swift in Sources */,
 				000000000000000000000025 /* ShellPaneProjectionService.swift in Sources */,
 				000000000000000000000026 /* ShellStatePersistenceStore.swift in Sources */,
+				000000000000000000000027 /* TerminalHostRuntimeReporter.swift in Sources */,
+				000000000000000000000028 /* TerminalHostWindowObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Terminal/TerminalHostRuntimeReporter.swift
+++ b/clients/apple/AlanNative/Services/Terminal/TerminalHostRuntimeReporter.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+#if os(macOS)
+final class TerminalHostRuntimeReporter {
+    private var lastReportedRuntime: TerminalHostRuntimeSnapshot?
+
+    func publish(
+        _ snapshot: TerminalHostRuntimeSnapshot,
+        observer: @escaping (TerminalHostRuntimeSnapshot) -> Void
+    ) {
+        if let lastReportedRuntime,
+           Self.snapshotsEqualIgnoringTimestamp(lastReportedRuntime, snapshot)
+        {
+            return
+        }
+
+        lastReportedRuntime = snapshot
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let lastReportedRuntime = self.lastReportedRuntime,
+                  Self.snapshotsEqualIgnoringTimestamp(lastReportedRuntime, snapshot)
+            else {
+                return
+            }
+            observer(snapshot)
+        }
+    }
+
+    private static func snapshotsEqualIgnoringTimestamp(
+        _ lhs: TerminalHostRuntimeSnapshot,
+        _ rhs: TerminalHostRuntimeSnapshot
+    ) -> Bool {
+        lhs.stage == rhs.stage
+            && lhs.paneID == rhs.paneID
+            && lhs.tabID == rhs.tabID
+            && lhs.logicalSize == rhs.logicalSize
+            && lhs.backingSize == rhs.backingSize
+            && lhs.displayName == rhs.displayName
+            && lhs.displayID == rhs.displayID
+            && lhs.attachedWindowTitle == rhs.attachedWindowTitle
+            && lhs.isFocused == rhs.isFocused
+            && lhs.renderer == rhs.renderer
+            && lhs.paneMetadata == rhs.paneMetadata
+            && lhs.surfaceState.equalsIgnoringTimestamp(rhs.surfaceState)
+    }
+}
+#endif

--- a/clients/apple/AlanNative/Services/Terminal/TerminalHostWindowObserver.swift
+++ b/clients/apple/AlanNative/Services/Terminal/TerminalHostWindowObserver.swift
@@ -1,0 +1,55 @@
+#if os(macOS)
+import AppKit
+
+final class TerminalHostWindowObserver {
+    private var observers: [NSObjectProtocol] = []
+
+    func install(
+        for window: NSWindow?,
+        onRuntimeEnvironmentChange: @escaping () -> Void,
+        onSurfaceEnvironmentChange: @escaping () -> Void
+    ) {
+        remove()
+        guard let window else { return }
+
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { _ in
+                onRuntimeEnvironmentChange()
+            },
+            center.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: window,
+                queue: .main
+            ) { _ in
+                onRuntimeEnvironmentChange()
+            },
+            center.addObserver(
+                forName: NSWindow.didChangeScreenNotification,
+                object: window,
+                queue: .main
+            ) { _ in
+                onSurfaceEnvironmentChange()
+                onRuntimeEnvironmentChange()
+            },
+            center.addObserver(
+                forName: NSWindow.didChangeOcclusionStateNotification,
+                object: window,
+                queue: .main
+            ) { _ in
+                onSurfaceEnvironmentChange()
+                onRuntimeEnvironmentChange()
+            },
+        ]
+    }
+
+    func remove() {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+    }
+}
+#endif

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -60,6 +60,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private let footerLabel = NSTextField(wrappingLabelWithString: "")
     private let statusBadge = NSTextField(labelWithString: "")
     private let surfaceController = AlanTerminalSurfaceController()
+    private let runtimeReporter = TerminalHostRuntimeReporter()
+    private let windowObserver = TerminalHostWindowObserver()
 
     private var pane: ShellPane?
     private var bootProfile: AlanShellBootProfile?
@@ -68,11 +70,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var workspaceCommandHandler: ((ShellWorkspaceCommand) -> Void)?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
-    private var windowObservers: [NSObjectProtocol] = []
     private var rendererSnapshot: TerminalRendererSnapshot = .placeholder
     private var paneMetadata: TerminalPaneMetadataSnapshot = .placeholder
     private var lastReportedMetadata: TerminalPaneMetadataSnapshot?
-    private var lastReportedRuntime: TerminalHostRuntimeSnapshot?
     private var trackingArea: NSTrackingArea?
     private var markedText = NSMutableAttributedString()
     private var keyTextAccumulator: [String]?
@@ -359,51 +359,20 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func teardownRuntimeIfNeeded() {
         guard !hasTornDownRuntime else { return }
         hasTornDownRuntime = true
-        removeWindowObservers()
+        windowObserver.remove()
         surfaceController.detach()
     }
 
     private func installWindowObservers() {
-        removeWindowObservers()
-        guard let window else { return }
-        let center = NotificationCenter.default
-        windowObservers = [
-            center.addObserver(
-                forName: NSWindow.didBecomeKeyNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
+        windowObserver.install(
+            for: window,
+            onRuntimeEnvironmentChange: { [weak self] in
                 self?.publishRuntimeSnapshot()
             },
-            center.addObserver(
-                forName: NSWindow.didResignKeyNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
-                self?.publishRuntimeSnapshot()
-            },
-            center.addObserver(
-                forName: NSWindow.didChangeScreenNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
+            onSurfaceEnvironmentChange: { [weak self] in
                 self?.synchronizeLiveHost()
-                self?.publishRuntimeSnapshot()
-            },
-            center.addObserver(
-                forName: NSWindow.didChangeOcclusionStateNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
-                self?.synchronizeLiveHost()
-                self?.publishRuntimeSnapshot()
-            },
-        ]
-    }
-
-    private func removeWindowObservers() {
-        windowObservers.forEach(NotificationCenter.default.removeObserver)
-        windowObservers.removeAll()
+            }
+        )
     }
 
     private func publishRuntimeSnapshot() {
@@ -436,47 +405,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             surfaceState: surfaceController.surfaceStateSnapshot,
             lastUpdatedAt: .now
         )
-        reportRuntimeIfNeeded(snapshot, runtimeObserver: runtimeObserver)
-    }
-
-    private func reportRuntimeIfNeeded(
-        _ snapshot: TerminalHostRuntimeSnapshot,
-        runtimeObserver: @escaping (TerminalHostRuntimeSnapshot) -> Void
-    ) {
-        if let lastReportedRuntime,
-           runtimeSnapshotEqualsIgnoringTimestamp(lastReportedRuntime, snapshot)
-        {
-            return
-        }
-
-        lastReportedRuntime = snapshot
-        DispatchQueue.main.async { [weak self] in
-            guard let self,
-                  let lastReportedRuntime = self.lastReportedRuntime,
-                  self.runtimeSnapshotEqualsIgnoringTimestamp(lastReportedRuntime, snapshot)
-            else {
-                return
-            }
-            runtimeObserver(snapshot)
-        }
-    }
-
-    private func runtimeSnapshotEqualsIgnoringTimestamp(
-        _ lhs: TerminalHostRuntimeSnapshot,
-        _ rhs: TerminalHostRuntimeSnapshot
-    ) -> Bool {
-        lhs.stage == rhs.stage
-            && lhs.paneID == rhs.paneID
-            && lhs.tabID == rhs.tabID
-            && lhs.logicalSize == rhs.logicalSize
-            && lhs.backingSize == rhs.backingSize
-            && lhs.displayName == rhs.displayName
-            && lhs.displayID == rhs.displayID
-            && lhs.attachedWindowTitle == rhs.attachedWindowTitle
-            && lhs.isFocused == rhs.isFocused
-            && lhs.renderer == rhs.renderer
-            && lhs.paneMetadata == rhs.paneMetadata
-            && lhs.surfaceState.equalsIgnoringTimestamp(rhs.surfaceState)
+        runtimeReporter.publish(snapshot, observer: runtimeObserver)
     }
 
     private func synchronizeLiveHost() {

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -32,6 +32,8 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 - `Services/Daemon/`: daemon HTTP client, event page reader, and console event reducer ownership
 - `Services/Shell/`: shell projection, persistence, and controller support
   services that keep runtime metadata and storage out of the observable host
+- `Services/Terminal/`: terminal host runtime reporting, window observation,
+  and terminal runtime service collaborators
 - `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces
 - `ShellModel.swift` / `ShellHostController.swift`: current shell state and controller
 - `ShellControlPlane.swift`: current file/socket shell control plane

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -359,6 +359,26 @@ require_pattern \
     "terminal host key equivalents must give Alan workspace shortcuts priority over Ghostty bindings"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "private let runtimeReporter = TerminalHostRuntimeReporter\\(\\)" \
+    "terminal host runtime snapshot publication must be owned by a focused collaborator"
+
+require_pattern \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostRuntimeReporter.swift" \
+    "snapshotsEqualIgnoringTimestamp" \
+    "terminal runtime reporter must preserve timestamp-insensitive snapshot deduplication"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "private let windowObserver = TerminalHostWindowObserver\\(\\)" \
+    "terminal host window notifications must be owned by a focused collaborator"
+
+require_pattern \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostWindowObserver.swift" \
+    "NSWindow\\.didChangeOcclusionStateNotification" \
+    "terminal host window observer must keep occlusion changes connected to surface/runtime refresh"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "host\\.performShellWorkspaceCommand\\(command\\)" \
     "terminal workspace shortcut routing must enter the shared shell workspace command handler"

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -35,7 +35,7 @@
 
 ## 6. Terminal Host And Runtime Service Boundaries
 
-- [ ] 6.1 Split `TerminalHostView.swift` so `AlanTerminalHostNSView` remains the AppKit bridge while input routing, overlay presentation, window observation, runtime snapshot publication, and Ghostty attachment have explicit collaborators.
+- [x] 6.1 Split `TerminalHostView.swift` so `AlanTerminalHostNSView` remains the AppKit bridge while input routing, overlay presentation, window observation, runtime snapshot publication, and Ghostty attachment have explicit collaborators.
 - [ ] 6.2 Keep terminal-area event ownership routed through the AppKit terminal host and preserve the weak activation boundary during extraction.
 - [ ] 6.3 Keep terminal runtime identity service-backed and pane-keyed while moving files or collaborators.
 - [ ] 6.4 Run focused terminal surface/runtime scripts after terminal-host or runtime-service extractions.


### PR DESCRIPTION
## Summary
- Extract terminal runtime snapshot deduplication/publication into Services/Terminal/TerminalHostRuntimeReporter
- Extract terminal host window key/screen/occlusion notification ownership into Services/Terminal/TerminalHostWindowObserver
- Add shell contract checks for the new terminal host collaborators
- Update Xcode project membership, Apple architecture docs, README layout, and mark OpenSpec task 6.1 complete

## Stack
- Base PR: #374

## Validation
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-architecture-maintainability.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

## Review Focus
- Behavior-preserving extraction: AlanTerminalHostNSView still owns the AppKit bridge, while runtime snapshot publication and window observation now have explicit collaborators.