### PR TITLE
Preserve terminal event ownership

### DIFF
--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -515,6 +515,11 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
+    "override func scrollWheel\\(with event: NSEvent\\)" \
+    "terminal scroll wheel events must remain owned by the AppKit terminal host"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
     "override func keyDown\\(with event: NSEvent\\)" \
     "terminal key events must remain owned by the AppKit terminal host"
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -500,6 +500,36 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
+    "override func mouseDown\\(with event: NSEvent\\)" \
+    "terminal pointer down events must remain owned by the AppKit terminal host"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "private func routePointer\\(_ input: AlanTerminalPointerInput\\)" \
+    "terminal pointer routing must stay behind the AppKit terminal host boundary"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "private func routeScrollWheel\\(_ event: NSEvent\\)" \
+    "terminal scroll routing must stay behind the AppKit terminal host boundary"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "override func keyDown\\(with event: NSEvent\\)" \
+    "terminal key events must remain owned by the AppKit terminal host"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "func insertText\\(_ string: Any, replacementRange: NSRange\\)" \
+    "terminal IME text insertion must remain owned by the AppKit terminal host"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "workspaceCommandHandler\\?\\(command\\)" \
+    "terminal workspace shortcuts must leave the AppKit host through the shared command callback"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
     "private let overlayCard = AlanTerminalPassiveOverlayView\\(\\)" \
     "passive terminal overlays must use a non-interactive overlay view"
 

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -36,7 +36,7 @@
 ## 6. Terminal Host And Runtime Service Boundaries
 
 - [x] 6.1 Split `TerminalHostView.swift` so `AlanTerminalHostNSView` remains the AppKit bridge while input routing, overlay presentation, window observation, runtime snapshot publication, and Ghostty attachment have explicit collaborators.
-- [ ] 6.2 Keep terminal-area event ownership routed through the AppKit terminal host and preserve the weak activation boundary during extraction.
+- [x] 6.2 Keep terminal-area event ownership routed through the AppKit terminal host and preserve the weak activation boundary during extraction.
 - [ ] 6.3 Keep terminal runtime identity service-backed and pane-keyed while moving files or collaborators.
 - [ ] 6.4 Run focused terminal surface/runtime scripts after terminal-host or runtime-service extractions.
 


### PR DESCRIPTION
## Summary
- Add shell contract checks that terminal pointer, scroll, key, IME, and workspace shortcut events stay owned by the AppKit terminal host
- Strengthen the weak activation delegate boundary contract during terminal-host extraction
- Mark OpenSpec task 6.2 complete

## Stack
- Base: main (after #375 merge)

## Validation
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json

## Review Focus
- This is a contract-only PR. It preserves the current event ownership boundary so later terminal-host extractions do not move terminal-area events back into SwiftUI wrappers or strong owner references.