### PR TITLE
Preserve terminal runtime identity

### DIFF
--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -99,6 +99,21 @@ require_pattern \
     "terminal runtime registry must delegate runtime authority to the service"
 
 require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
+    "runtimeService\\.surfaceHandle\\(for: paneID, bootProfile: bootProfile\\)" \
+    "terminal runtime registry must resolve service-owned handles by pane ID"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeService.swift" \
+    "private var handlesByPaneID: \\[String: AlanTerminalSurfaceHandle\\]" \
+    "terminal runtime service must keep runtime identity pane-keyed"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalRuntimeService.swift" \
+    "var registeredPaneIDs: Set<String>" \
+    "terminal runtime service must expose pane-keyed registration state"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalSurfaceController.swift" \
     "final class AlanTerminalSurfaceController" \
     "terminal surface behavior must be owned by a controller boundary"

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -15,10 +15,12 @@ struct TerminalRuntimeServiceTestRunner {
 private enum TerminalRuntimeServiceTests {
     static func run() {
         verifiesBootstrapReuseAndPaneHandleIdentity()
+        verifiesPaneScopedHandleIsolation()
         verifiesDeliveryAndMissingRuntimeResults()
         verifiesQueuedAndTimeoutDeliveryStates()
         verifiesControlResponseCarriesDeliveryDiagnostics()
         verifiesTeardownOnce()
+        verifiesFinalizePanesOnlyReleasesStaleHandles()
         verifiesBootstrapFailureDiagnostics()
         print("Terminal runtime service tests passed.")
     }
@@ -41,6 +43,28 @@ private enum TerminalRuntimeServiceTests {
         )
         secondWindow.ensureReady()
         expect(bootstrap.ensureCallCount == 1, "shared bootstrap must not reinitialize per window")
+    }
+
+    private static func verifiesPaneScopedHandleIsolation() {
+        let service = FakeAlanTerminalRuntimeService()
+        let first = service.surfaceHandle(for: "pane_1", bootProfile: nil)
+        let second = service.surfaceHandle(for: "pane_2", bootProfile: nil)
+
+        expect(first !== second, "different panes must receive distinct service-owned handles")
+        expect(first.paneID == "pane_1", "first handle must retain its pane identity")
+        expect(second.paneID == "pane_2", "second handle must retain its pane identity")
+        expect(
+            service.registeredPaneIDs == ["pane_1", "pane_2"],
+            "service must expose registered pane identities"
+        )
+        expect(
+            service.snapshot(for: "pane_1")?.paneID == "pane_1",
+            "snapshots must stay pane keyed"
+        )
+        expect(
+            service.snapshot(for: "pane_2")?.paneID == "pane_2",
+            "snapshots must stay pane keyed"
+        )
     }
 
     private static func verifiesDeliveryAndMissingRuntimeResults() {
@@ -115,6 +139,31 @@ private enum TerminalRuntimeServiceTests {
         expect(handle.teardownCount == 1, "first finalize must tear down exactly once")
         expect(service.finalizePane("pane_1") == .notStarted, "missing second finalize must be stable")
         expect(handle.teardownCount == 1, "second finalize must not repeat teardown")
+    }
+
+    private static func verifiesFinalizePanesOnlyReleasesStaleHandles() {
+        let service = FakeAlanTerminalRuntimeService()
+        let active = service.surfaceHandle(
+            for: "pane_active",
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+        let stale = service.surfaceHandle(
+            for: "pane_stale",
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+
+        service.finalizePanes(excluding: ["pane_active"])
+
+        expect(active.teardownCount == 0, "active pane handle must not be finalized")
+        expect(stale.teardownCount == 1, "stale pane handle must be finalized")
+        expect(
+            service.existingSurfaceHandle(for: "pane_active") === active,
+            "active pane handle must remain registered"
+        )
+        expect(
+            service.existingSurfaceHandle(for: "pane_stale") == nil,
+            "stale pane handle must be removed"
+        )
     }
 
     private static func verifiesBootstrapFailureDiagnostics() {

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -37,8 +37,8 @@
 
 - [x] 6.1 Split `TerminalHostView.swift` so `AlanTerminalHostNSView` remains the AppKit bridge while input routing, overlay presentation, window observation, runtime snapshot publication, and Ghostty attachment have explicit collaborators.
 - [x] 6.2 Keep terminal-area event ownership routed through the AppKit terminal host and preserve the weak activation boundary during extraction.
-- [ ] 6.3 Keep terminal runtime identity service-backed and pane-keyed while moving files or collaborators.
-- [ ] 6.4 Run focused terminal surface/runtime scripts after terminal-host or runtime-service extractions.
+- [x] 6.3 Keep terminal runtime identity service-backed and pane-keyed while moving files or collaborators.
+- [x] 6.4 Run focused terminal surface/runtime scripts after terminal-host or runtime-service extractions.
 
 ## 7. Control Plane And IPC Boundaries
 


### PR DESCRIPTION
## Summary
- tighten shell contracts so the terminal runtime registry resolves service-owned handles by pane ID
- add focused runtime-service coverage for pane-scoped handle isolation and stale-pane finalization
- mark OpenSpec tasks 6.3 and 6.4 complete

## Validation
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json

Review focus: please check whether the contract/test coverage makes terminal runtime identity clearly service-backed and pane-keyed without changing runtime behavior.