### PR TITLE
Extract shell control file poller

### DIFF
--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		00000000000000000000002A /* ShellLocalCommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012A /* ShellLocalCommandExecutor.swift */; };
 		00000000000000000000002B /* ShellSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012B /* ShellSocketServer.swift */; };
 		00000000000000000000002C /* ShellPublishedStateMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012C /* ShellPublishedStateMerger.swift */; };
+		00000000000000000000002D /* ShellControlFilePoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012D /* ShellControlFilePoller.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -99,6 +100,7 @@
 		00000000000000000000012A /* ShellLocalCommandExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellLocalCommandExecutor.swift; sourceTree = "<group>"; };
 		00000000000000000000012B /* ShellSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellSocketServer.swift; sourceTree = "<group>"; };
 		00000000000000000000012C /* ShellPublishedStateMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPublishedStateMerger.swift; sourceTree = "<group>"; };
+		00000000000000000000012D /* ShellControlFilePoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellControlFilePoller.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,6 +237,7 @@
 			isa = PBXGroup;
 			children = (
 				000000000000000000000125 /* ShellPaneProjectionService.swift */,
+				00000000000000000000012D /* ShellControlFilePoller.swift */,
 				00000000000000000000012A /* ShellLocalCommandExecutor.swift */,
 				00000000000000000000012C /* ShellPublishedStateMerger.swift */,
 				00000000000000000000012B /* ShellSocketServer.swift */,
@@ -393,6 +396,7 @@
 				00000000000000000000002A /* ShellLocalCommandExecutor.swift in Sources */,
 				00000000000000000000002B /* ShellSocketServer.swift in Sources */,
 				00000000000000000000002C /* ShellPublishedStateMerger.swift in Sources */,
+				00000000000000000000002D /* ShellControlFilePoller.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+final class AlanShellControlFilePoller {
+    private let windowID: String
+    private let fileManager: FileManager
+    private let commandsURL: URL
+    private let resultsURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let commandHandler: @MainActor (AlanShellControlCommand) -> AlanShellControlResponse
+    private let bindingProjectionHandler: @MainActor (String, ShellAlanBinding?) -> Void
+    private let diagnosticHandler: @MainActor (String) -> Void
+    private var pollSource: DispatchSourceTimer?
+    private var trackedPaneIDs: Set<String> = []
+    private var lastBindingPayloadByPaneID: [String: Data] = [:]
+
+    init(
+        windowID: String,
+        fileManager: FileManager,
+        commandsURL: URL,
+        resultsURL: URL,
+        encoder: JSONEncoder,
+        decoder: JSONDecoder,
+        commandHandler: @escaping @MainActor (AlanShellControlCommand) -> AlanShellControlResponse,
+        bindingProjectionHandler: @escaping @MainActor (String, ShellAlanBinding?) -> Void,
+        diagnosticHandler: @escaping @MainActor (String) -> Void
+    ) {
+        self.windowID = windowID
+        self.fileManager = fileManager
+        self.commandsURL = commandsURL
+        self.resultsURL = resultsURL
+        self.encoder = encoder
+        self.decoder = decoder
+        self.commandHandler = commandHandler
+        self.bindingProjectionHandler = bindingProjectionHandler
+        self.diagnosticHandler = diagnosticHandler
+    }
+
+    deinit {
+        pollSource?.cancel()
+    }
+
+    func start() {
+        stop()
+        let source = DispatchSource.makeTimerSource(queue: DispatchQueue(label: "dev.alan.shell.control.poll"))
+        source.schedule(deadline: .now() + .milliseconds(250), repeating: .milliseconds(250), leeway: .milliseconds(100))
+        source.setEventHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.pollCommands()
+                self?.pollBindings()
+            }
+        }
+        source.resume()
+        pollSource = source
+    }
+
+    func stop() {
+        pollSource?.cancel()
+        pollSource = nil
+    }
+
+    func updateTrackedPaneIDs(_ paneIDs: Set<String>) {
+        trackedPaneIDs = paneIDs
+        let stalePaneIDs = Set(lastBindingPayloadByPaneID.keys).subtracting(paneIDs)
+        for paneID in stalePaneIDs {
+            lastBindingPayloadByPaneID.removeValue(forKey: paneID)
+        }
+    }
+
+    private func pollCommands() {
+        ensurePollingDirectories()
+
+        let commandFiles: [URL]
+        do {
+            commandFiles = try fileManager.contentsOfDirectory(
+                at: commandsURL,
+                includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            )
+            .filter { $0.pathExtension == "json" }
+            .sorted(by: compareCommandFiles)
+        } catch {
+            diagnosticHandler("Failed to read shell command directory: \(error.localizedDescription)")
+            return
+        }
+
+        for fileURL in commandFiles {
+            handleCommandFile(at: fileURL)
+        }
+    }
+
+    private func ensurePollingDirectories() {
+        for url in [commandsURL, resultsURL] {
+            do {
+                try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+            } catch {
+                diagnosticHandler("Failed to create shell polling directory \(url.path): \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func handleCommandFile(at fileURL: URL) {
+        guard let data = try? Data(contentsOf: fileURL),
+              let command = try? decoder.decode(AlanShellControlCommand.self, from: data)
+        else {
+            diagnosticHandler("Ignored unreadable shell command file \(fileURL.lastPathComponent).")
+            do {
+                try fileManager.removeItem(at: fileURL)
+            } catch {
+                diagnosticHandler("Failed to remove unreadable shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
+            }
+            return
+        }
+
+        let response = commandHandler(command)
+        let responseURL = resultsURL.appendingPathComponent("\(command.requestID).json")
+
+        do {
+            let responseData = try encoder.encode(response)
+            try responseData.write(to: responseURL, options: .atomic)
+        } catch {
+            diagnosticHandler("Failed to write shell command result \(responseURL.lastPathComponent): \(error.localizedDescription)")
+        }
+
+        do {
+            try fileManager.removeItem(at: fileURL)
+        } catch {
+            diagnosticHandler("Failed to remove processed shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
+    private func compareCommandFiles(_ lhs: URL, _ rhs: URL) -> Bool {
+        let lhsValues = try? lhs.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
+        let rhsValues = try? rhs.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
+        let lhsDate = lhsValues?.creationDate ?? lhsValues?.contentModificationDate ?? .distantPast
+        let rhsDate = rhsValues?.creationDate ?? rhsValues?.contentModificationDate ?? .distantPast
+
+        if lhsDate != rhsDate {
+            return lhsDate < rhsDate
+        }
+
+        return lhs.lastPathComponent < rhs.lastPathComponent
+    }
+
+    private func pollBindings() {
+        for paneID in trackedPaneIDs.sorted() {
+            let bindingURL = alanShellBindingFileURL(
+                windowID: windowID,
+                paneID: paneID,
+                fileManager: fileManager
+            )
+
+            guard fileManager.fileExists(atPath: bindingURL.path) else {
+                if lastBindingPayloadByPaneID.removeValue(forKey: paneID) != nil {
+                    bindingProjectionHandler(paneID, nil)
+                }
+                continue
+            }
+
+            guard let data = try? Data(contentsOf: bindingURL) else {
+                diagnosticHandler("Failed to read Alan binding file for \(paneID).")
+                continue
+            }
+
+            if lastBindingPayloadByPaneID[paneID] == data {
+                continue
+            }
+
+            guard let projection = try? decoder.decode(AlanShellBindingProjection.self, from: data) else {
+                lastBindingPayloadByPaneID[paneID] = data
+                diagnosticHandler("Ignored invalid Alan binding file for \(paneID).")
+                continue
+            }
+
+            lastBindingPayloadByPaneID[paneID] = data
+            bindingProjectionHandler(paneID, projection.shellBinding)
+        }
+    }
+}
+#endif

--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -52,12 +52,10 @@ final class AlanShellControlPlane {
     private let eventsFileURL: URL
     private let commandHandler: (AlanShellControlCommand) -> AlanShellControlResponse
     private let stateAdoptionHandler: @MainActor (ShellStateSnapshot) -> Void
-    private let bindingProjectionHandler: @MainActor (String, ShellAlanBinding?) -> Void
     private let diagnosticHandler: @MainActor (String) -> Void
     private let socketServer: AlanShellSocketServer
-    private var pollSource: DispatchSourceTimer?
+    private var filePoller: AlanShellControlFilePoller?
     private var trackedPaneIDs: Set<String> = []
-    private var lastBindingPayloadByPaneID: [String: Data] = [:]
     private var events: [AlanShellEventEnvelope] = []
     private var nextEventOrdinal = 1
 
@@ -83,7 +81,6 @@ final class AlanShellControlPlane {
         self.eventsFileURL = rootURL.appendingPathComponent("events.jsonl")
         self.commandHandler = commandHandler
         self.stateAdoptionHandler = stateAdoptionHandler
-        self.bindingProjectionHandler = bindingProjectionHandler
         self.diagnosticHandler = diagnosticHandler
         self.socketServer = AlanShellSocketServer(
             socketURL: self.socketURL,
@@ -95,14 +92,28 @@ final class AlanShellControlPlane {
             },
             sideEffectHandler: { _ in }
         )
+        self.filePoller = nil
+        self.filePoller = AlanShellControlFilePoller(
+            windowID: windowID,
+            fileManager: fileManager,
+            commandsURL: commandsURL,
+            resultsURL: resultsURL,
+            encoder: encoder,
+            decoder: decoder,
+            commandHandler: { [weak self, commandHandler] command in
+                guard let self else { return commandHandler(command) }
+                return self.responseForPolledCommand(command)
+            },
+            bindingProjectionHandler: bindingProjectionHandler,
+            diagnosticHandler: diagnosticHandler
+        )
 
         ensureDirectories()
         socketServer.start()
-        startPolling()
+        filePoller?.start()
     }
 
     deinit {
-        pollSource?.cancel()
         socketServer.stop()
     }
 
@@ -138,20 +149,6 @@ final class AlanShellControlPlane {
         } catch {
             recordDiagnostic("Failed to persist shell state: \(error.localizedDescription)")
         }
-    }
-
-    private func startPolling() {
-        pollSource?.cancel()
-        let source = DispatchSource.makeTimerSource(queue: DispatchQueue(label: "dev.alan.shell.control.poll"))
-        source.schedule(deadline: .now() + .milliseconds(250), repeating: .milliseconds(250), leeway: .milliseconds(100))
-        source.setEventHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.pollCommands()
-                self?.pollBindings()
-            }
-        }
-        source.resume()
-        pollSource = source
     }
 
     private func ensureDirectories() {
@@ -196,6 +193,14 @@ final class AlanShellControlPlane {
         )
     }
 
+    private func responseForPolledCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        specialCommandResponse(for: command)
+            ?? socketServer.handleLocally(command)
+            ?? commandHandler(command)
+    }
+
     func recordTextDelivery(
         requestID: String,
         spaceID: String?,
@@ -231,6 +236,7 @@ final class AlanShellControlPlane {
         let paneIDs = Set(state.panes.map(\.paneID))
         let previousPaneIDs = trackedPaneIDs
         trackedPaneIDs = paneIDs
+        filePoller?.updateTrackedPaneIDs(paneIDs)
 
         for paneID in paneIDs {
             let paneURL = alanShellPaneSupportDirectoryURL(
@@ -243,11 +249,6 @@ final class AlanShellControlPlane {
             } catch {
                 recordDiagnostic("Failed to create pane support directory \(paneURL.path): \(error.localizedDescription)")
             }
-        }
-
-        let stalePaneIDs = Set(lastBindingPayloadByPaneID.keys).subtracting(paneIDs)
-        for paneID in stalePaneIDs {
-            lastBindingPayloadByPaneID.removeValue(forKey: paneID)
         }
 
         for paneID in previousPaneIDs.subtracting(paneIDs) {
@@ -481,109 +482,6 @@ final class AlanShellControlPlane {
         let slice = events.dropFirst(startIndex)
         let capped = limit.map { max(0, $0) } ?? 50
         return Array(slice.prefix(capped))
-    }
-
-    private func pollCommands() {
-        ensureDirectories()
-
-        let commandFiles: [URL]
-        do {
-            commandFiles = try fileManager.contentsOfDirectory(
-                at: commandsURL,
-                includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
-                options: [.skipsHiddenFiles]
-            )
-            .filter { $0.pathExtension == "json" }
-            .sorted(by: compareCommandFiles)
-        } catch {
-            recordDiagnostic("Failed to read shell command directory: \(error.localizedDescription)")
-            return
-        }
-
-        for fileURL in commandFiles {
-            handleCommandFile(at: fileURL)
-        }
-    }
-
-    private func handleCommandFile(at fileURL: URL) {
-        guard let data = try? Data(contentsOf: fileURL),
-              let command = try? decoder.decode(AlanShellControlCommand.self, from: data)
-        else {
-            recordDiagnostic("Ignored unreadable shell command file \(fileURL.lastPathComponent).")
-            do {
-                try fileManager.removeItem(at: fileURL)
-            } catch {
-                recordDiagnostic("Failed to remove unreadable shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
-            }
-            return
-        }
-
-        let response =
-            specialCommandResponse(for: command)
-            ?? socketServer.handleLocally(command)
-            ?? commandHandler(command)
-        let responseURL = resultsURL.appendingPathComponent("\(command.requestID).json")
-
-        do {
-            let responseData = try encoder.encode(response)
-            try responseData.write(to: responseURL, options: .atomic)
-        } catch {
-            recordDiagnostic("Failed to write shell command result \(responseURL.lastPathComponent): \(error.localizedDescription)")
-        }
-
-        do {
-            try fileManager.removeItem(at: fileURL)
-        } catch {
-            recordDiagnostic("Failed to remove processed shell command file \(fileURL.lastPathComponent): \(error.localizedDescription)")
-        }
-    }
-
-    private func compareCommandFiles(_ lhs: URL, _ rhs: URL) -> Bool {
-        let lhsValues = try? lhs.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
-        let rhsValues = try? rhs.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey])
-        let lhsDate = lhsValues?.creationDate ?? lhsValues?.contentModificationDate ?? .distantPast
-        let rhsDate = rhsValues?.creationDate ?? rhsValues?.contentModificationDate ?? .distantPast
-
-        if lhsDate != rhsDate {
-            return lhsDate < rhsDate
-        }
-
-        return lhs.lastPathComponent < rhs.lastPathComponent
-    }
-
-    private func pollBindings() {
-        for paneID in trackedPaneIDs.sorted() {
-            let bindingURL = alanShellBindingFileURL(
-                windowID: windowID,
-                paneID: paneID,
-                fileManager: fileManager
-            )
-
-            guard fileManager.fileExists(atPath: bindingURL.path) else {
-                if lastBindingPayloadByPaneID.removeValue(forKey: paneID) != nil {
-                    bindingProjectionHandler(paneID, nil)
-                }
-                continue
-            }
-
-            guard let data = try? Data(contentsOf: bindingURL) else {
-                recordDiagnostic("Failed to read Alan binding file for \(paneID).")
-                continue
-            }
-
-            if lastBindingPayloadByPaneID[paneID] == data {
-                continue
-            }
-
-            guard let projection = try? decoder.decode(AlanShellBindingProjection.self, from: data) else {
-                lastBindingPayloadByPaneID[paneID] = data
-                recordDiagnostic("Ignored invalid Alan binding file for \(paneID).")
-                continue
-            }
-
-            lastBindingPayloadByPaneID[paneID] = data
-            bindingProjectionHandler(paneID, projection.shellBinding)
-        }
     }
 }
 #endif

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -703,10 +703,15 @@ require_pattern \
     "enum AlanShellPublishedStateMerger" \
     "published state merging must live in a dedicated shell service owner"
 
+require_pattern \
+    "clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
+    "final class AlanShellControlFilePoller" \
+    "file-polling control plane must live in a dedicated shell service owner"
+
 reject_pattern \
     "clients/apple/AlanNative/ShellControlPlane.swift" \
-    "final class AlanShellSocketServer|SO_RCVTIMEO|SO_SNDTIMEO|maxRequestBytes|command_timeout|enum AlanShellPublishedStateMerger" \
-    "shell control-plane coordinator must not own socket transport bounds or state merging"
+    "final class AlanShellSocketServer|SO_RCVTIMEO|SO_SNDTIMEO|maxRequestBytes|command_timeout|enum AlanShellPublishedStateMerger|pollCommands\\(|pollBindings\\(|handleCommandFile\\(" \
+    "shell control-plane coordinator must not own socket transport bounds, state merging, or file polling"
 
 reject_pattern \
     "clients/apple/AlanNative" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \


### PR DESCRIPTION
## Summary
- move shell control command-file polling and Alan binding-file polling into Services/Shell/ShellControlFilePoller.swift
- keep ShellControlPlane focused on orchestration, published state, and event APIs
- update Xcode membership, focused Swift compile scripts, and shell contract guardrails

## Verification
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/check-architecture-maintainability.sh (completed with existing warnings)
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Review focus: please check that file-backed command/result handling and Alan binding projection are now reviewable independently from control-plane orchestration without changing their file formats or polling cadence.