### PR TITLE
Extract shell event store

### DIFF
--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		00000000000000000000002B /* ShellSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012B /* ShellSocketServer.swift */; };
 		00000000000000000000002C /* ShellPublishedStateMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012C /* ShellPublishedStateMerger.swift */; };
 		00000000000000000000002D /* ShellControlFilePoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012D /* ShellControlFilePoller.swift */; };
+		00000000000000000000002E /* ShellEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012E /* ShellEventStore.swift */; };
+		00000000000000000000002F /* ShellDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012F /* ShellDiagnostics.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -101,6 +103,8 @@
 		00000000000000000000012B /* ShellSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellSocketServer.swift; sourceTree = "<group>"; };
 		00000000000000000000012C /* ShellPublishedStateMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPublishedStateMerger.swift; sourceTree = "<group>"; };
 		00000000000000000000012D /* ShellControlFilePoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellControlFilePoller.swift; sourceTree = "<group>"; };
+		00000000000000000000012E /* ShellEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellEventStore.swift; sourceTree = "<group>"; };
+		00000000000000000000012F /* ShellDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellDiagnostics.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -238,6 +242,8 @@
 			children = (
 				000000000000000000000125 /* ShellPaneProjectionService.swift */,
 				00000000000000000000012D /* ShellControlFilePoller.swift */,
+				00000000000000000000012F /* ShellDiagnostics.swift */,
+				00000000000000000000012E /* ShellEventStore.swift */,
 				00000000000000000000012A /* ShellLocalCommandExecutor.swift */,
 				00000000000000000000012C /* ShellPublishedStateMerger.swift */,
 				00000000000000000000012B /* ShellSocketServer.swift */,
@@ -397,6 +403,8 @@
 				00000000000000000000002B /* ShellSocketServer.swift in Sources */,
 				00000000000000000000002C /* ShellPublishedStateMerger.swift in Sources */,
 				00000000000000000000002D /* ShellControlFilePoller.swift in Sources */,
+				00000000000000000000002E /* ShellEventStore.swift in Sources */,
+				00000000000000000000002F /* ShellDiagnostics.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+final class AlanShellDiagnostics {
+    private let handler: @MainActor (String) -> Void
+
+    init(handler: @escaping @MainActor (String) -> Void) {
+        self.handler = handler
+    }
+
+    func record(_ message: String) {
+        handler(message)
+    }
+}
+#endif

--- a/clients/apple/AlanNative/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellEventStore.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+final class AlanShellEventStore {
+    private let windowID: String
+    private let fileManager: FileManager
+    private let eventsFileURL: URL
+    private let encoder: JSONEncoder
+    private let diagnosticHandler: @MainActor (String) -> Void
+    private var events: [AlanShellEventEnvelope] = []
+    private var nextEventOrdinal = 1
+
+    init(
+        windowID: String,
+        fileManager: FileManager,
+        eventsFileURL: URL,
+        encoder: JSONEncoder,
+        diagnosticHandler: @escaping @MainActor (String) -> Void
+    ) {
+        self.windowID = windowID
+        self.fileManager = fileManager
+        self.eventsFileURL = eventsFileURL
+        self.encoder = encoder
+        self.diagnosticHandler = diagnosticHandler
+    }
+
+    var latestEventID: String? {
+        events.last?.eventID
+    }
+
+    func read(afterEventID: String?, limit: Int?) -> [AlanShellEventEnvelope] {
+        let startIndex: Int
+        if let afterEventID,
+           let index = events.firstIndex(where: { $0.eventID == afterEventID }) {
+            startIndex = events.index(after: index)
+        } else {
+            startIndex = 0
+        }
+
+        let slice = events.dropFirst(startIndex)
+        let capped = limit.map { max(0, $0) } ?? 50
+        return Array(slice.prefix(capped))
+    }
+
+    func recordTextDelivery(
+        requestID: String,
+        spaceID: String?,
+        tabID: String?,
+        paneID: String,
+        delivery: TerminalRuntimeDeliveryResult
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "request_id": .string(requestID),
+            "delivery_code": .string(delivery.code.rawValue),
+            "accepted_bytes": .number(Double(delivery.acceptedBytes))
+        ]
+        if let errorCode = delivery.errorCode {
+            payload["error_code"] = .string(errorCode)
+        }
+        if let errorMessage = delivery.errorMessage {
+            payload["error_message"] = .string(errorMessage)
+        }
+        if let runtimePhase = delivery.runtimePhase {
+            payload["runtime_phase"] = .string(runtimePhase)
+        }
+
+        append(
+            type: "pane.text_delivery",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            payload: payload
+        )
+    }
+
+    func recordChanges(from previousState: ShellStateSnapshot?, to currentState: ShellStateSnapshot) {
+        guard let previousState else { return }
+
+        let previousPanesByID = Dictionary(uniqueKeysWithValues: previousState.panes.map { ($0.paneID, $0) })
+        let currentPanesByID = Dictionary(uniqueKeysWithValues: currentState.panes.map { ($0.paneID, $0) })
+
+        if previousState.focusedPaneID != currentState.focusedPaneID {
+            append(
+                type: "focus.changed",
+                spaceID: currentState.focusedSpaceID,
+                tabID: currentState.focusedTabID,
+                paneID: currentState.focusedPaneID,
+                payload: [
+                    "previous_pane_id": .string(previousState.focusedPaneID ?? ""),
+                    "current_pane_id": .string(currentState.focusedPaneID ?? "")
+                ]
+            )
+        }
+
+        let previousTabs = Set(previousState.spaces.flatMap(\.tabs).map(\.tabID))
+        let currentTabs = Set(currentState.spaces.flatMap(\.tabs).map(\.tabID))
+        for createdTabID in currentTabs.subtracting(previousTabs).sorted() {
+            if let tab = currentState.tab(tabID: createdTabID),
+               let paneID = tab.paneTree.paneIDs.first,
+               let pane = currentPanesByID[paneID] {
+                append(
+                    type: "tab.created",
+                    spaceID: pane.spaceID,
+                    tabID: tab.tabID,
+                    paneID: paneID,
+                    payload: [
+                        "tab_id": .string(tab.tabID),
+                        "kind": .string(tab.kind.rawValue)
+                    ]
+                )
+            }
+        }
+        for closedTabID in previousTabs.subtracting(currentTabs).sorted() {
+            let pane = previousState.panes.first { $0.tabID == closedTabID }
+            append(
+                type: "tab.closed",
+                spaceID: pane?.spaceID,
+                tabID: closedTabID,
+                paneID: pane?.paneID,
+                payload: ["tab_id": .string(closedTabID)]
+            )
+        }
+
+        let allPaneIDs = Set(previousPanesByID.keys).union(currentPanesByID.keys)
+        for paneID in allPaneIDs.sorted() {
+            let previousPane = previousPanesByID[paneID]
+            let currentPane = currentPanesByID[paneID]
+
+            if let previousPane, let currentPane {
+                recordExistingPaneChanges(previousPane: previousPane, currentPane: currentPane)
+            } else if let currentPane {
+                append(
+                    type: "pane.created",
+                    spaceID: currentPane.spaceID,
+                    tabID: currentPane.tabID,
+                    paneID: currentPane.paneID,
+                    payload: [
+                        "pane_id": .string(currentPane.paneID),
+                        "tab_id": .string(currentPane.tabID)
+                    ]
+                )
+            } else if let previousPane {
+                append(
+                    type: "pane.closed",
+                    spaceID: previousPane.spaceID,
+                    tabID: previousPane.tabID,
+                    paneID: previousPane.paneID,
+                    payload: [
+                        "pane_id": .string(previousPane.paneID)
+                    ]
+                )
+            }
+        }
+    }
+
+    private func recordExistingPaneChanges(previousPane: ShellPane, currentPane: ShellPane) {
+        if previousPane.tabID != currentPane.tabID || previousPane.spaceID != currentPane.spaceID {
+            append(
+                type: "pane.moved",
+                spaceID: currentPane.spaceID,
+                tabID: currentPane.tabID,
+                paneID: currentPane.paneID,
+                payload: [
+                    "previous_space_id": .string(previousPane.spaceID),
+                    "current_space_id": .string(currentPane.spaceID),
+                    "previous_tab_id": .string(previousPane.tabID),
+                    "current_tab_id": .string(currentPane.tabID)
+                ]
+            )
+        }
+
+        let changedFields = changedMetadataFields(previousPane: previousPane, currentPane: currentPane)
+        if !changedFields.isEmpty {
+            append(
+                type: "pane.metadata_changed",
+                spaceID: currentPane.spaceID,
+                tabID: currentPane.tabID,
+                paneID: currentPane.paneID,
+                payload: [
+                    "changed_fields": .array(changedFields.map(AlanShellJSONValue.string))
+                ]
+            )
+        }
+
+        if previousPane.attention != currentPane.attention {
+            append(
+                type: "attention.changed",
+                spaceID: currentPane.spaceID,
+                tabID: currentPane.tabID,
+                paneID: currentPane.paneID,
+                payload: [
+                    "previous": .string(previousPane.attention.rawValue),
+                    "current": .string(currentPane.attention.rawValue)
+                ]
+            )
+        }
+
+        if previousPane.alanBinding != currentPane.alanBinding {
+            append(
+                type: "AlanBinding.changed",
+                spaceID: currentPane.spaceID,
+                tabID: currentPane.tabID,
+                paneID: currentPane.paneID,
+                payload: [
+                    "session_id": .string(currentPane.alanBinding?.sessionID ?? ""),
+                    "run_status": .string(currentPane.alanBinding?.runStatus ?? ""),
+                    "pending_yield": .bool(currentPane.alanBinding?.pendingYield ?? false)
+                ]
+            )
+        }
+    }
+
+    private func changedMetadataFields(
+        previousPane: ShellPane,
+        currentPane: ShellPane
+    ) -> [String] {
+        var changedFields: [String] = []
+        if previousPane.cwd != currentPane.cwd {
+            changedFields.append("cwd")
+        }
+        if previousPane.viewport?.title != currentPane.viewport?.title {
+            changedFields.append("viewport.title")
+        }
+        if previousPane.viewport?.summary != currentPane.viewport?.summary {
+            changedFields.append("viewport.summary")
+        }
+        if previousPane.context?.gitBranch != currentPane.context?.gitBranch {
+            changedFields.append("context.git_branch")
+        }
+        if previousPane.context?.lastCommandExitCode != currentPane.context?.lastCommandExitCode {
+            changedFields.append("context.last_command_exit_code")
+        }
+        if previousPane.context?.rendererPhase != currentPane.context?.rendererPhase {
+            changedFields.append("context.renderer_phase")
+        }
+        if previousPane.context?.displayName != currentPane.context?.displayName {
+            changedFields.append("context.display_name")
+        }
+        if previousPane.context?.displayID != currentPane.context?.displayID {
+            changedFields.append("context.display_id")
+        }
+        if previousPane.context?.windowTitle != currentPane.context?.windowTitle {
+            changedFields.append("context.window_title")
+        }
+        if previousPane.context?.socketPath != currentPane.context?.socketPath {
+            changedFields.append("context.socket_path")
+        }
+        if previousPane.context?.launchCommand != currentPane.context?.launchCommand {
+            changedFields.append("context.launch_command")
+        }
+        return changedFields
+    }
+
+    private func append(
+        type: String,
+        spaceID: String?,
+        tabID: String?,
+        paneID: String?,
+        payload: [String: AlanShellJSONValue]
+    ) {
+        let event = AlanShellEventEnvelope(
+            eventID: "ev_\(nextEventOrdinal)",
+            type: type,
+            timestamp: ISO8601DateFormatter().string(from: .now),
+            windowID: windowID,
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            payload: payload
+        )
+        nextEventOrdinal += 1
+        events.append(event)
+        if events.count > 200 {
+            events.removeFirst(events.count - 200)
+        }
+        persist(event)
+    }
+
+    private func persist(_ event: AlanShellEventEnvelope) {
+        if let data = try? encoder.encode(event),
+           let line = String(data: data, encoding: .utf8) {
+            do {
+                if fileManager.fileExists(atPath: eventsFileURL.path) {
+                    let handle = try FileHandle(forWritingTo: eventsFileURL)
+                    defer { try? handle.close() }
+                    _ = try handle.seekToEnd()
+                    try handle.write(contentsOf: Data("\(line)\n".utf8))
+                } else {
+                    try Data("\(line)\n".utf8).write(to: eventsFileURL, options: .atomic)
+                }
+            } catch {
+                diagnosticHandler("Failed to persist shell event log: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+#endif

--- a/clients/apple/AlanNative/ShellControlPlane.swift
+++ b/clients/apple/AlanNative/ShellControlPlane.swift
@@ -49,15 +49,13 @@ final class AlanShellControlPlane {
     private let commandsURL: URL
     private let resultsURL: URL
     private let stateFileURL: URL
-    private let eventsFileURL: URL
     private let commandHandler: (AlanShellControlCommand) -> AlanShellControlResponse
     private let stateAdoptionHandler: @MainActor (ShellStateSnapshot) -> Void
-    private let diagnosticHandler: @MainActor (String) -> Void
+    private let diagnostics: AlanShellDiagnostics
     private let socketServer: AlanShellSocketServer
+    private let eventStore: AlanShellEventStore
     private var filePoller: AlanShellControlFilePoller?
     private var trackedPaneIDs: Set<String> = []
-    private var events: [AlanShellEventEnvelope] = []
-    private var nextEventOrdinal = 1
 
     init(
         windowID: String,
@@ -78,10 +76,16 @@ final class AlanShellControlPlane {
         self.commandsURL = rootURL.appendingPathComponent("commands", isDirectory: true)
         self.resultsURL = rootURL.appendingPathComponent("results", isDirectory: true)
         self.stateFileURL = rootURL.appendingPathComponent("state.json")
-        self.eventsFileURL = rootURL.appendingPathComponent("events.jsonl")
         self.commandHandler = commandHandler
         self.stateAdoptionHandler = stateAdoptionHandler
-        self.diagnosticHandler = diagnosticHandler
+        self.diagnostics = AlanShellDiagnostics(handler: diagnosticHandler)
+        self.eventStore = AlanShellEventStore(
+            windowID: windowID,
+            fileManager: fileManager,
+            eventsFileURL: rootURL.appendingPathComponent("events.jsonl"),
+            encoder: encoder,
+            diagnosticHandler: diagnostics.record
+        )
         self.socketServer = AlanShellSocketServer(
             socketURL: self.socketURL,
             commandHandler: commandHandler,
@@ -105,7 +109,7 @@ final class AlanShellControlPlane {
                 return self.responseForPolledCommand(command)
             },
             bindingProjectionHandler: bindingProjectionHandler,
-            diagnosticHandler: diagnosticHandler
+            diagnosticHandler: diagnostics.record
         )
 
         ensureDirectories()
@@ -142,12 +146,12 @@ final class AlanShellControlPlane {
         let mergeResult = socketServer.mergePublishedState(state)
         let mergedState = mergeResult.merged
         synchronizePaneSupportDirectories(for: mergedState)
-        recordEvents(from: mergeResult.previous, to: mergedState)
+        eventStore.recordChanges(from: mergeResult.previous, to: mergedState)
         do {
             let data = try encoder.encode(mergedState)
             try data.write(to: stateFileURL, options: .atomic)
         } catch {
-            recordDiagnostic("Failed to persist shell state: \(error.localizedDescription)")
+            diagnostics.record("Failed to persist shell state: \(error.localizedDescription)")
         }
     }
 
@@ -156,18 +160,14 @@ final class AlanShellControlPlane {
             do {
                 try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
             } catch {
-                recordDiagnostic("Failed to create shell control directory \(url.path): \(error.localizedDescription)")
+                diagnostics.record("Failed to create shell control directory \(url.path): \(error.localizedDescription)")
             }
         }
     }
 
-    private func recordDiagnostic(_ message: String) {
-        diagnosticHandler(message)
-    }
-
     func specialCommandResponse(for command: AlanShellControlCommand) -> AlanShellControlResponse? {
         guard command.command == .eventsRead else { return nil }
-        let rows = readEvents(afterEventID: command.afterEventID, limit: command.limit)
+        let rows = eventStore.read(afterEventID: command.afterEventID, limit: command.limit)
         return AlanShellControlResponse(
             requestID: command.requestID,
             contractVersion: "0.1",
@@ -187,7 +187,7 @@ final class AlanShellControlPlane {
             acceptedBytes: nil,
             deliveryCode: nil,
             runtimePhase: nil,
-            latestEventID: events.last?.eventID,
+            latestEventID: eventStore.latestEventID,
             errorCode: nil,
             errorMessage: nil
         )
@@ -208,27 +208,12 @@ final class AlanShellControlPlane {
         paneID: String,
         delivery: TerminalRuntimeDeliveryResult
     ) {
-        var payload: [String: AlanShellJSONValue] = [
-            "request_id": .string(requestID),
-            "delivery_code": .string(delivery.code.rawValue),
-            "accepted_bytes": .number(Double(delivery.acceptedBytes))
-        ]
-        if let errorCode = delivery.errorCode {
-            payload["error_code"] = .string(errorCode)
-        }
-        if let errorMessage = delivery.errorMessage {
-            payload["error_message"] = .string(errorMessage)
-        }
-        if let runtimePhase = delivery.runtimePhase {
-            payload["runtime_phase"] = .string(runtimePhase)
-        }
-
-        appendEvent(
-            type: "pane.text_delivery",
+        eventStore.recordTextDelivery(
+            requestID: requestID,
             spaceID: spaceID,
             tabID: tabID,
             paneID: paneID,
-            payload: payload
+            delivery: delivery
         )
     }
 
@@ -247,7 +232,7 @@ final class AlanShellControlPlane {
             do {
                 try fileManager.createDirectory(at: paneURL, withIntermediateDirectories: true)
             } catch {
-                recordDiagnostic("Failed to create pane support directory \(paneURL.path): \(error.localizedDescription)")
+                diagnostics.record("Failed to create pane support directory \(paneURL.path): \(error.localizedDescription)")
             }
         }
 
@@ -260,228 +245,9 @@ final class AlanShellControlPlane {
             do {
                 try fileManager.removeItem(at: paneURL)
             } catch {
-                recordDiagnostic("Failed to remove stale pane support directory \(paneURL.path): \(error.localizedDescription)")
+                diagnostics.record("Failed to remove stale pane support directory \(paneURL.path): \(error.localizedDescription)")
             }
         }
-    }
-
-    private func recordEvents(from previousState: ShellStateSnapshot?, to currentState: ShellStateSnapshot) {
-        guard let previousState else { return }
-
-        let previousPanesByID = Dictionary(uniqueKeysWithValues: previousState.panes.map { ($0.paneID, $0) })
-        let currentPanesByID = Dictionary(uniqueKeysWithValues: currentState.panes.map { ($0.paneID, $0) })
-
-        if previousState.focusedPaneID != currentState.focusedPaneID {
-            appendEvent(
-                type: "focus.changed",
-                spaceID: currentState.focusedSpaceID,
-                tabID: currentState.focusedTabID,
-                paneID: currentState.focusedPaneID,
-                payload: [
-                    "previous_pane_id": .string(previousState.focusedPaneID ?? ""),
-                    "current_pane_id": .string(currentState.focusedPaneID ?? "")
-                ]
-            )
-        }
-
-        let previousTabs = Set(previousState.spaces.flatMap(\.tabs).map(\.tabID))
-        let currentTabs = Set(currentState.spaces.flatMap(\.tabs).map(\.tabID))
-        for createdTabID in currentTabs.subtracting(previousTabs).sorted() {
-            if let tab = currentState.tab(tabID: createdTabID),
-               let paneID = tab.paneTree.paneIDs.first,
-               let pane = currentPanesByID[paneID] {
-                appendEvent(
-                    type: "tab.created",
-                    spaceID: pane.spaceID,
-                    tabID: tab.tabID,
-                    paneID: paneID,
-                    payload: [
-                        "tab_id": .string(tab.tabID),
-                        "kind": .string(tab.kind.rawValue)
-                    ]
-                )
-            }
-        }
-        for closedTabID in previousTabs.subtracting(currentTabs).sorted() {
-            let pane = previousState.panes.first { $0.tabID == closedTabID }
-            appendEvent(
-                type: "tab.closed",
-                spaceID: pane?.spaceID,
-                tabID: closedTabID,
-                paneID: pane?.paneID,
-                payload: ["tab_id": .string(closedTabID)]
-            )
-        }
-
-        let allPaneIDs = Set(previousPanesByID.keys).union(currentPanesByID.keys)
-        for paneID in allPaneIDs.sorted() {
-            let previousPane = previousPanesByID[paneID]
-            let currentPane = currentPanesByID[paneID]
-
-            if let previousPane, let currentPane {
-                if previousPane.tabID != currentPane.tabID || previousPane.spaceID != currentPane.spaceID {
-                    appendEvent(
-                        type: "pane.moved",
-                        spaceID: currentPane.spaceID,
-                        tabID: currentPane.tabID,
-                        paneID: currentPane.paneID,
-                        payload: [
-                            "previous_space_id": .string(previousPane.spaceID),
-                            "current_space_id": .string(currentPane.spaceID),
-                            "previous_tab_id": .string(previousPane.tabID),
-                            "current_tab_id": .string(currentPane.tabID)
-                        ]
-                    )
-                }
-
-                var changedFields: [String] = []
-                if previousPane.cwd != currentPane.cwd {
-                    changedFields.append("cwd")
-                }
-                if previousPane.viewport?.title != currentPane.viewport?.title {
-                    changedFields.append("viewport.title")
-                }
-                if previousPane.viewport?.summary != currentPane.viewport?.summary {
-                    changedFields.append("viewport.summary")
-                }
-                if previousPane.context?.gitBranch != currentPane.context?.gitBranch {
-                    changedFields.append("context.git_branch")
-                }
-                if previousPane.context?.lastCommandExitCode != currentPane.context?.lastCommandExitCode {
-                    changedFields.append("context.last_command_exit_code")
-                }
-                if previousPane.context?.rendererPhase != currentPane.context?.rendererPhase {
-                    changedFields.append("context.renderer_phase")
-                }
-                if previousPane.context?.displayName != currentPane.context?.displayName {
-                    changedFields.append("context.display_name")
-                }
-                if previousPane.context?.displayID != currentPane.context?.displayID {
-                    changedFields.append("context.display_id")
-                }
-                if previousPane.context?.windowTitle != currentPane.context?.windowTitle {
-                    changedFields.append("context.window_title")
-                }
-                if previousPane.context?.socketPath != currentPane.context?.socketPath {
-                    changedFields.append("context.socket_path")
-                }
-                if previousPane.context?.launchCommand != currentPane.context?.launchCommand {
-                    changedFields.append("context.launch_command")
-                }
-                if !changedFields.isEmpty {
-                    appendEvent(
-                        type: "pane.metadata_changed",
-                        spaceID: currentPane.spaceID,
-                        tabID: currentPane.tabID,
-                        paneID: currentPane.paneID,
-                        payload: [
-                            "changed_fields": .array(changedFields.map(AlanShellJSONValue.string))
-                        ]
-                    )
-                }
-
-                if previousPane.attention != currentPane.attention {
-                    appendEvent(
-                        type: "attention.changed",
-                        spaceID: currentPane.spaceID,
-                        tabID: currentPane.tabID,
-                        paneID: currentPane.paneID,
-                        payload: [
-                            "previous": .string(previousPane.attention.rawValue),
-                            "current": .string(currentPane.attention.rawValue)
-                        ]
-                    )
-                }
-
-                if previousPane.alanBinding != currentPane.alanBinding {
-                    appendEvent(
-                        type: "AlanBinding.changed",
-                        spaceID: currentPane.spaceID,
-                        tabID: currentPane.tabID,
-                        paneID: currentPane.paneID,
-                        payload: [
-                            "session_id": .string(currentPane.alanBinding?.sessionID ?? ""),
-                            "run_status": .string(currentPane.alanBinding?.runStatus ?? ""),
-                            "pending_yield": .bool(currentPane.alanBinding?.pendingYield ?? false)
-                        ]
-                    )
-                }
-            } else if let currentPane {
-                appendEvent(
-                    type: "pane.created",
-                    spaceID: currentPane.spaceID,
-                    tabID: currentPane.tabID,
-                    paneID: currentPane.paneID,
-                    payload: [
-                        "pane_id": .string(currentPane.paneID),
-                        "tab_id": .string(currentPane.tabID)
-                    ]
-                )
-            } else if let previousPane {
-                appendEvent(
-                    type: "pane.closed",
-                    spaceID: previousPane.spaceID,
-                    tabID: previousPane.tabID,
-                    paneID: previousPane.paneID,
-                    payload: [
-                        "pane_id": .string(previousPane.paneID)
-                    ]
-                )
-            }
-        }
-    }
-
-    private func appendEvent(
-        type: String,
-        spaceID: String?,
-        tabID: String?,
-        paneID: String?,
-        payload: [String: AlanShellJSONValue]
-    ) {
-        let event = AlanShellEventEnvelope(
-            eventID: "ev_\(nextEventOrdinal)",
-            type: type,
-            timestamp: ISO8601DateFormatter().string(from: .now),
-            windowID: windowID,
-            spaceID: spaceID,
-            tabID: tabID,
-            paneID: paneID,
-            payload: payload
-        )
-        nextEventOrdinal += 1
-        events.append(event)
-        if events.count > 200 {
-            events.removeFirst(events.count - 200)
-        }
-        if let data = try? encoder.encode(event),
-           let line = String(data: data, encoding: .utf8) {
-            do {
-                if fileManager.fileExists(atPath: eventsFileURL.path) {
-                    let handle = try FileHandle(forWritingTo: eventsFileURL)
-                    defer { try? handle.close() }
-                    _ = try handle.seekToEnd()
-                    try handle.write(contentsOf: Data("\(line)\n".utf8))
-                } else {
-                    try Data("\(line)\n".utf8).write(to: eventsFileURL, options: .atomic)
-                }
-            } catch {
-                recordDiagnostic("Failed to persist shell event log: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    private func readEvents(afterEventID: String?, limit: Int?) -> [AlanShellEventEnvelope] {
-        let startIndex: Int
-        if let afterEventID,
-           let index = events.firstIndex(where: { $0.eventID == afterEventID }) {
-            startIndex = events.index(after: index)
-        } else {
-            startIndex = 0
-        }
-
-        let slice = events.dropFirst(startIndex)
-        let capped = limit.map { max(0, $0) } ?? 50
-        return Array(slice.prefix(capped))
     }
 }
 #endif

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -708,10 +708,20 @@ require_pattern \
     "final class AlanShellControlFilePoller" \
     "file-polling control plane must live in a dedicated shell service owner"
 
+require_pattern \
+    "clients/apple/AlanNative/Services/Shell/ShellEventStore.swift" \
+    "final class AlanShellEventStore" \
+    "shell event persistence must live in a dedicated shell service owner"
+
+require_pattern \
+    "clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift" \
+    "final class AlanShellDiagnostics" \
+    "shell diagnostics routing must live in a dedicated shell service owner"
+
 reject_pattern \
     "clients/apple/AlanNative/ShellControlPlane.swift" \
-    "final class AlanShellSocketServer|SO_RCVTIMEO|SO_SNDTIMEO|maxRequestBytes|command_timeout|enum AlanShellPublishedStateMerger|pollCommands\\(|pollBindings\\(|handleCommandFile\\(" \
-    "shell control-plane coordinator must not own socket transport bounds, state merging, or file polling"
+    "final class AlanShellSocketServer|SO_RCVTIMEO|SO_SNDTIMEO|maxRequestBytes|command_timeout|enum AlanShellPublishedStateMerger|pollCommands\\(|pollBindings\\(|handleCommandFile\\(|appendEvent\\(|readEvents\\(|recordEvents\\(|recordDiagnostic\\(" \
+    "shell control-plane coordinator must not own socket transport bounds, state merging, file polling, event persistence, or diagnostic routing"
 
 reject_pattern \
     "clients/apple/AlanNative" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -17,6 +17,8 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -17,6 +17,8 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -17,6 +17,8 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellControlFilePoller.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellDiagnostics.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellLocalCommandExecutor.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift" \

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -42,7 +42,7 @@
 
 ## 7. Control Plane And IPC Boundaries
 
-- [ ] 7.1 Split shell control-plane protocol DTOs from socket server, file-polling control plane, local command executor, state merger, event persistence, and diagnostics.
+- [x] 7.1 Split shell control-plane protocol DTOs from socket server, file-polling control plane, local command executor, state merger, event persistence, and diagnostics.
 - [x] 7.2 Keep socket transport behavior bounded by request size, request timeout, response timeout, and concurrency limits during extraction.
 - [x] 7.3 Keep local command execution authoritative against shell/runtime state and separate from transport read/write code.
 - [x] 7.4 Run focused shell control-plane contract scripts after IPC or local executor extraction.


### PR DESCRIPTION
## Summary
- move shell event buffering, event diffing, events-read support, and jsonl persistence into Services/Shell/ShellEventStore.swift
- add a small ShellDiagnostics owner for diagnostic routing shared by shell services
- keep ShellControlPlane as the orchestrator for socket, file polling, state publishing, pane support directories, and event store calls
- mark OpenSpec task 7.1 complete now that DTOs, socket transport, file polling, local executor, state merger, event persistence, and diagnostics have owning files

## Verification
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/check-architecture-maintainability.sh (completed with existing warnings)
- git diff --check
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Review focus: please check that shell event persistence and diagnostic routing are now reviewable independently from control-plane orchestration without changing event names, payloads, retention, or events-read behavior.