### PR TITLE
Track architecture migration debt in spec

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -42,9 +42,15 @@ Xcode target.
 | `Models/Shell/ShellStateMutations.swift` | 1034 | Foundation | Shell bootstrap defaults, state mutation result/error types, mutation helpers, and preview fixtures | `Models/Shell/` |
 | `ShellModel.swift` | 169 | Foundation | Shell title, label, and status presentation helpers | `Models/Shell/` or `Support/ShellPresentation/` |
 | `ShellHostController.swift` | 1632 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, runtime update intake, command routing, control-plane command handling | `Controllers/Shell/` plus service collaborators |
+| `Services/Shell/ShellControlFilePoller.swift` | 182 | Foundation; macOS gates | File-backed command/result polling and Alan binding-file projection | `Services/Shell/` |
+| `Services/Shell/ShellDiagnostics.swift` | 16 | Foundation; macOS gates | Shell service diagnostic routing | `Services/Shell/` |
+| `Services/Shell/ShellEventStore.swift` | 298 | Foundation; macOS gates | Shell event buffering, diffing, `events.read`, and jsonl persistence | `Services/Shell/` |
+| `Services/Shell/ShellLocalCommandExecutor.swift` | 706 | Foundation; macOS gates | Local shell control command execution against shell state | `Services/Shell/` |
 | `Services/Shell/ShellPaneProjectionService.swift` | 266 | Foundation; macOS gates | Pane boot context, runtime metadata, viewport, attention, and Alan binding projection | `Services/Shell/` |
+| `Services/Shell/ShellPublishedStateMerger.swift` | 158 | Foundation; macOS gates | Merge published shell state with authoritative runtime metadata | `Services/Shell/` |
+| `Services/Shell/ShellSocketServer.swift` | 397 | Foundation, Darwin; macOS gates | Bounded local socket transport, request parsing, and client response handling | `Services/Shell/` |
 | `Services/Shell/ShellStatePersistenceStore.swift` | 116 | Foundation; macOS gates | Shell state save/restore, persistence URL selection, and restored window context lookup | `Services/Shell/` |
-| `ShellControlPlane.swift` | 2075 | Foundation, Darwin; macOS gates | Protocol DTOs, socket server, file polling, local executor, state merging, persistence, diagnostics | `Services/ControlPlane/` plus `Models/ControlPlane/` |
+| `ShellControlPlane.swift` | 253 | Foundation; macOS gates | Shell control-plane orchestration across socket, file polling, state publishing, pane support directories, event store, and diagnostics | `Services/Shell/` |
 | `Models/API/DaemonAPIModels.swift` | 529 | Foundation | Daemon API response DTOs, operation payloads, JSON values, and API error type | `Models/API/` |
 | `Models/Console/ConsoleModels.swift` | 148 | Foundation | Console chat messages, timeline entries, structured questions, and pending-yield value state | `Models/Console/` |
 | `Services/Daemon/AlanAPIClient.swift` | 236 | Foundation | Daemon HTTP client, request construction, endpoint routing, and response validation | `Services/Daemon/` |
@@ -62,7 +68,7 @@ The accepted target under `clients/apple/AlanNative` is:
 - `Views/Console/`: mobile or legacy remote-control console screens and view
   models that are not the primary macOS shell path.
 - `Models/`: API DTOs, shell snapshots, shell IDs, enums, value types, and
-  compatibility decoding shims.
+  current-format decoding.
 - `Controllers/`: observable app and shell controllers that own UI state and
   delegate IO or domain work to services.
 - `Services/`: daemon API clients, event readers/reducers, terminal runtime
@@ -94,3 +100,44 @@ bash clients/apple/scripts/check-architecture-maintainability.sh
 The default mode reports known migration debt and fails only on narrow
 regressions such as new root-level Swift files or Xcode project membership drift.
 Use `--strict` when intentionally tightening the architecture gate.
+
+## Implementation Evidence
+
+The architecture-maintainability implementation was completed as behavior-
+preserving PR slices. The final validation pass before syncing this spec ran:
+
+- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
+- `bash clients/apple/scripts/test-terminal-surface-controller.sh`
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `bash clients/apple/scripts/check-architecture-maintainability.sh`
+- `git diff --check`
+- `openspec validate improve-macos-app-architecture-maintainability --type change --strict --json`
+- `openspec validate --all --strict --json`
+- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
+
+The macOS build succeeded. Local Xcode continued to print the existing
+CoreSimulator version warning while building for `platform=macOS`; simulator
+device support was not required for this validation.
+
+## Remaining Architecture Debt
+
+`check-architecture-maintainability.sh` currently completes in report mode with
+eight known warnings:
+
+- `ShellHostController.swift` remains large and still imports AppKit outside a
+  final narrow controller/service split.
+- `TerminalHostView.swift` remains large pending additional terminal-host
+  collaborator extraction.
+- `TerminalRuntimeRegistry.swift` still imports AppKit before it is moved under
+  a terminal service or bridge owner.
+- `TerminalSurfaceController.swift` remains large pending deeper terminal
+  surface adapter splits.
+- `Views/Console/ContentView.swift` remains large and imports AppKit because the
+  legacy/mobile console path is isolated but not fully decomposed.
+- `Controllers/` is documented as the target owner for observable controllers
+  but has not been introduced yet.
+
+The current architecture gate intentionally keeps those warnings non-blocking
+while failing narrower regressions such as new root-level Swift files, project
+membership drift, or reintroduced control-plane ownership in the wrong file.

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -139,3 +139,5 @@ seven known warnings:
 The current architecture gate intentionally keeps those warnings non-blocking
 while failing narrower regressions such as new root-level Swift files, project
 membership drift, or reintroduced control-plane ownership in the wrong file.
+The `macos-app-architecture-maintainability` spec requires this debt record to
+stay current whenever warnings are introduced, broadened, or resolved.

--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -70,7 +70,8 @@ The accepted target under `clients/apple/AlanNative` is:
 - `Models/`: API DTOs, shell snapshots, shell IDs, enums, value types, and
   current-format decoding.
 - `Controllers/`: observable app and shell controllers that own UI state and
-  delegate IO or domain work to services.
+  delegate IO or domain work to services. This folder currently records the
+  target owner while `ShellHostController.swift` remains tracked migration debt.
 - `Services/`: daemon API clients, event readers/reducers, terminal runtime
   services, Ghostty bootstrap, shell projection services, shell control plane,
   socket server, persistence, and other process or IO code.
@@ -123,7 +124,7 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode with
-eight known warnings:
+seven known warnings:
 
 - `ShellHostController.swift` remains large and still imports AppKit outside a
   final narrow controller/service split.
@@ -135,9 +136,6 @@ eight known warnings:
   surface adapter splits.
 - `Views/Console/ContentView.swift` remains large and imports AppKit because the
   legacy/mobile console path is isolated but not fully decomposed.
-- `Controllers/` is documented as the target owner for observable controllers
-  but has not been introduced yet.
-
 The current architecture gate intentionally keeps those warnings non-blocking
 while failing narrower regressions such as new root-level Swift files, project
 membership drift, or reintroduced control-plane ownership in the wrong file.

--- a/clients/apple/AlanNative/Controllers/README.md
+++ b/clients/apple/AlanNative/Controllers/README.md
@@ -1,0 +1,7 @@
+# Controllers
+
+Observable app and shell controllers belong here once they are split out of the
+remaining root-level migration files.
+
+Current controller migration debt is tracked in
+[`clients/apple/ARCHITECTURE.md`](../../ARCHITECTURE.md).

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -30,13 +30,21 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 - `Models/Console/`: legacy/mobile console value types
 - `Models/Shell/`: shell command enums, launch targets, snapshots, and shell mutation helpers
 - `Services/Daemon/`: daemon HTTP client, event page reader, and console event reducer ownership
-- `Services/Shell/`: shell projection, persistence, and controller support
-  services that keep runtime metadata and storage out of the observable host
+- `Services/Shell/`: shell projection, persistence, control-plane transport,
+  file polling, event store, diagnostics, and command-execution services that
+  keep runtime metadata and IO out of the observable host
 - `Services/Terminal/`: terminal host runtime reporting, window observation,
   and terminal runtime service collaborators
 - `TerminalPaneView.swift` / `TerminalHostView.swift`: current terminal pane and host surfaces
 - `ShellModel.swift` / `ShellHostController.swift`: current shell state and controller
-- `ShellControlPlane.swift`: current file/socket shell control plane
+- `ShellControlPlane.swift`: thin shell control-plane orchestration across the
+  shell service owners
+
+Run the current architecture report with:
+
+```bash
+bash clients/apple/scripts/check-architecture-maintainability.sh
+```
 
 ## Quick Start
 

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -29,6 +29,8 @@ recorded in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 - `Models/API/`: daemon API response, operation, and JSON value models
 - `Models/Console/`: legacy/mobile console value types
 - `Models/Shell/`: shell command enums, launch targets, snapshots, and shell mutation helpers
+- `Controllers/`: target owner for observable app and shell controllers; current
+  migration debt is tracked in `ARCHITECTURE.md`
 - `Services/Daemon/`: daemon HTTP client, event page reader, and console event reducer ownership
 - `Services/Shell/`: shell projection, persistence, control-plane transport,
   file polling, event store, diagnostics, and command-execution services that

--- a/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
@@ -9,7 +9,8 @@ services, and support code without reading every file in a flat directory.
 - **WHEN** a developer inspects `clients/apple/AlanNative`
 - **THEN** app entry code, shell views, console views, protocol models,
   observable controllers, service/IO code, and support utilities are grouped by
-  responsibility rather than mixed in one flat source directory
+  responsibility or explicitly documented as migration debt rather than silently
+  mixed in one flat source directory
 
 #### Scenario: README documents source layout
 - **WHEN** the Apple client README describes the directory structure
@@ -130,9 +131,9 @@ is active for macOS shell development.
 
 ### Requirement: Large files have planned ownership boundaries
 The Apple client SHALL avoid large multi-responsibility Swift files as the
-stable end state. When a file remains large during migration, the owning change
-SHALL document the intended split and avoid adding unrelated responsibilities to
-that file.
+stable end state. When a file remains large or in a transitional owner during
+migration, the owning change SHALL document the intended split and avoid adding
+unrelated responsibilities to that file.
 
 #### Scenario: Large file receives new behavior
 - **WHEN** a developer adds behavior to an existing large Apple client file
@@ -144,3 +145,26 @@ that file.
 - **WHEN** a behavior-preserving architecture refactor slice is completed
 - **THEN** the resulting file ownership makes future changes narrower to review
   than the previous large-file organization
+
+### Requirement: Architecture migration debt is explicit and bounded
+The Apple client SHALL keep known architecture-maintainability warnings visible
+as tracked migration debt until they are resolved by focused refactor slices.
+Known debt MUST identify the affected owner or file, the intended boundary, and
+whether the current architecture gate treats it as non-blocking.
+
+#### Scenario: Architecture report has warnings
+- **WHEN** `check-architecture-maintainability.sh` completes in report mode with
+  warnings
+- **THEN** `clients/apple/ARCHITECTURE.md` records the current warning classes
+  and explains why they remain non-blocking migration debt
+
+#### Scenario: New architecture warning appears
+- **WHEN** a change introduces a new architecture-maintainability warning or
+  broadens an existing one
+- **THEN** the change either resolves the warning in the target owner or updates
+  the migration debt record with a concrete follow-up boundary
+
+#### Scenario: Migration debt is reduced
+- **WHEN** a focused refactor slice resolves a tracked warning
+- **THEN** the architecture debt record and validation expectations are updated
+  in the same PR so the warning cannot silently reappear

--- a/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/tasks.md
@@ -68,6 +68,6 @@
 
 - [x] 10.1 Keep mechanical file moves separate from behavior edits in commits or PR descriptions.
 - [x] 10.2 Ask reviewers to evaluate whether source ownership, AppKit bridge boundaries, and validation gates make future work easier to maintain.
-- [ ] 10.3 Before archive, sync the accepted `macos-app-architecture-maintainability` requirements into `openspec/specs/`.
-- [ ] 10.4 Before archive, sync the accepted build/test contract delta into `openspec/specs/macos-shell-build-test-contract/spec.md`.
-- [ ] 10.5 Record implementation verification evidence and remaining architecture debt before archiving the change.
+- [x] 10.3 Before archive, sync the accepted `macos-app-architecture-maintainability` requirements into `openspec/specs/`.
+- [x] 10.4 Before archive, sync the accepted build/test contract delta into `openspec/specs/macos-shell-build-test-contract/spec.md`.
+- [x] 10.5 Record implementation verification evidence and remaining architecture debt before archiving the change.

--- a/openspec/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/specs/macos-app-architecture-maintainability/spec.md
@@ -1,0 +1,152 @@
+# macos-app-architecture-maintainability Specification
+
+## Purpose
+Define maintainable native Apple client source organization, SwiftUI/AppKit
+boundaries, service/model ownership, and validation expectations for macOS app
+architecture changes.
+
+## Requirements
+### Requirement: Apple client source layout mirrors architecture ownership
+The native Apple client SHALL organize source files by durable responsibility so
+developers can distinguish app startup, SwiftUI views, models, controllers,
+services, and support code without reading every file in a flat directory.
+
+#### Scenario: Source tree is inspected
+- **WHEN** a developer inspects `clients/apple/AlanNative`
+- **THEN** app entry code, shell views, console views, protocol models,
+  observable controllers, service/IO code, and support utilities are grouped by
+  responsibility rather than mixed in one flat source directory
+
+#### Scenario: README documents source layout
+- **WHEN** the Apple client README describes the directory structure
+- **THEN** the documented folders match the source tree and Xcode project
+  organization used by the current code
+
+### Requirement: SwiftUI scene roots compose focused feature views
+SwiftUI scene and root view files SHALL primarily compose stable layout,
+selection, and feature views. They MUST NOT accumulate unrelated design tokens,
+window coordination, command routing, inspector/debug panels, service clients,
+or platform bridge implementations.
+
+#### Scenario: macOS shell root is edited
+- **WHEN** a developer changes the default macOS shell layout
+- **THEN** the root view remains a readable composition of sidebar, workspace,
+  command, and optional utility surfaces, with feature-specific UI implemented
+  in dedicated view files
+
+#### Scenario: App commands are edited
+- **WHEN** a developer changes menu or keyboard command ownership
+- **THEN** command definitions and command routing live in app or shell command
+  files rather than being buried in unrelated view body code
+
+### Requirement: AppKit bridges are narrow and named
+The Apple client SHALL isolate AppKit bridge code behind small, named wrappers
+or coordinators for the specific desktop behavior they own, while keeping
+unrelated SwiftUI views free of ambient `NSWindow`, `NSView`, `NSApp`, socket,
+or process-management details.
+
+#### Scenario: Window placement changes
+- **WHEN** hidden-titlebar placement, minimum size, traffic-light metrics, or
+  primary-window focusing behavior changes
+- **THEN** the implementation is owned by an app/window support component rather
+  than by the macOS shell root view file
+
+#### Scenario: Material background changes
+- **WHEN** a SwiftUI view needs native material rendering
+- **THEN** the `NSVisualEffectView` bridge is isolated behind a reusable material
+  wrapper or support component
+
+#### Scenario: Terminal host bridge changes
+- **WHEN** terminal first-responder, hit-testing, IME, pointer, keyboard, or
+  Ghostty attachment behavior changes
+- **THEN** the AppKit terminal host keeps those behaviors behind the terminal
+  host boundary and does not leak AppKit ownership through unrelated SwiftUI
+  views
+
+### Requirement: Terminal host collaborators have explicit ownership
+The terminal host implementation SHALL separate runtime attachment, overlay
+presentation, input routing, window observation, metadata publishing, and
+surface coordination into explicit collaborators when those responsibilities
+become non-trivial.
+
+#### Scenario: Terminal input routing changes
+- **WHEN** keyboard, IME, paste, pointer, scroll, or terminal search routing is
+  modified
+- **THEN** the change is reviewable in terminal input/surface collaborators
+  without requiring a full audit of overlay layout or window observation code
+
+#### Scenario: Runtime snapshot publication changes
+- **WHEN** terminal runtime metadata publication changes
+- **THEN** the owning component clearly distinguishes snapshot construction from
+  AppKit layout and visible overlay presentation
+
+### Requirement: Control-plane implementation separates IPC, execution, and persistence
+The shell control-plane implementation SHALL keep protocol DTOs, local command
+execution, socket serving, file polling, state merging, event persistence, and
+diagnostics in reviewable ownership units.
+
+#### Scenario: Socket transport changes
+- **WHEN** local socket request size, timeout, accept loop, or client response
+  behavior changes
+- **THEN** the change is isolated to the socket transport owner and does not
+  require reviewing shell mutation semantics
+
+#### Scenario: Local command execution changes
+- **WHEN** a shell control command changes how it mutates shell state or applies
+  side effects
+- **THEN** the local command executor owns the behavior separately from socket
+  read/write and file-polling code
+
+#### Scenario: Persistence diagnostics change
+- **WHEN** state, event, command, or binding persistence diagnostics change
+- **THEN** the persistence/event owner can be reviewed independently from IPC
+  request parsing
+
+### Requirement: API clients and event reducers are not embedded in views
+The Apple client SHALL keep daemon API clients, event polling or streaming
+loops, protocol event reduction, and view model state projection outside
+complete SwiftUI view files so each can be tested or reviewed without editing a
+complete SwiftUI screen.
+
+#### Scenario: Session event mapping changes
+- **WHEN** daemon session events are mapped into chat messages, timeline rows,
+  pending-yield state, or connection state
+- **THEN** the reducer behavior is owned outside the SwiftUI view body and can
+  be tested without rendering the full console UI
+
+#### Scenario: API endpoint support changes
+- **WHEN** daemon API request or response DTOs change
+- **THEN** the API client and protocol models own that change separately from
+  shell or console layout files
+
+### Requirement: Mobile and legacy console surfaces are isolated from the primary macOS shell
+The Apple client SHALL keep mobile or legacy remote-control console surfaces
+separate from the primary macOS shell path so contributors can identify which UI
+is active for macOS shell development.
+
+#### Scenario: macOS shell contributor opens the project
+- **WHEN** a developer needs to change the default macOS shell experience
+- **THEN** primary shell files are distinguishable from iOS/mobile console files
+  by folder, naming, or project grouping
+
+#### Scenario: iOS console behavior changes
+- **WHEN** a developer changes the mobile console layout or event handling
+- **THEN** the change does not require editing primary macOS shell root files
+  unless a shared model or service contract is intentionally changed
+
+### Requirement: Large files have planned ownership boundaries
+The Apple client SHALL avoid large multi-responsibility Swift files as the
+stable end state. When a file remains large during migration, the owning change
+SHALL document the intended split and avoid adding unrelated responsibilities to
+that file.
+
+#### Scenario: Large file receives new behavior
+- **WHEN** a developer adds behavior to an existing large Apple client file
+- **THEN** the change either places the behavior in the target owner file or
+  documents why the temporary location is still compatible with the migration
+  plan
+
+#### Scenario: Refactor slice completes
+- **WHEN** a behavior-preserving architecture refactor slice is completed
+- **THEN** the resulting file ownership makes future changes narrower to review
+  than the previous large-file organization

--- a/openspec/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/specs/macos-app-architecture-maintainability/spec.md
@@ -15,7 +15,8 @@ services, and support code without reading every file in a flat directory.
 - **WHEN** a developer inspects `clients/apple/AlanNative`
 - **THEN** app entry code, shell views, console views, protocol models,
   observable controllers, service/IO code, and support utilities are grouped by
-  responsibility rather than mixed in one flat source directory
+  responsibility or explicitly documented as migration debt rather than silently
+  mixed in one flat source directory
 
 #### Scenario: README documents source layout
 - **WHEN** the Apple client README describes the directory structure
@@ -136,9 +137,9 @@ is active for macOS shell development.
 
 ### Requirement: Large files have planned ownership boundaries
 The Apple client SHALL avoid large multi-responsibility Swift files as the
-stable end state. When a file remains large during migration, the owning change
-SHALL document the intended split and avoid adding unrelated responsibilities to
-that file.
+stable end state. When a file remains large or in a transitional owner during
+migration, the owning change SHALL document the intended split and avoid adding
+unrelated responsibilities to that file.
 
 #### Scenario: Large file receives new behavior
 - **WHEN** a developer adds behavior to an existing large Apple client file

--- a/openspec/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/specs/macos-app-architecture-maintainability/spec.md
@@ -151,3 +151,26 @@ unrelated responsibilities to that file.
 - **WHEN** a behavior-preserving architecture refactor slice is completed
 - **THEN** the resulting file ownership makes future changes narrower to review
   than the previous large-file organization
+
+### Requirement: Architecture migration debt is explicit and bounded
+The Apple client SHALL keep known architecture-maintainability warnings visible
+as tracked migration debt until they are resolved by focused refactor slices.
+Known debt MUST identify the affected owner or file, the intended boundary, and
+whether the current architecture gate treats it as non-blocking.
+
+#### Scenario: Architecture report has warnings
+- **WHEN** `check-architecture-maintainability.sh` completes in report mode with
+  warnings
+- **THEN** `clients/apple/ARCHITECTURE.md` records the current warning classes
+  and explains why they remain non-blocking migration debt
+
+#### Scenario: New architecture warning appears
+- **WHEN** a change introduces a new architecture-maintainability warning or
+  broadens an existing one
+- **THEN** the change either resolves the warning in the target owner or updates
+  the migration debt record with a concrete follow-up boundary
+
+#### Scenario: Migration debt is reduced
+- **WHEN** a focused refactor slice resolves a tracked warning
+- **THEN** the architecture debt record and validation expectations are updated
+  in the same PR so the warning cannot silently reappear

--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -198,3 +198,32 @@ the pane-scoped native Find bar and removed inspector surface.
 #### Scenario: Passive search overlay blocked
 - **WHEN** terminal search UI changes
 - **THEN** shell contract checks fail if default Find UI is routed through the passive terminal overlay instead of `ShellFindBarView`
+
+### Requirement: Apple architecture maintainability has focused validation
+The Apple client SHALL provide focused validation for source layout,
+multi-responsibility hotspots, README/project drift, and SwiftUI/AppKit boundary
+regressions when architecture maintainability changes are implemented.
+
+#### Scenario: Architecture report is run
+- **WHEN** a developer runs the Apple architecture-maintainability check
+- **THEN** the report identifies files or project groups that violate the
+  accepted source ownership boundaries and gives actionable paths to the owning
+  files or folders
+
+#### Scenario: README and project layout drift
+- **WHEN** Apple client source folders or Xcode project groups are reorganized
+- **THEN** validation or review confirms `clients/apple/README.md`, source
+  paths, and project membership describe the same structure
+
+#### Scenario: AppKit bridge spreads into unrelated SwiftUI
+- **WHEN** a change introduces `NSWindow`, `NSView`, `NSApp`, Darwin socket, or
+  process-management ownership into a SwiftUI feature view that does not own a
+  platform bridge
+- **THEN** the architecture check fails or the review checklist requires moving
+  the behavior into an app, service, terminal host, or support boundary
+
+#### Scenario: Behavior-preserving move is reviewed
+- **WHEN** a refactor slice only moves or extracts Apple client code
+- **THEN** verification includes diff review, project membership validation, and
+  the focused Apple build or script checks needed to prove behavior was not
+  intentionally changed


### PR DESCRIPTION
## Summary
- add a canonical requirement that architecture migration warnings stay explicit and bounded
- sync the same requirement into the active improve-macos-app-architecture-maintainability change spec
- note in ARCHITECTURE.md that warning debt records must stay current when warnings are introduced, broadened, or resolved

## Verification
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- bash clients/apple/scripts/check-architecture-maintainability.sh (completed with 7 known warnings)
- git diff --check

This follows up on #384 after it merged while clarifying the remaining maintainability warnings should remain governed by the spec.