### PR TITLE
Track architecture migration debt in spec

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -139,3 +139,5 @@ seven known warnings:
 The current architecture gate intentionally keeps those warnings non-blocking
 while failing narrower regressions such as new root-level Swift files, project
 membership drift, or reintroduced control-plane ownership in the wrong file.
+The `macos-app-architecture-maintainability` spec requires this debt record to
+stay current whenever warnings are introduced, broadened, or resolved.

--- a/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/improve-macos-app-architecture-maintainability/specs/macos-app-architecture-maintainability/spec.md
@@ -9,7 +9,8 @@ services, and support code without reading every file in a flat directory.
 - **WHEN** a developer inspects `clients/apple/AlanNative`
 - **THEN** app entry code, shell views, console views, protocol models,
   observable controllers, service/IO code, and support utilities are grouped by
-  responsibility rather than mixed in one flat source directory
+  responsibility or explicitly documented as migration debt rather than silently
+  mixed in one flat source directory
 
 #### Scenario: README documents source layout
 - **WHEN** the Apple client README describes the directory structure
@@ -130,9 +131,9 @@ is active for macOS shell development.
 
 ### Requirement: Large files have planned ownership boundaries
 The Apple client SHALL avoid large multi-responsibility Swift files as the
-stable end state. When a file remains large during migration, the owning change
-SHALL document the intended split and avoid adding unrelated responsibilities to
-that file.
+stable end state. When a file remains large or in a transitional owner during
+migration, the owning change SHALL document the intended split and avoid adding
+unrelated responsibilities to that file.
 
 #### Scenario: Large file receives new behavior
 - **WHEN** a developer adds behavior to an existing large Apple client file
@@ -144,3 +145,26 @@ that file.
 - **WHEN** a behavior-preserving architecture refactor slice is completed
 - **THEN** the resulting file ownership makes future changes narrower to review
   than the previous large-file organization
+
+### Requirement: Architecture migration debt is explicit and bounded
+The Apple client SHALL keep known architecture-maintainability warnings visible
+as tracked migration debt until they are resolved by focused refactor slices.
+Known debt MUST identify the affected owner or file, the intended boundary, and
+whether the current architecture gate treats it as non-blocking.
+
+#### Scenario: Architecture report has warnings
+- **WHEN** `check-architecture-maintainability.sh` completes in report mode with
+  warnings
+- **THEN** `clients/apple/ARCHITECTURE.md` records the current warning classes
+  and explains why they remain non-blocking migration debt
+
+#### Scenario: New architecture warning appears
+- **WHEN** a change introduces a new architecture-maintainability warning or
+  broadens an existing one
+- **THEN** the change either resolves the warning in the target owner or updates
+  the migration debt record with a concrete follow-up boundary
+
+#### Scenario: Migration debt is reduced
+- **WHEN** a focused refactor slice resolves a tracked warning
+- **THEN** the architecture debt record and validation expectations are updated
+  in the same PR so the warning cannot silently reappear

--- a/openspec/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/specs/macos-app-architecture-maintainability/spec.md
@@ -151,3 +151,26 @@ unrelated responsibilities to that file.
 - **WHEN** a behavior-preserving architecture refactor slice is completed
 - **THEN** the resulting file ownership makes future changes narrower to review
   than the previous large-file organization
+
+### Requirement: Architecture migration debt is explicit and bounded
+The Apple client SHALL keep known architecture-maintainability warnings visible
+as tracked migration debt until they are resolved by focused refactor slices.
+Known debt MUST identify the affected owner or file, the intended boundary, and
+whether the current architecture gate treats it as non-blocking.
+
+#### Scenario: Architecture report has warnings
+- **WHEN** `check-architecture-maintainability.sh` completes in report mode with
+  warnings
+- **THEN** `clients/apple/ARCHITECTURE.md` records the current warning classes
+  and explains why they remain non-blocking migration debt
+
+#### Scenario: New architecture warning appears
+- **WHEN** a change introduces a new architecture-maintainability warning or
+  broadens an existing one
+- **THEN** the change either resolves the warning in the target owner or updates
+  the migration debt record with a concrete follow-up boundary
+
+#### Scenario: Migration debt is reduced
+- **WHEN** a focused refactor slice resolves a tracked warning
+- **THEN** the architecture debt record and validation expectations are updated
+  in the same PR so the warning cannot silently reappear


### PR DESCRIPTION
## Summary
- add a canonical requirement that architecture migration warnings stay explicit and bounded
- sync the same requirement into the active improve-macos-app-architecture-maintainability change spec
- note in ARCHITECTURE.md that warning debt records must stay current when warnings are introduced, broadened, or resolved

## Verification
- openspec validate improve-macos-app-architecture-maintainability --type change --strict --json
- openspec validate --all --strict --json
- bash clients/apple/scripts/check-architecture-maintainability.sh (completed with 7 known warnings)
- git diff --check

This follows up on #384 after it merged while clarifying the remaining maintainability warnings should remain governed by the spec.