### PR TITLE
Propose macOS architecture debt warning reduction

### DIFF
--- a/openspec/changes/reduce-macos-architecture-debt-warnings/.openspec.yaml
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/design.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`improve-macos-app-architecture-maintainability` established the Apple client
+source layout, validation report, and migration-debt ledger. The current report
+still completes with seven non-blocking warnings for large files or AppKit
+imports in transitional owners:
+
+- `ShellHostController.swift` remains large and imports AppKit.
+- `TerminalHostView.swift` remains large.
+- `TerminalRuntimeRegistry.swift` imports AppKit.
+- `TerminalSurfaceController.swift` remains large.
+- `Views/Console/ContentView.swift` remains large and imports AppKit.
+
+This change turns those warnings into a debt-reduction work queue. It should
+produce small stacked PRs that can be reviewed and merged independently while
+keeping the architecture report and debt ledger current.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce the architecture-maintainability warning count through focused,
+  behavior-preserving refactor slices.
+- Keep each slice tied to one owner boundary or warning class.
+- Update `clients/apple/ARCHITECTURE.md` and validation expectations in the
+  same slice that resolves a warning.
+- Preserve terminal runtime identity, terminal event ownership, shell command
+  vocabulary, and console/mobile isolation.
+
+**Non-Goals:**
+- Redesign the macOS shell UI.
+- Change daemon API routes, payloads, or runtime semantics.
+- Complete all terminal, shell, and console decomposition in one PR.
+- Make report mode fail on every known warning before the debt is reduced.
+
+## Decisions
+
+1. Address the smallest AppKit leak first.
+
+   `TerminalRuntimeRegistry.swift` should be the first implementation slice
+   because it likely has the narrowest behavioral surface. Removing or
+   relocating its AppKit dependency can reduce one warning before larger owner
+   splits begin.
+
+2. Split by owner, not by line count alone.
+
+   Large files should only shrink when code moves into a durable owner such as
+   a controller, service, bridge, adapter, or view component. Mechanical line
+   moves that leave responsibilities ambiguous do not count as resolving debt.
+
+3. Keep the warning count as an explicit validation signal.
+
+   Each slice should run `check-architecture-maintainability.sh` and document
+   the expected warning count. If the count changes, the script expectation and
+   `clients/apple/ARCHITECTURE.md` must be updated together.
+
+4. Use stacked PRs with a low-conflict order.
+
+   The preferred order is:
+   - remove the `TerminalRuntimeRegistry.swift` AppKit warning;
+   - reduce `ShellHostController.swift` controller/store/service debt;
+   - reduce `TerminalSurfaceController.swift` surface adapter debt;
+   - reduce `TerminalHostView.swift` terminal-host collaborator debt;
+   - reduce `Views/Console/ContentView.swift` console/mobile debt.
+
+   If discovery shows a later slice is lower risk or a dependency is inverted,
+   the task order may be adjusted, but each PR should still explain the
+   warning it resolves.
+
+## Risks / Trade-offs
+
+- Behavior-preserving moves can still alter object lifetimes or activation
+  paths. Mitigation: run focused shell, terminal runtime, and terminal surface
+  scripts for touched owners.
+- Stacked PRs can conflict when adjacent files are edited in parallel.
+  Mitigation: keep each slice narrow and restack after every merge.
+- Strictly chasing line count can create shallow abstractions. Mitigation: only
+  count a warning as resolved when the moved code has a named owner and clearer
+  review boundary.
+- Console cleanup touches legacy/mobile surfaces that are not the primary
+  macOS shell path. Mitigation: defer console decomposition until smaller shell
+  and terminal debt slices have landed.

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/proposal.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The macOS architecture-maintainability work is complete and archived, but the
+current architecture report still records seven non-blocking migration warnings.
+Those warnings should now be reduced through focused, reviewable refactor slices
+instead of remaining as open-ended debt.
+
+## What Changes
+
+- Reduce the existing architecture-maintainability warning count through
+  behavior-preserving refactors.
+- Keep each refactor slice scoped to one owner or warning class so stacked PRs
+  remain reviewable and easy to rebase.
+- Update `clients/apple/ARCHITECTURE.md` and the architecture validation
+  expectation whenever a warning is resolved.
+- Preserve the current product behavior, shell command vocabulary, terminal
+  runtime identity, and console/mobile separation while moving code.
+- Do not introduce new UI behavior, daemon API changes, or terminal runtime
+  semantics as part of debt cleanup.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `macos-app-architecture-maintainability`: define how existing tracked
+  architecture warnings are reduced, validated, and removed from the debt
+  record.
+
+## Impact
+
+- `clients/apple/AlanNative/ShellHostController.swift`
+- `clients/apple/AlanNative/TerminalHostView.swift`
+- `clients/apple/AlanNative/TerminalRuntimeRegistry.swift`
+- `clients/apple/AlanNative/TerminalSurfaceController.swift`
+- `clients/apple/AlanNative/Views/Console/ContentView.swift`
+- `clients/apple/ARCHITECTURE.md`
+- `clients/apple/scripts/check-architecture-maintainability.sh`
+- Focused Apple shell/terminal scripts for touched owners

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/specs/macos-app-architecture-maintainability/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Architecture warning debt is reduced by focused slices
+The Apple client SHALL reduce tracked architecture-maintainability warnings
+through focused, behavior-preserving refactor slices. Each slice MUST identify
+the warning class it resolves, the owner boundary it clarifies, and the
+verification commands that protect the moved behavior.
+
+#### Scenario: Focused slice resolves a warning
+- **WHEN** a refactor slice removes one or more warnings from
+  `check-architecture-maintainability.sh`
+- **THEN** the slice updates `clients/apple/ARCHITECTURE.md` with the new
+  warning count and removes or narrows the corresponding debt entry
+
+#### Scenario: Slice changes a terminal owner
+- **WHEN** a slice moves code from a terminal runtime, host, or surface owner
+- **THEN** focused terminal runtime or terminal surface scripts are run in
+  addition to the architecture report
+
+#### Scenario: Slice changes a shell controller owner
+- **WHEN** a slice moves controller, store, projection, or command-routing code
+  out of `ShellHostController.swift`
+- **THEN** shell contract validation is run and the shared
+  `ShellWorkspaceCommand` vocabulary remains the command boundary
+
+#### Scenario: Slice changes console or mobile owners
+- **WHEN** a slice moves code from `Views/Console/ContentView.swift`
+- **THEN** the primary macOS shell path remains distinguishable from
+  console/mobile surfaces by folder, naming, or project grouping
+
+### Requirement: Architecture validation expectations track reduced debt
+The architecture-maintainability gate SHALL keep current warning expectations
+aligned with the tracked debt ledger. A PR that resolves a warning MUST update
+the report expectations and documentation in the same change so the warning
+cannot silently reappear.
+
+#### Scenario: Warning count decreases
+- **WHEN** `check-architecture-maintainability.sh` reports fewer warnings than
+  the documented debt ledger
+- **THEN** the implementation updates the ledger and any script expectations
+  before the PR is considered complete
+
+#### Scenario: Warning count does not decrease
+- **WHEN** a refactor slice moves architecture code but does not reduce the
+  warning count
+- **THEN** the PR explains why the moved boundary is an intermediate step and
+  leaves the debt ledger accurate
+
+#### Scenario: New or broadened warning appears
+- **WHEN** a change introduces a new architecture warning or broadens an
+  existing warning while reducing another one
+- **THEN** the change either resolves the new warning before merge or records a
+  concrete follow-up boundary in the debt ledger

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
@@ -1,0 +1,46 @@
+## 1. Baseline And Sequencing
+
+- [ ] 1.1 Run `bash clients/apple/scripts/check-architecture-maintainability.sh` and record the current seven-warning baseline.
+- [ ] 1.2 Confirm `clients/apple/ARCHITECTURE.md` names each current warning class and explains why it is non-blocking migration debt.
+- [ ] 1.3 Confirm the first implementation slice targets the smallest AppKit-leak warning unless discovery shows a lower-risk dependency order.
+
+## 2. Terminal Runtime Registry AppKit Warning
+
+- [ ] 2.1 Inspect why `TerminalRuntimeRegistry.swift` imports AppKit and identify the durable owner for that dependency.
+- [ ] 2.2 Move or isolate the AppKit dependency so `TerminalRuntimeRegistry.swift` no longer triggers the architecture warning.
+- [ ] 2.3 Run the architecture report and focused terminal runtime validation.
+- [ ] 2.4 Update `clients/apple/ARCHITECTURE.md` to remove or narrow the `TerminalRuntimeRegistry.swift` debt entry and record the new warning count.
+- [ ] 2.5 Commit and open the first stacked PR for the resolved warning.
+
+## 3. Shell Host Controller Debt
+
+- [ ] 3.1 Identify the next `ShellHostController.swift` controller, store, projection, or command-routing boundary that can move without changing behavior.
+- [ ] 3.2 Extract the selected boundary into a named owner while preserving `ShellWorkspaceCommand` as the shared command vocabulary.
+- [ ] 3.3 Run shell contract validation and the architecture report.
+- [ ] 3.4 Update the debt ledger and warning expectation if the `ShellHostController.swift` warning count is reduced.
+- [ ] 3.5 Commit and open the next stacked PR.
+
+## 4. Terminal Surface And Host Debt
+
+- [ ] 4.1 Identify the next `TerminalSurfaceController.swift` adapter or input/surface boundary that can move without changing behavior.
+- [ ] 4.2 Extract the selected terminal surface boundary and run focused terminal surface validation.
+- [ ] 4.3 Identify the next `TerminalHostView.swift` collaborator boundary for runtime attachment, overlay presentation, input routing, window observation, metadata publishing, or surface coordination.
+- [ ] 4.4 Extract the selected terminal host boundary and run focused terminal host/runtime validation.
+- [ ] 4.5 Update `clients/apple/ARCHITECTURE.md` and script expectations after each reduced warning.
+- [ ] 4.6 Commit and open stacked PRs for each reduced terminal warning.
+
+## 5. Console Content View Debt
+
+- [ ] 5.1 Inspect `Views/Console/ContentView.swift` and identify the lowest-risk console/mobile boundary to extract first.
+- [ ] 5.2 Move the selected console view, model projection, or platform bridge code into a named console owner while preserving primary macOS shell separation.
+- [ ] 5.3 Run the architecture report and relevant Apple build or focused validation for the touched console path.
+- [ ] 5.4 Update `clients/apple/ARCHITECTURE.md` and script expectations if the console warning count is reduced.
+- [ ] 5.5 Commit and open the final stacked PR for this change's planned console debt reduction.
+
+## 6. Verification And Archive Readiness
+
+- [ ] 6.1 Run `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`.
+- [ ] 6.2 Run `openspec validate --all --strict --json`.
+- [ ] 6.3 Run `git diff --check`.
+- [ ] 6.4 Before archive, sync the accepted requirements into `openspec/specs/macos-app-architecture-maintainability/spec.md`.
+- [ ] 6.5 Archive the change after all selected warning-reduction slices are merged and the debt ledger is current.


### PR DESCRIPTION
## Summary
- add OpenSpec change `reduce-macos-architecture-debt-warnings`
- define focused stacked PR slices for reducing the current seven architecture-maintainability warnings
- add requirements that warning-count reductions update the debt ledger and validation expectations in the same PR

## Verification
- `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`
- `openspec validate --all --strict --json`
- `git diff --check`