### PR TITLE
Remove terminal runtime registry AppKit debt

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -124,14 +124,12 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode with
-seven known warnings:
+six known warnings:
 
 - `ShellHostController.swift` remains large and still imports AppKit outside a
   final narrow controller/service split.
 - `TerminalHostView.swift` remains large pending additional terminal-host
   collaborator extraction.
-- `TerminalRuntimeRegistry.swift` still imports AppKit before it is moved under
-  a terminal service or bridge owner.
 - `TerminalSurfaceController.swift` remains large pending deeper terminal
   surface adapter splits.
 - `Views/Console/ContentView.swift` remains large and imports AppKit because the

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 #if os(macOS)
-import AppKit
-
 @MainActor
 protocol TerminalRuntimeHandle: AnyObject {
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Baseline And Sequencing
 
-- [ ] 1.1 Run `bash clients/apple/scripts/check-architecture-maintainability.sh` and record the current seven-warning baseline.
-- [ ] 1.2 Confirm `clients/apple/ARCHITECTURE.md` names each current warning class and explains why it is non-blocking migration debt.
-- [ ] 1.3 Confirm the first implementation slice targets the smallest AppKit-leak warning unless discovery shows a lower-risk dependency order.
+- [x] 1.1 Run `bash clients/apple/scripts/check-architecture-maintainability.sh` and record the current seven-warning baseline.
+- [x] 1.2 Confirm `clients/apple/ARCHITECTURE.md` names each current warning class and explains why it is non-blocking migration debt.
+- [x] 1.3 Confirm the first implementation slice targets the smallest AppKit-leak warning unless discovery shows a lower-risk dependency order.
 
 ## 2. Terminal Runtime Registry AppKit Warning
 
-- [ ] 2.1 Inspect why `TerminalRuntimeRegistry.swift` imports AppKit and identify the durable owner for that dependency.
-- [ ] 2.2 Move or isolate the AppKit dependency so `TerminalRuntimeRegistry.swift` no longer triggers the architecture warning.
-- [ ] 2.3 Run the architecture report and focused terminal runtime validation.
-- [ ] 2.4 Update `clients/apple/ARCHITECTURE.md` to remove or narrow the `TerminalRuntimeRegistry.swift` debt entry and record the new warning count.
-- [ ] 2.5 Commit and open the first stacked PR for the resolved warning.
+- [x] 2.1 Inspect why `TerminalRuntimeRegistry.swift` imports AppKit and identify the durable owner for that dependency.
+- [x] 2.2 Move or isolate the AppKit dependency so `TerminalRuntimeRegistry.swift` no longer triggers the architecture warning.
+- [x] 2.3 Run the architecture report and focused terminal runtime validation.
+- [x] 2.4 Update `clients/apple/ARCHITECTURE.md` to remove or narrow the `TerminalRuntimeRegistry.swift` debt entry and record the new warning count.
+- [x] 2.5 Commit and open the first stacked PR for the resolved warning.
 
 ## 3. Shell Host Controller Debt
 


### PR DESCRIPTION
## Summary
- remove the unnecessary direct AppKit import from `TerminalRuntimeRegistry.swift`
- reduce the architecture-maintainability report from 7 known warnings to 6
- update the architecture debt ledger and OpenSpec task progress for the first warning-reduction slice

## Verification
- `bash clients/apple/scripts/check-architecture-maintainability.sh` (6 warnings)
- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
- `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`
- `openspec validate --all --strict --json`
- `git diff --check`

Stacked on #388.