### PR TITLE
Extract shell clipboard writer

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -124,10 +124,10 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode with
-six known warnings:
+five known warnings:
 
-- `ShellHostController.swift` remains large and still imports AppKit outside a
-  final narrow controller/service split.
+- `ShellHostController.swift` remains large pending additional controller,
+  store, and projection splits.
 - `TerminalHostView.swift` remains large pending additional terminal-host
   collaborator extraction.
 - `TerminalSurfaceController.swift` remains large pending deeper terminal

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		00000000000000000000002D /* ShellControlFilePoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012D /* ShellControlFilePoller.swift */; };
 		00000000000000000000002E /* ShellEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012E /* ShellEventStore.swift */; };
 		00000000000000000000002F /* ShellDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012F /* ShellDiagnostics.swift */; };
+		000000000000000000000030 /* ShellClipboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000130 /* ShellClipboardWriter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +106,7 @@
 		00000000000000000000012D /* ShellControlFilePoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellControlFilePoller.swift; sourceTree = "<group>"; };
 		00000000000000000000012E /* ShellEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellEventStore.swift; sourceTree = "<group>"; };
 		00000000000000000000012F /* ShellDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellDiagnostics.swift; sourceTree = "<group>"; };
+		000000000000000000000130 /* ShellClipboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellClipboardWriter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -241,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				000000000000000000000125 /* ShellPaneProjectionService.swift */,
+				000000000000000000000130 /* ShellClipboardWriter.swift */,
 				00000000000000000000012D /* ShellControlFilePoller.swift */,
 				00000000000000000000012F /* ShellDiagnostics.swift */,
 				00000000000000000000012E /* ShellEventStore.swift */,
@@ -405,6 +408,7 @@
 				00000000000000000000002D /* ShellControlFilePoller.swift in Sources */,
 				00000000000000000000002E /* ShellEventStore.swift in Sources */,
 				00000000000000000000002F /* ShellDiagnostics.swift in Sources */,
+				000000000000000000000030 /* ShellClipboardWriter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Shell/ShellClipboardWriter.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellClipboardWriter.swift
@@ -1,0 +1,12 @@
+#if os(macOS)
+import AppKit
+
+@MainActor
+final class ShellClipboardWriter {
+    func writeString(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+}
+#endif

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 #if os(macOS)
-import AppKit
 import SwiftUI
 
 struct ShellAttentionItem: Identifiable, Equatable {
@@ -84,6 +83,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let persistenceURL: URL
     private let persistenceStore: ShellStatePersistenceStore
     private let paneProjection: ShellPaneProjectionService
+    private let clipboardWriter: ShellClipboardWriter
     private lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
@@ -142,6 +142,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             fileManager: fileManager,
             persistenceURL: self.persistenceURL
         )
+        self.clipboardWriter = ShellClipboardWriter()
         self.shellState = shellState
         self.terminalRuntimeRegistry =
             terminalRuntimeRegistry
@@ -577,9 +578,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func copySnapshotJSON() {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(snapshotJSON, forType: .string)
+        clipboardWriter.writeString(snapshotJSON)
         lastCopiedAt = .now
     }
 

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
@@ -14,11 +14,11 @@
 
 ## 3. Shell Host Controller Debt
 
-- [ ] 3.1 Identify the next `ShellHostController.swift` controller, store, projection, or command-routing boundary that can move without changing behavior.
-- [ ] 3.2 Extract the selected boundary into a named owner while preserving `ShellWorkspaceCommand` as the shared command vocabulary.
-- [ ] 3.3 Run shell contract validation and the architecture report.
-- [ ] 3.4 Update the debt ledger and warning expectation if the `ShellHostController.swift` warning count is reduced.
-- [ ] 3.5 Commit and open the next stacked PR.
+- [x] 3.1 Identify the next `ShellHostController.swift` controller, store, projection, or command-routing boundary that can move without changing behavior.
+- [x] 3.2 Extract the selected boundary into a named owner while preserving `ShellWorkspaceCommand` as the shared command vocabulary.
+- [x] 3.3 Run shell contract validation and the architecture report.
+- [x] 3.4 Update the debt ledger and warning expectation if the `ShellHostController.swift` warning count is reduced.
+- [x] 3.5 Commit and open the next stacked PR.
 
 ## 4. Terminal Surface And Host Debt
 


### PR DESCRIPTION
## Summary
- move snapshot JSON clipboard writes out of `ShellHostController.swift` into `Services/Shell/ShellClipboardWriter.swift`
- remove the direct AppKit import from `ShellHostController.swift`
- reduce the architecture-maintainability report from 6 known warnings to 5
- update the architecture debt ledger and OpenSpec task progress

## Verification
- `bash clients/apple/scripts/check-architecture-maintainability.sh` (5 warnings)
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
- `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`
- `openspec validate --all --strict --json`
- `git diff --check`