### PR TITLE
Extract terminal host overlay support

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -124,12 +124,10 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode with
-four known warnings:
+three known warnings:
 
 - `ShellHostController.swift` remains large pending additional controller,
   store, and projection splits.
-- `TerminalHostView.swift` remains large pending additional terminal-host
-  collaborator extraction.
 - `Views/Console/ContentView.swift` remains large and imports AppKit because the
   legacy/mobile console path is isolated but not fully decomposed.
 The current architecture gate intentionally keeps those warnings non-blocking

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		00000000000000000000002F /* ShellDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000012F /* ShellDiagnostics.swift */; };
 		000000000000000000000030 /* ShellClipboardWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000130 /* ShellClipboardWriter.swift */; };
 		000000000000000000000031 /* TerminalNativeScrollViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000131 /* TerminalNativeScrollViewAdapter.swift */; };
+		000000000000000000000032 /* TerminalHostOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000132 /* TerminalHostOverlayPresenter.swift */; };
+		000000000000000000000033 /* TerminalHostViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000133 /* TerminalHostViewSupport.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,6 +111,8 @@
 		00000000000000000000012F /* ShellDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellDiagnostics.swift; sourceTree = "<group>"; };
 		000000000000000000000130 /* ShellClipboardWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellClipboardWriter.swift; sourceTree = "<group>"; };
 		000000000000000000000131 /* TerminalNativeScrollViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalNativeScrollViewAdapter.swift; sourceTree = "<group>"; };
+		000000000000000000000132 /* TerminalHostOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostOverlayPresenter.swift; sourceTree = "<group>"; };
+		000000000000000000000133 /* TerminalHostViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostViewSupport.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +266,8 @@
 			children = (
 				000000000000000000000127 /* TerminalHostRuntimeReporter.swift */,
 				000000000000000000000128 /* TerminalHostWindowObserver.swift */,
+				000000000000000000000132 /* TerminalHostOverlayPresenter.swift */,
+				000000000000000000000133 /* TerminalHostViewSupport.swift */,
 				000000000000000000000131 /* TerminalNativeScrollViewAdapter.swift */,
 			);
 			name = Services/Terminal;
@@ -413,6 +419,8 @@
 				00000000000000000000002F /* ShellDiagnostics.swift in Sources */,
 				000000000000000000000030 /* ShellClipboardWriter.swift in Sources */,
 				000000000000000000000031 /* TerminalNativeScrollViewAdapter.swift in Sources */,
+				000000000000000000000032 /* TerminalHostOverlayPresenter.swift in Sources */,
+				000000000000000000000033 /* TerminalHostViewSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Services/Terminal/TerminalHostOverlayPresenter.swift
+++ b/clients/apple/AlanNative/Services/Terminal/TerminalHostOverlayPresenter.swift
@@ -1,0 +1,164 @@
+#if os(macOS)
+import AppKit
+
+@MainActor
+final class TerminalHostOverlayPresenter {
+    let overlayCard = AlanTerminalPassiveOverlayView()
+
+    private let bodyStack = NSStackView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(wrappingLabelWithString: "")
+    private let commandLabel = NSTextField(wrappingLabelWithString: "")
+    private let footerLabel = NSTextField(wrappingLabelWithString: "")
+    private let statusBadge = NSTextField(labelWithString: "")
+
+    func install(in hostView: NSView) {
+        bodyStack.orientation = .vertical
+        bodyStack.alignment = .leading
+        bodyStack.spacing = 10
+        bodyStack.translatesAutoresizingMaskIntoConstraints = false
+
+        overlayCard.material = .hudWindow
+        overlayCard.blendingMode = .withinWindow
+        overlayCard.state = .active
+        overlayCard.translatesAutoresizingMaskIntoConstraints = false
+        overlayCard.wantsLayer = true
+        overlayCard.layer?.cornerRadius = ShellRadii.overlay
+        overlayCard.layer?.borderWidth = 1
+        overlayCard.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
+
+        statusBadge.font = .systemFont(ofSize: 11, weight: .semibold)
+        statusBadge.textColor = NSColor.white.withAlphaComponent(0.92)
+        statusBadge.drawsBackground = true
+        statusBadge.backgroundColor = NSColor.white.withAlphaComponent(0.10)
+        statusBadge.isBezeled = false
+        statusBadge.isEditable = false
+        statusBadge.isSelectable = false
+        statusBadge.alignment = .center
+        statusBadge.lineBreakMode = .byTruncatingTail
+        statusBadge.maximumNumberOfLines = 1
+        statusBadge.cell?.usesSingleLineMode = true
+        statusBadge.cell?.wraps = false
+        statusBadge.cell?.backgroundStyle = .raised
+
+        titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+        titleLabel.textColor = .white
+
+        subtitleLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.64)
+        subtitleLabel.maximumNumberOfLines = 2
+
+        commandLabel.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        commandLabel.textColor = NSColor(calibratedRed: 0.81, green: 0.90, blue: 0.98, alpha: 1)
+        commandLabel.maximumNumberOfLines = 3
+
+        footerLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        footerLabel.textColor = NSColor.white.withAlphaComponent(0.52)
+        footerLabel.maximumNumberOfLines = 4
+
+        [statusBadge, titleLabel, subtitleLabel, commandLabel, footerLabel].forEach(
+            bodyStack.addArrangedSubview
+        )
+
+        hostView.addSubview(overlayCard)
+        overlayCard.addSubview(bodyStack)
+
+        NSLayoutConstraint.activate([
+            overlayCard.centerXAnchor.constraint(equalTo: hostView.centerXAnchor),
+            overlayCard.centerYAnchor.constraint(equalTo: hostView.centerYAnchor),
+            overlayCard.widthAnchor.constraint(lessThanOrEqualToConstant: 460),
+            overlayCard.leadingAnchor.constraint(
+                greaterThanOrEqualTo: hostView.leadingAnchor,
+                constant: 24
+            ),
+            overlayCard.trailingAnchor.constraint(
+                lessThanOrEqualTo: hostView.trailingAnchor,
+                constant: -24
+            ),
+
+            bodyStack.topAnchor.constraint(equalTo: overlayCard.topAnchor, constant: 18),
+            bodyStack.leadingAnchor.constraint(equalTo: overlayCard.leadingAnchor, constant: 18),
+            bodyStack.trailingAnchor.constraint(equalTo: overlayCard.trailingAnchor, constant: -18),
+            bodyStack.bottomAnchor.constraint(equalTo: overlayCard.bottomAnchor, constant: -18),
+        ])
+    }
+
+    func configure(pane: ShellPane?, bootProfile: AlanShellBootProfile?) {
+        titleLabel.stringValue = pane?.viewport?.title ?? pane?.process?.program ?? "Terminal"
+        subtitleLabel.stringValue = pane?.viewport?.summary ?? "Preparing the native terminal view."
+
+        if let bootProfile {
+            commandLabel.stringValue = "$ \(bootProfile.launchCommandString)"
+
+            let envSummary = bootProfile.environmentPreview
+                .prefix(4)
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: "\n")
+            footerLabel.stringValue = [
+                "launch: \(bootProfile.command.strategy.rawValue)",
+                bootProfile.command.detail,
+                "cwd: \(bootProfile.workingDirectory)",
+                envSummary.isEmpty ? nil : envSummary,
+                "setup: \(bootProfile.ghostty.setupCommand)",
+            ]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+        } else {
+            commandLabel.stringValue = "$ /bin/zsh -l"
+            footerLabel.stringValue = "Select a pane to prepare a terminal boot profile."
+        }
+    }
+
+    func updateSubtitle(_ summary: String?) {
+        guard let summary else { return }
+        subtitleLabel.stringValue = summary
+    }
+
+    func syncStatusBadge(
+        bootProfile: AlanShellBootProfile?,
+        renderer: TerminalRendererSnapshot
+    ) {
+        if bootProfile == nil {
+            statusBadge.stringValue = "Select a pane"
+            return
+        }
+
+        if let bootProfile, !bootProfile.ghostty.isReady {
+            statusBadge.stringValue = "GhosttyKit pending"
+            return
+        }
+
+        statusBadge.stringValue = renderer.kind == .ghosttyLive
+            ? "Ghostty live · \(renderer.phaseLabel)"
+            : "GhosttyKit ready"
+    }
+
+    func syncOverlay(
+        overlayState: AlanTerminalOverlayState?,
+        bootProfile: AlanShellBootProfile?
+    ) {
+        guard let overlayState else {
+            overlayCard.isHidden = true
+            return
+        }
+
+        statusBadge.stringValue = overlayState.badge
+        titleLabel.stringValue = overlayState.title
+        subtitleLabel.stringValue = overlayState.message
+        if let action = overlayState.action {
+            commandLabel.stringValue = action
+        }
+        footerLabel.stringValue = bootProfile.map {
+            "launch: \($0.command.strategy.rawValue)\ncwd: \($0.workingDirectory)"
+        }
+        ?? "Select a pane to prepare a terminal boot profile."
+        overlayCard.isHidden = false
+    }
+}
+
+final class AlanTerminalPassiveOverlayView: NSVisualEffectView {
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+#endif

--- a/clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+struct TerminalHostView: NSViewRepresentable {
+    let pane: ShellPane?
+    let bootProfile: AlanShellBootProfile?
+    let isSelected: Bool
+    let runtimeRegistry: TerminalRuntimeRegistry
+    let activationDelegate: TerminalHostActivationDelegate?
+    let onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?
+    let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
+    let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
+
+    func makeNSView(context: Context) -> AlanTerminalHostNSView {
+        runtimeRegistry.hostView(
+            for: pane,
+            bootProfile: bootProfile,
+            isSelected: isSelected,
+            activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
+        )
+    }
+
+    func updateNSView(_ nsView: AlanTerminalHostNSView, context: Context) {
+        nsView.configure(
+            pane: pane,
+            bootProfile: bootProfile,
+            isSelected: isSelected,
+            surfaceHandle: runtimeRegistry.surfaceHandle(for: pane, bootProfile: bootProfile),
+            activationDelegate: activationDelegate,
+            onWorkspaceCommand: onWorkspaceCommand,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
+        )
+    }
+}
+
+@MainActor
+protocol TerminalHostActivationDelegate: AnyObject {
+    func terminalHostDidRequestActivation(paneID: String)
+}
+
+func makeCanvasView() -> NSView {
+#if canImport(GhosttyKit)
+    let view = AlanGhosttyCanvasView(frame: .zero)
+#else
+    let view = AlanTerminalFallbackCanvasView(frame: .zero)
+    view.wantsLayer = true
+    view.layer?.backgroundColor = NSColor.clear.cgColor
+#endif
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+}
+
+func terminalHostShouldAutoFocusAfterConfigure(
+    isSelected: Bool,
+    previousPaneID: String?,
+    paneID: String?,
+    wasSelected: Bool
+) -> Bool {
+    guard isSelected, paneID != nil else { return false }
+    return previousPaneID != paneID || !wasSelected
+}
+
+final class AlanTerminalFallbackCanvasView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+#endif

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -1,5 +1,3 @@
-import SwiftUI
-
 #if os(macOS)
 import AppKit
 #if canImport(QuartzCore)
@@ -9,56 +7,9 @@ import QuartzCore
 import GhosttyKit
 #endif
 
-struct TerminalHostView: NSViewRepresentable {
-    let pane: ShellPane?
-    let bootProfile: AlanShellBootProfile?
-    let isSelected: Bool
-    let runtimeRegistry: TerminalRuntimeRegistry
-    let activationDelegate: TerminalHostActivationDelegate?
-    let onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?
-    let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
-    let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
-
-    func makeNSView(context: Context) -> AlanTerminalHostNSView {
-        runtimeRegistry.hostView(
-            for: pane,
-            bootProfile: bootProfile,
-            isSelected: isSelected,
-            activationDelegate: activationDelegate,
-            onWorkspaceCommand: onWorkspaceCommand,
-            onRuntimeUpdate: onRuntimeUpdate,
-            onMetadataUpdate: onMetadataUpdate
-        )
-    }
-
-    func updateNSView(_ nsView: AlanTerminalHostNSView, context: Context) {
-        nsView.configure(
-            pane: pane,
-            bootProfile: bootProfile,
-            isSelected: isSelected,
-            surfaceHandle: runtimeRegistry.surfaceHandle(for: pane, bootProfile: bootProfile),
-            activationDelegate: activationDelegate,
-            onWorkspaceCommand: onWorkspaceCommand,
-            onRuntimeUpdate: onRuntimeUpdate,
-            onMetadataUpdate: onMetadataUpdate
-        )
-    }
-}
-
-@MainActor
-protocol TerminalHostActivationDelegate: AnyObject {
-    func terminalHostDidRequestActivation(paneID: String)
-}
-
 final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHandle {
     private let canvasView = makeCanvasView()
-    private let overlayCard = AlanTerminalPassiveOverlayView()
-    private let bodyStack = NSStackView()
-    private let titleLabel = NSTextField(labelWithString: "")
-    private let subtitleLabel = NSTextField(wrappingLabelWithString: "")
-    private let commandLabel = NSTextField(wrappingLabelWithString: "")
-    private let footerLabel = NSTextField(wrappingLabelWithString: "")
-    private let statusBadge = NSTextField(labelWithString: "")
+    private let overlayPresenter = TerminalHostOverlayPresenter()
     private let surfaceController = AlanTerminalSurfaceController()
     private let runtimeReporter = TerminalHostRuntimeReporter()
     private let windowObserver = TerminalHostWindowObserver()
@@ -196,37 +147,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
-        let title = pane?.viewport?.title ?? pane?.process?.program ?? "Terminal"
-        titleLabel.stringValue = title
-        subtitleLabel.stringValue = pane?.viewport?.summary ?? "Preparing the native terminal view."
-
-        if let bootProfile {
-            commandLabel.stringValue = "$ \(bootProfile.launchCommandString)"
-
-            let envSummary = bootProfile.environmentPreview
-                .prefix(4)
-                .map { "\($0.key)=\($0.value)" }
-                .joined(separator: "\n")
-            footerLabel.stringValue = [
-                "launch: \(bootProfile.command.strategy.rawValue)",
-                bootProfile.command.detail,
-                "cwd: \(bootProfile.workingDirectory)",
-                envSummary.isEmpty ? nil : envSummary,
-                "setup: \(bootProfile.ghostty.setupCommand)",
-            ]
-            .compactMap { $0 }
-            .joined(separator: "\n")
-        } else {
-            commandLabel.stringValue = "$ /bin/zsh -l"
-            footerLabel.stringValue = "Select a pane to prepare a terminal boot profile."
-        }
+        overlayPresenter.configure(pane: pane, bootProfile: bootProfile)
 
         synchronizeRendererSnapshot(with: bootProfile)
         syncStatusBadge()
         syncOverlayVisibility()
         synchronizeLiveHost()
         syncNativeScrollback()
-        if shouldAutoFocusAfterConfigure(
+        if terminalHostShouldAutoFocusAfterConfigure(
+            isSelected: isSelected,
             previousPaneID: previousPaneID,
             paneID: pane?.paneID,
             wasSelected: wasSelected
@@ -261,51 +190,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         translatesAutoresizingMaskIntoConstraints = false
 
-        bodyStack.orientation = .vertical
-        bodyStack.alignment = .leading
-        bodyStack.spacing = 10
-        bodyStack.translatesAutoresizingMaskIntoConstraints = false
-
-        overlayCard.material = .hudWindow
-        overlayCard.blendingMode = .withinWindow
-        overlayCard.state = .active
-        overlayCard.translatesAutoresizingMaskIntoConstraints = false
-        overlayCard.wantsLayer = true
-        overlayCard.layer?.cornerRadius = ShellRadii.overlay
-        overlayCard.layer?.borderWidth = 1
-        overlayCard.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
-
-        statusBadge.font = .systemFont(ofSize: 11, weight: .semibold)
-        statusBadge.textColor = NSColor.white.withAlphaComponent(0.92)
-        statusBadge.drawsBackground = true
-        statusBadge.backgroundColor = NSColor.white.withAlphaComponent(0.10)
-        statusBadge.isBezeled = false
-        statusBadge.isEditable = false
-        statusBadge.isSelectable = false
-        statusBadge.alignment = .center
-        statusBadge.lineBreakMode = .byTruncatingTail
-        statusBadge.maximumNumberOfLines = 1
-        statusBadge.cell?.usesSingleLineMode = true
-        statusBadge.cell?.wraps = false
-        statusBadge.cell?.backgroundStyle = .raised
-
-        titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
-        titleLabel.textColor = .white
-
-        subtitleLabel.font = .systemFont(ofSize: 12, weight: .medium)
-        subtitleLabel.textColor = NSColor.white.withAlphaComponent(0.64)
-        subtitleLabel.maximumNumberOfLines = 2
-
-        commandLabel.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
-        commandLabel.textColor = NSColor(calibratedRed: 0.81, green: 0.90, blue: 0.98, alpha: 1)
-        commandLabel.maximumNumberOfLines = 3
-
-        footerLabel.font = .systemFont(ofSize: 11, weight: .regular)
-        footerLabel.textColor = NSColor.white.withAlphaComponent(0.52)
-        footerLabel.maximumNumberOfLines = 4
-
-        [statusBadge, titleLabel, subtitleLabel, commandLabel, footerLabel].forEach(bodyStack.addArrangedSubview)
-
         let nativeScrollView = surfaceController.nativeScrollViewAdapter.scrollView
         surfaceController.nativeScrollViewAdapter.onScrollWheel = { [weak self] event in
             self?.routeScrollWheel(event) ?? false
@@ -315,8 +199,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         }
         surfaceController.nativeScrollViewAdapter.attachCanvasView(canvasView)
         addSubview(nativeScrollView)
-        addSubview(overlayCard)
-        overlayCard.addSubview(bodyStack)
+        overlayPresenter.install(in: self)
 
         NSLayoutConstraint.activate([
             nativeScrollView.topAnchor.constraint(equalTo: topAnchor),
@@ -324,16 +207,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             nativeScrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             nativeScrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            overlayCard.centerXAnchor.constraint(equalTo: centerXAnchor),
-            overlayCard.centerYAnchor.constraint(equalTo: centerYAnchor),
-            overlayCard.widthAnchor.constraint(lessThanOrEqualToConstant: 460),
-            overlayCard.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 24),
-            overlayCard.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -24),
-
-            bodyStack.topAnchor.constraint(equalTo: overlayCard.topAnchor, constant: 18),
-            bodyStack.leadingAnchor.constraint(equalTo: overlayCard.leadingAnchor, constant: 18),
-            bodyStack.trailingAnchor.constraint(equalTo: overlayCard.trailingAnchor, constant: -18),
-            bodyStack.bottomAnchor.constraint(equalTo: overlayCard.bottomAnchor, constant: -18),
         ])
     }
 
@@ -427,7 +300,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
                 guard let self else { return }
                 paneMetadata = snapshot
                 surfaceController.updateMetadata(snapshot)
-                subtitleLabel.stringValue = snapshot.summary ?? subtitleLabel.stringValue
+                overlayPresenter.updateSubtitle(snapshot.summary)
                 reportMetadataIfNeeded(snapshot)
                 syncOverlayVisibility()
                 publishRuntimeSnapshot()
@@ -469,40 +342,16 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func syncStatusBadge() {
-        if bootProfile == nil {
-            statusBadge.stringValue = "Select a pane"
-            return
-        }
-
-        if let bootProfile, !bootProfile.ghostty.isReady {
-            statusBadge.stringValue = "GhosttyKit pending"
-            return
-        }
-
-        statusBadge.stringValue = rendererSnapshot.kind == .ghosttyLive
-            ? "Ghostty live · \(rendererSnapshot.phaseLabel)"
-            : "GhosttyKit ready"
+        overlayPresenter.syncStatusBadge(bootProfile: bootProfile, renderer: rendererSnapshot)
     }
 
     private func syncOverlayVisibility() {
-        if let overlayState = surfaceController.overlayState(
+        let overlayState = surfaceController.overlayState(
             renderer: rendererSnapshot,
             metadata: paneMetadata,
             bootProfile: bootProfile
-        ) {
-            statusBadge.stringValue = overlayState.badge
-            titleLabel.stringValue = overlayState.title
-            subtitleLabel.stringValue = overlayState.message
-            if let action = overlayState.action {
-                commandLabel.stringValue = action
-            }
-            footerLabel.stringValue = bootProfile.map { "launch: \($0.command.strategy.rawValue)\ncwd: \($0.workingDirectory)" }
-                ?? "Select a pane to prepare a terminal boot profile."
-            overlayCard.isHidden = false
-            return
-        }
-
-        overlayCard.isHidden = true
+        )
+        overlayPresenter.syncOverlay(overlayState: overlayState, bootProfile: bootProfile)
     }
 
     private var isFocused: Bool {
@@ -523,15 +372,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             guard isSelected, pane != nil, window != nil else { return }
             requestTerminalFocus()
         }
-    }
-
-    private func shouldAutoFocusAfterConfigure(
-        previousPaneID: String?,
-        paneID: String?,
-        wasSelected: Bool
-    ) -> Bool {
-        guard isSelected, paneID != nil else { return false }
-        return previousPaneID != paneID || !wasSelected
     }
 
     private func requestTerminalFocus() {
@@ -1350,27 +1190,4 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 }
 
-private func makeCanvasView() -> NSView {
-#if canImport(GhosttyKit)
-    let view = AlanGhosttyCanvasView(frame: .zero)
-#else
-    let view = AlanTerminalFallbackCanvasView(frame: .zero)
-    view.wantsLayer = true
-    view.layer?.backgroundColor = NSColor.clear.cgColor
-#endif
-    view.translatesAutoresizingMaskIntoConstraints = false
-    return view
-}
-
-final class AlanTerminalFallbackCanvasView: NSView {
-    override var mouseDownCanMoveWindow: Bool { false }
-
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-}
-
-final class AlanTerminalPassiveOverlayView: NSVisualEffectView {
-    override var mouseDownCanMoveWindow: Bool { false }
-
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-}
 #endif

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -479,7 +479,7 @@ require_pattern \
     "terminal teardown must be idempotent"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
     "let isSelected: Bool" \
     "terminal hosts must know whether their pane is selected"
 
@@ -489,12 +489,12 @@ require_pattern \
     "terminal auto-focus must be gated to the selected pane"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
-    "shouldAutoFocusAfterConfigure" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
+    "terminalHostShouldAutoFocusAfterConfigure" \
     "terminal auto-focus must only be requested on initial attachment or selected-pane transitions"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
     "previousPaneID != paneID \\|\\| !wasSelected" \
     "terminal auto-focus must not refocus the same selected pane on every SwiftUI update"
 
@@ -504,7 +504,7 @@ require_pattern \
     "terminal auto-focus must coalesce pending first-responder requests"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
     "protocol TerminalHostActivationDelegate: AnyObject" \
     "terminal activation must use a narrow class-bound delegate"
 
@@ -564,8 +564,8 @@ require_pattern \
     "terminal workspace shortcuts must leave the AppKit host through the shared command callback"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
-    "private let overlayCard = AlanTerminalPassiveOverlayView\\(\\)" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostOverlayPresenter.swift" \
+    "let overlayCard = AlanTerminalPassiveOverlayView\\(\\)" \
     "passive terminal overlays must use a non-interactive overlay view"
 
 reject_pattern \
@@ -584,12 +584,12 @@ require_pattern \
     "terminal host views must not allow terminal pane clicks to drag the shell window"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
     "final class AlanTerminalFallbackCanvasView" \
     "fallback terminal canvas views must explicitly opt out of background window dragging"
 
 require_pattern \
-    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift" \
     "override func hitTest\\(_ point: NSPoint\\) -> NSView\\? \\{ nil \\}" \
     "fallback terminal canvas views must be transparent to AppKit hit-testing"
 

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
@@ -24,10 +24,10 @@
 
 - [x] 4.1 Identify the next `TerminalSurfaceController.swift` adapter or input/surface boundary that can move without changing behavior.
 - [x] 4.2 Extract the selected terminal surface boundary and run focused terminal surface validation.
-- [ ] 4.3 Identify the next `TerminalHostView.swift` collaborator boundary for runtime attachment, overlay presentation, input routing, window observation, metadata publishing, or surface coordination.
-- [ ] 4.4 Extract the selected terminal host boundary and run focused terminal host/runtime validation.
+- [x] 4.3 Identify the next `TerminalHostView.swift` collaborator boundary for runtime attachment, overlay presentation, input routing, window observation, metadata publishing, or surface coordination.
+- [x] 4.4 Extract the selected terminal host boundary and run focused terminal host/runtime validation.
 - [x] 4.5 Update `clients/apple/ARCHITECTURE.md` and script expectations after each reduced warning.
-- [ ] 4.6 Commit and open stacked PRs for each reduced terminal warning.
+- [x] 4.6 Commit and open stacked PRs for each reduced terminal warning.
 
 ## 5. Console Content View Debt
 


### PR DESCRIPTION
## Summary
- move terminal host overlay presentation into `Services/Terminal/TerminalHostOverlayPresenter.swift`
- move the SwiftUI representable wrapper and canvas support into `Services/Terminal/TerminalHostViewSupport.swift`
- reduce `TerminalHostView.swift` below the architecture large-file threshold
- reduce the architecture-maintainability report from 4 known warnings to 3
- update Xcode project membership, focused test inputs, architecture debt ledger, and OpenSpec task progress

## Verification
- `bash clients/apple/scripts/check-architecture-maintainability.sh` (3 warnings)
- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
- `bash clients/apple/scripts/test-terminal-surface-controller.sh`
- `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
- `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`
- `openspec validate --all --strict --json`
- `git diff --check`

Stacked on #391.