### PR TITLE
Extract shell host command handling

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -41,7 +41,8 @@ Xcode target.
 | `Models/Shell/ShellTreeMutations.swift` | 198 | Foundation | Split-tree resizing, equalization, split, removal, and attachment helpers | `Models/Shell/` |
 | `Models/Shell/ShellStateMutations.swift` | 1034 | Foundation | Shell bootstrap defaults, state mutation result/error types, mutation helpers, and preview fixtures | `Models/Shell/` |
 | `ShellModel.swift` | 169 | Foundation | Shell title, label, and status presentation helpers | `Models/Shell/` or `Support/ShellPresentation/` |
-| `ShellHostController.swift` | 1632 | Foundation, AppKit, SwiftUI; macOS gates | Observable shell controller, runtime update intake, command routing, control-plane command handling | `Controllers/Shell/` plus service collaborators |
+| `ShellHostController.swift` | 1100 | Foundation, SwiftUI; macOS gates | Observable shell controller, runtime update intake, command routing, and shell state mutation coordination | `Controllers/Shell/` plus service collaborators |
+| `Controllers/Shell/ShellHostControlCommandHandling.swift` | 538 | Foundation; macOS gates | Shell control-plane command response handling and routing/list helpers | `Controllers/Shell/` |
 | `Services/Shell/ShellControlFilePoller.swift` | 182 | Foundation; macOS gates | File-backed command/result polling and Alan binding-file projection | `Services/Shell/` |
 | `Services/Shell/ShellDiagnostics.swift` | 16 | Foundation; macOS gates | Shell service diagnostic routing | `Services/Shell/` |
 | `Services/Shell/ShellEventStore.swift` | 298 | Foundation; macOS gates | Shell event buffering, diffing, `events.read`, and jsonl persistence | `Services/Shell/` |
@@ -127,12 +128,11 @@ device support was not required for this validation.
 ## Remaining Architecture Debt
 
 `check-architecture-maintainability.sh` currently completes in report mode with
-one known warning:
+zero known warnings.
 
-- `ShellHostController.swift` remains large pending additional controller,
-  store, and projection splits.
-The current architecture gate intentionally keeps those warnings non-blocking
-while failing narrower regressions such as new root-level Swift files, project
-membership drift, or reintroduced control-plane ownership in the wrong file.
+The current architecture gate remains non-blocking for future documented
+warnings while failing narrower regressions such as new root-level Swift files,
+project membership drift, or reintroduced control-plane ownership in the wrong
+file.
 The `macos-app-architecture-maintainability` spec requires this debt record to
 stay current whenever warnings are introduced, broadened, or resolved.

--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		000000000000000000000034 /* AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* ConsoleAdaptiveColor.swift */; };
+		000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000137 /* ShellHostControlCommandHandling.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -119,6 +120,7 @@
 		000000000000000000000134 /* AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
+		000000000000000000000137 /* ShellHostControlCommandHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Shell/ShellHostControlCommandHandling.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +151,7 @@
 			children = (
 				000000000000000000000304 /* App */,
 				00000000000000000000030E /* Controllers/Console */,
+				00000000000000000000030F /* Controllers/Shell */,
 				000000000000000000000306 /* Views/Shell */,
 				000000000000000000000307 /* Views/Console */,
 				000000000000000000000309 /* Models/API */,
@@ -223,6 +226,14 @@
 				000000000000000000000134 /* AlanConsoleViewModel.swift */,
 			);
 			name = Controllers/Console;
+			sourceTree = "<group>";
+		};
+		00000000000000000000030F /* Controllers/Shell */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000137 /* ShellHostControlCommandHandling.swift */,
+			);
+			name = Controllers/Shell;
 			sourceTree = "<group>";
 		};
 		000000000000000000000308 /* Models/Console */ = {
@@ -441,6 +452,7 @@
 				000000000000000000000034 /* AlanConsoleViewModel.swift in Sources */,
 				000000000000000000000035 /* ConsoleSupportViews.swift in Sources */,
 				000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */,
+				000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -1,0 +1,538 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+extension ShellHostController {
+    func attentionInboxRows() -> [AlanShellAttentionInboxItem] {
+        attentionItems.map { item in
+            AlanShellAttentionInboxItem(
+                itemID: "attn_\(item.paneID)",
+                spaceID: item.spaceID,
+                tabID: item.tabID,
+                paneID: item.paneID,
+                attention: item.attention,
+                summary: item.summary
+            )
+        }
+    }
+
+    func routingCandidates(preferredPaneID: String?) -> [AlanShellRoutingCandidate] {
+        let preferredPane = preferredPaneID.flatMap { pane(paneID: $0) }
+        let focusedPane = self.focusedPane
+
+        return shellState.panes.map { candidate in
+            var score = 0.0
+            var reasons: [String] = []
+
+            if candidate.paneID == preferredPaneID {
+                score += 0.4
+                reasons.append("requested")
+            }
+            if candidate.paneID == shellState.focusedPaneID {
+                score += 0.3
+                reasons.append("focused")
+            }
+            if candidate.attention == .awaitingUser {
+                score += 0.25
+                reasons.append("attention:awaiting_user")
+            } else if candidate.attention == .notable {
+                score += 0.12
+                reasons.append("attention:notable")
+            }
+            if candidate.alanBinding?.pendingYield == true {
+                score += 0.2
+                reasons.append("alan_binding:yielded")
+            } else if let runStatus = candidate.alanBinding?.runStatus {
+                score += 0.08
+                reasons.append("alan_binding:\(runStatus)")
+            }
+            if let preferredPane, candidate.tabID == preferredPane.tabID {
+                score += 0.1
+                reasons.append("same_tab")
+            } else if let focusedPane, candidate.tabID == focusedPane.tabID {
+                score += 0.08
+                reasons.append("same_tab")
+            }
+            if let preferredPane, candidate.spaceID == preferredPane.spaceID {
+                score += 0.05
+                reasons.append("same_space")
+            } else if let focusedPane, candidate.spaceID == focusedPane.spaceID {
+                score += 0.04
+                reasons.append("same_space")
+            }
+            if let process = candidate.process?.program {
+                reasons.append("process:\(process)")
+            }
+
+            return AlanShellRoutingCandidate(
+                paneID: candidate.paneID,
+                score: min(score, 1.0),
+                reasons: Array(Set(reasons)).sorted()
+            )
+        }
+        .sorted {
+            $0.score == $1.score ? $0.paneID < $1.paneID : $0.score > $1.score
+        }
+    }
+
+    func paneList(tabID: String?) -> [ShellPane] {
+        guard let tabID else {
+            return shellState.panes
+        }
+        return shellState.panes.filter { $0.tabID == tabID }
+    }
+
+    func tabList(spaceID: String?) -> [ShellTab] {
+        if let spaceID {
+            return shellState.spaces.first(where: { $0.spaceID == spaceID })?.tabs ?? []
+        }
+        return shellState.spaces.flatMap(\.tabs)
+    }
+
+    func response(
+        requestID: String,
+        applied: Bool,
+        state: ShellStateSnapshot? = nil,
+        spaces: [ShellSpace]? = nil,
+        tabs: [ShellTab]? = nil,
+        panes: [ShellPane]? = nil,
+        pane: ShellPane? = nil,
+        items: [AlanShellAttentionInboxItem]? = nil,
+        candidates: [AlanShellRoutingCandidate]? = nil,
+        events: [AlanShellEventEnvelope]? = nil,
+        spaceID: String? = nil,
+        tabID: String? = nil,
+        paneID: String? = nil,
+        acceptedBytes: Int? = nil,
+        deliveryCode: String? = nil,
+        runtimePhase: String? = nil,
+        latestEventID: String? = nil,
+        errorCode: String? = nil,
+        errorMessage: String? = nil
+    ) -> AlanShellControlResponse {
+        AlanShellControlResponse(
+            requestID: requestID,
+            contractVersion: shellState.contractVersion,
+            applied: applied,
+            state: state,
+            spaces: spaces,
+            tabs: tabs,
+            panes: panes,
+            pane: pane,
+            items: items,
+            candidates: candidates,
+            events: events,
+            focusedPaneID: shellState.focusedPaneID,
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            acceptedBytes: acceptedBytes,
+            deliveryCode: deliveryCode,
+            runtimePhase: runtimePhase,
+            latestEventID: latestEventID,
+            errorCode: errorCode,
+            errorMessage: errorMessage
+        )
+    }
+
+    func handleControlPlaneCommand(_ command: AlanShellControlCommand) -> AlanShellControlResponse {
+        switch command.command {
+        case .state:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                state: shellState
+            )
+
+        case .spaceList:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaces: shellState.spaces
+            )
+
+        case .spaceCreate, .spaceOpenAlan:
+            let launchTarget: ShellLaunchTarget = command.command == .spaceOpenAlan ? .alan : .shell
+            let failureMessage = launchTarget == .alan
+                ? "Failed to create a new Alan space."
+                : "Failed to create a new shell space."
+            guard let spaceID = createSpace(
+                launchTarget: launchTarget,
+                title: command.title,
+                workingDirectory: command.cwd
+            ) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "space_create_failed",
+                    errorMessage: failureMessage
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: spaceID,
+                paneID: shellState.focusedPaneID
+            )
+
+        case .tabList:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                tabs: tabList(spaceID: command.spaceID),
+                spaceID: command.spaceID
+            )
+
+        case .tabOpen:
+            guard let tabID = openTerminalTab(
+                in: command.spaceID,
+                title: command.title,
+                workingDirectory: command.cwd
+            ) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: command.spaceID,
+                    errorCode: "space_not_found",
+                    errorMessage: "The requested space does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: shellState.focusedSpaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID
+            )
+
+        case .tabClose:
+            guard let tabID = command.tabID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "tab_required",
+                    errorMessage: "tab_id is required."
+                )
+            }
+
+            switch closeTab(tabID: tabID) {
+            case .closed:
+                return response(
+                    requestID: command.requestID,
+                    applied: true,
+                    tabID: tabID,
+                    paneID: shellState.focusedPaneID
+                )
+            case .tabNotFound:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: "tab_not_found",
+                    errorMessage: "The requested tab does not exist."
+                )
+            case .lastTab:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: "last_tab",
+                    errorMessage: "Alan Shell must keep at least one tab open."
+                )
+            }
+
+        case .paneList:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                panes: paneList(tabID: command.tabID),
+                tabID: command.tabID
+            )
+
+        case .paneSnapshot:
+            guard let paneID = command.paneID,
+                  let pane = pane(paneID: paneID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: command.paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                pane: pane,
+                spaceID: pane.spaceID,
+                tabID: pane.tabID,
+                paneID: pane.paneID
+            )
+
+        case .paneSplit:
+            guard let paneID = command.paneID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
+                )
+            }
+            guard let direction = command.direction else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "direction_required",
+                    errorMessage: "direction is required for pane.split."
+                )
+            }
+            guard let newPaneID = splitPane(paneID: paneID, direction: direction) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: newPaneID
+            )
+
+        case .paneClose:
+            guard let paneID = command.paneID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
+                )
+            }
+
+            switch closePane(paneID: paneID) {
+            case .closed:
+                return response(
+                    requestID: command.requestID,
+                    applied: true,
+                    spaceID: shellState.focusedSpaceID,
+                    tabID: shellState.focusedTabID,
+                    paneID: shellState.focusedPaneID
+                )
+            case .paneNotFound:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            case .lastTab:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "last_tab",
+                    errorMessage: "Alan Shell must keep at least one pane open."
+                )
+            }
+
+        case .paneLift:
+            guard let paneID = command.paneID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
+                )
+            }
+
+            switch liftPaneToTab(paneID: paneID, title: command.title) {
+            case .lifted:
+                return response(
+                    requestID: command.requestID,
+                    applied: true,
+                    spaceID: shellState.focusedSpaceID,
+                    tabID: shellState.focusedTabID,
+                    paneID: shellState.focusedPaneID
+                )
+            case .paneNotFound:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            case .lastPane:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "last_pane",
+                    errorMessage: "The pane needs at least one sibling before it can be lifted."
+                )
+            }
+
+        case .paneMove:
+            guard let paneID = command.paneID,
+                  let targetTabID = command.tabID
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: command.tabID,
+                    paneID: command.paneID,
+                    errorCode: "pane_move_target_required",
+                    errorMessage: "pane_id and tab_id are required."
+                )
+            }
+
+            let direction = command.direction ?? .vertical
+            guard movePane(paneID: paneID, toTab: targetTabID, direction: direction) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: targetTabID,
+                    paneID: paneID,
+                    errorCode: "invalid_move_target",
+                    errorMessage: "The requested pane could not be moved to the target tab."
+                )
+            }
+
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: shellState.focusedPaneID
+            )
+
+        case .paneFocus:
+            guard let paneID = command.paneID,
+                  shellState.panes.contains(where: { $0.paneID == paneID })
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: command.paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+
+            focus(paneID: paneID)
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: paneID
+            )
+
+        case .paneSendText:
+            guard let paneID = command.paneID,
+                  let targetPane = pane(paneID: paneID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: command.paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+
+            let text = command.text ?? ""
+            let delivery = terminalRuntimeRegistry.sendText(to: paneID, text: text)
+            controlPlane.recordTextDelivery(
+                requestID: command.requestID,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
+                paneID: paneID,
+                delivery: delivery
+            )
+
+            return response(
+                requestID: command.requestID,
+                applied: delivery.applied,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
+                paneID: paneID,
+                acceptedBytes: delivery.acceptedBytes,
+                deliveryCode: delivery.code.rawValue,
+                runtimePhase: delivery.runtimePhase,
+                errorCode: delivery.errorCode,
+                errorMessage: delivery.errorMessage
+            )
+
+        case .attentionInbox:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                items: attentionInboxRows()
+            )
+
+        case .attentionSet:
+            guard let paneID = command.paneID,
+                  let attention = command.attention
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "attention_target_required",
+                    errorMessage: "pane_id and attention are required."
+                )
+            }
+            guard let targetPane = pane(paneID: paneID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+            guard setAttention(attention, for: paneID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
+                paneID: paneID
+            )
+
+        case .routingCandidates:
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                candidates: routingCandidates(preferredPaneID: command.paneID)
+            )
+
+        case .eventsRead:
+            return controlPlane.specialCommandResponse(for: command)
+                ?? response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "events_unavailable",
+                    errorMessage: "events.read is handled by the shell control plane."
+                )
+        }
+    }
+
+}
+#endif

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -14,19 +14,19 @@ struct ShellAttentionItem: Identifiable, Equatable {
     var id: String { paneID }
 }
 
-private enum ShellTabCloseResult {
+enum ShellTabCloseResult {
     case closed
     case tabNotFound
     case lastTab
 }
 
-private enum ShellPaneCloseResult {
+enum ShellPaneCloseResult {
     case closed
     case paneNotFound
     case lastTab
 }
 
-private enum ShellPaneLiftResult {
+enum ShellPaneLiftResult {
     case lifted
     case paneNotFound
     case lastPane
@@ -84,7 +84,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let persistenceStore: ShellStatePersistenceStore
     private let paneProjection: ShellPaneProjectionService
     private let clipboardWriter: ShellClipboardWriter
-    private lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
+    lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
                 requestID: command.requestID,
@@ -984,7 +984,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         persistenceStore.save(shellState)
     }
 
-    private func pane(paneID: String) -> ShellPane? {
+    func pane(paneID: String) -> ShellPane? {
         shellState.panes.first { $0.paneID == paneID }
     }
 
@@ -1002,7 +1002,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         return "\(prefix)_\(nextOrdinal)"
     }
 
-    private func closeTab(tabID: String) -> ShellTabCloseResult {
+    func closeTab(tabID: String) -> ShellTabCloseResult {
         do {
             let result = try shellState.closingTab(tabID)
             applyMutationResult(result)
@@ -1016,7 +1016,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func closePane(paneID: String) -> ShellPaneCloseResult {
+    func closePane(paneID: String) -> ShellPaneCloseResult {
         do {
             let result = try shellState.closingPane(paneID)
             applyMutationResult(result)
@@ -1030,7 +1030,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func movePane(
+    func movePane(
         paneID: String,
         toTab targetTabID: String,
         direction: ShellSplitDirection
@@ -1048,7 +1048,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func liftPaneToTab(paneID: String, title: String? = nil) -> ShellPaneLiftResult {
+    func liftPaneToTab(paneID: String, title: String? = nil) -> ShellPaneLiftResult {
         do {
             let result = try shellState.movingPaneToNewTab(paneID, title: title)
             applyMutationResult(result)
@@ -1068,138 +1068,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func attentionInboxRows() -> [AlanShellAttentionInboxItem] {
-        attentionItems.map { item in
-            AlanShellAttentionInboxItem(
-                itemID: "attn_\(item.paneID)",
-                spaceID: item.spaceID,
-                tabID: item.tabID,
-                paneID: item.paneID,
-                attention: item.attention,
-                summary: item.summary
-            )
-        }
-    }
-
-    private func routingCandidates(preferredPaneID: String?) -> [AlanShellRoutingCandidate] {
-        let preferredPane = preferredPaneID.flatMap { pane(paneID: $0) }
-        let focusedPane = self.focusedPane
-
-        return shellState.panes.map { candidate in
-            var score = 0.0
-            var reasons: [String] = []
-
-            if candidate.paneID == preferredPaneID {
-                score += 0.4
-                reasons.append("requested")
-            }
-            if candidate.paneID == shellState.focusedPaneID {
-                score += 0.3
-                reasons.append("focused")
-            }
-            if candidate.attention == .awaitingUser {
-                score += 0.25
-                reasons.append("attention:awaiting_user")
-            } else if candidate.attention == .notable {
-                score += 0.12
-                reasons.append("attention:notable")
-            }
-            if candidate.alanBinding?.pendingYield == true {
-                score += 0.2
-                reasons.append("alan_binding:yielded")
-            } else if let runStatus = candidate.alanBinding?.runStatus {
-                score += 0.08
-                reasons.append("alan_binding:\(runStatus)")
-            }
-            if let preferredPane, candidate.tabID == preferredPane.tabID {
-                score += 0.1
-                reasons.append("same_tab")
-            } else if let focusedPane, candidate.tabID == focusedPane.tabID {
-                score += 0.08
-                reasons.append("same_tab")
-            }
-            if let preferredPane, candidate.spaceID == preferredPane.spaceID {
-                score += 0.05
-                reasons.append("same_space")
-            } else if let focusedPane, candidate.spaceID == focusedPane.spaceID {
-                score += 0.04
-                reasons.append("same_space")
-            }
-            if let process = candidate.process?.program {
-                reasons.append("process:\(process)")
-            }
-
-            return AlanShellRoutingCandidate(
-                paneID: candidate.paneID,
-                score: min(score, 1.0),
-                reasons: Array(Set(reasons)).sorted()
-            )
-        }
-        .sorted {
-            $0.score == $1.score ? $0.paneID < $1.paneID : $0.score > $1.score
-        }
-    }
-
-    private func paneList(tabID: String?) -> [ShellPane] {
-        guard let tabID else {
-            return shellState.panes
-        }
-        return shellState.panes.filter { $0.tabID == tabID }
-    }
-
-    private func tabList(spaceID: String?) -> [ShellTab] {
-        if let spaceID {
-            return shellState.spaces.first(where: { $0.spaceID == spaceID })?.tabs ?? []
-        }
-        return shellState.spaces.flatMap(\.tabs)
-    }
-
-    private func response(
-        requestID: String,
-        applied: Bool,
-        state: ShellStateSnapshot? = nil,
-        spaces: [ShellSpace]? = nil,
-        tabs: [ShellTab]? = nil,
-        panes: [ShellPane]? = nil,
-        pane: ShellPane? = nil,
-        items: [AlanShellAttentionInboxItem]? = nil,
-        candidates: [AlanShellRoutingCandidate]? = nil,
-        events: [AlanShellEventEnvelope]? = nil,
-        spaceID: String? = nil,
-        tabID: String? = nil,
-        paneID: String? = nil,
-        acceptedBytes: Int? = nil,
-        deliveryCode: String? = nil,
-        runtimePhase: String? = nil,
-        latestEventID: String? = nil,
-        errorCode: String? = nil,
-        errorMessage: String? = nil
-    ) -> AlanShellControlResponse {
-        AlanShellControlResponse(
-            requestID: requestID,
-            contractVersion: shellState.contractVersion,
-            applied: applied,
-            state: state,
-            spaces: spaces,
-            tabs: tabs,
-            panes: panes,
-            pane: pane,
-            items: items,
-            candidates: candidates,
-            events: events,
-            focusedPaneID: shellState.focusedPaneID,
-            spaceID: spaceID,
-            tabID: tabID,
-            paneID: paneID,
-            acceptedBytes: acceptedBytes,
-            deliveryCode: deliveryCode,
-            runtimePhase: runtimePhase,
-            latestEventID: latestEventID,
-            errorCode: errorCode,
-            errorMessage: errorMessage
-        )
-    }
-
     private func strongestAttention(in panes: [ShellPane]) -> ShellAttentionState {
         panes
             .map(\.attention)
@@ -1212,406 +1080,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         controlPlane.publish(state: shellState)
     }
 
-    private func handleControlPlaneCommand(_ command: AlanShellControlCommand) -> AlanShellControlResponse {
-        switch command.command {
-        case .state:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                state: shellState
-            )
-
-        case .spaceList:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaces: shellState.spaces
-            )
-
-        case .spaceCreate, .spaceOpenAlan:
-            let launchTarget: ShellLaunchTarget = command.command == .spaceOpenAlan ? .alan : .shell
-            let failureMessage = launchTarget == .alan
-                ? "Failed to create a new Alan space."
-                : "Failed to create a new shell space."
-            guard let spaceID = createSpace(
-                launchTarget: launchTarget,
-                title: command.title,
-                workingDirectory: command.cwd
-            ) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "space_create_failed",
-                    errorMessage: failureMessage
-                )
-            }
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: spaceID,
-                paneID: shellState.focusedPaneID
-            )
-
-        case .tabList:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                tabs: tabList(spaceID: command.spaceID),
-                spaceID: command.spaceID
-            )
-
-        case .tabOpen:
-            guard let tabID = openTerminalTab(
-                in: command.spaceID,
-                title: command.title,
-                workingDirectory: command.cwd
-            ) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    spaceID: command.spaceID,
-                    errorCode: "space_not_found",
-                    errorMessage: "The requested space does not exist."
-                )
-            }
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: tabID,
-                paneID: shellState.focusedPaneID
-            )
-
-        case .tabClose:
-            guard let tabID = command.tabID else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "tab_required",
-                    errorMessage: "tab_id is required."
-                )
-            }
-
-            switch closeTab(tabID: tabID) {
-            case .closed:
-                return response(
-                    requestID: command.requestID,
-                    applied: true,
-                    tabID: tabID,
-                    paneID: shellState.focusedPaneID
-                )
-            case .tabNotFound:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: tabID,
-                    errorCode: "tab_not_found",
-                    errorMessage: "The requested tab does not exist."
-                )
-            case .lastTab:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: tabID,
-                    errorCode: "last_tab",
-                    errorMessage: "Alan Shell must keep at least one tab open."
-                )
-            }
-
-        case .paneList:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                panes: paneList(tabID: command.tabID),
-                tabID: command.tabID
-            )
-
-        case .paneSnapshot:
-            guard let paneID = command.paneID,
-                  let pane = pane(paneID: paneID)
-            else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: command.paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                pane: pane,
-                spaceID: pane.spaceID,
-                tabID: pane.tabID,
-                paneID: pane.paneID
-            )
-
-        case .paneSplit:
-            guard let paneID = command.paneID else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "pane_required",
-                    errorMessage: "pane_id is required."
-                )
-            }
-            guard let direction = command.direction else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "direction_required",
-                    errorMessage: "direction is required for pane.split."
-                )
-            }
-            guard let newPaneID = splitPane(paneID: paneID, direction: direction) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: newPaneID
-            )
-
-        case .paneClose:
-            guard let paneID = command.paneID else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "pane_required",
-                    errorMessage: "pane_id is required."
-                )
-            }
-
-            switch closePane(paneID: paneID) {
-            case .closed:
-                return response(
-                    requestID: command.requestID,
-                    applied: true,
-                    spaceID: shellState.focusedSpaceID,
-                    tabID: shellState.focusedTabID,
-                    paneID: shellState.focusedPaneID
-                )
-            case .paneNotFound:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            case .lastTab:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "last_tab",
-                    errorMessage: "Alan Shell must keep at least one pane open."
-                )
-            }
-
-        case .paneLift:
-            guard let paneID = command.paneID else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "pane_required",
-                    errorMessage: "pane_id is required."
-                )
-            }
-
-            switch liftPaneToTab(paneID: paneID, title: command.title) {
-            case .lifted:
-                return response(
-                    requestID: command.requestID,
-                    applied: true,
-                    spaceID: shellState.focusedSpaceID,
-                    tabID: shellState.focusedTabID,
-                    paneID: shellState.focusedPaneID
-                )
-            case .paneNotFound:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            case .lastPane:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "last_pane",
-                    errorMessage: "The pane needs at least one sibling before it can be lifted."
-                )
-            }
-
-        case .paneMove:
-            guard let paneID = command.paneID,
-                  let targetTabID = command.tabID
-            else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: command.tabID,
-                    paneID: command.paneID,
-                    errorCode: "pane_move_target_required",
-                    errorMessage: "pane_id and tab_id are required."
-                )
-            }
-
-            let direction = command.direction ?? .vertical
-            guard movePane(paneID: paneID, toTab: targetTabID, direction: direction) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: targetTabID,
-                    paneID: paneID,
-                    errorCode: "invalid_move_target",
-                    errorMessage: "The requested pane could not be moved to the target tab."
-                )
-            }
-
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: shellState.focusedPaneID
-            )
-
-        case .paneFocus:
-            guard let paneID = command.paneID,
-                  shellState.panes.contains(where: { $0.paneID == paneID })
-            else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: command.paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-
-            focus(paneID: paneID)
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: paneID
-            )
-
-        case .paneSendText:
-            guard let paneID = command.paneID,
-                  let targetPane = pane(paneID: paneID)
-            else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: command.paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-
-            let text = command.text ?? ""
-            let delivery = terminalRuntimeRegistry.sendText(to: paneID, text: text)
-            controlPlane.recordTextDelivery(
-                requestID: command.requestID,
-                spaceID: targetPane.spaceID,
-                tabID: targetPane.tabID,
-                paneID: paneID,
-                delivery: delivery
-            )
-
-            return response(
-                requestID: command.requestID,
-                applied: delivery.applied,
-                spaceID: targetPane.spaceID,
-                tabID: targetPane.tabID,
-                paneID: paneID,
-                acceptedBytes: delivery.acceptedBytes,
-                deliveryCode: delivery.code.rawValue,
-                runtimePhase: delivery.runtimePhase,
-                errorCode: delivery.errorCode,
-                errorMessage: delivery.errorMessage
-            )
-
-        case .attentionInbox:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                items: attentionInboxRows()
-            )
-
-        case .attentionSet:
-            guard let paneID = command.paneID,
-                  let attention = command.attention
-            else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "attention_target_required",
-                    errorMessage: "pane_id and attention are required."
-                )
-            }
-            guard let targetPane = pane(paneID: paneID) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-            guard setAttention(attention, for: paneID) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            }
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: targetPane.spaceID,
-                tabID: targetPane.tabID,
-                paneID: paneID
-            )
-
-        case .routingCandidates:
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                candidates: routingCandidates(preferredPaneID: command.paneID)
-            )
-
-        case .eventsRead:
-            return controlPlane.specialCommandResponse(for: command)
-                ?? response(
-                    requestID: command.requestID,
-                    applied: false,
-                    errorCode: "events_unavailable",
-                    errorMessage: "events.read is handled by the shell control plane."
-                )
-        }
-    }
-
-    private static func attentionRank(for attention: ShellAttentionState) -> Int {
+    static func attentionRank(for attention: ShellAttentionState) -> Int {
         switch attention {
         case .idle:
             return 0

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -239,7 +239,7 @@ reject_pattern \
     "shell control plane transport must not own local command execution"
 
 require_pattern \
-    "clients/apple/AlanNative/ShellHostController.swift" \
+    "clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift" \
     "runtimePhase: delivery.runtimePhase" \
     "pane.send_text responses must expose the service runtime phase"
 
@@ -254,7 +254,7 @@ require_pattern \
     "terminal text delivery must go through the runtime registry"
 
 require_pattern \
-    "clients/apple/AlanNative/ShellHostController.swift" \
+    "clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift" \
     "terminalRuntimeRegistry\\.sendText\\(to: paneID, text: text\\)" \
     "pane.send_text must use the registry delivery result"
 
@@ -414,8 +414,8 @@ require_pattern \
     "terminal workspace shortcut routing must enter the shared shell workspace command handler"
 
 require_pattern \
-    "clients/apple/AlanNative/ShellHostController.swift" \
-    "private func handleControlPlaneCommand\\(_ command: AlanShellControlCommand\\)" \
+    "clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift" \
+    "func handleControlPlaneCommand\\(_ command: AlanShellControlCommand\\)" \
     "control-plane protocol commands must stay separate from UI command vocabulary while sharing shell mutation authority"
 
 require_pattern \

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -33,6 +33,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/TerminalRuntimeRegistry.swift" \
     "$REPO_ROOT/clients/apple/AlanNative/ShellHostController.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Controllers/Shell/ShellHostControlCommandHandling.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-runtime-metadata.swift" \
     -o "$TEST_BINARY"
 

--- a/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
+++ b/openspec/changes/reduce-macos-architecture-debt-warnings/tasks.md
@@ -42,5 +42,5 @@
 - [x] 6.1 Run `openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json`.
 - [x] 6.2 Run `openspec validate --all --strict --json`.
 - [x] 6.3 Run `git diff --check`.
-- [ ] 6.4 Before archive, sync the accepted requirements into `openspec/specs/macos-app-architecture-maintainability/spec.md`.
+- [x] 6.4 Before archive, sync the accepted requirements into `openspec/specs/macos-app-architecture-maintainability/spec.md`.
 - [ ] 6.5 Archive the change after all selected warning-reduction slices are merged and the debt ledger is current.

--- a/openspec/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/specs/macos-app-architecture-maintainability/spec.md
@@ -174,3 +174,55 @@ whether the current architecture gate treats it as non-blocking.
 - **WHEN** a focused refactor slice resolves a tracked warning
 - **THEN** the architecture debt record and validation expectations are updated
   in the same PR so the warning cannot silently reappear
+
+### Requirement: Architecture warning debt is reduced by focused slices
+The Apple client SHALL reduce tracked architecture-maintainability warnings
+through focused, behavior-preserving refactor slices. Each slice MUST identify
+the warning class it resolves, the owner boundary it clarifies, and the
+verification commands that protect the moved behavior.
+
+#### Scenario: Focused slice resolves a warning
+- **WHEN** a refactor slice removes one or more warnings from
+  `check-architecture-maintainability.sh`
+- **THEN** the slice updates `clients/apple/ARCHITECTURE.md` with the new
+  warning count and removes or narrows the corresponding debt entry
+
+#### Scenario: Slice changes a terminal owner
+- **WHEN** a slice moves code from a terminal runtime, host, or surface owner
+- **THEN** focused terminal runtime or terminal surface scripts are run in
+  addition to the architecture report
+
+#### Scenario: Slice changes a shell controller owner
+- **WHEN** a slice moves controller, store, projection, or command-routing code
+  out of `ShellHostController.swift`
+- **THEN** shell contract validation is run and the shared
+  `ShellWorkspaceCommand` vocabulary remains the command boundary
+
+#### Scenario: Slice changes console or mobile owners
+- **WHEN** a slice moves code from `Views/Console/ContentView.swift`
+- **THEN** the primary macOS shell path remains distinguishable from
+  console/mobile surfaces by folder, naming, or project grouping
+
+### Requirement: Architecture validation expectations track reduced debt
+The architecture-maintainability gate SHALL keep current warning expectations
+aligned with the tracked debt ledger. A PR that resolves a warning MUST update
+the report expectations and documentation in the same change so the warning
+cannot silently reappear.
+
+#### Scenario: Warning count decreases
+- **WHEN** `check-architecture-maintainability.sh` reports fewer warnings than
+  the documented debt ledger
+- **THEN** the implementation updates the ledger and any script expectations
+  before the PR is considered complete
+
+#### Scenario: Warning count does not decrease
+- **WHEN** a refactor slice moves architecture code but does not reduce the
+  warning count
+- **THEN** the PR explains why the moved boundary is an intermediate step and
+  leaves the debt ledger accurate
+
+#### Scenario: New or broadened warning appears
+- **WHEN** a change introduces a new architecture warning or broadens an
+  existing warning while reducing another one
+- **THEN** the change either resolves the new warning before merge or records a
+  concrete follow-up boundary in the debt ledger


### PR DESCRIPTION
## Summary
- Move shell control-plane command handling and response/list/routing helpers into Controllers/Shell/ShellHostControlCommandHandling
- Reduce ShellHostController below the architecture large-file threshold and update the debt ledger to zero known warnings
- Update shell contract script expectations for the terminal collaborators moved by this stacked series and sync accepted OpenSpec requirements into the active spec

## Validation
- bash clients/apple/scripts/check-architecture-maintainability.sh --strict
- bash clients/apple/scripts/check-shell-contracts.sh
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
- openspec validate reduce-macos-architecture-debt-warnings --type change --strict --json
- openspec validate --all --strict --json
- git diff --check