### PR TITLE
Propose macOS UI interaction polish

### DIFF
--- a/openspec/changes/optimize-macos-material-system/.openspec.yaml
+++ b/openspec/changes/optimize-macos-material-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/optimize-macos-material-system/design.md
+++ b/openspec/changes/optimize-macos-material-system/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The current shell material layer is concentrated in `ShellDesignTokens.swift`.
+It uses `NSVisualEffectView.Material.sidebar` for `ShellMaterialBackgroundView`,
+then overlays project-specific color washes. Other active shell surfaces still
+use direct fills such as `Color.white.opacity(...)`, `ShellPalette.window`, or
+opaque sidebar control colors.
+
+Apple's current guidance frames Liquid Glass as the top functional layer for
+controls and navigation, while standard materials provide structure inside the
+content layer. That maps well to Alan's desired product reading order:
+navigation and command entry float above a terminal-first content area, while
+the terminal itself remains stable, high contrast, and readable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish semantic material roles instead of choosing materials by apparent
+  color.
+- Make sidebar, command entry, compact buttons, and floating overlays feel native
+  and current without overwhelming terminal content.
+- Keep the terminal canvas visually dominant and legible across light mode,
+  reduce-transparency, and increased-contrast settings.
+- Centralize material bridge code so SwiftUI feature views request roles instead
+  of instantiating `NSVisualEffectView` details directly.
+
+**Non-Goals:**
+
+- Do not redesign sidebar information architecture; that is owned by
+  `streamline-macos-sidebar-ia`.
+- Do not redesign `Command-K` behavior; that is owned by
+  `polish-macos-command-input`.
+- Do not introduce dark-mode completeness as part of this pass.
+- Do not change shell runtime, terminal protocol, or command routing behavior.
+
+## Decisions
+
+1. Use semantic material roles.
+
+   Add or refine a small set of roles such as `windowBackdrop`, `sidebarGlass`,
+   `workspaceBackdrop`, `terminalSurround`, `floatingOverlay`, and
+   `controlGlass`. Views should request the role, not `NSVisualEffectView`
+   constants directly. This keeps the design vocabulary stable if AppKit or
+   SwiftUI exposes newer Liquid Glass APIs differently by SDK.
+
+   Alternative considered: directly swap all current fills to `.ultraThinMaterial`.
+   That would be fast, but it would blur the distinction between navigation,
+   content, and terminal surfaces.
+
+2. Reserve Liquid Glass-style treatment for navigation and controls.
+
+   Sidebar rail/list backgrounds, command entry points, floating command input,
+   and compact icon controls may use glass-like material treatment. Workspace and
+   terminal content backgrounds should use standard materials, tonal surfaces, or
+   subdued vibrancy to preserve legibility.
+
+   Alternative considered: make the entire window a continuous glass layer. This
+   conflicts with Apple's content-layer guidance and would make terminal text
+   harder to scan.
+
+3. Prefer system foreground styles over custom low-contrast grays on material.
+
+   Text and symbols over material should use `.primary`, `.secondary`,
+   `.tertiary`, accent, or other system-vibrant styles unless a specific token is
+   needed. Custom RGB colors stay available for Alan accent/attention, but not as
+   the default way to solve legibility.
+
+4. Material polish must degrade gracefully.
+
+   Implementation should explicitly review reduced transparency and increased
+   contrast. If a material role becomes too transparent or busy, the role should
+   fall back to a more solid standard material or tonal fill without changing the
+   view hierarchy.
+
+## Risks / Trade-offs
+
+- Visual regressions can be subjective -> Mitigate with screenshot/manual review
+  tasks that compare sidebar, terminal, controls, and overlays in the same run.
+- New SDK material APIs may not be available on every build host -> Keep roles
+  behind compatibility wrappers and use current AppKit/SwiftUI material APIs as
+  fallback.
+- Too much glass can reduce terminal readability -> Keep terminal canvas and
+  content layer out of Liquid Glass and verify contrast manually.

--- a/openspec/changes/optimize-macos-material-system/proposal.md
+++ b/openspec/changes/optimize-macos-material-system/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Alan's macOS shell already uses native material wrappers, but the visual system is
+still partly color-token driven and does not clearly separate navigation glass,
+content backgrounds, terminal canvas treatment, and button/control materials.
+Apple's current guidance distinguishes Liquid Glass as a functional layer for
+controls and navigation from standard materials used in the content layer; Alan
+should adopt that distinction before more UI polish accumulates local one-off
+effects.
+
+## What Changes
+
+- Define a semantic macOS shell material system for window background, sidebar,
+  terminal surround, overlay, and compact controls.
+- Treat Liquid Glass as a restrained functional layer for navigation, command
+  entry, floating controls, and transient interactive affordances.
+- Keep terminal content and workspace backgrounds on standard materials, tonal
+  surfaces, and legible contrast rather than applying Liquid Glass everywhere.
+- Replace hard-coded white/opaque fills in active shell chrome with reusable
+  material roles and system-vibrant foreground colors where appropriate.
+- Add visual verification expectations for material hierarchy, readability, and
+  reduced-transparency/high-contrast behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: tighten the native material contract around
+  functional Liquid Glass versus content-layer standard materials.
+- `macos-shell-build-test-contract`: require focused verification for material
+  hierarchy and accessibility-related material settings.
+
+## Impact
+
+- Affected Apple client code:
+  - `clients/apple/AlanNative/Support/ShellDesignTokens.swift`
+  - `clients/apple/AlanNative/MacShellRootView.swift`
+  - `clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift`
+  - `clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift`
+  - `clients/apple/AlanNative/TerminalPaneView.swift`
+  - `clients/apple/AlanNative/TerminalHostView.swift`
+- No runtime protocol or daemon API changes.
+- May add small reusable SwiftUI/AppKit wrappers for semantic material roles, but
+  must keep AppKit bridge ownership inside `Support/` or another approved bridge
+  boundary.
+- Research inputs:
+  - Apple Human Interface Guidelines, Materials:
+    `https://developer.apple.com/design/human-interface-guidelines/materials`
+  - Apple Technology Overview, Liquid Glass:
+    `https://developer.apple.com/documentation/TechnologyOverviews/liquid-glass`
+  - Apple Technology Overview, Adopting Liquid Glass:
+    `https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass`

--- a/openspec/changes/optimize-macos-material-system/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/optimize-macos-material-system/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Material hierarchy has focused verification
+The Apple client SHALL include focused verification for active-shell material
+changes so native material polish does not reduce terminal readability or
+reintroduce hard-coded visual effects.
+
+#### Scenario: Material review is captured
+- **WHEN** active macOS shell material roles, background surfaces, or compact control treatments change
+- **THEN** maintainers can inspect screenshots or manual notes covering the default light-mode sidebar, terminal content area, command entry, compact controls, and floating overlays
+
+#### Scenario: Accessibility material settings are reviewed
+- **WHEN** material hierarchy implementation is marked complete
+- **THEN** verification includes reduced-transparency or increased-contrast review notes, or a documented reason those settings could not be exercised locally
+
+#### Scenario: One-off material fills are checked
+- **WHEN** a change adds new active-shell material or translucent fills
+- **THEN** focused review or a lightweight check confirms the fill is attached to a shared semantic material/control role rather than a local hard-coded effect

--- a/openspec/changes/optimize-macos-material-system/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/optimize-macos-material-system/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Material hierarchy separates navigation from content
+The default macOS shell SHALL use material roles that distinguish the functional
+navigation/control layer from the content layer. Liquid Glass-style treatment
+SHALL be reserved for navigation, command entry, compact controls, and transient
+interactive affordances, while workspace and terminal content surfaces SHALL use
+standard materials, tonal surfaces, or stable opaque fills that preserve
+readability.
+
+#### Scenario: Sidebar uses functional material
+- **WHEN** the default shell renders the space rail, active-space tab list, and compact sidebar controls
+- **THEN** those navigation surfaces use a consistent functional material treatment with legible foreground content and restrained selection states
+
+#### Scenario: Terminal content avoids decorative glass
+- **WHEN** the active terminal pane or terminal surround is visible
+- **THEN** Alan does not apply Liquid Glass-style decorative transparency to the terminal content layer and keeps terminal text contrast stable
+
+#### Scenario: Workspace backdrop is semantic
+- **WHEN** the shell renders the main workspace background outside terminal panes
+- **THEN** the background uses a semantic material or tonal role chosen for hierarchy rather than hard-coded theme color dominance
+
+### Requirement: Active shell controls use semantic material roles
+Buttons, key hints, close controls, hover affordances, and command-entry controls SHALL use
+shared semantic material/control roles in the active macOS shell and MUST avoid one-off white,
+opaque, or ad hoc translucent fills in default shell chrome.
+
+#### Scenario: Compact icon button
+- **WHEN** a compact icon button appears in the sidebar, title bar, terminal chrome, or command entry
+- **THEN** its background, hover, pressed, disabled, and selected appearances come from shared shell control roles and keep stable dimensions
+
+#### Scenario: Foreground on material
+- **WHEN** text or symbols render on top of a material-backed shell control
+- **THEN** Alan uses system-vibrant foreground styles or approved shell tokens that remain legible across light appearance, reduced transparency, and increased contrast
+
+#### Scenario: AppKit bridge remains isolated
+- **WHEN** a SwiftUI shell view needs an AppKit-backed visual effect material
+- **THEN** the view uses a reusable support-layer wrapper rather than creating `NSVisualEffectView` bridge details inline

--- a/openspec/changes/optimize-macos-material-system/tasks.md
+++ b/openspec/changes/optimize-macos-material-system/tasks.md
@@ -1,0 +1,19 @@
+## 1. Material Roles
+
+- [ ] 1.1 Inventory active shell material, background, button, hover, and overlay fills in the Apple client.
+- [ ] 1.2 Define semantic material/control roles in the shell support layer for window, sidebar, workspace, terminal surround, floating overlay, and compact controls.
+- [ ] 1.3 Keep AppKit visual-effect bridge code isolated behind reusable support wrappers.
+
+## 2. Active Shell Application
+
+- [ ] 2.1 Apply the semantic roles to `MacShellRootView.swift` and workspace backgrounds.
+- [ ] 2.2 Apply the sidebar/control roles to `ShellSidebarView.swift` without changing sidebar information architecture.
+- [ ] 2.3 Apply terminal surround roles to active terminal shell chrome without reducing terminal text contrast.
+- [ ] 2.4 Apply overlay/control roles to active floating shell surfaces without redesigning `Command-K` behavior.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused Apple build or shell UI checks affected by the changed files.
+- [ ] 3.2 Capture screenshot or manual review notes for light-mode sidebar, terminal, command entry, controls, and overlays.
+- [ ] 3.3 Review reduced-transparency or increased-contrast behavior, or document why local verification was unavailable.
+- [ ] 3.4 Run `openspec validate --all --strict` before PR.

--- a/openspec/changes/polish-macos-command-input/.openspec.yaml
+++ b/openspec/changes/polish-macos-command-input/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/polish-macos-command-input/design.md
+++ b/openspec/changes/polish-macos-command-input/design.md
@@ -1,0 +1,79 @@
+## Context
+
+`ShellCommandTabView` currently owns a broad command palette:
+
+- action enum and matching logic,
+- best-match intent,
+- attention candidates,
+- routing candidates,
+- voice controller affordance,
+- rows grouped under visible sections.
+
+The user direction is narrower: `Command-K` should summon a beautiful Liquid
+Glass input box and should not show the candidate actions underneath. That makes
+this change mostly a surface simplification and interaction reset, not a command
+vocabulary expansion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `Command-K` feel like a native, premium floating input rather than a
+  dashboard-like command palette.
+- Remove default candidate/action/routing/attention lists from the overlay.
+- Keep keyboard and focus behavior crisp: open, type, submit, dismiss, restore
+  terminal focus.
+- Share material roles with the material-system direction where possible.
+
+**Non-Goals:**
+
+- Do not build a full fuzzy command launcher with ranked visible suggestions in
+  this change.
+- Do not expand command vocabulary beyond the existing workspace actions needed
+  for typed submission.
+- Do not add voice input to `Command-K`; voice MVP work owns voice interaction.
+- Do not change terminal `Command-F` Find behavior.
+
+## Decisions
+
+1. Replace the palette body with an input-only overlay.
+
+   The overlay should contain the search/command icon, text field, optional
+   compact key hint, and a slim close affordance if needed. It should not render
+   `Actions`, `Routing`, `Attention`, `Best match`, or command rows beneath the
+   field.
+
+   Alternative considered: keep suggestions but visually hide them until query
+   text exists. The user specifically asked to remove the candidate actions, so
+   the default surface should not become a conditional suggestion list.
+
+2. Keep typed execution minimal and deterministic.
+
+   Return may execute an exact or well-known typed command using existing shell
+   workspace command handlers. If the typed command cannot be resolved, the input
+   should remain open with a subtle non-row state such as shake, tint, or inline
+   placeholder/status. It should not open a candidate list.
+
+3. Make material and geometry do the product work.
+
+   The input should use a Liquid Glass-style material role, soft depth, and
+   restrained rounded geometry consistent with the shell radius scale. It should
+   look rich through native material behavior and focus treatment, not through
+   decorative gradients or a large panel.
+
+4. Preserve terminal focus ownership.
+
+   Opening the input temporarily captures keyboard focus. Dismissing it via
+   Escape, click-away, successful submit, or close control should return focus to
+   the previously focused terminal pane when available.
+
+## Risks / Trade-offs
+
+- Removing visible candidates reduces discoverability -> Mitigate through
+  sidebar/menu affordances, existing native menu items, and future optional typed
+  help if needed outside this default surface.
+- Exact typed routing may feel too limited -> Keep the implementation modular so
+  future fuzzy command resolution can improve submission without adding visible
+  candidate lists back by default.
+- Liquid material can become visually busy -> Share material roles with
+  `optimize-macos-material-system` and verify readability over the active shell.

--- a/openspec/changes/polish-macos-command-input/proposal.md
+++ b/openspec/changes/polish-macos-command-input/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`Command-K` currently opens a large command palette with action, routing, and
+attention candidate sections. That makes the shortcut feel like a dashboard
+surface instead of a focused, high-quality macOS command input. Alan should make
+`Command-K` a beautiful Liquid Glass-style input layer that is quick to summon,
+easy to dismiss, and visually consistent with the material polish direction.
+
+## What Changes
+
+- Redesign `Command-K` as a single floating input field with Liquid Glass-style
+  material, subtle depth, and native focus behavior.
+- Remove the always-visible candidate/action/routing/attention lists below the
+  input.
+- Keep the input field centered on typing and submission; typed command routing
+  may execute known commands, but suggestions are not shown in the default UI.
+- Remove command-palette voice/microphone affordances from this surface unless a
+  future voice-specific change reintroduces them in its own interaction model.
+- Preserve keyboard behavior: `Command-K` opens/focuses the input, Return submits
+  when a typed command can be resolved, Escape/click-away dismisses, and terminal
+  focus returns after dismissal.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: add a requirement that `Command-K` is a
+  floating Liquid Glass-style input rather than a multi-section command palette.
+- `macos-shell-workspace-interactions`: clarify command UI routing without
+  default visible candidate lists.
+- `macos-shell-build-test-contract`: require focused keyboard, visual, and focus
+  verification for the command input.
+
+## Impact
+
+- Affected Apple client code:
+  - `clients/apple/AlanNative/MacShellRootView.swift`
+  - `clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift`
+  - `clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift`
+  - `clients/apple/AlanNative/Support/ShellDesignTokens.swift`
+  - `clients/apple/scripts/check-shell-contracts.sh`
+- No daemon, runtime, terminal protocol, or shell control-plane command changes.
+- This may delete or heavily simplify `ShellCommandRow`,
+  `ShellCommandTabIntent`, and candidate-section rendering from the default
+  command surface.
+- Research inputs:
+  - Apple Human Interface Guidelines, Materials:
+    `https://developer.apple.com/design/human-interface-guidelines/materials`
+  - Apple Human Interface Guidelines, Search fields:
+    `https://developer.apple.com/design/human-interface-guidelines/search-fields`
+  - Apple Technology Overview, Liquid Glass:
+    `https://developer.apple.com/documentation/TechnologyOverviews/liquid-glass`

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Command input polish has focused verification
+The Apple client SHALL include focused verification for the `Command-K` input
+surface when command UI behavior or material treatment changes.
+
+#### Scenario: Command input keyboard flow is verified
+- **WHEN** `Command-K` implementation is marked complete
+- **THEN** focused tests or manual notes cover open/focus, typing, successful Return submission, unresolved Return behavior, Escape dismissal, click-away dismissal, and terminal focus restoration
+
+#### Scenario: Candidate sections stay removed
+- **WHEN** default command input UI changes
+- **THEN** shell contract checks or review notes confirm action, routing, attention, best-match, command-row, and microphone affordances are not visible in the default `Command-K` surface
+
+#### Scenario: Liquid input visual review is captured
+- **WHEN** command input material polish is marked complete
+- **THEN** maintainers can inspect screenshots or manual notes showing the input over the active light-mode shell with legible text, restrained depth, and no large panel below the field

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Command-K opens a Liquid Glass input
+The macOS shell SHALL present `Command-K` as a single floating Liquid
+Glass-style input layer that captures text entry without rendering default
+candidate sections below the input.
+
+#### Scenario: Command input opens
+- **WHEN** the user presses `Command-K` or activates the sidebar command entry
+- **THEN** Alan opens a floating material-backed input field, focuses the text field, and does not show action, routing, attention, or best-match lists below it
+
+#### Scenario: Command input is visually restrained
+- **WHEN** the command input is visible
+- **THEN** the surface uses a restrained native material treatment, stable geometry, and compact controls rather than a large card, dashboard panel, or multi-section palette
+
+#### Scenario: Command input dismisses
+- **WHEN** the user presses Escape, clicks outside the input, activates a close affordance, or successfully submits a resolved command
+- **THEN** Alan dismisses the input and returns keyboard focus to the previously focused terminal pane when available
+
+#### Scenario: No default voice affordance
+- **WHEN** the `Command-K` input is visible
+- **THEN** the input does not show a microphone or voice-listening affordance unless a future voice-specific requirement explicitly adds one
+
+#### Scenario: Unresolved command stays input-only
+- **WHEN** the user submits text that cannot be resolved to a supported command or destination
+- **THEN** Alan keeps the command surface input-only and communicates the unresolved state without opening candidate rows below the field

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Commands use native Mac surfaces
+Workspace actions SHALL be available through native menu/command routing,
+keyboard shortcuts, command input, and any restrained toolbar affordances that
+call the same shell controller mutations where the action is shared. The default
+`Command-K` command input SHALL accept typed commands without showing persistent
+candidate action lists.
+
+#### Scenario: Menu command
+- **WHEN** the user selects New Terminal Tab, New Alan Tab, Split, Focus Pane, Equalize Splits, Close Pane, or Close Tab from the menu bar
+- **THEN** Alan executes the same shell controller action used by keyboard and command input paths
+
+#### Scenario: Keyboard command
+- **WHEN** the user invokes a supported command-key shortcut
+- **THEN** the responder chain routes it to Alan's workspace command handler or terminal surface command handler as appropriate
+
+#### Scenario: Command input opens
+- **WHEN** the user opens `Go to or Command...`
+- **THEN** Alan focuses a single command input field instead of presenting default action, routing, or attention candidate lists
+
+#### Scenario: Typed command resolves
+- **WHEN** the user submits a typed command that Alan can resolve to a workspace action or routing target
+- **THEN** Alan executes the same shell controller action used by menu and keyboard paths and dismisses the command input
+
+#### Scenario: Typed command is unresolved
+- **WHEN** the user submits a typed command that Alan cannot resolve
+- **THEN** Alan leaves the command input open and communicates the unresolved state without exposing raw pane IDs or debug routing details

--- a/openspec/changes/polish-macos-command-input/tasks.md
+++ b/openspec/changes/polish-macos-command-input/tasks.md
@@ -1,0 +1,18 @@
+## 1. Command Surface Simplification
+
+- [ ] 1.1 Replace the default `ShellCommandTabView` body with an input-only floating command surface.
+- [ ] 1.2 Remove default rendering for action, routing, attention, best-match, command-row, and microphone affordances from `Command-K`.
+- [ ] 1.3 Keep `Command-K` open/focus, Escape, click-away, close, and focus-restoration behavior intact.
+
+## 2. Typed Command Routing
+
+- [ ] 2.1 Preserve a small deterministic typed-command resolver for existing workspace actions that are safe to execute from Return.
+- [ ] 2.2 Route resolved commands through the same `ShellHostController` workspace command handlers used by menus and shortcuts.
+- [ ] 2.3 Show unresolved command state inline without opening candidate rows or exposing raw debug identifiers.
+
+## 3. Material And Verification
+
+- [ ] 3.1 Apply the shared floating/liquid material role to the command input surface.
+- [ ] 3.2 Run focused Apple build or shell UI checks affected by command input changes.
+- [ ] 3.3 Capture screenshot or manual review notes for the default light-mode command input.
+- [ ] 3.4 Run `openspec validate --all --strict` before PR.

--- a/openspec/changes/streamline-macos-sidebar-ia/.openspec.yaml
+++ b/openspec/changes/streamline-macos-sidebar-ia/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/streamline-macos-sidebar-ia/design.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/design.md
@@ -1,0 +1,131 @@
+## Context
+
+`docs/spec/alan_macos_shell_ui_ux.md` pushed the sidebar toward a separate
+space rail plus tab list, but the macOS traffic-light area makes a left/right
+split inside the sidebar harder to align cleanly. The preferred interaction is
+closer to Arc's vertical sidebar model: tab/navigation content remains in one
+vertical column, while spaces are switched through a compact borderless control
+strip at the bottom and through horizontal swipe gestures over the sidebar.
+
+The current `ShellSidebarView` is already a vertical stack with a header, command
+launcher, tab section, and horizontal space dock. The right direction is not a
+second adjacent rail; it is to make that vertical structure quieter, remove
+instructional copy, and make the bottom space switcher feel intentional.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the sidebar as a single vertical navigation column that aligns cleanly
+  below and around the macOS traffic-light area.
+- Make spaces available through a bottom, borderless icon switcher and through
+  left/right swipe gestures inside the sidebar.
+- Reduce visible explanatory copy while preserving discoverability through icon
+  choice, placement, hover actions, tooltips, menus, and accessibility labels.
+- Keep tabs skimmable and lightweight, with attention and Alan state expressed
+  inline.
+- Make split tabs legible at a glance by showing a compact topology indicator
+  that communicates pane count, dominant split direction, and focused pane.
+- Keep `Command-K` entry available from the sidebar, but do not redesign its
+  overlay in this change.
+
+**Non-Goals:**
+
+- Do not redesign material treatment; that is owned by
+  `optimize-macos-material-system`.
+- Do not implement advanced drag/reorder behavior unless needed to make the
+  layout coherent.
+- Do not remove product terms such as Space and Tab from accessibility surfaces
+  or documentation; the goal is less visible explanation, not less semantic
+  structure.
+
+## Decisions
+
+1. Keep a vertical Arc-like sidebar.
+
+   The root sidebar should remain one vertical stack: top identity/window-safe
+   area, command entry, active-space tab list, and bottom space switcher. This
+   avoids traffic-light alignment problems and matches the Arc-like bottom space
+   switcher direction.
+
+   Alternative considered: render a narrow rail and a tab-list column side by
+   side. That looks structurally clean in an abstract layout, but it creates
+   alignment issues around macOS traffic lights and conflicts with the desired
+   Arc-like bottom switcher.
+
+2. Make the bottom space switcher borderless.
+
+   Space switcher items should be compact icon buttons without card borders,
+   framed backgrounds, or section chrome. Selection, hover, and attention should
+   be expressed through icon tone, subtle glow/tint, dot/count marks, or a small
+   backing only when state requires it.
+
+   Alternative considered: keep current rounded square rail items. That is
+   functional, but it reads heavier than the desired slim bottom switcher.
+
+3. Support horizontal sidebar swipe for space switching.
+
+   A left/right swipe over the sidebar should switch to the previous/next space.
+   This must not steal scroll from the tab list unless the gesture is clearly
+   horizontal. Trackpad interaction should feel like switching Arc spaces, not
+   like dragging a custom carousel.
+
+4. Remove visible labels where placement is enough.
+
+   Section headings such as `Tabs` and `Spaces`, shortcut-only accessory text,
+   and descriptive empty-state paragraphs should not be default chrome. Use
+   direct controls, subtle count/attention marks, hover help, context menus, and
+   accessibility labels instead.
+
+   Alternative considered: keep labels for clarity. The target product direction
+   is a native tool where structure teaches itself; visible labels should be
+   reserved for ambiguous controls or text that materially helps repeated use.
+
+5. Use progressive disclosure for secondary actions.
+
+   Close and more actions should appear on row hover/focus or context menu.
+   Default rows should prioritize title, compact context, status/attention, and
+   selection.
+
+6. Empty states should be actionable, not explanatory.
+
+   If no spaces or tabs exist, the sidebar should show a compact creation
+   affordance in the owning zone. It should avoid paragraph-style instruction
+   like "Create a space to start..." in normal chrome.
+
+7. Represent split tabs with a topology indicator, not a full thumbnail.
+
+   A split tab row should show a small indicator only when the tab contains more
+   than one pane. For two panes, the indicator can mirror the root split
+   direction with two segments. For three or more panes, it should summarize the
+   topology with a compact cluster or dominant-direction glyph plus pane count.
+   It should mark the focused pane and optionally attention, but it should not
+   try to render exact divider ratios inside the narrow tab row.
+
+   Alternative considered: draw a miniature proportional split layout. That
+   works for simple two-column splits, but Alan's terminal split tree supports
+   nested horizontal/vertical splits and arbitrary ratios, which would become
+   unreadable at sidebar size.
+
+8. Make the split indicator a quick focus target.
+
+   For two panes, clicking the visible segment should focus that pane. For more
+   complex layouts, clicking the indicator should provide a predictable focus
+   action such as cycling to the next pane, and a hover/focus or click-expanded
+   popover may expose a larger topology map for direct pane selection. This
+   keeps the row compact while preserving a path to precise focus.
+
+## Risks / Trade-offs
+
+- Removing visible copy can hurt first-run clarity -> Mitigate with stable
+  placement, recognizable symbols, hover help, and accessibility labels.
+- Horizontal swipe can conflict with vertical tab scrolling -> Gate space
+  switching on clear horizontal intent and keep vertical scroll behavior intact.
+- Borderless icons can become too subtle -> Use hover, selection, attention, and
+  accessibility labels to maintain discoverability without adding boxes back.
+- Split indicators can become noisy in tab rows -> Hide them for single-pane
+  tabs, summarize complex splits, and avoid proportional ratio rendering in the
+  default row.
+- This overlaps visually with material work -> Keep this change focused on
+  layout, visible copy, and interaction ownership; leave material tokens to the
+  material-system change.

--- a/openspec/changes/streamline-macos-sidebar-ia/proposal.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The current sidebar has moved toward the target shell model, but it still reads
+partly as a compact dashboard: header copy, section labels, shortcut hints,
+horizontal space dock, empty-state explanation, and repeated creation menus ask
+the user to parse the UI instead of making the structure self-evident. Alan's
+macOS shell should make spaces, tabs, attention, and creation affordances obvious
+through placement, shape, and interaction rather than explanatory text.
+
+## What Changes
+
+- Keep the default sidebar as a single vertical stack so the content aligns
+  cleanly around the macOS traffic-light area.
+- Replace section-like space presentation with a bottom, borderless space
+  switcher made of compact icon buttons.
+- Support left/right swipe gestures inside the sidebar to switch spaces.
+- Show compact split topology indicators on split tab rows so users can see
+  whether a tab contains multiple terminal panes and quickly focus a pane.
+- Remove nonessential descriptive copy from the default sidebar, including
+  product slogans, implementation-flavored empty-state text, and redundant
+  section labels.
+- Make creation affordances location-specific: compact space creation near the
+  bottom switcher and tab creation in the active-space tab list.
+- Represent attention and Alan attachment through tab-row and space-switcher
+  marks instead of separate explanatory blocks.
+- Preserve accessibility labels/tooltips even when visible text is reduced.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: replace the previous space-rail direction
+  with a vertical Arc-like sidebar, bottom borderless space switcher, swipe
+  switching, split-aware tab rows, and minimal visible copy.
+- `macos-shell-workspace-interactions`: require split tab indicators to route
+  focus through the same pane-focus model as terminal split interactions.
+- `macos-shell-build-test-contract`: require visual/manual verification for the
+  streamlined sidebar reading order and accessibility-preserving copy removal.
+
+## Impact
+
+- Affected Apple client code:
+  - `clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift`
+  - `clients/apple/AlanNative/Support/ShellDesignTokens.swift`
+  - `clients/apple/AlanNative/MacShellRootView.swift`
+- No shell runtime, daemon, protocol, or terminal rendering changes.
+- May require small helper views for bottom space-switcher items, tab-list
+  header controls, split indicators, empty states, gesture routing, and
+  accessibility labels.
+- Related reference docs:
+  - `docs/spec/alan_macos_shell_ui_ux.md`
+  - Apple Human Interface Guidelines, Sidebars:
+    `https://developer.apple.com/design/human-interface-guidelines/sidebars`

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Streamlined sidebar has focused verification
+The Apple client SHALL include focused verification for sidebar information
+architecture changes that remove visible copy or restructure space/tab
+navigation.
+
+#### Scenario: Sidebar reading order is reviewed
+- **WHEN** sidebar IA implementation is marked complete
+- **THEN** maintainers can inspect screenshots or manual notes showing the vertical sidebar, active-space tab list, bottom borderless space switcher, separate creation affordances, and no persistent explanatory sidebar blocks
+
+#### Scenario: Sidebar interaction states are reviewed
+- **WHEN** tab or space row secondary actions are progressively disclosed
+- **THEN** verification covers default, hover, selected, attention, and empty states without row resizing or layout shifts
+
+#### Scenario: Sidebar space swipe is reviewed
+- **WHEN** horizontal space switching is implemented in the sidebar
+- **THEN** verification covers left and right swipe behavior and confirms vertical tab-list scrolling still works
+
+#### Scenario: Split tab indicator is reviewed
+- **WHEN** split-aware tab row implementation is marked complete
+- **THEN** verification covers single-pane, two-pane horizontal, two-pane vertical, complex split, focused-pane, attention, pointer activation, and keyboard or accessibility activation states
+
+#### Scenario: Accessibility copy is preserved
+- **WHEN** visible sidebar text is removed or shortened
+- **THEN** review confirms accessibility labels, help text, menu labels, or equivalent nonvisual descriptions still identify the affected controls

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,6 +1,6 @@
 ## MODIFIED Requirements
 
-### Requirement: Sidebar matches vertical Arc-like space switching
+### Requirement: Sidebar matches space rail plus tab list
 The default macOS sidebar SHALL remain a single vertical navigation column that
 aligns cleanly around the macOS traffic-light area. Spaces SHALL be switched
 through a compact bottom borderless icon switcher and horizontal sidebar swipe

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Sidebar matches vertical Arc-like space switching
+The default macOS sidebar SHALL remain a single vertical navigation column that
+aligns cleanly around the macOS traffic-light area. Spaces SHALL be switched
+through a compact bottom borderless icon switcher and horizontal sidebar swipe
+gestures, while tabs for the active space remain the primary sidebar list. The
+sidebar SHALL be self-explaining through spatial structure, iconography,
+selection treatment, hover/focus affordances, and accessibility labels rather
+than persistent instructional copy.
+
+#### Scenario: Default sidebar reading order
+- **WHEN** a user opens the macOS app
+- **THEN** the sidebar reads as command entry, active-space tab list, and bottom space switcher in one vertical column rather than as unrelated dashboard sections or a two-column sidebar
+
+#### Scenario: Space selection
+- **WHEN** a user selects a space in the bottom switcher
+- **THEN** the tab list updates to show only tabs belonging to that active space
+
+#### Scenario: Sidebar swipe switches spaces
+- **WHEN** a user performs a clear horizontal swipe gesture inside the sidebar
+- **THEN** Alan switches to the previous or next space without disrupting vertical tab-list scrolling
+
+#### Scenario: Separate creation affordances
+- **WHEN** a user creates a new space or a new tab
+- **THEN** space creation is presented as a compact bottom-switcher affordance and tab creation is presented in the active-space tab list or toolbar context
+
+#### Scenario: Space switcher is borderless
+- **WHEN** the bottom space switcher is visible
+- **THEN** space buttons use slim borderless icon styling with selection, hover, and attention conveyed without persistent framed cards or section chrome
+
+#### Scenario: Lightweight tab rows
+- **WHEN** the active-space tab list contains terminal and Alan tabs
+- **THEN** each tab appears as a skimmable row with a compact marker, title, secondary context, and low-emphasis status rather than as a card or dashboard tile
+
+#### Scenario: Visible copy is minimized
+- **WHEN** the default sidebar has at least one space and one tab
+- **THEN** the sidebar does not rely on persistent explanatory paragraphs, product slogans, keyboard-shortcut labels, or redundant `Tabs` and `Spaces` headings to explain normal operation
+
+#### Scenario: Accessibility remains explicit
+- **WHEN** visible explanatory copy is removed from the sidebar
+- **THEN** controls, space switcher items, tab rows, creation buttons, and attention marks retain accessibility labels, help text, or menu labels that expose their purpose to assistive technologies
+
+## ADDED Requirements
+
+### Requirement: Sidebar actions are progressively disclosed
+The default macOS sidebar SHALL keep repeated tab and space rows visually quiet
+by showing secondary actions through hover, keyboard focus, context menu, or
+compact owner-zone controls rather than always-visible explanatory buttons.
+
+#### Scenario: Tab row default state
+- **WHEN** a tab row is visible and not hovered or keyboard focused
+- **THEN** the row prioritizes icon, title, compact context, selection, and attention state without persistent close/more text buttons
+
+#### Scenario: Tab row interaction state
+- **WHEN** a tab row is hovered, keyboard focused, or context-clicked
+- **THEN** close, more, move, or related secondary actions become available without resizing the row or shifting neighboring content
+
+#### Scenario: Empty sidebar state
+- **WHEN** the sidebar has no user-created spaces or no tabs in the active space
+- **THEN** the owning zone exposes a compact creation affordance without showing paragraph-style onboarding copy in the default shell
+
+### Requirement: Split tabs expose compact topology
+The default macOS sidebar SHALL show a compact split topology indicator on tab
+rows whose active tab contains multiple terminal panes. The indicator SHALL
+communicate pane count, dominant split direction when useful, and the currently
+focused pane without attempting to render exact split ratios in the tab row.
+
+#### Scenario: Single-pane tab row
+- **WHEN** a tab contains one terminal pane
+- **THEN** the tab row does not show a split topology indicator
+
+#### Scenario: Two-pane tab row
+- **WHEN** a tab contains two visible terminal panes
+- **THEN** the tab row shows a compact two-segment indicator that reflects the root split direction and marks the focused pane
+
+#### Scenario: Complex split tab row
+- **WHEN** a tab contains three or more visible terminal panes or nested split branches
+- **THEN** the tab row summarizes the split with a compact topology mark or pane count instead of a proportional miniature layout
+
+#### Scenario: Attention in split tab
+- **WHEN** a non-focused pane inside a split tab needs attention
+- **THEN** the split indicator or tab row conveys that attention without exposing raw pane IDs or adding a separate sidebar attention block

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Sidebar split indicators can focus panes
+Split topology indicators in the macOS sidebar SHALL route pane focus through
+the same shell controller focus model used by terminal split interactions.
+
+#### Scenario: Two-pane segment clicked
+- **WHEN** a user clicks a segment in a two-pane tab row split indicator
+- **THEN** Alan selects that pane and terminal focus follows it without changing the split tree or divider ratios
+
+#### Scenario: Complex split indicator clicked
+- **WHEN** a user clicks a compact indicator for a tab with three or more panes
+- **THEN** Alan performs a predictable pane-focus action or opens a compact pane picker, and the action does not mutate the split tree
+
+#### Scenario: Split indicator keyboard access
+- **WHEN** a split tab row or its split indicator has keyboard focus
+- **THEN** keyboard or accessibility activation can focus panes without relying on pointer-only interaction

--- a/openspec/changes/streamline-macos-sidebar-ia/tasks.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/tasks.md
@@ -1,0 +1,23 @@
+## 1. Sidebar Structure
+
+- [ ] 1.1 Keep `ShellSidebarView.swift` as a single vertical sidebar column that aligns cleanly around the macOS traffic-light area.
+- [ ] 1.2 Replace section-like space presentation with a bottom borderless icon space switcher.
+- [ ] 1.3 Keep command entry and tab creation in the active-space tab-list flow.
+- [ ] 1.4 Add left/right sidebar swipe handling for previous/next space switching without breaking vertical tab-list scrolling.
+
+## 2. Copy And Interaction Cleanup
+
+- [ ] 2.1 Remove persistent sidebar section labels, shortcut labels, product slogans, and paragraph-style empty-state copy that are not needed for repeated use.
+- [ ] 2.2 Preserve or add accessibility labels, help text, and menu labels for controls whose visible copy is reduced.
+- [ ] 2.3 Ensure tab rows expose secondary actions through hover/focus/context menu without layout shifts.
+- [ ] 2.4 Keep attention and Alan attachment expressed as compact row/switcher marks rather than separate sidebar blocks.
+- [ ] 2.5 Add compact split topology indicators to split tab rows, hiding them for single-pane tabs.
+- [ ] 2.6 Route split indicator activation through pane focus without mutating split layout or divider ratios.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused Apple build or shell UI checks affected by sidebar changes.
+- [ ] 3.2 Capture screenshot or manual review notes for default, selected, hover, attention, and empty sidebar states.
+- [ ] 3.3 Verify left/right sidebar swipe switches spaces and vertical tab-list scrolling still works.
+- [ ] 3.4 Verify split indicators for single-pane, two-pane horizontal, two-pane vertical, complex split, focus switching, and accessibility activation.
+- [ ] 3.5 Run `openspec validate --all --strict` before PR.


### PR DESCRIPTION
Summary
- Add OpenSpec changes for macOS material system, sidebar IA, and Cmd+K input polish.
- Capture vertical Arc-like sidebar direction, bottom borderless space switcher, sidebar swipe switching, and split tab topology indicators.
- Define Liquid Glass versus standard material boundaries and input-only Cmd+K interaction.

Validation
- openspec validate --all --strict
- git diff --check