### PR TITLE
Propose agent intelligence OpenSpec changes

### DIFF
--- a/openspec/changes/add-cognitive-model-routing/.openspec.yaml
+++ b/openspec/changes/add-cognitive-model-routing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -176,6 +176,25 @@ Alternatives considered:
 - Disable provider-native continuation whenever cognition is enabled. This is
   safe but gives up useful stateful-provider efficiency.
 
+## Implementation Ownership
+
+This change is primarily a runtime-routing change, not a prompt-only or
+skill-only feature.
+
+- Runtime owns `CognitiveRouter`, route precedence, the System 1 acceptance
+  commit point, escalation handling, routing metadata, and provider-native
+  continuation partitioning.
+- Tool governance owns read-only versus side-effecting capability classification
+  and enforces the unaccepted System 1 side-effect gate before tool execution.
+- Prompts describe the selected cognitive role, speculative boundary, and
+  internal escalation contract to the model, but prompts are not the security or
+  side-effect boundary.
+- Skills may adapt their guidance to the routed context, but they do not decide
+  the cognitive route, bypass tool governance, or expose `escalate_to_system2`
+  as a normal user tool.
+- Daemon and client surfaces carry override intent and display bounded routing
+  metadata; they do not independently decide provider/model routing.
+
 ## Risks / Trade-offs
 
 - System 1 fails to escalate -> Mitigate with safety-first deterministic gates

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -74,7 +74,7 @@ Alternatives considered:
 
 ### Decision: Use safety-first routing gates plus System 1 self-escalation
 
-Routing has three layers:
+Routing has four layers:
 
 1. explicit System 2 override, which can always choose the deeper route,
 2. deterministic gates for known high-risk or high-complexity cases,
@@ -107,10 +107,12 @@ For V1, System 1's auto route should behave like human fast cognition in a
 controlled environment: it can form an impression, gather read-only context, or
 ask to escalate, but it should not perform irreversible external side effects
 before System 2 has taken over or the runtime has accepted the System 1 plan.
-If a read-only tool was used before escalation, System 2 receives those results
-as part of the rerun context. If any side effect already happened, System 2 must
-continue from the observed post-side-effect state rather than replaying the
-original task as if nothing changed.
+Runtime must therefore withhold side-effecting tools from the unaccepted System
+1 phase. If a read-only tool was used before escalation, System 2 receives
+those results as part of the rerun context. If a side effect already happened
+after runtime accepted a System 1 execution phase, or due to an external client
+state change, System 2 must continue from the observed post-side-effect state
+rather than replaying the original task as if nothing changed.
 
 Alternatives considered:
 
@@ -172,6 +174,9 @@ Alternatives considered:
 - Model binding switching complicates provider state -> Mitigate by resolving
   the binding before constructing the request and by partitioning provider
   continuation by compatible provider/model/credential boundaries.
+- System 1 mutates workspace before escalation -> Mitigate by withholding
+  side-effecting tools until runtime accepts the fast route or routes to System
+  2.
 - Metadata becomes noisy -> Mitigate with compact routing reasons and stable
   enum fields.
 - Config ambiguity -> Mitigate by keeping `connection_profile` as the fallback

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -115,12 +115,22 @@ after runtime accepted a System 1 execution phase, or due to an external client
 state change, System 2 must continue from the observed post-side-effect state
 rather than replaying the original task as if nothing changed.
 
+This acceptance is a runtime-owned commit point, not a user-confirmation prompt.
+Before that commit point, System 1 may perform model-internal reasoning,
+calculation, planning, draft generation that is not streamed as accepted output,
+and read-only tool use. After runtime accepts the fast route, System 1 can
+execute permitted side-effecting tools under the same governance and policy
+rules as any other routed turn. Human confirmation is still required only when
+the active governance or tool policy would have required it anyway.
+
 Alternatives considered:
 
 - Ask System 1 to emit a JSON preamble. This is easier to parse but less aligned
   with Alan's action-oriented machine model.
 - Let System 1 answer and append a note that deeper reasoning is needed. This
   leaks low-confidence output and weakens the user experience.
+- Treat runtime acceptance as human approval. This would preserve safety but
+  would add unnecessary interruptions and undercut autonomous operation.
 
 ### Decision: Routing metadata is visible but bounded
 

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -2,7 +2,7 @@
 
 Alan already has connection profiles, model catalog metadata, and runtime-owned
 reasoning-effort resolution for a selected model. That lets an operator choose a
-model and effort, but it does not let the agent behave like a two-speed system:
+provider-backed model and effort, but it does not let the agent behave like a two-speed system:
 normally quick and inexpensive, while able to recognize when a task deserves
 deeper reasoning.
 
@@ -16,8 +16,8 @@ fast system is overconfident and the slow system fails to engage.
 
 **Goals:**
 
-- Let `agent.toml` configure System 1 and System 2 using existing connection
-  profile IDs and optional reasoning-effort intent.
+- Let `agent.toml` configure System 1 and System 2 as model bindings layered
+  above provider/credential configuration, with optional reasoning-effort intent.
 - Default to System 1 when safe, with explicit override and deterministic
   runtime gates.
 - Let the System 1 model self-escalate through an internal-only runtime action.
@@ -35,11 +35,33 @@ fast system is overconfident and the slow system fails to engage.
 
 ## Decisions
 
+### Decision: Split provider availability from cognitive model binding
+
+Configuration should have two conceptual layers:
+
+1. provider/credential availability, which describes authenticated AI providers
+   and the models Alan can use through them,
+2. cognitive model binding, which selects which available model acts as System 1
+   and which acts as System 2.
+
+This keeps System 1/System 2 out of provider auth and avoids copying provider
+credentials into the cognition block. Existing connection profiles can remain a
+compatibility path and can feed the provider/model availability layer, but
+cognitive routing should resolve to a concrete provider, credential scope,
+model, and request-control intent before dispatch.
+
+Alternatives considered:
+
+- Make System 1/System 2 reference full connection profiles directly. This is
+  simple but keeps model selection tangled with credential/profile ownership.
+- Create separate provider config for each system. This duplicates credentials
+  and makes model swaps harder to reason about.
+
 ### Decision: CognitiveRouter manages routing, not provider adapters
 
 `CognitiveRouter` runs in runtime before provider dispatch. It selects a
-cognitive system and connection profile, then delegates reasoning-effort
-resolution to the existing request-control resolver for the selected profile.
+cognitive system and concrete model binding, then delegates reasoning-effort
+resolution to the existing request-control resolver for the selected binding.
 Provider adapters receive a normal `GenerationRequest` and do not know why the
 runtime selected it.
 
@@ -68,12 +90,21 @@ Alternatives considered:
 - Hard-code all routing rules. This is predictable but will feel brittle and
   miss semantic complexity.
 
-### Decision: Escalation is an internal virtual action
+### Decision: Escalation is an internal virtual action with a side-effect boundary
 
 System 1 receives an internal-only action such as
 `escalate_to_system2(reason, needed_context)`. When runtime captures it, the
 fast draft is not accepted or streamed to the user. Runtime reruns System 2 with
 the original task and bounded triage notes.
+
+For V1, System 1's auto route should behave like human fast cognition in a
+controlled environment: it can form an impression, gather read-only context, or
+ask to escalate, but it should not perform irreversible external side effects
+before System 2 has taken over or the runtime has accepted the System 1 plan.
+If a read-only tool was used before escalation, System 2 receives those results
+as part of the rerun context. If any side effect already happened, System 2 must
+continue from the observed post-side-effect state rather than replaying the
+original task as if nothing changed.
 
 Alternatives considered:
 
@@ -84,9 +115,9 @@ Alternatives considered:
 
 ### Decision: Routing metadata is visible but bounded
 
-Turn/session metadata includes selected cognitive system, profile id, model,
-reasoning effort, routing source, and a short routing reason. It does not expose
-private reasoning traces.
+Turn/session metadata includes selected cognitive system, model binding id,
+provider, model, reasoning effort, routing source, and a short routing reason.
+It does not expose private reasoning traces.
 
 Alternatives considered:
 
@@ -106,15 +137,35 @@ Alternatives considered:
 - Run both systems and compare. This is expensive and creates answer selection
   complexity.
 
+### Decision: Treat provider-native continuation as an optimization partitioned by model binding
+
+Alan's tape-level continuation remains compatible across System 1 and System 2
+because runtime can project the accepted tape into whichever model binding is
+selected. Provider-native continuation state, such as a Responses
+`previous_response_id`, is not assumed to be portable across different cognitive
+model bindings.
+
+Runtime must partition, clear, or replay provider-native continuation when the
+selected cognitive binding changes provider family, credential scope, model, or
+other continuation-affecting settings. Reuse is allowed only inside a proven
+compatible binding boundary.
+
+Alternatives considered:
+
+- Assume all configured System 1/System 2 models can share provider continuation.
+  This is too provider-specific and risks invalid request chains.
+- Disable provider-native continuation whenever cognition is enabled. This is
+  safe but gives up useful stateful-provider efficiency.
+
 ## Risks / Trade-offs
 
 - System 1 fails to escalate -> Mitigate with deterministic gates and response
   guardrails that can force System 2 on contradiction or retry.
 - Routing adds latency -> Mitigate by using System 1 by default and avoiding a
   separate classifier call.
-- Profile switching complicates provider state -> Mitigate by resolving profile
-  selection before constructing the request and by keeping provider continuation
-  scoped to compatible profile/model boundaries.
+- Model binding switching complicates provider state -> Mitigate by resolving
+  the binding before constructing the request and by partitioning provider
+  continuation by compatible provider/model/credential boundaries.
 - Metadata becomes noisy -> Mitigate with compact routing reasons and stable
   enum fields.
 - Config ambiguity -> Mitigate by keeping `connection_profile` as the fallback
@@ -126,17 +177,14 @@ Alternatives considered:
    behavior as the default single-system path.
 2. Add routing metadata types and persistence with no behavior change.
 3. Add deterministic routing gates and explicit overrides.
-4. Add System 1 profile dispatch.
+4. Add System 1 model binding dispatch.
 5. Add internal System 1 escalation and System 2 rerun.
 6. Expose metadata in daemon/client DTOs.
 
 Existing agents without a cognition block continue to use their current single
-profile and request-control behavior.
+profile and request-control behavior. When cognition is enabled, both System 1
+and System 2 model bindings must resolve successfully.
 
 ## Open Questions
 
 - Which deterministic gates belong in V1 versus later policy configuration.
-- Whether `system2` should default to the same profile with higher effort when
-  no explicit System 2 profile is configured.
-- How much routing state can safely coexist with provider-managed continuation
-  for stateful Responses profiles.

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -74,12 +74,15 @@ Alternatives considered:
 
 ### Decision: Use safety-first routing gates plus System 1 self-escalation
 
-Routing has five layers:
+Routing first resolves explicit cognitive-system intent by scope: a turn-scoped
+intent applies only to that turn and supersedes any session-scoped intent, while
+session-scoped intent applies only when the turn did not supply its own intent.
+After resolving that effective explicit intent, routing has five layers:
 
-1. explicit System 2 override, which can always choose the deeper route,
+1. effective explicit System 2 intent, which can always choose the deeper route,
 2. deterministic gates for known high-risk or high-complexity cases,
-3. explicit System 1 override, which is honored only when no deterministic gate
-   requires System 2,
+3. effective explicit System 1 intent, which is honored only when no
+   deterministic gate requires System 2,
 4. configured default route, which may select System 1 or System 2,
 5. System 1 fallback attempt that can call internal `escalate_to_system2`.
 

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -169,13 +169,17 @@ model bindings.
 
 Runtime must partition, clear, or replay provider-native continuation when the
 selected cognitive binding changes provider family, credential scope, model, or
-other continuation-affecting settings. Reuse is allowed only inside a proven
-compatible binding boundary.
+other continuation-affecting settings. The compatibility boundary includes the
+cognitive-system prompt fingerprint and tool definition fingerprint, because
+System 1 may receive internal-only tools or speculative instructions that System
+2 must not inherit through provider-native state. Reuse is allowed only inside a
+proven compatible binding boundary.
 
 Alternatives considered:
 
 - Assume all configured System 1/System 2 models can share provider continuation.
-  This is too provider-specific and risks invalid request chains.
+  This is too provider-specific and risks invalid request chains or prompt/tool
+  leakage across cognitive phases.
 - Disable provider-native continuation whenever cognition is enabled. This is
   safe but gives up useful stateful-provider efficiency.
 

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -139,7 +139,9 @@ Alternatives considered:
 
 Turn/session metadata includes selected cognitive system, model binding id,
 provider, model, reasoning effort, routing source, and a short routing reason.
-It does not expose private reasoning traces.
+Create, list, read, reconnect, and fork DTOs expose that bounded metadata where
+they already report request-control metadata. It does not expose private
+reasoning traces.
 
 Alternatives considered:
 

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -18,8 +18,8 @@ fast system is overconfident and the slow system fails to engage.
 
 - Let `agent.toml` configure System 1 and System 2 as model bindings layered
   above provider/credential configuration, with optional reasoning-effort intent.
-- Default to System 1 when safe, with explicit override and deterministic
-  runtime gates that can force System 2 for safety.
+- Honor the configured default route when no override or deterministic gate
+  applies, falling back to System 1 when no default is configured.
 - Let the System 1 model self-escalate through an internal-only runtime action.
 - Suppress fast drafts when escalation occurs and rerun the original task on
   System 2 with bounded triage notes.
@@ -74,13 +74,14 @@ Alternatives considered:
 
 ### Decision: Use safety-first routing gates plus System 1 self-escalation
 
-Routing has four layers:
+Routing has five layers:
 
 1. explicit System 2 override, which can always choose the deeper route,
 2. deterministic gates for known high-risk or high-complexity cases,
 3. explicit System 1 override, which is honored only when no deterministic gate
    requires System 2,
-4. default System 1 attempt that can call internal `escalate_to_system2`.
+4. configured default route, which may select System 1 or System 2,
+5. System 1 fallback attempt that can call internal `escalate_to_system2`.
 
 This avoids a separate router LLM call on every turn while still letting the
 fast model recognize when a task should not be answered quickly.

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -1,0 +1,142 @@
+## Context
+
+Alan already has connection profiles, model catalog metadata, and runtime-owned
+reasoning-effort resolution for a selected model. That lets an operator choose a
+model and effort, but it does not let the agent behave like a two-speed system:
+normally quick and inexpensive, while able to recognize when a task deserves
+deeper reasoning.
+
+The desired model is inspired by System 1/System 2 from "Thinking, Fast and
+Slow": System 1 is fast, automatic, and pattern-driven; System 2 is slower,
+more deliberate, and used for complex reasoning or high-cost errors. Alan should
+borrow the useful structure without reproducing the human failure mode where the
+fast system is overconfident and the slow system fails to engage.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let `agent.toml` configure System 1 and System 2 using existing connection
+  profile IDs and optional reasoning-effort intent.
+- Default to System 1 when safe, with explicit override and deterministic
+  runtime gates.
+- Let the System 1 model self-escalate through an internal-only runtime action.
+- Suppress fast drafts when escalation occurs and rerun the original task on
+  System 2 with bounded triage notes.
+- Record every routing decision in audit-friendly metadata.
+
+**Non-Goals:**
+
+- Run two models in parallel by default.
+- Turn System 1/System 2 into separate child agents.
+- Move routing decisions into provider adapters.
+- Replace existing request-control resolution.
+- Expose hidden reasoning content as routing metadata.
+
+## Decisions
+
+### Decision: CognitiveRouter manages routing, not provider adapters
+
+`CognitiveRouter` runs in runtime before provider dispatch. It selects a
+cognitive system and connection profile, then delegates reasoning-effort
+resolution to the existing request-control resolver for the selected profile.
+Provider adapters receive a normal `GenerationRequest` and do not know why the
+runtime selected it.
+
+Alternatives considered:
+
+- Make each provider adapter decide whether to use a faster or deeper model.
+  This duplicates policy and breaks provider projection isolation.
+- Put routing entirely in daemon/client code. This prevents runtime from
+  auditing decisions consistently and makes CLI/TUI/macOS behavior diverge.
+
+### Decision: Use deterministic gates plus System 1 self-escalation
+
+Routing has three layers:
+
+1. explicit turn/session/config overrides,
+2. deterministic gates for known high-risk or high-complexity cases,
+3. a System 1 attempt that can call internal `escalate_to_system2`.
+
+This avoids a separate router LLM call on every turn while still letting the
+fast model recognize when a task should not be answered quickly.
+
+Alternatives considered:
+
+- Always call a small classifier model first. This is simple but adds latency to
+  every turn and makes the classifier another hidden model path.
+- Hard-code all routing rules. This is predictable but will feel brittle and
+  miss semantic complexity.
+
+### Decision: Escalation is an internal virtual action
+
+System 1 receives an internal-only action such as
+`escalate_to_system2(reason, needed_context)`. When runtime captures it, the
+fast draft is not accepted or streamed to the user. Runtime reruns System 2 with
+the original task and bounded triage notes.
+
+Alternatives considered:
+
+- Ask System 1 to emit a JSON preamble. This is easier to parse but less aligned
+  with Alan's action-oriented machine model.
+- Let System 1 answer and append a note that deeper reasoning is needed. This
+  leaks low-confidence output and weakens the user experience.
+
+### Decision: Routing metadata is visible but bounded
+
+Turn/session metadata includes selected cognitive system, profile id, model,
+reasoning effort, routing source, and a short routing reason. It does not expose
+private reasoning traces.
+
+Alternatives considered:
+
+- Hide routing completely. This undermines trust and makes debugging difficult.
+- Store full chain-of-thought. This violates provider and product boundaries.
+
+### Decision: Keep first version single-runtime and single-active-turn
+
+The first implementation changes provider selection within the existing turn
+loop. It does not spawn a second agent, merge transcripts, or run competing
+models.
+
+Alternatives considered:
+
+- Use child agents for System 2. This is useful later for delegated work but too
+  heavy for normal routing.
+- Run both systems and compare. This is expensive and creates answer selection
+  complexity.
+
+## Risks / Trade-offs
+
+- System 1 fails to escalate -> Mitigate with deterministic gates and response
+  guardrails that can force System 2 on contradiction or retry.
+- Routing adds latency -> Mitigate by using System 1 by default and avoiding a
+  separate classifier call.
+- Profile switching complicates provider state -> Mitigate by resolving profile
+  selection before constructing the request and by keeping provider continuation
+  scoped to compatible profile/model boundaries.
+- Metadata becomes noisy -> Mitigate with compact routing reasons and stable
+  enum fields.
+- Config ambiguity -> Mitigate by keeping `connection_profile` as the fallback
+  default and making cognition config explicit.
+
+## Migration Plan
+
+1. Add cognition config parsing while preserving existing `connection_profile`
+   behavior as the default single-system path.
+2. Add routing metadata types and persistence with no behavior change.
+3. Add deterministic routing gates and explicit overrides.
+4. Add System 1 profile dispatch.
+5. Add internal System 1 escalation and System 2 rerun.
+6. Expose metadata in daemon/client DTOs.
+
+Existing agents without a cognition block continue to use their current single
+profile and request-control behavior.
+
+## Open Questions
+
+- Which deterministic gates belong in V1 versus later policy configuration.
+- Whether `system2` should default to the same profile with higher effort when
+  no explicit System 2 profile is configured.
+- How much routing state can safely coexist with provider-managed continuation
+  for stateful Responses profiles.

--- a/openspec/changes/add-cognitive-model-routing/design.md
+++ b/openspec/changes/add-cognitive-model-routing/design.md
@@ -19,7 +19,7 @@ fast system is overconfident and the slow system fails to engage.
 - Let `agent.toml` configure System 1 and System 2 as model bindings layered
   above provider/credential configuration, with optional reasoning-effort intent.
 - Default to System 1 when safe, with explicit override and deterministic
-  runtime gates.
+  runtime gates that can force System 2 for safety.
 - Let the System 1 model self-escalate through an internal-only runtime action.
 - Suppress fast drafts when escalation occurs and rerun the original task on
   System 2 with bounded triage notes.
@@ -72,21 +72,27 @@ Alternatives considered:
 - Put routing entirely in daemon/client code. This prevents runtime from
   auditing decisions consistently and makes CLI/TUI/macOS behavior diverge.
 
-### Decision: Use deterministic gates plus System 1 self-escalation
+### Decision: Use safety-first routing gates plus System 1 self-escalation
 
 Routing has three layers:
 
-1. explicit turn/session/config overrides,
+1. explicit System 2 override, which can always choose the deeper route,
 2. deterministic gates for known high-risk or high-complexity cases,
-3. a System 1 attempt that can call internal `escalate_to_system2`.
+3. explicit System 1 override, which is honored only when no deterministic gate
+   requires System 2,
+4. default System 1 attempt that can call internal `escalate_to_system2`.
 
 This avoids a separate router LLM call on every turn while still letting the
 fast model recognize when a task should not be answered quickly.
+It also prevents clients from forcing the fast route through conditions the
+runtime already knows require System 2.
 
 Alternatives considered:
 
 - Always call a small classifier model first. This is simple but adds latency to
   every turn and makes the classifier another hidden model path.
+- Let System 1 overrides outrank deterministic gates. This makes manual control
+  simple but undercuts the safety boundary.
 - Hard-code all routing rules. This is predictable but will feel brittle and
   miss semantic complexity.
 
@@ -159,8 +165,8 @@ Alternatives considered:
 
 ## Risks / Trade-offs
 
-- System 1 fails to escalate -> Mitigate with deterministic gates and response
-  guardrails that can force System 2 on contradiction or retry.
+- System 1 fails to escalate -> Mitigate with safety-first deterministic gates
+  and response guardrails that can force System 2 on contradiction or retry.
 - Routing adds latency -> Mitigate by using System 1 by default and avoiding a
   separate classifier call.
 - Model binding switching complicates provider state -> Mitigate by resolving
@@ -176,7 +182,8 @@ Alternatives considered:
 1. Add cognition config parsing while preserving existing `connection_profile`
    behavior as the default single-system path.
 2. Add routing metadata types and persistence with no behavior change.
-3. Add deterministic routing gates and explicit overrides.
+3. Add deterministic routing gates and explicit overrides, with System 2 gates
+   superseding forced System 1 intent.
 4. Add System 1 model binding dispatch.
 5. Add internal System 1 escalation and System 2 rerun.
 6. Expose metadata in daemon/client DTOs.

--- a/openspec/changes/add-cognitive-model-routing/proposal.md
+++ b/openspec/changes/add-cognitive-model-routing/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Alan can already control reasoning effort for a selected model, but it cannot
+act like a two-speed agent that normally thinks quickly and deliberately
+escalates when a task needs deeper reasoning. Alan should support configurable
+System 1/System 2 model profiles with automatic, visible, and overridable
+routing.
+
+## What Changes
+
+- Add cognitive routing configuration for System 1 and System 2 profiles, each
+  backed by existing connection profiles and optional reasoning-effort intent.
+- Add a runtime-owned `CognitiveRouter` that applies explicit overrides,
+  deterministic gates, and System 1 self-escalation before provider dispatch.
+- Add an internal-only escalation action that lets the System 1 model request a
+  System 2 rerun without exposing the fast draft to the user.
+- Record routing decisions in turn/session metadata, rollout entries, logs, and
+  daemon/client DTOs.
+- Preserve existing provider adapter boundaries: adapters only project the
+  normalized request they receive and do not decide routing.
+- Keep first implementation single-runtime and single-active-turn; this is not
+  parallel multi-agent execution.
+
+## Capabilities
+
+### New Capabilities
+
+- `cognitive-model-routing`: Owns System 1/System 2 profile configuration,
+  automatic routing, internal escalation, override precedence, and routing
+  observability.
+
+### Modified Capabilities
+
+- `provider-request-controls`: Request-control resolution must compose with the
+  selected cognitive profile and remain the only authority for effective
+  reasoning effort.
+- `daemon-api-contract`: Daemon session and turn surfaces must expose routing
+  metadata and accept explicit cognitive-system overrides.
+
+## Impact
+
+- Affected runtime modules: request-control resolution, turn execution,
+  LLM-client construction, virtual/internal actions, rollout persistence, and
+  session startup metadata.
+- Affected configuration: `agent.toml` gains a cognition block that references
+  existing connection profile IDs instead of duplicating provider credentials.
+- Affected daemon/clients: session create/fork/submit DTOs and read/list
+  responses expose selected cognitive system and routing reason.
+- Affected tests: routing precedence, deterministic gates, System 1 escalation,
+  hidden fast-draft suppression, metadata persistence, and provider-boundary
+  contract tests.

--- a/openspec/changes/add-cognitive-model-routing/proposal.md
+++ b/openspec/changes/add-cognitive-model-routing/proposal.md
@@ -3,13 +3,14 @@
 Alan can already control reasoning effort for a selected model, but it cannot
 act like a two-speed agent that normally thinks quickly and deliberately
 escalates when a task needs deeper reasoning. Alan should support configurable
-System 1/System 2 model profiles with automatic, visible, and overridable
+System 1/System 2 model bindings with automatic, visible, and overridable
 routing.
 
 ## What Changes
 
-- Add cognitive routing configuration for System 1 and System 2 profiles, each
-  backed by existing connection profiles and optional reasoning-effort intent.
+- Add cognitive routing configuration for System 1 and System 2 model bindings,
+  layered above provider/credential configuration and optional reasoning-effort
+  intent.
 - Add a runtime-owned `CognitiveRouter` that applies explicit overrides,
   deterministic gates, and System 1 self-escalation before provider dispatch.
 - Add an internal-only escalation action that lets the System 1 model request a
@@ -25,14 +26,14 @@ routing.
 
 ### New Capabilities
 
-- `cognitive-model-routing`: Owns System 1/System 2 profile configuration,
+- `cognitive-model-routing`: Owns System 1/System 2 model binding configuration,
   automatic routing, internal escalation, override precedence, and routing
   observability.
 
 ### Modified Capabilities
 
 - `provider-request-controls`: Request-control resolution must compose with the
-  selected cognitive profile and remain the only authority for effective
+  selected cognitive model binding and remain the only authority for effective
   reasoning effort.
 - `daemon-api-contract`: Daemon session and turn surfaces must expose routing
   metadata and accept explicit cognitive-system overrides.
@@ -42,8 +43,9 @@ routing.
 - Affected runtime modules: request-control resolution, turn execution,
   LLM-client construction, virtual/internal actions, rollout persistence, and
   session startup metadata.
-- Affected configuration: `agent.toml` gains a cognition block that references
-  existing connection profile IDs instead of duplicating provider credentials.
+- Affected configuration: `agent.toml` gains a cognition block that binds
+  System 1 and System 2 to available provider/model entries without duplicating
+  provider credentials.
 - Affected daemon/clients: session create/fork/submit DTOs and read/list
   responses expose selected cognitive system and routing reason.
 - Affected tests: routing precedence, deterministic gates, System 1 escalation,

--- a/openspec/changes/add-cognitive-model-routing/proposal.md
+++ b/openspec/changes/add-cognitive-model-routing/proposal.md
@@ -12,7 +12,8 @@ routing.
   layered above provider/credential configuration and optional reasoning-effort
   intent.
 - Add a runtime-owned `CognitiveRouter` that applies explicit overrides,
-  deterministic gates, and System 1 self-escalation before provider dispatch.
+  deterministic safety gates, and System 1 self-escalation before provider
+  dispatch, with safety gates able to supersede forced System 1 intent.
 - Add an internal-only escalation action that lets the System 1 model request a
   System 2 rerun without exposing the fast draft to the user.
 - Record routing decisions in turn/session metadata, rollout entries, logs, and

--- a/openspec/changes/add-cognitive-model-routing/proposal.md
+++ b/openspec/changes/add-cognitive-model-routing/proposal.md
@@ -16,6 +16,8 @@ routing.
   dispatch, with safety gates able to supersede forced System 1 intent.
 - Add an internal-only escalation action that lets the System 1 model request a
   System 2 rerun without exposing the fast draft to the user.
+- Gate side-effecting tools during unaccepted System 1 attempts so workspace
+  mutation waits for accepted fast execution or System 2 routing.
 - Record routing decisions in turn/session metadata, rollout entries, logs, and
   daemon/client DTOs.
 - Preserve existing provider adapter boundaries: adapters only project the
@@ -50,5 +52,5 @@ routing.
 - Affected daemon/clients: session create/fork/submit DTOs and read/list
   responses expose selected cognitive system and routing reason.
 - Affected tests: routing precedence, deterministic gates, System 1 escalation,
-  hidden fast-draft suppression, metadata persistence, and provider-boundary
-  contract tests.
+  side-effect gating, hidden fast-draft suppression, metadata persistence, and
+  provider-boundary contract tests.

--- a/openspec/changes/add-cognitive-model-routing/proposal.md
+++ b/openspec/changes/add-cognitive-model-routing/proposal.md
@@ -22,6 +22,9 @@ routing.
   daemon/client DTOs.
 - Preserve existing provider adapter boundaries: adapters only project the
   normalized request they receive and do not decide routing.
+- Partition provider-native continuation by compatible prompt and tool state so
+  System 1-only escalation tools or speculative prompt context cannot leak into
+  System 2.
 - Keep first implementation single-runtime and single-active-turn; this is not
   parallel multi-agent execution.
 
@@ -52,5 +55,5 @@ routing.
 - Affected daemon/clients: session create/fork/submit DTOs and read/list
   responses expose selected cognitive system and routing reason.
 - Affected tests: routing precedence, deterministic gates, System 1 escalation,
-  side-effect gating, hidden fast-draft suppression, metadata persistence, and
-  provider-boundary contract tests.
+  side-effect gating, hidden fast-draft suppression, metadata persistence,
+  prompt/tool continuation partitioning, and provider-boundary contract tests.

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -43,9 +43,9 @@ Alan SHALL keep provider and credential availability separate from System
 
 ### Requirement: Runtime-Owned Cognitive Routing
 Alan SHALL select the cognitive system in runtime before provider dispatch by
-applying explicit overrides, deterministic safety gates, and System 1
-self-escalation. Deterministic safety gates SHALL supersede any explicit
-System 1 routing intent.
+applying explicit overrides, deterministic safety gates, configured defaults,
+System 1 fallback, and System 1 self-escalation. Deterministic safety gates
+SHALL supersede any explicit System 1 routing intent.
 
 #### Scenario: Explicit System 2 override wins
 - **WHEN** a session or turn explicitly requests System 2
@@ -66,8 +66,13 @@ System 1 routing intent.
 - **AND** the routing metadata records that the deterministic gate superseded
   the override
 
-#### Scenario: Default route uses System 1
+#### Scenario: Configured default route is honored
 - **WHEN** no override or deterministic gate applies
+- **AND** the resolved cognition config declares a default cognitive system
+- **THEN** Alan routes the turn to the configured default cognitive system
+
+#### Scenario: Missing default falls back to System 1
+- **WHEN** no override, deterministic gate, or configured default applies
 - **THEN** Alan starts the turn on System 1
 
 ### Requirement: System 1 Self-Escalation

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -80,6 +80,9 @@ Alan SHALL provide an internal-only escalation action that lets System 1 request
 a System 2 rerun with a bounded reason and needed-context summary. Alan SHALL
 withhold side-effecting tools from unaccepted System 1 attempts until runtime
 accepts the System 1 route for execution or routes the turn to System 2.
+Runtime acceptance of a System 1 route is an internal commit point and SHALL NOT
+itself require user confirmation unless the active governance or tool policy
+requires confirmation.
 
 #### Scenario: System 1 escalates
 - **WHEN** System 1 emits the internal escalation action
@@ -104,6 +107,13 @@ accepts the System 1 route for execution or routes the turn to System 2.
 - **THEN** runtime provides the read-only tool results to System 2 as observed
   context instead of discarding them
 
+#### Scenario: Speculative System 1 thinking and observation is allowed
+- **WHEN** runtime starts an automatic System 1 attempt
+- **THEN** System 1 can perform model-internal reasoning, calculation, planning,
+  unaccepted draft generation, and read-only tool use before route acceptance
+- **AND** runtime does not treat that speculative thinking or read-only
+  observation as an external side effect
+
 #### Scenario: Side-effecting tool is blocked before System 1 acceptance
 - **WHEN** runtime starts an automatic System 1 attempt
 - **AND** System 1 requests a side-effecting tool before runtime has accepted
@@ -112,6 +122,14 @@ accepts the System 1 route for execution or routes the turn to System 2.
   System 1 phase
 - **AND** runtime routes to System 2 or defers the side effect until the System
   1 route is accepted
+
+#### Scenario: Autonomous System 1 route can be accepted without user yield
+- **WHEN** runtime starts an automatic System 1 attempt under governance that
+  allows autonomous execution
+- **AND** no deterministic gate or policy rule requires System 2 or user
+  confirmation
+- **THEN** runtime can accept the System 1 route for execution without emitting
+  a user-confirmation yield
 
 #### Scenario: Accepted side effect already happened before escalation
 - **WHEN** a side-effecting tool has already completed after runtime accepted

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -2,23 +2,44 @@
 
 ### Requirement: Cognitive System Configuration
 Alan SHALL allow agent configuration to declare System 1 and System 2 cognitive
-profiles using existing connection profile identifiers and optional
-reasoning-effort intent.
+model bindings that resolve through available provider, credential, and model
+configuration with optional reasoning-effort intent.
 
-#### Scenario: Cognition config declares two systems
+#### Scenario: Cognition config declares two model bindings
 - **WHEN** `agent.toml` declares System 1 and System 2 cognition entries
-- **THEN** Alan resolves each entry through the normal connection profile and
-  request-control machinery
+- **THEN** Alan resolves each entry to a concrete provider, credential scope,
+  model, and request-control intent before provider dispatch
+
+#### Scenario: Cognition config omits a required system
+- **WHEN** cognition routing is enabled but System 1 or System 2 is not
+  configured
+- **THEN** Alan rejects startup or session creation with a diagnostic that names
+  the missing cognitive system
 
 #### Scenario: Cognition config is absent
 - **WHEN** an agent has no cognition configuration
 - **THEN** Alan preserves existing single-profile behavior using the resolved
   `connection_profile`
 
-#### Scenario: Invalid cognitive profile is rejected
-- **WHEN** cognition config references a missing connection profile
+#### Scenario: Invalid cognitive model binding is rejected
+- **WHEN** cognition config references a missing provider, credential scope, or
+  model binding
 - **THEN** Alan rejects startup or session creation with a diagnostic that names
-  the missing profile
+  the missing binding component
+
+### Requirement: Provider Availability And Cognitive Binding Separation
+Alan SHALL keep provider and credential availability separate from System
+1/System 2 cognitive-role assignment.
+
+#### Scenario: Provider availability is role-neutral
+- **WHEN** Alan loads configured AI providers and available models
+- **THEN** those provider/model entries do not themselves imply System 1 or
+  System 2 behavior
+
+#### Scenario: Cognitive binding selects from availability
+- **WHEN** Alan resolves System 1 or System 2
+- **THEN** the cognitive binding selects from available provider/model entries
+  rather than duplicating provider credentials inside the cognition block
 
 ### Requirement: Runtime-Owned Cognitive Routing
 Alan SHALL select the cognitive system in runtime before provider dispatch by
@@ -53,6 +74,25 @@ a System 2 rerun with a bounded reason and needed-context summary.
 - **THEN** the internal escalation action is not exposed as a normal external
   side-effecting tool
 
+#### Scenario: Escalation before external side effects
+- **WHEN** System 1 determines that a task needs System 2 before any
+  side-effecting tool has executed
+- **THEN** runtime reruns the original logical turn on System 2 and includes the
+  bounded System 1 triage notes
+
+#### Scenario: Read-only context before escalation
+- **WHEN** System 1 used read-only tools before emitting the internal escalation
+  action
+- **THEN** runtime provides the read-only tool results to System 2 as observed
+  context instead of discarding them
+
+#### Scenario: Side effect already happened before escalation
+- **WHEN** a side-effecting tool has already completed before escalation is
+  requested or forced
+- **THEN** runtime treats the side effect as part of the current session state
+  and System 2 continues from the observed post-side-effect state rather than
+  replaying the original task as if no side effect occurred
+
 ### Requirement: Cognitive Routing Observability
 Alan SHALL record cognitive routing metadata for each routed turn without
 exposing hidden reasoning content.
@@ -60,7 +100,8 @@ exposing hidden reasoning content.
 #### Scenario: Routed turn records metadata
 - **WHEN** Alan dispatches a model request through cognitive routing
 - **THEN** turn metadata records selected cognitive system, routing source,
-  profile id, model, effective reasoning effort, and a bounded routing reason
+  model binding id, provider, model, effective reasoning effort, and a bounded
+  routing reason
 
 #### Scenario: Escalated turn records both phases
 - **WHEN** System 1 escalates to System 2
@@ -76,3 +117,26 @@ model executions.
 - **WHEN** a System 1 attempt escalates to System 2
 - **THEN** runtime preserves one logical user turn and records the escalation as
   routing metadata rather than spawning a separate child-agent session
+
+### Requirement: Provider-Native Continuation Partitioning
+Alan SHALL treat provider-native continuation state as an optimization scoped to
+compatible cognitive model bindings, while preserving tape-level continuation
+across System 1 and System 2.
+
+#### Scenario: Compatible binding reuses native continuation
+- **WHEN** the selected cognitive model binding has the same provider family,
+  credential scope, model, and continuation-affecting settings as the current
+  provider-native continuation state
+- **THEN** runtime can reuse that provider-native continuation state
+
+#### Scenario: Incompatible binding clears native continuation
+- **WHEN** cognitive routing selects a model binding with a different provider
+  family, credential scope, model, or continuation-affecting setting
+- **THEN** runtime clears or isolates provider-native continuation and projects
+  the accepted tape into the selected provider request instead
+
+#### Scenario: Tape continuation remains authoritative
+- **WHEN** provider-native continuation cannot be reused after a cognitive
+  system switch
+- **THEN** Alan still continues from the accepted runtime tape rather than
+  losing conversation state

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -43,9 +43,11 @@ Alan SHALL keep provider and credential availability separate from System
 
 ### Requirement: Runtime-Owned Cognitive Routing
 Alan SHALL select the cognitive system in runtime before provider dispatch by
-applying explicit overrides, deterministic gates, and System 1 self-escalation.
+applying explicit overrides, deterministic safety gates, and System 1
+self-escalation. Deterministic safety gates SHALL supersede any explicit
+System 1 routing intent.
 
-#### Scenario: Explicit override wins
+#### Scenario: Explicit System 2 override wins
 - **WHEN** a session or turn explicitly requests System 2
 - **THEN** Alan routes the turn to System 2 regardless of the default routing
   mode
@@ -54,6 +56,15 @@ applying explicit overrides, deterministic gates, and System 1 self-escalation.
 - **WHEN** runtime detects a configured high-risk or high-complexity condition
   that requires deep reasoning
 - **THEN** Alan routes the turn to System 2 before generating a fast draft
+
+#### Scenario: System 1 override is superseded by gate
+- **WHEN** a session or turn explicitly requests System 1
+- **AND** runtime detects a configured high-risk or high-complexity condition
+  that requires deep reasoning
+- **THEN** Alan ignores or rejects the forced System 1 intent and routes the
+  turn to System 2 before generating a fast draft
+- **AND** the routing metadata records that the deterministic gate superseded
+  the override
 
 #### Scenario: Default route uses System 1
 - **WHEN** no override or deterministic gate applies

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Cognitive System Configuration
+Alan SHALL allow agent configuration to declare System 1 and System 2 cognitive
+profiles using existing connection profile identifiers and optional
+reasoning-effort intent.
+
+#### Scenario: Cognition config declares two systems
+- **WHEN** `agent.toml` declares System 1 and System 2 cognition entries
+- **THEN** Alan resolves each entry through the normal connection profile and
+  request-control machinery
+
+#### Scenario: Cognition config is absent
+- **WHEN** an agent has no cognition configuration
+- **THEN** Alan preserves existing single-profile behavior using the resolved
+  `connection_profile`
+
+#### Scenario: Invalid cognitive profile is rejected
+- **WHEN** cognition config references a missing connection profile
+- **THEN** Alan rejects startup or session creation with a diagnostic that names
+  the missing profile
+
+### Requirement: Runtime-Owned Cognitive Routing
+Alan SHALL select the cognitive system in runtime before provider dispatch by
+applying explicit overrides, deterministic gates, and System 1 self-escalation.
+
+#### Scenario: Explicit override wins
+- **WHEN** a session or turn explicitly requests System 2
+- **THEN** Alan routes the turn to System 2 regardless of the default routing
+  mode
+
+#### Scenario: Deterministic gate forces System 2
+- **WHEN** runtime detects a configured high-risk or high-complexity condition
+  that requires deep reasoning
+- **THEN** Alan routes the turn to System 2 before generating a fast draft
+
+#### Scenario: Default route uses System 1
+- **WHEN** no override or deterministic gate applies
+- **THEN** Alan starts the turn on System 1
+
+### Requirement: System 1 Self-Escalation
+Alan SHALL provide an internal-only escalation action that lets System 1 request
+a System 2 rerun with a bounded reason and needed-context summary.
+
+#### Scenario: System 1 escalates
+- **WHEN** System 1 emits the internal escalation action
+- **THEN** runtime does not accept the System 1 draft as user-visible output
+- **AND** runtime reruns the original task on System 2 with bounded triage notes
+
+#### Scenario: Escalation action is not a user tool
+- **WHEN** Alan exposes tool definitions to user-governed tools or client
+  dynamic tools
+- **THEN** the internal escalation action is not exposed as a normal external
+  side-effecting tool
+
+### Requirement: Cognitive Routing Observability
+Alan SHALL record cognitive routing metadata for each routed turn without
+exposing hidden reasoning content.
+
+#### Scenario: Routed turn records metadata
+- **WHEN** Alan dispatches a model request through cognitive routing
+- **THEN** turn metadata records selected cognitive system, routing source,
+  profile id, model, effective reasoning effort, and a bounded routing reason
+
+#### Scenario: Escalated turn records both phases
+- **WHEN** System 1 escalates to System 2
+- **THEN** rollout metadata records that System 1 requested escalation and that
+  System 2 produced the accepted draft
+
+### Requirement: Single Runtime First Implementation
+Alan SHALL implement cognitive routing inside the existing runtime turn loop
+without making System 1 and System 2 separate child agents or default parallel
+model executions.
+
+#### Scenario: System 2 rerun remains same logical turn
+- **WHEN** a System 1 attempt escalates to System 2
+- **THEN** runtime preserves one logical user turn and records the escalation as
+  routing metadata rather than spawning a separate child-agent session

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -72,7 +72,9 @@ System 1 routing intent.
 
 ### Requirement: System 1 Self-Escalation
 Alan SHALL provide an internal-only escalation action that lets System 1 request
-a System 2 rerun with a bounded reason and needed-context summary.
+a System 2 rerun with a bounded reason and needed-context summary. Alan SHALL
+withhold side-effecting tools from unaccepted System 1 attempts until runtime
+accepts the System 1 route for execution or routes the turn to System 2.
 
 #### Scenario: System 1 escalates
 - **WHEN** System 1 emits the internal escalation action
@@ -97,9 +99,18 @@ a System 2 rerun with a bounded reason and needed-context summary.
 - **THEN** runtime provides the read-only tool results to System 2 as observed
   context instead of discarding them
 
-#### Scenario: Side effect already happened before escalation
-- **WHEN** a side-effecting tool has already completed before escalation is
-  requested or forced
+#### Scenario: Side-effecting tool is blocked before System 1 acceptance
+- **WHEN** runtime starts an automatic System 1 attempt
+- **AND** System 1 requests a side-effecting tool before runtime has accepted
+  the System 1 route for execution
+- **THEN** runtime does not execute the side-effecting tool in the unaccepted
+  System 1 phase
+- **AND** runtime routes to System 2 or defers the side effect until the System
+  1 route is accepted
+
+#### Scenario: Accepted side effect already happened before escalation
+- **WHEN** a side-effecting tool has already completed after runtime accepted
+  the System 1 execution phase or after an external client changed state
 - **THEN** runtime treats the side effect as part of the current session state
   and System 2 continues from the observed post-side-effect state rather than
   replaying the original task as if no side effect occurred

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -181,15 +181,25 @@ across System 1 and System 2.
 
 #### Scenario: Compatible binding reuses native continuation
 - **WHEN** the selected cognitive model binding has the same provider family,
-  credential scope, model, and continuation-affecting settings as the current
+  credential scope, model, cognitive-system prompt fingerprint, tool definition
+  fingerprint, and continuation-affecting settings as the current
   provider-native continuation state
 - **THEN** runtime can reuse that provider-native continuation state
 
 #### Scenario: Incompatible binding clears native continuation
 - **WHEN** cognitive routing selects a model binding with a different provider
-  family, credential scope, model, or continuation-affecting setting
+  family, credential scope, model, cognitive-system prompt fingerprint, tool
+  definition fingerprint, or continuation-affecting setting
 - **THEN** runtime clears or isolates provider-native continuation and projects
   the accepted tape into the selected provider request instead
+
+#### Scenario: System 1-only tools do not leak to System 2
+- **WHEN** a System 1 attempt used provider-native continuation with
+  System-1-only prompt text or tools such as the internal escalation action
+- **AND** the turn routes or escalates to System 2 with a different prompt or
+  tool fingerprint
+- **THEN** runtime does not reuse the System 1 provider-native continuation for
+  the System 2 request
 
 #### Scenario: Tape continuation remains authoritative
 - **WHEN** provider-native continuation cannot be reused after a cognitive

--- a/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/cognitive-model-routing/spec.md
@@ -44,13 +44,23 @@ Alan SHALL keep provider and credential availability separate from System
 ### Requirement: Runtime-Owned Cognitive Routing
 Alan SHALL select the cognitive system in runtime before provider dispatch by
 applying explicit overrides, deterministic safety gates, configured defaults,
-System 1 fallback, and System 1 self-escalation. Deterministic safety gates
-SHALL supersede any explicit System 1 routing intent.
+System 1 fallback, and System 1 self-escalation. Turn-scoped explicit routing
+intent SHALL supersede session-scoped explicit routing intent for that turn.
+Deterministic safety gates SHALL supersede any effective explicit System 1
+routing intent.
 
-#### Scenario: Explicit System 2 override wins
-- **WHEN** a session or turn explicitly requests System 2
+#### Scenario: Effective System 2 intent wins
+- **WHEN** the effective routing intent after turn-over-session resolution
+  explicitly requests System 2
 - **THEN** Alan routes the turn to System 2 regardless of the default routing
   mode
+
+#### Scenario: Turn override supersedes session override
+- **WHEN** a session explicitly requests System 2
+- **AND** the current turn explicitly requests System 1
+- **AND** no deterministic gate requires System 2
+- **THEN** Alan honors the turn-scoped System 1 intent for that turn
+- **AND** routing metadata records the turn-scoped routing source
 
 #### Scenario: Deterministic gate forces System 2
 - **WHEN** runtime detects a configured high-risk or high-complexity condition
@@ -58,7 +68,8 @@ SHALL supersede any explicit System 1 routing intent.
 - **THEN** Alan routes the turn to System 2 before generating a fast draft
 
 #### Scenario: System 1 override is superseded by gate
-- **WHEN** a session or turn explicitly requests System 1
+- **WHEN** the effective routing intent after turn-over-session resolution
+  explicitly requests System 1
 - **AND** runtime detects a configured high-risk or high-complexity condition
   that requires deep reasoning
 - **THEN** Alan ignores or rejects the forced System 1 intent and routes the

--- a/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
@@ -7,13 +7,13 @@ and reconnect surfaces where request-control metadata is already reported.
 #### Scenario: Session response includes routing metadata
 - **WHEN** a session is created with cognitive routing enabled
 - **THEN** the daemon response includes the configured routing mode and the
-  active cognitive profile metadata available at startup
+  active cognitive model binding metadata available at startup
 
 #### Scenario: Turn read includes selected system
 - **WHEN** a client reads session history or reconnect state after a routed turn
 - **THEN** the response includes selected cognitive system, routing source,
-  profile id, model, effective reasoning effort, and bounded routing reason
-  when available
+  model binding id, provider, model, effective reasoning effort, and bounded
+  routing reason when available
 
 ### Requirement: Cognitive Routing API Overrides
 The daemon SHALL accept explicit cognitive-system override intent on session,
@@ -26,8 +26,8 @@ and request-control boundaries.
   provider dispatch
 
 #### Scenario: Invalid override is rejected
-- **WHEN** a client requests an unknown cognitive system or a system that is not
-  configured
+- **WHEN** a client requests an unknown cognitive system or a cognitive system
+  whose model binding is not configured
 - **THEN** the daemon or runtime rejects the request with a diagnostic rather
   than silently using the default route
 

--- a/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
@@ -25,6 +25,12 @@ and request-control boundaries.
 - **THEN** runtime receives turn-scoped routing intent and applies it before
   provider dispatch
 
+#### Scenario: Turn requests System 1 in gated context
+- **WHEN** a client submits a turn with a System 1 override
+- **AND** runtime detects a configured high-risk or high-complexity gate
+- **THEN** runtime rejects or supersedes the forced System 1 override and
+  reports the routing decision in metadata
+
 #### Scenario: Invalid override is rejected
 - **WHEN** a client requests an unknown cognitive system or a cognitive system
   whose model binding is not configured

--- a/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
@@ -1,13 +1,21 @@
 ## ADDED Requirements
 
 ### Requirement: Cognitive Routing API Metadata
-The daemon SHALL expose cognitive routing metadata in session, turn, read, fork,
-and reconnect surfaces where request-control metadata is already reported.
+The daemon SHALL expose cognitive routing metadata in session create, session
+list, session read, turn, fork, and reconnect surfaces where request-control
+metadata is already reported.
 
 #### Scenario: Session response includes routing metadata
 - **WHEN** a session is created with cognitive routing enabled
 - **THEN** the daemon response includes the configured routing mode and the
   active cognitive model binding metadata available at startup
+
+#### Scenario: Session list includes routing metadata
+- **WHEN** a client lists sessions after cognitive routing has selected or
+  configured cognitive model binding metadata for a session
+- **THEN** each session list item includes the selected cognitive system,
+  routing source, model binding id, provider, model, effective reasoning effort,
+  and bounded routing reason when available
 
 #### Scenario: Turn read includes selected system
 - **WHEN** a client reads session history or reconnect state after a routed turn

--- a/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
@@ -20,6 +20,12 @@ The daemon SHALL accept explicit cognitive-system override intent on session,
 fork, and turn submission surfaces where doing so preserves existing governance
 and request-control boundaries.
 
+#### Scenario: Turn override supersedes session override
+- **WHEN** a session was created with a cognitive-system override
+- **AND** a submitted turn includes its own cognitive-system override
+- **THEN** runtime treats the turn override as the effective routing intent for
+  that turn before applying deterministic gates
+
 #### Scenario: Turn requests System 2
 - **WHEN** a client submits a turn with a System 2 override
 - **THEN** runtime receives turn-scoped routing intent and applies it before

--- a/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/daemon-api-contract/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Cognitive Routing API Metadata
+The daemon SHALL expose cognitive routing metadata in session, turn, read, fork,
+and reconnect surfaces where request-control metadata is already reported.
+
+#### Scenario: Session response includes routing metadata
+- **WHEN** a session is created with cognitive routing enabled
+- **THEN** the daemon response includes the configured routing mode and the
+  active cognitive profile metadata available at startup
+
+#### Scenario: Turn read includes selected system
+- **WHEN** a client reads session history or reconnect state after a routed turn
+- **THEN** the response includes selected cognitive system, routing source,
+  profile id, model, effective reasoning effort, and bounded routing reason
+  when available
+
+### Requirement: Cognitive Routing API Overrides
+The daemon SHALL accept explicit cognitive-system override intent on session,
+fork, and turn submission surfaces where doing so preserves existing governance
+and request-control boundaries.
+
+#### Scenario: Turn requests System 2
+- **WHEN** a client submits a turn with a System 2 override
+- **THEN** runtime receives turn-scoped routing intent and applies it before
+  provider dispatch
+
+#### Scenario: Invalid override is rejected
+- **WHEN** a client requests an unknown cognitive system or a system that is not
+  configured
+- **THEN** the daemon or runtime rejects the request with a diagnostic rather
+  than silently using the default route
+
+#### Scenario: Routing endpoints are registered
+- **WHEN** cognitive routing DTOs or routes are added
+- **THEN** endpoint metadata and generated client drift checks cover the new
+  public surface

--- a/openspec/changes/add-cognitive-model-routing/specs/provider-request-controls/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/provider-request-controls/spec.md
@@ -2,26 +2,26 @@
 
 ### Requirement: Request Controls Compose With Cognitive Routing
 Alan SHALL resolve request controls after cognitive routing selects the
-effective cognitive profile, and the existing request-control resolver SHALL
+effective cognitive model binding, and the existing request-control resolver SHALL
 remain the sole authority for effective reasoning effort.
 
-#### Scenario: System 1 profile has effort intent
+#### Scenario: System 1 model binding has effort intent
 - **WHEN** cognitive routing selects System 1 with configured reasoning effort
   `low`
 - **THEN** Alan passes that intent through request-control resolution and
-  validates it against the selected System 1 provider and model
+  validates it against the selected System 1 provider/model binding
 
-#### Scenario: System 2 profile has effort intent
+#### Scenario: System 2 model binding has effort intent
 - **WHEN** cognitive routing selects System 2 with configured reasoning effort
   `high`
 - **THEN** Alan passes that intent through request-control resolution and
-  validates it against the selected System 2 provider and model
+  validates it against the selected System 2 provider/model binding
 
 #### Scenario: Turn effort override still wins
 - **WHEN** a turn has an explicit reasoning-effort override and cognitive
-  routing selects a profile with a different configured effort
+  routing selects a model binding with a different configured effort
 - **THEN** the request-control resolver applies the existing turn-override
-  precedence for the selected profile
+  precedence for the selected model binding
 
 #### Scenario: Provider adapters do not route
 - **WHEN** a provider adapter receives a `GenerationRequest`

--- a/openspec/changes/add-cognitive-model-routing/specs/provider-request-controls/spec.md
+++ b/openspec/changes/add-cognitive-model-routing/specs/provider-request-controls/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Request Controls Compose With Cognitive Routing
+Alan SHALL resolve request controls after cognitive routing selects the
+effective cognitive profile, and the existing request-control resolver SHALL
+remain the sole authority for effective reasoning effort.
+
+#### Scenario: System 1 profile has effort intent
+- **WHEN** cognitive routing selects System 1 with configured reasoning effort
+  `low`
+- **THEN** Alan passes that intent through request-control resolution and
+  validates it against the selected System 1 provider and model
+
+#### Scenario: System 2 profile has effort intent
+- **WHEN** cognitive routing selects System 2 with configured reasoning effort
+  `high`
+- **THEN** Alan passes that intent through request-control resolution and
+  validates it against the selected System 2 provider and model
+
+#### Scenario: Turn effort override still wins
+- **WHEN** a turn has an explicit reasoning-effort override and cognitive
+  routing selects a profile with a different configured effort
+- **THEN** the request-control resolver applies the existing turn-override
+  precedence for the selected profile
+
+#### Scenario: Provider adapters do not route
+- **WHEN** a provider adapter receives a `GenerationRequest`
+- **THEN** it projects the normalized request controls and does not select,
+  override, or reinterpret the cognitive system

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -1,23 +1,25 @@
 ## 1. Configuration And Resolution
 
-- [ ] 1.1 Add cognition config types for routing mode, default system, System 1 profile, System 2 profile, and per-system reasoning-effort intent.
-- [ ] 1.2 Resolve cognitive profiles through existing connection profile loading without duplicating provider credentials.
+- [ ] 1.1 Add cognition config types for routing mode, default system, System 1 model binding, System 2 model binding, and per-system reasoning-effort intent.
+- [ ] 1.2 Resolve cognitive model bindings through provider/model availability without duplicating provider credentials.
 - [ ] 1.3 Preserve existing `connection_profile` behavior when cognition config is absent.
-- [ ] 1.4 Add startup diagnostics for missing or invalid cognitive profile references.
+- [ ] 1.4 Add startup diagnostics for missing or invalid cognitive model binding references.
 
 ## 2. Runtime Routing Core
 
-- [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, profile id, model, effort, and bounded reason.
+- [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, provider/model binding id, model, effort, and bounded reason.
 - [ ] 2.2 Implement `CognitiveRouter` precedence for turn override, session override, config default, deterministic gates, and System 1 default route.
-- [ ] 2.3 Compose selected cognitive profile with existing request-control resolution before provider dispatch.
+- [ ] 2.3 Compose selected cognitive model binding with existing request-control resolution before provider dispatch.
 - [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
+- [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings.
 
 ## 3. System 1 Escalation
 
 - [ ] 3.1 Add an internal-only `escalate_to_system2` virtual action with bounded reason and needed-context fields.
 - [ ] 3.2 Inject the escalation contract only for System 1 attempts where auto routing allows escalation.
 - [ ] 3.3 Suppress System 1 visible output when escalation is captured.
-- [ ] 3.4 Rerun the original logical turn on System 2 with bounded System 1 triage notes.
+- [ ] 3.4 Rerun the original logical turn on System 2 with bounded System 1 triage notes when no side-effecting tool has executed.
+- [ ] 3.5 Continue from observed post-side-effect state when escalation happens after completed side-effecting tools.
 
 ## 4. Metadata And API Surfaces
 
@@ -28,9 +30,9 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid profile diagnostics, and override precedence.
-- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, and fast-draft suppression.
-- [ ] 5.3 Add request-control tests proving selected cognitive profile effort composes with existing turn/session/model precedence.
+- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, and override precedence.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, fast-draft suppression, side-effect boundaries, and continuation partitioning.
+- [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
 - [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.
 - [ ] 5.6 Run `openspec validate add-cognitive-model-routing --strict`.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -8,7 +8,7 @@
 ## 2. Runtime Routing Core
 
 - [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, provider/model binding id, model, effort, and bounded reason.
-- [ ] 2.2 Implement `CognitiveRouter` precedence for turn override, session override, config default, deterministic gates, and System 1 default route.
+- [ ] 2.2 Implement `CognitiveRouter` precedence for explicit System 2 override, deterministic safety gates, eligible System 1 override, config default, and System 1 default route.
 - [ ] 2.3 Compose selected cognitive model binding with existing request-control resolution before provider dispatch.
 - [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
 - [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings.
@@ -30,7 +30,7 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, and override precedence.
+- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, override precedence, and gated System 1 override rejection/supersession.
 - [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, fast-draft suppression, side-effect boundaries, and continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -11,7 +11,7 @@
 - [ ] 2.2 Implement `CognitiveRouter` precedence for turn-scoped override, session-scoped override, deterministic safety gates, eligible System 1 override, config default, and System 1 fallback route.
 - [ ] 2.3 Compose selected cognitive model binding with existing request-control resolution before provider dispatch.
 - [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
-- [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings.
+- [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings, prompt fingerprints, tool fingerprints, or other continuation-affecting settings.
 
 ## 3. System 1 Escalation
 
@@ -34,7 +34,7 @@
 ## 5. Verification
 
 - [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, turn-over-session override precedence, and gated System 1 override rejection/supersession.
-- [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, speculative read-only System 1 observation, unaccepted System 1 side-effect gating, autonomous System 1 acceptance without user yield, accepted side-effect continuation, and continuation partitioning.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, speculative read-only System 1 observation, unaccepted System 1 side-effect gating, autonomous System 1 acceptance without user yield, accepted side-effect continuation, and prompt/tool continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
 - [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -8,7 +8,7 @@
 ## 2. Runtime Routing Core
 
 - [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, provider/model binding id, model, effort, and bounded reason.
-- [ ] 2.2 Implement `CognitiveRouter` precedence for explicit System 2 override, deterministic safety gates, eligible System 1 override, config default, and System 1 default route.
+- [ ] 2.2 Implement `CognitiveRouter` precedence for explicit System 2 override, deterministic safety gates, eligible System 1 override, config default, and System 1 fallback route.
 - [ ] 2.3 Compose selected cognitive model binding with existing request-control resolution before provider dispatch.
 - [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
 - [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings.
@@ -32,7 +32,7 @@
 ## 5. Verification
 
 - [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, override precedence, and gated System 1 override rejection/supersession.
-- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, fast-draft suppression, unaccepted System 1 side-effect gating, accepted side-effect continuation, and continuation partitioning.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, unaccepted System 1 side-effect gating, accepted side-effect continuation, and continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
 - [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -18,8 +18,9 @@
 - [ ] 3.1 Add an internal-only `escalate_to_system2` virtual action with bounded reason and needed-context fields.
 - [ ] 3.2 Inject the escalation contract only for System 1 attempts where auto routing allows escalation.
 - [ ] 3.3 Suppress System 1 visible output when escalation is captured.
-- [ ] 3.4 Rerun the original logical turn on System 2 with bounded System 1 triage notes when no side-effecting tool has executed.
-- [ ] 3.5 Continue from observed post-side-effect state when escalation happens after completed side-effecting tools.
+- [ ] 3.4 Gate side-effecting tools during unaccepted System 1 attempts until runtime accepts the fast route or routes the turn to System 2.
+- [ ] 3.5 Rerun the original logical turn on System 2 with bounded System 1 triage notes when only read-only tools have executed.
+- [ ] 3.6 Continue from observed post-side-effect state when escalation happens after an accepted execution phase or external state change has already completed side effects.
 
 ## 4. Metadata And API Surfaces
 
@@ -31,7 +32,7 @@
 ## 5. Verification
 
 - [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, override precedence, and gated System 1 override rejection/supersession.
-- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, fast-draft suppression, side-effect boundaries, and continuation partitioning.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, fast-draft suppression, unaccepted System 1 side-effect gating, accepted side-effect continuation, and continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
 - [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -1,0 +1,42 @@
+## 1. Configuration And Resolution
+
+- [ ] 1.1 Add cognition config types for routing mode, default system, System 1 profile, System 2 profile, and per-system reasoning-effort intent.
+- [ ] 1.2 Resolve cognitive profiles through existing connection profile loading without duplicating provider credentials.
+- [ ] 1.3 Preserve existing `connection_profile` behavior when cognition config is absent.
+- [ ] 1.4 Add startup diagnostics for missing or invalid cognitive profile references.
+
+## 2. Runtime Routing Core
+
+- [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, profile id, model, effort, and bounded reason.
+- [ ] 2.2 Implement `CognitiveRouter` precedence for turn override, session override, config default, deterministic gates, and System 1 default route.
+- [ ] 2.3 Compose selected cognitive profile with existing request-control resolution before provider dispatch.
+- [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
+
+## 3. System 1 Escalation
+
+- [ ] 3.1 Add an internal-only `escalate_to_system2` virtual action with bounded reason and needed-context fields.
+- [ ] 3.2 Inject the escalation contract only for System 1 attempts where auto routing allows escalation.
+- [ ] 3.3 Suppress System 1 visible output when escalation is captured.
+- [ ] 3.4 Rerun the original logical turn on System 2 with bounded System 1 triage notes.
+
+## 4. Metadata And API Surfaces
+
+- [ ] 4.1 Persist routing metadata in rollout turn context and session state.
+- [ ] 4.2 Expose routing metadata in daemon create/list/read/reconnect/fork surfaces where request-control metadata is reported.
+- [ ] 4.3 Accept and validate session, fork, and turn-scoped cognitive-system override intent.
+- [ ] 4.4 Update generated or checked client DTO surfaces and endpoint drift checks.
+
+## 5. Verification
+
+- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid profile diagnostics, and override precedence.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, System 1 default route, System 1 escalation, and fast-draft suppression.
+- [ ] 5.3 Add request-control tests proving selected cognitive profile effort composes with existing turn/session/model precedence.
+- [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
+- [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.
+- [ ] 5.6 Run `openspec validate add-cognitive-model-routing --strict`.
+
+## 6. PR Review And Archive Readiness
+
+- [ ] 6.1 Review the implementation diff for provider-boundary violations, hidden draft leakage, and metadata overexposure.
+- [ ] 6.2 After merge, sync accepted delta requirements into `openspec/specs/`.
+- [ ] 6.3 Archive the completed OpenSpec change after the synced specs validate.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -18,9 +18,11 @@
 - [ ] 3.1 Add an internal-only `escalate_to_system2` virtual action with bounded reason and needed-context fields.
 - [ ] 3.2 Inject the escalation contract only for System 1 attempts where auto routing allows escalation.
 - [ ] 3.3 Suppress System 1 visible output when escalation is captured.
-- [ ] 3.4 Gate side-effecting tools during unaccepted System 1 attempts until runtime accepts the fast route or routes the turn to System 2.
-- [ ] 3.5 Rerun the original logical turn on System 2 with bounded System 1 triage notes when only read-only tools have executed.
-- [ ] 3.6 Continue from observed post-side-effect state when escalation happens after an accepted execution phase or external state change has already completed side effects.
+- [ ] 3.4 Allow speculative System 1 reasoning, calculation, unaccepted draft generation, and read-only tools before route acceptance.
+- [ ] 3.5 Treat System 1 route acceptance as a runtime-owned commit point rather than user confirmation.
+- [ ] 3.6 Gate side-effecting tools during unaccepted System 1 attempts until runtime accepts the fast route or routes the turn to System 2.
+- [ ] 3.7 Rerun the original logical turn on System 2 with bounded System 1 triage notes when only read-only tools have executed.
+- [ ] 3.8 Continue from observed post-side-effect state when escalation happens after an accepted execution phase or external state change has already completed side effects.
 
 ## 4. Metadata And API Surfaces
 
@@ -32,7 +34,7 @@
 ## 5. Verification
 
 - [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, override precedence, and gated System 1 override rejection/supersession.
-- [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, unaccepted System 1 side-effect gating, accepted side-effect continuation, and continuation partitioning.
+- [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, speculative read-only System 1 observation, unaccepted System 1 side-effect gating, autonomous System 1 acceptance without user yield, accepted side-effect continuation, and continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.
 - [ ] 5.5 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon routing behavior.

--- a/openspec/changes/add-cognitive-model-routing/tasks.md
+++ b/openspec/changes/add-cognitive-model-routing/tasks.md
@@ -8,7 +8,7 @@
 ## 2. Runtime Routing Core
 
 - [ ] 2.1 Add routing intent and metadata types for cognitive system, routing source, provider/model binding id, model, effort, and bounded reason.
-- [ ] 2.2 Implement `CognitiveRouter` precedence for explicit System 2 override, deterministic safety gates, eligible System 1 override, config default, and System 1 fallback route.
+- [ ] 2.2 Implement `CognitiveRouter` precedence for turn-scoped override, session-scoped override, deterministic safety gates, eligible System 1 override, config default, and System 1 fallback route.
 - [ ] 2.3 Compose selected cognitive model binding with existing request-control resolution before provider dispatch.
 - [ ] 2.4 Keep provider adapters unaware of cognitive routing decisions beyond the normalized generation request.
 - [ ] 2.5 Partition, clear, or replay provider-native continuation when cognitive routing switches provider/model bindings.
@@ -33,7 +33,7 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, override precedence, and gated System 1 override rejection/supersession.
+- [ ] 5.1 Add unit tests for cognition config parsing, fallback behavior, invalid model binding diagnostics, turn-over-session override precedence, and gated System 1 override rejection/supersession.
 - [ ] 5.2 Add runtime tests for deterministic System 2 gates, configured default routing, System 1 fallback route, System 1 escalation, fast-draft suppression, speculative read-only System 1 observation, unaccepted System 1 side-effect gating, autonomous System 1 acceptance without user yield, accepted side-effect continuation, and continuation partitioning.
 - [ ] 5.3 Add request-control tests proving selected cognitive model binding effort composes with existing turn/session/model precedence.
 - [ ] 5.4 Add daemon/API tests for routing metadata and override validation.

--- a/openspec/changes/add-proactive-memory-v2/.openspec.yaml
+++ b/openspec/changes/add-proactive-memory-v2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -84,7 +84,9 @@ Alternatives considered:
 
 Alan writes eligible stable memory without interrupting the user. Review happens
 through `alan memory recent`, `alan memory show`, `alan memory revert`, and
-daemon equivalents.
+daemon equivalents. Daemon memory write APIs must bind every recent, show, and
+revert request to an explicit workspace or session scope before reading or
+mutating a ledger.
 
 Alternatives considered:
 

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -72,6 +72,9 @@ Alternatives considered:
 Model-mediated write planning remains useful for semantic judgment, but runtime
 owns target canonicalization, dedupe, confidence downgrades, text bounds,
 path-safety checks, ledger creation, and file mutation.
+When `[memory].enabled = false`, runtime must treat all proactive memory write
+targets as ineligible and skip stable, staged, inbox, daily-note, consolidation,
+and ledger persistence.
 
 Alternatives considered:
 
@@ -86,7 +89,10 @@ Alan writes eligible stable memory without interrupting the user. Review happens
 through `alan memory recent`, `alan memory show`, `alan memory revert`, and
 daemon equivalents. Daemon memory write APIs must bind every recent, show, and
 revert request to an explicit workspace or session scope before reading or
-mutating a ledger.
+mutating a ledger. Session-scoped requests use the authorized session as the
+workspace authority. Workspace-scoped requests require host/admin authorization
+or an authorized session for that workspace with the read or admin authority
+needed by the operation.
 
 Alternatives considered:
 

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -179,6 +179,10 @@ permission expansion.
 - Skills may suggest candidate observations or explain memory behavior, but they
   must not directly mutate stable memory, staged memory, inbox entries, daily
   notes, or ledger files outside the runtime writer.
+- The built-in memory skill and any session-end prompt guidance must be updated
+  before this runtime writer is enabled so existing wrap-up flows either call
+  the runtime writer or pass through a compatibility bridge that creates ledger
+  entries, applies redaction, and preserves revert semantics.
 - Daemon and CLI APIs expose recent/show/revert review surfaces with explicit
   workspace or session scope; they do not choose memory targets without runtime
   validation.

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -159,6 +159,26 @@ Alternatives considered:
 - Store reverted content only in the ledger. This is safer for prompts and is
   acceptable as long as the stable memory target no longer exposes it.
 
+## Implementation Ownership
+
+This change is primarily a runtime memory/storage change, not a memory-skill
+permission expansion.
+
+- Runtime owns memory write planning orchestration, target canonicalization,
+  dedupe, confidence downgrade, sensitive-data validation, ledger writes, target
+  file mutation, and precise revert.
+- Prompt and memory surface renderers may display bounded summaries or
+  provenance references, but they must not become the ledger, reintroduce
+  reverted content, or rely on prompts as the secret-redaction boundary.
+- Skills may suggest candidate observations or explain memory behavior, but they
+  must not directly mutate stable memory, staged memory, inbox entries, daily
+  notes, or ledger files outside the runtime writer.
+- Daemon and CLI APIs expose recent/show/revert review surfaces with explicit
+  workspace or session scope; they do not choose memory targets without runtime
+  validation.
+- Client UI can make memory review easier later, but the first implementation's
+  correctness belongs to runtime validation, storage, and API contracts.
+
 ## Risks / Trade-offs
 
 - Incorrect stable memory write -> Mitigate with provenance, confidence,

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -1,0 +1,137 @@
+## Context
+
+Alan's target memory direction is pure-text, file-backed, auditable memory. The
+runtime already has turn-end memory promotion, memory recall bundles, and
+pre-compaction memory flushes, but stable memory writes are not yet a complete
+product surface: writes are difficult to inspect, revert, or connect to a clear
+evidence trail.
+
+The desired behavior is more proactive than "only remember when the user says
+remember this." Alan may learn from direct user statements, repeated behavior,
+and external or repository evidence, but the system must stay quiet by default
+and must not become a hidden provider-memory black box.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Promote durable user/workspace facts proactively when evidence and confidence
+  justify it.
+- Keep every stable memory mutation auditable through a durable write ledger.
+- Provide low-disturbance review and precise revert surfaces.
+- Preserve the existing pure-text memory layout and ordinary file inspection
+  workflow.
+- Allow ambiguous or conflicting observations to be staged until consolidation.
+
+**Non-Goals:**
+
+- Add vector search, graph storage, SQLite, or an external memory service.
+- Interrupt every memory write with a confirmation prompt.
+- Store every turn as stable semantic memory.
+- Let the model directly mutate memory files outside runtime validation.
+- Build the final macOS UI for memory review in this change.
+
+## Decisions
+
+### Decision: Add a memory write ledger instead of relying on inline comments
+
+Every stable memory mutation gets a `memory_write_id` and a ledger record under
+`.alan/memory/ledger/`. The target Markdown files remain readable, while the
+ledger owns audit details: target path, inserted anchor or range, normalized
+observation, confidence, evidence, rationale, source session/turn, timestamp,
+and revert status.
+
+Alternatives considered:
+
+- Inline provenance beside every memory line. This keeps context nearby but
+  bloats the files that are injected into prompts.
+- Rollout-only provenance. This preserves audit data but makes recent write
+  review and revert too expensive.
+
+### Decision: Keep runtime as the only memory writer
+
+Model-mediated write planning remains useful for semantic judgment, but runtime
+owns target canonicalization, dedupe, confidence downgrades, text bounds,
+path-safety checks, ledger creation, and file mutation.
+
+Alternatives considered:
+
+- Give the memory skill permission to edit stable memory directly. This is too
+  hard to audit and revert reliably.
+- Replace model judgment with Rust heuristics. This would miss many useful
+  stable facts and accumulate brittle phrase matching.
+
+### Decision: Use low-disturbance review by default
+
+Alan writes eligible stable memory without interrupting the user. Review happens
+through `alan memory recent`, `alan memory show`, `alan memory revert`, and
+daemon equivalents.
+
+Alternatives considered:
+
+- Confirm all writes. This prevents bad memory but makes Alan feel needy and
+  slows normal work.
+- Never auto-promote inferred facts. This is safer but fails the product goal of
+  proactive intelligence.
+
+### Decision: Treat evidence class as part of validation
+
+The write planner must identify whether evidence came from direct user
+statement, repeated behavior, or external/repository evidence. Direct stable
+statements can promote immediately at high confidence. Repeated behavior needs
+multiple evidence points or an existing stable-memory update. External evidence
+must include source paths, URLs, commands, or issue/PR references.
+
+Alternatives considered:
+
+- Single confidence field only. This is too weak for review and future policy.
+- Separate memory stores per evidence class. This adds complexity without
+  improving the first implementation.
+
+### Decision: Defer complex consolidation to a separate pass
+
+Turn-end memory observation should stay cheap and bounded. If the write planner
+finds ambiguity, conflicts, or cross-session patterns that need synthesis, it
+stages the observation and marks it for consolidation rather than forcing a
+stable write.
+
+Alternatives considered:
+
+- Always run deep consolidation at turn end. This is expensive and slows normal
+  interactions.
+- Never consolidate automatically. This allows inbox and daily notes to drift.
+
+## Risks / Trade-offs
+
+- Incorrect stable memory write -> Mitigate with provenance, confidence,
+  recent-write review, and precise revert.
+- Ledger and target files drift -> Mitigate by writing ledger and target updates
+  as one runtime operation where possible and by validating ledger targets in
+  tests.
+- Prompt pollution from provenance -> Mitigate by keeping detailed provenance
+  in the ledger and injecting only bounded recall bundles.
+- Revert becomes hard after manual edits -> Mitigate with anchored blocks and
+  fallback status that marks a write as requiring manual resolution instead of
+  applying a risky patch.
+- Proactive writes reveal hidden reasoning -> Mitigate by storing observations,
+  evidence, and rationale, not private reasoning traces.
+
+## Migration Plan
+
+1. Add the ledger layout and APIs without changing existing memory write
+   behavior.
+2. Route existing `memory_promotion` stable writes through the ledger.
+3. Add recent/show/revert CLI and daemon read surfaces.
+4. Expand write planning and validation to support direct statements, repeated
+   behavior, and external evidence.
+5. Add consolidation staging for ambiguous or conflicting observations.
+
+Existing memory files remain valid. Existing stable facts that lack ledger
+entries are treated as legacy memory and are not automatically reversible.
+
+## Open Questions
+
+- Whether ledger files should be one file per write or monthly JSONL plus a
+  generated recent Markdown view.
+- Whether the first implementation should expose `alan memory revert --dry-run`.
+- How much macOS UI should be included after the CLI/API surfaces are stable.

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -125,13 +125,14 @@ Alternatives considered:
   interactions.
 - Never consolidate automatically. This allows inbox and daily notes to drift.
 
-### Decision: Reject or redact sensitive material before stable writes
+### Decision: Reject or redact sensitive material before durable memory persistence
 
 The memory writer must treat API keys, access tokens, passwords, private
 credentials, and secret-like values as unsafe memory material. A useful fact may
 still be recorded after redaction, for example "the project uses a GitHub token
 from the host secret store," but plaintext secrets must not be written to stable
-memory or ledger evidence.
+memory, staged observations, inbox entries, daily notes, consolidation queues,
+or ledger evidence.
 
 Alternatives considered:
 
@@ -175,7 +176,7 @@ Alternatives considered:
   evidence, and rationale, not private reasoning traces.
 - Proactive writes capture secrets -> Mitigate by scanning candidates and
   evidence for secret-like material and rejecting or redacting before durable
-  write.
+  stable, staged, inbox, daily-note, or ledger persistence.
 
 ## Migration Plan
 

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -48,6 +48,25 @@ Alternatives considered:
 - Rollout-only provenance. This preserves audit data but makes recent write
   review and revert too expensive.
 
+### Decision: Use one Markdown ledger file per stable write
+
+V1 should store each stable write as a separate Markdown file, grouped by date,
+for example `.alan/memory/ledger/YYYY/MM/<memory_write_id>.md`. This makes each
+write easy to inspect with normal tools, gives revert code a stable record to
+load, and avoids rewriting a large append-only JSONL file when revert status
+changes.
+
+Recent-write listing can scan the dated ledger directories or maintain a small
+derived index, but the per-write Markdown ledger file remains the durable source
+of truth.
+
+Alternatives considered:
+
+- Monthly JSONL. This is compact and append-friendly, but precise revert status
+  updates either rewrite a shared file or require secondary tombstones.
+- Inline Markdown blocks only. This is easy to read in target files but weak for
+  bounded prompt recall and audit filtering.
+
 ### Decision: Keep runtime as the only memory writer
 
 Model-mediated write planning remains useful for semantic judgment, but runtime
@@ -82,6 +101,11 @@ statements can promote immediately at high confidence. Repeated behavior needs
 multiple evidence points or an existing stable-memory update. External evidence
 must include source paths, URLs, commands, or issue/PR references.
 
+Evidence must also be reviewable later. Ledger records should store the source
+kind, stable source locator, observed-at timestamp when relevant, and either a
+bounded excerpt, line/range, command summary, or content hash sufficient to
+explain why the fact was written without preserving large raw artifacts.
+
 Alternatives considered:
 
 - Single confidence field only. This is too weak for review and future policy.
@@ -101,6 +125,21 @@ Alternatives considered:
   interactions.
 - Never consolidate automatically. This allows inbox and daily notes to drift.
 
+### Decision: Reject or redact sensitive material before stable writes
+
+The memory writer must treat API keys, access tokens, passwords, private
+credentials, and secret-like values as unsafe memory material. A useful fact may
+still be recorded after redaction, for example "the project uses a GitHub token
+from the host secret store," but plaintext secrets must not be written to stable
+memory or ledger evidence.
+
+Alternatives considered:
+
+- Let provenance store exact command output. This is useful for debugging but
+  makes memory a secret sink.
+- Rely on user review after the fact. This violates the low-disturbance model
+  because bad writes may sit unnoticed.
+
 ## Risks / Trade-offs
 
 - Incorrect stable memory write -> Mitigate with provenance, confidence,
@@ -115,6 +154,9 @@ Alternatives considered:
   applying a risky patch.
 - Proactive writes reveal hidden reasoning -> Mitigate by storing observations,
   evidence, and rationale, not private reasoning traces.
+- Proactive writes capture secrets -> Mitigate by scanning candidates and
+  evidence for secret-like material and rejecting or redacting before durable
+  write.
 
 ## Migration Plan
 
@@ -131,7 +173,5 @@ entries are treated as legacy memory and are not automatically reversible.
 
 ## Open Questions
 
-- Whether ledger files should be one file per write or monthly JSONL plus a
-  generated recent Markdown view.
 - Whether the first implementation should expose `alan memory revert --dry-run`.
 - How much macOS UI should be included after the CLI/API surfaces are stable.

--- a/openspec/changes/add-proactive-memory-v2/design.md
+++ b/openspec/changes/add-proactive-memory-v2/design.md
@@ -140,6 +140,22 @@ Alternatives considered:
 - Rely on user review after the fact. This violates the low-disturbance model
   because bad writes may sit unnoticed.
 
+### Decision: Reverted memory must disappear from prompt-facing surfaces
+
+Revert must not leave a bad fact available for future recall just because it is
+visibly marked as reverted in `USER.md`, `MEMORY.md`, or a topic page. The
+preferred path is to remove the inserted stable-memory block when the ledger
+anchor still matches. If a target file keeps a tombstone or reverted marker for
+human auditability, every prompt-facing memory renderer must exclude that block
+from recall, handoff, session-summary, and daily-note surfaces.
+
+Alternatives considered:
+
+- Only mark reverted content inline. This is readable to humans, but prompt
+  assembly reads pure text and could re-inject the bad fact.
+- Store reverted content only in the ledger. This is safer for prompts and is
+  acceptable as long as the stable memory target no longer exposes it.
+
 ## Risks / Trade-offs
 
 - Incorrect stable memory write -> Mitigate with provenance, confidence,
@@ -152,6 +168,9 @@ Alternatives considered:
 - Revert becomes hard after manual edits -> Mitigate with anchored blocks and
   fallback status that marks a write as requiring manual resolution instead of
   applying a risky patch.
+- Reverted content leaks back into prompts -> Mitigate by removing reverted
+  stable-memory content or requiring prompt-facing surface renderers to filter
+  reverted blocks.
 - Proactive writes reveal hidden reasoning -> Mitigate by storing observations,
   evidence, and rationale, not private reasoning traces.
 - Proactive writes capture secrets -> Mitigate by scanning candidates and

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -18,6 +18,8 @@ keeping every write inspectable and reversible.
   recall, handoff, session-summary, or daily-note surfaces.
 - Extend memory validation so invalid, over-broad, duplicate, or unsafe write
   plans are rejected or downgraded before they mutate stable memory.
+- Honor disabled memory configuration so proactive planning and durable memory
+  writes do not run for workspaces that opt out of memory.
 - Add sensitive-data guardrails so secrets, credentials, and private tokens are
   not written into stable memory, staged/inbox/daily memory, or ledger evidence
   in plaintext.
@@ -38,9 +40,9 @@ keeping every write inspectable and reversible.
 - `runtime-memory-surfaces`: Memory and handoff surfaces must reference
   proactive write provenance and remain compact continuation aids rather than
   becoming the write ledger.
-- `daemon-api-contract`: Daemon APIs must expose workspace/session-scoped recent
-  memory writes, write inspection, and revert operations without leaking hidden
-  model reasoning.
+- `daemon-api-contract`: Daemon APIs must expose authorized workspace/session-
+  scoped recent memory writes, write inspection, and revert operations without
+  leaking hidden model reasoning.
 
 ## Impact
 

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -49,6 +49,9 @@ keeping every write inspectable and reversible.
 - Affected runtime modules: `memory_promotion`, `memory_flush`,
   `memory_recall`, prompt assets, session/rollout metadata, and memory layout
   helpers.
+- Affected built-in skills: the memory skill and session-end guidance must route
+  stable, staged, inbox, daily-note, and ledger writes through the runtime writer
+  or a compatibility bridge once the writer exists.
 - Affected CLI/daemon areas: memory inspection commands and daemon memory
   endpoints.
 - Affected storage: `.alan/memory/` gains ledger/recent-write metadata while

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Alan already has pure-text memory, turn-end memory promotion, recall bundles,
+and pre-compaction memory flushes, but the behavior is still too conservative
+and too hard to audit as a first-class product surface. Alan should feel more
+intelligent by proactively remembering durable user and workspace facts while
+keeping every write inspectable and reversible.
+
+## What Changes
+
+- Add proactive memory write planning that can promote stable facts from direct
+  user statements, repeated behavior, and external or repository evidence.
+- Add a durable memory write ledger that records provenance, confidence, write
+  rationale, target file, and revert state for every stable memory mutation.
+- Add low-disturbance review and revert surfaces through CLI and daemon APIs;
+  normal turns should not be interrupted by memory write confirmations.
+- Extend memory validation so invalid, over-broad, duplicate, or unsafe write
+  plans are rejected or downgraded before they mutate stable memory.
+- Add consolidation rules so ambiguous or conflicting observations can remain
+  staged until a stronger consolidation pass resolves them.
+- Keep memory writes file-backed, auditable, and compatible with the existing
+  pure-text memory direction.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-memory-write-audit`: Owns proactive memory write planning, provenance,
+  ledger entries, recent write inspection, and revert behavior.
+
+### Modified Capabilities
+
+- `runtime-memory-surfaces`: Memory and handoff surfaces must reference
+  proactive write provenance and remain compact continuation aids rather than
+  becoming the write ledger.
+- `daemon-api-contract`: Daemon APIs must expose recent memory writes, write
+  inspection, and revert operations without leaking hidden model reasoning.
+
+## Impact
+
+- Affected runtime modules: `memory_promotion`, `memory_flush`,
+  `memory_recall`, prompt assets, session/rollout metadata, and memory layout
+  helpers.
+- Affected CLI/daemon areas: memory inspection commands and daemon memory
+  endpoints.
+- Affected storage: `.alan/memory/` gains ledger/recent-write metadata while
+  preserving plain Markdown as the source of truth.
+- Affected tests: unit tests for write-plan validation and revert mechanics,
+  integration tests for daemon/CLI surfaces, and contract tests for auditability.

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -16,6 +16,8 @@ keeping every write inspectable and reversible.
   normal turns should not be interrupted by memory write confirmations.
 - Extend memory validation so invalid, over-broad, duplicate, or unsafe write
   plans are rejected or downgraded before they mutate stable memory.
+- Add sensitive-data guardrails so secrets, credentials, and private tokens are
+  not written into stable memory or ledger evidence in plaintext.
 - Add consolidation rules so ambiguous or conflicting observations can remain
   staged until a stronger consolidation pass resolves them.
 - Keep memory writes file-backed, auditable, and compatible with the existing

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -38,8 +38,9 @@ keeping every write inspectable and reversible.
 - `runtime-memory-surfaces`: Memory and handoff surfaces must reference
   proactive write provenance and remain compact continuation aids rather than
   becoming the write ledger.
-- `daemon-api-contract`: Daemon APIs must expose recent memory writes, write
-  inspection, and revert operations without leaking hidden model reasoning.
+- `daemon-api-contract`: Daemon APIs must expose workspace/session-scoped recent
+  memory writes, write inspection, and revert operations without leaking hidden
+  model reasoning.
 
 ## Impact
 

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -14,6 +14,8 @@ keeping every write inspectable and reversible.
   rationale, target file, and revert state for every stable memory mutation.
 - Add low-disturbance review and revert surfaces through CLI and daemon APIs;
   normal turns should not be interrupted by memory write confirmations.
+- Ensure reverted memory writes cannot be reintroduced into prompt-facing
+  recall, handoff, session-summary, or daily-note surfaces.
 - Extend memory validation so invalid, over-broad, duplicate, or unsafe write
   plans are rejected or downgraded before they mutate stable memory.
 - Add sensitive-data guardrails so secrets, credentials, and private tokens are

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -19,7 +19,8 @@ keeping every write inspectable and reversible.
 - Extend memory validation so invalid, over-broad, duplicate, or unsafe write
   plans are rejected or downgraded before they mutate stable memory.
 - Add sensitive-data guardrails so secrets, credentials, and private tokens are
-  not written into stable memory or ledger evidence in plaintext.
+  not written into stable memory, staged/inbox/daily memory, or ledger evidence
+  in plaintext.
 - Add consolidation rules so ambiguous or conflicting observations can remain
   staged until a stronger consolidation pass resolves them.
 - Keep memory writes file-backed, auditable, and compatible with the existing

--- a/openspec/changes/add-proactive-memory-v2/proposal.md
+++ b/openspec/changes/add-proactive-memory-v2/proposal.md
@@ -38,8 +38,9 @@ keeping every write inspectable and reversible.
 ### Modified Capabilities
 
 - `runtime-memory-surfaces`: Memory and handoff surfaces must reference
-  proactive write provenance and remain compact continuation aids rather than
-  becoming the write ledger.
+  proactive write provenance, replace the prior ordinary-tool memory-skill write
+  contract with the runtime writer or compatibility bridge, and remain compact
+  continuation aids rather than becoming the write ledger.
 - `daemon-api-contract`: Daemon APIs must expose authorized workspace/session-
   scoped recent memory writes, write inspection, and revert operations without
   leaking hidden model reasoning.

--- a/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
@@ -4,7 +4,8 @@
 The daemon SHALL expose endpoint-contract-backed APIs for recent memory write
 listing, single-write inspection, and memory write revert. These APIs SHALL bind
 each request to an explicit workspace or session scope before reading or
-mutating memory ledger state.
+mutating memory ledger state. Workspace-scoped requests SHALL require host/admin
+authorization or SHALL be bound to an authorized session for that workspace.
 
 #### Scenario: Recent memory writes endpoint
 - **WHEN** a client calls the recent memory writes endpoint
@@ -24,6 +25,20 @@ mutating memory ledger state.
 - **THEN** the daemon attempts the runtime memory revert operation and returns a
   success, already-reverted, not-found, or manual-resolution-required result
 
+#### Scenario: Workspace-scoped memory request is authorized
+- **WHEN** a client calls a recent, show, or revert memory write endpoint with a
+  workspace scope
+- **THEN** the daemon requires host/admin authorization or an authorized session
+  for that workspace with the read or admin authority needed by the operation
+  before reading or mutating the ledger
+
+#### Scenario: Unauthorized workspace scope is rejected
+- **WHEN** a client calls a recent, show, or revert memory write endpoint with a
+  workspace scope that is not covered by host/admin authorization or an
+  authorized session for that workspace
+- **THEN** the daemon rejects the request before reading or mutating any memory
+  ledger
+
 #### Scenario: Unscoped memory write request is rejected
 - **WHEN** a client calls a recent, show, or revert memory write endpoint without
   a workspace or session scope
@@ -34,4 +49,5 @@ mutating memory ledger state.
 - **WHEN** memory write APIs are added
 - **THEN** each route has canonical endpoint metadata and generated client
   helpers participate in drift checks
-- **AND** the endpoint metadata records the required workspace or session scope
+- **AND** the endpoint metadata records the required session scope and any
+  workspace-scope authorization requirement

--- a/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Memory Write API Contract
+The daemon SHALL expose endpoint-contract-backed APIs for recent memory write
+listing, single-write inspection, and memory write revert.
+
+#### Scenario: Recent memory writes endpoint
+- **WHEN** a client calls the recent memory writes endpoint
+- **THEN** the daemon returns bounded ledger metadata for recent stable memory
+  writes without hidden reasoning content
+
+#### Scenario: Memory write inspection endpoint
+- **WHEN** a client requests a memory write by id
+- **THEN** the daemon returns the write detail, provenance, target, confidence,
+  and revert status
+
+#### Scenario: Memory write revert endpoint
+- **WHEN** a client requests revert for a memory write by id
+- **THEN** the daemon attempts the runtime memory revert operation and returns a
+  success, already-reverted, not-found, or manual-resolution-required result
+
+#### Scenario: Memory endpoints are registered
+- **WHEN** memory write APIs are added
+- **THEN** each route has canonical endpoint metadata and generated client
+  helpers participate in drift checks

--- a/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/daemon-api-contract/spec.md
@@ -2,24 +2,36 @@
 
 ### Requirement: Memory Write API Contract
 The daemon SHALL expose endpoint-contract-backed APIs for recent memory write
-listing, single-write inspection, and memory write revert.
+listing, single-write inspection, and memory write revert. These APIs SHALL bind
+each request to an explicit workspace or session scope before reading or
+mutating memory ledger state.
 
 #### Scenario: Recent memory writes endpoint
 - **WHEN** a client calls the recent memory writes endpoint
+- **AND** the request identifies a workspace or session scope
 - **THEN** the daemon returns bounded ledger metadata for recent stable memory
-  writes without hidden reasoning content
+  writes in that scope without hidden reasoning content
 
 #### Scenario: Memory write inspection endpoint
 - **WHEN** a client requests a memory write by id
+- **AND** the request identifies a workspace or session scope
 - **THEN** the daemon returns the write detail, provenance, target, confidence,
-  and revert status
+  and revert status from that scope
 
 #### Scenario: Memory write revert endpoint
 - **WHEN** a client requests revert for a memory write by id
+- **AND** the request identifies a workspace or session scope
 - **THEN** the daemon attempts the runtime memory revert operation and returns a
   success, already-reverted, not-found, or manual-resolution-required result
+
+#### Scenario: Unscoped memory write request is rejected
+- **WHEN** a client calls a recent, show, or revert memory write endpoint without
+  a workspace or session scope
+- **THEN** the daemon rejects the request before reading or mutating any memory
+  ledger
 
 #### Scenario: Memory endpoints are registered
 - **WHEN** memory write APIs are added
 - **THEN** each route has canonical endpoint metadata and generated client
   helpers participate in drift checks
+- **AND** the endpoint metadata records the required workspace or session scope

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
@@ -30,3 +30,27 @@ stable memory content from reverted memory writes.
 - **WHEN** a reverted memory write was removed from the stable memory target
 - **THEN** prompt-facing memory renderers do not reintroduce the removed content
   from the ledger
+
+## MODIFIED Requirements
+
+### Requirement: Skill-Authored Semantic Memory Surfaces
+Memory and handoff surfaces SHALL prefer bounded semantic summaries authored by
+the active agent through the memory skill or another explicit agent-visible
+memory workflow. When that workflow causes stable, staged, inbox, daily-note, or
+ledger memory writes after the runtime memory writer is enabled, the durable
+write SHALL go through the runtime writer or its compatibility bridge rather
+than direct file mutation by ordinary tools.
+
+#### Scenario: Agent wraps significant work
+- **WHEN** a turn or session changes durable project state, decisions,
+  constraints, open loops, or next steps
+- **AND** the runtime memory writer is enabled
+- **THEN** the memory skill instructs the agent to produce a bounded semantic
+  continuation summary through an explicit agent-visible memory workflow
+- **AND** any stable, staged, inbox, daily-note, or ledger memory write caused
+  by that workflow goes through the runtime writer or compatibility bridge
+
+#### Scenario: Runtime refreshes memory surfaces
+- **WHEN** runtime refreshes generated memory surfaces at turn end
+- **THEN** it SHALL NOT initiate an extra hidden model request solely to
+  summarize memory state

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Memory Surfaces Reference Proactive Write Provenance
+Memory, handoff, session-summary, and daily-note surfaces SHALL remain compact
+continuation aids and SHALL reference proactive memory write provenance when
+stable-memory detail is omitted.
+
+#### Scenario: Stable write detail is omitted from recall
+- **WHEN** a recall or handoff surface includes a stable fact whose detailed
+  provenance is stored in the write ledger
+- **THEN** the surface includes the bounded fact and SHALL preserve a source
+  reference that lets the ledger or rollout be inspected
+
+#### Scenario: Surface does not become ledger
+- **WHEN** runtime renders a memory surface after proactive memory writes
+- **THEN** the surface does not duplicate the full write ledger content inside
+  prompt-facing memory text

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-surfaces/spec.md
@@ -15,3 +15,18 @@ stable-memory detail is omitted.
 - **WHEN** runtime renders a memory surface after proactive memory writes
 - **THEN** the surface does not duplicate the full write ledger content inside
   prompt-facing memory text
+
+### Requirement: Reverted Memory Is Excluded From Prompt Surfaces
+Memory, recall, handoff, session-summary, and daily-note surfaces SHALL exclude
+stable memory content from reverted memory writes.
+
+#### Scenario: Reverted content remains marked in target file
+- **WHEN** a stable memory target contains a machine-readable reverted block for
+  a previously inserted write
+- **THEN** prompt-facing memory renderers exclude that reverted block from
+  generated memory surfaces
+
+#### Scenario: Reverted content was removed
+- **WHEN** a reverted memory write was removed from the stable memory target
+- **THEN** prompt-facing memory renderers do not reintroduce the removed content
+  from the ledger

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -120,12 +120,14 @@ Alan SHALL expose low-disturbance recent-write inspection surfaces for stable
 memory writes without interrupting normal agent turns.
 
 #### Scenario: Recent writes are listed
-- **WHEN** a user asks for recent memory writes through CLI or daemon API
+- **WHEN** a user asks for recent memory writes through CLI or daemon API for a
+  workspace or session
 - **THEN** Alan returns bounded write metadata including id, timestamp, target,
   observation, confidence, and revert status
 
 #### Scenario: Write detail is shown
-- **WHEN** a user requests a single memory write by id
+- **WHEN** a user requests a single memory write by id for a workspace or
+  session
 - **THEN** Alan returns the write detail, provenance, target location, and
   revert eligibility
 

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -66,6 +66,47 @@ session or turn metadata, and revert status.
 - **THEN** Alan treats it as legacy memory and does not claim it is
   automatically reversible
 
+#### Scenario: Ledger is one file per write
+- **WHEN** runtime records a stable memory mutation
+- **THEN** it writes a dedicated Markdown ledger file for that
+  `memory_write_id` under the memory ledger directory
+
+### Requirement: Reviewable Evidence Provenance
+Alan SHALL persist enough provenance for each stable memory write to let a user
+review why the fact was written without storing large raw artifacts or hidden
+reasoning.
+
+#### Scenario: File evidence is recorded
+- **WHEN** a stable memory write is based on repository or local file evidence
+- **THEN** the ledger records the source kind, path, and a bounded line range,
+  excerpt, or content hash for the evidence
+
+#### Scenario: Command evidence is recorded
+- **WHEN** a stable memory write is based on command output
+- **THEN** the ledger records the command identity, observed-at time, and a
+  bounded non-secret excerpt or summary of the output
+
+#### Scenario: External evidence is recorded
+- **WHEN** a stable memory write is based on a URL, issue, PR, or other external
+  source
+- **THEN** the ledger records the source locator, observed-at time, and a
+  bounded excerpt or summary sufficient for later review
+
+### Requirement: Sensitive Data Memory Guardrail
+Alan SHALL reject or redact stable memory candidates and ledger evidence that
+contain secret-like or credential-like material.
+
+#### Scenario: Secret-like candidate is rejected
+- **WHEN** a memory candidate observation contains an API key, token, password,
+  private credential, or secret-like value
+- **THEN** runtime rejects the stable memory write or rewrites it into a
+  redacted non-secret observation before durable persistence
+
+#### Scenario: Secret-like evidence is redacted
+- **WHEN** evidence for a memory write contains secret-like material
+- **THEN** the ledger omits or redacts the secret-like material while preserving
+  enough non-secret provenance to explain the write
+
 ### Requirement: Recent Memory Write Inspection
 Alan SHALL expose low-disturbance recent-write inspection surfaces for stable
 memory writes without interrupting normal agent turns.

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -6,6 +6,13 @@ session finalization, and consolidation passes, and SHALL allow durable facts
 from direct user statements, repeated behavior, and external or repository
 evidence to become candidate stable memory writes.
 
+#### Scenario: Disabled memory suppresses proactive writes
+- **WHEN** the resolved runtime config has `[memory].enabled = false`
+- **THEN** runtime does not run proactive memory write planning for turns,
+  session finalization, or consolidation passes
+- **AND** runtime does not create stable, staged, inbox, daily-note,
+  consolidation, or ledger memory writes
+
 #### Scenario: Direct stable user statement is eligible
 - **WHEN** a user directly states a stable identity, preference, constraint, or
   workspace rule

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -52,6 +52,16 @@ the authority for proactive memory writes.
   materially updating it
 - **THEN** runtime avoids adding a duplicate stable memory entry
 
+#### Scenario: Built-in memory skill uses runtime writer
+- **WHEN** built-in memory skill guidance or session-end prompt guidance causes
+  a stable, staged, inbox, daily-note, or ledger memory write after the runtime
+  writer is enabled
+- **THEN** the write goes through the runtime writer or a compatibility bridge
+  that creates ledger metadata, applies validation, and preserves revert
+  semantics
+- **AND** direct file mutation by the skill is not the authority for the memory
+  write
+
 ### Requirement: Durable Memory Write Ledger
 Alan SHALL record every stable memory mutation in a durable ledger entry with a
 stable `memory_write_id`, target, provenance, confidence, rationale, source

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -93,14 +93,22 @@ reasoning.
   bounded excerpt or summary sufficient for later review
 
 ### Requirement: Sensitive Data Memory Guardrail
-Alan SHALL reject or redact stable memory candidates and ledger evidence that
-contain secret-like or credential-like material.
+Alan SHALL reject or redact memory candidates and evidence that contain
+secret-like or credential-like material before any stable, staged, inbox,
+daily-note, consolidation, or ledger persistence.
 
 #### Scenario: Secret-like candidate is rejected
 - **WHEN** a memory candidate observation contains an API key, token, password,
   private credential, or secret-like value
-- **THEN** runtime rejects the stable memory write or rewrites it into a
-  redacted non-secret observation before durable persistence
+- **THEN** runtime rejects the memory write or rewrites it into a redacted
+  non-secret observation before durable persistence
+
+#### Scenario: Secret-like staged candidate is rejected
+- **WHEN** a memory candidate or its evidence contains secret-like material
+- **AND** the candidate would otherwise be staged for inbox, daily-note, or
+  consolidation review rather than promoted to stable memory
+- **THEN** runtime rejects the staged write or rewrites it into redacted
+  non-secret content before writing any durable staged memory
 
 #### Scenario: Secret-like evidence is redacted
 - **WHEN** evidence for a memory write contains secret-like material

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Proactive Memory Write Planning
+Alan SHALL run bounded runtime-owned memory write planning for eligible turns,
+session finalization, and consolidation passes, and SHALL allow durable facts
+from direct user statements, repeated behavior, and external or repository
+evidence to become candidate stable memory writes.
+
+#### Scenario: Direct stable user statement is eligible
+- **WHEN** a user directly states a stable identity, preference, constraint, or
+  workspace rule
+- **THEN** the write planner can produce a candidate stable memory write with
+  direct-statement evidence
+
+#### Scenario: Repeated behavior is eligible
+- **WHEN** Alan observes the same durable user preference or workspace operating
+  pattern across multiple source turns or sessions
+- **THEN** the write planner can produce a candidate stable memory write with
+  repeated-behavior evidence
+
+#### Scenario: External evidence is eligible
+- **WHEN** Alan inspects files, issue or PR threads, command output, or
+  user-authorized external sources that directly support a durable fact
+- **THEN** the write planner can produce a candidate stable memory write with
+  source references for that evidence
+
+### Requirement: Runtime-Validated Memory Mutations
+Alan SHALL validate and canonicalize every memory write plan before mutating
+stable memory files. The model SHALL NOT directly mutate stable memory files as
+the authority for proactive memory writes.
+
+#### Scenario: Invalid target is rejected
+- **WHEN** a write plan names a target outside the allowed memory layout
+- **THEN** runtime rejects the candidate before any stable memory file is
+  mutated
+
+#### Scenario: Over-broad candidate is downgraded
+- **WHEN** a candidate has useful evidence but insufficient confidence for
+  stable memory
+- **THEN** runtime records or keeps it as staged memory rather than promoting it
+  into stable memory
+
+#### Scenario: Duplicate stable fact is deduped
+- **WHEN** a write plan repeats an existing stable memory observation without
+  materially updating it
+- **THEN** runtime avoids adding a duplicate stable memory entry
+
+### Requirement: Durable Memory Write Ledger
+Alan SHALL record every stable memory mutation in a durable ledger entry with a
+stable `memory_write_id`, target, provenance, confidence, rationale, source
+session or turn metadata, and revert status.
+
+#### Scenario: Stable write creates ledger entry
+- **WHEN** runtime promotes a candidate into `USER.md`, `MEMORY.md`, or a topic
+  page
+- **THEN** it records a ledger entry that identifies the inserted stable memory
+  content and its source evidence
+
+#### Scenario: Ledger omits hidden reasoning
+- **WHEN** runtime records a ledger entry produced by model-mediated planning
+- **THEN** the ledger stores observation, evidence, confidence, and rationale
+  without storing hidden chain-of-thought or provider-private reasoning content
+
+#### Scenario: Legacy memory lacks reversible ledger
+- **WHEN** a stable memory entry predates the ledger
+- **THEN** Alan treats it as legacy memory and does not claim it is
+  automatically reversible
+
+### Requirement: Recent Memory Write Inspection
+Alan SHALL expose low-disturbance recent-write inspection surfaces for stable
+memory writes without interrupting normal agent turns.
+
+#### Scenario: Recent writes are listed
+- **WHEN** a user asks for recent memory writes through CLI or daemon API
+- **THEN** Alan returns bounded write metadata including id, timestamp, target,
+  observation, confidence, and revert status
+
+#### Scenario: Write detail is shown
+- **WHEN** a user requests a single memory write by id
+- **THEN** Alan returns the write detail, provenance, target location, and
+  revert eligibility
+
+### Requirement: Reversible Stable Memory Writes
+Alan SHALL support precise revert for stable memory writes when the ledger entry
+still matches the target memory content, and SHALL fail safely when precise
+revert cannot be proven.
+
+#### Scenario: Revert succeeds
+- **WHEN** a user reverts a memory write whose anchored content still matches
+  the target memory file
+- **THEN** Alan removes or marks the inserted stable memory content and updates
+  the ledger revert status
+
+#### Scenario: Revert cannot be proven
+- **WHEN** the target memory file has changed so that Alan cannot identify the
+  inserted content safely
+- **THEN** Alan leaves the file unchanged and marks the write as requiring
+  manual resolution
+
+### Requirement: Ambiguous Memory Consolidation
+Alan SHALL stage ambiguous, conflicting, or cross-session memory observations
+for consolidation instead of forcing immediate stable-memory promotion.
+
+#### Scenario: Conflicting observation is staged
+- **WHEN** a candidate conflicts with existing stable memory
+- **THEN** Alan records the observation for consolidation and does not silently
+  overwrite the stable memory entry
+
+#### Scenario: Consolidation promotes resolved observation
+- **WHEN** a consolidation pass resolves staged observations into a stable fact
+- **THEN** Alan writes the stable memory through the same validated mutation and
+  ledger path as turn-end promotion

--- a/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
+++ b/openspec/changes/add-proactive-memory-v2/specs/runtime-memory-write-audit/spec.md
@@ -129,8 +129,14 @@ revert cannot be proven.
 #### Scenario: Revert succeeds
 - **WHEN** a user reverts a memory write whose anchored content still matches
   the target memory file
-- **THEN** Alan removes or marks the inserted stable memory content and updates
-  the ledger revert status
+- **THEN** Alan removes the inserted stable memory content or marks it with a
+  machine-readable reverted state that prompt-facing memory surfaces must filter
+- **AND** Alan updates the ledger revert status
+
+#### Scenario: Reverted write is not prompt-visible
+- **WHEN** a memory write has been reverted successfully
+- **THEN** its inserted stable memory content is not eligible for future
+  prompt-facing recall, handoff, session-summary, or daily-note surfaces
 
 #### Scenario: Revert cannot be proven
 - **WHEN** the target memory file has changed so that Alan cannot identify the

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -1,0 +1,38 @@
+## 1. Ledger And Storage
+
+- [ ] 1.1 Define memory write ledger record types with `memory_write_id`, target, anchor, confidence, evidence, rationale, source session/turn, timestamps, and revert status.
+- [ ] 1.2 Add pure-text ledger layout helpers under `.alan/memory/ledger/` and preserve compatibility with existing memory files.
+- [ ] 1.3 Add runtime validation for ledger-target path containment and allowed stable memory targets.
+
+## 2. Write Planning And Validation
+
+- [ ] 2.1 Extend turn-end memory promotion output parsing to carry evidence class, source references, confidence, and consolidation disposition.
+- [ ] 2.2 Add validation and canonicalization for direct statements, repeated behavior, and external/repository evidence.
+- [ ] 2.3 Route stable memory mutations through a single runtime writer that creates ledger entries and target-file updates together.
+- [ ] 2.4 Stage ambiguous, conflicting, or low-confidence observations for consolidation instead of stable promotion.
+
+## 3. Inspection And Revert Surfaces
+
+- [ ] 3.1 Add CLI commands for recent write listing, single-write inspection, and revert.
+- [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for recent, show, and revert operations.
+- [ ] 3.3 Add precise revert mechanics with safe failure when the target content no longer matches the ledger anchor.
+
+## 4. Memory Surface Integration
+
+- [ ] 4.1 Update recall, handoff, session-summary, and daily-note surfaces to keep provenance references bounded.
+- [ ] 4.2 Ensure prompt-facing memory surfaces do not duplicate full ledger content.
+- [ ] 4.3 Preserve legacy memory entries that do not have reversible ledger metadata.
+
+## 5. Verification
+
+- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, dedupe, path rejection, and confidence downgrades.
+- [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, and manual-resolution-required failures.
+- [ ] 5.3 Add daemon and CLI integration tests for recent, show, and revert surfaces.
+- [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.
+- [ ] 5.5 Run `openspec validate add-proactive-memory-v2 --strict`.
+
+## 6. PR Review And Archive Readiness
+
+- [ ] 6.1 Review the implementation diff for hidden memory writes, provenance gaps, and prompt-facing ledger leakage.
+- [ ] 6.2 After merge, sync accepted delta requirements into `openspec/specs/`.
+- [ ] 6.3 Archive the completed OpenSpec change after the synced specs validate.

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -9,9 +9,9 @@
 - [ ] 2.1 Extend turn-end memory promotion output parsing to carry evidence class, source references, confidence, and consolidation disposition.
 - [ ] 2.2 Add validation and canonicalization for direct statements, repeated behavior, and external/repository evidence.
 - [ ] 2.3 Add provenance normalization for file, command, issue/PR, URL, and repeated-behavior evidence with bounded excerpts, ranges, hashes, or summaries.
-- [ ] 2.4 Add sensitive-data rejection/redaction for candidate observations and evidence before durable writes.
+- [ ] 2.4 Add sensitive-data rejection/redaction for candidate observations and evidence before stable, staged, inbox, daily-note, consolidation, or ledger persistence.
 - [ ] 2.5 Route stable memory mutations through a single runtime writer that creates ledger entries and target-file updates together.
-- [ ] 2.6 Stage ambiguous, conflicting, or low-confidence observations for consolidation instead of stable promotion.
+- [ ] 2.6 Stage ambiguous, conflicting, or low-confidence observations for consolidation only after sensitive-data validation.
 
 ## 3. Inspection And Revert Surfaces
 
@@ -28,7 +28,7 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, secret redaction, dedupe, path rejection, and confidence downgrades.
+- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, stable and staged secret redaction, dedupe, path rejection, and confidence downgrades.
 - [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, reverted prompt-surface exclusion, and manual-resolution-required failures.
 - [ ] 5.3 Add daemon and CLI integration tests for recent, show, and revert surfaces.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -16,7 +16,7 @@
 ## 3. Inspection And Revert Surfaces
 
 - [ ] 3.1 Add CLI commands for recent write listing, single-write inspection, and revert.
-- [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for recent, show, and revert operations.
+- [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for workspace/session-scoped recent, show, and revert operations.
 - [ ] 3.3 Add precise revert mechanics that remove matched stable-memory content or mark it with a machine-readable reverted state, with safe failure when the target content no longer matches the ledger anchor.
 
 ## 4. Memory Surface Integration
@@ -30,7 +30,7 @@
 
 - [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, stable and staged secret redaction, dedupe, path rejection, and confidence downgrades.
 - [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, reverted prompt-surface exclusion, and manual-resolution-required failures.
-- [ ] 5.3 Add daemon and CLI integration tests for recent, show, and revert surfaces.
+- [ ] 5.3 Add daemon and CLI integration tests for recent, show, revert, workspace/session scoping, and unscoped request rejection.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.
 - [ ] 5.5 Run `openspec validate add-proactive-memory-v2 --strict`.
 

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -1,15 +1,17 @@
 ## 1. Ledger And Storage
 
 - [ ] 1.1 Define memory write ledger record types with `memory_write_id`, target, anchor, confidence, evidence, rationale, source session/turn, timestamps, and revert status.
-- [ ] 1.2 Add pure-text ledger layout helpers under `.alan/memory/ledger/` and preserve compatibility with existing memory files.
+- [ ] 1.2 Add one-file-per-write Markdown ledger layout helpers under `.alan/memory/ledger/YYYY/MM/` and preserve compatibility with existing memory files.
 - [ ] 1.3 Add runtime validation for ledger-target path containment and allowed stable memory targets.
 
 ## 2. Write Planning And Validation
 
 - [ ] 2.1 Extend turn-end memory promotion output parsing to carry evidence class, source references, confidence, and consolidation disposition.
 - [ ] 2.2 Add validation and canonicalization for direct statements, repeated behavior, and external/repository evidence.
-- [ ] 2.3 Route stable memory mutations through a single runtime writer that creates ledger entries and target-file updates together.
-- [ ] 2.4 Stage ambiguous, conflicting, or low-confidence observations for consolidation instead of stable promotion.
+- [ ] 2.3 Add provenance normalization for file, command, issue/PR, URL, and repeated-behavior evidence with bounded excerpts, ranges, hashes, or summaries.
+- [ ] 2.4 Add sensitive-data rejection/redaction for candidate observations and evidence before durable writes.
+- [ ] 2.5 Route stable memory mutations through a single runtime writer that creates ledger entries and target-file updates together.
+- [ ] 2.6 Stage ambiguous, conflicting, or low-confidence observations for consolidation instead of stable promotion.
 
 ## 3. Inspection And Revert Surfaces
 
@@ -25,7 +27,7 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, dedupe, path rejection, and confidence downgrades.
+- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, secret redaction, dedupe, path rejection, and confidence downgrades.
 - [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, and manual-resolution-required failures.
 - [ ] 5.3 Add daemon and CLI integration tests for recent, show, and revert surfaces.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -17,18 +17,19 @@
 
 - [ ] 3.1 Add CLI commands for recent write listing, single-write inspection, and revert.
 - [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for recent, show, and revert operations.
-- [ ] 3.3 Add precise revert mechanics with safe failure when the target content no longer matches the ledger anchor.
+- [ ] 3.3 Add precise revert mechanics that remove matched stable-memory content or mark it with a machine-readable reverted state, with safe failure when the target content no longer matches the ledger anchor.
 
 ## 4. Memory Surface Integration
 
 - [ ] 4.1 Update recall, handoff, session-summary, and daily-note surfaces to keep provenance references bounded.
 - [ ] 4.2 Ensure prompt-facing memory surfaces do not duplicate full ledger content.
-- [ ] 4.3 Preserve legacy memory entries that do not have reversible ledger metadata.
+- [ ] 4.3 Ensure prompt-facing memory surfaces exclude reverted blocks and never reintroduce reverted content from ledger records.
+- [ ] 4.4 Preserve legacy memory entries that do not have reversible ledger metadata.
 
 ## 5. Verification
 
 - [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, secret redaction, dedupe, path rejection, and confidence downgrades.
-- [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, and manual-resolution-required failures.
+- [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, reverted prompt-surface exclusion, and manual-resolution-required failures.
 - [ ] 5.3 Add daemon and CLI integration tests for recent, show, and revert surfaces.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.
 - [ ] 5.5 Run `openspec validate add-proactive-memory-v2 --strict`.

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -26,10 +26,11 @@
 - [ ] 4.2 Ensure prompt-facing memory surfaces do not duplicate full ledger content.
 - [ ] 4.3 Ensure prompt-facing memory surfaces exclude reverted blocks and never reintroduce reverted content from ledger records.
 - [ ] 4.4 Preserve legacy memory entries that do not have reversible ledger metadata.
+- [ ] 4.5 Update the built-in memory skill and session-end prompt guidance so stable, staged, inbox, daily-note, and ledger writes go through the runtime writer or a compatibility bridge instead of direct file mutation.
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, disabled-memory write suppression, stable and staged secret redaction, dedupe, path rejection, and confidence downgrades.
+- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, disabled-memory write suppression, stable and staged secret redaction, dedupe, path rejection, skill/prompt compatibility routing, and confidence downgrades.
 - [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, reverted prompt-surface exclusion, and manual-resolution-required failures.
 - [ ] 5.3 Add daemon and CLI integration tests for recent, show, revert, session scoping, authorized workspace scoping, unscoped request rejection, and unauthorized workspace-scope rejection.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -26,7 +26,7 @@
 - [ ] 4.2 Ensure prompt-facing memory surfaces do not duplicate full ledger content.
 - [ ] 4.3 Ensure prompt-facing memory surfaces exclude reverted blocks and never reintroduce reverted content from ledger records.
 - [ ] 4.4 Preserve legacy memory entries that do not have reversible ledger metadata.
-- [ ] 4.5 Update the built-in memory skill and session-end prompt guidance so stable, staged, inbox, daily-note, and ledger writes go through the runtime writer or a compatibility bridge instead of direct file mutation.
+- [ ] 4.5 Update the built-in memory skill, session-end prompt guidance, and `runtime-memory-surfaces` semantic-summary contract so stable, staged, inbox, daily-note, and ledger writes go through the runtime writer or a compatibility bridge instead of direct file mutation.
 
 ## 5. Verification
 

--- a/openspec/changes/add-proactive-memory-v2/tasks.md
+++ b/openspec/changes/add-proactive-memory-v2/tasks.md
@@ -3,6 +3,7 @@
 - [ ] 1.1 Define memory write ledger record types with `memory_write_id`, target, anchor, confidence, evidence, rationale, source session/turn, timestamps, and revert status.
 - [ ] 1.2 Add one-file-per-write Markdown ledger layout helpers under `.alan/memory/ledger/YYYY/MM/` and preserve compatibility with existing memory files.
 - [ ] 1.3 Add runtime validation for ledger-target path containment and allowed stable memory targets.
+- [ ] 1.4 Ensure `[memory].enabled = false` makes proactive stable, staged, inbox, daily-note, consolidation, and ledger writes ineligible.
 
 ## 2. Write Planning And Validation
 
@@ -16,7 +17,7 @@
 ## 3. Inspection And Revert Surfaces
 
 - [ ] 3.1 Add CLI commands for recent write listing, single-write inspection, and revert.
-- [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for workspace/session-scoped recent, show, and revert operations.
+- [ ] 3.2 Add daemon memory endpoints and endpoint-contract metadata for session-scoped recent/show/revert operations and authorized workspace-scoped recent/show/revert operations.
 - [ ] 3.3 Add precise revert mechanics that remove matched stable-memory content or mark it with a machine-readable reverted state, with safe failure when the target content no longer matches the ledger anchor.
 
 ## 4. Memory Surface Integration
@@ -28,9 +29,9 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, stable and staged secret redaction, dedupe, path rejection, and confidence downgrades.
+- [ ] 5.1 Add unit tests for write-plan normalization, evidence validation, provenance persistence, disabled-memory write suppression, stable and staged secret redaction, dedupe, path rejection, and confidence downgrades.
 - [ ] 5.2 Add storage tests for ledger creation, target updates, successful revert, already-reverted writes, reverted prompt-surface exclusion, and manual-resolution-required failures.
-- [ ] 5.3 Add daemon and CLI integration tests for recent, show, revert, workspace/session scoping, and unscoped request rejection.
+- [ ] 5.3 Add daemon and CLI integration tests for recent, show, revert, session scoping, authorized workspace scoping, unscoped request rejection, and unauthorized workspace-scope rejection.
 - [ ] 5.4 Run `cargo test --workspace` or the narrower documented Rust test suites covering runtime and daemon memory behavior.
 - [ ] 5.5 Run `openspec validate add-proactive-memory-v2 --strict`.
 


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal for proactive memory V2 with ledger-backed provenance, recent/show/revert surfaces, and secret redaction guardrails.
- Add OpenSpec proposal for cognitive model routing with System 1/System 2 model bindings, self-escalation, side-effect boundaries, and continuation partitioning.
- Keep both changes as separate apply-ready OpenSpec tracks so memory can land before routing.

## Test Plan
- openspec validate add-proactive-memory-v2 --strict
- openspec validate add-cognitive-model-routing --strict