### PR TITLE
Polish macOS shell materials and command input

### DIFF
--- a/clients/apple/AlanNative/App/AlanMacShellCommands.swift
+++ b/clients/apple/AlanNative/App/AlanMacShellCommands.swift
@@ -25,6 +25,11 @@ struct AlanMacShellCommands: Commands {
             }
             .keyboardShortcut("t", modifiers: [.command, .option])
 
+            Button("Go to or Command...") {
+                host.requestCommandInput()
+            }
+            .keyboardShortcut("p", modifiers: .command)
+
             Divider()
 
             Button("Split Right") {

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -10,11 +10,26 @@ struct MacShellRootView: View {
         self.host = host
     }
 
+    private func presentCommandInput() {
+        withAnimation(.easeOut(duration: 0.18)) {
+            isCommandTabPresented = true
+        }
+    }
+
+    private func dismissCommandInput() {
+        withAnimation(.easeOut(duration: 0.18)) {
+            isCommandTabPresented = false
+        }
+        DispatchQueue.main.async {
+            host.refocusSelectedTerminalPane()
+        }
+    }
+
     var body: some View {
         ZStack {
             ShellSpaceKeyboardShortcuts(host: host)
 
-            ShellPalette.canvas
+            ShellMaterialBackgroundView(.windowBackdrop)
                 .ignoresSafeArea()
 
             HStack(spacing: 0) {
@@ -22,30 +37,21 @@ struct MacShellRootView: View {
                     host: host,
                     chromeMetrics: windowChromeMetrics
                 ) {
-                    withAnimation(.easeOut(duration: 0.18)) {
-                        isCommandTabPresented = true
-                    }
+                    presentCommandInput()
                 }
                 .frame(width: 286)
 
                 ShellWorkspaceView(host: host)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea(edges: .top)
-                    .background {
-                        ShellMaterialBackgroundView()
-                            .ignoresSafeArea(edges: .top)
-                    }
             }
             .frame(minWidth: 1260, minHeight: 800)
-            .background(ShellPalette.window)
 
             if isCommandTabPresented {
-                Color.black.opacity(0.16)
+                ShellPalette.overlayScrim
                     .ignoresSafeArea()
                     .onTapGesture {
-                        withAnimation(.easeOut(duration: 0.18)) {
-                            isCommandTabPresented = false
-                        }
+                        dismissCommandInput()
                     }
 
                 ShellCommandTabView(
@@ -57,6 +63,9 @@ struct MacShellRootView: View {
             }
         }
         .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
+        .onChange(of: host.commandInputRequestID) { _, _ in
+            presentCommandInput()
+        }
         .background(ShellWindowPlacementView(metrics: $windowChromeMetrics))
     }
 }

--- a/clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/AlanNative/Services/Terminal/TerminalHostViewSupport.swift
@@ -10,6 +10,7 @@ struct TerminalHostView: NSViewRepresentable {
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?
+    let onCommandInput: (() -> Void)?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -20,6 +21,7 @@ struct TerminalHostView: NSViewRepresentable {
             isSelected: isSelected,
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
+            onCommandInput: onCommandInput,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -33,6 +35,7 @@ struct TerminalHostView: NSViewRepresentable {
             surfaceHandle: runtimeRegistry.surfaceHandle(for: pane, bootProfile: bootProfile),
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
+            onCommandInput: onCommandInput,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -123,6 +123,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var lastCopiedAt: Date?
     @Published private(set) var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
     @Published private(set) var controlPlaneDiagnostics: [String] = []
+    @Published private(set) var commandInputRequestID = 0
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
 
@@ -344,6 +345,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func focus(paneID: String) {
         guard let result = try? shellState.focusingPane(paneID) else { return }
         applyMutationResult(result)
+    }
+
+    func requestCommandInput() {
+        commandInputRequestID += 1
+    }
+
+    func refocusSelectedTerminalPane() {
+        guard let paneID = selectedPane?.paneID else { return }
+        terminalRuntimeRegistry.requestFocus(for: paneID)
     }
 
     func terminalHostDidRequestActivation(paneID: String) {

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -138,6 +138,12 @@ enum ShellPalette {
         dark: (0.125, 0.140, 0.170),
         darkAlpha: 0.64
     )
+    static let overlayScrim = Color.shellAdaptive(
+        light: (0.10, 0.11, 0.15),
+        lightAlpha: 0.16,
+        dark: (0.0, 0.0, 0.0),
+        darkAlpha: 0.34
+    )
     static let materialScrim = Color.shellAdaptive(
         light: (0.922, 0.924, 0.953),
         lightAlpha: 0.35,
@@ -169,24 +175,124 @@ enum ShellRadii {
     static let overlay: CGFloat = 12
 }
 
-private struct SidebarMaterialView: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = .sidebar
-        view.blendingMode = .behindWindow
-        view.state = .followsWindowActiveState
-        return view
+enum ShellMaterialRole {
+    case windowBackdrop
+    case sidebarGlass
+    case workspaceBackdrop
+    case terminalSurround
+    case terminalChrome
+    case terminalChromeSelected
+    case floatingOverlay
+    case floatingInput
+    case controlGlass
+    case controlGlassStrong
+    case controlGlassHover
+    case controlGlassSelected
+    case panel
+    case panelSoft
+
+    var visualEffectMaterial: NSVisualEffectView.Material? {
+        switch self {
+        case .windowBackdrop:
+            return .windowBackground
+        case .sidebarGlass:
+            return .sidebar
+        case .workspaceBackdrop:
+            return .contentBackground
+        case .floatingOverlay, .floatingInput:
+            return .popover
+        case .terminalSurround,
+             .terminalChrome,
+             .terminalChromeSelected,
+             .controlGlass,
+             .controlGlassStrong,
+             .controlGlassHover,
+             .controlGlassSelected,
+             .panel,
+             .panelSoft:
+            return nil
+        }
     }
 
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
-}
+    var blendingMode: NSVisualEffectView.BlendingMode {
+        switch self {
+        case .windowBackdrop, .sidebarGlass:
+            return .behindWindow
+        case .workspaceBackdrop,
+             .floatingOverlay,
+             .floatingInput,
+             .terminalSurround,
+             .terminalChrome,
+             .terminalChromeSelected,
+             .controlGlass,
+             .controlGlassStrong,
+             .controlGlassHover,
+             .controlGlassSelected,
+             .panel,
+             .panelSoft:
+            return .withinWindow
+        }
+    }
 
-struct ShellMaterialBackgroundView: View {
-    var body: some View {
-        ZStack {
-            SidebarMaterialView()
-            ShellPalette.materialScrim
-            LinearGradient(
+    var fill: Color {
+        switch self {
+        case .windowBackdrop:
+            return ShellPalette.window
+        case .sidebarGlass:
+            return ShellPalette.materialScrim
+        case .workspaceBackdrop:
+            return ShellPalette.workspace.opacity(0.74)
+        case .terminalSurround:
+            return ShellPalette.terminal
+        case .terminalChrome:
+            return ShellPalette.terminalSoft.opacity(0.34)
+        case .terminalChromeSelected:
+            return ShellPalette.terminalSoft.opacity(0.52)
+        case .floatingOverlay:
+            return ShellPalette.window.opacity(0.86)
+        case .floatingInput:
+            return ShellPalette.panel.opacity(0.92)
+        case .controlGlass:
+            return ShellPalette.sidebarControl
+        case .controlGlassStrong:
+            return ShellPalette.sidebarControlStrong
+        case .controlGlassHover:
+            return ShellPalette.sidebarHover
+        case .controlGlassSelected:
+            return ShellPalette.sidebarSelection
+        case .panel:
+            return ShellPalette.panel
+        case .panelSoft:
+            return ShellPalette.panelSoft
+        }
+    }
+
+    var stroke: Color {
+        switch self {
+        case .terminalSurround:
+            return ShellPalette.line.opacity(0.18)
+        case .floatingOverlay:
+            return ShellPalette.line.opacity(0.42)
+        case .floatingInput:
+            return ShellPalette.line.opacity(0.32)
+        case .controlGlass,
+             .controlGlassStrong,
+             .controlGlassHover,
+             .controlGlassSelected:
+            return ShellPalette.line.opacity(0.18)
+        case .terminalChrome, .terminalChromeSelected:
+            return ShellPalette.line.opacity(0.16)
+        case .panel, .panelSoft:
+            return ShellPalette.line.opacity(0.22)
+        case .windowBackdrop, .sidebarGlass, .workspaceBackdrop:
+            return ShellPalette.line.opacity(0.0)
+        }
+    }
+
+    var gradientOverlay: LinearGradient? {
+        switch self {
+        case .windowBackdrop, .sidebarGlass, .workspaceBackdrop:
+            return LinearGradient(
                 colors: [
                     ShellPalette.materialTopWash,
                     ShellPalette.materialBottomShade,
@@ -194,7 +300,184 @@ struct ShellMaterialBackgroundView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
+        case .floatingOverlay, .floatingInput:
+            return LinearGradient(
+                colors: [
+                    Color.white.opacity(0.10),
+                    ShellPalette.materialBottomShade,
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .terminalSurround,
+             .terminalChrome,
+             .terminalChromeSelected,
+             .controlGlass,
+             .controlGlassStrong,
+             .controlGlassHover,
+             .controlGlassSelected,
+             .panel,
+             .panelSoft:
+            return nil
         }
+    }
+
+    func resolvedFill(reduceTransparency: Bool, increasedContrast: Bool) -> Color {
+        if reduceTransparency {
+            switch self {
+            case .windowBackdrop, .sidebarGlass, .workspaceBackdrop:
+                return ShellPalette.window
+            case .floatingOverlay:
+                return ShellPalette.window.opacity(increasedContrast ? 0.98 : 0.94)
+            case .floatingInput, .panel, .panelSoft:
+                return ShellPalette.panel
+            case .controlGlass, .controlGlassHover:
+                return increasedContrast ? ShellPalette.sidebarControlStrong : ShellPalette.panelSoft
+            case .controlGlassStrong, .controlGlassSelected:
+                return ShellPalette.sidebarControlStrong
+            case .terminalSurround:
+                return ShellPalette.terminal
+            case .terminalChrome:
+                return ShellPalette.terminalSoft.opacity(increasedContrast ? 0.50 : 0.40)
+            case .terminalChromeSelected:
+                return ShellPalette.terminalSoft.opacity(increasedContrast ? 0.68 : 0.56)
+            }
+        }
+
+        if increasedContrast {
+            switch self {
+            case .floatingOverlay:
+                return ShellPalette.window.opacity(0.94)
+            case .floatingInput, .panelSoft:
+                return ShellPalette.panel
+            case .controlGlass, .controlGlassHover:
+                return ShellPalette.sidebarControlStrong
+            case .controlGlassSelected:
+                return ShellPalette.sidebarControlStrong
+            case .terminalChrome:
+                return ShellPalette.terminalSoft.opacity(0.48)
+            case .terminalChromeSelected:
+                return ShellPalette.terminalSoft.opacity(0.66)
+            case .windowBackdrop,
+                 .sidebarGlass,
+                 .workspaceBackdrop,
+                 .terminalSurround,
+                 .controlGlassStrong,
+                 .panel:
+                break
+            }
+        }
+
+        return fill
+    }
+
+    func resolvedStroke(increasedContrast: Bool) -> Color {
+        guard increasedContrast else {
+            return stroke
+        }
+
+        switch self {
+        case .windowBackdrop, .sidebarGlass, .workspaceBackdrop:
+            return ShellPalette.line.opacity(0.0)
+        case .terminalSurround,
+             .terminalChrome,
+             .terminalChromeSelected,
+             .controlGlass,
+             .controlGlassStrong,
+             .controlGlassHover,
+             .controlGlassSelected,
+             .panel,
+             .panelSoft:
+            return ShellPalette.line.opacity(0.34)
+        case .floatingOverlay, .floatingInput:
+            return ShellPalette.line.opacity(0.52)
+        }
+    }
+}
+
+private struct ShellVisualEffectView: NSViewRepresentable {
+    let role: ShellMaterialRole
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = role.visualEffectMaterial ?? .contentBackground
+        view.blendingMode = role.blendingMode
+        view.state = .followsWindowActiveState
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = role.visualEffectMaterial ?? .contentBackground
+        nsView.blendingMode = role.blendingMode
+    }
+}
+
+struct ShellMaterialBackgroundView: View {
+    let role: ShellMaterialRole
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    init(_ role: ShellMaterialRole = .sidebarGlass) {
+        self.role = role
+    }
+
+    var body: some View {
+        ZStack {
+            if role.visualEffectMaterial != nil && !reduceTransparency {
+                ShellVisualEffectView(role: role)
+            }
+            role.resolvedFill(
+                reduceTransparency: reduceTransparency,
+                increasedContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+            )
+            if !reduceTransparency, let gradient = role.gradientOverlay {
+                gradient
+            }
+        }
+    }
+}
+
+struct ShellMaterialTintView: View {
+    let role: ShellMaterialRole
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    init(_ role: ShellMaterialRole) {
+        self.role = role
+    }
+
+    var body: some View {
+        ZStack {
+            role.resolvedFill(
+                reduceTransparency: reduceTransparency,
+                increasedContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+            )
+            if !reduceTransparency, let gradient = role.gradientOverlay {
+                gradient
+            }
+        }
+    }
+}
+
+struct ShellMaterialShape<MaterialShape: InsettableShape>: View {
+    let role: ShellMaterialRole
+    let shape: MaterialShape
+    var showsStroke = false
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        let increasedContrast = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+
+        shape
+            .fill(
+                role.resolvedFill(
+                    reduceTransparency: reduceTransparency,
+                    increasedContrast: increasedContrast
+                )
+            )
+            .overlay {
+                if showsStroke || increasedContrast {
+                    shape.stroke(role.resolvedStroke(increasedContrast: increasedContrast), lineWidth: 1)
+                }
+            }
     }
 }
 #endif

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -19,6 +19,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var isSelected = false
     private weak var activationDelegate: TerminalHostActivationDelegate?
     private var workspaceCommandHandler: ((ShellWorkspaceCommand) -> Void)?
+    private var commandInputHandler: (() -> Void)?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var rendererSnapshot: TerminalRendererSnapshot = .placeholder
@@ -132,6 +133,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
+        onCommandInput: (() -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
@@ -144,6 +146,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         surfaceController.bind(surfaceHandle: surfaceHandle, paneID: pane?.paneID)
         self.activationDelegate = activationDelegate
         workspaceCommandHandler = onWorkspaceCommand
+        commandInputHandler = onCommandInput
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
@@ -378,6 +381,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         window?.makeFirstResponder(self)
         synchronizeLiveHost()
         publishRuntimeSnapshot()
+    }
+
+    func focusTerminal() {
+        requestTerminalFocus()
     }
 
     private func activateTerminalHostForMouseEvent() {
@@ -733,6 +740,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 #endif
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if routeCommandInputKeyIfNeeded(event) {
+            return true
+        }
         if routeWorkspaceKeyCommandIfNeeded(event) {
             return true
         }
@@ -761,6 +771,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func keyDown(with event: NSEvent) {
+        if routeCommandInputKeyIfNeeded(event) {
+            return
+        }
         if routeWorkspaceKeyCommandIfNeeded(event) {
             return
         }
@@ -999,6 +1012,19 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return false
         }
         workspaceCommandHandler?(command)
+        return true
+    }
+
+    private func routeCommandInputKeyIfNeeded(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown, !event.isARepeat else { return false }
+
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .numericPad, .function])
+        guard flags == [.command] else { return false }
+        guard event.charactersIgnoringModifiers?.lowercased() == "p" else { return false }
+
+        commandInputHandler?()
         return true
     }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -113,8 +113,10 @@ struct TerminalPaneView: View {
         .padding(.horizontal, 9)
         .padding(.vertical, 6)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .fill(Color.white.opacity(0.62))
+            ShellMaterialShape(
+                role: .terminalChrome,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+            )
         )
         .overlay {
             RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
@@ -454,7 +456,12 @@ private struct ShellTerminalSurfaceFrame: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .background(ShellPalette.terminal)
+            .background(
+                ShellMaterialShape(
+                    role: .terminalSurround,
+                    shape: shape
+                )
+            )
             .clipShape(shape)
             .overlay {
                 shape.stroke(
@@ -487,6 +494,9 @@ private struct ShellPaneTreeLayoutView: View {
                     activationDelegate: host,
                     onWorkspaceCommand: { command in
                         host.performShellWorkspaceCommand(command)
+                    },
+                    onCommandInput: {
+                        host.requestCommandInput()
                     },
                     onClosePane: {
                         host.closePaneByID(pane.paneID)
@@ -646,6 +656,7 @@ private struct ShellTerminalLeafView: View {
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onWorkspaceCommand: (ShellWorkspaceCommand) -> Void
+    let onCommandInput: () -> Void
     let onClosePane: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
@@ -669,6 +680,7 @@ private struct ShellTerminalLeafView: View {
                     runtimeRegistry: runtimeRegistry,
                     activationDelegate: activationDelegate,
                     onWorkspaceCommand: onWorkspaceCommand,
+                    onCommandInput: onCommandInput,
                     onRuntimeUpdate: onRuntimeUpdate,
                     onMetadataUpdate: onMetadataUpdate
                 )
@@ -739,7 +751,11 @@ private struct ShellPaneTitleBarView: View {
         .frame(height: 28)
         .background(
             Rectangle()
-                .fill(isSelected ? ShellPalette.terminalSoft.opacity(0.52) : Color.black.opacity(0.08))
+                .fill(
+                    isSelected
+                        ? ShellMaterialRole.terminalChromeSelected.fill
+                        : ShellMaterialRole.terminalChrome.fill
+                )
         )
         .overlay(alignment: .bottom) {
             Rectangle()
@@ -837,8 +853,10 @@ private struct ShellFindBarView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
-                .fill(ShellPalette.panel.opacity(0.96))
+            ShellMaterialShape(
+                role: .floatingInput,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
+            )
         )
         .overlay {
             RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
@@ -909,8 +927,10 @@ private struct TerminalActionLabel: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .fill(Color.white.opacity(0.8))
+            ShellMaterialShape(
+                role: .controlGlass,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+            )
         )
     }
 }
@@ -953,8 +973,10 @@ private struct TerminalInfoCard<Content: View>: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
-                .fill(Color.white.opacity(0.76))
+            ShellMaterialShape(
+                role: .panel,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
+            )
         )
         .overlay {
             RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
@@ -993,8 +1015,10 @@ private struct TerminalMonoLine: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background(
-                RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
-                    .fill(ShellPalette.canvas.opacity(0.78))
+                ShellMaterialShape(
+                    role: .panelSoft,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
+                )
             )
     }
 }

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -56,6 +56,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         isSelected: Bool,
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
+        onCommandInput: (() -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
@@ -86,6 +87,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             surfaceHandle: surfaceHandle,
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
+            onCommandInput: onCommandInput,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -154,6 +156,10 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     func dismissFindInteraction(for paneID: String, refocusTerminal: Bool = true) {
         hostViewsByPaneID[paneID]?.dismissFindInteraction(refocusTerminal: refocusTerminal)
+    }
+
+    func requestFocus(for paneID: String) {
+        hostViewsByPaneID[paneID]?.focusTerminal()
     }
 
     var registeredPaneIDs: Set<String> {

--- a/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
@@ -1,13 +1,9 @@
 import SwiftUI
 
 #if os(macOS)
-private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
-    case newSpace
-    case newAlanSpace
-    case openTab
-    case openAlanTab
-    case jumpToAttention
-    case focusBestPane
+private enum ShellCommandInputAction: CaseIterable {
+    case newTerminalTab
+    case newAlanTab
     case splitRight
     case splitDown
     case splitLeft
@@ -17,478 +13,181 @@ private enum ShellCommandTabAction: String, CaseIterable, Identifiable {
     case focusUp
     case focusDown
     case equalizeSplits
-    case liftPane
     case closePane
     case closeTab
-    case copySnapshot
+    case jumpToAttention
 
-    var id: String { rawValue }
-
-    var title: String {
+    var aliases: Set<String> {
         switch self {
-        case .newSpace:
-            return "Create Space"
-        case .newAlanSpace:
-            return "Create Space with Alan"
-        case .openTab:
-            return "Open New Tab"
-        case .openAlanTab:
-            return "Open In Alan"
-        case .jumpToAttention:
-            return "Jump To Attention"
-        case .focusBestPane:
-            return "Focus Best Routing Pane"
+        case .newTerminalTab:
+            return ["new tab", "new terminal tab", "open tab", "open terminal tab"]
+        case .newAlanTab:
+            return ["new alan tab", "open alan tab", "open in alan", "alan tab"]
         case .splitRight:
-            return "Split Pane Right"
+            return ["split right", "split pane right"]
         case .splitDown:
-            return "Split Pane Down"
+            return ["split down", "split below", "split pane down"]
         case .splitLeft:
-            return "Split Pane Left"
+            return ["split left", "split pane left"]
         case .splitUp:
-            return "Split Pane Up"
+            return ["split up", "split above", "split pane up"]
         case .focusLeft:
-            return "Focus Pane Left"
+            return ["focus left", "focus pane left", "pane left"]
         case .focusRight:
-            return "Focus Pane Right"
+            return ["focus right", "focus pane right", "pane right"]
         case .focusUp:
-            return "Focus Pane Up"
+            return ["focus up", "focus pane up", "pane up"]
         case .focusDown:
-            return "Focus Pane Down"
+            return ["focus down", "focus pane down", "pane down"]
         case .equalizeSplits:
-            return "Equalize Splits"
-        case .liftPane:
-            return "Lift Focused Pane To Tab"
+            return ["equalize splits", "balance splits", "reset splits"]
         case .closePane:
-            return "Close Focused Pane"
+            return ["close pane", "close focused pane"]
         case .closeTab:
-            return "Close Current Tab"
-        case .copySnapshot:
-            return "Copy Shell Snapshot"
+            return ["close tab", "close current tab"]
+        case .jumpToAttention:
+            return ["jump to attention", "focus attention", "attention"]
         }
     }
 
-    var detail: String {
-        switch self {
-        case .newSpace:
-            return "Start a fresh space with a plain login shell."
-        case .newAlanSpace:
-            return "Start a fresh space that opens directly into Alan."
-        case .openTab:
-            return "Open another tab inside the current space."
-        case .openAlanTab:
-            return "Open another tab that boots directly into Alan."
-        case .jumpToAttention:
-            return "Jump to the strongest pane that currently needs approval or attention."
-        case .focusBestPane:
-            return "Use shell routing signals to jump to the strongest candidate pane."
-        case .splitRight:
-            return "Create a side-by-side split to the right of the focused pane."
-        case .splitDown:
-            return "Create a stacked split beneath the focused pane."
-        case .splitLeft:
-            return "Create a side-by-side split to the left of the focused pane."
-        case .splitUp:
-            return "Create a stacked split above the focused pane."
-        case .focusLeft:
-            return "Move terminal focus to the pane on the left."
-        case .focusRight:
-            return "Move terminal focus to the pane on the right."
-        case .focusUp:
-            return "Move terminal focus to the pane above."
-        case .focusDown:
-            return "Move terminal focus to the pane below."
-        case .equalizeSplits:
-            return "Return the current tab's split dividers to equal ratios."
-        case .liftPane:
-            return "Move the focused pane into its own tab without losing shell identity."
-        case .closePane:
-            return "Close the focused pane and keep the remaining tab layout intact."
-        case .closeTab:
-            return "Close the current tab while preserving the rest of the space."
-        case .copySnapshot:
-            return "Copy the canonical shell JSON for debugging or agent context."
-        }
+    static func resolve(_ rawValue: String) -> ShellCommandInputAction? {
+        let normalized = normalizedCommand(rawValue)
+        guard !normalized.isEmpty else { return nil }
+        return allCases.first { $0.aliases.contains(normalized) }
     }
 
-    func matches(query: String) -> Bool {
-        query.isEmpty
-            || title.localizedCaseInsensitiveContains(query)
-            || detail.localizedCaseInsensitiveContains(query)
-            || keywordMatches(query: query)
+    private static func normalizedCommand(_ rawValue: String) -> String {
+        rawValue
+            .lowercased()
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
     }
-
-    private func keywordMatches(query: String) -> Bool {
-        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalizedQuery.isEmpty else { return false }
-        return keywords.contains { normalizedQuery.contains($0) }
-    }
-
-    private var keywords: [String] {
-        switch self {
-        case .newSpace:
-            return ["new space", "fresh space", "workspace", "terminal space"]
-        case .newAlanSpace:
-            return ["new space with alan", "alan space", "agent space"]
-        case .openTab:
-            return ["open tab", "new tab", "open terminal tab"]
-        case .openAlanTab:
-            return ["open in alan", "alan tab", "new alan tab"]
-        case .jumpToAttention:
-            return ["jump to attention", "jump attention", "focus waiting pane", "approval", "waiting pane"]
-        case .focusBestPane:
-            return ["best pane", "route", "routing", "focus best", "jump pane"]
-        case .splitRight:
-            return ["split right", "split vertical", "side by side"]
-        case .splitDown:
-            return ["split down", "split horizontal", "split below", "stack split"]
-        case .splitLeft:
-            return ["split left"]
-        case .splitUp:
-            return ["split up", "split above"]
-        case .focusLeft:
-            return ["focus left", "pane left"]
-        case .focusRight:
-            return ["focus right", "pane right"]
-        case .focusUp:
-            return ["focus up", "pane up"]
-        case .focusDown:
-            return ["focus down", "pane down"]
-        case .equalizeSplits:
-            return ["equalize", "balance splits", "reset split ratios"]
-        case .liftPane:
-            return ["lift pane", "move pane", "extract pane"]
-        case .closePane:
-            return ["close pane", "remove pane"]
-        case .closeTab:
-            return ["close tab", "close tab"]
-        case .copySnapshot:
-            return ["copy snapshot", "copy json", "debug snapshot"]
-        }
-    }
-}
-
-private struct ShellCommandTabIntent: Identifiable {
-    enum Route {
-        case action(ShellCommandTabAction)
-        case attention(ShellAttentionItem)
-        case candidate(AlanShellRoutingCandidate)
-    }
-
-    let title: String
-    let detail: String
-    let accent: Color
-    let route: Route
-
-    var id: String { title }
 }
 
 struct ShellCommandTabView: View {
     @ObservedObject var host: ShellHostController
     @Binding var isPresented: Bool
     @State private var query = ""
+    @State private var unresolvedMessage: String?
+    @State private var unresolvedAttemptID = 0
     @FocusState private var isQueryFocused: Bool
-    @StateObject private var voiceController = ShellVoiceCommandController()
-
-    private var matchingActions: [ShellCommandTabAction] {
-        let allActions = ShellCommandTabAction.allCases.filter { $0.matches(query: query) }
-
-        guard query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return allActions
-        }
-
-        let defaultActions: [ShellCommandTabAction] = [
-            .openTab,
-            .openAlanTab,
-            .splitRight,
-            .splitDown,
-            .equalizeSplits,
-            .jumpToAttention,
-            .newSpace,
-        ]
-
-        return defaultActions.filter { allActions.contains($0) }
-    }
-
-    private var matchingAttention: [ShellAttentionItem] {
-        let visibleItems = host.attentionItems.filter {
-            $0.attention == .awaitingUser || $0.attention == .notable
-        }
-
-        guard !query.isEmpty else { return Array(visibleItems.prefix(2)) }
-        return visibleItems.filter {
-            $0.title.localizedCaseInsensitiveContains(query)
-                || $0.summary.localizedCaseInsensitiveContains(query)
-        }
-    }
-
-    private var matchingRoutingCandidates: [AlanShellRoutingCandidate] {
-        let candidates = host.routingCandidates
-        guard !query.isEmpty else { return Array(candidates.prefix(2)) }
-
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return candidates.filter { candidate in
-            guard let pane = host.shellState.panes.first(where: { $0.paneID == candidate.paneID }) else {
-                return candidate.paneID.localizedCaseInsensitiveContains(query)
-            }
-
-            return candidate.paneID.localizedCaseInsensitiveContains(query)
-                || (pane.viewport?.title?.localizedCaseInsensitiveContains(query) ?? false)
-                || (pane.viewport?.summary?.localizedCaseInsensitiveContains(query) ?? false)
-                || (pane.process?.program.localizedCaseInsensitiveContains(query) ?? false)
-                || candidate.reasons.contains { $0.lowercased().contains(normalized) }
-        }
-    }
-
-    private var primaryIntent: ShellCommandTabIntent? {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalized.isEmpty else { return nil }
-
-        if normalized.contains("route")
-            || normalized.contains("best pane")
-            || normalized.contains("focus best")
-        {
-            if let candidate = matchingRoutingCandidates.first {
-                return ShellCommandTabIntent(
-                    title: "Focus \(routingTitle(for: candidate))",
-                    detail: routingDetail(for: candidate),
-                    accent: ShellPalette.accent,
-                    route: .candidate(candidate)
-                )
-            }
-        }
-
-        if normalized.contains("attention") || normalized.contains("waiting") || normalized.contains("jump") {
-            if let firstAttention = matchingAttention.first {
-                return ShellCommandTabIntent(
-                    title: "Jump To \(firstAttention.title)",
-                    detail: "Focus the pane that currently needs attention first.",
-                    accent: firstAttention.attention == .awaitingUser ? ShellPalette.accent : ShellPalette.ink,
-                    route: .attention(firstAttention)
-                )
-            }
-        }
-
-        if let action = matchingActions.first {
-            return ShellCommandTabIntent(
-                title: title(for: action),
-                detail: detail(for: action),
-                accent: ShellPalette.accent,
-                route: .action(action)
-            )
-        }
-
-        return nil
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 14) {
-                HStack(alignment: .center, spacing: 12) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(ShellPalette.accent)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(ShellPalette.accent)
 
-                    TextField(
-                        "",
-                        text: $query,
-                        prompt: Text("Go to or Command...")
-                            .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
-                    )
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundStyle(ShellPalette.ink)
-                    .focused($isQueryFocused)
-                    .onSubmit {
-                        executePrimaryIntent()
-                    }
-
-                    Text("⌘K")
-                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                TextField(
+                    "",
+                    text: $query,
+                    prompt: Text("Go to or Command...")
                         .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 4)
-                        .background(
-                            RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                                .fill(ShellPalette.canvas.opacity(0.95))
-                        )
-
-                    Button {
-                        voiceController.toggleListening { recognizedCommand in
-                            query = recognizedCommand
-                            executePrimaryIntent()
-                        }
-                    } label: {
-                        Image(systemName: voiceController.isListening ? "mic.fill" : "mic")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(voiceController.isListening ? ShellPalette.accent : ShellPalette.mutedInk)
-                            .frame(width: 26, height: 26)
-                            .background(
-                                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                                    .fill(ShellPalette.canvas.opacity(0.92))
-                            )
-                    }
-                    .buttonStyle(.plain)
-
-                    Button {
-                        isPresented = false
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 11, weight: .bold))
-                            .foregroundStyle(ShellPalette.mutedInk)
-                            .frame(width: 26, height: 26)
-                            .background(
-                                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                                    .fill(ShellPalette.canvas.opacity(0.92))
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
-                        .fill(Color.white.opacity(0.9))
                 )
-                .overlay {
-                    RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
-                        .stroke(ShellPalette.line.opacity(0.32), lineWidth: 1)
+                .textFieldStyle(.plain)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(ShellPalette.ink)
+                .focused($isQueryFocused)
+                .onChange(of: query) { _, _ in
+                    unresolvedMessage = nil
                 }
-                .shadow(color: Color.black.opacity(0.035), radius: 10, y: 4)
-
-                if voiceController.isListening || primaryIntent != nil {
-                    VStack(alignment: .leading, spacing: 12) {
-                        if voiceController.isListening {
-                            HStack(spacing: 8) {
-                                Circle()
-                                    .fill(ShellPalette.attention)
-                                    .frame(width: 8, height: 8)
-                                Text("Listening for shell actions")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(ShellPalette.mutedInk)
-                            }
-                        }
-
-                        if let primaryIntent {
-                            VStack(alignment: .leading, spacing: 10) {
-                                sectionLabel("Best match")
-                                Button {
-                                    execute(primaryIntent.route)
-                                } label: {
-                                    ShellCommandRow(
-                                        title: primaryIntent.title,
-                                        detail: primaryIntent.detail,
-                                        accent: primaryIntent.accent
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
+                .onSubmit {
+                    submit()
+                }
+                .onKeyPress(.return) {
+                    submit()
+                    return .handled
                 }
 
-                VStack(alignment: .leading, spacing: 10) {
-                    sectionLabel("Actions")
-                    VStack(spacing: 8) {
-                        ForEach(matchingActions) { action in
-                            Button {
-                                perform(action)
-                            } label: {
-                                ShellCommandRow(
-                                    title: title(for: action),
-                                    detail: detail(for: action),
-                                    accent: ShellPalette.accent
+                Text("⌘P")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.85))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(
+                        ShellMaterialShape(
+                            role: .controlGlass,
+                            shape: RoundedRectangle(
+                                cornerRadius: ShellRadii.control,
+                                style: .continuous
+                            )
+                        )
+                    )
+
+                Button {
+                    dismissAndRestoreFocus()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(ShellPalette.mutedInk)
+                        .frame(width: 26, height: 26)
+                        .background(
+                            ShellMaterialShape(
+                                role: .controlGlass,
+                                shape: RoundedRectangle(
+                                    cornerRadius: ShellRadii.control,
+                                    style: .continuous
                                 )
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
+                            )
+                        )
                 }
+                .buttonStyle(.plain)
+                .help("Close command input")
+            }
 
-                if !matchingRoutingCandidates.isEmpty && !query.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionLabel("Routing")
-                        VStack(spacing: 8) {
-                            ForEach(matchingRoutingCandidates) { candidate in
-                                Button {
-                                    execute(.candidate(candidate))
-                                } label: {
-                                    ShellCommandRow(
-                                        title: "Focus \(routingTitle(for: candidate))",
-                                        detail: routingDetail(for: candidate),
-                                        accent: ShellPalette.accent
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
-                }
-
-                if !matchingAttention.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionLabel("Attention")
-                        VStack(spacing: 8) {
-                            ForEach(matchingAttention) { item in
-                                Button {
-                                    host.focusAttentionItem(item)
-                                    isPresented = false
-                                } label: {
-                                    ShellCommandRow(
-                                        title: shellNormalizedTitle(item.title) ?? item.title,
-                                        detail: shellUserFacingSummary(item.summary) ?? "Needs attention",
-                                        accent: item.attention == .awaitingUser ? ShellPalette.attention : ShellPalette.ink
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
-                }
+            if let unresolvedMessage {
+                Text(unresolvedMessage)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                    .padding(.leading, 27)
+                    .transition(.opacity)
             }
         }
-        .padding(16)
-        .frame(width: 478, height: 568)
-        .background(
-            ZStack {
-                RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
-                    .fill(ShellPalette.window.opacity(0.9))
-            }
-        )
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(width: 520, alignment: .leading)
+        .background {
+            ShellMaterialBackgroundView(.floatingOverlay)
+                .clipShape(RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous))
+        }
         .overlay {
             RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
-                .stroke(ShellPalette.line.opacity(0.42), lineWidth: 1)
+                .stroke(ShellMaterialRole.floatingOverlay.stroke, lineWidth: 1)
         }
-        .shadow(color: Color.black.opacity(0.12), radius: 26, y: 16)
+        .shadow(color: Color.black.opacity(0.12), radius: 24, y: 14)
+        .offset(x: unresolvedAttemptID.isMultiple(of: 2) ? 0 : 1.5)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: unresolvedAttemptID)
         .onAppear {
             isQueryFocused = true
         }
-        .onDisappear {
-            voiceController.stopListening()
-        }
         .onExitCommand {
-            voiceController.stopListening()
-            isPresented = false
+            dismissAndRestoreFocus()
         }
     }
 
-    private func perform(_ action: ShellCommandTabAction) {
+    private func submit() {
+        guard let action = ShellCommandInputAction.resolve(query) else {
+            unresolvedMessage = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "Type a command name."
+                : "No matching command."
+            unresolvedAttemptID += 1
+            isQueryFocused = true
+            return
+        }
+
+        perform(action)
+    }
+
+    private func perform(_ action: ShellCommandInputAction) {
         switch action {
-        case .newSpace:
-            _ = host.createTerminalSpace()
-        case .newAlanSpace:
-            _ = host.createAlanSpace()
-        case .openTab:
+        case .newTerminalTab:
             host.performShellWorkspaceCommand(.newTerminalTab)
-        case .openAlanTab:
+        case .newAlanTab:
             host.performShellWorkspaceCommand(.newAlanTab)
-        case .jumpToAttention:
-            if let firstAttention = host.attentionItems.first {
-                host.focusAttentionItem(firstAttention)
-            }
-        case .focusBestPane:
-            _ = host.focusTopRoutingCandidate()
         case .splitRight:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.splitRight)
         case .splitDown:
@@ -507,115 +206,23 @@ struct ShellCommandTabView: View {
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusDown)
         case .equalizeSplits:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.equalizeSplits)
-        case .liftPane:
-            _ = host.liftSelectedPaneToTab()
         case .closePane:
-            host.performShellWorkspaceCommand(.closePane)
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.closePane)
         case .closeTab:
-            host.performShellWorkspaceCommand(.closeTab)
-        case .copySnapshot:
-            host.copySnapshotJSON()
-        }
-        isPresented = false
-    }
-
-    private func execute(_ route: ShellCommandTabIntent.Route) {
-        switch route {
-        case let .action(action):
-            perform(action)
-        case let .attention(item):
-            host.focusAttentionItem(item)
-            isPresented = false
-        case let .candidate(candidate):
-            host.focus(paneID: candidate.paneID)
-            isPresented = false
-        }
-    }
-
-    private func executePrimaryIntent() {
-        guard let primaryIntent else { return }
-        execute(primaryIntent.route)
-    }
-
-    private func routingDetail(for candidate: AlanShellRoutingCandidate) -> String {
-        let title = routingTitle(for: candidate)
-        let reasons = candidate.reasons.prefix(3).joined(separator: " • ")
-        let detail = reasons.isEmpty ? "score \(Int(candidate.score * 100))" : reasons
-        return "\(title) • \(detail)"
-    }
-
-    private func routingTitle(for candidate: AlanShellRoutingCandidate) -> String {
-        guard let pane = host.shellState.panes.first(where: { $0.paneID == candidate.paneID }) else {
-            return "Terminal Pane"
-        }
-
-        return shellDisplayTitle(
-            rawTitle: pane.viewport?.title,
-            workingDirectoryName: pane.context?.workingDirectoryName,
-            cwd: pane.cwd,
-            program: pane.process?.program,
-            launchTarget: pane.resolvedLaunchTarget,
-            fallback: pane.viewport?.summary
-        )
-    }
-
-    private func title(for action: ShellCommandTabAction) -> String {
-        action.title
-    }
-
-    private func detail(for action: ShellCommandTabAction) -> String {
-        action.detail
-    }
-
-    private func sectionLabel(_ value: String) -> some View {
-        Text(value)
-            .font(.system(size: 10, weight: .semibold, design: .rounded))
-            .textCase(.uppercase)
-            .foregroundStyle(ShellPalette.mutedInk)
-    }
-}
-
-private struct ShellCommandRow: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var isHovered = false
-    let title: String
-    let detail: String
-    let accent: Color
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Circle()
-                .fill(accent)
-                .frame(width: 7, height: 7)
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(ShellPalette.ink)
-                Text(detail)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(ShellPalette.mutedInk)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .lineLimit(2)
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.closeTab)
+        case .jumpToAttention:
+            if let firstAttention = host.attentionItems.first {
+                host.focusAttentionItem(firstAttention)
             }
+        }
+        dismissAndRestoreFocus()
+    }
 
-            Spacer(minLength: 0)
+    private func dismissAndRestoreFocus() {
+        isPresented = false
+        DispatchQueue.main.async {
+            host.refocusSelectedTerminalPane()
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .fill(Color.white.opacity(0.84))
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .stroke(ShellPalette.line.opacity(isHovered ? 0.24 : 0.12), lineWidth: 1)
-        }
-        .scaleEffect(isHovered ? 1.004 : 1)
-        .shadow(color: isHovered ? Color.black.opacity(0.022) : .clear, radius: 6, y: 3)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
-        .onHover { isHovered = $0 }
     }
 }
 #endif

--- a/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
@@ -19,17 +19,15 @@ struct ShellSidebarView: View {
         .padding(.top, chromeMetrics.trafficLightsTopInset)
         .padding(.bottom, 15)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background {
-            ShellMaterialBackgroundView()
-                .ignoresSafeArea(edges: .top)
-        }
     }
 
     private var sidebarHeader: some View {
         HStack(alignment: .center, spacing: 10) {
             ZStack {
-                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                    .fill(ShellPalette.sidebarControlStrong)
+                ShellMaterialShape(
+                    role: .controlGlassStrong,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                )
                 Text("A")
                     .font(.system(size: 12.5, weight: .bold, design: .rounded))
                     .foregroundStyle(ShellPalette.accent)
@@ -63,8 +61,10 @@ struct ShellSidebarView: View {
                     .foregroundStyle(.primary)
                     .frame(width: 26, height: 26)
                     .background(
-                        RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                            .fill(ShellPalette.sidebarControl)
+                        ShellMaterialShape(
+                            role: .controlGlass,
+                            shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                        )
                     )
             }
             .menuStyle(.borderlessButton)
@@ -84,19 +84,20 @@ struct ShellSidebarView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                Text("⌘K")
+                Text("⌘P")
                     .font(.system(size: 11, weight: .semibold, design: .monospaced))
                     .foregroundStyle(.tertiary)
             }
             .padding(.horizontal, 11)
             .padding(.vertical, 10)
             .background(
-                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                    .fill(ShellPalette.sidebarControl)
+                ShellMaterialShape(
+                    role: .controlGlass,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                )
             )
         }
         .buttonStyle(.plain)
-        .keyboardShortcut("k", modifiers: [.command])
     }
 
     private var tabSection: some View {
@@ -171,8 +172,10 @@ struct ShellSidebarView: View {
                         .foregroundStyle(.primary)
                         .frame(width: 30, height: 30)
                         .background(
-                            RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                                .fill(ShellPalette.sidebarControl)
+                            ShellMaterialShape(
+                                role: .controlGlass,
+                                shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                            )
                         )
                 }
                 .menuStyle(.borderlessButton)
@@ -358,12 +361,12 @@ private struct ShellSpaceRailItem: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ZStack {
-                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                    .fill(
-                        isSelected
-                            ? ShellPalette.railSelection
-                            : (isHovered ? ShellPalette.railHover : ShellPalette.railBase)
-                    )
+                ShellMaterialShape(
+                    role: isSelected
+                        ? .controlGlassSelected
+                        : (isHovered ? .controlGlassHover : .controlGlass),
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                )
                 Image(systemName: symbolName)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(isSelected ? ShellPalette.accent : .primary)
@@ -463,12 +466,14 @@ private struct ShellTabSidebarRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .fill(
-                    isSelected
-                        ? ShellPalette.sidebarSelection
-                        : (isHovered ? ShellPalette.sidebarHover : Color.clear)
-                )
+            Group {
+                if isSelected || isHovered {
+                    ShellMaterialShape(
+                        role: isSelected ? .controlGlassSelected : .controlGlassHover,
+                        shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                    )
+                }
+            }
         )
         .scaleEffect(isHovered && !isSelected ? 1.005 : 1)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
@@ -530,8 +535,10 @@ private struct ShellEmptyStateRow: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .fill(ShellPalette.panelSoft)
+            ShellMaterialShape(
+                role: .panelSoft,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+            )
         )
     }
 }

--- a/openspec/changes/optimize-macos-material-system/design.md
+++ b/openspec/changes/optimize-macos-material-system/design.md
@@ -29,7 +29,7 @@ the terminal itself remains stable, high contrast, and readable.
 
 - Do not redesign sidebar information architecture; that is owned by
   `streamline-macos-sidebar-ia`.
-- Do not redesign `Command-K` behavior; that is owned by
+- Do not redesign command input behavior; that is owned by
   `polish-macos-command-input`.
 - Do not introduce dark-mode completeness as part of this pass.
 - Do not change shell runtime, terminal protocol, or command routing behavior.

--- a/openspec/changes/optimize-macos-material-system/tasks.md
+++ b/openspec/changes/optimize-macos-material-system/tasks.md
@@ -1,19 +1,27 @@
 ## 1. Material Roles
 
-- [ ] 1.1 Inventory active shell material, background, button, hover, and overlay fills in the Apple client.
-- [ ] 1.2 Define semantic material/control roles in the shell support layer for window, sidebar, workspace, terminal surround, floating overlay, and compact controls.
-- [ ] 1.3 Keep AppKit visual-effect bridge code isolated behind reusable support wrappers.
+- [x] 1.1 Inventory active shell material, background, button, hover, and overlay fills in the Apple client.
+- [x] 1.2 Define semantic material/control roles in the shell support layer for window, sidebar, workspace, terminal surround, floating overlay, and compact controls.
+- [x] 1.3 Keep AppKit visual-effect bridge code isolated behind reusable support wrappers.
 
 ## 2. Active Shell Application
 
-- [ ] 2.1 Apply the semantic roles to `MacShellRootView.swift` and workspace backgrounds.
-- [ ] 2.2 Apply the sidebar/control roles to `ShellSidebarView.swift` without changing sidebar information architecture.
-- [ ] 2.3 Apply terminal surround roles to active terminal shell chrome without reducing terminal text contrast.
-- [ ] 2.4 Apply overlay/control roles to active floating shell surfaces without redesigning `Command-K` behavior.
+- [x] 2.1 Apply the semantic roles to `MacShellRootView.swift` and workspace backgrounds.
+- [x] 2.2 Apply the sidebar/control roles to `ShellSidebarView.swift` without changing sidebar information architecture.
+- [x] 2.3 Apply terminal surround roles to active terminal shell chrome without reducing terminal text contrast.
+- [x] 2.4 Apply overlay/control roles to active floating shell surfaces without redesigning command input behavior.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused Apple build or shell UI checks affected by the changed files.
-- [ ] 3.2 Capture screenshot or manual review notes for light-mode sidebar, terminal, command entry, controls, and overlays.
-- [ ] 3.3 Review reduced-transparency or increased-contrast behavior, or document why local verification was unavailable.
-- [ ] 3.4 Run `openspec validate --all --strict` before PR.
+- [x] 3.1 Run focused Apple build or shell UI checks affected by the changed files.
+- [x] 3.2 Capture screenshot or manual review notes for light-mode sidebar, terminal, command entry, controls, and overlays.
+- [x] 3.3 Review reduced-transparency or increased-contrast behavior, or document why local verification was unavailable.
+- [x] 3.4 Run `openspec validate --all --strict` before PR.
+
+### Verification Notes
+
+- 2026-05-12: Built `AlanNative` Debug for macOS after the material-role changes.
+- 2026-05-12: Captured light-mode default shell review screenshot at `/tmp/alan-ui-polish-material-default.png`; sidebar, terminal content area, compact controls, and the unified window backdrop were reviewed together.
+- 2026-05-12: Captured command input review screenshot at `/tmp/alan-ui-polish-command-input-command-p-retry.png`; command entry, floating overlay material, and terminal scrim treatment were reviewed together.
+- 2026-05-12: Reduced-transparency behavior is handled in the shared material wrappers by disabling AppKit visual-effect material when `accessibilityReduceTransparency` is active and falling back to solid semantic fills. Increased-contrast behavior is handled by `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`, which strengthens fills and strokes for control, overlay, panel, and terminal chrome roles. I did not toggle global macOS accessibility settings during the run.
+- 2026-05-12: Checked active shell files for escaped one-off `.ultraThinMaterial`, `Color.white.opacity(...)`, or direct shell background/control fills; the remaining direct palette match is the space-rail attention-dot stroke, not a material or translucent background fill.

--- a/openspec/changes/polish-macos-command-input/design.md
+++ b/openspec/changes/polish-macos-command-input/design.md
@@ -9,7 +9,7 @@
 - voice controller affordance,
 - rows grouped under visible sections.
 
-The user direction is narrower: `Command-K` should summon a beautiful Liquid
+The user direction is narrower: the command shortcut should summon a beautiful Liquid
 Glass input box and should not show the candidate actions underneath. That makes
 this change mostly a surface simplification and interaction reset, not a command
 vocabulary expansion.
@@ -18,7 +18,7 @@ vocabulary expansion.
 
 **Goals:**
 
-- Make `Command-K` feel like a native, premium floating input rather than a
+- Make `Command-P` feel like a native, premium floating input rather than a
   dashboard-like command palette.
 - Remove default candidate/action/routing/attention lists from the overlay.
 - Keep keyboard and focus behavior crisp: open, type, submit, dismiss, restore
@@ -31,7 +31,7 @@ vocabulary expansion.
   this change.
 - Do not expand command vocabulary beyond the existing workspace actions needed
   for typed submission.
-- Do not add voice input to `Command-K`; voice MVP work owns voice interaction.
+- Do not add voice input to the command input; voice MVP work owns voice interaction.
 - Do not change terminal `Command-F` Find behavior.
 
 ## Decisions

--- a/openspec/changes/polish-macos-command-input/proposal.md
+++ b/openspec/changes/polish-macos-command-input/proposal.md
@@ -1,14 +1,14 @@
 ## Why
 
-`Command-K` currently opens a large command palette with action, routing, and
+The shell command input currently opens a large command palette with action, routing, and
 attention candidate sections. That makes the shortcut feel like a dashboard
 surface instead of a focused, high-quality macOS command input. Alan should make
-`Command-K` a beautiful Liquid Glass-style input layer that is quick to summon,
+`Command-P` a beautiful Liquid Glass-style input layer that is quick to summon,
 easy to dismiss, and visually consistent with the material polish direction.
 
 ## What Changes
 
-- Redesign `Command-K` as a single floating input field with Liquid Glass-style
+- Redesign `Command-P` as a single floating input field with Liquid Glass-style
   material, subtle depth, and native focus behavior.
 - Remove the always-visible candidate/action/routing/attention lists below the
   input.
@@ -16,7 +16,7 @@ easy to dismiss, and visually consistent with the material polish direction.
   may execute known commands, but suggestions are not shown in the default UI.
 - Remove command-palette voice/microphone affordances from this surface unless a
   future voice-specific change reintroduces them in its own interaction model.
-- Preserve keyboard behavior: `Command-K` opens/focuses the input, Return submits
+- Preserve keyboard behavior: `Command-P` opens/focuses the input, Return submits
   when a typed command can be resolved, Escape/click-away dismisses, and terminal
   focus returns after dismissal.
 
@@ -28,7 +28,7 @@ None.
 
 ### Modified Capabilities
 
-- `macos-shell-ui-ux-conformance`: add a requirement that `Command-K` is a
+- `macos-shell-ui-ux-conformance`: add a requirement that the command input is a
   floating Liquid Glass-style input rather than a multi-section command palette.
 - `macos-shell-workspace-interactions`: clarify command UI routing without
   default visible candidate lists.

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-build-test-contract/spec.md
@@ -1,16 +1,16 @@
 ## ADDED Requirements
 
 ### Requirement: Command input polish has focused verification
-The Apple client SHALL include focused verification for the `Command-K` input
+The Apple client SHALL include focused verification for the `Command-P` input
 surface when command UI behavior or material treatment changes.
 
 #### Scenario: Command input keyboard flow is verified
-- **WHEN** `Command-K` implementation is marked complete
+- **WHEN** command input implementation is marked complete
 - **THEN** focused tests or manual notes cover open/focus, typing, successful Return submission, unresolved Return behavior, Escape dismissal, click-away dismissal, and terminal focus restoration
 
 #### Scenario: Candidate sections stay removed
 - **WHEN** default command input UI changes
-- **THEN** shell contract checks or review notes confirm action, routing, attention, best-match, command-row, and microphone affordances are not visible in the default `Command-K` surface
+- **THEN** shell contract checks or review notes confirm action, routing, attention, best-match, command-row, and microphone affordances are not visible in the default command input surface
 
 #### Scenario: Liquid input visual review is captured
 - **WHEN** command input material polish is marked complete

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,12 +1,12 @@
 ## ADDED Requirements
 
-### Requirement: Command-K opens a Liquid Glass input
-The macOS shell SHALL present `Command-K` as a single floating Liquid
+### Requirement: Command input opens as a Liquid Glass input
+The macOS shell SHALL present `Command-P` as a single floating Liquid
 Glass-style input layer that captures text entry without rendering default
 candidate sections below the input.
 
 #### Scenario: Command input opens
-- **WHEN** the user presses `Command-K` or activates the sidebar command entry
+- **WHEN** the user presses `Command-P` or activates the sidebar command entry
 - **THEN** Alan opens a floating material-backed input field, focuses the text field, and does not show action, routing, attention, or best-match lists below it
 
 #### Scenario: Command input is visually restrained
@@ -18,7 +18,7 @@ candidate sections below the input.
 - **THEN** Alan dismisses the input and returns keyboard focus to the previously focused terminal pane when available
 
 #### Scenario: No default voice affordance
-- **WHEN** the `Command-K` input is visible
+- **WHEN** the command input is visible
 - **THEN** the input does not show a microphone or voice-listening affordance unless a future voice-specific requirement explicitly adds one
 
 #### Scenario: Unresolved command stays input-only

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
@@ -4,7 +4,7 @@
 Workspace actions SHALL be available through native menu/command routing,
 keyboard shortcuts, command input, and any restrained toolbar affordances that
 call the same shell controller mutations where the action is shared. The default
-`Command-K` command input SHALL accept typed commands without showing persistent
+`Command-P` command input SHALL accept typed commands without showing persistent
 candidate action lists.
 
 #### Scenario: Menu command

--- a/openspec/changes/polish-macos-command-input/tasks.md
+++ b/openspec/changes/polish-macos-command-input/tasks.md
@@ -1,18 +1,29 @@
 ## 1. Command Surface Simplification
 
-- [ ] 1.1 Replace the default `ShellCommandTabView` body with an input-only floating command surface.
-- [ ] 1.2 Remove default rendering for action, routing, attention, best-match, command-row, and microphone affordances from `Command-K`.
-- [ ] 1.3 Keep `Command-K` open/focus, Escape, click-away, close, and focus-restoration behavior intact.
+- [x] 1.1 Replace the default `ShellCommandTabView` body with an input-only floating command surface.
+- [x] 1.2 Remove default rendering for action, routing, attention, best-match, command-row, and microphone affordances from the command input.
+- [x] 1.3 Keep `Command-P` open/focus, Escape, click-away, close, and focus-restoration behavior intact.
 
 ## 2. Typed Command Routing
 
-- [ ] 2.1 Preserve a small deterministic typed-command resolver for existing workspace actions that are safe to execute from Return.
-- [ ] 2.2 Route resolved commands through the same `ShellHostController` workspace command handlers used by menus and shortcuts.
-- [ ] 2.3 Show unresolved command state inline without opening candidate rows or exposing raw debug identifiers.
+- [x] 2.1 Preserve a small deterministic typed-command resolver for existing workspace actions that are safe to execute from Return.
+- [x] 2.2 Route resolved commands through the same `ShellHostController` workspace command handlers used by menus and shortcuts.
+- [x] 2.3 Show unresolved command state inline without opening candidate rows or exposing raw debug identifiers.
 
 ## 3. Material And Verification
 
-- [ ] 3.1 Apply the shared floating/liquid material role to the command input surface.
-- [ ] 3.2 Run focused Apple build or shell UI checks affected by command input changes.
-- [ ] 3.3 Capture screenshot or manual review notes for the default light-mode command input.
-- [ ] 3.4 Run `openspec validate --all --strict` before PR.
+- [x] 3.1 Apply the shared floating/liquid material role to the command input surface.
+- [x] 3.2 Run focused Apple build or shell UI checks affected by command input changes.
+- [x] 3.3 Capture screenshot or manual review notes for the default light-mode command input.
+- [x] 3.4 Run `openspec validate --all --strict` before PR.
+
+### Verification Notes
+
+- 2026-05-12: Chose `Command-P` for the command input shortcut. It intentionally replaces the app-level Print shortcut for Alan's shell window, avoids terminal `Command-K` clear/edit conflicts, and keeps the visible hint compact.
+- 2026-05-12: Built `AlanNative` Debug for macOS after the command input changes. Xcode still reported the local CoreSimulator version warning, but the macOS build succeeded.
+- 2026-05-12: Ran `bash clients/apple/scripts/check-shell-contracts.sh`; shell contract checks passed.
+- 2026-05-12: Ran `openspec validate --all --strict`; all 25 items passed.
+- 2026-05-12: Captured default `Command-P` command input screenshot at `/tmp/alan-ui-polish-command-input-command-p-retry.png`; the surface is a single floating input with no action, routing, attention, best-match, command-row, or microphone affordances.
+- 2026-05-12: Captured unresolved Return state at `/tmp/alan-ui-polish-command-input-unresolved-return-retry.png`; unresolved text stays input-only and shows `No matching command.` inline.
+- 2026-05-12: Captured resolved typed command state at `/tmp/alan-ui-polish-command-input-resolved-new-tab.png`; submitting `new tab` used the shared workspace command path, dismissed the input, and created a new terminal tab.
+- 2026-05-12: Captured Escape/focus-restoration state at `/tmp/alan-ui-polish-command-input-escape-focus.png`; Escape dismissed the input and returned focus to the terminal prompt.

--- a/openspec/changes/streamline-macos-sidebar-ia/design.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/design.md
@@ -26,7 +26,7 @@ instructional copy, and make the bottom space switcher feel intentional.
   inline.
 - Make split tabs legible at a glance by showing a compact topology indicator
   that communicates pane count, dominant split direction, and focused pane.
-- Keep `Command-K` entry available from the sidebar, but do not redesign its
+- Keep the command input entry available from the sidebar, but do not redesign its
   overlay in this change.
 
 **Non-Goals:**


### PR DESCRIPTION
## Summary
- add semantic macOS material roles and use a single unified shell window backdrop
- simplify Go to or Command into an input-only floating surface on Command-P
- route typed commands through shared shell workspace handlers and keep unresolved input inline

## Verification
- xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination 'platform=macOS' build
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate --all --strict
- manual screenshots: /tmp/alan-ui-polish-command-input-command-p-retry.png, /tmp/alan-ui-polish-command-input-unresolved-return-retry.png, /tmp/alan-ui-polish-command-input-resolved-new-tab.png, /tmp/alan-ui-polish-command-input-escape-focus.png