### PR TITLE
Polish macOS shell chrome and command input

### DIFF
--- a/clients/apple/AlanNative.xcodeproj/project.pbxproj
+++ b/clients/apple/AlanNative.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		000000000000000000000035 /* ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* ConsoleAdaptiveColor.swift */; };
 		000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000137 /* ShellHostControlCommandHandling.swift */; };
+		000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -121,6 +122,7 @@
 		000000000000000000000135 /* ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
 		000000000000000000000137 /* ShellHostControlCommandHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Shell/ShellHostControlCommandHandling.swift; sourceTree = "<group>"; };
+		000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSwipeMonitor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +197,7 @@
 			children = (
 				000000000000000000000118 /* ShellDesignTokens.swift */,
 				000000000000000000000136 /* ConsoleAdaptiveColor.swift */,
+				000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */,
 				000000000000000000000119 /* ShellWindowPlacement.swift */,
 				00000000000000000000011D /* ShellVoiceCommandController.swift */,
 			);
@@ -453,6 +456,7 @@
 				000000000000000000000035 /* ConsoleSupportViews.swift in Sources */,
 				000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */,
 				000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */,
+				000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/AlanNative/AlanNativeApp.swift
+++ b/clients/apple/AlanNative/AlanNativeApp.swift
@@ -6,8 +6,7 @@ struct AlanNativeApp: App {
     private let singletonGuard: AlanAppSingletonGuard
     @StateObject private var primaryShellOwner: AlanMacPrimaryShellOwner
     @NSApplicationDelegateAdaptor(AlanMacAppDelegate.self) private var appDelegate
-    @AppStorage("alanShellAppearanceMode") private var appearanceModeRawValue =
-        ShellAppearanceMode.system.rawValue
+    @AppStorage("alanShellAppearanceMode") private var appearanceMode = ShellAppearanceMode.system
     @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
 
     init() {
@@ -21,7 +20,7 @@ struct AlanNativeApp: App {
         Window("Alan", id: "main") {
             MacShellRootView(
                 host: primaryShellOwner.host,
-                appearanceMode: appearanceModeBinding,
+                appearanceMode: $appearanceMode,
                 isSidebarCollapsed: $isSidebarCollapsed
             )
                 .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
@@ -39,15 +38,4 @@ struct AlanNativeApp: App {
         #endif
     }
 
-    private var appearanceMode: ShellAppearanceMode {
-        ShellAppearanceMode(rawValue: appearanceModeRawValue) ?? .system
-    }
-
-    private var appearanceModeBinding: Binding<ShellAppearanceMode> {
-        Binding {
-            appearanceMode
-        } set: { mode in
-            appearanceModeRawValue = mode.rawValue
-        }
-    }
 }

--- a/clients/apple/AlanNative/AlanNativeApp.swift
+++ b/clients/apple/AlanNative/AlanNativeApp.swift
@@ -17,7 +17,7 @@ struct AlanNativeApp: App {
 
     var body: some Scene {
         #if os(macOS)
-        Window("Alan", id: "main") {
+        WindowGroup("Alan", id: "main") {
             MacShellRootView(
                 host: primaryShellOwner.host,
                 appearanceMode: $appearanceMode,
@@ -30,7 +30,13 @@ struct AlanNativeApp: App {
             AlanMacShellCommands(host: primaryShellOwner.host)
         }
         .windowStyle(.hiddenTitleBar)
-        .defaultSize(width: 1360, height: 860)
+        .defaultWindowPlacement { _, context in
+            let frame = ShellWindowSizing.defaultFrame(in: context.defaultDisplay.visibleRect)
+            return WindowPlacement(frame.origin, size: frame.size)
+        }
+        .windowResizability(.contentMinSize)
+        .restorationBehavior(.disabled)
+        .defaultLaunchBehavior(.presented)
         #else
         WindowGroup("Alan") {
             ContentView()

--- a/clients/apple/AlanNative/AlanNativeApp.swift
+++ b/clients/apple/AlanNative/AlanNativeApp.swift
@@ -17,7 +17,7 @@ struct AlanNativeApp: App {
 
     var body: some Scene {
         #if os(macOS)
-        WindowGroup("Alan", id: "main") {
+        Window("Alan", id: "main") {
             MacShellRootView(
                 host: primaryShellOwner.host,
                 appearanceMode: $appearanceMode,

--- a/clients/apple/AlanNative/AlanNativeApp.swift
+++ b/clients/apple/AlanNative/AlanNativeApp.swift
@@ -6,6 +6,9 @@ struct AlanNativeApp: App {
     private let singletonGuard: AlanAppSingletonGuard
     @StateObject private var primaryShellOwner: AlanMacPrimaryShellOwner
     @NSApplicationDelegateAdaptor(AlanMacAppDelegate.self) private var appDelegate
+    @AppStorage("alanShellAppearanceMode") private var appearanceModeRawValue =
+        ShellAppearanceMode.system.rawValue
+    @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
 
     init() {
         singletonGuard = AlanMacAppStartup.acquireSingletonOrTerminate()
@@ -16,7 +19,11 @@ struct AlanNativeApp: App {
     var body: some Scene {
         #if os(macOS)
         Window("Alan", id: "main") {
-            MacShellRootView(host: primaryShellOwner.host)
+            MacShellRootView(
+                host: primaryShellOwner.host,
+                appearanceMode: appearanceModeBinding,
+                isSidebarCollapsed: $isSidebarCollapsed
+            )
                 .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
                 .toolbar(removing: .title)
         }
@@ -30,5 +37,17 @@ struct AlanNativeApp: App {
             ContentView()
         }
         #endif
+    }
+
+    private var appearanceMode: ShellAppearanceMode {
+        ShellAppearanceMode(rawValue: appearanceModeRawValue) ?? .system
+    }
+
+    private var appearanceModeBinding: Binding<ShellAppearanceMode> {
+        Binding {
+            appearanceMode
+        } set: { mode in
+            appearanceModeRawValue = mode.rawValue
+        }
     }
 }

--- a/clients/apple/AlanNative/App/AlanMacShellCommands.swift
+++ b/clients/apple/AlanNative/App/AlanMacShellCommands.swift
@@ -25,7 +25,7 @@ struct AlanMacShellCommands: Commands {
             }
             .keyboardShortcut("t", modifiers: [.command, .option])
 
-            Button("Go to or Command...") {
+            Button("Ask Alan...") {
                 host.requestCommandInput()
             }
             .keyboardShortcut("p", modifiers: .command)

--- a/clients/apple/AlanNative/GhosttyLiveHost.swift
+++ b/clients/apple/AlanNative/GhosttyLiveHost.swift
@@ -37,7 +37,9 @@ final class AlanGhosttyLiveHost: NSObject {
         focused: Bool
     ) {
         let canvasChanged = self.canvasView !== canvasView
-        let bootProfileChanged = self.bootProfile != bootProfile
+        let needsSurfaceRecreation = bootProfile?.requiresSurfaceRecreation(
+            comparedTo: self.bootProfile
+        ) ?? (self.bootProfile != nil)
 
         self.canvasView = canvasView
         self.bootProfile = bootProfile
@@ -67,7 +69,7 @@ final class AlanGhosttyLiveHost: NSObject {
             return
         }
 
-        if surface == nil || bootProfileChanged || canvasChanged {
+        if surface == nil || needsSurfaceRecreation || canvasChanged {
             createSurface(on: canvasView, bootProfile: bootProfile)
         }
 

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -292,19 +292,16 @@ struct MacShellRootView: View {
     }
 
     private var collapsedSidebarRevealZone: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Color.clear
-                .frame(width: sidebarWidth, height: windowChromeMetrics.collapsedRevealHeaderHeight)
-            Color.clear
-                .frame(width: 18)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
-        }
-        .ignoresSafeArea()
-        .zIndex(10)
+        Color.clear
+            .frame(width: ShellSidebarMetrics.collapsedRevealEdgeWidth)
+            .frame(maxHeight: .infinity, alignment: .topLeading)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .ignoresSafeArea()
+            .zIndex(10)
     }
 
     private var floatingSidebarPanel: some View {
@@ -367,11 +364,6 @@ struct MacShellRootView: View {
                     + (isSidebarCollapsed ? floatingSidebarInset : 0)
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .onHover { hovering in
-                if isSidebarCollapsed {
-                    hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
-                }
-            }
         }
         .ignoresSafeArea(edges: .top)
         .zIndex(30)

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -252,7 +252,10 @@ struct MacShellRootView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea(edges: .top)
             }
-            .frame(minWidth: 1260, minHeight: 800)
+            .frame(
+                minWidth: ShellWindowSizing.minimumSize.width,
+                minHeight: ShellWindowSizing.minimumSize.height
+            )
 
             if isSidebarCollapsed {
                 collapsedSidebarRevealZone

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -2,9 +2,14 @@ import SwiftUI
 
 #if os(macOS)
 struct MacShellRootView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var host: ShellHostController
     @State private var isCommandTabPresented = false
+    @State private var isSpaceSwipeGestureLocked = false
+    @State private var spaceTransition: ShellSpaceTransition?
+    @State private var spaceTransitionToken = 0
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
+    private let sidebarWidth: CGFloat = 264
 
     init(host: ShellHostController) {
         self.host = host
@@ -25,6 +30,139 @@ struct MacShellRootView: View {
         }
     }
 
+    private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
+        switch update.phase {
+        case .began:
+            guard spaceTransition?.isSettling != true else { return }
+            isSpaceSwipeGestureLocked = true
+            beginSpaceTransition()
+        case .changed:
+            guard spaceTransition?.isSettling != true else { return }
+            isSpaceSwipeGestureLocked = true
+            updateSpaceTransition(translationX: update.translationX)
+        case .ended:
+            finishSpaceTransition(velocityX: update.velocityX)
+        case .cancelled:
+            settleSpaceTransition(committing: false)
+        }
+    }
+
+    private func beginSpaceTransition() {
+        guard let sourceSpaceID = host.selectedSpace?.spaceID else { return }
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            spaceTransition = ShellSpaceTransition(
+                sourceSpaceID: sourceSpaceID,
+                targetSpaceID: nil,
+                direction: 1,
+                offsetX: 0,
+                progress: 0,
+                isSettling: false
+            )
+        }
+    }
+
+    private func updateSpaceTransition(translationX: CGFloat) {
+        guard abs(translationX) > 0.5 else { return }
+        let sourceSpaceID = spaceTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
+        guard let sourceSpaceID else { return }
+
+        let direction = translationX < 0 ? 1 : -1
+        let targetSpaceID = adjacentSpaceID(from: sourceSpaceID, direction: direction)
+        let offsetX = targetSpaceID == nil ? resistedEdgeOffset(for: translationX) : translationX
+        let progress = min(abs(offsetX) / sidebarSwipePageWidth, 0.98)
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            spaceTransition = ShellSpaceTransition(
+                sourceSpaceID: sourceSpaceID,
+                targetSpaceID: targetSpaceID,
+                direction: direction,
+                offsetX: offsetX,
+                progress: progress,
+                isSettling: false
+            )
+        }
+    }
+
+    private func finishSpaceTransition(velocityX: CGFloat) {
+        guard let transition = spaceTransition else {
+            isSpaceSwipeGestureLocked = false
+            return
+        }
+        guard transition.targetSpaceID != nil else {
+            settleSpaceTransition(committing: false)
+            return
+        }
+
+        let velocityDirection = velocityX < 0 ? 1 : -1
+        let fastEnough = abs(velocityX) >= 120 && velocityDirection == transition.direction
+        let farEnough = transition.progress >= 0.28
+        settleSpaceTransition(committing: farEnough || fastEnough)
+    }
+
+    private func settleSpaceTransition(committing: Bool) {
+        guard var transition = spaceTransition else {
+            isSpaceSwipeGestureLocked = false
+            return
+        }
+        transition.isSettling = true
+        transition.offsetX = committing ? -CGFloat(transition.direction) * sidebarSwipePageWidth : 0
+        transition.progress = committing ? 1 : 0
+        spaceTransitionToken += 1
+        let token = spaceTransitionToken
+        let duration = reduceMotion ? 0.12 : 0.28
+
+        withAnimation(settleAnimation) {
+            spaceTransition = transition
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+            guard spaceTransitionToken == token else { return }
+            if committing, let targetSpaceID = transition.targetSpaceID {
+                host.select(spaceID: targetSpaceID)
+                DispatchQueue.main.async {
+                    host.refocusSelectedTerminalPane()
+                }
+            }
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                spaceTransition = nil
+                isSpaceSwipeGestureLocked = false
+            }
+        }
+    }
+
+    private var settleAnimation: Animation {
+        if reduceMotion {
+            return .easeOut(duration: 0.12)
+        }
+        return .interactiveSpring(response: 0.28, dampingFraction: 0.86, blendDuration: 0.04)
+    }
+
+    private var sidebarSwipePageWidth: CGFloat {
+        max(sidebarWidth, 1)
+    }
+
+    private func resistedEdgeOffset(for translationX: CGFloat) -> CGFloat {
+        let edgeLimit = sidebarSwipePageWidth * 0.18
+        let distance = abs(translationX)
+        let resistedDistance = edgeLimit * distance / (distance + edgeLimit)
+        return translationX < 0 ? -resistedDistance : resistedDistance
+    }
+
+    private func adjacentSpaceID(from sourceSpaceID: String, direction: Int) -> String? {
+        guard let sourceIndex = host.spaces.firstIndex(where: { $0.spaceID == sourceSpaceID }) else {
+            return nil
+        }
+        let targetIndex = sourceIndex + direction
+        guard host.spaces.indices.contains(targetIndex) else { return nil }
+        return host.spaces[targetIndex].spaceID
+    }
+
     var body: some View {
         ZStack {
             ShellSpaceKeyboardShortcuts(host: host)
@@ -35,11 +173,14 @@ struct MacShellRootView: View {
             HStack(spacing: 0) {
                 ShellSidebarView(
                     host: host,
-                    chromeMetrics: windowChromeMetrics
+                    chromeMetrics: windowChromeMetrics,
+                    spaceTransition: spaceTransition,
+                    isSpaceSwipeGestureLocked: isSpaceSwipeGestureLocked,
+                    onSpaceSwipe: handleSpaceSwipe
                 ) {
                     presentCommandInput()
                 }
-                .frame(width: 286)
+                .frame(width: sidebarWidth)
 
                 ShellWorkspaceView(host: host)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -8,7 +8,9 @@ struct MacShellRootView: View {
     @Binding private var isSidebarCollapsed: Bool
     @State private var isCommandTabPresented = false
     @State private var isSidebarPanelRevealed = false
+    @State private var areFloatingSidebarTrafficLightsVisible = false
     @State private var sidebarRevealToken = 0
+    @State private var floatingSidebarTrafficLightRevealToken = 0
     @State private var isSpaceSwipeGestureLocked = false
     @State private var spaceTransition: ShellSpaceTransition?
     @State private var spaceTransitionToken = 0
@@ -16,6 +18,7 @@ struct MacShellRootView: View {
     @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
     private let sidebarWidth: CGFloat = 264
     private let floatingSidebarInset: CGFloat = 6
+    private let floatingSidebarTrafficLightRevealDelay: TimeInterval = 0.08
 
     init(
         host: ShellHostController,
@@ -179,12 +182,34 @@ struct MacShellRootView: View {
         !isSidebarCollapsed || isSidebarPanelRevealed
     }
 
+    private var windowChromeSurface: ShellWindowChromeSurface {
+        ShellWindowChromeSurface(
+            isVisible: isSidebarSurfaceVisible,
+            origin: isSidebarCollapsed && isSidebarPanelRevealed
+                ? CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
+                : .zero,
+            width: sidebarWidth,
+            showsStandardTrafficLights: shouldShowStandardTrafficLights
+        )
+    }
+
+    private var shouldShowStandardTrafficLights: Bool {
+        guard isSidebarCollapsed else { return true }
+        return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
+    }
+
     private func revealCollapsedSidebarPanel() {
         guard isSidebarCollapsed else { return }
         sidebarRevealToken += 1
+        guard !isSidebarPanelRevealed else { return }
+
+        areFloatingSidebarTrafficLightsVisible = false
+        floatingSidebarTrafficLightRevealToken += 1
+        let token = floatingSidebarTrafficLightRevealToken
         withAnimation(sidebarPanelRevealAnimation) {
             isSidebarPanelRevealed = true
         }
+        scheduleFloatingSidebarTrafficLightReveal(token: token)
     }
 
     private func scheduleCollapsedSidebarHide() {
@@ -193,9 +218,30 @@ struct MacShellRootView: View {
         let token = sidebarRevealToken
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
             guard sidebarRevealToken == token, isSidebarCollapsed else { return }
+            areFloatingSidebarTrafficLightsVisible = false
+            floatingSidebarTrafficLightRevealToken += 1
             withAnimation(sidebarPanelHideAnimation) {
                 isSidebarPanelRevealed = false
             }
+        }
+    }
+
+    private func scheduleFloatingSidebarTrafficLightReveal(token: Int) {
+        let delay = reduceMotion ? 0 : floatingSidebarTrafficLightRevealDelay
+        let reveal = {
+            guard floatingSidebarTrafficLightRevealToken == token,
+                  isSidebarCollapsed,
+                  isSidebarPanelRevealed
+            else {
+                return
+            }
+            areFloatingSidebarTrafficLightsVisible = true
+        }
+
+        if delay <= 0 {
+            DispatchQueue.main.async(execute: reveal)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: reveal)
         }
     }
 
@@ -230,6 +276,8 @@ struct MacShellRootView: View {
         withAnimation(sidebarPinnedStateAnimation) {
             isSidebarCollapsed = collapsed
             isSidebarPanelRevealed = false
+            areFloatingSidebarTrafficLightsVisible = false
+            floatingSidebarTrafficLightRevealToken += 1
         }
     }
 
@@ -301,6 +349,7 @@ struct MacShellRootView: View {
             ShellWindowPlacementView(
                 metrics: $windowChromeMetrics,
                 appearanceMode: appearanceMode,
+                chromeSurface: windowChromeSurface,
                 systemColorScheme: $systemColorScheme
             )
         )

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -4,15 +4,26 @@ import SwiftUI
 struct MacShellRootView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var host: ShellHostController
+    @Binding private var appearanceMode: ShellAppearanceMode
+    @Binding private var isSidebarCollapsed: Bool
     @State private var isCommandTabPresented = false
+    @State private var isSidebarPanelRevealed = false
+    @State private var sidebarRevealToken = 0
     @State private var isSpaceSwipeGestureLocked = false
     @State private var spaceTransition: ShellSpaceTransition?
     @State private var spaceTransitionToken = 0
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
     private let sidebarWidth: CGFloat = 264
+    private let floatingSidebarInset: CGFloat = 6
 
-    init(host: ShellHostController) {
+    init(
+        host: ShellHostController,
+        appearanceMode: Binding<ShellAppearanceMode> = .constant(.system),
+        isSidebarCollapsed: Binding<Bool> = .constant(false)
+    ) {
         self.host = host
+        _appearanceMode = appearanceMode
+        _isSidebarCollapsed = isSidebarCollapsed
     }
 
     private func presentCommandInput() {
@@ -163,6 +174,41 @@ struct MacShellRootView: View {
         return host.spaces[targetIndex].spaceID
     }
 
+    private var isSidebarSurfaceVisible: Bool {
+        !isSidebarCollapsed || isSidebarPanelRevealed
+    }
+
+    private func revealCollapsedSidebarPanel() {
+        guard isSidebarCollapsed else { return }
+        sidebarRevealToken += 1
+        withAnimation(sidebarPanelAnimation) {
+            isSidebarPanelRevealed = true
+        }
+    }
+
+    private func scheduleCollapsedSidebarHide() {
+        guard isSidebarCollapsed else { return }
+        sidebarRevealToken += 1
+        let token = sidebarRevealToken
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+            guard sidebarRevealToken == token, isSidebarCollapsed else { return }
+            withAnimation(sidebarPanelAnimation) {
+                isSidebarPanelRevealed = false
+            }
+        }
+    }
+
+    private var sidebarPanelAnimation: Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.16)
+    }
+
+    private func updateSidebarCollapsed(_ collapsed: Bool) {
+        withAnimation(sidebarPanelAnimation) {
+            isSidebarCollapsed = collapsed
+            isSidebarPanelRevealed = false
+        }
+    }
+
     var body: some View {
         ZStack {
             ShellSpaceKeyboardShortcuts(host: host)
@@ -171,22 +217,32 @@ struct MacShellRootView: View {
                 .ignoresSafeArea()
 
             HStack(spacing: 0) {
-                ShellSidebarView(
-                    host: host,
-                    chromeMetrics: windowChromeMetrics,
-                    spaceTransition: spaceTransition,
-                    isSpaceSwipeGestureLocked: isSpaceSwipeGestureLocked,
-                    onSpaceSwipe: handleSpaceSwipe
-                ) {
-                    presentCommandInput()
+                if !isSidebarCollapsed {
+                    sidebarContent
+                    .frame(width: sidebarWidth)
+                    .ignoresSafeArea(edges: .top)
+                    .transition(.move(edge: .leading).combined(with: .opacity))
                 }
-                .frame(width: sidebarWidth)
 
                 ShellWorkspaceView(host: host)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea(edges: .top)
             }
             .frame(minWidth: 1260, minHeight: 800)
+
+            if isSidebarCollapsed {
+                collapsedSidebarRevealZone
+
+                if isSidebarPanelRevealed {
+                    floatingSidebarPanel
+                        .transition(.move(edge: .leading).combined(with: .opacity))
+                }
+            }
+
+            if isSidebarSurfaceVisible {
+                sidebarChromeControls
+                    .transition(.opacity)
+            }
 
             if isCommandTabPresented {
                 ShellPalette.overlayScrim
@@ -199,15 +255,204 @@ struct MacShellRootView: View {
                     host: host,
                     isPresented: $isCommandTabPresented
                 )
-                .frame(width: 520)
+                .frame(width: 560)
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
         .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
+        .animation(sidebarPanelAnimation, value: isSidebarCollapsed)
+        .animation(sidebarPanelAnimation, value: isSidebarPanelRevealed)
+        .preferredColorScheme(appearanceMode.colorScheme)
+        .onChange(of: isSidebarCollapsed) { _, collapsed in
+            if !collapsed {
+                isSidebarPanelRevealed = false
+            }
+        }
         .onChange(of: host.commandInputRequestID) { _, _ in
             presentCommandInput()
         }
-        .background(ShellWindowPlacementView(metrics: $windowChromeMetrics))
+        .background(
+            ShellWindowPlacementView(
+                metrics: $windowChromeMetrics,
+                appearanceMode: appearanceMode
+            )
+        )
+    }
+
+    private var sidebarContent: some View {
+        ShellSidebarView(
+            host: host,
+            chromeMetrics: windowChromeMetrics,
+            spaceTransition: spaceTransition,
+            isSpaceSwipeGestureLocked: isSpaceSwipeGestureLocked,
+            onSpaceSwipe: handleSpaceSwipe
+        ) {
+            presentCommandInput()
+        }
+    }
+
+    private var collapsedSidebarRevealZone: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Color.clear
+                .frame(width: sidebarWidth, height: windowChromeMetrics.collapsedRevealHeaderHeight)
+            Color.clear
+                .frame(width: 18)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
+        }
+        .ignoresSafeArea()
+        .zIndex(10)
+    }
+
+    private var floatingSidebarPanel: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: ShellRadii.floatingSidebarPanel, style: .continuous)
+                .fill(.clear)
+                .background {
+                    ShellMaterialBackgroundView(.sidebarGlass)
+                        .clipShape(
+                            RoundedRectangle(
+                                cornerRadius: ShellRadii.floatingSidebarPanel,
+                                style: .continuous
+                            )
+                        )
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: ShellRadii.floatingSidebarPanel, style: .continuous)
+                        .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
+                }
+
+            sidebarContent
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: ShellRadii.floatingSidebarPanel,
+                        style: .continuous
+                    )
+                )
+        }
+        .frame(width: sidebarWidth, alignment: .topLeading)
+        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .padding(.leading, floatingSidebarInset)
+        .padding(.top, floatingSidebarInset)
+        .padding(.bottom, floatingSidebarInset)
+        .shellShadow(ShellShadows.floatingOverlay)
+        .onHover { hovering in
+            hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
+        }
+        .ignoresSafeArea(edges: [.top, .bottom])
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .zIndex(20)
+    }
+
+    private var sidebarChromeControls: some View {
+        GeometryReader { _ in
+            HStack(spacing: ShellSidebarMetrics.titlebarToolSpacing) {
+                ShellSidebarCollapseControl(isCollapsed: isSidebarCollapsed) {
+                    updateSidebarCollapsed(!isSidebarCollapsed)
+                }
+
+                ShellAppearanceModeControl(mode: $appearanceMode)
+            }
+            .padding(
+                .leading,
+                windowChromeMetrics.titlebarToolLeadingInset
+                    + (isSidebarCollapsed ? floatingSidebarInset : 0)
+            )
+            .padding(
+                .top,
+                windowChromeMetrics.titlebarToolTopInset
+                    + (isSidebarCollapsed ? floatingSidebarInset : 0)
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .onHover { hovering in
+                if isSidebarCollapsed {
+                    hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
+                }
+            }
+        }
+        .ignoresSafeArea(edges: .top)
+        .zIndex(30)
+    }
+}
+
+private struct ShellSidebarCollapseControl: View {
+    let isCollapsed: Bool
+    let action: () -> Void
+
+    var body: some View {
+        ShellGhostChromeButton(
+            systemName: "sidebar.left",
+            help: isCollapsed ? "Pin Sidebar" : "Hide Sidebar",
+            accessibilityLabel: isCollapsed ? "Pin Sidebar" : "Hide Sidebar",
+            action: action
+        )
+    }
+}
+
+private struct ShellAppearanceModeControl: View {
+    @Binding var mode: ShellAppearanceMode
+
+    var body: some View {
+        ShellGhostChromeButton(
+            systemName: mode.symbolName,
+            help: "Appearance: \(mode.label). Click for \(mode.next.label).",
+            accessibilityLabel: "Appearance",
+            accessibilityValue: mode.label
+        ) {
+            mode = mode.next
+        }
+    }
+}
+
+private struct ShellGhostChromeButton: View {
+    let systemName: String
+    let help: String
+    let accessibilityLabel: String
+    var accessibilityValue: String?
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 14, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(iconForeground)
+                .frame(
+                    width: ShellSidebarMetrics.titlebarToolWidth,
+                    height: ShellSidebarMetrics.titlebarToolHeight
+                )
+                .background {
+                    if isHovered {
+                        RoundedRectangle(cornerRadius: ShellRadii.titlebarTool, style: .continuous)
+                            .fill(ShellPalette.titlebarToolGlassTint.opacity(0.20))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: ShellRadii.titlebarTool, style: .continuous)
+                                    .stroke(ShellPalette.line.opacity(0.18), lineWidth: 0.6)
+                            }
+                    }
+                }
+                .contentShape(
+                    RoundedRectangle(cornerRadius: ShellRadii.titlebarTool, style: .continuous)
+                )
+        }
+        .buttonStyle(.plain)
+        .controlSize(.regular)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .help(help)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(accessibilityValue ?? "")
+    }
+
+    private var iconForeground: Color {
+        isHovered
+            ? ShellPalette.sidebarInk.opacity(0.84)
+            : ShellPalette.sidebarMutedInk.opacity(0.76)
     }
 }
 #endif

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -181,7 +181,7 @@ struct MacShellRootView: View {
     private func revealCollapsedSidebarPanel() {
         guard isSidebarCollapsed else { return }
         sidebarRevealToken += 1
-        withAnimation(sidebarPanelAnimation) {
+        withAnimation(sidebarPanelRevealAnimation) {
             isSidebarPanelRevealed = true
         }
     }
@@ -192,18 +192,37 @@ struct MacShellRootView: View {
         let token = sidebarRevealToken
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
             guard sidebarRevealToken == token, isSidebarCollapsed else { return }
-            withAnimation(sidebarPanelAnimation) {
+            withAnimation(sidebarPanelHideAnimation) {
                 isSidebarPanelRevealed = false
             }
         }
     }
 
-    private var sidebarPanelAnimation: Animation? {
+    private func handleCollapsedSidebarHover(_ hovering: Bool) {
+        hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
+    }
+
+    private func handleCollapsedSidebarToolbarHover(_ hovering: Bool) {
+        guard isSidebarCollapsed else { return }
+        handleCollapsedSidebarHover(hovering)
+    }
+
+    private var sidebarPanelRevealAnimation: Animation? {
+        reduceMotion
+            ? nil
+            : .interactiveSpring(response: 0.28, dampingFraction: 0.86, blendDuration: 0.02)
+    }
+
+    private var sidebarPanelHideAnimation: Animation? {
+        reduceMotion ? nil : .easeInOut(duration: 0.18)
+    }
+
+    private var sidebarPinnedStateAnimation: Animation? {
         reduceMotion ? nil : .easeOut(duration: 0.16)
     }
 
     private func updateSidebarCollapsed(_ collapsed: Bool) {
-        withAnimation(sidebarPanelAnimation) {
+        withAnimation(sidebarPinnedStateAnimation) {
             isSidebarCollapsed = collapsed
             isSidebarPanelRevealed = false
         }
@@ -235,7 +254,7 @@ struct MacShellRootView: View {
 
                 if isSidebarPanelRevealed {
                     floatingSidebarPanel
-                        .transition(.move(edge: .leading).combined(with: .opacity))
+                        .transition(floatingSidebarPanelTransition)
                 }
             }
 
@@ -260,8 +279,7 @@ struct MacShellRootView: View {
             }
         }
         .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
-        .animation(sidebarPanelAnimation, value: isSidebarCollapsed)
-        .animation(sidebarPanelAnimation, value: isSidebarPanelRevealed)
+        .animation(sidebarPinnedStateAnimation, value: isSidebarCollapsed)
         .preferredColorScheme(appearanceMode.colorScheme)
         .onChange(of: isSidebarCollapsed) { _, collapsed in
             if !collapsed {
@@ -296,9 +314,7 @@ struct MacShellRootView: View {
             .frame(width: ShellSidebarMetrics.collapsedRevealEdgeWidth)
             .frame(maxHeight: .infinity, alignment: .topLeading)
             .contentShape(Rectangle())
-            .onHover { hovering in
-                hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
-            }
+            .onHover(perform: handleCollapsedSidebarHover)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .ignoresSafeArea()
             .zIndex(10)
@@ -336,12 +352,17 @@ struct MacShellRootView: View {
         .padding(.top, floatingSidebarInset)
         .padding(.bottom, floatingSidebarInset)
         .shellShadow(ShellShadows.floatingPanel)
-        .onHover { hovering in
-            hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
-        }
+        .onHover(perform: handleCollapsedSidebarHover)
         .ignoresSafeArea(edges: [.top, .bottom])
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .zIndex(20)
+    }
+
+    private var floatingSidebarPanelTransition: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: .leading).combined(with: .opacity),
+            removal: .move(edge: .leading)
+        )
     }
 
     private var sidebarChromeControls: some View {
@@ -363,6 +384,8 @@ struct MacShellRootView: View {
                 windowChromeMetrics.titlebarToolTopInset
                     + (isSidebarCollapsed ? floatingSidebarInset : 0)
             )
+            .contentShape(Rectangle())
+            .onHover(perform: handleCollapsedSidebarToolbarHover)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .ignoresSafeArea(edges: .top)

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -13,6 +13,7 @@ struct MacShellRootView: View {
     @State private var spaceTransition: ShellSpaceTransition?
     @State private var spaceTransitionToken = 0
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
+    @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
     private let sidebarWidth: CGFloat = 264
     private let floatingSidebarInset: CGFloat = 6
 
@@ -221,6 +222,10 @@ struct MacShellRootView: View {
         reduceMotion ? nil : .easeOut(duration: 0.16)
     }
 
+    private var resolvedAppearanceColorScheme: ColorScheme {
+        appearanceMode.resolvedColorScheme(systemColorScheme: systemColorScheme)
+    }
+
     private func updateSidebarCollapsed(_ collapsed: Bool) {
         withAnimation(sidebarPinnedStateAnimation) {
             isSidebarCollapsed = collapsed
@@ -280,7 +285,7 @@ struct MacShellRootView: View {
         }
         .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
         .animation(sidebarPinnedStateAnimation, value: isSidebarCollapsed)
-        .preferredColorScheme(appearanceMode.colorScheme)
+        .environment(\.colorScheme, resolvedAppearanceColorScheme)
         .onChange(of: isSidebarCollapsed) { _, collapsed in
             if !collapsed {
                 isSidebarPanelRevealed = false
@@ -292,7 +297,8 @@ struct MacShellRootView: View {
         .background(
             ShellWindowPlacementView(
                 metrics: $windowChromeMetrics,
-                appearanceMode: appearanceMode
+                appearanceMode: appearanceMode,
+                systemColorScheme: $systemColorScheme
             )
         )
     }

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -243,7 +243,7 @@ struct MacShellRootView: View {
                     .transition(.move(edge: .leading).combined(with: .opacity))
                 }
 
-                ShellWorkspaceView(host: host)
+                ShellWorkspaceView(host: host, hasExpandedSidebar: !isSidebarCollapsed)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .ignoresSafeArea(edges: .top)
             }

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -338,7 +338,7 @@ struct MacShellRootView: View {
         .padding(.leading, floatingSidebarInset)
         .padding(.top, floatingSidebarInset)
         .padding(.bottom, floatingSidebarInset)
-        .shellShadow(ShellShadows.floatingOverlay)
+        .shellShadow(ShellShadows.floatingPanel)
         .onHover { hovering in
             hovering ? revealCollapsedSidebarPanel() : scheduleCollapsedSidebarHide()
         }

--- a/clients/apple/AlanNative/MacShellRootView.swift
+++ b/clients/apple/AlanNative/MacShellRootView.swift
@@ -19,6 +19,7 @@ struct MacShellRootView: View {
     private let sidebarWidth: CGFloat = 264
     private let floatingSidebarInset: CGFloat = 6
     private let floatingSidebarTrafficLightRevealDelay: TimeInterval = 0.08
+    private let hiddenCommandInputOpacity = 0.001
 
     init(
         host: ShellHostController,
@@ -30,14 +31,22 @@ struct MacShellRootView: View {
         _isSidebarCollapsed = isSidebarCollapsed
     }
 
+    private func toggleCommandInput() {
+        if isCommandTabPresented {
+            dismissCommandInput()
+        } else {
+            presentCommandInput()
+        }
+    }
+
     private func presentCommandInput() {
-        withAnimation(.easeOut(duration: 0.18)) {
+        withAnimation(commandInputAnimation) {
             isCommandTabPresented = true
         }
     }
 
     private func dismissCommandInput() {
-        withAnimation(.easeOut(duration: 0.18)) {
+        withAnimation(commandInputAnimation) {
             isCommandTabPresented = false
         }
         DispatchQueue.main.async {
@@ -182,6 +191,14 @@ struct MacShellRootView: View {
         !isSidebarCollapsed || isSidebarPanelRevealed
     }
 
+    private var commandInputOpacity: Double {
+        isCommandTabPresented ? 1 : hiddenCommandInputOpacity
+    }
+
+    private var commandInputAnimation: Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.14)
+    }
+
     private var windowChromeSurface: ShellWindowChromeSurface {
         ShellWindowChromeSurface(
             isVisible: isSidebarSurfaceVisible,
@@ -320,21 +337,29 @@ struct MacShellRootView: View {
             }
 
             if isCommandTabPresented {
-                ShellPalette.overlayScrim
+                Color.clear
                     .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .transition(.identity)
+                    .transaction { transaction in
+                        transaction.animation = nil
+                        transaction.disablesAnimations = true
+                    }
                     .onTapGesture {
                         dismissCommandInput()
                     }
-
-                ShellCommandTabView(
-                    host: host,
-                    isPresented: $isCommandTabPresented
-                )
-                .frame(width: 560)
-                .transition(.move(edge: .top).combined(with: .opacity))
             }
+
+            ShellCommandTabView(
+                host: host,
+                isPresented: $isCommandTabPresented,
+                isActive: isCommandTabPresented
+            )
+            .frame(width: 560)
+            .opacity(commandInputOpacity)
+            .allowsHitTesting(isCommandTabPresented)
+            .accessibilityHidden(!isCommandTabPresented)
         }
-        .animation(.easeOut(duration: 0.18), value: isCommandTabPresented)
         .animation(sidebarPinnedStateAnimation, value: isSidebarCollapsed)
         .environment(\.colorScheme, resolvedAppearanceColorScheme)
         .onChange(of: isSidebarCollapsed) { _, collapsed in
@@ -343,7 +368,7 @@ struct MacShellRootView: View {
             }
         }
         .onChange(of: host.commandInputRequestID) { _, _ in
-            presentCommandInput()
+            toggleCommandInput()
         }
         .background(
             ShellWindowPlacementView(

--- a/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/AlanNative/Models/Shell/ShellStateMutations.swift
@@ -120,13 +120,14 @@ extension ShellStateSnapshot {
         launchTarget: ShellLaunchTarget,
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
         let spaceIndex = spaces.count + 1
         let spaceID = nextID(prefix: "space", existing: spaces.map(\.spaceID))
         let tabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
-        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID))
+        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
         let pane = makeTerminalPane(
             paneID: paneID,
             tabID: tabID,
@@ -172,6 +173,7 @@ extension ShellStateSnapshot {
     func creatingAlanSpace(
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
@@ -179,6 +181,7 @@ extension ShellStateSnapshot {
             launchTarget: .alan,
             title: title,
             workingDirectory: workingDirectory,
+            reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
         )
@@ -187,6 +190,7 @@ extension ShellStateSnapshot {
     func creatingTerminalSpace(
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) -> ShellStateMutationResult {
@@ -194,6 +198,7 @@ extension ShellStateSnapshot {
             launchTarget: .shell,
             title: title,
             workingDirectory: workingDirectory,
+            reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
         )
@@ -204,6 +209,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
@@ -215,7 +221,7 @@ extension ShellStateSnapshot {
         }
 
         let tabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
-        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID))
+        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
         let pane = makeTerminalPane(
             paneID: paneID,
             tabID: tabID,
@@ -264,6 +270,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
@@ -272,6 +279,7 @@ extension ShellStateSnapshot {
             in: requestedSpaceID,
             title: title,
             workingDirectory: workingDirectory,
+            reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
         )
@@ -281,6 +289,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
@@ -289,6 +298,7 @@ extension ShellStateSnapshot {
             in: requestedSpaceID,
             title: title,
             workingDirectory: workingDirectory,
+            reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
         )
@@ -297,12 +307,14 @@ extension ShellStateSnapshot {
     func splittingPane(
         _ paneID: String,
         direction: ShellSplitDirection,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
         try splittingPane(
             paneID,
             placement: .defaultPlacement(for: direction),
+            reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
         )
@@ -311,6 +323,7 @@ extension ShellStateSnapshot {
     func splittingPane(
         _ paneID: String,
         placement: ShellPaneSplitDirection,
+        reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
     ) throws -> ShellStateMutationResult {
@@ -320,7 +333,7 @@ extension ShellStateSnapshot {
             throw ShellStateMutationError.paneNotFound
         }
 
-        let newPaneID = nextID(prefix: "pane", existing: panes.map(\.paneID))
+        let newPaneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
         let splitNodeID = nextID(
             prefix: "node",
             existing: spaces.flatMap(\.tabs).flatMap { $0.paneTree.nodeIDs }

--- a/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/AlanNative/Services/Shell/ShellSocketServer.swift
@@ -351,6 +351,8 @@ final class AlanShellSocketServer {
     }
 
     func handleLocally(_ command: AlanShellControlCommand) -> AlanShellControlResponse? {
+        guard !command.command.allocatesPaneID else { return nil }
+
         let localResult: AlanShellLocalCommandResult? = {
             stateLock.lock()
             defer { stateLock.unlock() }
@@ -390,6 +392,17 @@ final class AlanShellSocketServer {
             }
         } else {
             try? Data(line.utf8).write(to: logURL, options: .atomic)
+        }
+    }
+}
+
+private extension AlanShellControlCommandKind {
+    var allocatesPaneID: Bool {
+        switch self {
+        case .spaceCreate, .spaceOpenAlan, .tabOpen, .paneSplit:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/clients/apple/AlanNative/ShellHostController.swift
+++ b/clients/apple/AlanNative/ShellHostController.swift
@@ -369,7 +369,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         let result = shellState.creatingSpace(
             launchTarget: launchTarget,
             title: title,
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
         )
         applyMutationResult(result)
         return result.spaceID
@@ -398,7 +399,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 launchTarget: launchTarget,
                 in: spaceID,
                 title: title,
-                workingDirectory: workingDirectory
+                workingDirectory: workingDirectory,
+                reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
             )
         } catch {
             return nil
@@ -457,7 +459,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         do {
             result = try shellState.splittingPane(
                 paneID,
-                placement: placement
+                placement: placement,
+                reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
             )
         } catch {
             return nil

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -38,6 +38,20 @@ enum ShellPalette {
         light: (0.972, 0.973, 0.985),
         dark: (0.055, 0.061, 0.074)
     )
+    static let windowBackdropTint = Color.shellAdaptive(
+        light: (0.755, 0.765, 0.850),
+        lightAlpha: 0.44,
+        dark: (0.040, 0.047, 0.062),
+        darkAlpha: 0.78
+    )
+    static let sidebarInk = Color.shellAdaptive(
+        light: (0.030, 0.060, 0.220),
+        dark: (0.90, 0.92, 0.97)
+    )
+    static let sidebarMutedInk = Color.shellAdaptive(
+        light: (0.430, 0.430, 0.540),
+        dark: (0.65, 0.68, 0.76)
+    )
     static let sidebar = Color.shellAdaptive(
         light: (0.922, 0.924, 0.953),
         dark: (0.071, 0.079, 0.096)
@@ -54,27 +68,51 @@ enum ShellPalette {
     )
     static let sidebarSelection = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.15,
+        lightAlpha: 0.24,
         dark: (0.205, 0.225, 0.270),
         darkAlpha: 0.72
     )
     static let sidebarHover = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.08,
+        lightAlpha: 0.11,
         dark: (0.185, 0.205, 0.245),
         darkAlpha: 0.46
     )
+    static let sidebarRowHover = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.13,
+        dark: (0.185, 0.205, 0.245),
+        darkAlpha: 0.40
+    )
+    static let sidebarRowSelected = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        lightAlpha: 0.78,
+        dark: (0.215, 0.235, 0.282),
+        darkAlpha: 0.78
+    )
     static let sidebarControl = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.12,
+        lightAlpha: 0.18,
         dark: (0.190, 0.210, 0.252),
         darkAlpha: 0.54
     )
     static let sidebarControlStrong = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.18,
+        lightAlpha: 0.24,
         dark: (0.215, 0.235, 0.282),
         darkAlpha: 0.72
+    )
+    static let commandGlassTint = Color.shellAdaptive(
+        light: (0.720, 0.730, 0.790),
+        lightAlpha: 1.0,
+        dark: (0.215, 0.235, 0.282),
+        darkAlpha: 0.72
+    )
+    static let titlebarToolGlassTint = Color.shellAdaptive(
+        light: (0.720, 0.730, 0.790),
+        lightAlpha: 1.0,
+        dark: (0.215, 0.235, 0.282),
+        darkAlpha: 0.70
     )
     static let railBase = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
@@ -90,7 +128,7 @@ enum ShellPalette {
     )
     static let railSelection = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.22,
+        lightAlpha: 0.30,
         dark: (0.235, 0.255, 0.310),
         darkAlpha: 0.78
     )
@@ -145,20 +183,20 @@ enum ShellPalette {
         darkAlpha: 0.34
     )
     static let materialScrim = Color.shellAdaptive(
-        light: (0.922, 0.924, 0.953),
-        lightAlpha: 0.35,
+        light: (0.760, 0.770, 0.865),
+        lightAlpha: 0.34,
         dark: (0.030, 0.037, 0.050),
         darkAlpha: 0.78
     )
     static let materialTopWash = Color.shellAdaptive(
         light: (1.0, 1.0, 1.0),
-        lightAlpha: 0.06,
+        lightAlpha: 0.08,
         dark: (0.130, 0.150, 0.205),
         darkAlpha: 0.18
     )
     static let materialBottomShade = Color.shellAdaptive(
-        light: (0.84, 0.86, 0.92),
-        lightAlpha: 0.04,
+        light: (0.60, 0.62, 0.76),
+        lightAlpha: 0.06,
         dark: (0.012, 0.016, 0.024),
         darkAlpha: 0.34
     )
@@ -173,6 +211,132 @@ enum ShellRadii {
     static let row: CGFloat = 8
     static let surface: CGFloat = 10
     static let overlay: CGFloat = 12
+    static let floatingSidebarPanel: CGFloat = 16
+    static let titlebarTool: CGFloat = 9
+    static let terminalSurface: CGFloat = 22
+}
+
+enum ShellSidebarMetrics {
+    static let edgeInset: CGFloat = 12
+    static let rowInset: CGFloat = 10
+    static let iconColumnWidth: CGFloat = 16
+    static let iconPointSize: CGFloat = 12
+    static let trafficLightLeadingInset: CGFloat = 14
+    static let trafficLightTopInset: CGFloat = 16
+    static let trafficLightFallbackGroupWidth: CGFloat = 58
+    static let trafficLightFallbackButtonHeight: CGFloat = 14
+    static let titlebarToolWidth: CGFloat = 31
+    static let titlebarToolHeight: CGFloat = 30
+    static let titlebarToolGapAfterTrafficLights: CGFloat = 12
+    static let titlebarToolSpacing: CGFloat = 6
+    static let commandLauncherGapBelowTrafficLights: CGFloat = 15
+    static let commandLauncherHeight: CGFloat = 34
+}
+
+struct ShellShadowStyle {
+    let color: Color
+    let radius: CGFloat
+    let x: CGFloat
+    let y: CGFloat
+
+    init(color: Color, radius: CGFloat, x: CGFloat = 0, y: CGFloat) {
+        self.color = color
+        self.radius = radius
+        self.x = x
+        self.y = y
+    }
+}
+
+enum ShellShadows {
+    static let none = ShellShadowStyle(color: .clear, radius: 0, y: 0)
+    static let terminalSurface = ShellShadowStyle(color: Color.black.opacity(0.075), radius: 9, y: 3)
+    static let floatingOverlay = ShellShadowStyle(color: Color.black.opacity(0.10), radius: 13, y: 7)
+    static let floatingInput = ShellShadowStyle(color: Color.black.opacity(0.10), radius: 8, y: 3)
+    static let commandPalette = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.16, 0.17, 0.24),
+            lightAlpha: 0.18,
+            dark: (0, 0, 0),
+            darkAlpha: 0.38
+        ),
+        radius: 26,
+        y: 15
+    )
+    static let sidebarSelection = ShellShadowStyle(color: Color.black.opacity(0.035), radius: 3, y: 1)
+    static let spaceSelection = ShellShadowStyle(
+        color: ShellPalette.accent.opacity(0.085),
+        radius: 4,
+        y: 1.5
+    )
+}
+
+extension View {
+    func shellShadow(_ style: ShellShadowStyle) -> some View {
+        shadow(color: style.color, radius: style.radius, x: style.x, y: style.y)
+    }
+}
+
+enum ShellAppearanceMode: String, CaseIterable, Identifiable {
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system:
+            return "System"
+        case .light:
+            return "Light"
+        case .dark:
+            return "Dark"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .system:
+            return "circle.lefthalf.filled"
+        case .light:
+            return "sun.max"
+        case .dark:
+            return "moon"
+        }
+    }
+
+    var next: ShellAppearanceMode {
+        switch self {
+        case .system:
+            return .light
+        case .light:
+            return .dark
+        case .dark:
+            return .system
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system:
+            return nil
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+
+    var nsAppearanceName: NSAppearance.Name? {
+        switch self {
+        case .system:
+            return nil
+        case .light:
+            return .aqua
+        case .dark:
+            return .darkAqua
+        }
+    }
 }
 
 enum ShellMaterialRole {
@@ -194,7 +358,7 @@ enum ShellMaterialRole {
     var visualEffectMaterial: NSVisualEffectView.Material? {
         switch self {
         case .windowBackdrop:
-            return .windowBackground
+            return .sidebar
         case .sidebarGlass:
             return .sidebar
         case .workspaceBackdrop:
@@ -237,7 +401,7 @@ enum ShellMaterialRole {
     var fill: Color {
         switch self {
         case .windowBackdrop:
-            return ShellPalette.window
+            return ShellPalette.windowBackdropTint
         case .sidebarGlass:
             return ShellPalette.materialScrim
         case .workspaceBackdrop:
@@ -478,6 +642,90 @@ struct ShellMaterialShape<MaterialShape: InsettableShape>: View {
                     shape.stroke(role.resolvedStroke(increasedContrast: increasedContrast), lineWidth: 1)
                 }
             }
+    }
+}
+
+struct ShellLiquidGlassSurface<SurfaceShape: InsettableShape>: View {
+    let shape: SurfaceShape
+    var tint = ShellPalette.sidebarControl
+    var tintOpacity: Double = 0.16
+    var strokeOpacity: Double = 0.20
+    var usesSystemGlassInLightMode = false
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        let increasedContrast = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+
+        if usesSystemGlassEffect(increasedContrast: increasedContrast) {
+            baseFill(increasedContrast: increasedContrast)
+                .glassEffect(.regular.interactive(), in: shape)
+        } else {
+            baseFill(increasedContrast: increasedContrast)
+        }
+    }
+
+    private func usesSystemGlassEffect(increasedContrast: Bool) -> Bool {
+        guard !reduceTransparency, !increasedContrast else { return false }
+        return colorScheme == .dark || usesSystemGlassInLightMode
+    }
+
+    @ViewBuilder
+    private func baseFill(increasedContrast: Bool) -> some View {
+        if colorScheme == .light {
+            lightInsetFill(increasedContrast: increasedContrast)
+        } else {
+            darkGlassFill(increasedContrast: increasedContrast)
+        }
+    }
+
+    private func lightInsetFill(increasedContrast: Bool) -> some View {
+        let effectiveTintOpacity = increasedContrast ? max(tintOpacity, 0.26) : tintOpacity
+        let effectiveStrokeOpacity = increasedContrast ? 0.44 : max(strokeOpacity, 0.12)
+
+        return ZStack {
+            shape
+                .fill(
+                    tint.opacity(
+                        increasedContrast ? max(effectiveTintOpacity, 0.34) : effectiveTintOpacity
+                    )
+                )
+
+            shape
+                .strokeBorder(
+                    ShellPalette.line.opacity(increasedContrast ? 0.50 : effectiveStrokeOpacity),
+                    lineWidth: 0.55
+                )
+        }
+    }
+
+    private func darkGlassFill(increasedContrast: Bool) -> some View {
+        return ZStack {
+            shape
+                .fill(
+                    tint.opacity(
+                        increasedContrast ? max(tintOpacity, 0.34) : tintOpacity
+                    )
+                )
+
+            shape
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(0.045),
+                            Color.white.opacity(0),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            shape
+                .strokeBorder(
+                    ShellPalette.line.opacity(increasedContrast ? 0.50 : strokeOpacity),
+                    lineWidth: 0.7
+                )
+        }
     }
 }
 #endif

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -213,7 +213,7 @@ enum ShellRadii {
     static let row: CGFloat = 8
     static let surface: CGFloat = 10
     static let overlay: CGFloat = 12
-    static let floatingSidebarPanel: CGFloat = 16
+    static let floatingSidebarPanel: CGFloat = 14
     static let titlebarTool: CGFloat = 9
     static let terminalSurface: CGFloat = 12
 }

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -207,13 +207,15 @@ enum ShellPalette {
 }
 
 enum ShellRadii {
+    static let micro: CGFloat = 2
+    static let badge: CGFloat = 4
     static let control: CGFloat = 6
     static let row: CGFloat = 8
     static let surface: CGFloat = 10
     static let overlay: CGFloat = 12
     static let floatingSidebarPanel: CGFloat = 16
     static let titlebarTool: CGFloat = 9
-    static let terminalSurface: CGFloat = 22
+    static let terminalSurface: CGFloat = 12
 }
 
 enum ShellSidebarMetrics {
@@ -249,25 +251,75 @@ struct ShellShadowStyle {
 
 enum ShellShadows {
     static let none = ShellShadowStyle(color: .clear, radius: 0, y: 0)
-    static let terminalSurface = ShellShadowStyle(color: Color.black.opacity(0.075), radius: 9, y: 3)
-    static let floatingOverlay = ShellShadowStyle(color: Color.black.opacity(0.10), radius: 13, y: 7)
-    static let floatingInput = ShellShadowStyle(color: Color.black.opacity(0.10), radius: 8, y: 3)
-    static let commandPalette = ShellShadowStyle(
+    static let navigationSelection = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.18, 0.20, 0.28),
+            lightAlpha: 0.11,
+            dark: (0, 0, 0),
+            darkAlpha: 0.26
+        ),
+        radius: 2.2,
+        x: -0.2,
+        y: 0.9
+    )
+    static let terminalSurface = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.18, 0.20, 0.28),
+            lightAlpha: 0.22,
+            dark: (0, 0, 0),
+            darkAlpha: 0.34
+        ),
+        radius: 3,
+        x: -0.7,
+        y: 1.4
+    )
+    static let terminalSurfaceRim = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.18, 0.20, 0.28),
+            lightAlpha: 0.12,
+            dark: (0, 0, 0),
+            darkAlpha: 0.28
+        ),
+        radius: 0.8,
+        x: -0.5,
+        y: 0.3
+    )
+    static let floatingInput = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.16, 0.17, 0.24),
+            lightAlpha: 0.16,
+            dark: (0, 0, 0),
+            darkAlpha: 0.32
+        ),
+        radius: 5,
+        x: -0.5,
+        y: 2.2
+    )
+    static let floatingPanel = ShellShadowStyle(
         color: Color.shellAdaptive(
             light: (0.16, 0.17, 0.24),
             lightAlpha: 0.18,
             dark: (0, 0, 0),
-            darkAlpha: 0.38
+            darkAlpha: 0.36
         ),
-        radius: 26,
-        y: 15
+        radius: 10,
+        x: -1,
+        y: 5
     )
-    static let sidebarSelection = ShellShadowStyle(color: Color.black.opacity(0.035), radius: 3, y: 1)
-    static let spaceSelection = ShellShadowStyle(
-        color: ShellPalette.accent.opacity(0.085),
-        radius: 4,
-        y: 1.5
+    static let commandPalette = ShellShadowStyle(
+        color: Color.shellAdaptive(
+            light: (0.16, 0.17, 0.24),
+            lightAlpha: 0.20,
+            dark: (0, 0, 0),
+            darkAlpha: 0.40
+        ),
+        radius: 22,
+        x: -1,
+        y: 12
     )
+    static let floatingOverlay = floatingPanel
+    static let sidebarSelection = navigationSelection
+    static let spaceSelection = navigationSelection
 }
 
 extension View {
@@ -692,10 +744,38 @@ struct ShellLiquidGlassSurface<SurfaceShape: InsettableShape>: View {
                 )
 
             shape
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(increasedContrast ? 0.18 : 0.13),
+                            Color.white.opacity(0.02),
+                            ShellPalette.sidebarInk.opacity(increasedContrast ? 0.018 : 0.012),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            shape
                 .strokeBorder(
                     ShellPalette.line.opacity(increasedContrast ? 0.50 : effectiveStrokeOpacity),
                     lineWidth: 0.55
                 )
+
+            shape
+                .strokeBorder(Color.white.opacity(increasedContrast ? 0.22 : 0.16), lineWidth: 0.45)
+                .mask {
+                    shape.fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white,
+                                Color.white.opacity(0),
+                            ],
+                            startPoint: .top,
+                            endPoint: .center
+                        )
+                    )
+                }
         }
     }
 

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -393,6 +393,18 @@ enum ShellAppearanceMode: String, CaseIterable, Identifiable {
         }
     }
 
+    func resolvedColorScheme(systemColorScheme: ColorScheme) -> ColorScheme {
+        colorScheme ?? systemColorScheme
+    }
+
+    static var currentSystemColorScheme: ColorScheme {
+        colorScheme(for: NSApplication.shared.effectiveAppearance)
+    }
+
+    static func colorScheme(for appearance: NSAppearance) -> ColorScheme {
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
+    }
+
     var nsAppearanceName: NSAppearance.Name? {
         switch self {
         case .system:
@@ -401,6 +413,19 @@ enum ShellAppearanceMode: String, CaseIterable, Identifiable {
             return .aqua
         case .dark:
             return .darkAqua
+        }
+    }
+}
+
+private extension ColorScheme {
+    var shellNSAppearance: NSAppearance? {
+        switch self {
+        case .light:
+            return NSAppearance(named: .aqua)
+        case .dark:
+            return NSAppearance(named: .darkAqua)
+        @unknown default:
+            return nil
         }
     }
 }
@@ -627,18 +652,24 @@ enum ShellMaterialRole {
 
 private struct ShellVisualEffectView: NSViewRepresentable {
     let role: ShellMaterialRole
+    @Environment(\.colorScheme) private var colorScheme
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
-        view.material = role.visualEffectMaterial ?? .contentBackground
-        view.blendingMode = role.blendingMode
+        applyConfiguration(to: view)
         view.state = .followsWindowActiveState
         return view
     }
 
     func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        applyConfiguration(to: nsView)
+    }
+
+    private func applyConfiguration(to nsView: NSVisualEffectView) {
         nsView.material = role.visualEffectMaterial ?? .contentBackground
         nsView.blendingMode = role.blendingMode
+        nsView.appearance = colorScheme.shellNSAppearance
+        nsView.needsDisplay = true
     }
 }
 

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -215,7 +215,7 @@ enum ShellRadii {
     static let overlay: CGFloat = 12
     static let floatingSidebarPanel: CGFloat = 14
     static let titlebarTool: CGFloat = 9
-    static let terminalSurface: CGFloat = 12
+    static let terminalSurface: CGFloat = 10
 }
 
 enum ShellSidebarMetrics {

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -223,6 +223,10 @@ enum ShellSidebarMetrics {
     static let rowInset: CGFloat = 10
     static let iconColumnWidth: CGFloat = 16
     static let iconPointSize: CGFloat = 12
+    static let spaceDockInternalVerticalPadding: CGFloat = 2
+    static var spaceDockOuterBottomInset: CGFloat {
+        max(edgeInset - spaceDockInternalVerticalPadding, 0)
+    }
     static let trafficLightLeadingInset: CGFloat = 14
     static let trafficLightTopInset: CGFloat = 16
     static let trafficLightFallbackGroupWidth: CGFloat = 58

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -238,6 +238,15 @@ enum ShellSidebarMetrics {
 
 enum ShellWorkspaceMetrics {
     static let terminalSurfaceInset: CGFloat = 8
+
+    static func terminalSurfaceInsets(hasExpandedSidebar: Bool) -> EdgeInsets {
+        EdgeInsets(
+            top: terminalSurfaceInset,
+            leading: hasExpandedSidebar ? 0 : terminalSurfaceInset,
+            bottom: terminalSurfaceInset,
+            trailing: terminalSurfaceInset
+        )
+    }
 }
 
 struct ShellShadowStyle {

--- a/clients/apple/AlanNative/Support/ShellDesignTokens.swift
+++ b/clients/apple/AlanNative/Support/ShellDesignTokens.swift
@@ -231,8 +231,13 @@ enum ShellSidebarMetrics {
     static let titlebarToolHeight: CGFloat = 30
     static let titlebarToolGapAfterTrafficLights: CGFloat = 12
     static let titlebarToolSpacing: CGFloat = 6
+    static let collapsedRevealEdgeWidth: CGFloat = 12
     static let commandLauncherGapBelowTrafficLights: CGFloat = 15
     static let commandLauncherHeight: CGFloat = 34
+}
+
+enum ShellWorkspaceMetrics {
+    static let terminalSurfaceInset: CGFloat = 8
 }
 
 struct ShellShadowStyle {

--- a/clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift
+++ b/clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift
@@ -107,6 +107,12 @@ struct ShellSidebarSwipeMonitor: NSViewRepresentable {
             monitor = nil
         }
 
+#if ALAN_TESTING
+        func handleForTesting(_ event: NSEvent) -> NSEvent? {
+            handle(event)
+        }
+#endif
+
         private func handle(_ event: NSEvent) -> NSEvent? {
             if ignoresHorizontalMomentum, !event.momentumPhase.isEmpty {
                 if event.momentumPhase.contains(.ended) || event.momentumPhase.contains(.cancelled) {
@@ -163,12 +169,14 @@ struct ShellSidebarSwipeMonitor: NSViewRepresentable {
                    abs(accumulatedY) > abs(accumulatedX) * verticalIntentBias {
                     intent = .vertical
                     lastEventTime = now
+                    schedulePhaseLessEndIfNeeded(for: event, velocityX: eventVelocityX)
                     return event
                 }
 
                 guard abs(accumulatedX) >= intentLockDistance,
                       abs(accumulatedX) > abs(accumulatedY) * horizontalIntentBias else {
                     lastEventTime = now
+                    schedulePhaseLessEndIfNeeded(for: event, velocityX: eventVelocityX)
                     return nil
                 }
 
@@ -204,6 +212,7 @@ struct ShellSidebarSwipeMonitor: NSViewRepresentable {
                     resetAccumulatedScroll()
                 } else {
                     lastEventTime = now
+                    schedulePhaseLessEndIfNeeded(for: event, velocityX: eventVelocityX)
                 }
                 return event
 
@@ -271,16 +280,21 @@ struct ShellSidebarSwipeMonitor: NSViewRepresentable {
 
             phaseLessEndWorkItem?.cancel()
             let workItem = DispatchWorkItem { [weak self] in
-                guard let self, self.intent == .horizontal else { return }
-                self.onUpdate(
-                    ShellSidebarSwipeUpdate(
-                        phase: .ended,
-                        translationX: self.accumulatedX,
-                        velocityX: velocityX
+                guard let self else { return }
+                switch self.intent {
+                case .horizontal:
+                    self.onUpdate(
+                        ShellSidebarSwipeUpdate(
+                            phase: .ended,
+                            translationX: self.accumulatedX,
+                            velocityX: velocityX
+                        )
                     )
-                )
-                self.resetAccumulatedScroll()
-                self.ignoresHorizontalMomentum = true
+                    self.resetAccumulatedScroll()
+                    self.ignoresHorizontalMomentum = true
+                case .vertical, .undecided:
+                    self.resetAccumulatedScroll()
+                }
             }
             phaseLessEndWorkItem = workItem
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.16, execute: workItem)

--- a/clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift
+++ b/clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+enum ShellSidebarSwipePhase {
+    case began
+    case changed
+    case ended
+    case cancelled
+}
+
+struct ShellSidebarSwipeUpdate {
+    let phase: ShellSidebarSwipePhase
+    let translationX: CGFloat
+    let velocityX: CGFloat
+}
+
+struct ShellSpaceTransition: Equatable {
+    let sourceSpaceID: String
+    var targetSpaceID: String?
+    var direction: Int
+    var offsetX: CGFloat
+    var progress: CGFloat
+    var isSettling: Bool
+
+    var isEdgeResistance: Bool {
+        targetSpaceID == nil
+    }
+
+    func sourceOffset(in width: CGFloat) -> CGFloat {
+        offsetX
+    }
+
+    func targetOffset(in width: CGFloat) -> CGFloat {
+        offsetX + CGFloat(direction) * width
+    }
+}
+
+struct ShellSidebarSwipeMonitor: NSViewRepresentable {
+    let onUpdate: (ShellSidebarSwipeUpdate) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onUpdate: onUpdate)
+    }
+
+    func makeNSView(context: Context) -> MonitorView {
+        let view = MonitorView()
+        view.coordinator = context.coordinator
+        context.coordinator.install(for: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: MonitorView, context: Context) {
+        context.coordinator.onUpdate = onUpdate
+        nsView.coordinator = context.coordinator
+        context.coordinator.install(for: nsView)
+    }
+
+    final class MonitorView: NSView {
+        var coordinator: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            coordinator?.install(for: self)
+        }
+
+        deinit {
+            coordinator?.uninstall()
+        }
+    }
+
+    final class Coordinator {
+        var onUpdate: (ShellSidebarSwipeUpdate) -> Void
+        private weak var view: NSView?
+        private var monitor: Any?
+        private var accumulatedX: CGFloat = 0
+        private var accumulatedY: CGFloat = 0
+        private var lastEmittedX: CGFloat = 0
+        private var lastVelocityX: CGFloat = 0
+        private var lastEventTime: TimeInterval = 0
+        private var isPhasefulGesture = false
+        private var intent = GestureIntent.undecided
+        private var ignoresHorizontalMomentum = false
+        private var phaseLessEndWorkItem: DispatchWorkItem?
+        private let intentLockDistance: CGFloat = 5
+        private let horizontalIntentBias: CGFloat = 1.14
+        private let verticalIntentBias: CGFloat = 1.18
+
+        init(onUpdate: @escaping (ShellSidebarSwipeUpdate) -> Void) {
+            self.onUpdate = onUpdate
+        }
+
+        func install(for view: NSView) {
+            self.view = view
+            guard monitor == nil else { return }
+
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                self?.handle(event) ?? event
+            }
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+        }
+
+        private func handle(_ event: NSEvent) -> NSEvent? {
+            if ignoresHorizontalMomentum, !event.momentumPhase.isEmpty {
+                if event.momentumPhase.contains(.ended) || event.momentumPhase.contains(.cancelled) {
+                    ignoresHorizontalMomentum = false
+                    resetAccumulatedScroll()
+                }
+                return nil
+            }
+
+            guard let view, view.window === event.window else {
+                return event
+            }
+
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) || intent == .horizontal else {
+                return event
+            }
+
+            if event.phase.contains(.began) {
+                ignoresHorizontalMomentum = false
+                resetAccumulatedScroll()
+            }
+
+            if !event.phase.isEmpty || !event.momentumPhase.isEmpty {
+                isPhasefulGesture = true
+            }
+
+            let horizontal = pageDeltaX(from: event)
+            let vertical = pageDeltaY(from: event)
+            let hasDelta = abs(horizontal) > 0 || abs(vertical) > 0
+            let canUseTerminalDeltaForFlick = intent == .undecided
+                && hasDelta
+                && (event.phase.contains(.ended) || event.momentumPhase.contains(.began))
+
+            if let shouldConsume = finishIfNeeded(event: event, velocityX: lastVelocityX),
+               !canUseTerminalDeltaForFlick
+            {
+                return shouldConsume ? nil : event
+            }
+
+            guard abs(horizontal) > 0 || abs(vertical) > 0 else {
+                return event
+            }
+
+            accumulatedX += horizontal
+            accumulatedY += vertical
+            let now = event.timestamp > 0 ? event.timestamp : ProcessInfo.processInfo.systemUptime
+            let elapsed = lastEventTime > 0 ? max(now - lastEventTime, 0.001) : 0.016
+            let eventVelocityX = horizontal / elapsed
+
+            switch intent {
+            case .undecided:
+                if abs(accumulatedY) >= intentLockDistance,
+                   abs(accumulatedY) > abs(accumulatedX) * verticalIntentBias {
+                    intent = .vertical
+                    lastEventTime = now
+                    return event
+                }
+
+                guard abs(accumulatedX) >= intentLockDistance,
+                      abs(accumulatedX) > abs(accumulatedY) * horizontalIntentBias else {
+                    lastEventTime = now
+                    return nil
+                }
+
+                intent = .horizontal
+                lastEmittedX = accumulatedX
+                lastEventTime = now
+                lastVelocityX = eventVelocityX
+                onUpdate(ShellSidebarSwipeUpdate(phase: .began, translationX: 0, velocityX: 0))
+                onUpdate(
+                    ShellSidebarSwipeUpdate(
+                        phase: .changed,
+                        translationX: accumulatedX,
+                        velocityX: eventVelocityX
+                    )
+                )
+                if event.phase.contains(.ended) || event.momentumPhase.contains(.began) {
+                    onUpdate(
+                        ShellSidebarSwipeUpdate(
+                            phase: event.phase.contains(.cancelled) ? .cancelled : .ended,
+                            translationX: accumulatedX,
+                            velocityX: eventVelocityX
+                        )
+                    )
+                    resetAccumulatedScroll()
+                    ignoresHorizontalMomentum = true
+                    return nil
+                }
+                schedulePhaseLessEndIfNeeded(for: event, velocityX: eventVelocityX)
+                return nil
+
+            case .vertical:
+                if event.phase.contains(.ended) || event.phase.contains(.cancelled) {
+                    resetAccumulatedScroll()
+                } else {
+                    lastEventTime = now
+                }
+                return event
+
+            case .horizontal:
+                let velocityX = (accumulatedX - lastEmittedX) / elapsed
+                lastEmittedX = accumulatedX
+                lastEventTime = now
+                lastVelocityX = velocityX
+
+                onUpdate(
+                    ShellSidebarSwipeUpdate(
+                        phase: .changed,
+                        translationX: accumulatedX,
+                        velocityX: velocityX
+                    )
+                )
+                schedulePhaseLessEndIfNeeded(for: event, velocityX: velocityX)
+                return nil
+            }
+        }
+
+        private func finishIfNeeded(event: NSEvent, velocityX: CGFloat) -> Bool? {
+            let isCancelled = event.phase.contains(.cancelled) || event.momentumPhase.contains(.cancelled)
+            let isEnded = event.phase.contains(.ended) || event.momentumPhase.contains(.began)
+            guard isCancelled || isEnded else { return nil }
+
+            switch intent {
+            case .horizontal:
+                onUpdate(
+                    ShellSidebarSwipeUpdate(
+                        phase: isCancelled ? .cancelled : .ended,
+                        translationX: accumulatedX,
+                        velocityX: velocityX
+                    )
+                )
+                resetAccumulatedScroll()
+                ignoresHorizontalMomentum = true
+                return true
+
+            case .vertical, .undecided:
+                resetAccumulatedScroll()
+                return false
+            }
+        }
+
+        private func resetAccumulatedScroll() {
+            phaseLessEndWorkItem?.cancel()
+            phaseLessEndWorkItem = nil
+            accumulatedX = 0
+            accumulatedY = 0
+            lastEmittedX = 0
+            lastVelocityX = 0
+            lastEventTime = 0
+            isPhasefulGesture = false
+            intent = .undecided
+        }
+
+        private func schedulePhaseLessEndIfNeeded(for event: NSEvent, velocityX: CGFloat) {
+            guard !isPhasefulGesture,
+                  event.phase.isEmpty,
+                  event.momentumPhase.isEmpty
+            else {
+                return
+            }
+
+            phaseLessEndWorkItem?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self, self.intent == .horizontal else { return }
+                self.onUpdate(
+                    ShellSidebarSwipeUpdate(
+                        phase: .ended,
+                        translationX: self.accumulatedX,
+                        velocityX: velocityX
+                    )
+                )
+                self.resetAccumulatedScroll()
+                self.ignoresHorizontalMomentum = true
+            }
+            phaseLessEndWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.16, execute: workItem)
+        }
+
+        private func pageDeltaX(from event: NSEvent) -> CGFloat {
+            if event.hasPreciseScrollingDeltas {
+                return event.scrollingDeltaX
+            }
+            return event.deltaX * 10
+        }
+
+        private func pageDeltaY(from event: NSEvent) -> CGFloat {
+            if event.hasPreciseScrollingDeltas {
+                return event.scrollingDeltaY
+            }
+            return event.deltaY * 10
+        }
+
+        private enum GestureIntent {
+            case undecided
+            case horizontal
+            case vertical
+        }
+    }
+}
+#endif

--- a/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
+++ b/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
@@ -51,6 +51,7 @@ struct ShellWindowPlacementView: NSViewRepresentable {
 }
 
 struct ShellWindowChromeMetrics: Equatable {
+    var standardTrafficLightsVisible = true
     var trafficLightGroupFrame = CGRect(
         x: ShellSidebarMetrics.trafficLightLeadingInset,
         y: ShellSidebarMetrics.trafficLightTopInset,
@@ -59,7 +60,11 @@ struct ShellWindowChromeMetrics: Equatable {
     )
 
     var titlebarToolLeadingInset: CGFloat {
-        trafficLightGroupFrame.maxX + ShellSidebarMetrics.titlebarToolGapAfterTrafficLights
+        guard standardTrafficLightsVisible else {
+            return ShellSidebarMetrics.edgeInset
+        }
+
+        return trafficLightGroupFrame.maxX + ShellSidebarMetrics.titlebarToolGapAfterTrafficLights
     }
 
     var titlebarToolTopInset: CGFloat {
@@ -164,6 +169,14 @@ final class ShellWindowPlacementNSView: NSView {
     private var configuredWindowNumber: Int?
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
     private var doubleClickZoomOverlay: ShellWindowDoubleClickZoomOverlayView?
+    private weak var observedWindow: NSWindow?
+    private weak var observedTitlebarView: NSView?
+    private var windowObservers: [NSObjectProtocol] = []
+    private var titlebarObservers: [NSObjectProtocol] = []
+    private var chromeSyncScheduled = false
+    private var isSynchronizingChrome = false
+    private var liveResizeChromeSyncTimer: Timer?
+    private var nativeFullScreenOverride: Bool?
 
     init(
         appearanceMode: ShellAppearanceMode,
@@ -181,6 +194,12 @@ final class ShellWindowPlacementNSView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        stopLiveResizeChromeSync()
+        removeWindowObservers()
+        removeTitlebarObservers()
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         resolveWindowIfNeeded()
@@ -194,6 +213,12 @@ final class ShellWindowPlacementNSView: NSView {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         publishEffectiveSystemColorScheme()
+    }
+
+    override func layout() {
+        super.layout()
+        guard window?.inLiveResize == true else { return }
+        synchronizeChromeIfAttached()
     }
 
     func updateMetricsHandler(_ handler: @escaping (ShellWindowChromeMetrics) -> Void) {
@@ -218,15 +243,11 @@ final class ShellWindowPlacementNSView: NSView {
             guard let self, let window = self.window else { return }
             if self.configuredWindowNumber != window.windowNumber {
                 AlanShellWindowPlacement.configure(window, appearanceMode: self.appearanceMode)
+                self.installWindowObservers(for: window)
                 self.configuredWindowNumber = window.windowNumber
             }
 
-            let metrics = AlanShellWindowPlacement.chromeMetrics(for: window)
-            self.installDoubleClickZoomOverlayIfNeeded(for: window)
-            self.publishEffectiveSystemColorScheme()
-            guard self.lastPublishedMetrics != metrics else { return }
-            self.lastPublishedMetrics = metrics
-            self.metricsHandler(metrics)
+            self.synchronizeChrome(for: window)
         }
     }
 
@@ -240,9 +261,205 @@ final class ShellWindowPlacementNSView: NSView {
         systemAppearanceHandler(ShellAppearanceMode.colorScheme(for: appearance))
     }
 
-    private func installDoubleClickZoomOverlayIfNeeded(for window: NSWindow) {
-        guard let titlebarView = AlanShellWindowPlacement.titlebarControlContainer(for: window)
-        else {
+    private func installWindowObservers(for window: NSWindow) {
+        guard observedWindow !== window else { return }
+
+        removeWindowObservers()
+        observedWindow = window
+
+        let center = NotificationCenter.default
+        windowObservers = [
+            center.addObserver(
+                forName: NSWindow.willStartLiveResizeNotification,
+                object: window,
+                queue: nil
+            ) { [weak self] _ in
+                self?.startLiveResizeChromeSync()
+            },
+            center.addObserver(
+                forName: NSWindow.didResizeNotification,
+                object: window,
+                queue: nil
+            ) { [weak self] _ in
+                self?.synchronizeChromeIfAttached()
+            },
+            center.addObserver(
+                forName: NSWindow.didEndLiveResizeNotification,
+                object: window,
+                queue: nil
+            ) { [weak self] _ in
+                self?.stopLiveResizeChromeSync()
+                self?.synchronizeChromeIfAttached()
+                self?.scheduleChromeSync(after: 0.02)
+            },
+            center.addObserver(
+                forName: NSWindow.didChangeScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.scheduleChromeSync()
+            },
+            center.addObserver(
+                forName: NSWindow.willEnterFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.nativeFullScreenOverride = true
+                self?.scheduleChromeSync()
+            },
+            center.addObserver(
+                forName: NSWindow.didEnterFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.nativeFullScreenOverride = nil
+                self?.scheduleChromeSync()
+            },
+            center.addObserver(
+                forName: NSWindow.willExitFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.nativeFullScreenOverride = true
+                self?.scheduleChromeSync()
+            },
+            center.addObserver(
+                forName: NSWindow.didExitFullScreenNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.nativeFullScreenOverride = nil
+                self?.scheduleChromeSync()
+                self?.scheduleChromeSync(after: 0.08)
+            },
+        ]
+    }
+
+    private func removeWindowObservers() {
+        stopLiveResizeChromeSync()
+        windowObservers.forEach(NotificationCenter.default.removeObserver)
+        windowObservers.removeAll()
+        observedWindow = nil
+    }
+
+    private func installTitlebarObservers(for titlebarView: NSView?) {
+        guard observedTitlebarView !== titlebarView else { return }
+
+        removeTitlebarObservers()
+        guard let titlebarView else { return }
+
+        observedTitlebarView = titlebarView
+        titlebarView.postsFrameChangedNotifications = true
+        titlebarView.postsBoundsChangedNotifications = true
+
+        let center = NotificationCenter.default
+        titlebarObservers = [
+            center.addObserver(
+                forName: NSView.frameDidChangeNotification,
+                object: titlebarView,
+                queue: nil
+            ) { [weak self] _ in
+                self?.synchronizeChromeIfAttached()
+            },
+            center.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: titlebarView,
+                queue: nil
+            ) { [weak self] _ in
+                self?.synchronizeChromeIfAttached()
+            },
+        ]
+    }
+
+    private func removeTitlebarObservers() {
+        titlebarObservers.forEach(NotificationCenter.default.removeObserver)
+        titlebarObservers.removeAll()
+        observedTitlebarView = nil
+    }
+
+    private func scheduleChromeSync(after delay: TimeInterval = 0) {
+        let shouldCoalesce = delay <= 0
+        if shouldCoalesce {
+            guard !chromeSyncScheduled else { return }
+            chromeSyncScheduled = true
+        }
+
+        let work = { [weak self] in
+            guard let self else { return }
+            if shouldCoalesce {
+                self.chromeSyncScheduled = false
+            }
+            guard let window = self.window else { return }
+            self.synchronizeChrome(for: window)
+        }
+
+        if delay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
+    }
+
+    private func startLiveResizeChromeSync() {
+        stopLiveResizeChromeSync()
+        synchronizeChromeIfAttached()
+
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+
+            guard self.window?.inLiveResize == true else {
+                timer.invalidate()
+                self.liveResizeChromeSyncTimer = nil
+                self.synchronizeChromeIfAttached()
+                return
+            }
+
+            self.synchronizeChromeIfAttached()
+        }
+        timer.tolerance = 1.0 / 120.0
+        RunLoop.main.add(timer, forMode: .eventTracking)
+        RunLoop.main.add(timer, forMode: .common)
+        liveResizeChromeSyncTimer = timer
+        timer.fire()
+    }
+
+    private func stopLiveResizeChromeSync() {
+        liveResizeChromeSyncTimer?.invalidate()
+        liveResizeChromeSyncTimer = nil
+    }
+
+    private func synchronizeChromeIfAttached() {
+        guard let window else { return }
+        synchronizeChrome(for: window)
+    }
+
+    private func synchronizeChrome(for window: NSWindow) {
+        guard !isSynchronizingChrome else { return }
+        isSynchronizingChrome = true
+        defer {
+            isSynchronizingChrome = false
+        }
+
+        let titlebarView = AlanShellWindowPlacement.titlebarControlContainer(for: window)
+        installTitlebarObservers(for: titlebarView)
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            nativeFullScreenOverride: nativeFullScreenOverride
+        )
+        installDoubleClickZoomOverlayIfNeeded(in: titlebarView)
+        publishEffectiveSystemColorScheme()
+        guard lastPublishedMetrics != metrics else { return }
+        lastPublishedMetrics = metrics
+        metricsHandler(metrics)
+    }
+
+    private func installDoubleClickZoomOverlayIfNeeded(in titlebarView: NSView?) {
+        guard let titlebarView else {
+            doubleClickZoomOverlay?.removeFromSuperview()
+            doubleClickZoomOverlay = nil
             return
         }
 
@@ -311,7 +528,7 @@ final class ShellWindowDoubleClickZoomOverlayView: NSView {
     }
 }
 
-private enum AlanShellWindowPlacement {
+enum AlanShellWindowPlacement {
     static func configure(_ window: NSWindow, appearanceMode: ShellAppearanceMode) {
         window.title = "Alan"
         applyAppearance(to: window, appearanceMode: appearanceMode)
@@ -338,8 +555,17 @@ private enum AlanShellWindowPlacement {
         window.displayIfNeeded()
     }
 
-    static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {
+    static func synchronizeChrome(
+        for window: NSWindow,
+        nativeFullScreenOverride: Bool? = nil
+    ) -> ShellWindowChromeMetrics {
         var metrics = ShellWindowChromeMetrics()
+        let isNativeFullScreen = nativeFullScreenOverride ?? window.styleMask.contains(.fullScreen)
+
+        guard !isNativeFullScreen else {
+            metrics.standardTrafficLightsVisible = false
+            return metrics
+        }
 
         if let trafficLightGroupFrame = repositionStandardWindowButtons(in: window) {
             metrics.trafficLightGroupFrame = trafficLightGroupFrame
@@ -373,11 +599,13 @@ private enum AlanShellWindowPlacement {
         let deltaTop = ShellSidebarMetrics.trafficLightTopInset - currentVisualTopInset
         let deltaY = superview.isFlipped ? deltaTop : -deltaTop
 
-        for button in buttons {
-            var frame = button.frame
-            frame.origin.x += deltaX
-            frame.origin.y += deltaY
-            button.setFrameOrigin(frame.origin)
+        if abs(deltaX) > 0.5 || abs(deltaY) > 0.5 {
+            for button in buttons {
+                var frame = button.frame
+                frame.origin.x += deltaX
+                frame.origin.y += deltaY
+                button.setFrameOrigin(frame.origin)
+            }
         }
 
         let movedGroupFrame = buttons

--- a/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
+++ b/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
@@ -6,6 +6,7 @@ import AppKit
 struct ShellWindowPlacementView: NSViewRepresentable {
     @Binding var metrics: ShellWindowChromeMetrics
     let appearanceMode: ShellAppearanceMode
+    var chromeSurface: ShellWindowChromeSurface = .visible
     @Binding var systemColorScheme: ColorScheme
 
     func makeNSView(context: Context) -> ShellWindowPlacementNSView {
@@ -13,6 +14,7 @@ struct ShellWindowPlacementView: NSViewRepresentable {
         let systemColorSchemeBinding = _systemColorScheme
         return ShellWindowPlacementNSView(
             appearanceMode: appearanceMode,
+            chromeSurface: chromeSurface,
             metricsHandler: metricsHandler(metricsBinding),
             systemAppearanceHandler: systemAppearanceHandler(systemColorSchemeBinding)
         )
@@ -24,6 +26,7 @@ struct ShellWindowPlacementView: NSViewRepresentable {
         nsView.updateAppearanceMode(appearanceMode)
         nsView.updateMetricsHandler(metricsHandler(metricsBinding))
         nsView.updateSystemAppearanceHandler(systemAppearanceHandler(systemColorSchemeBinding))
+        nsView.updateChromeSurface(chromeSurface)
         nsView.resolveWindowIfNeeded()
     }
 
@@ -48,6 +51,15 @@ struct ShellWindowPlacementView: NSViewRepresentable {
             }
         }
     }
+}
+
+struct ShellWindowChromeSurface: Equatable {
+    var isVisible = true
+    var origin: CGPoint = .zero
+    var width: CGFloat?
+    var showsStandardTrafficLights = true
+
+    static let visible = ShellWindowChromeSurface()
 }
 
 struct ShellWindowChromeMetrics: Equatable {
@@ -129,18 +141,30 @@ enum ShellWindowSizing {
 
 enum ShellWindowDoubleClickZoomHitTesting {
     static let topChromeBandHeight: CGFloat = 36
-    static let reservedLeadingChromeWidth: CGFloat = 160
-    static let reservedTopChromeHeight: CGFloat = 64
+    static let contentInteractionTopInset: CGFloat = ShellWorkspaceMetrics.terminalSurfaceInset
 
     static func isWindowTopChromeZoomCandidate(
         locationInWindow point: CGPoint,
-        in window: NSWindow
+        in window: NSWindow,
+        chromeSurface: ShellWindowChromeSurface = .visible
     ) -> Bool {
         let windowSize = window.frame.size
         let windowBounds = CGRect(origin: .zero, size: windowSize)
         guard windowBounds.contains(point) else { return false }
         guard isPointInWindowTopChromeBand(point, windowSize: windowSize) else { return false }
-        return !isPointInReservedChromeControls(point, windowSize: windowSize)
+        if isPointAboveContentInteractionBand(point, windowSize: windowSize) {
+            return true
+        }
+
+        guard isPointInSidebarChromeBand(point, windowSize: windowSize, chromeSurface: chromeSurface)
+        else {
+            return false
+        }
+        return !isPointInSidebarChromeControls(
+            point,
+            windowSize: windowSize,
+            chromeSurface: chromeSurface
+        )
     }
 
     static func isPointInWindowTopChromeBand(
@@ -151,19 +175,104 @@ enum ShellWindowDoubleClickZoomHitTesting {
         return visualTopInset >= 0 && visualTopInset <= topChromeBandHeight
     }
 
-    static func isPointInReservedChromeControls(
+    static func isPointAboveContentInteractionBand(
         _ point: CGPoint,
         windowSize: CGSize
     ) -> Bool {
         let visualTopInset = windowSize.height - point.y
-        return point.x <= reservedLeadingChromeWidth
-            && visualTopInset >= 0
-            && visualTopInset <= reservedTopChromeHeight
+        return visualTopInset >= 0 && visualTopInset <= contentInteractionTopInset
+    }
+
+    static func isPointInSidebarChromeBand(
+        _ point: CGPoint,
+        windowSize: CGSize,
+        chromeSurface: ShellWindowChromeSurface
+    ) -> Bool {
+        guard chromeSurface.isVisible, let chromeSurfaceWidth = chromeSurface.width else {
+            return false
+        }
+
+        let localPoint = localTopLeadingPoint(
+            point,
+            windowSize: windowSize,
+            chromeSurface: chromeSurface
+        )
+        return localPoint.x >= 0
+            && localPoint.x <= chromeSurfaceWidth
+            && localPoint.y >= 0
+            && localPoint.y <= topChromeBandHeight
+    }
+
+    static func isPointInSidebarChromeControls(
+        _ point: CGPoint,
+        windowSize: CGSize,
+        chromeSurface: ShellWindowChromeSurface
+    ) -> Bool {
+        let localPoint = localTopLeadingPoint(
+            point,
+            windowSize: windowSize,
+            chromeSurface: chromeSurface
+        )
+        return standardTrafficLightControlFrames.contains { $0.contains(localPoint) }
+            || sidebarTitlebarToolControlFrame.contains(localPoint)
+    }
+
+    private static var standardTrafficLightGroupFrame: CGRect {
+        CGRect(
+            x: ShellSidebarMetrics.trafficLightLeadingInset,
+            y: ShellSidebarMetrics.trafficLightTopInset,
+            width: ShellSidebarMetrics.trafficLightFallbackGroupWidth,
+            height: ShellSidebarMetrics.trafficLightFallbackButtonHeight
+        )
+    }
+
+    private static var standardTrafficLightControlFrames: [CGRect] {
+        let groupFrame = standardTrafficLightGroupFrame
+        let buttonWidth = ShellSidebarMetrics.trafficLightFallbackButtonHeight
+        let gap = max((groupFrame.width - (buttonWidth * 3)) / 2, 0)
+
+        return (0..<3).map { index in
+            CGRect(
+                x: groupFrame.minX + (CGFloat(index) * (buttonWidth + gap)),
+                y: groupFrame.minY,
+                width: buttonWidth,
+                height: buttonWidth
+            )
+        }
+    }
+
+    private static var sidebarTitlebarToolControlFrame: CGRect {
+        let trafficLights = standardTrafficLightGroupFrame
+        let firstButtonX = trafficLights.maxX + ShellSidebarMetrics.titlebarToolGapAfterTrafficLights
+        let buttonCount: CGFloat = 2
+        let totalButtonWidth =
+            (buttonCount * ShellSidebarMetrics.titlebarToolWidth)
+            + ((buttonCount - 1) * ShellSidebarMetrics.titlebarToolSpacing)
+
+        return CGRect(
+            x: firstButtonX,
+            y: max(0, trafficLights.midY - (ShellSidebarMetrics.titlebarToolHeight / 2)),
+            width: totalButtonWidth,
+            height: ShellSidebarMetrics.titlebarToolHeight
+        )
+    }
+
+    private static func localTopLeadingPoint(
+        _ point: CGPoint,
+        windowSize: CGSize,
+        chromeSurface: ShellWindowChromeSurface
+    ) -> CGPoint {
+        let visualTopInset = windowSize.height - point.y
+        return CGPoint(
+            x: point.x - chromeSurface.origin.x,
+            y: visualTopInset - chromeSurface.origin.y
+        )
     }
 }
 
 final class ShellWindowPlacementNSView: NSView {
     private var appearanceMode: ShellAppearanceMode
+    private var chromeSurface: ShellWindowChromeSurface
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
     private var systemAppearanceHandler: (ColorScheme) -> Void
     private var configuredWindowNumber: Int?
@@ -180,10 +289,12 @@ final class ShellWindowPlacementNSView: NSView {
 
     init(
         appearanceMode: ShellAppearanceMode,
+        chromeSurface: ShellWindowChromeSurface = .visible,
         metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void,
         systemAppearanceHandler: @escaping (ColorScheme) -> Void = { _ in }
     ) {
         self.appearanceMode = appearanceMode
+        self.chromeSurface = chromeSurface
         self.metricsHandler = metricsHandler
         self.systemAppearanceHandler = systemAppearanceHandler
         super.init(frame: .zero)
@@ -236,6 +347,13 @@ final class ShellWindowPlacementNSView: NSView {
         guard didChange else { return }
         applyAppearanceToAttachedWindow()
         publishEffectiveSystemColorScheme()
+    }
+
+    func updateChromeSurface(_ surface: ShellWindowChromeSurface) {
+        let didChange = chromeSurface != surface
+        chromeSurface = surface
+        guard didChange else { return }
+        synchronizeChromeIfAttached()
     }
 
     func resolveWindowIfNeeded() {
@@ -447,6 +565,7 @@ final class ShellWindowPlacementNSView: NSView {
         installTitlebarObservers(for: titlebarView)
         let metrics = AlanShellWindowPlacement.synchronizeChrome(
             for: window,
+            chromeSurface: chromeSurface,
             nativeFullScreenOverride: nativeFullScreenOverride
         )
         installDoubleClickZoomOverlayIfNeeded(in: titlebarView)
@@ -466,11 +585,13 @@ final class ShellWindowPlacementNSView: NSView {
         if let doubleClickZoomOverlay,
            doubleClickZoomOverlay.superview === titlebarView {
             doubleClickZoomOverlay.frame = titlebarView.bounds
+            doubleClickZoomOverlay.chromeSurface = chromeSurface
             return
         }
 
         doubleClickZoomOverlay?.removeFromSuperview()
         let overlay = ShellWindowDoubleClickZoomOverlayView(frame: titlebarView.bounds)
+        overlay.chromeSurface = chromeSurface
         overlay.autoresizingMask = [.width, .height]
         titlebarView.addSubview(overlay, positioned: .below, relativeTo: titlebarView.subviews.first)
         doubleClickZoomOverlay = overlay
@@ -478,6 +599,7 @@ final class ShellWindowPlacementNSView: NSView {
 }
 
 final class ShellWindowDoubleClickZoomOverlayView: NSView {
+    var chromeSurface = ShellWindowChromeSurface.visible
     private var restoreFrame: NSRect?
 
     override var mouseDownCanMoveWindow: Bool {
@@ -494,7 +616,8 @@ final class ShellWindowDoubleClickZoomOverlayView: NSView {
         let windowPoint = convert(point, to: nil)
         guard ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
             locationInWindow: windowPoint,
-            in: window
+            in: window,
+            chromeSurface: chromeSurface
         ) else {
             return nil
         }
@@ -529,6 +652,11 @@ final class ShellWindowDoubleClickZoomOverlayView: NSView {
 }
 
 enum AlanShellWindowPlacement {
+    private struct StandardWindowButtonGroup {
+        let buttons: [NSButton]
+        let superview: NSView
+    }
+
     static func configure(_ window: NSWindow, appearanceMode: ShellAppearanceMode) {
         window.title = "Alan"
         applyAppearance(to: window, appearanceMode: appearanceMode)
@@ -557,18 +685,44 @@ enum AlanShellWindowPlacement {
 
     static func synchronizeChrome(
         for window: NSWindow,
+        chromeSurface: ShellWindowChromeSurface = .visible,
         nativeFullScreenOverride: Bool? = nil
     ) -> ShellWindowChromeMetrics {
         var metrics = ShellWindowChromeMetrics()
         let isNativeFullScreen = nativeFullScreenOverride ?? window.styleMask.contains(.fullScreen)
 
-        guard !isNativeFullScreen else {
+        guard chromeSurface.isVisible, !isNativeFullScreen else {
+            setStandardWindowButtons(in: window, hidden: true)
             metrics.standardTrafficLightsVisible = false
             return metrics
         }
 
-        if let trafficLightGroupFrame = repositionStandardWindowButtons(in: window) {
-            metrics.trafficLightGroupFrame = trafficLightGroupFrame
+        if chromeSurface.showsStandardTrafficLights {
+            setStandardWindowButtons(in: window, hidden: false, alphaValue: 0)
+        }
+
+        if let trafficLightGroupFrame = repositionStandardWindowButtons(
+            in: window,
+            chromeSurfaceOrigin: chromeSurface.origin
+        ) {
+            metrics.trafficLightGroupFrame = localTrafficLightGroupFrame(
+                for: trafficLightGroupFrame
+            )
+        }
+        setStandardWindowButtons(
+            in: window,
+            hidden: !chromeSurface.showsStandardTrafficLights,
+            alphaValue: 1
+        )
+        if chromeSurface.showsStandardTrafficLights,
+           let trafficLightGroupFrame = repositionStandardWindowButtons(
+               in: window,
+               chromeSurfaceOrigin: chromeSurface.origin
+           )
+        {
+            metrics.trafficLightGroupFrame = localTrafficLightGroupFrame(
+                for: trafficLightGroupFrame
+            )
         }
 
         return metrics
@@ -578,7 +732,32 @@ enum AlanShellWindowPlacement {
         window.standardWindowButton(.closeButton)?.superview
     }
 
-    private static func repositionStandardWindowButtons(in window: NSWindow) -> CGRect? {
+    private static func setStandardWindowButtons(
+        in window: NSWindow,
+        hidden: Bool,
+        alphaValue: CGFloat? = nil
+    ) {
+        guard let group = standardWindowButtonGroup(in: window) else { return }
+        group.buttons.forEach { button in
+            if let alphaValue, button.alphaValue != alphaValue {
+                button.alphaValue = alphaValue
+            }
+            if button.isHidden != hidden {
+                button.isHidden = hidden
+            }
+        }
+    }
+
+    private static func localTrafficLightGroupFrame(for frame: CGRect) -> CGRect {
+        CGRect(
+            x: ShellSidebarMetrics.trafficLightLeadingInset,
+            y: ShellSidebarMetrics.trafficLightTopInset,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    private static func standardWindowButtonGroup(in window: NSWindow) -> StandardWindowButtonGroup? {
         let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
         let buttons = buttonTypes.compactMap { window.standardWindowButton($0) }
 
@@ -589,14 +768,29 @@ enum AlanShellWindowPlacement {
             return nil
         }
 
+        return StandardWindowButtonGroup(buttons: buttons, superview: superview)
+    }
+
+    private static func repositionStandardWindowButtons(
+        in window: NSWindow,
+        chromeSurfaceOrigin: CGPoint
+    ) -> CGRect? {
+        guard let buttonGroup = standardWindowButtonGroup(in: window) else { return nil }
+        let buttons = buttonGroup.buttons
+        let superview = buttonGroup.superview
+
         let currentGroupFrame = buttons
             .map(\.frame)
             .reduce(NSRect.null) { $0.union($1) }
         guard !currentGroupFrame.isNull else { return nil }
 
         let currentVisualTopInset = visualTopInset(of: currentGroupFrame, in: superview)
-        let deltaX = ShellSidebarMetrics.trafficLightLeadingInset - currentGroupFrame.minX
-        let deltaTop = ShellSidebarMetrics.trafficLightTopInset - currentVisualTopInset
+        let targetLeadingInset =
+            ShellSidebarMetrics.trafficLightLeadingInset + chromeSurfaceOrigin.x
+        let targetTopInset =
+            ShellSidebarMetrics.trafficLightTopInset + chromeSurfaceOrigin.y
+        let deltaX = targetLeadingInset - currentGroupFrame.minX
+        let deltaTop = targetTopInset - currentVisualTopInset
         let deltaY = superview.isFlipped ? deltaTop : -deltaTop
 
         if abs(deltaX) > 0.5 || abs(deltaY) > 0.5 {

--- a/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
+++ b/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
@@ -78,11 +78,92 @@ struct ShellWindowChromeMetrics: Equatable {
     }
 }
 
+enum ShellWindowSizing {
+    static let defaultWidthRatio: CGFloat = 0.90
+    static let defaultHeightRatio: CGFloat = 0.80
+    static let visibleFrameMargin: CGFloat = 16
+    static let zoomFrameTolerance: CGFloat = 1
+    static let minimumSize = CGSize(width: 1180, height: 760)
+
+    static func defaultFrame(in visibleFrame: CGRect) -> CGRect {
+        let size = defaultSize(in: visibleFrame)
+
+        return CGRect(
+            x: visibleFrame.midX - (size.width / 2),
+            y: visibleFrame.midY - (size.height / 2),
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    static func defaultSize(in visibleFrame: CGRect) -> CGSize {
+        let maxWidth = max(visibleFrame.width - (visibleFrameMargin * 2), 1)
+        let maxHeight = max(visibleFrame.height - (visibleFrameMargin * 2), 1)
+
+        return CGSize(
+            width: min(max(visibleFrame.width * defaultWidthRatio, minimumSize.width), maxWidth),
+            height: min(max(visibleFrame.height * defaultHeightRatio, minimumSize.height), maxHeight)
+        )
+    }
+
+    static func zoomFrame(in visibleFrame: CGRect) -> CGRect {
+        visibleFrame
+    }
+
+    static func frame(
+        _ lhs: CGRect,
+        approximatelyMatches rhs: CGRect,
+        tolerance: CGFloat = zoomFrameTolerance
+    ) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) <= tolerance
+            && abs(lhs.origin.y - rhs.origin.y) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}
+
+enum ShellWindowDoubleClickZoomHitTesting {
+    static let topChromeBandHeight: CGFloat = 36
+    static let reservedLeadingChromeWidth: CGFloat = 160
+    static let reservedTopChromeHeight: CGFloat = 64
+
+    static func isWindowTopChromeZoomCandidate(
+        locationInWindow point: CGPoint,
+        in window: NSWindow
+    ) -> Bool {
+        let windowSize = window.frame.size
+        let windowBounds = CGRect(origin: .zero, size: windowSize)
+        guard windowBounds.contains(point) else { return false }
+        guard isPointInWindowTopChromeBand(point, windowSize: windowSize) else { return false }
+        return !isPointInReservedChromeControls(point, windowSize: windowSize)
+    }
+
+    static func isPointInWindowTopChromeBand(
+        _ point: CGPoint,
+        windowSize: CGSize
+    ) -> Bool {
+        let visualTopInset = windowSize.height - point.y
+        return visualTopInset >= 0 && visualTopInset <= topChromeBandHeight
+    }
+
+    static func isPointInReservedChromeControls(
+        _ point: CGPoint,
+        windowSize: CGSize
+    ) -> Bool {
+        let visualTopInset = windowSize.height - point.y
+        return point.x <= reservedLeadingChromeWidth
+            && visualTopInset >= 0
+            && visualTopInset <= reservedTopChromeHeight
+    }
+}
+
 final class ShellWindowPlacementNSView: NSView {
     private var appearanceMode: ShellAppearanceMode
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
     private var systemAppearanceHandler: (ColorScheme) -> Void
+    private var configuredWindowNumber: Int?
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
+    private var doubleClickZoomOverlay: ShellWindowDoubleClickZoomOverlayView?
 
     init(
         appearanceMode: ShellAppearanceMode,
@@ -135,7 +216,13 @@ final class ShellWindowPlacementNSView: NSView {
     func resolveWindowIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self, let window = self.window else { return }
-            let metrics = AlanShellWindowPlacement.apply(to: window, appearanceMode: self.appearanceMode)
+            if self.configuredWindowNumber != window.windowNumber {
+                AlanShellWindowPlacement.configure(window, appearanceMode: self.appearanceMode)
+                self.configuredWindowNumber = window.windowNumber
+            }
+
+            let metrics = AlanShellWindowPlacement.chromeMetrics(for: window)
+            self.installDoubleClickZoomOverlayIfNeeded(for: window)
             self.publishEffectiveSystemColorScheme()
             guard self.lastPublishedMetrics != metrics else { return }
             self.lastPublishedMetrics = metrics
@@ -152,12 +239,80 @@ final class ShellWindowPlacementNSView: NSView {
         let appearance = window?.effectiveAppearance ?? effectiveAppearance
         systemAppearanceHandler(ShellAppearanceMode.colorScheme(for: appearance))
     }
+
+    private func installDoubleClickZoomOverlayIfNeeded(for window: NSWindow) {
+        guard let titlebarView = AlanShellWindowPlacement.titlebarControlContainer(for: window)
+        else {
+            return
+        }
+
+        if let doubleClickZoomOverlay,
+           doubleClickZoomOverlay.superview === titlebarView {
+            doubleClickZoomOverlay.frame = titlebarView.bounds
+            return
+        }
+
+        doubleClickZoomOverlay?.removeFromSuperview()
+        let overlay = ShellWindowDoubleClickZoomOverlayView(frame: titlebarView.bounds)
+        overlay.autoresizingMask = [.width, .height]
+        titlebarView.addSubview(overlay, positioned: .below, relativeTo: titlebarView.subviews.first)
+        doubleClickZoomOverlay = overlay
+    }
+}
+
+final class ShellWindowDoubleClickZoomOverlayView: NSView {
+    private var restoreFrame: NSRect?
+
+    override var mouseDownCanMoveWindow: Bool {
+        true
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let window else { return nil }
+        guard bounds.contains(point) else { return nil }
+        let windowPoint = convert(point, to: nil)
+        guard ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+            locationInWindow: windowPoint,
+            in: window
+        ) else {
+            return nil
+        }
+        return self
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard event.clickCount == 2, let window else {
+            window?.performDrag(with: event)
+            return
+        }
+        toggleVisibleFrameZoom(for: window)
+    }
+
+    private func toggleVisibleFrameZoom(for window: NSWindow) {
+        let visibleFrame =
+            window.screen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? window.frame
+        let zoomFrame = ShellWindowSizing.zoomFrame(in: visibleFrame)
+
+        if ShellWindowSizing.frame(window.frame, approximatelyMatches: zoomFrame),
+           let restoreFrame,
+           !ShellWindowSizing.frame(restoreFrame, approximatelyMatches: zoomFrame) {
+            window.setFrame(restoreFrame, display: true, animate: true)
+            self.restoreFrame = nil
+        } else {
+            restoreFrame = window.frame
+            window.setFrame(zoomFrame, display: true, animate: true)
+        }
+    }
 }
 
 private enum AlanShellWindowPlacement {
-    private static var positionedWindowNumbers: Set<Int> = []
-
-    static func apply(to window: NSWindow, appearanceMode: ShellAppearanceMode) -> ShellWindowChromeMetrics {
+    static func configure(_ window: NSWindow, appearanceMode: ShellAppearanceMode) {
         window.title = "Alan"
         applyAppearance(to: window, appearanceMode: appearanceMode)
         window.titleVisibility = .hidden
@@ -165,22 +320,14 @@ private enum AlanShellWindowPlacement {
         window.titlebarSeparatorStyle = .none
         window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = true
-        window.minSize = NSSize(width: 1180, height: 760)
+        window.minSize = ShellWindowSizing.minimumSize
         window.tabbingMode = .disallowed
-
-        if positionedWindowNumbers.insert(window.windowNumber).inserted {
-            window.setFrame(centeredFrameOnMainScreen(for: window), display: true)
-        } else if shouldResetFrame(window.frame) {
-            window.setFrame(centeredFrame(for: window), display: true)
-        }
 
         if !window.isVisible {
             window.makeKeyAndOrderFront(nil)
         }
 
         NSApp.activate(ignoringOtherApps: true)
-
-        return chromeMetrics(for: window)
     }
 
     static func applyAppearance(to window: NSWindow, appearanceMode: ShellAppearanceMode) {
@@ -191,7 +338,7 @@ private enum AlanShellWindowPlacement {
         window.displayIfNeeded()
     }
 
-    private static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {
+    static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {
         var metrics = ShellWindowChromeMetrics()
 
         if let trafficLightGroupFrame = repositionStandardWindowButtons(in: window) {
@@ -199,6 +346,10 @@ private enum AlanShellWindowPlacement {
         }
 
         return metrics
+    }
+
+    static func titlebarControlContainer(for window: NSWindow) -> NSView? {
+        window.standardWindowButton(.closeButton)?.superview
     }
 
     private static func repositionStandardWindowButtons(in window: NSWindow) -> CGRect? {
@@ -261,89 +412,6 @@ private enum AlanShellWindowPlacement {
             width: contentFrame.width,
             height: contentFrame.height
         )
-    }
-
-    private static func shouldResetFrame(_ frame: NSRect) -> Bool {
-        let screens = NSScreen.screens
-        guard !screens.isEmpty else { return false }
-
-        let frameArea = max(frame.width * frame.height, 1)
-        let largestVisibleArea = screens
-            .map(\.visibleFrame)
-            .map { visibleFrame -> CGFloat in
-                let intersection = visibleFrame.intersection(frame)
-                guard !intersection.isNull else { return 0 }
-                return intersection.width * intersection.height
-            }
-            .max() ?? 0
-
-        let visibleRatio = largestVisibleArea / frameArea
-        let targetVisibleFrame = preferredVisibleFrame(for: frame)
-
-        return visibleRatio < 0.55
-            || frame.width > targetVisibleFrame.width
-            || frame.height > targetVisibleFrame.height
-            || !targetVisibleFrame.insetBy(dx: -48, dy: -48).intersects(frame)
-    }
-
-    private static func centeredFrame(for window: NSWindow) -> NSRect {
-        let visibleFrame = preferredVisibleFrame(for: window.frame)
-        return centeredFrame(in: visibleFrame, minSize: window.minSize)
-    }
-
-    private static func centeredFrameOnMainScreen(for window: NSWindow) -> NSRect {
-        let visibleFrame = primaryVisibleFrame() ?? preferredVisibleFrame(for: window.frame)
-        return centeredFrame(in: visibleFrame, minSize: window.minSize)
-    }
-
-    private static func centeredFrame(in visibleFrame: NSRect, minSize: NSSize) -> NSRect {
-        let targetWidth = min(
-            max(visibleFrame.width * 0.84, minSize.width),
-            visibleFrame.width - 32
-        )
-        let targetHeight = min(
-            max(visibleFrame.height * 0.86, minSize.height),
-            visibleFrame.height - 32
-        )
-
-        let origin = CGPoint(
-            x: visibleFrame.midX - (targetWidth / 2),
-            y: visibleFrame.midY - (targetHeight / 2)
-        )
-
-        return NSRect(origin: origin, size: NSSize(width: targetWidth, height: targetHeight))
-    }
-
-    private static func preferredVisibleFrame(for frame: NSRect) -> NSRect {
-        if let containingScreen = NSScreen.screens.first(where: {
-            !$0.visibleFrame.intersection(frame).isNull
-        }) {
-            return containingScreen.visibleFrame
-        }
-
-        if let mainFrame = NSScreen.main?.visibleFrame {
-            return mainFrame
-        }
-
-        return NSScreen.screens.first?.visibleFrame ?? NSRect(x: 80, y: 80, width: 1440, height: 900)
-    }
-
-    private static func primaryVisibleFrame() -> NSRect? {
-        if let originScreen = NSScreen.screens.first(where: {
-            abs($0.frame.minX) < 1 && abs($0.frame.minY) < 1
-        }) {
-            return originScreen.visibleFrame
-        }
-
-        return NSScreen.screens
-            .sorted {
-                if $0.frame.minY == $1.frame.minY {
-                    return $0.frame.minX < $1.frame.minX
-                }
-                return $0.frame.minY < $1.frame.minY
-            }
-            .first?
-            .visibleFrame
     }
 }
 #endif

--- a/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
+++ b/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
@@ -6,29 +6,47 @@ import AppKit
 struct ShellWindowPlacementView: NSViewRepresentable {
     @Binding var metrics: ShellWindowChromeMetrics
     let appearanceMode: ShellAppearanceMode
+    @Binding var systemColorScheme: ColorScheme
 
     func makeNSView(context: Context) -> ShellWindowPlacementNSView {
         let metricsBinding = _metrics
-        return ShellWindowPlacementNSView(appearanceMode: appearanceMode) { metrics in
-            let newMetrics = metrics
-            DispatchQueue.main.async {
-                guard metricsBinding.wrappedValue != newMetrics else { return }
-                metricsBinding.wrappedValue = newMetrics
-            }
-        }
+        let systemColorSchemeBinding = _systemColorScheme
+        return ShellWindowPlacementNSView(
+            appearanceMode: appearanceMode,
+            metricsHandler: metricsHandler(metricsBinding),
+            systemAppearanceHandler: systemAppearanceHandler(systemColorSchemeBinding)
+        )
     }
 
     func updateNSView(_ nsView: ShellWindowPlacementNSView, context: Context) {
         let metricsBinding = _metrics
+        let systemColorSchemeBinding = _systemColorScheme
         nsView.updateAppearanceMode(appearanceMode)
-        nsView.updateMetricsHandler { metrics in
-            let newMetrics = metrics
+        nsView.updateMetricsHandler(metricsHandler(metricsBinding))
+        nsView.updateSystemAppearanceHandler(systemAppearanceHandler(systemColorSchemeBinding))
+        nsView.resolveWindowIfNeeded()
+    }
+
+    private func metricsHandler(
+        _ metricsBinding: Binding<ShellWindowChromeMetrics>
+    ) -> (ShellWindowChromeMetrics) -> Void {
+        { metrics in
             DispatchQueue.main.async {
-                guard metricsBinding.wrappedValue != newMetrics else { return }
-                metricsBinding.wrappedValue = newMetrics
+                guard metricsBinding.wrappedValue != metrics else { return }
+                metricsBinding.wrappedValue = metrics
             }
         }
-        nsView.resolveWindowIfNeeded()
+    }
+
+    private func systemAppearanceHandler(
+        _ systemColorSchemeBinding: Binding<ColorScheme>
+    ) -> (ColorScheme) -> Void {
+        { colorScheme in
+            DispatchQueue.main.async {
+                guard systemColorSchemeBinding.wrappedValue != colorScheme else { return }
+                systemColorSchemeBinding.wrappedValue = colorScheme
+            }
+        }
     }
 }
 
@@ -63,14 +81,17 @@ struct ShellWindowChromeMetrics: Equatable {
 final class ShellWindowPlacementNSView: NSView {
     private var appearanceMode: ShellAppearanceMode
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
+    private var systemAppearanceHandler: (ColorScheme) -> Void
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
 
     init(
         appearanceMode: ShellAppearanceMode,
-        metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void
+        metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void,
+        systemAppearanceHandler: @escaping (ColorScheme) -> Void = { _ in }
     ) {
         self.appearanceMode = appearanceMode
         self.metricsHandler = metricsHandler
+        self.systemAppearanceHandler = systemAppearanceHandler
         super.init(frame: .zero)
     }
 
@@ -89,22 +110,47 @@ final class ShellWindowPlacementNSView: NSView {
         resolveWindowIfNeeded()
     }
 
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        publishEffectiveSystemColorScheme()
+    }
+
     func updateMetricsHandler(_ handler: @escaping (ShellWindowChromeMetrics) -> Void) {
         metricsHandler = handler
     }
 
+    func updateSystemAppearanceHandler(_ handler: @escaping (ColorScheme) -> Void) {
+        systemAppearanceHandler = handler
+        publishEffectiveSystemColorScheme()
+    }
+
     func updateAppearanceMode(_ mode: ShellAppearanceMode) {
+        let didChange = appearanceMode != mode
         appearanceMode = mode
+        guard didChange else { return }
+        applyAppearanceToAttachedWindow()
+        publishEffectiveSystemColorScheme()
     }
 
     func resolveWindowIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self, let window = self.window else { return }
             let metrics = AlanShellWindowPlacement.apply(to: window, appearanceMode: self.appearanceMode)
+            self.publishEffectiveSystemColorScheme()
             guard self.lastPublishedMetrics != metrics else { return }
             self.lastPublishedMetrics = metrics
             self.metricsHandler(metrics)
         }
+    }
+
+    private func applyAppearanceToAttachedWindow() {
+        guard let window else { return }
+        AlanShellWindowPlacement.applyAppearance(to: window, appearanceMode: appearanceMode)
+    }
+
+    private func publishEffectiveSystemColorScheme() {
+        let appearance = window?.effectiveAppearance ?? effectiveAppearance
+        systemAppearanceHandler(ShellAppearanceMode.colorScheme(for: appearance))
     }
 }
 
@@ -113,7 +159,7 @@ private enum AlanShellWindowPlacement {
 
     static func apply(to window: NSWindow, appearanceMode: ShellAppearanceMode) -> ShellWindowChromeMetrics {
         window.title = "Alan"
-        window.appearance = appearanceMode.nsAppearanceName.flatMap(NSAppearance.init(named:))
+        applyAppearance(to: window, appearanceMode: appearanceMode)
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.titlebarSeparatorStyle = .none
@@ -135,6 +181,14 @@ private enum AlanShellWindowPlacement {
         NSApp.activate(ignoringOtherApps: true)
 
         return chromeMetrics(for: window)
+    }
+
+    static func applyAppearance(to window: NSWindow, appearanceMode: ShellAppearanceMode) {
+        let appearance = appearanceMode.nsAppearanceName.flatMap(NSAppearance.init(named:))
+        window.appearance = appearance
+        window.contentView?.appearance = appearance
+        window.contentView?.needsDisplay = true
+        window.displayIfNeeded()
     }
 
     private static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {

--- a/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
+++ b/clients/apple/AlanNative/Support/ShellWindowPlacement.swift
@@ -5,10 +5,11 @@ import AppKit
 
 struct ShellWindowPlacementView: NSViewRepresentable {
     @Binding var metrics: ShellWindowChromeMetrics
+    let appearanceMode: ShellAppearanceMode
 
     func makeNSView(context: Context) -> ShellWindowPlacementNSView {
         let metricsBinding = _metrics
-        return ShellWindowPlacementNSView { metrics in
+        return ShellWindowPlacementNSView(appearanceMode: appearanceMode) { metrics in
             let newMetrics = metrics
             DispatchQueue.main.async {
                 guard metricsBinding.wrappedValue != newMetrics else { return }
@@ -19,6 +20,7 @@ struct ShellWindowPlacementView: NSViewRepresentable {
 
     func updateNSView(_ nsView: ShellWindowPlacementNSView, context: Context) {
         let metricsBinding = _metrics
+        nsView.updateAppearanceMode(appearanceMode)
         nsView.updateMetricsHandler { metrics in
             let newMetrics = metrics
             DispatchQueue.main.async {
@@ -31,14 +33,43 @@ struct ShellWindowPlacementView: NSViewRepresentable {
 }
 
 struct ShellWindowChromeMetrics: Equatable {
-    var trafficLightsTopInset: CGFloat = 0
+    var trafficLightGroupFrame = CGRect(
+        x: ShellSidebarMetrics.trafficLightLeadingInset,
+        y: ShellSidebarMetrics.trafficLightTopInset,
+        width: ShellSidebarMetrics.trafficLightFallbackGroupWidth,
+        height: ShellSidebarMetrics.trafficLightFallbackButtonHeight
+    )
+
+    var titlebarToolLeadingInset: CGFloat {
+        trafficLightGroupFrame.maxX + ShellSidebarMetrics.titlebarToolGapAfterTrafficLights
+    }
+
+    var titlebarToolTopInset: CGFloat {
+        max(
+            0,
+            trafficLightGroupFrame.midY - (ShellSidebarMetrics.titlebarToolHeight / 2)
+        )
+    }
+
+    var commandLauncherTopInset: CGFloat {
+        trafficLightGroupFrame.maxY + ShellSidebarMetrics.commandLauncherGapBelowTrafficLights
+    }
+
+    var collapsedRevealHeaderHeight: CGFloat {
+        commandLauncherTopInset + ShellSidebarMetrics.commandLauncherHeight + 8
+    }
 }
 
 final class ShellWindowPlacementNSView: NSView {
+    private var appearanceMode: ShellAppearanceMode
     private var metricsHandler: (ShellWindowChromeMetrics) -> Void
     private var lastPublishedMetrics: ShellWindowChromeMetrics?
 
-    init(metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void) {
+    init(
+        appearanceMode: ShellAppearanceMode,
+        metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void
+    ) {
+        self.appearanceMode = appearanceMode
         self.metricsHandler = metricsHandler
         super.init(frame: .zero)
     }
@@ -62,14 +93,17 @@ final class ShellWindowPlacementNSView: NSView {
         metricsHandler = handler
     }
 
+    func updateAppearanceMode(_ mode: ShellAppearanceMode) {
+        appearanceMode = mode
+    }
+
     func resolveWindowIfNeeded() {
         DispatchQueue.main.async { [weak self] in
-            guard let window = self?.window else { return }
-            AlanShellWindowPlacement.apply(to: window)
-            let metrics = AlanShellWindowPlacement.chromeMetrics(for: window)
-            guard self?.lastPublishedMetrics != metrics else { return }
-            self?.lastPublishedMetrics = metrics
-            self?.metricsHandler(metrics)
+            guard let self, let window = self.window else { return }
+            let metrics = AlanShellWindowPlacement.apply(to: window, appearanceMode: self.appearanceMode)
+            guard self.lastPublishedMetrics != metrics else { return }
+            self.lastPublishedMetrics = metrics
+            self.metricsHandler(metrics)
         }
     }
 }
@@ -77,8 +111,13 @@ final class ShellWindowPlacementNSView: NSView {
 private enum AlanShellWindowPlacement {
     private static var positionedWindowNumbers: Set<Int> = []
 
-    static func apply(to window: NSWindow) {
+    static func apply(to window: NSWindow, appearanceMode: ShellAppearanceMode) -> ShellWindowChromeMetrics {
         window.title = "Alan"
+        window.appearance = appearanceMode.nsAppearanceName.flatMap(NSAppearance.init(named:))
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
+        window.styleMask.insert(.fullSizeContentView)
         window.isMovableByWindowBackground = true
         window.minSize = NSSize(width: 1180, height: 760)
         window.tabbingMode = .disallowed
@@ -94,28 +133,79 @@ private enum AlanShellWindowPlacement {
         }
 
         NSApp.activate(ignoringOtherApps: true)
+
+        return chromeMetrics(for: window)
     }
 
-    static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {
-        let buttonFrames = [
-            NSWindow.ButtonType.closeButton,
-            .miniaturizeButton,
-            .zoomButton,
-        ].compactMap { buttonType -> NSRect? in
-            window.standardWindowButton(buttonType)?.frame
+    private static func chromeMetrics(for window: NSWindow) -> ShellWindowChromeMetrics {
+        var metrics = ShellWindowChromeMetrics()
+
+        if let trafficLightGroupFrame = repositionStandardWindowButtons(in: window) {
+            metrics.trafficLightGroupFrame = trafficLightGroupFrame
         }
 
-        guard let firstFrame = buttonFrames.first else {
-            return ShellWindowChromeMetrics()
+        return metrics
+    }
+
+    private static func repositionStandardWindowButtons(in window: NSWindow) -> CGRect? {
+        let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        let buttons = buttonTypes.compactMap { window.standardWindowButton($0) }
+
+        guard buttons.count == buttonTypes.count,
+              let superview = buttons.first?.superview,
+              buttons.allSatisfy({ $0.superview === superview })
+        else {
+            return nil
         }
 
-        let trafficLightsFrame = buttonFrames.dropFirst().reduce(firstFrame) { partialResult, frame in
-            partialResult.union(frame)
-        }
-        let topInset = max(0, trafficLightsFrame.maxY + 10)
+        let currentGroupFrame = buttons
+            .map(\.frame)
+            .reduce(NSRect.null) { $0.union($1) }
+        guard !currentGroupFrame.isNull else { return nil }
 
-        return ShellWindowChromeMetrics(
-            trafficLightsTopInset: ceil(topInset)
+        let currentVisualTopInset = visualTopInset(of: currentGroupFrame, in: superview)
+        let deltaX = ShellSidebarMetrics.trafficLightLeadingInset - currentGroupFrame.minX
+        let deltaTop = ShellSidebarMetrics.trafficLightTopInset - currentVisualTopInset
+        let deltaY = superview.isFlipped ? deltaTop : -deltaTop
+
+        for button in buttons {
+            var frame = button.frame
+            frame.origin.x += deltaX
+            frame.origin.y += deltaY
+            button.setFrameOrigin(frame.origin)
+        }
+
+        let movedGroupFrame = buttons
+            .map(\.frame)
+            .reduce(NSRect.null) { $0.union($1) }
+        guard !movedGroupFrame.isNull else { return nil }
+
+        return topLeadingFrame(for: movedGroupFrame, in: superview, window: window)
+    }
+
+    private static func visualTopInset(of frame: NSRect, in view: NSView) -> CGFloat {
+        if view.isFlipped {
+            return frame.minY
+        }
+
+        return max(0, view.bounds.height - frame.maxY)
+    }
+
+    private static func topLeadingFrame(
+        for frame: NSRect,
+        in view: NSView,
+        window: NSWindow
+    ) -> CGRect? {
+        guard let contentView = window.contentView else { return nil }
+        let windowFrame = view.convert(frame, to: nil)
+        let contentFrame = contentView.convert(windowFrame, from: nil)
+        let topInset = visualTopInset(of: contentFrame, in: contentView)
+
+        return CGRect(
+            x: contentFrame.minX,
+            y: topInset,
+            width: contentFrame.width,
+            height: contentFrame.height
         )
     }
 

--- a/clients/apple/AlanNative/TerminalHostRuntime.swift
+++ b/clients/apple/AlanNative/TerminalHostRuntime.swift
@@ -470,6 +470,14 @@ struct AlanShellBootProfile: Equatable {
     let environment: [String: String]
     let ghostty: GhosttyIntegrationStatus
 
+    func requiresSurfaceRecreation(comparedTo previous: AlanShellBootProfile?) -> Bool {
+        guard let previous else { return true }
+        // Runtime PWD updates change workingDirectory but must not respawn the pane.
+        return command != previous.command
+            || environment != previous.environment
+            || ghostty != previous.ghostty
+    }
+
     var launchCommandString: String {
         command.launchCommandString
     }
@@ -519,6 +527,12 @@ struct AlanShellBootProfile: Equatable {
         if let repoRoot = command.repoRoot {
             environment["ALAN_REPOSITORY_ROOT"] = repoRoot
         }
+
+        if let terminfoPath = ghostty.terminfoPath {
+            environment["TERMINFO"] = terminfoPath
+        }
+        environment["TERM_PROGRAM"] = "Alan"
+        environment["COLORTERM"] = "truecolor"
 
         return AlanShellBootProfile(
             command: command,

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -182,7 +182,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func configureView() {
         wantsLayer = true
         layer?.backgroundColor = NSColor(calibratedRed: 0.06, green: 0.08, blue: 0.10, alpha: 1).cgColor
-        layer?.cornerRadius = ShellRadii.surface
+        layer?.cornerRadius = ShellRadii.terminalSurface
         layer?.cornerCurve = .continuous
         layer?.masksToBounds = true
         layer?.borderWidth = 0

--- a/clients/apple/AlanNative/TerminalHostView.swift
+++ b/clients/apple/AlanNative/TerminalHostView.swift
@@ -182,8 +182,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func configureView() {
         wantsLayer = true
         layer?.backgroundColor = NSColor(calibratedRed: 0.06, green: 0.08, blue: 0.10, alpha: 1).cgColor
-        layer?.cornerRadius = ShellRadii.terminalSurface
-        layer?.cornerCurve = .continuous
         layer?.masksToBounds = true
         layer?.borderWidth = 0
         layer?.shadowColor = NSColor.black.cgColor

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -452,7 +452,7 @@ struct TerminalPaneView: View {
 }
 
 private struct ShellTerminalSurfaceFrame: ViewModifier {
-    private let shape = RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
+    private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
 
     func body(content: Content) -> some View {
         content
@@ -469,11 +469,7 @@ private struct ShellTerminalSurfaceFrame: ViewModifier {
                     lineWidth: 1
                 )
             }
-            .shadow(
-                color: Color.black.opacity(0.10),
-                radius: 18,
-                y: 8
-            )
+            .shellShadow(ShellShadows.terminalSurface)
     }
 }
 
@@ -862,7 +858,7 @@ private struct ShellFindBarView: View {
             RoundedRectangle(cornerRadius: ShellRadii.surface, style: .continuous)
                 .stroke(ShellPalette.line.opacity(0.35), lineWidth: 1)
         }
-        .shadow(color: Color.black.opacity(0.12), radius: 14, y: 6)
+        .shellShadow(ShellShadows.floatingInput)
         .onAppear {
             query = searchState.query
             isFocused = true

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -452,24 +452,55 @@ struct TerminalPaneView: View {
 }
 
 private struct ShellTerminalSurfaceFrame: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
     private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
 
     func body(content: Content) -> some View {
         content
-            .background(
+            .clipShape(shape)
+            .background {
                 ShellMaterialShape(
                     role: .terminalSurround,
                     shape: shape
                 )
-            )
-            .clipShape(shape)
-            .overlay {
-                shape.stroke(
-                    ShellPalette.line.opacity(0.18),
-                    lineWidth: 1
-                )
+                .shellShadow(ShellShadows.terminalSurfaceRim)
+                .shellShadow(ShellShadows.terminalSurface)
             }
-            .shellShadow(ShellShadows.terminalSurface)
+            .overlay {
+                terminalSurfaceRim
+            }
+    }
+
+    private var terminalSurfaceRim: some View {
+        ZStack {
+            shape
+                .strokeBorder(
+                    ShellPalette.line.opacity(colorScheme == .light ? 0.30 : 0.26),
+                    lineWidth: 0.85
+                )
+
+            shape
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(colorScheme == .light ? 0.18 : 0.07),
+                            Color.white.opacity(0.015),
+                            Color.black.opacity(colorScheme == .light ? 0.14 : 0.32),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.65
+                )
+
+            shape
+                .inset(by: 1)
+                .strokeBorder(
+                    Color.white.opacity(colorScheme == .light ? 0.06 : 0.03),
+                    lineWidth: 0.4
+                )
+        }
+        .allowsHitTesting(false)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 #if os(macOS)
 struct TerminalPaneView: View {
     @ObservedObject var host: ShellHostController
+    let terminalSurfaceInsets: EdgeInsets
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -14,7 +15,7 @@ struct TerminalPaneView: View {
             }
 
         }
-        .padding(ShellWorkspaceMetrics.terminalSurfaceInset)
+        .padding(terminalSurfaceInsets)
     }
 
     private var paneMetadataStrip: some View {

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -14,9 +14,7 @@ struct TerminalPaneView: View {
             }
 
         }
-        .padding(.top, 8)
-        .padding(.trailing, 8)
-        .padding(.bottom, 8)
+        .padding(ShellWorkspaceMetrics.terminalSurfaceInset)
     }
 
     private var paneMetadataStrip: some View {

--- a/clients/apple/AlanNative/TerminalPaneView.swift
+++ b/clients/apple/AlanNative/TerminalPaneView.swift
@@ -6,153 +6,9 @@ struct TerminalPaneView: View {
     let terminalSurfaceInsets: EdgeInsets
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            paneCanvas
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            if showsMetadataStrip {
-                paneMetadataStrip
-            }
-
-        }
-        .padding(terminalSurfaceInsets)
-    }
-
-    private var paneMetadataStrip: some View {
-        let selectedPane = host.selectedPane
-        let selectedPaneTitle = selectedPane.map {
-            shellDisplayTitle(
-                rawTitle: $0.viewport?.title,
-                workingDirectoryName: $0.context?.workingDirectoryName,
-                cwd: $0.cwd,
-                program: $0.process?.program,
-                launchTarget: $0.resolvedLaunchTarget
-            )
-        }
-
-        return ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                if let selectedPane,
-                   let status = shellTerminalStatusSummary(for: selectedPane)
-                {
-                    compactMetaChip(
-                        title: status,
-                        icon: statusIcon(for: selectedPane),
-                        tint: statusTint(for: selectedPane)
-                    )
-                }
-
-                if let workingDirectory = shellVisibleLabel(
-                    selectedPane?.context?.workingDirectoryName
-                        ?? selectedPane?.cwd
-                )
-                   , workingDirectory != selectedPaneTitle
-                {
-                    compactMetaChip(title: workingDirectory, icon: "folder")
-                }
-
-                if let branch = selectedPane?.context?.gitBranch {
-                    compactMetaChip(title: branch, icon: "point.topleft.down.curvedto.point.bottomright.up")
-                }
-
-                if let attention = selectedPane?.attention,
-                   attention == .awaitingUser || attention == .notable
-                {
-                    compactMetaChip(
-                        title: attention.rawValue.replacingOccurrences(of: "_", with: " "),
-                        icon: "bell.badge",
-                        tint: attention == .awaitingUser ? ShellPalette.attention : ShellPalette.mutedInk
-                    )
-                }
-
-                if let binding = selectedPane?.alanBinding {
-                    compactMetaChip(
-                        title: "Alan \(binding.runStatus)",
-                        icon: "sparkles",
-                        tint: ShellPalette.accent
-                    )
-                }
-            }
-        }
-    }
-
-    private var showsMetadataStrip: Bool {
-        let selectedPane = host.selectedPane
-        let selectedPaneTitle = selectedPane.map {
-            shellDisplayTitle(
-                rawTitle: $0.viewport?.title,
-                workingDirectoryName: $0.context?.workingDirectoryName,
-                cwd: $0.cwd,
-                program: $0.process?.program,
-                launchTarget: $0.resolvedLaunchTarget
-            )
-        }
-
-        let workingDirectory = shellVisibleLabel(
-            selectedPane?.context?.workingDirectoryName
-                ?? selectedPane?.cwd
-        )
-
-        return selectedPane.flatMap(shellTerminalStatusSummary) != nil
-            || (workingDirectory != nil && workingDirectory != selectedPaneTitle)
-            || selectedPane?.context?.gitBranch != nil
-            || selectedPane?.attention == .awaitingUser
-            || selectedPane?.attention == .notable
-            || selectedPane?.alanBinding != nil
-    }
-
-    private func compactMetaChip(title: String, icon: String, tint: Color? = nil) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: icon)
-            Text(title)
-                .lineLimit(1)
-        }
-        .font(.system(size: 11, weight: .semibold))
-        .foregroundStyle(tint ?? ShellPalette.mutedInk)
-        .padding(.horizontal, 9)
-        .padding(.vertical, 6)
-        .background(
-            ShellMaterialShape(
-                role: .terminalChrome,
-                shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-            )
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                .stroke(ShellPalette.line.opacity(0.22), lineWidth: 1)
-        }
-    }
-
-    private func statusIcon(for pane: ShellPane) -> String {
-        if pane.context?.processState == "exited"
-            || pane.context?.surfaceReadiness == "child_exited"
-        {
-            return "checkmark.circle"
-        }
-        if pane.context?.rendererHealth == "failed"
-            || pane.context?.rendererPhase == "failed"
-            || pane.context?.surfaceReadiness == "renderer_failed"
-        {
-            return "exclamationmark.triangle"
-        }
-        if pane.attention == .awaitingUser || pane.attention == .notable {
-            return "bell.badge"
-        }
-        return "info.circle"
-    }
-
-    private func statusTint(for pane: ShellPane) -> Color {
-        if pane.context?.rendererHealth == "failed"
-            || pane.context?.rendererPhase == "failed"
-            || pane.context?.surfaceReadiness == "renderer_failed"
-            || pane.attention == .awaitingUser
-        {
-            return ShellPalette.attention
-        }
-        if pane.attention == .notable {
-            return ShellPalette.mutedInk
-        }
-        return ShellPalette.mutedInk
+        paneCanvas
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(terminalSurfaceInsets)
     }
 
     private var paneCanvas: some View {
@@ -691,6 +547,7 @@ private struct ShellTerminalLeafView: View {
         VStack(spacing: 0) {
             ShellPaneTitleBarView(
                 title: shellPaneTitleBarTitle(for: pane),
+                pane: pane,
                 isSelected: isSelected,
                 onFocusPane: {
                     activationDelegate?.terminalHostDidRequestActivation(paneID: pane.paneID)
@@ -748,6 +605,7 @@ private struct ShellTerminalLeafView: View {
 
 private struct ShellPaneTitleBarView: View {
     let title: String
+    let pane: ShellPane
     let isSelected: Bool
     let onFocusPane: () -> Void
     let onClosePane: () -> Void
@@ -760,6 +618,15 @@ private struct ShellPaneTitleBarView: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+            if !accessories.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach(accessories) { accessory in
+                        ShellPaneTitleBarAccessoryView(accessory: accessory, isSelected: isSelected)
+                    }
+                }
+                .layoutPriority(1)
+            }
 
             Button(action: onClosePane) {
                 Image(systemName: "xmark")
@@ -790,6 +657,122 @@ private struct ShellPaneTitleBarView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture(perform: onFocusPane)
+    }
+
+    private var accessories: [ShellPaneTitleBarAccessory] {
+        var items: [ShellPaneTitleBarAccessory] = []
+
+        if let status = shellTerminalStatusSummary(for: pane) {
+            items.append(
+                ShellPaneTitleBarAccessory(
+                    id: "status",
+                    icon: statusIcon,
+                    title: statusTitle(status),
+                    help: status,
+                    tint: statusTint
+                )
+            )
+        }
+
+        if let branch = shellVisibleLabel(pane.context?.gitBranch) {
+            items.append(
+                ShellPaneTitleBarAccessory(
+                    id: "branch",
+                    icon: "point.topleft.down.curvedto.point.bottomright.up",
+                    title: branch,
+                    help: "Git branch \(branch)",
+                    tint: ShellPalette.mutedInk,
+                    maxWidth: 120
+                )
+            )
+        }
+
+        if let binding = pane.alanBinding {
+            let bindingTitle = binding.pendingYield ? "Input" : shellVisibleLabel(binding.runStatus)
+            items.append(
+                ShellPaneTitleBarAccessory(
+                    id: "alan",
+                    icon: "sparkles",
+                    title: bindingTitle,
+                    help: "Alan \(binding.runStatus)",
+                    tint: ShellPalette.accent,
+                    maxWidth: 72
+                )
+            )
+        }
+
+        return items
+    }
+
+    private var statusIcon: String {
+        if pane.context?.processState == "exited"
+            || pane.context?.surfaceReadiness == "child_exited"
+        {
+            return "checkmark.circle"
+        }
+        if pane.context?.rendererHealth == "failed"
+            || pane.context?.rendererPhase == "failed"
+            || pane.context?.surfaceReadiness == "renderer_failed"
+        {
+            return "exclamationmark.triangle"
+        }
+        if pane.attention == .awaitingUser || pane.attention == .notable {
+            return "bell.badge"
+        }
+        return "info.circle"
+    }
+
+    private var statusTint: Color {
+        if pane.context?.rendererHealth == "failed"
+            || pane.context?.rendererPhase == "failed"
+            || pane.context?.surfaceReadiness == "renderer_failed"
+            || pane.attention == .awaitingUser
+        {
+            return ShellPalette.attention
+        }
+        return ShellPalette.mutedInk
+    }
+
+    private func statusTitle(_ status: String) -> String? {
+        if pane.attention == .notable,
+           status == "Terminal bell"
+        {
+            return nil
+        }
+        return status
+    }
+}
+
+private struct ShellPaneTitleBarAccessory: Identifiable {
+    let id: String
+    let icon: String
+    let title: String?
+    let help: String
+    let tint: Color
+    var maxWidth: CGFloat?
+}
+
+private struct ShellPaneTitleBarAccessoryView: View {
+    let accessory: ShellPaneTitleBarAccessory
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: accessory.icon)
+                .font(.system(size: 10, weight: .semibold))
+
+            if let title = accessory.title {
+                Text(title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: accessory.maxWidth, alignment: .leading)
+            }
+        }
+        .foregroundStyle(accessory.tint.opacity(isSelected ? 0.86 : 0.58))
+        .fixedSize(horizontal: false, vertical: true)
+        .help(accessory.help)
+        .accessibilityLabel(accessory.help)
     }
 }
 

--- a/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
+++ b/clients/apple/AlanNative/TerminalRuntimeRegistry.swift
@@ -116,6 +116,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     func releaseRuntimes(excluding activePaneIDs: Set<String>) {
         let stalePaneIDs = Set(hostViewsByPaneID.keys)
             .union(snapshotsByPaneID.keys)
+            .union(runtimeService.registeredPaneIDs)
             .subtracting(activePaneIDs)
         stalePaneIDs.forEach { releaseRuntime($0) }
     }

--- a/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
@@ -76,68 +76,8 @@ struct ShellCommandTabView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center, spacing: 12) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(ShellPalette.accent)
-
-                TextField(
-                    "",
-                    text: $query,
-                    prompt: Text("Go to or Command...")
-                        .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
-                )
-                .textFieldStyle(.plain)
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(ShellPalette.ink)
-                .focused($isQueryFocused)
-                .onChange(of: query) { _, _ in
-                    unresolvedMessage = nil
-                }
-                .onSubmit {
-                    submit()
-                }
-                .onKeyPress(.return) {
-                    submit()
-                    return .handled
-                }
-
-                Text("⌘P")
-                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.85))
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
-                    .background(
-                        ShellMaterialShape(
-                            role: .controlGlass,
-                            shape: RoundedRectangle(
-                                cornerRadius: ShellRadii.control,
-                                style: .continuous
-                            )
-                        )
-                    )
-
-                Button {
-                    dismissAndRestoreFocus()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                        .frame(width: 26, height: 26)
-                        .background(
-                            ShellMaterialShape(
-                                role: .controlGlass,
-                                shape: RoundedRectangle(
-                                    cornerRadius: ShellRadii.control,
-                                    style: .continuous
-                                )
-                            )
-                        )
-                }
-                .buttonStyle(.plain)
-                .help("Close command input")
-            }
+        VStack(alignment: .leading, spacing: 9) {
+            commandInputBar
 
             if let unresolvedMessage {
                 Text(unresolvedMessage)
@@ -147,18 +87,7 @@ struct ShellCommandTabView: View {
                     .transition(.opacity)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .frame(width: 520, alignment: .leading)
-        .background {
-            ShellMaterialBackgroundView(.floatingOverlay)
-                .clipShape(RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous))
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: ShellRadii.overlay, style: .continuous)
-                .stroke(ShellMaterialRole.floatingOverlay.stroke, lineWidth: 1)
-        }
-        .shadow(color: Color.black.opacity(0.12), radius: 24, y: 14)
+        .frame(width: 560, alignment: .leading)
         .offset(x: unresolvedAttemptID.isMultiple(of: 2) ? 0 : 1.5)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: unresolvedAttemptID)
         .onAppear {
@@ -167,6 +96,68 @@ struct ShellCommandTabView: View {
         .onExitCommand {
             dismissAndRestoreFocus()
         }
+    }
+
+    private var commandInputBar: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(ShellPalette.accent)
+
+            TextField(
+                "",
+                text: $query,
+                prompt: Text("Ask Alan...")
+                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
+            )
+            .textFieldStyle(.plain)
+            .font(.system(size: 17, weight: .medium))
+            .foregroundStyle(ShellPalette.ink)
+            .focused($isQueryFocused)
+            .onChange(of: query) { _, _ in
+                unresolvedMessage = nil
+            }
+            .onSubmit {
+                submit()
+            }
+            .onKeyPress(.return) {
+                submit()
+                return .handled
+            }
+
+            Text("⌘P")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundStyle(ShellPalette.mutedInk.opacity(0.78))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(
+                    ShellMaterialShape(
+                        role: .controlGlass,
+                        shape: RoundedRectangle(
+                            cornerRadius: ShellRadii.control,
+                            style: .continuous
+                        )
+                    )
+                )
+
+            Button {
+                dismissAndRestoreFocus()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.88))
+                    .frame(width: 26, height: 26)
+                    .contentShape(RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .help("Close command input")
+        }
+        .padding(.horizontal, 18)
+        .frame(width: 560, height: 56, alignment: .leading)
+        .background {
+            ShellCommandPaletteGlassSurface()
+        }
+        .shellShadow(ShellShadows.commandPalette)
     }
 
     private func submit() {
@@ -222,6 +213,63 @@ struct ShellCommandTabView: View {
         isPresented = false
         DispatchQueue.main.async {
             host.refocusSelectedTerminalPane()
+        }
+    }
+}
+
+private struct ShellCommandPaletteGlassSurface: View {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let shape = Capsule()
+
+        if reduceTransparency {
+            surface(shape: shape)
+        } else {
+            surface(shape: shape)
+                .glassEffect(.regular.interactive(), in: shape)
+        }
+    }
+
+    private func surface(shape: Capsule) -> some View {
+        ZStack {
+            ShellMaterialBackgroundView(.floatingOverlay)
+                .clipShape(shape)
+
+            shape
+                .fill(ShellPalette.commandGlassTint.opacity(colorScheme == .light ? 0.18 : 0.10))
+
+            shape
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(colorScheme == .light ? 0.44 : 0.12),
+                            Color.white.opacity(colorScheme == .light ? 0.06 : 0.02),
+                            ShellPalette.sidebarInk.opacity(colorScheme == .light ? 0.035 : 0.10),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            shape
+                .strokeBorder(ShellPalette.line.opacity(colorScheme == .light ? 0.28 : 0.30), lineWidth: 0.8)
+
+            shape
+                .strokeBorder(Color.white.opacity(colorScheme == .light ? 0.50 : 0.16), lineWidth: 0.65)
+                .mask {
+                    shape.fill(
+                        LinearGradient(
+                            colors: [
+                                Color.white,
+                                Color.white.opacity(0),
+                            ],
+                            startPoint: .top,
+                            endPoint: .center
+                        )
+                    )
+                }
         }
     }
 }

--- a/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift
@@ -69,6 +69,7 @@ private enum ShellCommandInputAction: CaseIterable {
 struct ShellCommandTabView: View {
     @ObservedObject var host: ShellHostController
     @Binding var isPresented: Bool
+    var isActive = true
     @State private var query = ""
     @State private var unresolvedMessage: String?
     @State private var unresolvedAttemptID = 0
@@ -91,7 +92,10 @@ struct ShellCommandTabView: View {
         .offset(x: unresolvedAttemptID.isMultiple(of: 2) ? 0 : 1.5)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: unresolvedAttemptID)
         .onAppear {
-            isQueryFocused = true
+            updateActiveState(isActive)
+        }
+        .onChange(of: isActive) { _, active in
+            updateActiveState(active)
         }
         .onExitCommand {
             dismissAndRestoreFocus()
@@ -99,20 +103,33 @@ struct ShellCommandTabView: View {
     }
 
     private var commandInputBar: some View {
+        ZStack {
+            GlassEffectContainer(spacing: 10) {
+                ShellCommandPaletteGlassSurface()
+            }
+
+            commandInputContent
+                .padding(.horizontal, 18)
+        }
+        .frame(width: 560, height: 56, alignment: .leading)
+        .shellShadow(ShellShadows.commandPalette)
+    }
+
+    private var commandInputContent: some View {
         HStack(alignment: .center, spacing: 12) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(ShellPalette.accent)
+                .foregroundStyle(.primary)
 
             TextField(
                 "",
                 text: $query,
                 prompt: Text("Ask Alan...")
-                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.9))
+                    .foregroundStyle(.secondary)
             )
             .textFieldStyle(.plain)
             .font(.system(size: 17, weight: .medium))
-            .foregroundStyle(ShellPalette.ink)
+            .foregroundStyle(.primary)
             .focused($isQueryFocused)
             .onChange(of: query) { _, _ in
                 unresolvedMessage = nil
@@ -125,39 +142,20 @@ struct ShellCommandTabView: View {
                 return .handled
             }
 
-            Text("⌘P")
-                .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                .foregroundStyle(ShellPalette.mutedInk.opacity(0.78))
-                .padding(.horizontal, 7)
-                .padding(.vertical, 4)
-                .background(
-                    ShellMaterialShape(
-                        role: .controlGlass,
-                        shape: RoundedRectangle(
-                            cornerRadius: ShellRadii.control,
-                            style: .continuous
-                        )
-                    )
-                )
-
             Button {
                 dismissAndRestoreFocus()
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(ShellPalette.mutedInk.opacity(0.88))
+                    .foregroundStyle(.secondary)
                     .frame(width: 26, height: 26)
-                    .contentShape(RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous))
+                    .contentShape(
+                        RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                    )
             }
             .buttonStyle(.plain)
             .help("Close command input")
         }
-        .padding(.horizontal, 18)
-        .frame(width: 560, height: 56, alignment: .leading)
-        .background {
-            ShellCommandPaletteGlassSurface()
-        }
-        .shellShadow(ShellShadows.commandPalette)
     }
 
     private func submit() {
@@ -209,11 +207,31 @@ struct ShellCommandTabView: View {
         dismissAndRestoreFocus()
     }
 
+    private func updateActiveState(_ active: Bool) {
+        if active {
+            query = ""
+            unresolvedMessage = nil
+            unresolvedAttemptID = 0
+            DispatchQueue.main.async {
+                isQueryFocused = true
+            }
+        } else {
+            isQueryFocused = false
+            unresolvedMessage = nil
+        }
+    }
+
     private func dismissAndRestoreFocus() {
-        isPresented = false
+        withAnimation(commandInputAnimation) {
+            isPresented = false
+        }
         DispatchQueue.main.async {
             host.refocusSelectedTerminalPane()
         }
+    }
+
+    private var commandInputAnimation: Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.14)
     }
 }
 
@@ -225,14 +243,16 @@ private struct ShellCommandPaletteGlassSurface: View {
         let shape = Capsule()
 
         if reduceTransparency {
-            surface(shape: shape)
+            fallbackSurface(shape: shape)
         } else {
-            surface(shape: shape)
+            Color.clear
+                .clipShape(shape)
                 .glassEffect(.regular.interactive(), in: shape)
+                .glassEffectTransition(.identity)
         }
     }
 
-    private func surface(shape: Capsule) -> some View {
+    private func fallbackSurface(shape: Capsule) -> some View {
         ZStack {
             ShellMaterialBackgroundView(.floatingOverlay)
                 .clipShape(shape)

--- a/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
@@ -599,7 +599,7 @@ private struct ShellSpaceSwitcherItem: View {
         }
         .frame(width: 30, height: 30)
         .scaleEffect(isSelected ? 1 : (isHovered || isPreviewed ? 1.015 : 1))
-        .shellShadow(isSelected || isPreviewed ? ShellShadows.spaceSelection : ShellShadows.none)
+        .shellShadow(isSelected || isPreviewed ? ShellShadows.navigationSelection : ShellShadows.none)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isPreviewed)
@@ -687,7 +687,7 @@ private enum ShellSidebarRowVisualState: Equatable {
         case .normal, .hover:
             return ShellShadows.none
         case .selected:
-            return ShellShadows.sidebarSelection
+            return ShellShadows.navigationSelection
         }
     }
 }
@@ -913,7 +913,7 @@ private struct ShellSplitTopologyIndicator: View {
             .foregroundStyle(summary.focusedPaneID == nil ? .secondary : ShellPalette.accent)
             .frame(width: 28, height: 18)
             .background(
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                RoundedRectangle(cornerRadius: ShellRadii.badge, style: .continuous)
                     .fill(ShellPalette.canvas.opacity(0.55))
             )
         }
@@ -928,7 +928,7 @@ private struct ShellSplitTopologyIndicator: View {
         return Button {
             onFocusPane(paneID)
         } label: {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
                 .fill(isFocused ? ShellPalette.accent.opacity(0.9) : ShellPalette.mutedInk.opacity(0.24))
         }
         .buttonStyle(.plain)

--- a/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
@@ -10,6 +10,8 @@ struct ShellSidebarView: View {
     let openCommandTab: () -> Void
     @State private var hoveredTabID: String?
     @State private var hoveredSpaceID: String?
+    @State private var isCommandLauncherHovered = false
+    @State private var tabListScrollOffsetY: CGFloat = 0
 
     var body: some View {
         GeometryReader { proxy in
@@ -19,18 +21,24 @@ struct ShellSidebarView: View {
             ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
         }
         .scrollDisabled(isTabListScrollDisabled)
+        .onChange(of: sourceSpaceID) { _, _ in
+            tabListScrollOffsetY = 0
+        }
     }
 
     private func sidebarContent(pageWidth: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 0) {
             commandLauncher
-                .padding(.horizontal, 12)
+                .padding(.horizontal, ShellSidebarMetrics.edgeInset)
+                .padding(.bottom, 10)
             spaceLabelRow(pageWidth: pageWidth)
+                .padding(.bottom, 2)
             tabSection(pageWidth: pageWidth)
             spaceDock
-                .padding(.horizontal, 12)
+                .padding(.horizontal, ShellSidebarMetrics.edgeInset)
+                .padding(.top, 10)
         }
-        .padding(.top, chromeMetrics.trafficLightsTopInset)
+        .padding(.top, chromeMetrics.commandLauncherTopInset)
         .padding(.bottom, 15)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -49,30 +57,41 @@ struct ShellSidebarView: View {
         Button(action: openCommandTab) {
             HStack(spacing: 10) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                Text("Go to or Command...")
+                    .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
+                    .foregroundStyle(commandLauncherForeground)
+                    .frame(width: ShellSidebarMetrics.iconColumnWidth)
+                Text("Ask Alan...")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(commandLauncherForeground)
                     .lineLimit(1)
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, 11)
-            .padding(.vertical, 10)
-            .background(
-                ShellMaterialShape(
-                    role: .controlGlass,
-                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+            .padding(.horizontal, ShellSidebarMetrics.rowInset)
+            .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
+            .background {
+                ShellLiquidGlassSurface(
+                    shape: Capsule(),
+                    tint: ShellPalette.commandGlassTint,
+                    tintOpacity: isCommandLauncherHovered ? 0.22 : 0.18,
+                    strokeOpacity: isCommandLauncherHovered ? 0.22 : 0.16
                 )
-            )
+            }
+            .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .help("Go to or Command, Command-P")
-        .accessibilityLabel("Go to or Command")
+        .onHover { isHovering in
+            isCommandLauncherHovered = isHovering
+        }
+        .help("Ask Alan, Command-P")
+        .accessibilityLabel("Ask Alan")
+    }
+
+    private var commandLauncherForeground: Color {
+        ShellPalette.sidebarMutedInk.opacity(isCommandLauncherHovered ? 0.92 : 0.80)
     }
 
     private func tabSection(pageWidth: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
             GeometryReader { proxy in
                 ZStack(alignment: .topLeading) {
                     tabListPage(for: sourceSpaceID)
@@ -87,6 +106,9 @@ struct ShellSidebarView: View {
                     }
                 }
                 .clipped()
+                .overlay(alignment: .top) {
+                    ShellSidebarScrollBoundary(progress: tabListBoundaryProgress)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -94,11 +116,19 @@ struct ShellSidebarView: View {
 
     private func tabListPage(for spaceID: String?) -> some View {
         ScrollView(.vertical, showsIndicators: false) {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: ShellSidebarTabListOffsetPreferenceKey.self,
+                    value: proxy.frame(in: .named(tabListCoordinateSpaceName(for: spaceID))).minY
+                )
+            }
+            .frame(height: 0)
+
             VStack(alignment: .leading, spacing: 4) {
                 if let space = space(for: spaceID) {
                     if space.tabs.isEmpty {
                         ShellCompactEmptyAction(
-                            title: "New tab",
+                            title: "New Tab",
                             systemImage: "plus",
                             action: {
                                 _ = host.openTerminalTab()
@@ -112,7 +142,7 @@ struct ShellSidebarView: View {
                     }
                 } else {
                     ShellCompactEmptyAction(
-                        title: "New space",
+                        title: "New Space",
                         systemImage: "plus",
                         action: {
                             _ = host.createTerminalSpace()
@@ -122,6 +152,13 @@ struct ShellSidebarView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(.top, 2)
+            .padding(.horizontal, ShellSidebarMetrics.edgeInset)
+        }
+        .coordinateSpace(name: tabListCoordinateSpaceName(for: spaceID))
+        .onPreferenceChange(ShellSidebarTabListOffsetPreferenceKey.self) { offsetY in
+            guard spaceID == sourceSpaceID else { return }
+            tabListScrollOffsetY = offsetY
         }
     }
 
@@ -162,7 +199,7 @@ struct ShellSidebarView: View {
             } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 12.5, weight: .semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ShellPalette.sidebarInk.opacity(0.76))
                     .frame(width: 30, height: 30)
                     .background {
                         if hoveredSpaceID == "__new_space__" {
@@ -207,6 +244,14 @@ struct ShellSidebarView: View {
 
     private func targetOffset(in width: CGFloat) -> CGFloat {
         activeTransition?.targetOffset(in: width) ?? 0
+    }
+
+    private var tabListBoundaryProgress: CGFloat {
+        min(max(-tabListScrollOffsetY / 18, 0), 1)
+    }
+
+    private func tabListCoordinateSpaceName(for spaceID: String?) -> String {
+        "ShellSidebarTabListScroll-\(spaceID ?? "none")"
     }
 
     private func space(for spaceID: String?) -> ShellSpace? {
@@ -409,6 +454,40 @@ struct ShellSidebarView: View {
     }
 }
 
+private struct ShellSidebarTabListOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct ShellSidebarScrollBoundary: View {
+    let progress: CGFloat
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Rectangle()
+                .fill(ShellPalette.line.opacity(0.36))
+                .frame(height: 0.5)
+
+            LinearGradient(
+                colors: [
+                    ShellPalette.sidebarInk.opacity(0.10),
+                    ShellPalette.sidebarInk.opacity(0.035),
+                    ShellPalette.sidebarInk.opacity(0),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 14)
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .opacity(progress)
+        .allowsHitTesting(false)
+    }
+}
+
 private struct ShellSidebarSpaceHeaderPager: View {
     @ObservedObject var host: ShellHostController
     let transition: ShellSpaceTransition?
@@ -449,25 +528,19 @@ private struct ShellSidebarSpaceHeaderPager: View {
         let space = space(for: spaceID)
         return HStack(spacing: 10) {
             Image(systemName: symbolName(for: space))
-                .font(.system(size: 10.5, weight: .semibold))
-                .foregroundStyle(ShellPalette.accent)
-                .frame(width: 14)
+                .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
+                .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.78))
+                .frame(width: ShellSidebarMetrics.iconColumnWidth)
 
             Text(space?.title ?? "Space")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(ShellPalette.ink)
+                .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.82))
                 .lineLimit(1)
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, ShellSidebarMetrics.rowInset)
         .padding(.vertical, 5)
-        .background(
-            ShellMaterialShape(
-                role: .controlGlass,
-                shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-            )
-        )
-        .padding(.leading, 2)
-        .padding(.trailing, 12)
+        .padding(.leading, ShellSidebarMetrics.edgeInset)
+        .padding(.trailing, ShellSidebarMetrics.edgeInset)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -522,11 +595,11 @@ private struct ShellSpaceSwitcherItem: View {
             }
             Image(systemName: symbolName)
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(isSelected || isPreviewed ? ShellPalette.accent : .primary)
+                .foregroundStyle(isSelected || isPreviewed ? ShellPalette.accent : ShellPalette.sidebarInk.opacity(0.74))
         }
         .frame(width: 30, height: 30)
-        .scaleEffect(isSelected ? 1 : (isHovered || isPreviewed ? 1.03 : 1))
-        .shadow(color: isSelected || isPreviewed ? ShellPalette.accent.opacity(0.12) : .clear, radius: 8, y: 3)
+        .scaleEffect(isSelected ? 1 : (isHovered || isPreviewed ? 1.015 : 1))
+        .shellShadow(isSelected || isPreviewed ? ShellShadows.spaceSelection : ShellShadows.none)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isPreviewed)
@@ -571,6 +644,89 @@ private struct ShellTabSplitSummary: Equatable {
     }
 }
 
+private enum ShellSidebarRowVisualState: Equatable {
+    case normal
+    case hover
+    case selected
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .normal:
+            return ShellRadii.row
+        case .hover:
+            return ShellRadii.surface
+        case .selected:
+            return ShellRadii.overlay
+        }
+    }
+
+    var fill: Color? {
+        switch self {
+        case .normal:
+            return nil
+        case .hover:
+            return ShellPalette.sidebarRowHover
+        case .selected:
+            return ShellPalette.sidebarRowSelected
+        }
+    }
+
+    var stroke: Color {
+        switch self {
+        case .normal:
+            return .clear
+        case .hover:
+            return ShellPalette.line.opacity(0.08)
+        case .selected:
+            return ShellPalette.line.opacity(0.12)
+        }
+    }
+
+    var shadow: ShellShadowStyle {
+        switch self {
+        case .normal, .hover:
+            return ShellShadows.none
+        case .selected:
+            return ShellShadows.sidebarSelection
+        }
+    }
+}
+
+private struct ShellSidebarRowBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let state: ShellSidebarRowVisualState
+
+    var body: some View {
+        if let fill = state.fill {
+            let shape = RoundedRectangle(cornerRadius: state.cornerRadius, style: .continuous)
+            shape
+                .fill(fill)
+                .overlay {
+                    shape.stroke(state.stroke, lineWidth: 0.5)
+                }
+                .overlay {
+                    if colorScheme == .light && state == .selected {
+                        shape
+                            .stroke(Color.white.opacity(0.34), lineWidth: 0.55)
+                            .mask {
+                                shape.fill(
+                                    LinearGradient(
+                                        colors: [
+                                            Color.white,
+                                            Color.white.opacity(0),
+                                        ],
+                                        startPoint: .top,
+                                        endPoint: .bottom
+                                    )
+                                )
+                            }
+                    }
+                }
+                .shellShadow(state.shadow)
+        }
+    }
+}
+
 private struct ShellTabSidebarRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isKeyboardFocused: Bool
@@ -588,78 +744,108 @@ private struct ShellTabSidebarRow: View {
     let onClose: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: iconName)
-                .font(.system(size: 11.5, weight: .semibold))
-                .foregroundStyle(isSelected ? ShellPalette.accent : .secondary)
-                .frame(width: 14)
+        ZStack(alignment: .trailing) {
+            HStack(spacing: 10) {
+                Image(systemName: iconName)
+                    .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
+                    .foregroundStyle(iconForeground)
+                    .frame(width: ShellSidebarMetrics.iconColumnWidth)
 
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
-                    Text(title)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text(title)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(titleForeground)
+                            .lineLimit(1)
 
-                    if showsAlanMarker {
-                        Image(systemName: "sparkles")
-                            .font(.system(size: 9, weight: .bold))
-                            .foregroundStyle(ShellPalette.accent)
+                        if showsAlanMarker {
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(ShellPalette.accent)
+                        }
                     }
+
+                    Text(subtitle)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(subtitleForeground)
+                        .lineLimit(1)
                 }
 
-                Text(subtitle)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
+                Spacer(minLength: 8)
 
-            Spacer(minLength: 8)
-
-            if let splitSummary {
-                ShellSplitTopologyIndicator(
-                    summary: splitSummary,
-                    onFocusPane: onFocusPane,
-                    onFocusNextSplitPane: onFocusNextSplitPane
-                )
-            }
-
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 18, height: 18)
-            }
-            .buttonStyle(.plain)
-            .opacity(isInteractionActive ? 1 : 0)
-            .accessibilityHidden(!isInteractionActive)
-            .help("Close tab")
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            Group {
-                if isSelected || isHovered || isKeyboardFocused {
-                    ShellMaterialShape(
-                        role: isSelected ? .controlGlassSelected : .controlGlassHover,
-                        shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                if let splitSummary {
+                    ShellSplitTopologyIndicator(
+                        summary: splitSummary,
+                        onFocusPane: onFocusPane,
+                        onFocusNextSplitPane: onFocusNextSplitPane
                     )
                 }
             }
+            .padding(.trailing, 24)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9.5, weight: .bold))
+                    .foregroundStyle(closeForeground)
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(showsCloseButton ? 1 : 0)
+            .allowsHitTesting(showsCloseButton)
+            .accessibilityHidden(!showsCloseButton)
+            .help("Close tab")
+        }
+        .padding(.horizontal, ShellSidebarMetrics.rowInset)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            ShellSidebarRowBackground(state: visualState)
         )
-        .scaleEffect(isHovered && !isSelected ? 1.005 : 1)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isInteractionActive)
+        .contentShape(RoundedRectangle(cornerRadius: visualState.cornerRadius, style: .continuous))
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: visualState)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: showsCloseButton)
         .focusable()
         .focused($isKeyboardFocused)
+        .focusEffectDisabled()
         .accessibilityLabel(accessibilityLabel)
         .help("Select tab")
     }
 
+    private var visualState: ShellSidebarRowVisualState {
+        if isSelected {
+            return .selected
+        }
+
+        if isHovered || isKeyboardFocused {
+            return .hover
+        }
+
+        return .normal
+    }
+
     private var isInteractionActive: Bool {
         isHovered || showsCloseAffordance || isKeyboardFocused
+    }
+
+    private var showsCloseButton: Bool {
+        isSelected || isInteractionActive
+    }
+
+    private var iconForeground: Color {
+        isSelected ? ShellPalette.accent : ShellPalette.sidebarMutedInk.opacity(0.84)
+    }
+
+    private var titleForeground: Color {
+        isSelected ? ShellPalette.sidebarInk : ShellPalette.sidebarInk.opacity(0.88)
+    }
+
+    private var subtitleForeground: Color {
+        isSelected ? ShellPalette.sidebarMutedInk.opacity(0.90) : ShellPalette.sidebarMutedInk.opacity(0.68)
+    }
+
+    private var closeForeground: Color {
+        isSelected ? ShellPalette.sidebarInk.opacity(0.50) : ShellPalette.sidebarMutedInk.opacity(0.72)
     }
 
     private var accessibilityLabel: String {
@@ -751,6 +937,9 @@ private struct ShellSplitTopologyIndicator: View {
 }
 
 private struct ShellCompactEmptyAction: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @FocusState private var isKeyboardFocused: Bool
+    @State private var isHovered = false
     let title: String
     let systemImage: String
     let action: () -> Void
@@ -764,19 +953,31 @@ private struct ShellCompactEmptyAction: View {
                     .font(.system(size: 12, weight: .semibold))
                 Spacer(minLength: 0)
             }
-            .foregroundStyle(.secondary)
+            .foregroundStyle(foreground)
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                ShellMaterialShape(
-                    role: .panelSoft,
-                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                )
+                ShellSidebarRowBackground(state: visualState)
             )
         }
         .buttonStyle(.plain)
+        .focusable()
+        .focused($isKeyboardFocused)
+        .focusEffectDisabled()
+        .onHover { isHovered = $0 }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: visualState)
         .accessibilityLabel(title)
+    }
+
+    private var visualState: ShellSidebarRowVisualState {
+        isHovered || isKeyboardFocused ? .hover : .normal
+    }
+
+    private var foreground: Color {
+        isHovered || isKeyboardFocused
+            ? ShellPalette.sidebarMutedInk.opacity(0.86)
+            : ShellPalette.sidebarMutedInk.opacity(0.58)
     }
 }
 #endif

--- a/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
@@ -39,7 +39,7 @@ struct ShellSidebarView: View {
                 .padding(.top, 10)
         }
         .padding(.top, chromeMetrics.commandLauncherTopInset)
-        .padding(.bottom, 15)
+        .padding(.bottom, ShellSidebarMetrics.spaceDockOuterBottomInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -186,17 +186,10 @@ struct ShellSidebarView: View {
                         }
                     }
                 }
-                .padding(.vertical, 2)
+                .padding(.vertical, ShellSidebarMetrics.spaceDockInternalVerticalPadding)
             }
 
-            Menu {
-                Button("New Space") {
-                    _ = host.createTerminalSpace()
-                }
-                Button("New Space with Alan") {
-                    _ = host.createAlanSpace()
-                }
-            } label: {
+            Button(action: createSpaceFromDock) {
                 Image(systemName: "plus")
                     .font(.system(size: 12.5, weight: .semibold))
                     .foregroundStyle(ShellPalette.sidebarInk.opacity(0.76))
@@ -210,15 +203,17 @@ struct ShellSidebarView: View {
                         }
                     }
             }
-            .menuStyle(.borderlessButton)
             .buttonStyle(.plain)
-            .menuIndicator(.hidden)
             .help("Create a new space")
             .accessibilityLabel("Create space")
             .onHover { isHovering in
                 hoveredSpaceID = isHovering ? "__new_space__" : nil
             }
         }
+    }
+
+    private func createSpaceFromDock() {
+        _ = host.createTerminalSpace()
     }
 
     private var activeTransition: ShellSpaceTransition? {

--- a/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift
@@ -4,73 +4,45 @@ import SwiftUI
 struct ShellSidebarView: View {
     @ObservedObject var host: ShellHostController
     let chromeMetrics: ShellWindowChromeMetrics
+    let spaceTransition: ShellSpaceTransition?
+    let isSpaceSwipeGestureLocked: Bool
+    let onSpaceSwipe: (ShellSidebarSwipeUpdate) -> Void
     let openCommandTab: () -> Void
     @State private var hoveredTabID: String?
     @State private var hoveredSpaceID: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            sidebarHeader
-            commandLauncher
-            tabSection
-            spaceDock
+        GeometryReader { proxy in
+            sidebarContent(pageWidth: max(proxy.size.width, 1))
         }
-        .padding(.horizontal, 12)
-        .padding(.top, chromeMetrics.trafficLightsTopInset)
-        .padding(.bottom, 15)
-        .frame(maxHeight: .infinity, alignment: .top)
+        .background {
+            ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
+        }
+        .scrollDisabled(isTabListScrollDisabled)
     }
 
-    private var sidebarHeader: some View {
-        HStack(alignment: .center, spacing: 10) {
-            ZStack {
-                ShellMaterialShape(
-                    role: .controlGlassStrong,
-                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                )
-                Text("A")
-                    .font(.system(size: 12.5, weight: .bold, design: .rounded))
-                    .foregroundStyle(ShellPalette.accent)
-            }
-            .frame(width: 28, height: 28)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(host.selectedSpace?.title ?? "Alan")
-                    .font(.system(size: 15.5, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                Text(spaceSubtitle)
-                    .font(.system(size: 10.5, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            .layoutPriority(1)
-
-            Spacer(minLength: 8)
-
-            Menu {
-                Button("New Tab") {
-                    _ = host.openTerminalTab()
-                }
-                Button("Open in Alan") {
-                    _ = host.openAlanTab()
-                }
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 26, height: 26)
-                    .background(
-                        ShellMaterialShape(
-                            role: .controlGlass,
-                            shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                        )
-                    )
-            }
-            .menuStyle(.borderlessButton)
-            .buttonStyle(.plain)
-            .menuIndicator(.hidden)
+    private func sidebarContent(pageWidth: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            commandLauncher
+                .padding(.horizontal, 12)
+            spaceLabelRow(pageWidth: pageWidth)
+            tabSection(pageWidth: pageWidth)
+            spaceDock
+                .padding(.horizontal, 12)
         }
+        .padding(.top, chromeMetrics.trafficLightsTopInset)
+        .padding(.bottom, 15)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func spaceLabelRow(pageWidth: CGFloat) -> some View {
+        ShellSidebarSpaceHeaderPager(
+            host: host,
+            transition: activeTransition,
+            pageWidth: pageWidth
+        )
+        .frame(maxWidth: .infinity)
+        .frame(height: 28)
     }
 
     private var commandLauncher: some View {
@@ -84,9 +56,6 @@ struct ShellSidebarView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                Text("⌘P")
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.tertiary)
             }
             .padding(.horizontal, 11)
             .padding(.vertical, 10)
@@ -98,106 +67,167 @@ struct ShellSidebarView: View {
             )
         }
         .buttonStyle(.plain)
+        .help("Go to or Command, Command-P")
+        .accessibilityLabel("Go to or Command")
     }
 
-    private var tabSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("Tabs")
-                    .font(.system(size: 11, weight: .semibold))
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
-                if let selectedSpace = host.selectedSpace {
-                    Text("\(selectedSpace.tabs.count)")
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-            }
+    private func tabSection(pageWidth: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            GeometryReader { proxy in
+                ZStack(alignment: .topLeading) {
+                    tabListPage(for: sourceSpaceID)
+                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
+                        .offset(x: sourceOffset(in: pageWidth))
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 4) {
-                    if let selectedSpace = host.selectedSpace {
-                        ForEach(selectedSpace.tabs) { tab in
-                            tabListRow(for: tab)
-                        }
-                    } else {
-                        ShellEmptyStateRow(
-                            title: "No spaces yet",
-                            detail: "Create a space to start a new stack of terminal tabs."
-                        )
+                    if let targetSpaceID = activeTransition?.targetSpaceID {
+                        tabListPage(for: targetSpaceID)
+                            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
+                            .offset(x: targetOffset(in: pageWidth))
+                            .allowsHitTesting(false)
                     }
                 }
+                .clipped()
             }
         }
-        .frame(maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func tabListPage(for spaceID: String?) -> some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 4) {
+                if let space = space(for: spaceID) {
+                    if space.tabs.isEmpty {
+                        ShellCompactEmptyAction(
+                            title: "New tab",
+                            systemImage: "plus",
+                            action: {
+                                _ = host.openTerminalTab()
+                            }
+                        )
+                        .help("Create a tab in this space")
+                    } else {
+                        ForEach(space.tabs) { tab in
+                            tabListRow(for: tab)
+                        }
+                    }
+                } else {
+                    ShellCompactEmptyAction(
+                        title: "New space",
+                        systemImage: "plus",
+                        action: {
+                            _ = host.createTerminalSpace()
+                        }
+                    )
+                    .help("Create a space")
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
     }
 
     private var spaceDock: some View {
-        ShellSidebarSection(title: "Spaces", accessory: "⌥⌘1-9") {
-            HStack(spacing: 10) {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(host.spaces) { space in
-                            Button {
-                                host.select(spaceID: space.spaceID)
-                            } label: {
-                                ShellSpaceRailItem(
-                                    title: space.title,
-                                    symbolName: spaceSymbol(for: space),
-                                    attention: space.attention,
-                                    isSelected: host.selectedSpace?.spaceID == space.spaceID,
-                                    isHovered: hoveredSpaceID == space.spaceID
-                                )
-                            }
-                            .buttonStyle(.plain)
-                            .onHover { isHovering in
-                                hoveredSpaceID = isHovering ? space.spaceID : nil
-                            }
+        HStack(spacing: 8) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(host.spaces) { space in
+                        Button {
+                            host.select(spaceID: space.spaceID)
+                        } label: {
+                            ShellSpaceSwitcherItem(
+                                title: space.title,
+                                symbolName: spaceSymbol(for: space),
+                                attention: space.attention,
+                                tabCount: space.tabs.count,
+                                isSelected: host.selectedSpace?.spaceID == space.spaceID,
+                                isPreviewed: activeTransition?.targetSpaceID == space.spaceID,
+                                isHovered: hoveredSpaceID == space.spaceID
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { isHovering in
+                            hoveredSpaceID = isHovering ? space.spaceID : nil
                         }
                     }
-                    .padding(.vertical, 2)
                 }
+                .padding(.vertical, 2)
+            }
 
-                Menu {
-                    Button("New Space") {
-                        _ = host.createTerminalSpace()
-                    }
-                    Button("New Space with Alan") {
-                        _ = host.createAlanSpace()
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12.5, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .frame(width: 30, height: 30)
-                        .background(
+            Menu {
+                Button("New Space") {
+                    _ = host.createTerminalSpace()
+                }
+                Button("New Space with Alan") {
+                    _ = host.createAlanSpace()
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 30, height: 30)
+                    .background {
+                        if hoveredSpaceID == "__new_space__" {
                             ShellMaterialShape(
-                                role: .controlGlass,
+                                role: .controlGlassHover,
                                 shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                             )
-                        )
-                }
-                .menuStyle(.borderlessButton)
-                .buttonStyle(.plain)
-                .menuIndicator(.hidden)
-                .help("Create a new space")
+                        }
+                    }
+            }
+            .menuStyle(.borderlessButton)
+            .buttonStyle(.plain)
+            .menuIndicator(.hidden)
+            .help("Create a new space")
+            .accessibilityLabel("Create space")
+            .onHover { isHovering in
+                hoveredSpaceID = isHovering ? "__new_space__" : nil
             }
         }
     }
 
-    private var spaceSubtitle: String {
-        guard let selectedSpace = host.selectedSpace else {
-            return "Terminal-first on macOS"
+    private var activeTransition: ShellSpaceTransition? {
+        guard let spaceTransition,
+              spaceTransition.sourceSpaceID == host.selectedSpace?.spaceID
+        else {
+            return nil
         }
+        return spaceTransition
+    }
 
-        let count = selectedSpace.tabs.count
-        return count == 1 ? "1 tab" : "\(count) tabs"
+    private var isTabListScrollDisabled: Bool {
+        isSpaceSwipeGestureLocked || activeTransition != nil
+    }
+
+    private var sourceSpaceID: String? {
+        activeTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
+    }
+
+    private func sourceOffset(in width: CGFloat) -> CGFloat {
+        activeTransition?.sourceOffset(in: width) ?? 0
+    }
+
+    private func targetOffset(in width: CGFloat) -> CGFloat {
+        activeTransition?.targetOffset(in: width) ?? 0
+    }
+
+    private func space(for spaceID: String?) -> ShellSpace? {
+        guard let spaceID else { return host.selectedSpace }
+        return host.spaces.first { $0.spaceID == spaceID }
     }
 
     private func close(tab: ShellTab) {
         host.select(tabID: tab.tabID)
         _ = host.closeSelectedTab()
+    }
+
+    private func focusPane(_ paneID: String, in tab: ShellTab) {
+        host.select(tabID: tab.tabID)
+        host.focus(paneID: paneID)
+        host.refocusSelectedTerminalPane()
+    }
+
+    private func focusNextSplitPane(in tab: ShellTab, summary: ShellTabSplitSummary) {
+        guard let paneID = summary.nextPaneID(after: host.shellState.focusedPaneID) else { return }
+        focusPane(paneID, in: tab)
     }
 
     @ViewBuilder
@@ -211,9 +241,16 @@ struct ShellSidebarView: View {
             iconName: tabIconName(for: tab),
             attention: strongestAttention(for: tab),
             showsAlanMarker: showsAlanMarker(for: tab),
+            splitSummary: splitSummary(for: tab),
             isSelected: isSelected,
             isHovered: isHovered,
-            showsMenuAffordance: isHovered,
+            showsCloseAffordance: isHovered,
+            onFocusPane: { paneID in
+                focusPane(paneID, in: tab)
+            },
+            onFocusNextSplitPane: { summary in
+                focusNextSplitPane(in: tab, summary: summary)
+            },
             onClose: { close(tab: tab) }
         )
         .contentShape(Rectangle())
@@ -235,6 +272,28 @@ struct ShellSidebarView: View {
                 close(tab: tab)
             }
         }
+    }
+
+    private func splitSummary(for tab: ShellTab) -> ShellTabSplitSummary? {
+        let paneIDs = tab.paneTree.paneIDs.filter { paneID in
+            host.shellState.panes.contains { $0.paneID == paneID }
+        }
+        guard paneIDs.count > 1 else { return nil }
+
+        let children = tab.paneTree.children ?? []
+        let isSimpleTwoPaneSplit = paneIDs.count == 2
+            && tab.paneTree.kind == .split
+            && children.count == 2
+            && children.allSatisfy { $0.kind == .pane }
+
+        return ShellTabSplitSummary(
+            paneIDs: paneIDs,
+            direction: isSimpleTwoPaneSplit ? tab.paneTree.direction : nil,
+            focusedPaneID: paneIDs.contains(host.shellState.focusedPaneID ?? "")
+                ? host.shellState.focusedPaneID
+                : nil,
+            isComplex: !isSimpleTwoPaneSplit
+        )
     }
 
     private func fallbackTitle(for tab: ShellTab) -> String {
@@ -350,71 +409,182 @@ struct ShellSidebarView: View {
     }
 }
 
-private struct ShellSpaceRailItem: View {
+private struct ShellSidebarSpaceHeaderPager: View {
+    @ObservedObject var host: ShellHostController
+    let transition: ShellSpaceTransition?
+    let pageWidth: CGFloat
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                headerPage(for: sourceSpaceID)
+                    .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
+                    .offset(x: sourceOffset(in: pageWidth))
+
+                if let targetSpaceID = activeTransition?.targetSpaceID {
+                    headerPage(for: targetSpaceID)
+                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
+                        .offset(x: targetOffset(in: pageWidth))
+                }
+            }
+            .clipped()
+        }
+        .frame(height: 26)
+    }
+
+    private var activeTransition: ShellSpaceTransition? {
+        guard let transition,
+              transition.sourceSpaceID == host.selectedSpace?.spaceID
+        else {
+            return nil
+        }
+        return transition
+    }
+
+    private var sourceSpaceID: String? {
+        activeTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
+    }
+
+    private func headerPage(for spaceID: String?) -> some View {
+        let space = space(for: spaceID)
+        return HStack(spacing: 10) {
+            Image(systemName: symbolName(for: space))
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundStyle(ShellPalette.accent)
+                .frame(width: 14)
+
+            Text(space?.title ?? "Space")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(ShellPalette.ink)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            ShellMaterialShape(
+                role: .controlGlass,
+                shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+            )
+        )
+        .padding(.leading, 2)
+        .padding(.trailing, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func sourceOffset(in width: CGFloat) -> CGFloat {
+        activeTransition?.sourceOffset(in: width) ?? 0
+    }
+
+    private func targetOffset(in width: CGFloat) -> CGFloat {
+        activeTransition?.targetOffset(in: width) ?? 0
+    }
+
+    private func space(for spaceID: String?) -> ShellSpace? {
+        guard let spaceID else { return host.selectedSpace }
+        return host.spaces.first { $0.spaceID == spaceID }
+    }
+
+    private func symbolName(for space: ShellSpace?) -> String {
+        guard let space else { return "terminal" }
+        let hasAlan = host.shellState.panes.contains { pane in
+            pane.spaceID == space.spaceID && pane.resolvedLaunchTarget == .alan
+        }
+
+        if hasAlan {
+            return "sparkles"
+        }
+
+        if space.tabs.count > 1 {
+            return "square.stack.3d.up"
+        }
+
+        return "terminal"
+    }
+}
+
+private struct ShellSpaceSwitcherItem: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let title: String
     let symbolName: String
     let attention: ShellAttentionState
+    let tabCount: Int
     let isSelected: Bool
+    let isPreviewed: Bool
     let isHovered: Bool
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            ZStack {
+        ZStack {
+            if isSelected || isHovered || isPreviewed {
                 ShellMaterialShape(
-                    role: isSelected
-                        ? .controlGlassSelected
-                        : (isHovered ? .controlGlassHover : .controlGlass),
-                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                    role: isSelected ? .controlGlassSelected : .controlGlassHover,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
                 )
-                Image(systemName: symbolName)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(isSelected ? ShellPalette.accent : .primary)
             }
-            .frame(width: 34, height: 34)
-
-            if attention != .idle {
-                Circle()
-                    .fill(attentionColor)
-                    .frame(width: 9, height: 9)
-                    .overlay {
-                        Circle()
-                            .stroke(ShellPalette.sidebarCard, lineWidth: 1.5)
-                    }
-                    .offset(x: 2, y: -2)
-            }
+            Image(systemName: symbolName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(isSelected || isPreviewed ? ShellPalette.accent : .primary)
         }
-        .scaleEffect(isSelected ? 1 : (isHovered ? 1.03 : 1))
-        .shadow(color: isSelected ? ShellPalette.accent.opacity(0.12) : .clear, radius: 8, y: 3)
+        .frame(width: 30, height: 30)
+        .scaleEffect(isSelected ? 1 : (isHovered || isPreviewed ? 1.03 : 1))
+        .shadow(color: isSelected || isPreviewed ? ShellPalette.accent.opacity(0.12) : .clear, radius: 8, y: 3)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isPreviewed)
         .help(title)
+        .accessibilityLabel(accessibilityLabel)
     }
 
-    private var attentionColor: Color {
-        switch attention {
-        case .idle:
-            return ShellPalette.line
-        case .active:
-            return ShellPalette.accent
-        case .awaitingUser:
-            return ShellPalette.attention
-        case .notable:
-            return Color(red: 0.71, green: 0.58, blue: 0.28)
+    private var accessibilityLabel: String {
+        var parts = [title, tabCount == 1 ? "1 tab" : "\(tabCount) tabs"]
+        if isSelected {
+            parts.append("selected")
         }
+        if isPreviewed {
+            parts.append("preview")
+        }
+        if attention != .idle {
+            parts.append("needs attention")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+private struct ShellTabSplitSummary: Equatable {
+    let paneIDs: [String]
+    let direction: ShellSplitDirection?
+    let focusedPaneID: String?
+    let isComplex: Bool
+
+    var paneCount: Int {
+        paneIDs.count
+    }
+
+    func nextPaneID(after currentPaneID: String?) -> String? {
+        guard !paneIDs.isEmpty else { return nil }
+        guard let currentPaneID,
+              let currentIndex = paneIDs.firstIndex(of: currentPaneID)
+        else {
+            return paneIDs.first
+        }
+
+        return paneIDs[(currentIndex + 1) % paneIDs.count]
     }
 }
 
 private struct ShellTabSidebarRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @FocusState private var isKeyboardFocused: Bool
     let title: String
     let subtitle: String
     let iconName: String
     let attention: ShellAttentionState?
     let showsAlanMarker: Bool
+    let splitSummary: ShellTabSplitSummary?
     let isSelected: Bool
     let isHovered: Bool
-    let showsMenuAffordance: Bool
+    let showsCloseAffordance: Bool
+    let onFocusPane: (String) -> Void
+    let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
     let onClose: () -> Void
 
     var body: some View {
@@ -428,7 +598,6 @@ private struct ShellTabSidebarRow: View {
                 HStack(spacing: 6) {
                     Text(title)
                         .font(.system(size: 13, weight: .semibold))
-                        .tracking(-0.1)
                         .foregroundStyle(.primary)
                         .lineLimit(1)
 
@@ -447,27 +616,31 @@ private struct ShellTabSidebarRow: View {
 
             Spacer(minLength: 8)
 
-            if let attention {
-                Circle()
-                    .fill(attentionColor(for: attention))
-                    .frame(width: 8, height: 8)
+            if let splitSummary {
+                ShellSplitTopologyIndicator(
+                    summary: splitSummary,
+                    onFocusPane: onFocusPane,
+                    onFocusNextSplitPane: onFocusNextSplitPane
+                )
             }
 
-            if showsMenuAffordance {
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 18, height: 18)
-                }
-                .buttonStyle(.plain)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 18)
             }
+            .buttonStyle(.plain)
+            .opacity(isInteractionActive ? 1 : 0)
+            .accessibilityHidden(!isInteractionActive)
+            .help("Close tab")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             Group {
-                if isSelected || isHovered {
+                if isSelected || isHovered || isKeyboardFocused {
                     ShellMaterialShape(
                         role: isSelected ? .controlGlassSelected : .controlGlassHover,
                         shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
@@ -478,68 +651,132 @@ private struct ShellTabSidebarRow: View {
         .scaleEffect(isHovered && !isSelected ? 1.005 : 1)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: isInteractionActive)
+        .focusable()
+        .focused($isKeyboardFocused)
+        .accessibilityLabel(accessibilityLabel)
+        .help("Select tab")
     }
 
-    private func attentionColor(for attention: ShellAttentionState) -> Color {
-        switch attention {
-        case .idle:
-            return ShellPalette.line
-        case .active:
-            return ShellPalette.accent
-        case .awaitingUser:
-            return ShellPalette.attention
-        case .notable:
-            return Color(red: 0.71, green: 0.58, blue: 0.28)
+    private var isInteractionActive: Bool {
+        isHovered || showsCloseAffordance || isKeyboardFocused
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [title, subtitle]
+        if isSelected {
+            parts.append("selected")
         }
+        if attention != nil {
+            parts.append("needs attention")
+        }
+        if let splitSummary {
+            parts.append("\(splitSummary.paneCount) panes")
+        }
+        return parts.joined(separator: ", ")
     }
 }
 
-private struct ShellSidebarSection<Content: View>: View {
-    let title: String
-    let accessory: String?
-    @ViewBuilder let content: Content
+private struct ShellSplitTopologyIndicator: View {
+    let summary: ShellTabSplitSummary
+    let onFocusPane: (String) -> Void
+    let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(title)
-                    .font(.system(size: 11, weight: .semibold))
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
-                if let accessory {
-                    Text(accessory)
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(.tertiary)
+        if summary.isComplex {
+            complexButton
+        } else {
+            twoPaneIndicator
+        }
+    }
+
+    private var twoPaneIndicator: some View {
+        let panes = Array(summary.paneIDs.prefix(2).enumerated())
+        let isVertical = summary.direction == .vertical
+
+        return Group {
+            if isVertical {
+                HStack(spacing: 2) {
+                    ForEach(panes, id: \.element) { index, paneID in
+                        segmentButton(index: index, paneID: paneID)
+                    }
+                }
+            } else {
+                VStack(spacing: 2) {
+                    ForEach(panes, id: \.element) { index, paneID in
+                        segmentButton(index: index, paneID: paneID)
+                    }
                 }
             }
-
-            content
         }
+        .frame(width: 25, height: 16)
+        .help("Focus split pane")
+        .accessibilityLabel("Split tab, \(summary.paneCount) panes")
+    }
+
+    private var complexButton: some View {
+        Button {
+            onFocusNextSplitPane(summary)
+        } label: {
+            HStack(spacing: 2) {
+                Image(systemName: "rectangle.split.3x1")
+                    .font(.system(size: 8, weight: .bold))
+                Text("\(summary.paneCount)")
+                    .font(.system(size: 8, weight: .bold, design: .monospaced))
+            }
+            .foregroundStyle(summary.focusedPaneID == nil ? .secondary : ShellPalette.accent)
+            .frame(width: 28, height: 18)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(ShellPalette.canvas.opacity(0.55))
+            )
+        }
+        .buttonStyle(.plain)
+        .help("Focus next split pane")
+        .accessibilityLabel("Split tab, \(summary.paneCount) panes")
+    }
+
+    private func segmentButton(index: Int, paneID: String) -> some View {
+        let isFocused = summary.focusedPaneID == paneID
+
+        return Button {
+            onFocusPane(paneID)
+        } label: {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(isFocused ? ShellPalette.accent.opacity(0.9) : ShellPalette.mutedInk.opacity(0.24))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Focus pane \(index + 1)")
     }
 }
 
-private struct ShellEmptyStateRow: View {
+private struct ShellCompactEmptyAction: View {
     let title: String
-    let detail: String
+    let systemImage: String
+    let action: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.system(size: 13, weight: .semibold))
-            Text(detail)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(ShellPalette.mutedInk)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            ShellMaterialShape(
-                role: .panelSoft,
-                shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                ShellMaterialShape(
+                    role: .panelSoft,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                )
             )
-        )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
     }
 }
 #endif

--- a/clients/apple/AlanNative/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/AlanNative/Views/Shell/ShellWorkspaceView.swift
@@ -3,9 +3,15 @@ import SwiftUI
 #if os(macOS)
 struct ShellWorkspaceView: View {
     @ObservedObject var host: ShellHostController
+    let hasExpandedSidebar: Bool
 
     var body: some View {
-        TerminalPaneView(host: host)
+        TerminalPaneView(
+            host: host,
+            terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
+                hasExpandedSidebar: hasExpandedSidebar
+            )
+        )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -184,6 +184,31 @@ reject_pattern \
     "Find UI must render through ShellFindBarView instead of the passive terminal overlay card"
 
 require_pattern \
+    "clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
+    "spaceDockOuterBottomInset" \
+    "bottom space dock must use a tokenized outer inset to align with the sidebar edge"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
+    "padding\\(\\.bottom, ShellSidebarMetrics\\.spaceDockOuterBottomInset\\)" \
+    "bottom space dock must align its visible controls to the sidebar bottom edge inset"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
+    "padding\\(\\.vertical, ShellSidebarMetrics\\.spaceDockInternalVerticalPadding\\)" \
+    "space dock internal vertical padding must stay paired with its bottom alignment token"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
+    "Button\\(action: createSpaceFromDock\\)" \
+    "bottom space dock add control must be a direct button, not a variant menu"
+
+reject_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
+    "New Space with Alan|createAlanSpace|menuIndicator\\(\\.hidden\\)" \
+    "bottom space dock add control must not expose the removed New Space with Alan menu path"
+
+require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.swift" \
     "verifiesScrollbackActionsReachSurfaceEngine" \
     "surface controller tests must prove scrollback actions reach the surface engine"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -478,6 +478,26 @@ require_pattern \
     "terminalSurfaceInsets\\(hasExpandedSidebar" \
     "terminal workspace surface insets must account for expanded sidebar adjacency"
 
+require_pattern \
+    "clients/apple/scripts/test-shell-window-placement.swift" \
+    "verifiesSystemModeClearsExplicitWindowAppearanceImmediately" \
+    "window-placement tests must cover immediate reset to system appearance mode"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-window-placement.sh" \
+    "ShellWindowPlacement\\.swift" \
+    "window-placement tests must compile the macOS shell appearance bridge"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "resolvedAppearanceColorScheme" \
+    "mac shell root must resolve system appearance into an explicit SwiftUI colorScheme environment"
+
+reject_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "preferredColorScheme" \
+    "mac shell appearance switching must not rely on clearing a stale SwiftUI preferredColorScheme preference"
+
 reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "padding\\(ShellWorkspaceMetrics\\.terminalSurfaceInset\\)" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -393,6 +393,36 @@ require_pattern \
     "handleCollapsedSidebarToolbarHover" \
     "collapsed sidebar toolbar controls must keep the floating panel revealed while hovered"
 
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "windowChromeSurface" \
+    "collapsed sidebar chrome must publish its floating surface state to AppKit"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "isVisible: isSidebarSurfaceVisible" \
+    "traffic lights must hide when the collapsed sidebar surface is hidden"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "floatingSidebarTrafficLightRevealDelay" \
+    "floating sidebar traffic lights must not appear ahead of panel reveal timing"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "scheduleFloatingSidebarTrafficLightReveal" \
+    "floating sidebar traffic-light visibility must be delayed separately from panel insertion"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "guard !isSidebarPanelRevealed else" \
+    "repeated floating sidebar hover enters must not reset visible traffic lights"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "floatingSidebarTrafficLightRevealToken" \
+    "floating sidebar traffic-light reveal timing must not share the hover-retention token"
+
 reject_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
     "frame\\(width: sidebarWidth, height: windowChromeMetrics\\.collapsedRevealHeaderHeight\\)" \
@@ -660,6 +690,31 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "contentInteractionTopInset" \
+    "window double-click zoom overlay must not cover terminal surface title-bar controls"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "isPointInSidebarChromeBand" \
+    "window double-click zoom overlay must include blank sidebar chrome outside real controls"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "width: sidebarWidth" \
+    "window double-click zoom hit testing must know the sidebar chrome width"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-window-placement.swift" \
+    "verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit" \
+    "shell window placement tests must prove terminal title-bar controls are not intercepted by zoom overlay"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-window-placement.swift" \
+    "verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit" \
+    "shell window placement tests must prove blank sidebar chrome remains a double-click zoom target"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
     "NSWindow\\.didResizeNotification" \
     "hidden-titlebar shell windows must resynchronize traffic-light placement after resize"
 
@@ -687,6 +742,36 @@ require_pattern \
     "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
     "standardTrafficLightsVisible = false" \
     "native fullscreen must stop reserving titlebar space for hidden traffic lights"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "ShellWindowChromeSurface" \
+    "window chrome sync must accept sidebar surface visibility and origin"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "setStandardWindowButtons\\(in: window, hidden: true\\)" \
+    "standard traffic lights must hide with a hidden sidebar surface"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "chromeSurfaceOrigin" \
+    "standard traffic lights must follow the visible floating sidebar surface origin"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "showsStandardTrafficLights" \
+    "window chrome sync must distinguish surface layout from actual traffic-light visibility"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "setStandardWindowButtons\\(in: window, hidden: false, alphaValue: 0\\)" \
+    "floating sidebar traffic lights must be made invisible before AppKit-visible repositioning"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "localTrafficLightGroupFrame" \
+    "floating sidebar traffic lights must be rechecked after standard button visibility changes"
 
 require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
@@ -765,8 +850,13 @@ reject_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "Window\\(\"Alan\", id: \"main\"\\)" \
+    "macOS app scene must use a launch-presented singleton primary Window"
+
+reject_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
     "WindowGroup\\(\"Alan\", id: \"main\"\\)" \
-    "macOS app scene must use a launch-presented primary WindowGroup"
+    "macOS primary shell scene must not use a WindowGroup that can miss first-launch presentation"
 
 require_pattern \
     "clients/apple/AlanNative/AlanNativeApp.swift" \
@@ -789,9 +879,19 @@ require_pattern \
     "macOS app singleton guard must use an OS-backed exclusive lock"
 
 require_pattern \
-    "justfile" \
+    "clients/apple/scripts/run-alan-debug-app.sh" \
     "pkill -x Alan" \
     "just app must stop the previous Alan process before launching a fresh debug build"
+
+require_pattern \
+    "clients/apple/scripts/run-alan-debug-app.sh" \
+    "wait_for_alan_to_exit" \
+    "just app must wait for the previous Alan process to release singleton ownership before relaunching"
+
+require_pattern \
+    "justfile" \
+    "clients/apple/scripts/run-alan-debug-app\\.sh" \
+    "just app must use the guarded native app runner"
 
 require_pattern \
     "clients/apple/README.md" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -659,6 +659,36 @@ require_pattern \
     "hidden-titlebar shell windows must make non-interactive background regions draggable"
 
 require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "NSWindow\\.didResizeNotification" \
+    "hidden-titlebar shell windows must resynchronize traffic-light placement after resize"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "NSWindow\\.willStartLiveResizeNotification" \
+    "hidden-titlebar shell windows must start continuous traffic-light sync during live resize"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "liveResizeChromeSyncTimer" \
+    "hidden-titlebar shell windows must keep a scoped live-resize chrome sync timer"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "RunLoop\\.main\\.add\\(timer, forMode: \\.eventTracking\\)" \
+    "live-resize chrome sync must run in the event-tracking run loop mode"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "NSWindow\\.didEnterFullScreenNotification" \
+    "hidden-titlebar shell windows must publish native fullscreen chrome state"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "standardTrafficLightsVisible = false" \
+    "native fullscreen must stop reserving titlebar space for hidden traffic lights"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
     "override var mouseDownCanMoveWindow: Bool \\{ false \\}" \
     "terminal host views must not allow terminal pane clicks to drag the shell window"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -378,6 +378,21 @@ require_pattern \
     "collapsedRevealEdgeWidth" \
     "collapsed sidebar reveal must use a narrow edge hot zone token"
 
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "sidebarPanelRevealAnimation" \
+    "collapsed sidebar reveal must use a dedicated spring reveal animation"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "sidebarPanelHideAnimation" \
+    "collapsed sidebar hide must use a dedicated fast exit animation"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "handleCollapsedSidebarToolbarHover" \
+    "collapsed sidebar toolbar controls must keep the floating panel revealed while hovered"
+
 reject_pattern \
     "clients/apple/AlanNative/MacShellRootView.swift" \
     "frame\\(width: sidebarWidth, height: windowChromeMetrics\\.collapsedRevealHeaderHeight\\)" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -448,6 +448,26 @@ require_pattern \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
 
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "ShellWorkspaceView\\(host: host, hasExpandedSidebar: !isSidebarCollapsed\\)" \
+    "mac shell root must pass expanded sidebar state into workspace spacing"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellWorkspaceView.swift" \
+    "hasExpandedSidebar: Bool" \
+    "workspace view must expose sidebar-aware terminal surface spacing"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "terminalSurfaceInsets: EdgeInsets" \
+    "terminal pane must receive semantic terminal surface edge insets"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "padding\\(terminalSurfaceInsets\\)" \
+    "terminal pane must apply state-aware terminal surface edge insets"
+
 reject_pattern \
     "clients/apple/AlanNative/TerminalHostView.swift" \
     "cornerRadius = ShellRadii\\.terminalSurface" \
@@ -455,13 +475,13 @@ reject_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
-    "terminalSurfaceInset" \
-    "terminal workspace surface inset must be a shared semantic token"
+    "terminalSurfaceInsets\\(hasExpandedSidebar" \
+    "terminal workspace surface insets must account for expanded sidebar adjacency"
 
-require_pattern \
+reject_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "padding\\(ShellWorkspaceMetrics\\.terminalSurfaceInset\\)" \
-    "terminal surface must use equal workspace inset on all four edges"
+    "terminal surface must not apply equal workspace inset when the sidebar is expanded"
 
 require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -448,6 +448,11 @@ require_pattern \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
 
+reject_pattern \
+    "clients/apple/AlanNative/TerminalHostView.swift" \
+    "cornerRadius = ShellRadii\\.terminalSurface" \
+    "terminal host view must not apply an inner rounded corner inside the outer terminal surface"
+
 require_pattern \
     "clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
     "terminalSurfaceInset" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -374,6 +374,16 @@ require_pattern \
     "command entry copy must match the accepted shell command UI label"
 
 require_pattern \
+    "clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
+    "collapsedRevealEdgeWidth" \
+    "collapsed sidebar reveal must use a narrow edge hot zone token"
+
+reject_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "frame\\(width: sidebarWidth, height: windowChromeMetrics\\.collapsedRevealHeaderHeight\\)" \
+    "collapsed sidebar reveal must not use the full titlebar/header width as a hover zone"
+
+require_pattern \
     "clients/apple/AlanNative/TerminalSurfaceController.swift" \
     "func routeWorkspaceCommand\\(_ input: AlanTerminalKeyInput\\) -> ShellWorkspaceCommand\\?" \
     "terminal input routing must recognize Alan workspace shortcuts before terminal bindings"
@@ -422,6 +432,16 @@ require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \
     "ShellTerminalSurfaceFrame" \
     "terminal panes must share one outer rounded terminal surface frame"
+
+require_pattern \
+    "clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
+    "terminalSurfaceInset" \
+    "terminal workspace surface inset must be a shared semantic token"
+
+require_pattern \
+    "clients/apple/AlanNative/TerminalPaneView.swift" \
+    "padding\\(ShellWorkspaceMetrics\\.terminalSurfaceInset\\)" \
+    "terminal surface must use equal workspace inset on all four edges"
 
 require_pattern \
     "clients/apple/AlanNative/TerminalPaneView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -394,6 +394,66 @@ require_pattern \
     "command UI tab actions must use the shared shell workspace command vocabulary"
 
 require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift" \
+    "GlassEffectContainer\\(spacing:" \
+    "floating Ask Alan command input must group custom Liquid Glass surfaces"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift" \
+    "\\.glassEffect\\(\\.regular\\.interactive\\(\\), in: shape\\)" \
+    "floating Ask Alan command input must use the default system Liquid Glass material"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift" \
+    "\\.glassEffectTransition\\(\\.identity\\)" \
+    "floating Ask Alan command input must disable Liquid Glass material insertion animation"
+
+require_pattern \
+    "clients/apple/AlanNative/Views/Shell/ShellCommandTabView.swift" \
+    "private var commandInputContent: some View" \
+    "floating Ask Alan command input foreground content must render outside the glass-effect layer"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "private let hiddenCommandInputOpacity = 0\\.001" \
+    "floating Ask Alan command input must keep the Liquid Glass surface mounted before presentation"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "private func toggleCommandInput\\(\\)" \
+    "Command-P must toggle the floating Ask Alan command input"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "isActive: isCommandTabPresented" \
+    "floating Ask Alan command input must separate mounted glass identity from active text focus"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "withAnimation\\(commandInputAnimation\\)" \
+    "floating Ask Alan command input must fade between hidden and visible states"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "\\.opacity\\(commandInputOpacity\\)" \
+    "floating Ask Alan command input must use opacity fade instead of moving from an edge"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "Color\\.clear" \
+    "floating Ask Alan click-away layer must avoid visible dimming under Liquid Glass"
+
+require_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "\\.transition\\(\\.identity\\)" \
+    "floating Ask Alan click-away layer must not animate behind Liquid Glass on insertion"
+
+reject_pattern \
+    "clients/apple/AlanNative/MacShellRootView.swift" \
+    "ShellPalette\\.overlayScrim" \
+    "floating Ask Alan must not place a visible dimming scrim behind Liquid Glass"
+
+require_pattern \
     "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
     "Ask Alan\\.\\.\\." \
     "command entry copy must match the accepted shell command UI label"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -735,8 +735,13 @@ reject_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/AlanNativeApp.swift" \
-    "Window\\(\"Alan\", id: \"main\"\\)" \
-    "macOS app scene must use a unique primary Window instead of a repeatable WindowGroup"
+    "WindowGroup\\(\"Alan\", id: \"main\"\\)" \
+    "macOS app scene must use a launch-presented primary WindowGroup"
+
+require_pattern \
+    "clients/apple/AlanNative/AlanNativeApp.swift" \
+    "defaultLaunchBehavior\\(\\.presented\\)" \
+    "macOS primary window must be presented when the app launches without restoration"
 
 require_pattern \
     "clients/apple/AlanNative/App/AlanMacShellCommands.swift" \
@@ -752,6 +757,11 @@ require_pattern \
     "clients/apple/AlanNative/AlanAppSingletonGuard.swift" \
     "flock\\(descriptor, LOCK_EX \\| LOCK_NB\\)" \
     "macOS app singleton guard must use an OS-backed exclusive lock"
+
+require_pattern \
+    "justfile" \
+    "pkill -x Alan" \
+    "just app must stop the previous Alan process before launching a fresh debug build"
 
 require_pattern \
     "clients/apple/README.md" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -370,7 +370,7 @@ require_pattern \
 
 require_pattern \
     "clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift" \
-    "Go to or Command\\.\\.\\." \
+    "Ask Alan\\.\\.\\." \
     "command entry copy must match the accepted shell command UI label"
 
 require_pattern \

--- a/clients/apple/scripts/run-alan-debug-app.sh
+++ b/clients/apple/scripts/run-alan-debug-app.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DERIVED_DATA="$REPO_ROOT/target/xcode-derived"
+APP_BUNDLE="$DERIVED_DATA/Build/Products/Debug/Alan.app"
+
+wait_for_alan_to_exit() {
+    local timeout_ticks=100
+
+    for _ in $(seq 1 "$timeout_ticks"); do
+        if ! pgrep -x Alan >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    printf 'error: timed out waiting for the previous Alan app process to exit\n' >&2
+    return 1
+}
+
+if pgrep -x Alan >/dev/null 2>&1; then
+    pkill -x Alan || true
+    wait_for_alan_to_exit
+fi
+
+xcodebuild \
+    -project "$REPO_ROOT/clients/apple/AlanNative.xcodeproj" \
+    -scheme AlanNative \
+    -configuration Debug \
+    -destination platform=macOS \
+    -derivedDataPath "$DERIVED_DATA" \
+    build
+
+wait_for_alan_to_exit
+/usr/bin/open -n "$APP_BUNDLE"

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -18,6 +18,7 @@ final class AlanTerminalHostNSView: NSView {
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
+        onCommandInput: (() -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {}
@@ -39,5 +40,7 @@ final class AlanTerminalHostNSView: NSView {
     func selectPreviousFindMatch() {}
 
     func dismissFindInteraction(refocusTerminal: Bool = true) {}
+
+    func focusTerminal() {}
 }
 #endif

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -20,6 +20,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarPrefersTerminalTitle()
         verifiesPaneTitleBarFallbackOrdering()
         verifiesPaneTitleBarSuppressesInternalTitles()
+        verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         print("Shell runtime metadata tests passed.")
     }
 
@@ -359,6 +360,52 @@ private enum ShellRuntimeMetadataTests {
             )
         )
         expect(preservedLongTitle == longTitle, "pane title helper must leave long titles available for UI truncation")
+    }
+
+    private static func verifiesOpeningTabSkipsStaleRuntimePaneIDs() {
+        let windowID = "metadata_test_\(UUID().uuidString)"
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let context = ShellWindowContext.make(
+            windowID: windowID,
+            terminalRuntimeRegistry: registry
+        )
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let controller = ShellHostController(
+            shellState: .bootstrapDefault(windowID: windowID),
+            windowContext: context,
+            persistenceURL: persistenceURL,
+            terminalRuntimeRegistry: registry
+        )
+        let stalePane = ShellPane(
+            paneID: "pane_2",
+            tabID: "tab_stale",
+            spaceID: "space_main",
+            launchTarget: .shell,
+            cwd: "/tmp",
+            process: nil,
+            attention: .idle,
+            context: nil,
+            viewport: nil,
+            alanBinding: nil
+        )
+        _ = registry.surfaceHandle(for: stalePane, bootProfile: nil)
+
+        expect(
+            registry.registeredPaneIDs.contains("pane_2"),
+            "test setup must register a runtime-only stale pane"
+        )
+
+        _ = controller.openTerminalTab()
+
+        expect(
+            controller.selectedPane?.paneID == "pane_3",
+            "opening a tab must skip pane IDs still owned by the terminal runtime registry"
+        )
+        expect(
+            !registry.registeredPaneIDs.contains("pane_2"),
+            "opening a tab must release stale runtime-only panes after adopting the new state"
+        )
     }
 
     private static func makeController() -> ShellHostController {

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-sidebar-swipe-monitor-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-sidebar-swipe-monitor-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    -D ALAN_TESTING \
+    "$REPO_ROOT/clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
@@ -1,0 +1,187 @@
+import AppKit
+import Foundation
+
+#if os(macOS)
+@main
+struct ShellSidebarSwipeMonitorTestRunner {
+    @MainActor
+    static func main() {
+        ShellSidebarSwipeMonitorTests.run()
+    }
+}
+
+@MainActor
+private enum ShellSidebarSwipeMonitorTests {
+    static func run() {
+        verifiesPhaseLessVerticalGestureResetsAfterIdle()
+        verifiesPhaseLessUndecidedGestureResetsAfterIdle()
+        verifiesPhaseLessHorizontalGestureStillEndsAfterIdle()
+        print("Shell sidebar swipe monitor tests passed.")
+    }
+
+    private static func verifiesPhaseLessVerticalGestureResetsAfterIdle() {
+        let harness = MonitorHarness()
+
+        let verticalEvent = harness.event(deltaX: 0, deltaY: 8)
+        let verticalResult = harness.coordinator.handleForTesting(verticalEvent)
+        expect(verticalResult === verticalEvent, "vertical wheel input must pass through")
+        expect(harness.updates.isEmpty, "vertical wheel input must not emit space swipe updates")
+
+        drainMainQueue()
+
+        let horizontalEvent = harness.event(deltaX: 8, deltaY: 0)
+        let horizontalResult = harness.coordinator.handleForTesting(horizontalEvent)
+        expect(horizontalResult == nil, "horizontal input after idle vertical input must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed],
+            "phase-less vertical intent must reset before the next horizontal swipe"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func verifiesPhaseLessUndecidedGestureResetsAfterIdle() {
+        let harness = MonitorHarness()
+
+        let undecidedEvent = harness.event(deltaX: 0, deltaY: 4.8)
+        let undecidedResult = harness.coordinator.handleForTesting(undecidedEvent)
+        expect(undecidedResult == nil, "undecided wheel input inside the sidebar should be consumed")
+        expect(harness.updates.isEmpty, "undecided wheel input must not emit space swipe updates")
+
+        drainMainQueue()
+
+        let horizontalEvent = harness.event(deltaX: 5.1, deltaY: 0)
+        let horizontalResult = harness.coordinator.handleForTesting(horizontalEvent)
+        expect(horizontalResult == nil, "horizontal input after idle undecided input must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed],
+            "phase-less undecided input must not bias the next horizontal swipe"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func verifiesPhaseLessHorizontalGestureStillEndsAfterIdle() {
+        let harness = MonitorHarness()
+
+        let horizontalEvent = harness.event(deltaX: 8, deltaY: 0)
+        let horizontalResult = harness.coordinator.handleForTesting(horizontalEvent)
+        expect(horizontalResult == nil, "horizontal wheel input must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed],
+            "horizontal wheel input must begin and change immediately"
+        )
+
+        drainMainQueue()
+
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed, .ended],
+            "phase-less horizontal input must still synthesize an idle end"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func drainMainQueue() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.24))
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        guard condition() else {
+            fputs("error: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+@MainActor
+private final class MonitorHarness {
+    let window: NSWindow
+    let view: ShellSidebarSwipeMonitor.MonitorView
+    let coordinator: ShellSidebarSwipeMonitor.Coordinator
+    private let recorder: SwipeUpdateRecorder
+    var updates: [ShellSidebarSwipeUpdate] {
+        recorder.updates
+    }
+    private var eventTime: TimeInterval = 1
+
+    init() {
+        let recorder = SwipeUpdateRecorder()
+        self.recorder = recorder
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 480),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        view = ShellSidebarSwipeMonitor.MonitorView(
+            frame: NSRect(x: 0, y: 0, width: 240, height: 480)
+        )
+        coordinator = ShellSidebarSwipeMonitor.Coordinator { update in
+            recorder.updates.append(update)
+        }
+        view.coordinator = coordinator
+        window.contentView = view
+        coordinator.install(for: view)
+    }
+
+    func event(deltaX: CGFloat, deltaY: CGFloat) -> NSEvent {
+        eventTime += 0.016
+        return RecordingSidebarScrollWheelEvent(
+            window: window,
+            locationInWindow: NSPoint(x: 120, y: 240),
+            deltaX: deltaX,
+            deltaY: deltaY,
+            timestamp: eventTime
+        )
+    }
+
+    func uninstall() {
+        coordinator.uninstall()
+    }
+}
+
+@MainActor
+private final class SwipeUpdateRecorder {
+    var updates: [ShellSidebarSwipeUpdate] = []
+}
+
+private final class RecordingSidebarScrollWheelEvent: NSEvent {
+    private weak var recordedWindow: NSWindow?
+    private let recordedLocationInWindow: NSPoint
+    private let recordedDeltaX: CGFloat
+    private let recordedDeltaY: CGFloat
+    private let recordedTimestamp: TimeInterval
+
+    init(
+        window: NSWindow,
+        locationInWindow: NSPoint,
+        deltaX: CGFloat,
+        deltaY: CGFloat,
+        timestamp: TimeInterval
+    ) {
+        recordedWindow = window
+        recordedLocationInWindow = locationInWindow
+        recordedDeltaX = deltaX
+        recordedDeltaY = deltaY
+        recordedTimestamp = timestamp
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override var window: NSWindow? { recordedWindow }
+    override var locationInWindow: NSPoint { recordedLocationInWindow }
+    override var scrollingDeltaX: CGFloat { recordedDeltaX }
+    override var scrollingDeltaY: CGFloat { recordedDeltaY }
+    override var hasPreciseScrollingDeltas: Bool { true }
+    override var phase: NSEvent.Phase { [] }
+    override var momentumPhase: NSEvent.Phase { [] }
+    override var timestamp: TimeInterval { recordedTimestamp }
+}
+#endif

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -20,6 +20,7 @@ private enum ShellSplitModelTests {
         try verifiesPaneScopedCloseKeepsInactivePaneTargeting()
         try verifiesPaneScopedCloseClosesSinglePaneTab()
         try verifiesPaneScopedClosePreservesFinalPane()
+        try verifiesPaneAllocationSkipsReservedRuntimeIDs()
         try verifiesSplitDecodeRequiresPersistedRatio()
         print("Shell split model tests passed.")
     }
@@ -223,6 +224,41 @@ private enum ShellSplitModelTests {
         } catch ShellStateMutationError.lastTab {
             // Expected.
         }
+    }
+
+    private static func verifiesPaneAllocationSkipsReservedRuntimeIDs() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+
+        let openedTab = try state.openingTerminalTab(
+            in: nil,
+            title: nil,
+            workingDirectory: nil,
+            reservedPaneIDs: ["pane_2"]
+        )
+        expect(
+            openedTab.paneID == "pane_3",
+            "opening a tab must not reuse a pane ID reserved by a live runtime"
+        )
+
+        let splitPane = try state.splittingPane(
+            "pane_1",
+            direction: .vertical,
+            reservedPaneIDs: ["pane_2"]
+        )
+        expect(
+            splitPane.paneID == "pane_3",
+            "splitting a pane must not reuse a pane ID reserved by a live runtime"
+        )
+
+        let newSpace = state.creatingTerminalSpace(
+            title: nil,
+            workingDirectory: nil,
+            reservedPaneIDs: ["pane_2"]
+        )
+        expect(
+            newSpace.paneID == "pane_3",
+            "creating a space must not reuse a pane ID reserved by a live runtime"
+        )
     }
 
     private static func verifiesSplitDecodeRequiresPersistedRatio() throws {

--- a/clients/apple/scripts/test-shell-window-placement.sh
+++ b/clients/apple/scripts/test-shell-window-placement.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-window-placement-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-window-placement-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/AlanNative/Support/ShellDesignTokens.swift" \
+    "$REPO_ROOT/clients/apple/AlanNative/Support/ShellWindowPlacement.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-window-placement.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -10,9 +10,134 @@ struct ShellWindowPlacementTestRunner {
 
 private enum ShellWindowPlacementTests {
     static func run() throws {
+        try verifiesDefaultFrameUsesVisibleRegionRatios()
+        try verifiesDefaultFrameFitsSmallVisibleRegions()
+        try verifiesZoomFrameUsesEntireVisibleRegion()
+        try verifiesApproximateZoomFrameMatching()
+        try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
+        try verifiesTrafficLightAreaDoesNotTriggerDoubleClickZoom()
+        try verifiesTitlebarOverlayAcceptsTopBlankHit()
+        try verifiesTitlebarOverlayRejectsTrafficLightHit()
         try verifiesAppearanceModeAppliesToAttachedWindowImmediately()
         try verifiesSystemModeClearsExplicitWindowAppearanceImmediately()
         print("Shell window placement tests passed.")
+    }
+
+    private static func verifiesDefaultFrameUsesVisibleRegionRatios() throws {
+        let visibleFrame = CGRect(x: 10, y: 40, width: 1600, height: 1000)
+
+        let frame = ShellWindowSizing.defaultFrame(in: visibleFrame)
+
+        expect(frame.width == 1440, "default window width must use 90% of visible width")
+        expect(frame.height == 800, "default window height must use 80% of visible height")
+        expect(frame.midX == visibleFrame.midX, "default window frame must be horizontally centered")
+        expect(frame.midY == visibleFrame.midY, "default window frame must be vertically centered")
+    }
+
+    private static func verifiesDefaultFrameFitsSmallVisibleRegions() throws {
+        let visibleFrame = CGRect(x: 0, y: 80, width: 1000, height: 700)
+
+        let frame = ShellWindowSizing.defaultFrame(in: visibleFrame)
+
+        expect(
+            visibleFrame.contains(frame),
+            "default window frame must stay inside the visible screen region"
+        )
+        expect(frame.width == 968, "default window width must clamp to visible width with margins")
+        expect(frame.height == 668, "default window height must clamp to visible height with margins")
+    }
+
+    private static func verifiesZoomFrameUsesEntireVisibleRegion() throws {
+        let visibleFrame = CGRect(x: -120, y: 60, width: 1920, height: 1080)
+
+        let frame = ShellWindowSizing.zoomFrame(in: visibleFrame)
+
+        expect(frame == visibleFrame, "zoom frame must match the screen visible region exactly")
+    }
+
+    private static func verifiesApproximateZoomFrameMatching() throws {
+        let visibleFrame = CGRect(x: 0, y: 60, width: 1512, height: 889)
+        let nearlyZoomed = CGRect(x: 0.5, y: 59.5, width: 1511.5, height: 889.5)
+        let notZoomed = CGRect(x: 20, y: 80, width: 1200, height: 760)
+
+        expect(
+            ShellWindowSizing.frame(nearlyZoomed, approximatelyMatches: visibleFrame),
+            "zoom frame matching must allow AppKit rounding differences"
+        )
+        expect(
+            !ShellWindowSizing.frame(notZoomed, approximatelyMatches: visibleFrame),
+            "zoom frame matching must reject clearly different frames"
+        )
+    }
+
+    private static func verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        let location = CGPoint(x: 420, y: window.frame.height - 12)
+
+        expect(
+            ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window
+            ),
+            "top titlebar blank points must trigger double-click visible-frame zoom"
+        )
+    }
+
+    private static func verifiesTrafficLightAreaDoesNotTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        let location = CGPoint(x: 42, y: window.frame.height - 18)
+
+        expect(
+            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window
+            ),
+            "traffic light region must keep its standard button behavior"
+        )
+    }
+
+    private static func verifiesTitlebarOverlayAcceptsTopBlankHit() throws {
+        let window = makeTestWindow()
+        let overlay = ShellWindowDoubleClickZoomOverlayView(
+            frame: CGRect(origin: .zero, size: window.frame.size)
+        )
+        window.contentView?.addSubview(overlay)
+
+        let windowPoint = CGPoint(x: 420, y: window.frame.height - 12)
+        let overlayPoint = overlay.convert(windowPoint, from: nil)
+
+        expect(
+            overlay.hitTest(overlayPoint) === overlay,
+            "titlebar overlay must accept top blank titlebar hits"
+        )
+    }
+
+    private static func verifiesTitlebarOverlayRejectsTrafficLightHit() throws {
+        let window = makeTestWindow()
+        let overlay = ShellWindowDoubleClickZoomOverlayView(
+            frame: CGRect(origin: .zero, size: window.frame.size)
+        )
+        window.contentView?.addSubview(overlay)
+
+        let windowPoint = CGPoint(x: 42, y: window.frame.height - 18)
+        let overlayPoint = overlay.convert(windowPoint, from: nil)
+
+        expect(
+            overlay.hitTest(overlayPoint) == nil,
+            "titlebar overlay must leave traffic light hits to standard window buttons"
+        )
     }
 
     private static func verifiesAppearanceModeAppliesToAttachedWindowImmediately() throws {
@@ -55,6 +180,15 @@ private enum ShellWindowPlacementTests {
         window.contentView = contentView
 
         return (window, placementView)
+    }
+
+    private static func makeTestWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
     }
 
     private static func expect(

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -1,0 +1,68 @@
+import AppKit
+import Foundation
+
+@main
+struct ShellWindowPlacementTestRunner {
+    static func main() throws {
+        try ShellWindowPlacementTests.run()
+    }
+}
+
+private enum ShellWindowPlacementTests {
+    static func run() throws {
+        try verifiesAppearanceModeAppliesToAttachedWindowImmediately()
+        try verifiesSystemModeClearsExplicitWindowAppearanceImmediately()
+        print("Shell window placement tests passed.")
+    }
+
+    private static func verifiesAppearanceModeAppliesToAttachedWindowImmediately() throws {
+        let (window, placementView) = makeAttachedPlacementView()
+
+        placementView.updateAppearanceMode(.dark)
+
+        expect(
+            window.appearance?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua,
+            "dark appearance mode must apply to the attached window immediately"
+        )
+    }
+
+    private static func verifiesSystemModeClearsExplicitWindowAppearanceImmediately() throws {
+        let (window, placementView) = makeAttachedPlacementView()
+        placementView.updateAppearanceMode(.dark)
+
+        placementView.updateAppearanceMode(.system)
+
+        expect(
+            window.appearance == nil,
+            "system appearance mode must clear the explicit window appearance immediately"
+        )
+    }
+
+    private static func makeAttachedPlacementView() -> (
+        window: NSWindow,
+        placementView: ShellWindowPlacementNSView
+    ) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentView?.bounds ?? .zero)
+        let placementView = ShellWindowPlacementNSView(appearanceMode: .system) { _ in }
+
+        contentView.addSubview(placementView)
+        window.contentView = contentView
+
+        return (window, placementView)
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: @autoclosure () -> String
+    ) {
+        guard condition() else {
+            fatalError(message())
+        }
+    }
+}

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -14,6 +14,8 @@ private enum ShellWindowPlacementTests {
         try verifiesDefaultFrameFitsSmallVisibleRegions()
         try verifiesZoomFrameUsesEntireVisibleRegion()
         try verifiesApproximateZoomFrameMatching()
+        try verifiesTitlebarToolsMoveToLeadingEdgeWhenTrafficLightsAreHidden()
+        try verifiesFullscreenChromeMetricsHideTrafficLightReservation()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
         try verifiesTrafficLightAreaDoesNotTriggerDoubleClickZoom()
         try verifiesTitlebarOverlayAcceptsTopBlankHit()
@@ -67,6 +69,34 @@ private enum ShellWindowPlacementTests {
         expect(
             !ShellWindowSizing.frame(notZoomed, approximatelyMatches: visibleFrame),
             "zoom frame matching must reject clearly different frames"
+        )
+    }
+
+    private static func verifiesTitlebarToolsMoveToLeadingEdgeWhenTrafficLightsAreHidden() throws {
+        var metrics = ShellWindowChromeMetrics()
+        metrics.standardTrafficLightsVisible = false
+
+        expect(
+            metrics.titlebarToolLeadingInset == ShellSidebarMetrics.edgeInset,
+            "titlebar tools must move to the leading edge when native fullscreen hides traffic lights"
+        )
+    }
+
+    private static func verifiesFullscreenChromeMetricsHideTrafficLightReservation() throws {
+        let window = makeTestWindow()
+
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            nativeFullScreenOverride: true
+        )
+
+        expect(
+            !metrics.standardTrafficLightsVisible,
+            "native fullscreen metrics must stop reserving leading space for traffic lights"
+        )
+        expect(
+            metrics.titlebarToolLeadingInset == ShellSidebarMetrics.edgeInset,
+            "native fullscreen titlebar tools must align to the leading edge"
         )
     }
 

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -16,9 +16,19 @@ private enum ShellWindowPlacementTests {
         try verifiesApproximateZoomFrameMatching()
         try verifiesTitlebarToolsMoveToLeadingEdgeWhenTrafficLightsAreHidden()
         try verifiesFullscreenChromeMetricsHideTrafficLightReservation()
+        try verifiesHiddenSidebarSurfaceHidesTrafficLights()
+        try verifiesFloatingSidebarSurfaceRevealsTrafficLightsAtSurfaceOrigin()
+        try verifiesPendingFloatingSidebarRevealHidesTrafficLightsButReservesLayout()
+        try verifiesFloatingSidebarRevealAfterPendingHiddenStateUsesSurfaceOrigin()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
-        try verifiesTrafficLightAreaDoesNotTriggerDoubleClickZoom()
+        try verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom()
+        try verifiesTrafficLightControlsDoNotTriggerDoubleClickZoom()
+        try verifiesTrafficLightGapsCanTriggerDoubleClickZoom()
+        try verifiesSidebarChromeBlankAreaCanTriggerDoubleClickZoom()
+        try verifiesSidebarToolbarButtonsDoNotTriggerDoubleClickZoom()
         try verifiesTitlebarOverlayAcceptsTopBlankHit()
+        try verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit()
+        try verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit()
         try verifiesTitlebarOverlayRejectsTrafficLightHit()
         try verifiesAppearanceModeAppliesToAttachedWindowImmediately()
         try verifiesSystemModeClearsExplicitWindowAppearanceImmediately()
@@ -100,6 +110,128 @@ private enum ShellWindowPlacementTests {
         )
     }
 
+    private static func verifiesHiddenSidebarSurfaceHidesTrafficLights() throws {
+        let window = makeTestWindow()
+
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            chromeSurface: ShellWindowChromeSurface(isVisible: false)
+        )
+
+        expect(
+            !metrics.standardTrafficLightsVisible,
+            "hidden sidebar surfaces must stop reserving titlebar space for traffic lights"
+        )
+        expect(
+            standardWindowButtons(in: window).allSatisfy(\.isHidden),
+            "hidden sidebar surfaces must hide standard traffic-light controls"
+        )
+    }
+
+    private static func verifiesFloatingSidebarSurfaceRevealsTrafficLightsAtSurfaceOrigin() throws {
+        let window = makeTestWindow()
+        let surfaceOrigin = CGPoint(x: 6, y: 6)
+
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            chromeSurface: ShellWindowChromeSurface(isVisible: true, origin: surfaceOrigin)
+        )
+        let actualFrame = actualTrafficLightFrame(in: window)
+
+        expect(
+            standardWindowButtons(in: window).allSatisfy { !$0.isHidden },
+            "visible floating sidebar surfaces must show standard traffic-light controls"
+        )
+        expect(
+            actualFrame.minX.isApproximately(
+                ShellSidebarMetrics.trafficLightLeadingInset + surfaceOrigin.x
+            ),
+            "floating sidebar traffic lights must move to the visible surface origin; actual \(actualFrame.minX), expected \(ShellSidebarMetrics.trafficLightLeadingInset + surfaceOrigin.x)"
+        )
+        expect(
+            actualFrame.minY.isApproximately(
+                ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y
+            ),
+            "floating sidebar traffic lights must move down with the visible surface origin; actual \(actualFrame.minY), expected \(ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y)"
+        )
+        expect(
+            metrics.trafficLightGroupFrame.minX.isApproximately(
+                ShellSidebarMetrics.trafficLightLeadingInset
+            ),
+            "published chrome metrics must remain local to the sidebar surface"
+        )
+        expect(
+            metrics.trafficLightGroupFrame.minY.isApproximately(
+                ShellSidebarMetrics.trafficLightTopInset
+            ),
+            "published chrome metrics must not include the floating surface offset; actual \(metrics.trafficLightGroupFrame.minY), expected \(ShellSidebarMetrics.trafficLightTopInset)"
+        )
+    }
+
+    private static func verifiesPendingFloatingSidebarRevealHidesTrafficLightsButReservesLayout() throws {
+        let window = makeTestWindow()
+        let surfaceOrigin = CGPoint(x: 6, y: 6)
+
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            chromeSurface: ShellWindowChromeSurface(
+                isVisible: true,
+                origin: surfaceOrigin,
+                showsStandardTrafficLights: false
+            )
+        )
+
+        expect(
+            standardWindowButtons(in: window).allSatisfy(\.isHidden),
+            "pending floating sidebar reveal must keep standard traffic lights hidden"
+        )
+        expect(
+            metrics.standardTrafficLightsVisible,
+            "pending floating sidebar reveal must reserve the traffic-light layout space"
+        )
+        expect(
+            metrics.titlebarToolLeadingInset
+                > ShellSidebarMetrics.edgeInset + ShellSidebarMetrics.titlebarToolWidth,
+            "titlebar tools must not jump to the leading edge while traffic lights wait for panel reveal timing"
+        )
+    }
+
+    private static func verifiesFloatingSidebarRevealAfterPendingHiddenStateUsesSurfaceOrigin() throws {
+        let window = makeTestWindow()
+        let surfaceOrigin = CGPoint(x: 6, y: 6)
+        let pendingSurface = ShellWindowChromeSurface(
+            isVisible: true,
+            origin: surfaceOrigin,
+            showsStandardTrafficLights: false
+        )
+        let revealedSurface = ShellWindowChromeSurface(
+            isVisible: true,
+            origin: surfaceOrigin,
+            showsStandardTrafficLights: true
+        )
+
+        _ = AlanShellWindowPlacement.synchronizeChrome(for: window, chromeSurface: pendingSurface)
+        _ = AlanShellWindowPlacement.synchronizeChrome(for: window, chromeSurface: revealedSurface)
+
+        let actualFrame = actualTrafficLightFrame(in: window)
+        expect(
+            standardWindowButtons(in: window).allSatisfy { !$0.isHidden },
+            "floating sidebar traffic lights must become visible after pending reveal"
+        )
+        expect(
+            actualFrame.minX.isApproximately(
+                ShellSidebarMetrics.trafficLightLeadingInset + surfaceOrigin.x
+            ),
+            "floating sidebar traffic lights must not flash at the non-floating x position after pending reveal; actual \(actualFrame.minX), expected \(ShellSidebarMetrics.trafficLightLeadingInset + surfaceOrigin.x)"
+        )
+        expect(
+            actualFrame.minY.isApproximately(
+                ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y
+            ),
+            "floating sidebar traffic lights must not flash at the non-floating y position after pending reveal; actual \(actualFrame.minY), expected \(ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y)"
+        )
+    }
+
     private static func verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
@@ -108,7 +240,7 @@ private enum ShellWindowPlacementTests {
             defer: false
         )
 
-        let location = CGPoint(x: 420, y: window.frame.height - 12)
+        let location = CGPoint(x: 420, y: window.frame.height - 4)
 
         expect(
             ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
@@ -119,22 +251,111 @@ private enum ShellWindowPlacementTests {
         )
     }
 
-    private static func verifiesTrafficLightAreaDoesNotTriggerDoubleClickZoom() throws {
+    private static func verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(
+            x: 760,
+            y: window.frame.height - ShellWorkspaceMetrics.terminalSurfaceInset - 12
+        )
+
+        expect(
+            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "terminal surface title-bar controls must receive clicks instead of the window zoom overlay"
+        )
+    }
+
+    private static func verifiesTrafficLightControlsDoNotTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
 
         let location = CGPoint(x: 42, y: window.frame.height - 18)
 
         expect(
             !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
                 locationInWindow: location,
-                in: window
+                in: window,
+                chromeSurface: chromeSurface
             ),
             "traffic light region must keep its standard button behavior"
+        )
+    }
+
+    private static func verifiesTrafficLightGapsCanTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(x: 32, y: window.frame.height - 18)
+
+        expect(
+            ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "blank gaps in the traffic-light titlebar area must trigger double-click visible-frame zoom"
+        )
+    }
+
+    private static func verifiesSidebarChromeBlankAreaCanTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(x: 190, y: window.frame.height - 20)
+
+        expect(
+            ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "blank sidebar chrome beside the traffic lights and toolbar controls must trigger double-click visible-frame zoom"
+        )
+    }
+
+    private static func verifiesSidebarToolbarButtonsDoNotTriggerDoubleClickZoom() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(x: 98, y: window.frame.height - 20)
+
+        expect(
+            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "sidebar titlebar toolbar buttons must receive clicks instead of the window zoom overlay"
         )
     }
 
@@ -145,7 +366,7 @@ private enum ShellWindowPlacementTests {
         )
         window.contentView?.addSubview(overlay)
 
-        let windowPoint = CGPoint(x: 420, y: window.frame.height - 12)
+        let windowPoint = CGPoint(x: 420, y: window.frame.height - 4)
         let overlayPoint = overlay.convert(windowPoint, from: nil)
 
         expect(
@@ -154,11 +375,49 @@ private enum ShellWindowPlacementTests {
         )
     }
 
+    private static func verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit() throws {
+        let window = makeTestWindow()
+        let overlay = ShellWindowDoubleClickZoomOverlayView(
+            frame: CGRect(origin: .zero, size: window.frame.size)
+        )
+        overlay.chromeSurface = ShellWindowChromeSurface(width: 264)
+        window.contentView?.addSubview(overlay)
+
+        let windowPoint = CGPoint(x: 190, y: window.frame.height - 20)
+        let overlayPoint = overlay.convert(windowPoint, from: nil)
+
+        expect(
+            overlay.hitTest(overlayPoint) === overlay,
+            "titlebar overlay must accept blank sidebar chrome hits below the top content inset"
+        )
+    }
+
+    private static func verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit() throws {
+        let window = makeTestWindow()
+        let overlay = ShellWindowDoubleClickZoomOverlayView(
+            frame: CGRect(origin: .zero, size: window.frame.size)
+        )
+        overlay.chromeSurface = ShellWindowChromeSurface(width: 264)
+        window.contentView?.addSubview(overlay)
+
+        let windowPoint = CGPoint(
+            x: window.frame.width - 40,
+            y: window.frame.height - ShellWorkspaceMetrics.terminalSurfaceInset - 12
+        )
+        let overlayPoint = overlay.convert(windowPoint, from: nil)
+
+        expect(
+            overlay.hitTest(overlayPoint) == nil,
+            "titlebar overlay must leave terminal surface title-bar controls clickable"
+        )
+    }
+
     private static func verifiesTitlebarOverlayRejectsTrafficLightHit() throws {
         let window = makeTestWindow()
         let overlay = ShellWindowDoubleClickZoomOverlayView(
             frame: CGRect(origin: .zero, size: window.frame.size)
         )
+        overlay.chromeSurface = ShellWindowChromeSurface(width: 264)
         window.contentView?.addSubview(overlay)
 
         let windowPoint = CGPoint(x: 42, y: window.frame.height - 18)
@@ -213,11 +472,47 @@ private enum ShellWindowPlacementTests {
     }
 
     private static func makeTestWindow() -> NSWindow {
-        NSWindow(
+        let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
+        )
+        window.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 520))
+        return window
+    }
+
+    private static func standardWindowButtons(in window: NSWindow) -> [NSButton] {
+        let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        let buttons = buttonTypes.compactMap { window.standardWindowButton($0) }
+
+        expect(
+            buttons.count == buttonTypes.count,
+            "test window must expose all standard window buttons"
+        )
+
+        return buttons
+    }
+
+    private static func actualTrafficLightFrame(in window: NSWindow) -> CGRect {
+        let buttons = standardWindowButtons(in: window)
+        guard let superview = buttons.first?.superview,
+              buttons.allSatisfy({ $0.superview === superview })
+        else {
+            fatalError("test window standard buttons must share a superview")
+        }
+
+        let buttonFrame = buttons
+            .map(\.frame)
+            .reduce(NSRect.null) { $0.union($1) }
+        let windowFrame = superview.convert(buttonFrame, to: nil)
+        let topInset = max(0, window.frame.height - windowFrame.maxY)
+
+        return CGRect(
+            x: windowFrame.minX,
+            y: topInset,
+            width: windowFrame.width,
+            height: windowFrame.height
         )
     }
 
@@ -228,5 +523,11 @@ private enum ShellWindowPlacementTests {
         guard condition() else {
             fatalError(message())
         }
+    }
+}
+
+private extension CGFloat {
+    func isApproximately(_ other: CGFloat, tolerance: CGFloat = 1) -> Bool {
+        abs(self - other) <= tolerance
     }
 }

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -14,6 +14,8 @@ struct TerminalRuntimeServiceTestRunner {
 @MainActor
 private enum TerminalRuntimeServiceTests {
     static func run() {
+        verifiesGhosttyTerminfoEnvironmentProjection()
+        verifiesRuntimeCwdDoesNotRequireSurfaceRecreation()
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
         verifiesDeliveryAndMissingRuntimeResults()
@@ -23,6 +25,56 @@ private enum TerminalRuntimeServiceTests {
         verifiesFinalizePanesOnlyReleasesStaleHandles()
         verifiesBootstrapFailureDiagnostics()
         print("Terminal runtime service tests passed.")
+    }
+
+    private static func verifiesGhosttyTerminfoEnvironmentProjection() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-ghostty-terminfo-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        setenv("ALAN_GHOSTTY_TERMINFO_DIR", tempDir.path, 1)
+        defer {
+            unsetenv("ALAN_GHOSTTY_TERMINFO_DIR")
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let state = ShellStateSnapshot.bootstrapDefault()
+        let pane = state.panes[0]
+        let profile = AlanShellBootProfile.forPane(pane, shellState: state)
+
+        expect(
+            profile.environment["TERMINFO"] == tempDir.path,
+            "boot profile must pass Ghostty terminfo to terminal child processes"
+        )
+        expect(
+            profile.environment["TERM_PROGRAM"] == "Alan",
+            "boot profile must identify Alan as the terminal program"
+        )
+        expect(
+            profile.environment["COLORTERM"] == "truecolor",
+            "boot profile must advertise truecolor terminal support"
+        )
+    }
+
+    private static func verifiesRuntimeCwdDoesNotRequireSurfaceRecreation() {
+        let base = sampleBootProfile(workingDirectory: "/Users/morris")
+        let afterCd = sampleBootProfile(workingDirectory: "/Users/morris/Developer/Alan")
+        let differentEnvironment = sampleBootProfile(
+            workingDirectory: "/Users/morris/Developer/Alan",
+            environment: ["TERMINFO": "/tmp/other-terminfo"]
+        )
+
+        expect(
+            !afterCd.requiresSurfaceRecreation(comparedTo: base),
+            "runtime cwd updates must not recreate the Ghostty surface"
+        )
+        expect(
+            differentEnvironment.requiresSurfaceRecreation(comparedTo: base),
+            "terminal environment changes must recreate the Ghostty surface"
+        )
+        expect(
+            base.requiresSurfaceRecreation(comparedTo: nil),
+            "missing previous boot profile must require initial surface creation"
+        )
     }
 
     private static func verifiesBootstrapReuseAndPaneHandleIdentity() {
@@ -184,6 +236,34 @@ private enum TerminalRuntimeServiceTests {
         let diagnostics = service.ensureReady()
         expect(diagnostics.phase == .failed, "failed bootstrap must publish failed phase")
         expect(diagnostics.failureReason == "missing resources", "failed bootstrap must retain reason")
+    }
+
+    private static func sampleBootProfile(
+        workingDirectory: String,
+        environment: [String: String] = ["TERMINFO": "/tmp/ghostty-terminfo"]
+    ) -> AlanShellBootProfile {
+        AlanShellBootProfile(
+            command: AlanCommandResolution(
+                strategy: .loginShellFallback,
+                executablePath: "/bin/zsh",
+                launchPath: "/bin/zsh",
+                arguments: ["-l"],
+                bootCommand: "/bin/zsh -l",
+                surfaceCommand: nil,
+                summary: "Launching pane with the default login shell",
+                detail: "/bin/zsh",
+                repoRoot: nil,
+                candidates: []
+            ),
+            workingDirectory: workingDirectory,
+            environment: environment,
+            ghostty: GhosttyIntegrationStatus(
+                frameworkPath: "/tmp/GhosttyKit.xcframework",
+                resourcesPath: "/tmp/ghostty-resources",
+                terminfoPath: "/tmp/ghostty-terminfo",
+                candidates: []
+            )
+        )
     }
 
     private static func expect(

--- a/justfile
+++ b/justfile
@@ -54,6 +54,7 @@ build:
 
 # Build and launch the native macOS app
 app:
+    -pkill -x Alan
     xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
     /usr/bin/open -n target/xcode-derived/Build/Products/Debug/Alan.app
 

--- a/justfile
+++ b/justfile
@@ -54,9 +54,7 @@ build:
 
 # Build and launch the native macOS app
 app:
-    -pkill -x Alan
-    xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build
-    /usr/bin/open -n target/xcode-derived/Build/Products/Debug/Alan.app
+    clients/apple/scripts/run-alan-debug-app.sh
 
 # Install alan to ~/.alan/bin
 install:

--- a/openspec/changes/optimize-macos-material-system/design.md
+++ b/openspec/changes/optimize-macos-material-system/design.md
@@ -73,6 +73,25 @@ the terminal itself remains stable, high contrast, and readable.
    fall back to a more solid standard material or tonal fill without changing the
    view hierarchy.
 
+5. Treat radius and shadow as surface semantics, not decorative effects.
+
+   The current terminal surface establishes the baseline for a primary content
+   surface: continuous 12pt corners, a focused contact shadow, and a restrained
+   rim/highlight treatment. Other active shell elements should derive from a
+   smaller semantic scale: micro geometry for split indicators, 6-10pt compact
+   controls and inputs, 12pt selected/content surfaces, 16pt collapsed floating
+   panels, and capsules only for semantic pill inputs such as `Ask Alan...` and
+   the command palette. Shadow should appear only where elevation changes the
+   interaction model: selected navigation rows, floating inputs, the terminal
+   surface, collapsed sidebar panels, and modal command entry. Static sidebar
+   controls and titlebar ghost buttons should rely on tint, stroke, hover, and
+   highlight instead of default shadows.
+
+   Alternative considered: give every translucent control a small shadow to
+   make the glass visible. That made light mode feel dirty because dark ambient
+   shadow mixed with the sidebar material. Focused adaptive contact shadows are
+   clearer and closer to native macOS hierarchy.
+
 ## Risks / Trade-offs
 
 - Visual regressions can be subjective -> Mitigate with screenshot/manual review

--- a/openspec/changes/optimize-macos-material-system/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/optimize-macos-material-system/specs/macos-shell-build-test-contract/spec.md
@@ -16,3 +16,11 @@ reintroduce hard-coded visual effects.
 #### Scenario: One-off material fills are checked
 - **WHEN** a change adds new active-shell material or translucent fills
 - **THEN** focused review or a lightweight check confirms the fill is attached to a shared semantic material/control role rather than a local hard-coded effect
+
+#### Scenario: Elevation hierarchy is reviewed
+- **WHEN** active macOS shell radius, shadow, rim, or floating-surface treatment changes
+- **THEN** focused review confirms terminal surface, sidebar selection, titlebar controls, command launcher, Find bar, command palette, and collapsed sidebar panel use the shared semantic radius/elevation scale
+
+#### Scenario: Light-mode shadow cleanliness is reviewed
+- **WHEN** active shell elevation changes are marked complete
+- **THEN** maintainers can inspect screenshots or notes confirming light-mode shadows are focused and adaptive rather than broad, dirty, or purely black halos

--- a/openspec/changes/optimize-macos-material-system/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/optimize-macos-material-system/specs/macos-shell-ui-ux-conformance/spec.md
@@ -36,3 +36,28 @@ opaque, or ad hoc translucent fills in default shell chrome.
 #### Scenario: AppKit bridge remains isolated
 - **WHEN** a SwiftUI shell view needs an AppKit-backed visual effect material
 - **THEN** the view uses a reusable support-layer wrapper rather than creating `NSVisualEffectView` bridge details inline
+
+### Requirement: Active shell surfaces use semantic elevation
+The active macOS shell SHALL pair its material roles with a small semantic
+radius and shadow scale. Surface elevation MUST communicate hierarchy and
+interaction state rather than decorate every translucent control.
+
+#### Scenario: Primary terminal surface anchors elevation
+- **WHEN** the active terminal surface is visible
+- **THEN** it uses the primary content-surface treatment with continuous 12pt corners, a focused adaptive contact shadow, and restrained rim/highlight treatment
+
+#### Scenario: Static controls stay quiet
+- **WHEN** sidebar command launchers, titlebar ghost buttons, or compact static controls are idle
+- **THEN** they avoid default shadows and use material tint, stroke, hover, or highlight to show affordance
+
+#### Scenario: Selected navigation uses light elevation
+- **WHEN** a sidebar row or space switcher item is selected or previewed
+- **THEN** it may use a very light adaptive contact shadow that is smaller than floating overlay shadows and does not produce dirty dark halos in light mode
+
+#### Scenario: Floating surfaces carry stronger elevation
+- **WHEN** the command palette, pane Find bar, or collapsed sidebar panel floats above the shell
+- **THEN** it uses semantic floating-surface shadows that are visible, focused, and adaptive while keeping the terminal content visually dominant
+
+#### Scenario: Radius scale remains role-based
+- **WHEN** active shell visual chrome is updated
+- **THEN** micro indicators, compact controls, rows, floating inputs, primary surfaces, collapsed panels, and semantic pill inputs use the shared shell radius roles instead of local one-off values

--- a/openspec/changes/optimize-macos-material-system/tasks.md
+++ b/openspec/changes/optimize-macos-material-system/tasks.md
@@ -10,6 +10,7 @@
 - [x] 2.2 Apply the sidebar/control roles to `ShellSidebarView.swift` without changing sidebar information architecture.
 - [x] 2.3 Apply terminal surround roles to active terminal shell chrome without reducing terminal text contrast.
 - [x] 2.4 Apply overlay/control roles to active floating shell surfaces without redesigning command input behavior.
+- [x] 2.5 Align active shell radius and shadow usage to the semantic elevation scale, keeping the approved terminal surface treatment as the baseline.
 
 ## 3. Verification
 
@@ -17,6 +18,7 @@
 - [x] 3.2 Capture screenshot or manual review notes for light-mode sidebar, terminal, command entry, controls, and overlays.
 - [x] 3.3 Review reduced-transparency or increased-contrast behavior, or document why local verification was unavailable.
 - [x] 3.4 Run `openspec validate --all --strict` before PR.
+- [x] 3.5 Re-run focused shell/OpenSpec/build verification after the elevation-scale polish pass.
 
 ### Verification Notes
 
@@ -25,3 +27,5 @@
 - 2026-05-12: Captured command input review screenshot at `/tmp/alan-ui-polish-command-input-command-p-retry.png`; command entry, floating overlay material, and terminal scrim treatment were reviewed together.
 - 2026-05-12: Reduced-transparency behavior is handled in the shared material wrappers by disabling AppKit visual-effect material when `accessibilityReduceTransparency` is active and falling back to solid semantic fills. Increased-contrast behavior is handled by `NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast`, which strengthens fills and strokes for control, overlay, panel, and terminal chrome roles. I did not toggle global macOS accessibility settings during the run.
 - 2026-05-12: Checked active shell files for escaped one-off `.ultraThinMaterial`, `Color.white.opacity(...)`, or direct shell background/control fills; the remaining direct palette match is the space-rail attention-dot stroke, not a material or translucent background fill.
+- 2026-05-13: Extended the material-system spec with semantic elevation requirements. The approved terminal surface treatment now anchors the hierarchy; selected navigation, floating inputs, floating panels, and command palette shadows use shared adaptive elevation tokens while static titlebar and command launcher controls stay shadowless.
+- 2026-05-13: Verified the elevation polish with `git diff --check`, `openspec validate optimize-macos-material-system --type change --strict`, `bash clients/apple/scripts/check-shell-contracts.sh`, and `xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -derivedDataPath target/xcode-derived build`. The Xcode build passed with the existing CoreSimulator version warning.

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-ui-ux-conformance/spec.md
@@ -9,9 +9,14 @@ candidate sections below the input.
 - **WHEN** the user presses `Command-P` or activates the sidebar command entry
 - **THEN** Alan opens a floating material-backed input field, focuses the text field, and does not show action, routing, attention, or best-match lists below it
 
+#### Scenario: Command input toggles from shortcut
+- **WHEN** the command input is already open and the user presses `Command-P`
+- **THEN** Alan dismisses the input and returns keyboard focus to the previously focused terminal pane when available
+
 #### Scenario: Command input is visually restrained
 - **WHEN** the command input is visible
 - **THEN** the surface uses a restrained native material treatment, stable geometry, and compact controls rather than a large card, dashboard panel, or multi-section palette
+- **AND** it appears and disappears with an opacity-only fade instead of moving down from the top edge
 
 #### Scenario: Command input dismisses
 - **WHEN** the user presses Escape, clicks outside the input, activates a close affordance, or successfully submits a resolved command

--- a/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/polish-macos-command-input/specs/macos-shell-workspace-interactions/spec.md
@@ -19,6 +19,10 @@ candidate action lists.
 - **WHEN** the user opens `Go to or Command...`
 - **THEN** Alan focuses a single command input field instead of presenting default action, routing, or attention candidate lists
 
+#### Scenario: Command input shortcut toggles
+- **WHEN** the user presses `Command-P` while the command input is focused or visible
+- **THEN** Alan dismisses the command input instead of opening a duplicate surface
+
 #### Scenario: Typed command resolves
 - **WHEN** the user submits a typed command that Alan can resolve to a workspace action or routing target
 - **THEN** Alan executes the same shell controller action used by menu and keyboard paths and dismisses the command input

--- a/openspec/changes/streamline-macos-sidebar-ia/design.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/design.md
@@ -27,6 +27,10 @@ instructional copy, and make the bottom space switcher feel intentional.
   choice, placement, hover actions, tooltips, menus, and accessibility labels.
 - Keep tabs skimmable and lightweight, with Alan state expressed inline and
   attention preserved outside default sidebar notification dots.
+- Calibrate the sidebar surface, tab rows, and controls as a unified tinted
+  material stack: macOS visual effect material remains visible beneath a cool
+  translucent wash, while row states are expressed through layered alpha,
+  subtle tint, and restrained shadows rather than opaque white panels.
 - Make split tabs legible at a glance by showing a compact topology indicator
   that communicates pane count, dominant split direction, and focused pane.
 - Keep the command input entry available from the sidebar, but do not redesign its
@@ -34,8 +38,10 @@ instructional copy, and make the bottom space switcher feel intentional.
 
 **Non-Goals:**
 
-- Do not redesign material treatment; that is owned by
-  `optimize-macos-material-system`.
+- Do not redesign the whole app material system; that broader token cleanup is
+  owned by `optimize-macos-material-system`. This change may tune the local
+  sidebar-facing backdrop, row, and control tokens needed for the Arc-like
+  sidebar IA to read correctly.
 - Do not implement advanced drag/reorder behavior unless needed to make the
   layout coherent.
 - Do not remove product terms such as Space and Tab from accessibility surfaces
@@ -142,13 +148,35 @@ instructional copy, and make the bottom space switcher feel intentional.
    Default rows should prioritize title, compact context, Alan attachment, and
    selection.
 
-6. Empty states should be actionable, not explanatory.
+6. Separate tab row visual states by strength.
+
+   Normal tab rows should sit directly on the sidebar material without a
+   persistent container. Hover and keyboard-focus states should introduce only a
+   subtle translucent pill so the row feels interactive without becoming a
+   card. The selected tab should be the strongest state: a brighter rounded
+   selection surface with a light shadow and stable trailing close affordance.
+   Tab list rows should keep a stable sidebar gutter so the selected surface is
+   inset into the material rather than flush to the window edge. This preserves
+   the Arc-like hierarchy where most rows remain quiet and only the active item
+   reads as a distinct object.
+
+7. Treat the space title as a sticky boundary.
+
+   The space title should remain fixed above the tab list as a quiet grayscale
+   label, not as a control or pill. At rest, the title and first tab row should
+   have a compact quiet material gap with no permanent rule, so the tab row
+   still reads as part of the same group. When tab rows scroll upward underneath
+   that title region, a subtle divider and downward shadow should fade in at the
+   boundary and the tab rows should clip below it. This creates the same
+   native-feeling depth cue as Arc without adding static section chrome.
+
+8. Empty states should be actionable, not explanatory.
 
    If no spaces or tabs exist, the sidebar should show a compact creation
    affordance in the owning zone. It should avoid paragraph-style instruction
    like "Create a space to start..." in normal chrome.
 
-7. Represent split tabs with a topology indicator, not a full thumbnail.
+9. Represent split tabs with a topology indicator, not a full thumbnail.
 
    A split tab row should show a small indicator only when the tab contains more
    than one pane. For two panes, the indicator can mirror the root split
@@ -162,7 +190,7 @@ instructional copy, and make the bottom space switcher feel intentional.
    nested horizontal/vertical splits and arbitrary ratios, which would become
    unreadable at sidebar size.
 
-8. Make the split indicator a quick focus target.
+10. Make the split indicator a quick focus target.
 
    For two panes, clicking the visible segment should focus that pane. For more
    complex layouts, clicking the indicator should provide a predictable focus

--- a/openspec/changes/streamline-macos-sidebar-ia/design.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/design.md
@@ -17,13 +17,16 @@ instructional copy, and make the bottom space switcher feel intentional.
 **Goals:**
 
 - Keep the sidebar as a single vertical navigation column that aligns cleanly
-  below and around the macOS traffic-light area.
+  below and around the macOS traffic-light area, with an initial narrow macOS
+  width target around 264 pt rather than a dashboard-like wide column.
 - Make spaces available through a bottom, borderless icon switcher and through
-  left/right swipe gestures inside the sidebar.
+  left/right swipe gestures inside the sidebar that drive a sidebar-local,
+  direct-manipulation space preview while the workspace stays stable until
+  commit.
 - Reduce visible explanatory copy while preserving discoverability through icon
   choice, placement, hover actions, tooltips, menus, and accessibility labels.
-- Keep tabs skimmable and lightweight, with attention and Alan state expressed
-  inline.
+- Keep tabs skimmable and lightweight, with Alan state expressed inline and
+  attention preserved outside default sidebar notification dots.
 - Make split tabs legible at a glance by showing a compact topology indicator
   that communicates pane count, dominant split direction, and focused pane.
 - Keep the command input entry available from the sidebar, but do not redesign its
@@ -44,9 +47,10 @@ instructional copy, and make the bottom space switcher feel intentional.
 1. Keep a vertical Arc-like sidebar.
 
    The root sidebar should remain one vertical stack: top identity/window-safe
-   area, command entry, active-space tab list, and bottom space switcher. This
-   avoids traffic-light alignment problems and matches the Arc-like bottom space
-   switcher direction.
+   area, command entry, active-space tab list, and bottom space switcher. Use a
+   restrained width around 264 pt so the sidebar reads as navigation chrome
+   instead of a dashboard panel. This avoids traffic-light alignment problems
+   and matches the Arc-like bottom space switcher direction.
 
    Alternative considered: render a narrow rail and a tab-list column side by
    side. That looks structurally clean in an abstract layout, but it creates
@@ -56,26 +60,77 @@ instructional copy, and make the bottom space switcher feel intentional.
 2. Make the bottom space switcher borderless.
 
    Space switcher items should be compact icon buttons without card borders,
-   framed backgrounds, or section chrome. Selection, hover, and attention should
-   be expressed through icon tone, subtle glow/tint, dot/count marks, or a small
-   backing only when state requires it.
+   framed backgrounds, section chrome, or notification dots. Selection and hover
+   should be expressed through icon tone, subtle glow/tint, or a small backing
+   only when state requires it.
 
    Alternative considered: keep current rounded square rail items. That is
    functional, but it reads heavier than the desired slim bottom switcher.
 
-3. Support horizontal sidebar swipe for space switching.
+3. Support horizontal sidebar swipe as direct manipulation, not a trigger.
 
-   A left/right swipe over the sidebar should switch to the previous/next space.
-   This must not steal scroll from the tab list unless the gesture is clearly
-   horizontal. Trackpad interaction should feel like switching Arc spaces, not
-   like dragging a custom carousel.
+   A left/right swipe over the sidebar should begin a transient space
+   transition. While the gesture is active, the sidebar's current space header
+   and tab list should move with the finger and the adjacent space should
+   preview from the side. The workspace terminal surface should remain visually
+   stable during the gesture and update only after release commits the new
+   selected space. The header and tab-list previews should compute their
+   horizontal offsets from the same full sidebar page width, not from the
+   padded content width or the space-title row's accessory width, so they move
+   at the same pixel speed and avoid visible side gaps during the swipe. The
+   space-title row should stay a quiet label rather than adding a persistent
+   trailing creation button, and the title pager itself should remain
+   full-width. Dragging should use a translation-first model: the sidebar pages
+   render directly from the current horizontal finger/scroll translation, while
+   normalized progress is derived only for release-time commit decisions. The
+   commit threshold should not amplify, quantize, or otherwise shape the drag
+   preview. Alan should commit the selected space only after release crosses a
+   distance or velocity threshold; otherwise it should cancel back to the
+   original space. Fast horizontal flicks should be able to lock and commit
+   from the release/momentum handoff even if they do not produce a long stream
+   of intermediate changed events.
+
+   This transition belongs in view state, not in `ShellHostController`
+   selection state. `ShellHostController` should still change selected space via
+   the existing selection path once the gesture commits. This keeps terminal
+   focus, runtime snapshots, and control-plane state stable while the gesture is
+   only previewing.
+
+   The gesture recognizer should use an explicit axis lock before routing
+   scroll-wheel events. During the initial dead zone, mixed scroll deltas should
+   be buffered rather than leaked to the vertical tab list. Once horizontal
+   intent locks, vertical deltas are ignored, native vertical tab-list scrolling
+   is disabled for that gesture, and the sidebar preview is the only movement.
+   Once vertical intent locks, the sidebar space preview does not begin and
+   native vertical tab-list scrolling receives the gesture. Phaseful
+   trackpad gestures should remain fully direct: if the fingers pause while
+   still touching the trackpad, the sidebar preview should hold its current
+   offset rather than settling. Alan should settle only when the gesture ends,
+   is cancelled, or enters momentum. The recognizer must process
+   ended/cancelled/momentum phases before ignoring zero-delta scroll events,
+   because macOS may deliver the release event with no scroll delta. It should
+   settle using the last effective finger velocity rather than recomputing
+   velocity from a zero-delta release event. Phase-less scroll devices may use a
+   short idle fallback to avoid leaving the preview stuck. At the first or last
+   space, the transition should rubber-band rather than wrapping; keyboard
+   shortcuts may continue to wrap through the existing discrete command path.
+
+   Alternative considered: keep a scroll-delta threshold and call
+   `selectAdjacentSpace`. That is cheaper, but it feels like a page trigger
+   rather than native direct manipulation and does not match the desired Arc-like
+   or Apple interaction quality.
+
+   Alternative considered: drag the entire workspace surface with the sidebar.
+   That made too much of the window move during a sidebar navigation gesture and
+   did not match Arc's interaction model, where the current page stays stable
+   until the sidebar space switch commits.
 
 4. Remove visible labels where placement is enough.
 
    Section headings such as `Tabs` and `Spaces`, shortcut-only accessory text,
    and descriptive empty-state paragraphs should not be default chrome. Use
-   direct controls, subtle count/attention marks, hover help, context menus, and
-   accessibility labels instead.
+   direct controls, subtle counts where they are useful, hover help, context
+   menus, and accessibility labels instead.
 
    Alternative considered: keep labels for clarity. The target product direction
    is a native tool where structure teaches itself; visible labels should be
@@ -84,7 +139,7 @@ instructional copy, and make the bottom space switcher feel intentional.
 5. Use progressive disclosure for secondary actions.
 
    Close and more actions should appear on row hover/focus or context menu.
-   Default rows should prioritize title, compact context, status/attention, and
+   Default rows should prioritize title, compact context, Alan attachment, and
    selection.
 
 6. Empty states should be actionable, not explanatory.
@@ -99,8 +154,8 @@ instructional copy, and make the bottom space switcher feel intentional.
    than one pane. For two panes, the indicator can mirror the root split
    direction with two segments. For three or more panes, it should summarize the
    topology with a compact cluster or dominant-direction glyph plus pane count.
-   It should mark the focused pane and optionally attention, but it should not
-   try to render exact divider ratios inside the narrow tab row.
+   It should mark the focused pane, but it should not render notification dots
+   or try to show exact divider ratios inside the narrow tab row.
 
    Alternative considered: draw a miniature proportional split layout. That
    works for simple two-column splits, but Alan's terminal split tree supports
@@ -119,9 +174,13 @@ instructional copy, and make the bottom space switcher feel intentional.
 
 - Removing visible copy can hurt first-run clarity -> Mitigate with stable
   placement, recognizable symbols, hover help, and accessibility labels.
-- Horizontal swipe can conflict with vertical tab scrolling -> Gate space
-  switching on clear horizontal intent and keep vertical scroll behavior intact.
-- Borderless icons can become too subtle -> Use hover, selection, attention, and
+- Horizontal swipe can conflict with vertical tab scrolling -> Lock horizontal
+  intent before consuming scroll-wheel events, keep vertical scrolling native,
+  and make commit/cancel happen only on release.
+- Delaying workspace updates until commit can feel abrupt if the sidebar settle
+  is too long -> Keep the settle short, commit through the existing selection
+  path after release, and avoid moving the large terminal surface during drag.
+- Borderless icons can become too subtle -> Use hover, selection, and
   accessibility labels to maintain discoverability without adding boxes back.
 - Split indicators can become noisy in tab rows -> Hide them for single-pane
   tabs, summarize complex splits, and avoid proportional ratio rendering in the

--- a/openspec/changes/streamline-macos-sidebar-ia/proposal.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/proposal.md
@@ -4,16 +4,21 @@ The current sidebar has moved toward the target shell model, but it still reads
 partly as a compact dashboard: header copy, section labels, shortcut hints,
 horizontal space dock, empty-state explanation, and repeated creation menus ask
 the user to parse the UI instead of making the structure self-evident. Alan's
-macOS shell should make spaces, tabs, attention, and creation affordances obvious
-through placement, shape, and interaction rather than explanatory text.
+macOS shell should make spaces, tabs, and creation affordances obvious through
+placement, shape, and interaction rather than explanatory text or ambient
+notification dots.
 
 ## What Changes
 
-- Keep the default sidebar as a single vertical stack so the content aligns
-  cleanly around the macOS traffic-light area.
+- Keep the default sidebar as a restrained, narrow single vertical stack so the
+  content aligns cleanly around the macOS traffic-light area.
 - Replace section-like space presentation with a bottom, borderless space
   switcher made of compact icon buttons.
-- Support left/right swipe gestures inside the sidebar to switch spaces.
+- Support left/right swipe gestures inside the sidebar with sidebar-local
+  direct manipulation: sidebar content tracks the gesture near 1:1 across the
+  full sidebar page width, previews the adjacent space without static side
+  gaps, and commits or cancels on release while the workspace stays visually
+  stable until commit.
 - Show compact split topology indicators on split tab rows so users can see
   whether a tab contains multiple terminal panes and quickly focus a pane.
 - Remove nonessential descriptive copy from the default sidebar, including
@@ -21,8 +26,8 @@ through placement, shape, and interaction rather than explanatory text.
   section labels.
 - Make creation affordances location-specific: compact space creation near the
   bottom switcher and tab creation in the active-space tab list.
-- Represent attention and Alan attachment through tab-row and space-switcher
-  marks instead of separate explanatory blocks.
+- Keep Alan attachment inline, while preserving attention in accessibility and
+  control surfaces instead of default sidebar notification dots.
 - Preserve accessibility labels/tooltips even when visible text is reduced.
 
 ## Capabilities
@@ -34,10 +39,13 @@ None.
 ### Modified Capabilities
 
 - `macos-shell-ui-ux-conformance`: replace the previous space-rail direction
-  with a vertical Arc-like sidebar, bottom borderless space switcher, swipe
-  switching, split-aware tab rows, and minimal visible copy.
+  with a vertical Arc-like sidebar, bottom borderless space switcher,
+  sidebar-local direct-manipulation swipe switching, split-aware tab rows, and
+  minimal visible copy.
 - `macos-shell-workspace-interactions`: require split tab indicators to route
-  focus through the same pane-focus model as terminal split interactions.
+  focus through the same pane-focus model as terminal split interactions, and
+  require sidebar swipe to preview adjacent spaces in the sidebar without
+  moving workspace content or mutating selection until commit.
 - `macos-shell-build-test-contract`: require visual/manual verification for the
   streamlined sidebar reading order and accessibility-preserving copy removal.
 
@@ -46,6 +54,7 @@ None.
 - Affected Apple client code:
   - `clients/apple/AlanNative/Views/Shell/ShellSidebarView.swift`
   - `clients/apple/AlanNative/Support/ShellDesignTokens.swift`
+  - `clients/apple/AlanNative/Support/ShellSidebarSwipeMonitor.swift`
   - `clients/apple/AlanNative/MacShellRootView.swift`
 - No shell runtime, daemon, protocol, or terminal rendering changes.
 - May require small helper views for bottom space-switcher items, tab-list

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
@@ -12,6 +12,8 @@ navigation.
 #### Scenario: Sidebar interaction states are reviewed
 - **WHEN** tab or space row secondary actions are progressively disclosed
 - **THEN** verification covers default, hover, selected, no-notification-dot, and empty states without row resizing or layout shifts
+- **AND** verification covers the tab row hierarchy where normal rows are containerless, hover/focus rows are subtle, selected rows are strongest, and creation rows stay muted until interaction
+- **AND** verification covers the space-title/tab-list scroll boundary where the divider and shadow appear only as tab rows scroll underneath the fixed space title region
 
 #### Scenario: Sidebar space swipe is reviewed
 - **WHEN** horizontal space switching is implemented in the sidebar

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-build-test-contract/spec.md
@@ -11,15 +11,15 @@ navigation.
 
 #### Scenario: Sidebar interaction states are reviewed
 - **WHEN** tab or space row secondary actions are progressively disclosed
-- **THEN** verification covers default, hover, selected, attention, and empty states without row resizing or layout shifts
+- **THEN** verification covers default, hover, selected, no-notification-dot, and empty states without row resizing or layout shifts
 
 #### Scenario: Sidebar space swipe is reviewed
 - **WHEN** horizontal space switching is implemented in the sidebar
-- **THEN** verification covers left and right swipe behavior and confirms vertical tab-list scrolling still works
+- **THEN** verification covers gesture-tracked left and right sidebar previews, translation-first drag mapping, fast horizontal flick commit, full-width space-title and tab-list motion, stationary hold, zero-delta release, horizontal/vertical axis lock, later vertical movement during a horizontal swipe, no static side padding gaps during page motion, a stable workspace during drag, commit, cancel, edge resistance, and confirms vertical tab-list scrolling still works
 
 #### Scenario: Split tab indicator is reviewed
 - **WHEN** split-aware tab row implementation is marked complete
-- **THEN** verification covers single-pane, two-pane horizontal, two-pane vertical, complex split, focused-pane, attention, pointer activation, and keyboard or accessibility activation states
+- **THEN** verification covers single-pane, two-pane horizontal, two-pane vertical, complex split, focused-pane, no-notification-dot, pointer activation, and keyboard or accessibility activation states
 
 #### Scenario: Accessibility copy is preserved
 - **WHEN** visible sidebar text is removed or shortened

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
@@ -2,16 +2,21 @@
 
 ### Requirement: Sidebar matches space rail plus tab list
 The default macOS sidebar SHALL remain a single vertical navigation column that
-aligns cleanly around the macOS traffic-light area. Spaces SHALL be switched
-through a compact bottom borderless icon switcher and horizontal sidebar swipe
-gestures, while tabs for the active space remain the primary sidebar list. The
-sidebar SHALL be self-explaining through spatial structure, iconography,
-selection treatment, hover/focus affordances, and accessibility labels rather
-than persistent instructional copy.
+aligns cleanly around the macOS traffic-light area, with a restrained initial
+width around 264 pt. Spaces SHALL be switched through a compact bottom
+borderless icon switcher and horizontal sidebar swipe gestures, while tabs for
+the active space remain the primary sidebar list.
+Horizontal sidebar swipe SHALL feel like direct manipulation: content tracks the
+gesture inside the sidebar, previews the adjacent space there, and commits or
+cancels on release rather than acting as a threshold-only trigger. The workspace
+surface SHALL remain visually stable during the sidebar swipe and update only
+after the switch commits. The sidebar SHALL be self-explaining through spatial
+structure, iconography, selection treatment, hover/focus affordances, and
+accessibility labels rather than persistent instructional copy.
 
 #### Scenario: Default sidebar reading order
 - **WHEN** a user opens the macOS app
-- **THEN** the sidebar reads as command entry, active-space tab list, and bottom space switcher in one vertical column rather than as unrelated dashboard sections or a two-column sidebar
+- **THEN** the sidebar reads as a narrow command entry, active-space tab list, and bottom space switcher in one vertical column rather than as unrelated dashboard sections or a two-column sidebar
 
 #### Scenario: Space selection
 - **WHEN** a user selects a space in the bottom switcher
@@ -19,7 +24,25 @@ than persistent instructional copy.
 
 #### Scenario: Sidebar swipe switches spaces
 - **WHEN** a user performs a clear horizontal swipe gesture inside the sidebar
-- **THEN** Alan switches to the previous or next space without disrupting vertical tab-list scrolling
+- **THEN** Alan previews the previous or next space with gesture-tracked motion across the sidebar header and tab list
+- **AND** the preview is rendered from horizontal finger translation across the full sidebar page width rather than from threshold-derived progress
+- **AND** the active-space title pager uses the same full-width movement as the tab list rather than a narrowed header row
+- **AND** the moving pages do not expose static left or right padding gaps
+- **AND** the workspace terminal surface remains on the current space during the drag
+- **AND** Alan commits to the previewed space only after the user releases past a distance or velocity threshold
+- **AND** a fast horizontal flick can commit from release velocity even when the visible drag distance is short
+- **AND** the workspace terminal surface updates through the committed shell selection after the transition settles
+- **AND** Alan cancels back to the original space when the release does not meet the commit threshold
+- **AND** once horizontal intent is locked, vertical movement is not applied to the tab list even if the fingers move upward or downward before release
+- **AND** once vertical intent is locked, vertical tab-list scrolling remains native and is not consumed by the horizontal space pager
+
+#### Scenario: Space swipe reaches an edge
+- **WHEN** a user swipes beyond the first or last space
+- **THEN** the sidebar uses a resisted edge motion instead of wrapping or abruptly changing selection
+
+#### Scenario: Reduced motion space swipe
+- **WHEN** reduced motion is enabled
+- **THEN** Alan may reduce the transition to a shorter fade or lower-distance movement while preserving release-based commit and cancel semantics
 
 #### Scenario: Separate creation affordances
 - **WHEN** a user creates a new space or a new tab
@@ -27,7 +50,7 @@ than persistent instructional copy.
 
 #### Scenario: Space switcher is borderless
 - **WHEN** the bottom space switcher is visible
-- **THEN** space buttons use slim borderless icon styling with selection, hover, and attention conveyed without persistent framed cards or section chrome
+- **THEN** space buttons use slim borderless icon styling with selection and hover conveyed without persistent framed cards, section chrome, or notification dots
 
 #### Scenario: Lightweight tab rows
 - **WHEN** the active-space tab list contains terminal and Alan tabs
@@ -35,11 +58,11 @@ than persistent instructional copy.
 
 #### Scenario: Visible copy is minimized
 - **WHEN** the default sidebar has at least one space and one tab
-- **THEN** the sidebar does not rely on persistent explanatory paragraphs, product slogans, keyboard-shortcut labels, or redundant `Tabs` and `Spaces` headings to explain normal operation
+- **THEN** the sidebar does not rely on persistent explanatory paragraphs, product slogans, keyboard-shortcut labels, redundant `Tabs` and `Spaces` headings, or always-visible creation icons in the space-title row to explain normal operation
 
 #### Scenario: Accessibility remains explicit
 - **WHEN** visible explanatory copy is removed from the sidebar
-- **THEN** controls, space switcher items, tab rows, creation buttons, and attention marks retain accessibility labels, help text, or menu labels that expose their purpose to assistive technologies
+- **THEN** controls, space switcher items, tab rows, creation buttons, and reduced state cues retain accessibility labels, help text, or menu labels that expose their purpose to assistive technologies
 
 ## ADDED Requirements
 
@@ -50,7 +73,7 @@ compact owner-zone controls rather than always-visible explanatory buttons.
 
 #### Scenario: Tab row default state
 - **WHEN** a tab row is visible and not hovered or keyboard focused
-- **THEN** the row prioritizes icon, title, compact context, selection, and attention state without persistent close/more text buttons
+- **THEN** the row prioritizes icon, title, compact context, selection, and Alan attachment without persistent close/more text buttons or notification dots
 
 #### Scenario: Tab row interaction state
 - **WHEN** a tab row is hovered, keyboard focused, or context-clicked
@@ -78,6 +101,6 @@ focused pane without attempting to render exact split ratios in the tab row.
 - **WHEN** a tab contains three or more visible terminal panes or nested split branches
 - **THEN** the tab row summarizes the split with a compact topology mark or pane count instead of a proportional miniature layout
 
-#### Scenario: Attention in split tab
+#### Scenario: Split tab avoids notification dots
 - **WHEN** a non-focused pane inside a split tab needs attention
-- **THEN** the split indicator or tab row conveys that attention without exposing raw pane IDs or adding a separate sidebar attention block
+- **THEN** the split indicator and tab row do not add notification dots, expose raw pane IDs, or add a separate sidebar attention block

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-ui-ux-conformance/spec.md
@@ -6,6 +6,9 @@ aligns cleanly around the macOS traffic-light area, with a restrained initial
 width around 264 pt. Spaces SHALL be switched through a compact bottom
 borderless icon switcher and horizontal sidebar swipe gestures, while tabs for
 the active space remain the primary sidebar list.
+The sidebar surface SHALL read as a unified tinted macOS material stack, with
+visual effect material, cool translucent wash, control alpha, and row shadows
+working together rather than as an opaque white panel with independent cards.
 Horizontal sidebar swipe SHALL feel like direct manipulation: content tracks the
 gesture inside the sidebar, previews the adjacent space there, and commits or
 cancels on release rather than acting as a threshold-only trigger. The workspace
@@ -17,6 +20,7 @@ accessibility labels rather than persistent instructional copy.
 #### Scenario: Default sidebar reading order
 - **WHEN** a user opens the macOS app
 - **THEN** the sidebar reads as a narrow command entry, active-space tab list, and bottom space switcher in one vertical column rather than as unrelated dashboard sections or a two-column sidebar
+- **AND** the sidebar surface has a cool material tint that remains coherent across empty space, controls, rows, and the bottom switcher
 
 #### Scenario: Space selection
 - **WHEN** a user selects a space in the bottom switcher
@@ -55,6 +59,24 @@ accessibility labels rather than persistent instructional copy.
 #### Scenario: Lightweight tab rows
 - **WHEN** the active-space tab list contains terminal and Alan tabs
 - **THEN** each tab appears as a skimmable row with a compact marker, title, secondary context, and low-emphasis status rather than as a card or dashboard tile
+
+#### Scenario: Tab row state hierarchy
+- **WHEN** tab rows are displayed in normal, hover, keyboard-focus, and selected states
+- **THEN** normal rows sit directly on the sidebar material without a persistent container
+- **AND** hover and keyboard-focus rows use only a subtle translucent backing without shadow or scale changes
+- **AND** keyboard focus does not introduce the system blue focus ring over the tab row selection surface
+- **AND** the selected row uses the strongest rounded selection surface with a light shadow while preserving stable text and accessory alignment
+- **AND** selected row surfaces are inset into the sidebar gutter rather than flush to the window edge
+- **AND** trailing close affordances appear for selected, hover, or focus states without resizing the row or shifting neighboring rows
+- **AND** compact creation rows remain muted by default and gain a subtle backing only on hover or focus
+
+#### Scenario: Space title scroll boundary
+- **WHEN** the active-space tab list is at its resting top position
+- **THEN** the active-space title appears as a quiet grayscale label without a persistent pill or control background
+- **AND** the area between the space title label and the first tab row keeps a compact quiet material gap without a persistent divider
+- **WHEN** the user scrolls the active-space tab list upward so tab rows move underneath the fixed space title region
+- **THEN** Alan gradually reveals a subtle divider and downward shadow at the title/list boundary
+- **AND** tab rows clip underneath that boundary instead of drawing over the space title
 
 #### Scenario: Visible copy is minimized
 - **WHEN** the default sidebar has at least one space and one tab

--- a/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/specs/macos-shell-workspace-interactions/spec.md
@@ -1,5 +1,65 @@
 ## ADDED Requirements
 
+### Requirement: Sidebar swipe previews spaces without moving the workspace
+Horizontal swipe gestures that originate inside the macOS sidebar SHALL drive a
+sidebar-local space transition preview. The preview SHALL include the sidebar's
+active-space header and tab list, SHALL keep the workspace terminal surface on
+the current space while the gesture is active, and SHALL avoid mutating durable
+shell selection until the gesture commits.
+
+#### Scenario: Gesture-tracked sidebar preview
+- **WHEN** a user horizontally swipes inside the sidebar and an adjacent space exists
+- **THEN** the current sidebar space header and tab list move with the gesture while the adjacent space previews from the side
+- **AND** the space header and tab list use the same full sidebar page width for horizontal offsets
+- **AND** the preview movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+- **AND** the space header pager is not narrowed by row padding or trailing creation controls
+- **AND** the sidebar pager avoids static left or right padding gaps while pages move
+- **AND** the workspace terminal surface remains visually stable on the original selected space
+- **AND** vertical tab-list scrolling does not move while horizontal intent is locked
+- **AND** later vertical finger movement during the same horizontal swipe does not move the tab list vertically
+
+#### Scenario: Undecided axis does not leak movement
+- **WHEN** a sidebar scroll gesture has not yet crossed the horizontal or vertical intent threshold
+- **THEN** Alan buffers the initial mixed deltas instead of applying partial vertical tab-list scrolling
+- **AND** the gesture is routed only after horizontal or vertical intent is locked
+
+#### Scenario: Commit updates shell selection
+- **WHEN** the user releases a space swipe past the commit threshold
+- **THEN** Alan updates selected space and tab through the shell controller selection path
+- **AND** the workspace terminal surface and terminal focus follow the committed space after the transition settles
+- **AND** release is honored even when the macOS ended or momentum-start event carries zero scroll delta
+
+#### Scenario: Cancel preserves shell selection
+- **WHEN** the user releases a space swipe before the commit threshold
+- **THEN** Alan returns the sidebar preview to the original space
+- **AND** selected space, selected tab, terminal focus, split tree, and divider ratios remain unchanged
+- **AND** release is honored even when the macOS ended or momentum-start event carries zero scroll delta
+
+#### Scenario: Stationary gesture holds preview
+- **WHEN** a user pauses a phaseful horizontal trackpad swipe while their fingers remain on the trackpad
+- **THEN** Alan keeps the sidebar preview at the current gesture offset
+- **AND** Alan does not commit or cancel until the gesture ends, is cancelled, or enters momentum
+
+#### Scenario: Release uses last finger velocity
+- **WHEN** a phaseful horizontal trackpad swipe ends or enters momentum
+- **THEN** Alan evaluates commit using the current preview progress and the last effective finger velocity before release
+- **AND** Alan does not replace that velocity with a zero-delta ended event
+
+#### Scenario: Fast flick can commit
+- **WHEN** a user performs a fast horizontal flick inside the sidebar
+- **THEN** Alan recognizes the dominant horizontal release or momentum handoff as a space swipe
+- **AND** Alan may commit from velocity even when the gesture produced only a short visible translation before release
+
+#### Scenario: Phase-less gesture settles
+- **WHEN** a horizontal sidebar swipe comes from a scroll device that does not provide gesture phases
+- **THEN** Alan may treat a short idle gap as release to avoid leaving the preview stuck
+- **AND** shell selection follows the same commit threshold as other sidebar swipes
+
+#### Scenario: Vertical scroll is not captured
+- **WHEN** a user's gesture is primarily vertical in the sidebar tab list
+- **THEN** the native vertical tab-list scroll receives the gesture and the workspace space transition does not begin
+- **AND** horizontal sidebar preview movement is not applied while vertical intent is locked
+
 ### Requirement: Sidebar split indicators can focus panes
 Split topology indicators in the macOS sidebar SHALL route pane focus through
 the same shell controller focus model used by terminal split interactions.

--- a/openspec/changes/streamline-macos-sidebar-ia/tasks.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/tasks.md
@@ -1,23 +1,25 @@
 ## 1. Sidebar Structure
 
-- [ ] 1.1 Keep `ShellSidebarView.swift` as a single vertical sidebar column that aligns cleanly around the macOS traffic-light area.
-- [ ] 1.2 Replace section-like space presentation with a bottom borderless icon space switcher.
-- [ ] 1.3 Keep command entry and tab creation in the active-space tab-list flow.
-- [ ] 1.4 Add left/right sidebar swipe handling for previous/next space switching without breaking vertical tab-list scrolling.
+- [x] 1.1 Keep `ShellSidebarView.swift` as a single vertical sidebar column that aligns cleanly around the macOS traffic-light area.
+- [x] 1.2 Replace section-like space presentation with a bottom borderless icon space switcher.
+- [x] 1.3 Keep command entry and tab creation in the active-space tab-list flow.
+- [x] 1.4 Replace trigger-style sidebar swipe with gesture-tracked, sidebar-local space transition preview that uses translation-first drag mapping across the full sidebar page width while the workspace remains stable until commit.
+- [x] 1.5 Keep shell selection immutable during swipe preview and commit/cancel through the existing selection path on release.
+- [x] 1.6 Preserve native vertical tab-list scrolling by locking horizontal intent before consuming sidebar scroll-wheel events, and disable tab-list vertical scrolling while a horizontal swipe is locked.
 
 ## 2. Copy And Interaction Cleanup
 
-- [ ] 2.1 Remove persistent sidebar section labels, shortcut labels, product slogans, and paragraph-style empty-state copy that are not needed for repeated use.
-- [ ] 2.2 Preserve or add accessibility labels, help text, and menu labels for controls whose visible copy is reduced.
-- [ ] 2.3 Ensure tab rows expose secondary actions through hover/focus/context menu without layout shifts.
-- [ ] 2.4 Keep attention and Alan attachment expressed as compact row/switcher marks rather than separate sidebar blocks.
-- [ ] 2.5 Add compact split topology indicators to split tab rows, hiding them for single-pane tabs.
-- [ ] 2.6 Route split indicator activation through pane focus without mutating split layout or divider ratios.
+- [x] 2.1 Remove persistent sidebar section labels, shortcut labels, product slogans, and paragraph-style empty-state copy that are not needed for repeated use.
+- [x] 2.2 Preserve or add accessibility labels, help text, and menu labels for controls whose visible copy is reduced.
+- [x] 2.3 Ensure tab rows expose secondary actions through hover/focus/context menu without layout shifts.
+- [x] 2.4 Remove sidebar notification dots while keeping Alan attachment inline and attention available to accessibility/control surfaces.
+- [x] 2.5 Add compact split topology indicators to split tab rows, hiding them for single-pane tabs.
+- [x] 2.6 Route split indicator activation through pane focus without mutating split layout or divider ratios.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused Apple build or shell UI checks affected by sidebar changes.
-- [ ] 3.2 Capture screenshot or manual review notes for default, selected, hover, attention, and empty sidebar states.
-- [ ] 3.3 Verify left/right sidebar swipe switches spaces and vertical tab-list scrolling still works.
-- [ ] 3.4 Verify split indicators for single-pane, two-pane horizontal, two-pane vertical, complex split, focus switching, and accessibility activation.
-- [ ] 3.5 Run `openspec validate --all --strict` before PR.
+- [x] 3.1 Run focused Apple build or shell UI checks affected by sidebar changes.
+- [x] 3.2 Capture screenshot or manual review notes for default, selected, hover, no-notification-dot, and empty sidebar states.
+- [ ] 3.3 Verify left/right sidebar swipe tracks gesture translation directly, commits on fast horizontal flicks, keeps the space title and tab list on the same full-width page motion, avoids static side padding gaps, holds position while fingers pause, honors zero-delta release, keeps horizontal and vertical movement axis-locked, previews sidebar content, keeps the workspace stable during drag, commits, cancels, resists edges, and leaves vertical tab-list scrolling intact.
+- [x] 3.4 Verify split indicators for single-pane, two-pane horizontal, two-pane vertical, complex split, focus switching, and accessibility activation.
+- [x] 3.5 Run `openspec validate --all --strict` before PR.

--- a/openspec/changes/streamline-macos-sidebar-ia/tasks.md
+++ b/openspec/changes/streamline-macos-sidebar-ia/tasks.md
@@ -15,11 +15,12 @@
 - [x] 2.4 Remove sidebar notification dots while keeping Alan attachment inline and attention available to accessibility/control surfaces.
 - [x] 2.5 Add compact split topology indicators to split tab rows, hiding them for single-pane tabs.
 - [x] 2.6 Route split indicator activation through pane focus without mutating split layout or divider ratios.
+- [x] 2.7 Separate tab row visual states so normal rows are containerless, hover/focus rows are subtle, selected rows are strongest, close actions do not shift layout, and creation rows stay muted until interaction.
 
 ## 3. Verification
 
 - [x] 3.1 Run focused Apple build or shell UI checks affected by sidebar changes.
 - [x] 3.2 Capture screenshot or manual review notes for default, selected, hover, no-notification-dot, and empty sidebar states.
-- [ ] 3.3 Verify left/right sidebar swipe tracks gesture translation directly, commits on fast horizontal flicks, keeps the space title and tab list on the same full-width page motion, avoids static side padding gaps, holds position while fingers pause, honors zero-delta release, keeps horizontal and vertical movement axis-locked, previews sidebar content, keeps the workspace stable during drag, commits, cancels, resists edges, and leaves vertical tab-list scrolling intact.
+- [x] 3.3 Verify left/right sidebar swipe tracks gesture translation directly, commits on fast horizontal flicks, keeps the space title and tab list on the same full-width page motion, avoids static side padding gaps, holds position while fingers pause, honors zero-delta release, keeps horizontal and vertical movement axis-locked, previews sidebar content, keeps the workspace stable during drag, commits, cancels, resists edges, and leaves vertical tab-list scrolling intact.
 - [x] 3.4 Verify split indicators for single-pane, two-pane horizontal, two-pane vertical, complex split, focus switching, and accessibility activation.
 - [x] 3.5 Run `openspec validate --all --strict` before PR.

--- a/openspec/specs/macos-app-instance-lifecycle/spec.md
+++ b/openspec/specs/macos-app-instance-lifecycle/spec.md
@@ -37,7 +37,7 @@ window instead of creating another primary shell window.
 
 #### Scenario: First owned launch creates primary window
 - **WHEN** the owned Alan app instance completes launch
-- **THEN** exactly one primary Alan shell window is presented
+- **THEN** exactly one primary Alan shell window is presented without requiring a Dock icon click, application reopen, or other secondary activation step
 
 #### Scenario: New Window command
 - **WHEN** the user invokes the New Window menu item or presses `Command-N`
@@ -79,7 +79,7 @@ routing, reopen, and lock-release behavior.
 
 #### Scenario: Window singleton verified
 - **WHEN** macOS scene or command behavior changes
-- **THEN** tests, local scripts, or manual notes verify initial launch, `Command-N`, Dock reopen, close/reopen, repeated `open`, and forced `open -n`
+- **THEN** tests, local scripts, or manual notes verify initial launch through the local app runner, `Command-N`, Dock reopen, close/reopen, repeated `open`, and forced `open -n`
 
 #### Scenario: Documentation updated
 - **WHEN** singleton behavior changes the shell window lifecycle contract

--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -159,6 +159,10 @@ ownership when pane title bars are changed.
 - **WHEN** pane title-bar implementation is ready for review
 - **THEN** maintainers can inspect automated shell contract checks or manual notes covering terminal click-to-focus, typing, selection drag, right click, scrolling, and close-button interaction
 
+#### Scenario: Window chrome and collapsed sidebar guardrails run
+- **WHEN** hidden-titlebar window chrome, titlebar double-click behavior, local app launch behavior, or collapsed-sidebar floating-panel behavior changes
+- **THEN** focused checks verify launch presents one primary window, empty titlebar double-click zoom targets only non-control chrome, system traffic-light buttons keep their normal behavior, and collapsed-sidebar reveal uses narrow hover targets with stable workspace geometry
+
 #### Scenario: Visual evidence captured
 - **WHEN** pane title-bar UI polish is marked complete
 - **THEN** maintainers can inspect a running-app screenshot or manual note showing light-mode single-pane and split-pane tabs with compact pane title bars, readable titles, restrained close buttons, and no default debug labels

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -39,6 +39,8 @@ theme panels, and ornamental controls.
 #### Scenario: Stable compact controls
 - **WHEN** the user hovers, selects, inserts, closes, or switches tabs and spaces
 - **THEN** rows, icon controls, counters, and status marks keep stable dimensions and do not resize the sidebar or terminal content
+- **AND** the bottom space dock aligns its visible controls to the sidebar edge inset so the leading and bottom margins match optically
+- **AND** the bottom space dock add button directly creates a standard new space instead of opening a menu of space variants
 
 ### Requirement: Collapsed sidebar uses a lightweight floating panel
 When the sidebar is collapsed, the macOS shell SHALL reveal navigation through a

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -120,6 +120,14 @@ frequent actions.
 - **WHEN** a user double-clicks an empty, non-control area of the hidden-titlebar chrome
 - **THEN** Alan toggles the window between its previous frame and the current screen's visible work area while leaving the system traffic-light buttons, including the green button, on their normal macOS behavior
 
+#### Scenario: Native fullscreen chrome
+- **WHEN** the hidden-titlebar shell window enters native macOS fullscreen and the system takes over or hides the traffic-light controls
+- **THEN** Alan moves its lightweight titlebar controls to the leading edge without reserving traffic-light space
+- **AND WHEN** the window is actively live-resized
+- **THEN** Alan continuously resynchronizes the standard traffic-light controls during the resize interaction rather than only correcting the final resting position
+- **AND WHEN** the window exits native fullscreen or finishes resizing
+- **THEN** Alan keeps the standard traffic-light controls at their intended inset and returns its titlebar controls to the post-traffic-light position
+
 ### Requirement: Default shell does not expose inspector chrome
 The default macOS shell SHALL not include a persistent right-side inspector,
 inspector toggle, or inspector command surface.

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -53,6 +53,12 @@ hover, while keeping the terminal workspace stable.
 - **WHEN** the pointer moves from the edge hot zone onto the floating sidebar panel or collapsed titlebar controls
 - **THEN** the floating panel remains revealed until the pointer leaves those related surfaces
 
+#### Scenario: Floating panel owns traffic lights
+- **WHEN** the sidebar is collapsed and the floating panel is hidden
+- **THEN** the standard macOS traffic-light controls are hidden with the sidebar surface instead of remaining on the bare window corner
+- **AND WHEN** the floating sidebar panel is revealed
+- **THEN** the standard macOS traffic-light controls reappear on that floating sidebar surface without appearing ahead of the panel reveal timing or changing terminal workspace geometry
+
 #### Scenario: Floating panel motion
 - **WHEN** reduced motion is disabled
 - **THEN** the floating sidebar panel enters with a short spring-like leading-edge reveal and exits with a faster low-emphasis hide animation
@@ -119,6 +125,7 @@ frequent actions.
 #### Scenario: Empty titlebar zoom
 - **WHEN** a user double-clicks an empty, non-control area of the hidden-titlebar chrome
 - **THEN** Alan toggles the window between its previous frame and the current screen's visible work area while leaving the system traffic-light buttons, including the green button, on their normal macOS behavior
+- **AND** empty sidebar or floating-sidebar chrome in the traffic-light/titlebar-control band participates in double-click zoom while the actual traffic-light buttons, lightweight titlebar buttons, and terminal pane titlebar controls remain clickable
 
 #### Scenario: Native fullscreen chrome
 - **WHEN** the hidden-titlebar shell window enters native macOS fullscreen and the system takes over or hides the traffic-light controls

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -123,6 +123,14 @@ frequent actions.
 #### Scenario: Command entry
 - **WHEN** the user invokes the command UI
 - **THEN** the entry point is labeled and organized as `Go to or Command...`
+- **AND WHEN** the floating Ask Alan command input is presented
+- **THEN** the input surface uses the system Liquid Glass effect for its primary material instead of relying on a custom blur, opaque fill, or gradient-only imitation
+- **AND** the Liquid Glass material follows the app's current light or dark appearance instead of assuming the active terminal theme is dark
+- **AND** the active terminal theme only contributes sampled background color through the system material and MUST NOT switch the command input's light or dark foreground palette
+- **AND** foreground text and controls render above the Liquid Glass layer using system foreground hierarchy so the glass material does not blur or wash out typed content
+- **AND** Alan keeps the Liquid Glass surface mounted across hidden and visible states, disables material insertion animation, and uses an opacity-only fade instead of moving the input from an edge
+- **AND** Alan uses a transparent click-away layer rather than a visible dimming scrim behind the Liquid Glass surface so the material does not flash between undimmed and dimmed sampled backgrounds
+- **AND** pressing `Command-P` while the input is already open dismisses it and returns keyboard focus to the previously focused terminal pane when available
 
 #### Scenario: Empty titlebar zoom
 - **WHEN** a user double-clicks an empty, non-control area of the hidden-titlebar chrome

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -40,6 +40,31 @@ theme panels, and ornamental controls.
 - **WHEN** the user hovers, selects, inserts, closes, or switches tabs and spaces
 - **THEN** rows, icon controls, counters, and status marks keep stable dimensions and do not resize the sidebar or terminal content
 
+### Requirement: Collapsed sidebar uses a lightweight floating panel
+When the sidebar is collapsed, the macOS shell SHALL reveal navigation through a
+small floating material panel triggered by intentional edge or titlebar-control
+hover, while keeping the terminal workspace stable.
+
+#### Scenario: Narrow reveal target
+- **WHEN** the sidebar is collapsed and the pointer approaches the left edge
+- **THEN** Alan uses a narrow edge hot zone to reveal the floating sidebar panel rather than a full titlebar or header-width hover region
+
+#### Scenario: Floating panel hover retention
+- **WHEN** the pointer moves from the edge hot zone onto the floating sidebar panel or collapsed titlebar controls
+- **THEN** the floating panel remains revealed until the pointer leaves those related surfaces
+
+#### Scenario: Floating panel motion
+- **WHEN** reduced motion is disabled
+- **THEN** the floating sidebar panel enters with a short spring-like leading-edge reveal and exits with a faster low-emphasis hide animation
+
+#### Scenario: Reduced motion respected
+- **WHEN** reduced motion is enabled
+- **THEN** collapsed-sidebar reveal and hide behavior avoids springy movement while preserving the same hover targets and visibility state
+
+#### Scenario: Workspace stability
+- **WHEN** the floating sidebar panel appears or disappears
+- **THEN** terminal content, split geometry, and window size remain stable instead of being resized by the transient sidebar surface
+
 #### Scenario: No dashboard treatment
 - **WHEN** the user views the default shell
 - **THEN** the UI does not present page-like sections, nested cards, large explanatory panels, or marketing-style hero composition
@@ -90,6 +115,10 @@ frequent actions.
 #### Scenario: Command entry
 - **WHEN** the user invokes the command UI
 - **THEN** the entry point is labeled and organized as `Go to or Command...`
+
+#### Scenario: Empty titlebar zoom
+- **WHEN** a user double-clicks an empty, non-control area of the hidden-titlebar chrome
+- **THEN** Alan toggles the window between its previous frame and the current screen's visible work area while leaving the system traffic-light buttons, including the green button, on their normal macOS behavior
 
 ### Requirement: Default shell does not expose inspector chrome
 The default macOS shell SHALL not include a persistent right-side inspector,
@@ -245,6 +274,10 @@ terminal title is unavailable.
 #### Scenario: Debug terms suppressed
 - **WHEN** terminal metadata contains implementation-oriented summaries such as `title updated`, `window attached`, or raw runtime state
 - **THEN** the title bar does not expose those terms outside explicit developer/debug-only surfaces
+
+#### Scenario: Metadata stays in title chrome
+- **WHEN** terminal status, branch, attention, or Alan binding metadata is useful in the default pane UI
+- **THEN** Alan presents it as lightweight pane-title-bar accessories rather than as a persistent bottom status strip below the terminal canvas
 
 ### Requirement: Pane close button targets its pane
 The pane title bar close button SHALL close the pane represented by that title


### PR DESCRIPTION
## Summary
- Polish macOS shell chrome behavior around traffic lights, sidebar collapse/floating panel timing, launch/window placement, and titlebar interactions.
- Refine sidebar space dock spacing and simplify new-space creation behavior.
- Update Ask Alan command input to use system Liquid Glass with stable sampling, opacity-only fade, and Command-P toggle behavior.
- Preserve Ghostty terminal panes across runtime cwd updates while still recreating the surface for command, environment, or Ghostty dependency changes.
- Pass Ghostty terminfo and terminal identity environment into terminal child processes.
- Reset phase-less sidebar wheel gesture state after idle for vertical and undecided gestures, while preserving horizontal idle-end behavior.
- Align OpenSpec and shell contract checks with the polished macOS shell UX constraints.

## Test Plan
- [x] bash clients/apple/scripts/test-terminal-runtime-service.sh
- [x] bash clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
- [x] bash clients/apple/scripts/check-shell-contracts.sh
- [x] openspec validate --all --strict
- [x] git diff --check
- [x] xcodebuild -project clients/apple/AlanNative.xcodeproj -scheme AlanNative -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

Note: xcodebuild still reports the local CoreSimulator out-of-date warning, but the macOS build succeeds.