### PR TITLE
Spec: refine macOS sidebar interactions

### DIFF
--- a/openspec/changes/refine-macos-sidebar-interactions/.openspec.yaml
+++ b/openspec/changes/refine-macos-sidebar-interactions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/refine-macos-sidebar-interactions/design.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The current macOS shell sidebar has three related interaction problems:
+
+- Sidebar tab and space clicks update `selectedSpaceID` / `selectedTabID` without updating the authoritative `shellState.focusedPaneID`. Later runtime metadata or state publication calls `synchronizeSelection()` and restores selection from the old focused pane.
+- Pinned-sidebar collapse is expressed as conditional SwiftUI insertion/removal, while titlebar controls and AppKit traffic-light placement are synchronized through a separate bridge. This produces uncoordinated motion and can make collapse appear instantaneous.
+- Horizontal space swipe is represented as a sidebar-local source/target transition. It previews the sidebar header and tab list only, commits after settle, and does not model spaces as a continuous sequence.
+
+The implementation must preserve alan's terminal-first layout, native material sidebar, hidden-titlebar window behavior, and terminal event ownership boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make sidebar tab and space selection persist by routing selection through authoritative shell focus.
+- Give pinned sidebar collapse and expansion one coordinated motion model across sidebar width, terminal content inset, sidebar toolbar controls, and standard macOS traffic lights.
+- Replace sidebar-only swipe semantics with a continuous pager over the ordered `ShellSpace` sequence.
+- Keep collapsed floating sidebar reveal transient: it must not resize terminal content, and it must retain the narrow edge/titlebar-control hover behavior.
+- Add focused automated and contract verification for the new interaction guarantees.
+
+**Non-Goals:**
+
+- Redesign the sidebar information architecture, visual palette, or command input.
+- Add new space types, workspace persistence formats, or cross-window space movement.
+- Rework terminal pane input ownership or Ghostty rendering.
+- Implement a full visual snapshot automation system beyond the focused checks needed for this change.
+
+## Decisions
+
+1. **Selection actions update focus, not only view-local selection.**
+
+   Sidebar tab and space selection will resolve a target pane from the selected tab and call the existing shell focus mutation path. This keeps `selectedSpaceID`, `selectedTabID`, `shellState.focusedSpaceID`, `shellState.focusedTabID`, and `shellState.focusedPaneID` converged. The target pane should prefer the tab's current focused pane when present, otherwise the first pane in that tab's pane tree.
+
+   Alternative considered: preserve a separate "preview selection" state and delay focus until terminal click. That matches passive preview behavior but keeps the current flashback failure mode and makes sidebar navigation feel unreliable.
+
+2. **Pinned sidebar motion uses a continuous presentation progress.**
+
+   The pinned sidebar should remain mounted while its visible width, content opacity/offset, and workspace leading inset animate from expanded to collapsed. The same progress drives titlebar tool position and the `ShellWindowChromeSurface` origin/visibility passed to AppKit.
+
+   Alternative considered: tune the existing `.transition(.move(edge: .leading))`. This would not coordinate the HStack layout, titlebar overlay, and AppKit traffic lights because they still change through separate state paths.
+
+3. **AppKit traffic lights are animated through the window chrome bridge.**
+
+   `ShellWindowPlacement` should receive enough surface motion information to move standard traffic-light controls with the same timing as the sidebar toolbar. Visibility changes should avoid showing controls before the floating panel reveal and avoid leaving controls visible after the surface is hidden.
+
+   Alternative considered: draw custom traffic-light replicas in SwiftUI. That would break native macOS traffic-light behavior and conflicts with the existing hidden-titlebar contract.
+
+4. **Space swipe is a pager over the ordered space sequence.**
+
+   The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`, `pageWidth`, and settlement phase. Adjacent pages are rendered from the same offset so the user can see the next or previous space edge while dragging. The visible space page includes the sidebar navigation content and the terminal workspace surface for the source and adjacent target spaces, while preserving terminal runtime identity. Commit and cancel use the same pager model rather than a sidebar-only source/target transition.
+
+   Alternative considered: keep sidebar-only preview and only fix commit timing. That would solve some failures but would not match the virtual-desktop physical model requested for spaces.
+
+5. **Commit focus is applied at the authoritative transition point.**
+
+   When a pager commit is selected, shell focus should update through the controller selection path before or at the start of the settle-to-target phase, while visual transition state keeps rendering the old and new pages until animation completion. This prevents runtime metadata updates from snapping the UI back during the settle animation.
+
+   Alternative considered: wait until animation completion before changing shell state. That is the current source of race-prone behavior because unrelated runtime updates can arrive while the visual transition is in flight.
+
+## Risks / Trade-offs
+
+- **Risk: traffic-light animation fights AppKit layout corrections.** → Keep the AppKit bridge as the only owner of standard button frames, coalesce chrome syncs, and ensure final frames are corrected without visible jumps.
+- **Risk: immediate focus commit changes terminal runtime focus while the old page is still visible during settle.** → Keep a short visual transition overlay/pager state that decouples rendering from the already-committed focus for the duration of settlement.
+- **Risk: continuous pager could create multiple live terminal hosts during drag.** → Reuse existing pane runtimes and render only the current and adjacent space pages needed for the gesture.
+- **Risk: gesture axis arbitration regresses vertical sidebar scrolling.** → Preserve the existing intent lock behavior and add tests for undecided, vertical, phaseful, phase-less, momentum, and fast flick paths.
+
+## Migration Plan
+
+Implement in narrow stages: first selection/focus convergence, then pinned sidebar/chrome motion, then space pager refactor. Keep existing persisted shell state format unchanged. If a later stage regresses, it can be reverted independently because selection convergence does not require the pager implementation.
+
+## Open Questions
+
+None.

--- a/openspec/changes/refine-macos-sidebar-interactions/proposal.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The macOS sidebar currently feels unreliable and physically inconsistent: tab and space selection can flash back to the previously focused terminal, pinned-sidebar collapse is not a coordinated motion, and horizontal space swipes are modeled as a sidebar-only preview instead of a continuous space sequence.
+
+This change formalizes a focused interaction pass so sidebar navigation, window chrome, and space switching share one authoritative focus and motion contract.
+
+## What Changes
+
+- Make sidebar tab and space selection authoritative focus transitions: selecting a tab or space updates the shell focused pane through the same shell-state path used by terminal activation.
+- Replace pinned-sidebar insertion/removal with a continuous collapse and expand motion so the sidebar, terminal content inset, titlebar controls, and macOS traffic-light controls move together.
+- Refine collapsed/floating sidebar chrome timing so traffic lights do not jump, appear ahead of the panel, or linger on the bare window corner.
+- Replace the sidebar-only space swipe preview with a continuous pager model over the ordered space sequence, including edge preview, commit/cancel animation, and terminal focus handoff.
+- Add focused tests and shell contract checks for selection persistence, sidebar/chrome animation invariants, and pager gesture behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: clarify continuous sidebar chrome motion, pinned-sidebar collapse/expand behavior, and coordinated traffic-light/titlebar control movement.
+- `macos-shell-workspace-interactions`: replace sidebar-only space swipe preview semantics with authoritative focus selection and continuous space pager switching.
+- `macos-shell-build-test-contract`: require focused verification for selection/focus stability, space pager gestures, and coordinated sidebar/window-chrome behavior.
+
+## Impact
+
+- Apple client SwiftUI/AppKit shell UI:
+  - `clients/apple/alan-macos/MacShellRootView.swift`
+  - `clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift`
+  - `clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift`
+  - `clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift`
+  - `clients/apple/alan-macos/Support/ShellWindowPlacement.swift`
+- Shell state and runtime focus coordination:
+  - `clients/apple/alan-macos/ShellHostController.swift`
+  - `clients/apple/alan-macos/TerminalRuntimeRegistry.swift`
+  - `clients/apple/alan-macos/TerminalHostView.swift`
+- Focused Apple scripts and contract checks under `clients/apple/scripts/`.

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -13,7 +13,7 @@ are changed.
 
 #### Scenario: Space pager gesture tested
 - **WHEN** horizontal space swipe behavior changes
-- **THEN** focused tests cover horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
+- **THEN** focused tests cover undecided-axis buffering, horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
 
 #### Scenario: Pinned sidebar motion reviewed
 - **WHEN** pinned sidebar collapse or expansion behavior changes

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Sidebar interaction refinement has focused verification
+The Apple client SHALL include focused automated checks or documented manual
+verification for sidebar selection/focus convergence, continuous space pager
+behavior, and coordinated sidebar/window-chrome motion when those interactions
+are changed.
+
+#### Scenario: Sidebar selection convergence tested
+- **WHEN** sidebar tab or space selection behavior changes
+- **THEN** focused tests verify that selecting a tab or space updates shell focused pane, selected tab, selected space, and terminal runtime focus consistently
+- **AND** tests or contract checks cover the case where runtime metadata arrives immediately after selection without reverting to the previous tab
+
+#### Scenario: Space pager gesture tested
+- **WHEN** horizontal space swipe behavior changes
+- **THEN** focused tests cover horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
+
+#### Scenario: Pinned sidebar motion reviewed
+- **WHEN** pinned sidebar collapse or expansion behavior changes
+- **THEN** maintainers can inspect automated invariants, screenshots, or manual notes showing that the sidebar surface, workspace inset, titlebar controls, and standard macOS traffic-light controls move as one coordinated transition
+
+#### Scenario: Floating sidebar chrome reviewed
+- **WHEN** collapsed floating-sidebar reveal or hide behavior changes
+- **THEN** focused checks or manual notes verify narrow edge hover, hover retention, stable terminal workspace geometry, native traffic-light behavior, and no visible traffic-light jump from the non-floating corner

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Collapsed sidebar uses a lightweight floating panel
+When the sidebar is collapsed, the macOS shell SHALL reveal navigation through a
+small floating material panel triggered by intentional edge or titlebar-control
+hover, while keeping the terminal workspace stable.
+
+#### Scenario: Narrow reveal target
+- **WHEN** the sidebar is collapsed and the pointer approaches the left edge
+- **THEN** alan uses a narrow edge hot zone to reveal the floating sidebar panel rather than a full titlebar or header-width hover region
+
+#### Scenario: Floating panel hover retention
+- **WHEN** the pointer moves from the edge hot zone onto the floating sidebar panel or collapsed titlebar controls
+- **THEN** the floating panel remains revealed until the pointer leaves those related surfaces
+
+#### Scenario: Floating panel owns traffic lights
+- **WHEN** the sidebar is collapsed and the floating panel is hidden
+- **THEN** the standard macOS traffic-light controls are hidden with the sidebar surface instead of remaining on the bare window corner
+- **AND WHEN** the floating sidebar panel is revealed
+- **THEN** the standard macOS traffic-light controls reappear on that floating sidebar surface without appearing ahead of the panel reveal timing, jumping from the non-floating corner, or changing terminal workspace geometry
+
+#### Scenario: Floating panel motion
+- **WHEN** reduced motion is disabled
+- **THEN** the floating sidebar panel enters with a short spring-like leading-edge reveal and exits with a faster low-emphasis hide animation
+- **AND** the standard macOS traffic-light controls and lightweight sidebar titlebar controls move with the visible floating surface instead of snapping after the panel has moved
+
+#### Scenario: Reduced motion respected
+- **WHEN** reduced motion is enabled
+- **THEN** collapsed-sidebar reveal and hide behavior avoids springy movement while preserving the same hover targets and visibility state
+
+#### Scenario: Workspace stability
+- **WHEN** the floating sidebar panel appears or disappears
+- **THEN** terminal content, split geometry, and window size remain stable instead of being resized by the transient sidebar surface
+
+#### Scenario: No dashboard treatment
+- **WHEN** the user views the default shell
+- **THEN** the UI does not present page-like sections, nested cards, large explanatory panels, or marketing-style hero composition
+
+## ADDED Requirements
+
+### Requirement: Pinned sidebar motion is continuous and coordinated
+Pinned sidebar collapse and expansion SHALL be represented as a coordinated
+motion of the sidebar surface, workspace inset, lightweight sidebar titlebar
+controls, and standard macOS traffic-light controls rather than as independent
+insertions, removals, or frame jumps.
+
+#### Scenario: Sidebar collapses
+- **WHEN** the user hides the pinned sidebar and reduced motion is disabled
+- **THEN** the sidebar surface moves or narrows out with a short, crisp animation
+- **AND** the terminal workspace adjusts its leading inset continuously with the sidebar motion
+- **AND** lightweight sidebar titlebar controls and standard macOS traffic-light controls move with the same visual timing instead of jumping to their final positions
+
+#### Scenario: Sidebar expands
+- **WHEN** the user pins or expands the sidebar and reduced motion is disabled
+- **THEN** the sidebar surface, terminal workspace inset, lightweight sidebar titlebar controls, and standard macOS traffic-light controls move together with a short, non-dragging animation
+- **AND** the expanded state settles without delayed toolbar drift or terminal content relayout after the visual motion has completed
+
+#### Scenario: Reduced motion collapse
+- **WHEN** reduced motion is enabled and the pinned sidebar is hidden or shown
+- **THEN** alan avoids springy movement while still applying one coherent final layout for sidebar surface, workspace inset, titlebar controls, and traffic-light controls
+
+#### Scenario: Native traffic-light behavior preserved
+- **WHEN** sidebar or titlebar chrome moves during pinned or floating sidebar transitions
+- **THEN** alan continues using the standard macOS traffic-light controls for close, minimize, and zoom behavior rather than drawing custom replacements

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -49,6 +49,11 @@ preserving terminal runtime identity.
 - **AND** movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
 - **AND** vertical tab-list scrolling does not move while horizontal intent is locked
 
+#### Scenario: Undecided axis buffers mixed deltas
+- **WHEN** a sidebar scroll gesture has not yet crossed the horizontal or vertical intent threshold
+- **THEN** alan buffers the initial mixed deltas instead of applying partial vertical tab-list scrolling or horizontal pager movement
+- **AND** the gesture is routed only after horizontal or vertical intent is locked
+
 #### Scenario: Pager reaches sequence edge
 - **WHEN** a user swipes past the first or last available space
 - **THEN** alan applies bounded edge resistance rather than wrapping unexpectedly or showing a nonexistent space page

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,91 @@
+## REMOVED Requirements
+
+### Requirement: Sidebar swipe previews spaces without moving the workspace
+**Reason**: Sidebar-only previews make spaces feel like a local list animation rather than a continuous workspace sequence, and delaying shell selection until after settlement leaves room for runtime focus updates to snap the UI back to the previous tab or space.
+
+**Migration**: Use the new continuous space pager and authoritative sidebar selection requirements in this change.
+
+## ADDED Requirements
+
+### Requirement: Sidebar selection commits authoritative shell focus
+Sidebar tab and space selection SHALL update the authoritative shell focused
+pane through the same shell controller focus model used by terminal activation,
+so sidebar selection, focused space, focused tab, focused pane, and terminal
+runtime focus converge.
+
+#### Scenario: Tab row clicked
+- **WHEN** a user clicks a tab row in the active sidebar space
+- **THEN** alan resolves the target tab's preferred pane and updates shell focus to that pane through the shell controller focus path
+- **AND** later terminal runtime metadata, state publication, or selection synchronization does not restore the previously focused tab
+
+#### Scenario: Space switcher clicked
+- **WHEN** a user clicks a space in the bottom sidebar space switcher
+- **THEN** alan selects that space, resolves the target tab and pane for that space, and updates shell focus through the shell controller focus path
+- **AND** terminal focus follows the selected pane when the pane runtime is available
+
+#### Scenario: Selected tab contains multiple panes
+- **WHEN** a sidebar selection targets a tab with multiple panes
+- **THEN** alan prefers the tab's currently focused pane when that pane belongs to the selected tab
+- **AND** alan otherwise chooses a stable pane from the tab's pane tree without changing split structure or divider ratios
+
+#### Scenario: Runtime update races selection
+- **WHEN** terminal runtime metadata or control-plane state publication occurs immediately after sidebar selection
+- **THEN** the committed sidebar selection remains on the selected tab and space because the shell focused pane already matches the selection
+
+### Requirement: Space switching uses a continuous pager
+Horizontal space switching SHALL model spaces as an ordered, continuous sequence
+with a current page index, adjacent page preview, drag offset, and commit/cancel
+settlement, so swiping behaves like a native carousel or virtual desktop. The
+space page SHALL include the sidebar navigation content and the terminal
+workspace surface for each visible source or adjacent target space while
+preserving terminal runtime identity.
+
+#### Scenario: Gesture-tracked pager preview
+- **WHEN** a user horizontally swipes inside the sidebar and an adjacent space exists
+- **THEN** alan renders the current and adjacent space pages from the same horizontal drag offset
+- **AND** the user can see the edge of the adjacent space while dragging toward it
+- **AND** the sidebar active-space header, sidebar tab list, and terminal workspace surface move as parts of the same space page
+- **AND** visible terminal panes keep their runtime identities instead of being restarted or recreated as a side effect of the drag
+- **AND** movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+- **AND** vertical tab-list scrolling does not move while horizontal intent is locked
+
+#### Scenario: Pager reaches sequence edge
+- **WHEN** a user swipes past the first or last available space
+- **THEN** alan applies bounded edge resistance rather than wrapping unexpectedly or showing a nonexistent space page
+- **AND** releasing before a valid target is selected returns the pager to the current space
+
+#### Scenario: Commit updates focus at the authoritative transition point
+- **WHEN** the user releases a space swipe past the commit threshold or with sufficient release velocity toward an adjacent space
+- **THEN** alan commits the target space through the shell controller selection and focus path
+- **AND** the visual pager settles smoothly to the committed space without being reverted by concurrent runtime updates
+- **AND** terminal focus follows the selected pane when the pane runtime is available
+
+#### Scenario: Cancel preserves focus and layout
+- **WHEN** the user releases a space swipe before the commit threshold
+- **THEN** alan animates the pager back to the original space
+- **AND** selected space, selected tab, terminal focus, split tree, and divider ratios remain unchanged
+
+#### Scenario: Phaseful gesture waits for real release
+- **WHEN** a user pauses a phaseful horizontal trackpad swipe while their fingers remain on the trackpad
+- **THEN** alan keeps the pager at the current drag offset
+- **AND** alan does not commit or cancel until the gesture ends, is cancelled, or enters momentum
+
+#### Scenario: Release uses last effective velocity
+- **WHEN** a phaseful horizontal trackpad swipe ends or enters momentum
+- **THEN** alan evaluates commit using current pager progress and the last effective finger velocity before release
+- **AND** alan does not replace that velocity with a zero-delta ended event
+
+#### Scenario: Fast flick can commit
+- **WHEN** a user performs a fast horizontal flick inside the sidebar
+- **THEN** alan recognizes the dominant horizontal release or momentum handoff as a space switch
+- **AND** alan may commit from velocity even when the gesture produced only a short visible translation before release
+
+#### Scenario: Phase-less gesture settles
+- **WHEN** a horizontal sidebar swipe comes from a scroll device that does not provide gesture phases
+- **THEN** alan may treat a short idle gap as release to avoid leaving the pager stuck
+- **AND** shell selection follows the same commit threshold as other sidebar swipes
+
+#### Scenario: Vertical scroll is not captured
+- **WHEN** a user's gesture is primarily vertical in the sidebar tab list
+- **THEN** the native vertical tab-list scroll receives the gesture and the workspace space transition does not begin
+- **AND** horizontal pager movement is not applied while vertical intent is locked

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -1,0 +1,40 @@
+## 1. Selection And Focus Convergence
+
+- [ ] 1.1 Add shell-controller helpers that resolve a target pane for a selected tab or space, preferring an existing focused pane in that tab and otherwise using a stable pane from the tab tree.
+- [ ] 1.2 Change `select(spaceID:)`, `select(tabID:)`, indexed space selection, adjacent space selection, and sidebar click paths so committed sidebar selection updates authoritative `shellState.focusedPaneID` through the shell focus mutation path.
+- [ ] 1.3 Ensure committed sidebar selection requests terminal focus for the selected pane when a runtime is available, without stealing focus during transient preview-only gestures.
+- [ ] 1.4 Add focused tests proving tab clicks and space clicks are not reverted by immediate terminal runtime metadata or control-plane state publication.
+- [ ] 1.5 Add split-tab coverage proving sidebar selection chooses a stable pane without changing split trees or divider ratios.
+
+## 2. Coordinated Sidebar And Window Chrome Motion
+
+- [ ] 2.1 Replace pinned-sidebar conditional insertion/removal with a mounted sidebar presentation state that drives visible width, content opacity or offset, and workspace leading inset.
+- [ ] 2.2 Tune pinned collapse and expansion timing to be short and crisp in normal motion and non-springy under reduced motion.
+- [ ] 2.3 Extend the window chrome bridge so standard macOS traffic-light controls move with the sidebar/titlebar-control motion and settle to corrected final AppKit frames.
+- [ ] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
+- [ ] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
+
+## 3. Continuous Space Pager
+
+- [ ] 3.1 Replace the sidebar-only `ShellSpaceTransition` model with a pager state that tracks source index, target index, drag offset, page width, commit/cancel state, and settlement phase.
+- [ ] 3.2 Preserve gesture axis arbitration in `ShellSidebarSwipeMonitor`, including undecided buffering, vertical scroll pass-through, phaseful release, phase-less idle release, momentum handoff, and fast flick velocity.
+- [ ] 3.3 Render current and adjacent space pages from the same pager offset so users can see the target space edge while dragging.
+- [ ] 3.4 Include sidebar header, sidebar tab list, and terminal workspace surface in the pager page motion while preserving terminal runtime identities.
+- [ ] 3.5 Apply bounded edge resistance at the first and last spaces and prevent accidental wraparound.
+- [ ] 3.6 Commit the target space through the authoritative selection/focus path at the transition point so concurrent runtime updates cannot snap the UI back during settlement.
+- [ ] 3.7 Cancel below-threshold gestures back to the source page without changing selected space, selected tab, focused pane, split tree, or divider ratios.
+
+## 4. Verification
+
+- [ ] 4.1 Extend focused shell tests for sidebar selection/focus convergence and runtime-update race coverage.
+- [ ] 4.2 Extend sidebar swipe monitor or pager tests for horizontal, vertical, undecided, edge, cancel, commit, phaseful, phase-less, and fast-flick cases.
+- [ ] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or sidebar-only space swipe semantics.
+- [ ] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
+
+## 5. OpenSpec And Review Readiness
+
+- [ ] 5.1 Keep `proposal.md`, `design.md`, `tasks.md`, and all delta specs aligned if implementation discoveries change the contract.
+- [ ] 5.2 Run `openspec validate refine-macos-sidebar-interactions --strict` after spec edits and after implementation.
+- [ ] 5.3 Run `openspec validate --all --strict` before opening or updating a PR.
+- [ ] 5.4 Prepare archive readiness notes after implementation so the delta specs can be synced into `openspec/specs/` before archiving.


### PR DESCRIPTION
## Summary
- Add OpenSpec change for macOS sidebar interaction refinements
- Specify authoritative sidebar selection/focus convergence
- Specify coordinated sidebar/window chrome motion and continuous space pager behavior
- Add verification tasks for selection stability, gesture behavior, and traffic-light/sidebar chrome motion

## Validation
- openspec validate refine-macos-sidebar-interactions --strict
- openspec validate --all --strict
- git diff --check