### PR TITLE
Implement persistent macOS shell workspaces

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* ConsoleAdaptiveColor.swift */; };
 		000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000137 /* ShellHostControlCommandHandling.swift */; };
 		000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */; };
+		000000000000000000000039 /* ShellWorkspaceManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000139 /* ShellWorkspaceManifest.swift */; };
+		00000000000000000000003A /* ShellWorkspaceManifestStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013A /* ShellWorkspaceManifestStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -123,6 +125,8 @@
 		000000000000000000000136 /* ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
 		000000000000000000000137 /* ShellHostControlCommandHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Shell/ShellHostControlCommandHandling.swift; sourceTree = "<group>"; };
 		000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSwipeMonitor.swift; sourceTree = "<group>"; };
+		000000000000000000000139 /* ShellWorkspaceManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellWorkspaceManifest.swift; sourceTree = "<group>"; };
+		00000000000000000000013A /* ShellWorkspaceManifestStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellWorkspaceManifestStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -270,6 +274,7 @@
 				000000000000000000000121 /* ShellValueTypes.swift */,
 				000000000000000000000122 /* ShellSnapshots.swift */,
 				000000000000000000000129 /* ShellControlPlaneDTOs.swift */,
+				000000000000000000000139 /* ShellWorkspaceManifest.swift */,
 				000000000000000000000123 /* ShellTreeMutations.swift */,
 				000000000000000000000124 /* ShellStateMutations.swift */,
 			);
@@ -288,6 +293,7 @@
 				00000000000000000000012C /* ShellPublishedStateMerger.swift */,
 				00000000000000000000012B /* ShellSocketServer.swift */,
 				000000000000000000000126 /* ShellStatePersistenceStore.swift */,
+				00000000000000000000013A /* ShellWorkspaceManifestStore.swift */,
 			);
 			name = Services/Shell;
 			sourceTree = "<group>";
@@ -457,6 +463,8 @@
 				000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */,
 				000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */,
 				000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */,
+				000000000000000000000039 /* ShellWorkspaceManifest.swift in Sources */,
+				00000000000000000000003A /* ShellWorkspaceManifestStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -14,7 +14,7 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
         host = ShellHostController.live(
             fileManager: fileManager,
             windowContext: windowContext,
-            startupMode: .fresh
+            startupMode: .workspaceManifest
         )
     }
 }

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -31,6 +31,11 @@ final class AlanGhosttyLiveHost: NSObject {
     private var metadata = TerminalPaneMetadataSnapshot.placeholder
     private let terminalModeTracker = AlanTerminalModeTracker()
 
+    private enum KeyCode {
+        static let returnKey: UInt32 = 36
+        static let keypadEnter: UInt32 = 76
+    }
+
     func attach(
         to canvasView: AlanGhosttyCanvasView,
         bootProfile: AlanShellBootProfile?,
@@ -103,6 +108,9 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let surface else { return false }
         let handled = ghostty_surface_key(surface, keyEvent)
         ghostty_surface_refresh(surface)
+        if handled, isCommandSubmissionKey(keyEvent) {
+            markForegroundCommandStarted()
+        }
         return handled
     }
 
@@ -117,7 +125,11 @@ final class AlanGhosttyLiveHost: NSObject {
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
         }
         ghostty_surface_refresh(surface)
-        updateMetadata(summary: "input committed", attention: .active)
+        updateMetadata(
+            summary: "input committed",
+            attention: .active,
+            activeTaskState: text.contains("\n") || text.contains("\r") ? .foregroundCommand : nil
+        )
     }
 
     func sendPreedit(_ text: String?) {
@@ -356,7 +368,8 @@ final class AlanGhosttyLiveHost: NSObject {
             summary: "booting \(bootProfile.command.summary.lowercased())",
             attention: .active,
             processExited: false,
-            lastCommandExitCode: nil
+            lastCommandExitCode: nil,
+            activeTaskState: bootProfile.surfaceCommand == nil ? .inactive : .foregroundCommand
         )
 
         var surfaceConfig = ghostty_surface_config_new()
@@ -649,7 +662,8 @@ final class AlanGhosttyLiveHost: NSObject {
                     summary: "process exited with status \(exitCode)",
                     attention: .awaitingUser,
                     processExited: true,
-                    lastCommandExitCode: Int(exitCode)
+                    lastCommandExitCode: Int(exitCode),
+                    activeTaskState: .inactive
                 )
             }
             return true
@@ -669,7 +683,8 @@ final class AlanGhosttyLiveHost: NSObject {
                     summary: summary,
                     attention: exitCode == 0 ? .active : .notable,
                     processExited: false,
-                    lastCommandExitCode: Int(exitCode)
+                    lastCommandExitCode: Int(exitCode),
+                    activeTaskState: .inactive
                 )
             }
             return true
@@ -763,7 +778,8 @@ final class AlanGhosttyLiveHost: NSObject {
         summary: String? = nil,
         attention: ShellAttentionState? = nil,
         processExited: Bool? = nil,
-        lastCommandExitCode: Int? = nil
+        lastCommandExitCode: Int? = nil,
+        activeTaskState: ShellTabActiveTaskState? = nil
     ) {
         let nextTitle = title ?? metadata.title
         let nextWorkingDirectory = workingDirectory ?? metadata.workingDirectory
@@ -771,6 +787,7 @@ final class AlanGhosttyLiveHost: NSObject {
         let nextAttention = attention ?? metadata.attention
         let nextProcessExited = processExited ?? metadata.processExited
         let nextLastCommandExitCode = lastCommandExitCode ?? metadata.lastCommandExitCode
+        let nextActiveTaskState = activeTaskState ?? metadata.activeTaskState
 
         guard
             nextTitle != metadata.title
@@ -779,6 +796,7 @@ final class AlanGhosttyLiveHost: NSObject {
                 || nextAttention != metadata.attention
                 || nextProcessExited != metadata.processExited
                 || nextLastCommandExitCode != metadata.lastCommandExitCode
+                || nextActiveTaskState != metadata.activeTaskState
         else {
             return
         }
@@ -790,10 +808,20 @@ final class AlanGhosttyLiveHost: NSObject {
             attention: nextAttention,
             processExited: nextProcessExited,
             lastCommandExitCode: nextLastCommandExitCode,
-            lastUpdatedAt: .now
+            lastUpdatedAt: .now,
+            activeTaskState: nextActiveTaskState
         )
         metadata = snapshot
         onMetadataChange?(snapshot)
+    }
+
+    private func isCommandSubmissionKey(_ keyEvent: ghostty_input_key_s) -> Bool {
+        keyEvent.action == GHOSTTY_ACTION_PRESS
+            && (keyEvent.keycode == KeyCode.returnKey || keyEvent.keycode == KeyCode.keypadEnter)
+    }
+
+    private func markForegroundCommandStarted() {
+        updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }
 
     private func resetMetadata() {

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -12,8 +12,11 @@ struct MacShellRootView: View {
     @State private var sidebarRevealToken = 0
     @State private var floatingSidebarTrafficLightRevealToken = 0
     @State private var isSpaceSwipeGestureLocked = false
-    @State private var spaceTransition: ShellSpaceTransition?
-    @State private var spaceTransitionToken = 0
+    @State private var pinnedSidebarPresentationProgress: CGFloat
+    @State private var spacePager: ShellSpacePagerState?
+    @State private var spacePagerToken = 0
+    @State private var spacePagerPageWidth: CGFloat = 1
+    @State private var spacePagerPageSelectedPaneIDs: [Int: String] = [:]
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
     @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
     private let sidebarWidth: CGFloat = 264
@@ -29,6 +32,9 @@ struct MacShellRootView: View {
         self.host = host
         _appearanceMode = appearanceMode
         _isSidebarCollapsed = isSidebarCollapsed
+        _pinnedSidebarPresentationProgress = State(
+            initialValue: isSidebarCollapsed.wrappedValue ? 0 : 1
+        )
     }
 
     private func toggleCommandInput() {
@@ -57,104 +63,111 @@ struct MacShellRootView: View {
     private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
         switch update.phase {
         case .began:
-            guard spaceTransition?.isSettling != true else { return }
+            guard spacePager?.isSettling != true else { return }
             isSpaceSwipeGestureLocked = true
-            beginSpaceTransition()
+            beginSpacePager()
         case .changed:
-            guard spaceTransition?.isSettling != true else { return }
+            guard spacePager?.isSettling != true else { return }
             isSpaceSwipeGestureLocked = true
-            updateSpaceTransition(translationX: update.translationX)
+            updateSpacePager(translationX: update.translationX)
         case .ended:
-            finishSpaceTransition(velocityX: update.velocityX)
+            finishSpacePager(velocityX: update.velocityX)
         case .cancelled:
-            settleSpaceTransition(committing: false)
+            settleSpacePager(committing: false)
         }
     }
 
-    private func beginSpaceTransition() {
-        guard let sourceSpaceID = host.selectedSpace?.spaceID else { return }
+    private func beginSpacePager() {
+        guard let sourceIndex = selectedSpaceIndex else { return }
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            spaceTransition = ShellSpaceTransition(
-                sourceSpaceID: sourceSpaceID,
-                targetSpaceID: nil,
-                direction: 1,
-                offsetX: 0,
-                progress: 0,
-                isSettling: false
+            spacePagerPageSelectedPaneIDs = [
+                sourceIndex: host.selectedPane?.paneID,
+            ].compactMapValues { $0 }
+            spacePager = ShellSpacePagerState(
+                sourceIndex: sourceIndex,
+                targetIndex: nil,
+                dragOffset: 0,
+                pageWidth: sidebarSwipePageWidth,
+                settlementPhase: .dragging
             )
         }
     }
 
-    private func updateSpaceTransition(translationX: CGFloat) {
+    private func updateSpacePager(translationX: CGFloat) {
         guard abs(translationX) > 0.5 else { return }
-        let sourceSpaceID = spaceTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
-        guard let sourceSpaceID else { return }
+        guard let sourceIndex = spacePager?.sourceIndex ?? selectedSpaceIndex else { return }
 
         let direction = translationX < 0 ? 1 : -1
-        let targetSpaceID = adjacentSpaceID(from: sourceSpaceID, direction: direction)
-        let offsetX = targetSpaceID == nil ? resistedEdgeOffset(for: translationX) : translationX
-        let progress = min(abs(offsetX) / sidebarSwipePageWidth, 0.98)
+        let targetIndex = adjacentSpaceIndex(from: sourceIndex, direction: direction)
+        let dragOffset = targetIndex == nil ? resistedEdgeOffset(for: translationX) : translationX
 
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            spaceTransition = ShellSpaceTransition(
-                sourceSpaceID: sourceSpaceID,
-                targetSpaceID: targetSpaceID,
-                direction: direction,
-                offsetX: offsetX,
-                progress: progress,
-                isSettling: false
+            if let targetIndex {
+                spacePagerPageSelectedPaneIDs[targetIndex] =
+                    spacePagerPageSelectedPaneIDs[targetIndex]
+                    ?? firstPaneID(forSpaceAt: targetIndex)
+            }
+            spacePager = ShellSpacePagerState(
+                sourceIndex: sourceIndex,
+                targetIndex: targetIndex,
+                dragOffset: dragOffset,
+                pageWidth: sidebarSwipePageWidth,
+                settlementPhase: .dragging
             )
         }
     }
 
-    private func finishSpaceTransition(velocityX: CGFloat) {
-        guard let transition = spaceTransition else {
+    private func finishSpacePager(velocityX: CGFloat) {
+        guard let pager = spacePager else {
             isSpaceSwipeGestureLocked = false
             return
         }
-        guard transition.targetSpaceID != nil else {
-            settleSpaceTransition(committing: false)
+        guard pager.targetIndex != nil else {
+            settleSpacePager(committing: false)
             return
         }
 
         let velocityDirection = velocityX < 0 ? 1 : -1
-        let fastEnough = abs(velocityX) >= 120 && velocityDirection == transition.direction
-        let farEnough = transition.progress >= 0.28
-        settleSpaceTransition(committing: farEnough || fastEnough)
+        let fastEnough = abs(velocityX) >= 120 && velocityDirection == pager.direction
+        let farEnough = pager.progress >= 0.28
+        settleSpacePager(committing: farEnough || fastEnough)
     }
 
-    private func settleSpaceTransition(committing: Bool) {
-        guard var transition = spaceTransition else {
+    private func settleSpacePager(committing: Bool) {
+        guard var pager = spacePager else {
             isSpaceSwipeGestureLocked = false
             return
         }
-        transition.isSettling = true
-        transition.offsetX = committing ? -CGFloat(transition.direction) * sidebarSwipePageWidth : 0
-        transition.progress = committing ? 1 : 0
-        spaceTransitionToken += 1
-        let token = spaceTransitionToken
+        let targetIndex = pager.targetIndex
+        if committing,
+           let targetIndex,
+           host.spaces.indices.contains(targetIndex)
+        {
+            host.select(spaceID: host.spaces[targetIndex].spaceID)
+        }
+
+        pager.settlementPhase = committing ? .settlingToTarget : .settlingToSource
+        pager.pageWidth = sidebarSwipePageWidth
+        pager.dragOffset = committing ? -CGFloat(pager.direction) * sidebarSwipePageWidth : 0
+        spacePagerToken += 1
+        let token = spacePagerToken
         let duration = reduceMotion ? 0.12 : 0.28
 
         withAnimation(settleAnimation) {
-            spaceTransition = transition
+            spacePager = pager
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-            guard spaceTransitionToken == token else { return }
-            if committing, let targetSpaceID = transition.targetSpaceID {
-                host.select(spaceID: targetSpaceID)
-                DispatchQueue.main.async {
-                    host.refocusSelectedTerminalPane()
-                }
-            }
+            guard spacePagerToken == token else { return }
             var transaction = Transaction()
             transaction.disablesAnimations = true
             withTransaction(transaction) {
-                spaceTransition = nil
+                spacePager = nil
+                spacePagerPageSelectedPaneIDs = [:]
                 isSpaceSwipeGestureLocked = false
             }
         }
@@ -168,7 +181,7 @@ struct MacShellRootView: View {
     }
 
     private var sidebarSwipePageWidth: CGFloat {
-        max(sidebarWidth, 1)
+        max(spacePagerPageWidth, 1)
     }
 
     private func resistedEdgeOffset(for translationX: CGFloat) -> CGFloat {
@@ -178,17 +191,96 @@ struct MacShellRootView: View {
         return translationX < 0 ? -resistedDistance : resistedDistance
     }
 
-    private func adjacentSpaceID(from sourceSpaceID: String, direction: Int) -> String? {
-        guard let sourceIndex = host.spaces.firstIndex(where: { $0.spaceID == sourceSpaceID }) else {
-            return nil
-        }
+    private func adjacentSpaceIndex(from sourceIndex: Int, direction: Int) -> Int? {
         let targetIndex = sourceIndex + direction
         guard host.spaces.indices.contains(targetIndex) else { return nil }
-        return host.spaces[targetIndex].spaceID
+        return targetIndex
+    }
+
+    private var selectedSpaceIndex: Int? {
+        guard let selectedSpaceID = host.selectedSpace?.spaceID else { return nil }
+        return host.spaces.firstIndex { $0.spaceID == selectedSpaceID }
+    }
+
+    private var previewedSpaceID: String? {
+        guard let targetIndex = spacePager?.targetIndex else { return nil }
+        return spaceID(forSpaceAt: targetIndex)
+    }
+
+    private var swipeEnabledSpaceIndex: Int? {
+        spacePager?.sourceIndex ?? selectedSpaceIndex
+    }
+
+    private var floatingSidebarDisplaySpaceID: String? {
+        if let sourceIndex = spacePager?.sourceIndex {
+            return spaceID(forSpaceAt: sourceIndex)
+        }
+        return host.selectedSpace?.spaceID
+    }
+
+    private func spaceID(forSpaceAt index: Int) -> String? {
+        guard host.spaces.indices.contains(index) else { return nil }
+        return host.spaces[index].spaceID
+    }
+
+    private func firstPaneID(forSpaceAt index: Int) -> String? {
+        guard host.spaces.indices.contains(index) else { return nil }
+        let space = host.spaces[index]
+        return space.tabs
+            .flatMap(\.paneTree.paneIDs)
+            .first { paneID in
+                host.shellState.panes.contains { $0.paneID == paneID }
+            }
+    }
+
+    private func selectedPaneID(forSpaceAt index: Int) -> String? {
+        if let paneID = spacePagerPageSelectedPaneIDs[index] {
+            return paneID
+        }
+        if index == selectedSpaceIndex,
+           let paneID = host.selectedPane?.paneID
+        {
+            return paneID
+        }
+        return firstPaneID(forSpaceAt: index)
     }
 
     private var isSidebarSurfaceVisible: Bool {
-        !isSidebarCollapsed || isSidebarPanelRevealed
+        isPinnedSidebarSurfaceActive || isSidebarPanelRevealed
+    }
+
+    private var isPinnedSidebarSurfaceActive: Bool {
+        !isSidebarCollapsed || pinnedSidebarPresentationProgress > 0.001
+    }
+
+    private var isPinnedSidebarFullyCollapsed: Bool {
+        pinnedSidebarPresentationProgress <= 0.001
+    }
+
+    private var sidebarPinnedVisibleWidth: CGFloat {
+        sidebarWidth * clampedPinnedSidebarPresentationProgress
+    }
+
+    private var sidebarPinnedChromeOffsetX: CGFloat {
+        -sidebarWidth * (1 - clampedPinnedSidebarPresentationProgress)
+    }
+
+    private var sidebarPinnedContentOpacity: Double {
+        Double(clampedPinnedSidebarPresentationProgress)
+    }
+
+    private var clampedPinnedSidebarPresentationProgress: CGFloat {
+        min(max(pinnedSidebarPresentationProgress, 0), 1)
+    }
+
+    private var sidebarChromeSurfaceOrigin: CGPoint {
+        if isSidebarPanelRevealed {
+            return CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
+        }
+        guard isPinnedSidebarSurfaceActive else {
+            return .zero
+        }
+        return CGPoint(x: sidebarPinnedChromeOffsetX, y: 0)
     }
 
     private var commandInputOpacity: Double {
@@ -202,21 +294,22 @@ struct MacShellRootView: View {
     private var windowChromeSurface: ShellWindowChromeSurface {
         ShellWindowChromeSurface(
             isVisible: isSidebarSurfaceVisible,
-            origin: isSidebarCollapsed && isSidebarPanelRevealed
-                ? CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
-                : .zero,
+            origin: sidebarChromeSurfaceOrigin,
             width: sidebarWidth,
             showsStandardTrafficLights: shouldShowStandardTrafficLights
         )
     }
 
     private var shouldShowStandardTrafficLights: Bool {
+        if isPinnedSidebarSurfaceActive {
+            return true
+        }
         guard isSidebarCollapsed else { return true }
         return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
     }
 
     private func revealCollapsedSidebarPanel() {
-        guard isSidebarCollapsed else { return }
+        guard isSidebarCollapsed, isPinnedSidebarFullyCollapsed else { return }
         sidebarRevealToken += 1
         guard !isSidebarPanelRevealed else { return }
 
@@ -267,7 +360,7 @@ struct MacShellRootView: View {
     }
 
     private func handleCollapsedSidebarToolbarHover(_ hovering: Bool) {
-        guard isSidebarCollapsed else { return }
+        guard isSidebarCollapsed, isPinnedSidebarFullyCollapsed else { return }
         handleCollapsedSidebarHover(hovering)
     }
 
@@ -292,6 +385,7 @@ struct MacShellRootView: View {
     private func updateSidebarCollapsed(_ collapsed: Bool) {
         withAnimation(sidebarPinnedStateAnimation) {
             isSidebarCollapsed = collapsed
+            pinnedSidebarPresentationProgress = collapsed ? 0 : 1
             isSidebarPanelRevealed = false
             areFloatingSidebarTrafficLightsVisible = false
             floatingSidebarTrafficLightRevealToken += 1
@@ -305,24 +399,13 @@ struct MacShellRootView: View {
             ShellMaterialBackgroundView(.windowBackdrop)
                 .ignoresSafeArea()
 
-            HStack(spacing: 0) {
-                if !isSidebarCollapsed {
-                    sidebarContent
-                    .frame(width: sidebarWidth)
-                    .ignoresSafeArea(edges: .top)
-                    .transition(.move(edge: .leading).combined(with: .opacity))
-                }
+            spacePagerPages
+                .frame(
+                    minWidth: ShellWindowSizing.minimumSize.width,
+                    minHeight: ShellWindowSizing.minimumSize.height
+                )
 
-                ShellWorkspaceView(host: host, hasExpandedSidebar: !isSidebarCollapsed)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .ignoresSafeArea(edges: .top)
-            }
-            .frame(
-                minWidth: ShellWindowSizing.minimumSize.width,
-                minHeight: ShellWindowSizing.minimumSize.height
-            )
-
-            if isSidebarCollapsed {
+            if isSidebarCollapsed && isPinnedSidebarFullyCollapsed {
                 collapsedSidebarRevealZone
 
                 if isSidebarPanelRevealed {
@@ -360,12 +443,13 @@ struct MacShellRootView: View {
             .allowsHitTesting(isCommandTabPresented)
             .accessibilityHidden(!isCommandTabPresented)
         }
-        .animation(sidebarPinnedStateAnimation, value: isSidebarCollapsed)
+        .animation(sidebarPinnedStateAnimation, value: pinnedSidebarPresentationProgress)
         .environment(\.colorScheme, resolvedAppearanceColorScheme)
+        .onAppear {
+            pinnedSidebarPresentationProgress = isSidebarCollapsed ? 0 : 1
+        }
         .onChange(of: isSidebarCollapsed) { _, collapsed in
-            if !collapsed {
-                isSidebarPanelRevealed = false
-            }
+            synchronizePinnedSidebarPresentation(collapsed: collapsed)
         }
         .onChange(of: host.commandInputRequestID) { _, _ in
             toggleCommandInput()
@@ -380,12 +464,116 @@ struct MacShellRootView: View {
         )
     }
 
-    private var sidebarContent: some View {
+    private var spacePagerPages: some View {
+        GeometryReader { proxy in
+            let pageWidth = max(proxy.size.width, 1)
+            ZStack(alignment: .leading) {
+                ForEach(spacePageIndices, id: \.self) { index in
+                    spacePage(index: index, pageWidth: pageWidth)
+                        .frame(width: pageWidth, height: proxy.size.height, alignment: .topLeading)
+                        .offset(x: spacePageOffset(for: index, pageWidth: pageWidth))
+                        .allowsHitTesting(spacePager == nil && index == selectedSpaceIndex)
+                }
+            }
+            .clipped()
+            .onAppear {
+                updateSpacePagerPageWidth(pageWidth)
+            }
+            .onChange(of: proxy.size.width) { _, width in
+                updateSpacePagerPageWidth(max(width, 1))
+            }
+        }
+    }
+
+    private var spacePageIndices: [Int] {
+        guard let spacePager else {
+            return selectedSpaceIndex.map { [$0] } ?? []
+        }
+        return spacePager.pageIndicesForRendering.filter { host.spaces.indices.contains($0) }
+    }
+
+    private func spacePage(index: Int, pageWidth: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            pinnedSidebarSurface(
+                displaySpaceID: spaceID(forSpaceAt: index),
+                previewedSpaceID: previewedSpaceID,
+                isSwipeEnabled: index == swipeEnabledSpaceIndex
+            )
+
+            ShellWorkspaceView(
+                host: host,
+                expandedSidebarProgress: clampedPinnedSidebarPresentationProgress,
+                spaceID: spaceID(forSpaceAt: index),
+                selectedPaneID: selectedPaneID(forSpaceAt: index)
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .ignoresSafeArea(edges: .top)
+        }
+        .frame(width: pageWidth, alignment: .leading)
+    }
+
+    private func spacePageOffset(for index: Int, pageWidth: CGFloat) -> CGFloat {
+        guard var spacePager else { return 0 }
+        spacePager.pageWidth = pageWidth
+        return spacePager.offset(for: index)
+    }
+
+    private func updateSpacePagerPageWidth(_ pageWidth: CGFloat) {
+        let clampedPageWidth = max(pageWidth, 1)
+        spacePagerPageWidth = clampedPageWidth
+        guard var spacePager,
+              spacePager.pageWidth != clampedPageWidth
+        else {
+            return
+        }
+        spacePager.pageWidth = clampedPageWidth
+        self.spacePager = spacePager
+    }
+
+    private func pinnedSidebarSurface(
+        displaySpaceID: String?,
+        previewedSpaceID: String?,
+        isSwipeEnabled: Bool
+    ) -> some View {
+        sidebarContent(
+            displaySpaceID: displaySpaceID,
+            previewedSpaceID: previewedSpaceID,
+            isSwipeEnabled: isSwipeEnabled
+        )
+            .frame(width: sidebarWidth)
+            .offset(x: sidebarPinnedChromeOffsetX)
+            .opacity(sidebarPinnedContentOpacity)
+            .allowsHitTesting(!isSidebarCollapsed)
+            .frame(width: sidebarPinnedVisibleWidth, alignment: .leading)
+            .clipped()
+            .ignoresSafeArea(edges: .top)
+    }
+
+    private func synchronizePinnedSidebarPresentation(collapsed: Bool) {
+        withAnimation(sidebarPinnedStateAnimation) {
+            pinnedSidebarPresentationProgress = collapsed ? 0 : 1
+            if collapsed {
+                isSidebarPanelRevealed = false
+                areFloatingSidebarTrafficLightsVisible = false
+                floatingSidebarTrafficLightRevealToken += 1
+            } else {
+                isSidebarPanelRevealed = false
+            }
+        }
+    }
+
+    private func sidebarContent(
+        displaySpaceID: String? = nil,
+        previewedSpaceID: String? = nil,
+        isSwipeEnabled: Bool = true
+    ) -> some View {
         ShellSidebarView(
             host: host,
             chromeMetrics: windowChromeMetrics,
-            spaceTransition: spaceTransition,
+            displaySpaceID: displaySpaceID,
+            previewedSpaceID: previewedSpaceID,
             isSpaceSwipeGestureLocked: isSpaceSwipeGestureLocked,
+            isSwipeEnabled: isSwipeEnabled,
             onSpaceSwipe: handleSpaceSwipe
         ) {
             presentCommandInput()
@@ -421,7 +609,11 @@ struct MacShellRootView: View {
                         .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
                 }
 
-            sidebarContent
+            sidebarContent(
+                displaySpaceID: floatingSidebarDisplaySpaceID,
+                previewedSpaceID: previewedSpaceID,
+                isSwipeEnabled: true
+            )
                 .clipShape(
                     RoundedRectangle(
                         cornerRadius: ShellRadii.floatingSidebarPanel,
@@ -460,12 +652,14 @@ struct MacShellRootView: View {
             .padding(
                 .leading,
                 windowChromeMetrics.titlebarToolLeadingInset
-                    + (isSidebarCollapsed ? floatingSidebarInset : 0)
             )
             .padding(
                 .top,
                 windowChromeMetrics.titlebarToolTopInset
-                    + (isSidebarCollapsed ? floatingSidebarInset : 0)
+            )
+            .offset(
+                x: sidebarChromeSurfaceOrigin.x,
+                y: sidebarChromeSurfaceOrigin.y
             )
             .contentShape(Rectangle())
             .onHover(perform: handleCollapsedSidebarToolbarHover)

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -204,6 +204,53 @@ extension ShellStateSnapshot {
         )
     }
 
+    func deletingSpace(
+        _ spaceID: String,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory()
+    ) throws -> ShellStateMutationResult {
+        guard let targetSpace = space(spaceID: spaceID) else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+
+        let removedPaneIDs = Set(targetSpace.tabs.flatMap(\.paneTree.paneIDs))
+        let remainingSpaces = spaces.filter { $0.spaceID != spaceID }
+        let remainingPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
+
+        guard !remainingSpaces.isEmpty else {
+            let defaultState = ShellStateSnapshot.bootstrapDefault(
+                windowID: windowID,
+                workingDirectory: defaultWorkingDirectory
+            )
+            return ShellStateMutationResult(
+                state: defaultState,
+                spaceID: defaultState.focusedSpaceID,
+                tabID: defaultState.focusedTabID,
+                paneID: defaultState.focusedPaneID
+            )
+        }
+
+        let focusedPaneID = remainingPanes.first?.paneID
+        let focusedPane = focusedPaneID.flatMap { paneID in
+            remainingPanes.first { $0.paneID == paneID }
+        }
+        let nextState = ShellStateSnapshot(
+            contractVersion: contractVersion,
+            windowID: windowID,
+            focusedSpaceID: focusedPane?.spaceID ?? remainingSpaces.first?.spaceID,
+            focusedTabID: focusedPane?.tabID,
+            focusedPaneID: focusedPaneID,
+            spaces: rebuildingAttention(in: remainingSpaces, panes: remainingPanes),
+            panes: remainingPanes
+        )
+
+        return ShellStateMutationResult(
+            state: nextState,
+            spaceID: nextState.focusedSpaceID,
+            tabID: nextState.focusedTabID,
+            paneID: nextState.focusedPaneID
+        )
+    }
+
     func openingTab(
         launchTarget: ShellLaunchTarget,
         in requestedSpaceID: String?,
@@ -762,9 +809,6 @@ extension ShellStateSnapshot {
     }
 
     func closingTab(_ tabID: String) throws -> ShellStateMutationResult {
-        guard totalTabCount > 1 else {
-            throw ShellStateMutationError.lastTab
-        }
         guard let targetSpace = spaces.first(where: { space in
             space.tabs.contains(where: { $0.tabID == tabID })
         }),
@@ -774,11 +818,8 @@ extension ShellStateSnapshot {
         }
 
         let removedPaneIDs = Set(targetTab.paneTree.paneIDs)
-        let nextSpaces = spaces.compactMap { space -> ShellSpace? in
+        let nextSpaces = spaces.map { space -> ShellSpace in
             let remainingTabs = space.tabs.filter { $0.tabID != tabID }
-            guard !remainingTabs.isEmpty else {
-                return space.spaceID == targetSpace.spaceID ? nil : space
-            }
             return ShellSpace(
                 spaceID: space.spaceID,
                 title: space.title,
@@ -787,18 +828,32 @@ extension ShellStateSnapshot {
             )
         }
         let nextPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
-        let preferredPaneID = nextPanes.first(where: { $0.spaceID == targetSpace.spaceID })?.paneID
+        let targetSpaceAfterClose = nextSpaces.first { $0.spaceID == targetSpace.spaceID }
+        let preferredPaneID =
+            targetSpaceAfterClose?.tabs
+                .flatMap(\.paneTree.paneIDs)
+                .first { paneID in nextPanes.contains { $0.paneID == paneID } }
+            ?? nextPanes.first(where: { $0.spaceID == targetSpace.spaceID })?.paneID
             ?? nextPanes.first?.paneID
-        let nextState = replacing(
+        let focusedPane = preferredPaneID.flatMap { paneID in
+            nextPanes.first { $0.paneID == paneID }
+        }
+        let focusedSpaceID = focusedPane?.spaceID ?? targetSpaceAfterClose?.spaceID ?? nextSpaces.first?.spaceID
+        let focusedTabID = focusedPane?.tabID
+        let nextState = ShellStateSnapshot(
+            contractVersion: contractVersion,
+            windowID: windowID,
+            focusedSpaceID: focusedSpaceID,
+            focusedTabID: focusedTabID,
+            focusedPaneID: preferredPaneID,
             spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
-            panes: nextPanes,
-            focusedPaneID: preferredPaneID
+            panes: nextPanes
         )
 
         return ShellStateMutationResult(
             state: nextState,
             spaceID: nextState.focusedSpaceID,
-            tabID: tabID,
+            tabID: nextState.focusedTabID,
             paneID: nextState.focusedPaneID
         )
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -105,6 +105,24 @@ enum ShellLaunchTarget: String, Codable, CaseIterable {
     case alan
 }
 
+enum ShellTabActiveTaskState: String, Codable, Equatable, CaseIterable {
+    case inactive
+    case foregroundCommand = "foreground_command"
+    case alanRunning = "alan_running"
+    case alanPendingYield = "alan_pending_yield"
+    case alanSession = "alan_session"
+    case unknown
+
+    var protectsFromPruning: Bool {
+        switch self {
+        case .inactive:
+            return false
+        case .foregroundCommand, .alanRunning, .alanPendingYield, .alanSession, .unknown:
+            return true
+        }
+    }
+}
+
 struct ShellProcessBinding: Codable, Equatable {
     let program: String
     let argvPreview: [String]?

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+struct ShellWorkspaceManifest: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var windowID: String
+    var selectedSpaceID: String?
+    var selectedTabID: String?
+    var spaces: [ShellWorkspaceSpaceRecord]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case windowID = "window_id"
+        case selectedSpaceID = "selected_space_id"
+        case selectedTabID = "selected_tab_id"
+        case spaces
+    }
+
+    static func defaultManifest(
+        windowID: String,
+        defaultWorkingDirectory: String,
+        now: Date
+    ) -> ShellWorkspaceManifest {
+        let spaceID = "space_main"
+        let tabID = "tab_main"
+        let paneID = "pane_1"
+        let snapshot = ShellTabRestoreSnapshot(
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            ),
+            panes: [
+                ShellPaneRestoreRecord(
+                    paneID: paneID,
+                    launchTarget: .shell,
+                    cwd: defaultWorkingDirectory,
+                    title: "Shell"
+                )
+            ]
+        )
+
+        return ShellWorkspaceManifest(
+            schemaVersion: currentSchemaVersion,
+            windowID: windowID,
+            selectedSpaceID: spaceID,
+            selectedTabID: tabID,
+            spaces: [
+                ShellWorkspaceSpaceRecord(
+                    spaceID: spaceID,
+                    title: "Terminal",
+                    order: 0,
+                    createdAt: now,
+                    updatedAt: now,
+                    tabs: [
+                        ShellWorkspaceTabRecord(
+                            tabID: tabID,
+                            title: "Shell",
+                            kind: .terminal,
+                            createdAt: now,
+                            lastActivatedAt: now,
+                            lastActivityAt: now,
+                            isPinned: false,
+                            pinSnapshot: nil,
+                            liveSnapshot: snapshot,
+                            activeTask: .inactive
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+}
+
+struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
+    var spaceID: String
+    var title: String
+    var order: Int
+    var createdAt: Date
+    var updatedAt: Date
+    var tabs: [ShellWorkspaceTabRecord]
+
+    var id: String { spaceID }
+
+    private enum CodingKeys: String, CodingKey {
+        case spaceID = "space_id"
+        case title
+        case order
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case tabs
+    }
+}
+
+struct ShellWorkspaceTabRecord: Codable, Equatable, Identifiable {
+    var tabID: String
+    var title: String?
+    var kind: ShellTabKind
+    var createdAt: Date
+    var lastActivatedAt: Date
+    var lastActivityAt: Date
+    var isPinned: Bool
+    var pinSnapshot: ShellTabRestoreSnapshot?
+    var liveSnapshot: ShellTabRestoreSnapshot?
+    var activeTask: ShellTabActiveTaskState
+
+    var id: String { tabID }
+
+    private enum CodingKeys: String, CodingKey {
+        case tabID = "tab_id"
+        case title
+        case kind
+        case createdAt = "created_at"
+        case lastActivatedAt = "last_activated_at"
+        case lastActivityAt = "last_activity_at"
+        case isPinned = "is_pinned"
+        case pinSnapshot = "pin_snapshot"
+        case liveSnapshot = "live_snapshot"
+        case activeTask = "active_task"
+    }
+
+    func restoreSnapshot(defaultWorkingDirectory: String) -> ShellTabRestoreSnapshot {
+        if isPinned, let pinSnapshot {
+            return pinSnapshot
+        }
+
+        if let liveSnapshot {
+            return liveSnapshot
+        }
+
+        let paneID = "pane_\(tabID)"
+        return ShellTabRestoreSnapshot(
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            ),
+            panes: [
+                ShellPaneRestoreRecord(
+                    paneID: paneID,
+                    launchTarget: .shell,
+                    cwd: defaultWorkingDirectory,
+                    title: title
+                )
+            ]
+        )
+    }
+
+    func shouldRetain(now: Date, ttl: TimeInterval) -> Bool {
+        if isPinned {
+            return true
+        }
+
+        if activeTask.protectsFromPruning {
+            return true
+        }
+
+        return now.timeIntervalSince(max(lastActivatedAt, lastActivityAt)) <= ttl
+    }
+}
+
+struct ShellTabRestoreSnapshot: Codable, Equatable {
+    var paneTree: ShellPaneTreeNode
+    var panes: [ShellPaneRestoreRecord]
+
+    private enum CodingKeys: String, CodingKey {
+        case paneTree = "pane_tree"
+        case panes
+    }
+}
+
+struct ShellPaneRestoreRecord: Codable, Equatable, Identifiable {
+    var paneID: String
+    var launchTarget: ShellLaunchTarget
+    var cwd: String?
+    var title: String?
+
+    var id: String { paneID }
+
+    private enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case launchTarget = "launch_target"
+        case cwd
+        case title
+    }
+}
+
+extension ShellWorkspaceManifest {
+    func pruningExpiredTabs(now: Date, ttl: TimeInterval) -> ShellWorkspaceManifest {
+        var pruned = self
+        pruned.spaces = spaces.map { space in
+            var space = space
+            space.tabs = space.tabs.filter { $0.shouldRetain(now: now, ttl: ttl) }
+            space.updatedAt = now
+            return space
+        }
+        pruned.repairSelection()
+        return pruned
+    }
+
+    mutating func repairSelection() {
+        guard !spaces.isEmpty else {
+            selectedSpaceID = nil
+            selectedTabID = nil
+            return
+        }
+
+        if selectedSpaceID == nil || !spaces.contains(where: { $0.spaceID == selectedSpaceID }) {
+            selectedSpaceID = spaces.first?.spaceID
+        }
+
+        guard let selectedSpaceID,
+              let selectedSpace = spaces.first(where: { $0.spaceID == selectedSpaceID })
+        else {
+            selectedTabID = nil
+            return
+        }
+
+        let selectedTabStillExists = selectedTabID.map { selectedTabID in
+            selectedSpace.tabs.contains { $0.tabID == selectedTabID }
+        } ?? false
+
+        if !selectedTabStillExists {
+            selectedTabID = selectedSpace.tabs.first?.tabID
+        }
+    }
+}
+
+struct ShellWorkspaceMaterializer {
+    static func materialize(
+        manifest: ShellWorkspaceManifest,
+        defaultWorkingDirectory: String,
+        now: Date
+    ) -> ShellStateSnapshot {
+        var repairedManifest = manifest
+        repairedManifest.repairSelection()
+
+        let sourceManifest = repairedManifest.spaces.isEmpty
+            ? ShellWorkspaceManifest.defaultManifest(
+                windowID: manifest.windowID,
+                defaultWorkingDirectory: defaultWorkingDirectory,
+                now: now
+            )
+            : repairedManifest
+
+        let spaces = sourceManifest.spaces.sorted { lhs, rhs in
+            if lhs.order == rhs.order {
+                return lhs.spaceID < rhs.spaceID
+            }
+            return lhs.order < rhs.order
+        }
+
+        var shellSpaces: [ShellSpace] = []
+        var panes: [ShellPane] = []
+
+        for space in spaces {
+            let shellTabs = space.tabs.map { tabRecord -> ShellTab in
+                let restoreSnapshot = tabRecord.restoreSnapshot(
+                    defaultWorkingDirectory: defaultWorkingDirectory
+                )
+
+                panes.append(
+                    contentsOf: restoreSnapshot.panes.map { paneRecord in
+                        makePane(
+                            record: paneRecord,
+                            tabID: tabRecord.tabID,
+                            spaceID: space.spaceID,
+                            selectedTabID: sourceManifest.selectedTabID,
+                            defaultWorkingDirectory: defaultWorkingDirectory
+                        )
+                    }
+                )
+
+                return ShellTab(
+                    tabID: tabRecord.tabID,
+                    kind: tabRecord.kind,
+                    title: tabRecord.title,
+                    paneTree: restoreSnapshot.paneTree
+                )
+            }
+
+            shellSpaces.append(
+                ShellSpace(
+                    spaceID: space.spaceID,
+                    title: space.title,
+                    attention: strongestAttention(for: shellTabs, panes: panes),
+                    tabs: shellTabs
+                )
+            )
+        }
+
+        let focusedSpaceID = sourceManifest.selectedSpaceID
+        let focusedTabID = focusedSpaceID.flatMap { spaceID in
+            let selectedSpace = shellSpaces.first { $0.spaceID == spaceID }
+            if let selectedTabID = sourceManifest.selectedTabID,
+               selectedSpace?.tabs.contains(where: { $0.tabID == selectedTabID }) == true
+            {
+                return selectedTabID
+            }
+            return selectedSpace?.tabs.first?.tabID
+        }
+        let focusedPaneID = focusedTabID
+            .flatMap { tabID in shellSpaces.lazy.flatMap(\.tabs).first { $0.tabID == tabID } }
+            .flatMap { $0.paneTree.paneIDs.first }
+
+        return ShellStateSnapshot(
+            contractVersion: "0.1",
+            windowID: sourceManifest.windowID,
+            focusedSpaceID: focusedSpaceID,
+            focusedTabID: focusedTabID,
+            focusedPaneID: focusedPaneID,
+            spaces: shellSpaces,
+            panes: panes
+        )
+    }
+
+    private static func makePane(
+        record: ShellPaneRestoreRecord,
+        tabID: String,
+        spaceID: String,
+        selectedTabID: String?,
+        defaultWorkingDirectory: String
+    ) -> ShellPane {
+        let launchTarget = record.launchTarget
+        let title = record.title ?? defaultViewportTitle(for: launchTarget)
+        return ShellPane(
+            paneID: record.paneID,
+            tabID: tabID,
+            spaceID: spaceID,
+            launchTarget: launchTarget,
+            cwd: record.cwd ?? defaultWorkingDirectory,
+            process: nil,
+            attention: tabID == selectedTabID ? .active : .idle,
+            context: nil,
+            viewport: ShellViewportSnapshot(
+                title: title,
+                summary: nil,
+                visibleExcerpt: nil,
+                lastActivityAt: nil
+            ),
+            alanBinding: nil
+        )
+    }
+
+    private static func strongestAttention(
+        for tabs: [ShellTab],
+        panes: [ShellPane]
+    ) -> ShellAttentionState {
+        let paneIDs = Set(tabs.flatMap(\.paneTree.paneIDs))
+        return panes
+            .filter { paneIDs.contains($0.paneID) }
+            .map(\.attention)
+            .max { attentionRank(for: $0) < attentionRank(for: $1) }
+            ?? .idle
+    }
+
+    private static func attentionRank(for attention: ShellAttentionState) -> Int {
+        switch attention {
+        case .idle:
+            return 0
+        case .active:
+            return 1
+        case .notable:
+            return 2
+        case .awaitingUser:
+            return 3
+        }
+    }
+
+    private static func defaultViewportTitle(for launchTarget: ShellLaunchTarget) -> String {
+        switch launchTarget {
+        case .shell:
+            return "Shell"
+        case .alan:
+            return "alan"
+        }
+    }
+}

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -72,6 +72,7 @@ struct ShellPaneProjectionService {
         processExited: Bool?,
         lastCommandExitCode: Int?,
         lastMetadataAt: Date?,
+        activeTaskState: ShellTabActiveTaskState? = nil,
         existing: ShellContextSnapshot?,
         runtime: TerminalHostRuntimeSnapshot? = nil
     ) -> ShellContextSnapshot {
@@ -94,8 +95,11 @@ struct ShellPaneProjectionService {
             launchCommand: bootProfile.launchCommandString,
             launchStrategy: bootProfile.command.strategy.rawValue,
             shellIntegrationSource: "ghostty_shell_integration",
-            processState: projectedProcessExited.map { $0 ? "exited" : "running" }
-                ?? existing?.processState,
+            processState: projectedProcessState(
+                processExited: projectedProcessExited,
+                activeTaskState: activeTaskState,
+                existing: existing?.processState
+            ),
             rendererPhase: runtime?.renderer.phase.rawValue ?? existing?.rendererPhase,
             rendererHealth: runtime?.surfaceState.rendererHealth
                 ?? runtime?.renderer.phase.rawValue
@@ -179,6 +183,26 @@ struct ShellPaneProjectionService {
         case .unready(let reason):
             return reason.rawValue
         }
+    }
+
+    private func projectedProcessState(
+        processExited: Bool?,
+        activeTaskState: ShellTabActiveTaskState?,
+        existing: String?
+    ) -> String? {
+        if processExited == true {
+            return "exited"
+        }
+
+        if activeTaskState == .foregroundCommand {
+            return "foreground_command"
+        }
+
+        if processExited == false {
+            return "running"
+        }
+
+        return existing
     }
 
     private func workingDirectoryName(for path: String?) -> String? {

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+struct ShellWorkspaceManifestLoadResult: Equatable {
+    var manifest: ShellWorkspaceManifest
+    var recovery: ShellWorkspaceManifestRecovery
+}
+
+enum ShellWorkspaceManifestRecovery: Equatable {
+    case loadedExisting
+    case createdDefault
+    case quarantinedCorruptFile(URL)
+}
+
+struct ShellWorkspaceManifestStore {
+    let fileManager: FileManager
+    let manifestURL: URL
+
+    init(
+        fileManager: FileManager = .default,
+        manifestURL: URL
+    ) {
+        self.fileManager = fileManager
+        self.manifestURL = manifestURL
+    }
+
+    init(
+        fileManager: FileManager = .default,
+        windowID: String
+    ) {
+        self.init(
+            fileManager: fileManager,
+            manifestURL: Self.defaultManifestURL(windowID: windowID, fileManager: fileManager)
+        )
+    }
+
+    func loadOrCreateDefault(
+        windowID: String,
+        defaultWorkingDirectory: String,
+        now: Date
+    ) throws -> ShellWorkspaceManifestLoadResult {
+        if !fileManager.fileExists(atPath: manifestURL.path) {
+            let manifest = ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: defaultWorkingDirectory,
+                now: now
+            )
+            try save(manifest)
+            return ShellWorkspaceManifestLoadResult(manifest: manifest, recovery: .createdDefault)
+        }
+
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            let manifest = try Self.decoder.decode(ShellWorkspaceManifest.self, from: data)
+            guard manifest.schemaVersion == ShellWorkspaceManifest.currentSchemaVersion else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: [],
+                        debugDescription: "Unsupported shell workspace manifest schema"
+                    )
+                )
+            }
+            return ShellWorkspaceManifestLoadResult(manifest: manifest, recovery: .loadedExisting)
+        } catch {
+            let corruptURL = quarantineURL(now: now)
+            if fileManager.fileExists(atPath: corruptURL.path) {
+                try fileManager.removeItem(at: corruptURL)
+            }
+            try fileManager.moveItem(at: manifestURL, to: corruptURL)
+
+            let manifest = ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: defaultWorkingDirectory,
+                now: now
+            )
+            try save(manifest)
+            return ShellWorkspaceManifestLoadResult(
+                manifest: manifest,
+                recovery: .quarantinedCorruptFile(corruptURL)
+            )
+        }
+    }
+
+    func save(_ manifest: ShellWorkspaceManifest) throws {
+        let directoryURL = manifestURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        let data = try Self.encoder.encode(manifest)
+        try data.write(to: manifestURL, options: .atomic)
+    }
+
+    static func defaultManifestURL(
+        windowID: String,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let applicationSupportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? fileManager.temporaryDirectory
+        return applicationSupportURL
+            .appendingPathComponent("alan-macos", isDirectory: true)
+            .appendingPathComponent("shell-workspace-\(sanitizedWindowID(windowID)).json")
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static func sanitizedWindowID(_ windowID: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        let scalars = windowID.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : "_"
+        }
+        let sanitized = String(scalars)
+        return sanitized.isEmpty ? "window_main" : sanitized
+    }
+
+    private func quarantineURL(now: Date) -> URL {
+        let basename = manifestURL.deletingPathExtension().lastPathComponent
+        let pathExtension = manifestURL.pathExtension.isEmpty ? "json" : manifestURL.pathExtension
+        let stamp = ISO8601DateFormatter()
+            .string(from: now)
+            .replacingOccurrences(of: ":", with: "")
+        return manifestURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(basename).corrupt-\(stamp).\(pathExtension)")
+    }
+}

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -800,7 +800,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 metadataProcessExited: runtime.paneMetadata.processExited,
                 surfaceState: runtime.surfaceState
             ) ?? runtime.paneMetadata.processExited
-            recordTerminalActiveTask(
+            let activeTaskChanged = recordTerminalActiveTask(
                 runtime.paneMetadata.activeTaskState,
                 processExited: runtimeProcessExited,
                 for: paneID
@@ -817,7 +817,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 runtime: runtime
             )
 
-            updatePaneState(paneID: paneID) { current in
+            let didPublishPaneUpdate = updatePaneState(paneID: paneID) { current in
                 let projectedBinding = paneProjection.projectedAlanBinding(
                     for: current,
                     binding: current.alanBinding,
@@ -846,6 +846,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     alanBinding: projectedBinding
                 )
             }
+            if activeTaskChanged && !didPublishPaneUpdate {
+                syncWorkspaceManifestFromShellState()
+            }
         }
     }
 
@@ -857,7 +860,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             metadataProcessExited: metadata.processExited,
             surfaceState: runtime.surfaceState
         ) ?? metadata.processExited
-        recordTerminalActiveTask(
+        let activeTaskChanged = recordTerminalActiveTask(
             metadata.activeTaskState,
             processExited: metadataProcessExited,
             for: paneID
@@ -874,7 +877,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             runtime: runtime
         )
 
-        updatePaneState(
+        let didPublishPaneUpdate = updatePaneState(
             paneID: pane.paneID,
             tabTitleOverride: metadata.title
         ) { current in
@@ -906,6 +909,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 viewport: viewport,
                 alanBinding: projectedBinding
             )
+        }
+        if activeTaskChanged && !didPublishPaneUpdate {
+            syncWorkspaceManifestFromShellState()
         }
     }
 
@@ -1007,18 +1013,21 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
+    @discardableResult
     private func updatePaneState(
         paneID: String,
         tabTitleOverride: String? = nil,
         transform: (ShellPane) -> ShellPane
-    ) {
-        guard let existingPane = shellState.panes.first(where: { $0.paneID == paneID }) else { return }
+    ) -> Bool {
+        guard let existingPane = shellState.panes.first(where: { $0.paneID == paneID }) else {
+            return false
+        }
         let transformedPane = transform(existingPane)
         let currentTabTitle = shellState.tab(tabID: existingPane.tabID)?.title
         let requestedTabTitle = tabTitleOverride ?? currentTabTitle
 
         guard transformedPane != existingPane || requestedTabTitle != currentTabTitle else {
-            return
+            return false
         }
 
         let updatedPanes = shellState.panes.map { pane in
@@ -1041,6 +1050,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         )
         synchronizeSelection()
         publishControlPlaneState()
+        return true
     }
 
     private func rebuildSpaces(
@@ -1369,18 +1379,23 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         return .inactive
     }
 
+    @discardableResult
     private func recordTerminalActiveTask(
         _ activeTaskState: ShellTabActiveTaskState?,
         processExited: Bool,
         for paneID: String
-    ) {
+    ) -> Bool {
+        let nextState: ShellTabActiveTaskState?
         if processExited {
-            terminalActiveTasksByPaneID[paneID] = .inactive
-            return
+            nextState = .inactive
+        } else {
+            nextState = activeTaskState
         }
 
-        guard let activeTaskState else { return }
-        terminalActiveTasksByPaneID[paneID] = activeTaskState
+        guard let nextState else { return false }
+        guard terminalActiveTasksByPaneID[paneID] != nextState else { return false }
+        terminalActiveTasksByPaneID[paneID] = nextState
+        return true
     }
 
     private func strongestTerminalActiveTask(in panes: [ShellPane]) -> ShellTabActiveTaskState? {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -812,6 +812,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 processExited: runtime.paneMetadata.processExited,
                 lastCommandExitCode: runtime.paneMetadata.lastCommandExitCode,
                 lastMetadataAt: runtime.paneMetadata.lastUpdatedAt,
+                activeTaskState: runtime.paneMetadata.activeTaskState,
                 existing: pane.context,
                 runtime: runtime
             )
@@ -868,6 +869,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             processExited: metadata.processExited,
             lastCommandExitCode: metadata.lastCommandExitCode,
             lastMetadataAt: metadata.lastUpdatedAt,
+            activeTaskState: metadata.activeTaskState,
             existing: pane.context,
             runtime: runtime
         )
@@ -927,6 +929,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             processExited: nil,
             lastCommandExitCode: pane.context?.lastCommandExitCode,
             lastMetadataAt: nil,
+            activeTaskState: runtime.paneMetadata.activeTaskState,
             existing: pane.context,
             runtime: runtime
         )
@@ -978,6 +981,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             processExited: nil,
             lastCommandExitCode: pane.context?.lastCommandExitCode,
             lastMetadataAt: nil,
+            activeTaskState: runtime.paneMetadata.activeTaskState,
             existing: pane.context,
             runtime: runtime
         )
@@ -1122,6 +1126,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 processExited: nil,
                 lastCommandExitCode: pane.context?.lastCommandExitCode,
                 lastMetadataAt: nil,
+                activeTaskState: self.runtime(for: pane.paneID).paneMetadata.activeTaskState,
                 existing: pane.context,
                 runtime: self.runtime(for: pane.paneID)
             )

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -75,13 +75,18 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     enum StartupMode {
         case fresh
         case restorePrevious
+        case workspaceManifest
     }
 
+    private static let unpinnedTabRetentionTTL: TimeInterval = 12 * 60 * 60
     private static let iso8601Formatter = ISO8601DateFormatter()
     private let fileManager: FileManager
     private let windowContext: ShellWindowContext
     private let persistenceURL: URL
     private let persistenceStore: ShellStatePersistenceStore
+    private let workspaceManifestStore: ShellWorkspaceManifestStore?
+    private var workspaceManifest: ShellWorkspaceManifest?
+    private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     private let paneProjection: ShellPaneProjectionService
     private let clipboardWriter: ShellClipboardWriter
     lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
@@ -132,7 +137,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         fileManager: FileManager = .default,
         windowContext: ShellWindowContext? = nil,
         persistenceURL: URL? = nil,
-        terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil
+        terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil,
+        workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
+        workspaceManifest: ShellWorkspaceManifest? = nil
     ) {
         self.fileManager = fileManager
         self.paneProjection = ShellPaneProjectionService(fileManager: fileManager)
@@ -143,6 +150,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             fileManager: fileManager,
             persistenceURL: self.persistenceURL
         )
+        self.workspaceManifestStore = workspaceManifestStore
+        self.workspaceManifest = workspaceManifest
         self.clipboardWriter = ShellClipboardWriter()
         self.shellState = shellState
         self.terminalRuntimeRegistry =
@@ -169,8 +178,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     static func live(
         fileManager: FileManager = .default,
         windowContext: ShellWindowContext? = nil,
-        startupMode: StartupMode = .fresh
+        startupMode: StartupMode = .fresh,
+        workspaceManifestURL: URL? = nil,
+        defaultWorkingDirectory: String? = nil,
+        now: Date = .now
     ) -> ShellHostController {
+        let usesStableWindowContext = startupMode == .restorePrevious || startupMode == .workspaceManifest
         let resolvedWindowContext =
             windowContext
             ?? ShellStatePersistenceStore.restoredWindowContext(
@@ -179,13 +192,21 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             )
             ?? ShellStatePersistenceStore.defaultWindowContext(
                 fileManager: fileManager,
-                restorePrevious: startupMode == .restorePrevious
+                restorePrevious: usesStableWindowContext
             )
         let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
+        let manifestStore: ShellWorkspaceManifestStore?
+        let manifest: ShellWorkspaceManifest?
+        let manifestRecovery: ShellWorkspaceManifestRecovery?
+        let retiredTabCount: Int
         switch startupMode {
         case .fresh:
             shellState = .bootstrapDefault(windowID: resolvedWindowContext.windowID)
+            manifestStore = nil
+            manifest = nil
+            manifestRecovery = nil
+            retiredTabCount = 0
         case .restorePrevious:
             shellState =
                 ShellStatePersistenceStore.restoreShellState(
@@ -193,16 +214,72 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     persistenceURL: persistenceURL
                 )
                 ?? .bootstrapDefault(windowID: resolvedWindowContext.windowID)
+            manifestStore = nil
+            manifest = nil
+            manifestRecovery = nil
+            retiredTabCount = 0
+        case .workspaceManifest:
+            let workingDirectory = defaultWorkingDirectory
+                ?? fileManager.homeDirectoryForCurrentUser.path
+            let store = ShellWorkspaceManifestStore(
+                fileManager: fileManager,
+                manifestURL: workspaceManifestURL
+                    ?? ShellWorkspaceManifestStore.defaultManifestURL(
+                        windowID: resolvedWindowContext.windowID,
+                        fileManager: fileManager
+                    )
+            )
+            let loadResult = try? store.loadOrCreateDefault(
+                windowID: resolvedWindowContext.windowID,
+                defaultWorkingDirectory: workingDirectory,
+                now: now
+            )
+            let loadedManifest = loadResult?.manifest
+                ?? ShellWorkspaceManifest.defaultManifest(
+                    windowID: resolvedWindowContext.windowID,
+                    defaultWorkingDirectory: workingDirectory,
+                    now: now
+                )
+            let retainedManifest = loadedManifest.pruningExpiredTabs(
+                now: now,
+                ttl: Self.unpinnedTabRetentionTTL
+            )
+            retiredTabCount = max(
+                loadedManifest.spaces.reduce(0) { $0 + $1.tabs.count }
+                    - retainedManifest.spaces.reduce(0) { $0 + $1.tabs.count },
+                0
+            )
+            if retainedManifest != loadedManifest {
+                try? store.save(retainedManifest)
+            }
+            shellState = ShellWorkspaceMaterializer.materialize(
+                manifest: retainedManifest,
+                defaultWorkingDirectory: workingDirectory,
+                now: now
+            )
+            manifestStore = store
+            manifest = retainedManifest
+            manifestRecovery = loadResult?.recovery
         }
 
         let controller = ShellHostController(
             shellState: shellState,
             fileManager: fileManager,
             windowContext: resolvedWindowContext,
-            persistenceURL: persistenceURL
+            persistenceURL: persistenceURL,
+            workspaceManifestStore: manifestStore,
+            workspaceManifest: manifest
         )
         if startupMode == .fresh {
             controller.persistShellState()
+        }
+        if let manifestRecovery {
+            controller.recordWorkspaceManifestRecovery(manifestRecovery)
+        }
+        if retiredTabCount > 0 {
+            controller.recordControlPlaneDiagnostic(
+                "workspace manifest retired \(retiredTabCount) inactive unpinned tab(s)"
+            )
         }
         return controller
     }
@@ -306,16 +383,27 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func select(spaceID: String) {
-        guard let space = shellState.spaces.first(where: { $0.spaceID == spaceID }) else { return }
-        selectedSpaceID = spaceID
-        selectedTabID = space.tabs.first?.tabID
-        terminalRuntime = runtime(for: selectedPane?.paneID)
+        guard let paneID = targetPaneID(forSpaceID: spaceID) else {
+            guard shellState.space(spaceID: spaceID) != nil else { return }
+            shellState = ShellStateSnapshot(
+                contractVersion: shellState.contractVersion,
+                windowID: shellState.windowID,
+                focusedSpaceID: spaceID,
+                focusedTabID: nil,
+                focusedPaneID: nil,
+                spaces: shellState.spaces,
+                panes: shellState.panes
+            )
+            synchronizeSelection()
+            publishControlPlaneState()
+            return
+        }
+        focus(paneID: paneID, requestTerminalFocus: true)
     }
 
     func select(tabID: String) {
-        guard selectedSpace?.tabs.contains(where: { $0.tabID == tabID }) == true else { return }
-        selectedTabID = tabID
-        terminalRuntime = runtime(for: selectedPane?.paneID)
+        guard let paneID = targetPaneID(forTabID: tabID, in: selectedSpace) else { return }
+        focus(paneID: paneID, requestTerminalFocus: true)
     }
 
     func selectSpace(at index: Int) {
@@ -337,14 +425,53 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func focusAttentionItem(_ item: ShellAttentionItem) {
-        select(spaceID: item.spaceID)
-        select(tabID: item.tabID)
-        focus(paneID: item.paneID)
+        focus(paneID: item.paneID, requestTerminalFocus: true)
     }
 
     func focus(paneID: String) {
+        focus(paneID: paneID, requestTerminalFocus: false)
+    }
+
+    private func focus(paneID: String, requestTerminalFocus: Bool) {
         guard let result = try? shellState.focusingPane(paneID) else { return }
         applyMutationResult(result)
+        if requestTerminalFocus {
+            terminalRuntimeRegistry.requestFocus(for: paneID)
+        }
+    }
+
+    private func targetPaneID(forSpaceID spaceID: String) -> String? {
+        guard let space = shellState.spaces.first(where: { $0.spaceID == spaceID }) else {
+            return nil
+        }
+        let targetTab =
+            space.tabs.first { tab in
+                guard let focusedPaneID = shellState.focusedPaneID else { return false }
+                return tab.contains(paneID: focusedPaneID)
+            }
+            ?? space.tabs.first
+        return targetTab.flatMap(targetPaneID)
+    }
+
+    private func targetPaneID(
+        forTabID tabID: String,
+        in space: ShellSpace?
+    ) -> String? {
+        guard let tab = space?.tabs.first(where: { $0.tabID == tabID }) else {
+            return nil
+        }
+        return targetPaneID(for: tab)
+    }
+
+    private func targetPaneID(for tab: ShellTab) -> String? {
+        if let focusedPaneID = shellState.focusedPaneID,
+           tab.contains(paneID: focusedPaneID)
+        {
+            return focusedPaneID
+        }
+        return tab.paneTree.paneIDs.first { paneID in
+            pane(paneID: paneID)?.tabID == tab.tabID
+        }
     }
 
     func requestCommandInput() {
@@ -384,6 +511,61 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @discardableResult
     func createAlanSpace(title: String? = nil, workingDirectory: String? = nil) -> String? {
         createSpace(launchTarget: .alan, title: title, workingDirectory: workingDirectory)
+    }
+
+    @discardableResult
+    func deleteSpace(spaceID: String) -> Bool {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.deletingSpace(spaceID)
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
+    }
+
+    func isTabPinned(tabID: String) -> Bool {
+        workspaceManifest?
+            .spaces
+            .flatMap(\.tabs)
+            .first { $0.tabID == tabID }?
+            .isPinned == true
+    }
+
+    @discardableResult
+    func pinTab(tabID: String? = nil) -> Bool {
+        guard let targetTabID = tabID ?? selectedTabID else { return false }
+        return updateWorkspaceManifestTab(tabID: targetTabID) { tab, snapshot in
+            tab.isPinned = true
+            tab.pinSnapshot = snapshot
+            tab.liveSnapshot = snapshot
+        } diagnostic: {
+            "workspace manifest pinned tab: \($0)"
+        }
+    }
+
+    @discardableResult
+    func unpinTab(tabID: String? = nil) -> Bool {
+        guard let targetTabID = tabID ?? selectedTabID else { return false }
+        return updateWorkspaceManifestTab(tabID: targetTabID) { tab, _ in
+            tab.isPinned = false
+            tab.pinSnapshot = nil
+        } diagnostic: {
+            "workspace manifest unpinned tab: \($0)"
+        }
+    }
+
+    @discardableResult
+    func updatePinnedTabSnapshot(tabID: String? = nil) -> Bool {
+        guard let targetTabID = tabID ?? selectedTabID else { return false }
+        guard isTabPinned(tabID: targetTabID) else { return false }
+        return updateWorkspaceManifestTab(tabID: targetTabID) { tab, snapshot in
+            tab.pinSnapshot = snapshot
+            tab.liveSnapshot = snapshot
+        } diagnostic: {
+            "workspace manifest updated pinned tab: \($0)"
+        }
     }
 
     @discardableResult
@@ -618,6 +800,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 metadataProcessExited: runtime.paneMetadata.processExited,
                 surfaceState: runtime.surfaceState
             ) ?? runtime.paneMetadata.processExited
+            recordTerminalActiveTask(
+                runtime.paneMetadata.activeTaskState,
+                processExited: runtimeProcessExited,
+                for: paneID
+            )
             let projectedContext = paneProjection.projectedContext(
                 for: pane,
                 bootProfile: bootProfile,
@@ -669,6 +856,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             metadataProcessExited: metadata.processExited,
             surfaceState: runtime.surfaceState
         ) ?? metadata.processExited
+        recordTerminalActiveTask(
+            metadata.activeTaskState,
+            processExited: metadataProcessExited,
+            for: paneID
+        )
         let projectedContext = paneProjection.projectedContext(
             for: pane,
             bootProfile: bootProfile,
@@ -988,13 +1180,245 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return
         }
 
-        selectedSpaceID = selectedSpaceID ?? shellState.spaces.first?.spaceID
-        selectedTabID = selectedTabID ?? selectedSpace?.tabs.first?.tabID
+        selectedSpaceID = shellState.focusedSpaceID ?? selectedSpaceID ?? shellState.spaces.first?.spaceID
+        selectedTabID = shellState.focusedTabID ?? selectedSpace?.tabs.first?.tabID
         terminalRuntime = runtime(for: selectedPane?.paneID)
     }
 
     private func persistShellState() {
         persistenceStore.save(shellState)
+    }
+
+    private func syncWorkspaceManifestFromShellState(now: Date = .now) {
+        guard let workspaceManifestStore else { return }
+
+        let nextManifest = makeWorkspaceManifestFromShellState(now: now)
+        do {
+            try workspaceManifestStore.save(nextManifest)
+            workspaceManifest = nextManifest
+        } catch {
+            recordControlPlaneDiagnostic("workspace manifest save failed: \(error)")
+        }
+    }
+
+    private func updateWorkspaceManifestTab(
+        tabID: String,
+        mutate: (inout ShellWorkspaceTabRecord, ShellTabRestoreSnapshot) -> Void,
+        diagnostic: (String) -> String
+    ) -> Bool {
+        guard let tab = shellState.tab(tabID: tabID),
+              let workspaceManifestStore
+        else {
+            return false
+        }
+
+        let panes = shellState.panes(in: tabID)
+        let snapshot = makeRestoreSnapshot(for: tab, panes: panes)
+        var manifest = makeWorkspaceManifestFromShellState(now: .now)
+        var didUpdate = false
+
+        for spaceIndex in manifest.spaces.indices {
+            guard let tabIndex = manifest.spaces[spaceIndex].tabs.firstIndex(where: { $0.tabID == tabID }) else {
+                continue
+            }
+            mutate(&manifest.spaces[spaceIndex].tabs[tabIndex], snapshot)
+            didUpdate = true
+            break
+        }
+
+        guard didUpdate else { return false }
+
+        do {
+            try workspaceManifestStore.save(manifest)
+            workspaceManifest = manifest
+            objectWillChange.send()
+            recordControlPlaneDiagnostic(diagnostic(tabID))
+            return true
+        } catch {
+            recordControlPlaneDiagnostic("workspace manifest save failed: \(error)")
+            return false
+        }
+    }
+
+    private func makeWorkspaceManifestFromShellState(now: Date) -> ShellWorkspaceManifest {
+        let existingSpaces = Dictionary(
+            uniqueKeysWithValues: (workspaceManifest?.spaces ?? []).map { ($0.spaceID, $0) }
+        )
+        let existingTabs = Dictionary(
+            uniqueKeysWithValues: (workspaceManifest?.spaces ?? [])
+                .flatMap(\.tabs)
+                .map { ($0.tabID, $0) }
+        )
+
+        let spaces = shellState.spaces.enumerated().map { index, space -> ShellWorkspaceSpaceRecord in
+            let existingSpace = existingSpaces[space.spaceID]
+            let tabRecords = space.tabs.map { tab -> ShellWorkspaceTabRecord in
+                let existingTab = existingTabs[tab.tabID]
+                let panes = shellState.panes(in: tab.tabID)
+                let snapshot = makeRestoreSnapshot(for: tab, panes: panes)
+                let paneActivityAt = panes.compactMap { paneActivityDate($0) }.max()
+                let lastActivatedAt = tab.tabID == shellState.focusedTabID
+                    ? now
+                    : (existingTab?.lastActivatedAt ?? now)
+                let lastActivityAt = max(
+                    existingTab?.lastActivityAt ?? now,
+                    paneActivityAt ?? existingTab?.lastActivityAt ?? now
+                )
+
+                return ShellWorkspaceTabRecord(
+                    tabID: tab.tabID,
+                    title: tab.title,
+                    kind: tab.kind,
+                    createdAt: existingTab?.createdAt ?? now,
+                    lastActivatedAt: lastActivatedAt,
+                    lastActivityAt: lastActivityAt,
+                    isPinned: existingTab?.isPinned ?? false,
+                    pinSnapshot: existingTab?.pinSnapshot,
+                    liveSnapshot: snapshot,
+                    activeTask: projectedActiveTask(for: tab, panes: panes)
+                )
+            }
+
+            return ShellWorkspaceSpaceRecord(
+                spaceID: space.spaceID,
+                title: space.title,
+                order: existingSpace?.order ?? index,
+                createdAt: existingSpace?.createdAt ?? now,
+                updatedAt: now,
+                tabs: tabRecords
+            )
+        }
+
+        var manifest = ShellWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            windowID: shellState.windowID,
+            selectedSpaceID: shellState.focusedSpaceID ?? selectedSpaceID,
+            selectedTabID: shellState.focusedTabID,
+            spaces: spaces
+        )
+        manifest.repairSelection()
+        return manifest
+    }
+
+    private func makeRestoreSnapshot(
+        for tab: ShellTab,
+        panes: [ShellPane]
+    ) -> ShellTabRestoreSnapshot {
+        let paneByID = Dictionary(uniqueKeysWithValues: panes.map { ($0.paneID, $0) })
+        let restorePanes = tab.paneTree.paneIDs.compactMap { paneID -> ShellPaneRestoreRecord? in
+            guard let pane = paneByID[paneID] else { return nil }
+            return ShellPaneRestoreRecord(
+                paneID: pane.paneID,
+                launchTarget: pane.resolvedLaunchTarget,
+                cwd: pane.cwd,
+                title: pane.viewport?.title ?? tab.title
+            )
+        }
+        return ShellTabRestoreSnapshot(paneTree: tab.paneTree, panes: restorePanes)
+    }
+
+    private func paneActivityDate(_ pane: ShellPane) -> Date? {
+        if let lastActivityAt = pane.viewport?.lastActivityAt,
+           let date = Self.iso8601Formatter.date(from: lastActivityAt)
+        {
+            return date
+        }
+
+        if let lastMetadataAt = pane.context?.lastMetadataAt,
+           let date = Self.iso8601Formatter.date(from: lastMetadataAt)
+        {
+            return date
+        }
+
+        return nil
+    }
+
+    private func projectedActiveTask(
+        for tab: ShellTab,
+        panes: [ShellPane]
+    ) -> ShellTabActiveTaskState {
+        if let terminalActiveTask = strongestTerminalActiveTask(
+            in: panes.filter { tab.contains(paneID: $0.paneID) }
+        ),
+           terminalActiveTask.protectsFromPruning
+        {
+            return terminalActiveTask
+        }
+
+        for pane in panes where tab.contains(paneID: pane.paneID) {
+            if pane.alanBinding?.pendingYield == true {
+                return .alanPendingYield
+            }
+
+            if let runStatus = pane.alanBinding?.runStatus,
+               !Self.inactiveAlanRunStatuses.contains(runStatus.lowercased())
+            {
+                return .alanRunning
+            }
+
+            if pane.context?.processState == "foreground_command" {
+                return .foregroundCommand
+            }
+        }
+
+        return .inactive
+    }
+
+    private func recordTerminalActiveTask(
+        _ activeTaskState: ShellTabActiveTaskState?,
+        processExited: Bool,
+        for paneID: String
+    ) {
+        if processExited {
+            terminalActiveTasksByPaneID[paneID] = .inactive
+            return
+        }
+
+        guard let activeTaskState else { return }
+        terminalActiveTasksByPaneID[paneID] = activeTaskState
+    }
+
+    private func strongestTerminalActiveTask(in panes: [ShellPane]) -> ShellTabActiveTaskState? {
+        panes
+            .compactMap { terminalActiveTasksByPaneID[$0.paneID] }
+            .max { activeTaskRank($0) < activeTaskRank($1) }
+    }
+
+    private func activeTaskRank(_ state: ShellTabActiveTaskState) -> Int {
+        switch state {
+        case .inactive:
+            return 0
+        case .unknown:
+            return 1
+        case .foregroundCommand:
+            return 2
+        case .alanRunning:
+            return 3
+        case .alanSession:
+            return 4
+        case .alanPendingYield:
+            return 5
+        }
+    }
+
+    private static let inactiveAlanRunStatuses: Set<String> = [
+        "completed",
+        "failed",
+        "cancelled",
+        "canceled",
+        "exited",
+        "idle",
+    ]
+
+    private func recordWorkspaceManifestRecovery(_ recovery: ShellWorkspaceManifestRecovery) {
+        switch recovery {
+        case .loadedExisting:
+            return
+        case .createdDefault:
+            recordControlPlaneDiagnostic("workspace manifest created default")
+        case .quarantinedCorruptFile(let url):
+            recordControlPlaneDiagnostic("workspace manifest corrupt file quarantined: \(url.path)")
+        }
     }
 
     func pane(paneID: String) -> ShellPane? {
@@ -1089,6 +1513,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func publishControlPlaneState() {
+        syncWorkspaceManifestFromShellState()
         persistShellState()
         controlPlane.publish(state: shellState)
     }

--- a/clients/apple/alan-macos/Support/ShellDesignTokens.swift
+++ b/clients/apple/alan-macos/Support/ShellDesignTokens.swift
@@ -243,13 +243,18 @@ enum ShellSidebarMetrics {
 enum ShellWorkspaceMetrics {
     static let terminalSurfaceInset: CGFloat = 8
 
-    static func terminalSurfaceInsets(hasExpandedSidebar: Bool) -> EdgeInsets {
-        EdgeInsets(
+    static func terminalSurfaceInsets(expandedSidebarProgress: CGFloat) -> EdgeInsets {
+        let progress = min(max(expandedSidebarProgress, 0), 1)
+        return EdgeInsets(
             top: terminalSurfaceInset,
-            leading: hasExpandedSidebar ? 0 : terminalSurfaceInset,
+            leading: terminalSurfaceInset * (1 - progress),
             bottom: terminalSurfaceInset,
             trailing: terminalSurfaceInset
         )
+    }
+
+    static func terminalSurfaceInsets(hasExpandedSidebar: Bool) -> EdgeInsets {
+        terminalSurfaceInsets(expandedSidebarProgress: hasExpandedSidebar ? 1 : 0)
     }
 }
 

--- a/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift
@@ -16,24 +16,53 @@ struct ShellSidebarSwipeUpdate {
     let velocityX: CGFloat
 }
 
-struct ShellSpaceTransition: Equatable {
-    let sourceSpaceID: String
-    var targetSpaceID: String?
-    var direction: Int
-    var offsetX: CGFloat
-    var progress: CGFloat
-    var isSettling: Bool
+enum ShellSpacePagerSettlementPhase: Equatable {
+    case dragging
+    case settlingToSource
+    case settlingToTarget
+}
+
+struct ShellSpacePagerState: Equatable {
+    let sourceIndex: Int
+    var targetIndex: Int?
+    var dragOffset: CGFloat
+    var pageWidth: CGFloat
+    var settlementPhase: ShellSpacePagerSettlementPhase
+
+    var isSettling: Bool {
+        settlementPhase != .dragging
+    }
 
     var isEdgeResistance: Bool {
-        targetSpaceID == nil
+        targetIndex == nil
     }
 
-    func sourceOffset(in width: CGFloat) -> CGFloat {
-        offsetX
+    var committedTargetIndex: Int? {
+        guard settlementPhase == .settlingToTarget else { return nil }
+        return targetIndex
     }
 
-    func targetOffset(in width: CGFloat) -> CGFloat {
-        offsetX + CGFloat(direction) * width
+    var direction: Int {
+        guard let targetIndex else {
+            return dragOffset < 0 ? 1 : -1
+        }
+        return targetIndex >= sourceIndex ? 1 : -1
+    }
+
+    var progress: CGFloat {
+        let width = max(pageWidth, 1)
+        return min(abs(dragOffset) / width, 0.98)
+    }
+
+    var pageIndicesForRendering: [Int] {
+        guard let targetIndex, targetIndex != sourceIndex else {
+            return [sourceIndex]
+        }
+        return [sourceIndex, targetIndex]
+    }
+
+    func offset(for index: Int) -> CGFloat {
+        CGFloat(index - sourceIndex) * max(pageWidth, 1) + dragOffset
     }
 }
 

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -600,6 +600,27 @@ struct TerminalPaneMetadataSnapshot: Equatable {
     let processExited: Bool
     let lastCommandExitCode: Int?
     let lastUpdatedAt: Date?
+    let activeTaskState: ShellTabActiveTaskState?
+
+    init(
+        title: String?,
+        workingDirectory: String?,
+        summary: String?,
+        attention: ShellAttentionState,
+        processExited: Bool,
+        lastCommandExitCode: Int?,
+        lastUpdatedAt: Date?,
+        activeTaskState: ShellTabActiveTaskState? = nil
+    ) {
+        self.title = title
+        self.workingDirectory = workingDirectory
+        self.summary = summary
+        self.attention = attention
+        self.processExited = processExited
+        self.lastCommandExitCode = lastCommandExitCode
+        self.lastUpdatedAt = lastUpdatedAt
+        self.activeTaskState = activeTaskState
+    }
 
     static let placeholder = TerminalPaneMetadataSnapshot(
         title: nil,

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -610,7 +610,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         processExited: Bool,
         lastCommandExitCode: Int?,
         lastUpdatedAt: Date?,
-        activeTaskState: ShellTabActiveTaskState? = nil
+        activeTaskState: ShellTabActiveTaskState? = .inactive
     ) {
         self.title = title
         self.workingDirectory = workingDirectory
@@ -629,7 +629,8 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         attention: .idle,
         processExited: false,
         lastCommandExitCode: nil,
-        lastUpdatedAt: nil
+        lastUpdatedAt: nil,
+        activeTaskState: .inactive
     )
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -3,7 +3,24 @@ import SwiftUI
 #if os(macOS)
 struct TerminalPaneView: View {
     @ObservedObject var host: ShellHostController
+    let tab: ShellTab?
+    let spaceID: String?
+    let selectedPaneID: String?
     let terminalSurfaceInsets: EdgeInsets
+
+    init(
+        host: ShellHostController,
+        tab: ShellTab? = nil,
+        spaceID: String? = nil,
+        selectedPaneID: String? = nil,
+        terminalSurfaceInsets: EdgeInsets
+    ) {
+        self.host = host
+        self.tab = tab
+        self.spaceID = spaceID
+        self.selectedPaneID = selectedPaneID
+        self.terminalSurfaceInsets = terminalSurfaceInsets
+    }
 
     var body: some View {
         paneCanvas
@@ -13,26 +30,55 @@ struct TerminalPaneView: View {
 
     private var paneCanvas: some View {
         Group {
-            if let paneTree = host.selectedTabPaneTree {
+            if let paneTree = displayTab?.paneTree {
                 ShellPaneTreeLayoutView(
                     node: paneTree,
-                    host: host
+                    host: host,
+                    selectedPaneID: displaySelectedPaneID
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             } else {
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("No tab selected")
-                        .font(.system(size: 18, weight: .semibold))
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Empty Space")
+                        .font(.system(size: 17, weight: .semibold))
                         .foregroundStyle(ShellPalette.ink)
-                    Text("Open a tab to start a new shell here.")
-                        .font(.system(size: 14, weight: .medium))
+                    Text("Start a terminal in this space.")
+                        .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(ShellPalette.mutedInk)
+                    Button {
+                        _ = host.openTerminalTab(in: displaySpaceID)
+                    } label: {
+                        Label("New Tab", systemImage: "plus")
+                            .font(.system(size: 12, weight: .semibold))
+                            .padding(.horizontal, 11)
+                            .frame(height: 28)
+                    }
+                    .buttonStyle(.plain)
+                    .background {
+                        ShellMaterialShape(
+                            role: .controlGlassHover,
+                            shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                        )
+                    }
+                    .help("Create a tab in this space")
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding(28)
             }
         }
         .modifier(ShellTerminalSurfaceFrame())
+    }
+
+    private var displayTab: ShellTab? {
+        tab ?? host.selectedTab
+    }
+
+    private var displaySpaceID: String? {
+        spaceID ?? host.selectedSpace?.spaceID
+    }
+
+    private var displaySelectedPaneID: String? {
+        selectedPaneID ?? host.selectedPane?.paneID
     }
 
     private var runtimeCard: some View {
@@ -362,6 +408,7 @@ private struct ShellTerminalSurfaceFrame: ViewModifier {
 private struct ShellPaneTreeLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
+    let selectedPaneID: String?
 
     var body: some View {
         switch node.kind {
@@ -371,7 +418,7 @@ private struct ShellPaneTreeLayoutView: View {
                 ShellTerminalLeafView(
                     pane: pane,
                     bootProfile: host.bootProfile(for: pane),
-                    isSelected: host.selectedPane?.paneID == pane.paneID,
+                    isSelected: selectedPaneID == pane.paneID,
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     activationDelegate: host,
                     onWorkspaceCommand: { command in
@@ -390,7 +437,7 @@ private struct ShellPaneTreeLayoutView: View {
                 )
             }
         case .split:
-            ShellSplitLayoutView(node: node, host: host)
+            ShellSplitLayoutView(node: node, host: host, selectedPaneID: selectedPaneID)
         }
     }
 }
@@ -398,6 +445,7 @@ private struct ShellPaneTreeLayoutView: View {
 private struct ShellSplitLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
+    let selectedPaneID: String?
     @State private var dragStartRatio: Double?
     @State private var dragPreviewRatio: Double?
 
@@ -410,20 +458,36 @@ private struct ShellSplitLayoutView: View {
             GeometryReader { proxy in
                 if node.direction == .vertical {
                     HStack(spacing: 0) {
-                        ShellPaneTreeLayoutView(node: children[0], host: host)
+                        ShellPaneTreeLayoutView(
+                            node: children[0],
+                            host: host,
+                            selectedPaneID: selectedPaneID
+                        )
                             .frame(width: primaryLength(total: proxy.size.width))
                         ShellSplitDividerView(direction: .vertical)
                             .gesture(resizeGesture(totalLength: proxy.size.width))
-                        ShellPaneTreeLayoutView(node: children[1], host: host)
+                        ShellPaneTreeLayoutView(
+                            node: children[1],
+                            host: host,
+                            selectedPaneID: selectedPaneID
+                        )
                             .frame(width: secondaryLength(total: proxy.size.width))
                     }
                 } else {
                     VStack(spacing: 0) {
-                        ShellPaneTreeLayoutView(node: children[0], host: host)
+                        ShellPaneTreeLayoutView(
+                            node: children[0],
+                            host: host,
+                            selectedPaneID: selectedPaneID
+                        )
                             .frame(height: primaryLength(total: proxy.size.height))
                         ShellSplitDividerView(direction: .horizontal)
                             .gesture(resizeGesture(totalLength: proxy.size.height))
-                        ShellPaneTreeLayoutView(node: children[1], host: host)
+                        ShellPaneTreeLayoutView(
+                            node: children[1],
+                            host: host,
+                            selectedPaneID: selectedPaneID
+                        )
                             .frame(height: secondaryLength(total: proxy.size.height))
                     }
                 }
@@ -445,7 +509,11 @@ private struct ShellSplitLayoutView: View {
             if index > 0 {
                 ShellSplitDividerView(direction: node.direction ?? .vertical)
             }
-            ShellPaneTreeLayoutView(node: child, host: host)
+            ShellPaneTreeLayoutView(
+                node: child,
+                host: host,
+                selectedPaneID: selectedPaneID
+            )
         }
     }
 

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -553,7 +553,8 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             attention: currentSnapshot.metadata.attention,
             processExited: currentSnapshot.metadata.processExited,
             lastCommandExitCode: currentSnapshot.metadata.lastCommandExitCode,
-            lastUpdatedAt: currentSnapshot.metadata.lastUpdatedAt
+            lastUpdatedAt: currentSnapshot.metadata.lastUpdatedAt,
+            activeTaskState: currentSnapshot.metadata.activeTaskState
         )
     }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -4,8 +4,10 @@ import SwiftUI
 struct ShellSidebarView: View {
     @ObservedObject var host: ShellHostController
     let chromeMetrics: ShellWindowChromeMetrics
-    let spaceTransition: ShellSpaceTransition?
+    let displaySpaceID: String?
+    let previewedSpaceID: String?
     let isSpaceSwipeGestureLocked: Bool
+    let isSwipeEnabled: Bool
     let onSpaceSwipe: (ShellSidebarSwipeUpdate) -> Void
     let openCommandTab: () -> Void
     @State private var hoveredTabID: String?
@@ -14,11 +16,11 @@ struct ShellSidebarView: View {
     @State private var tabListScrollOffsetY: CGFloat = 0
 
     var body: some View {
-        GeometryReader { proxy in
-            sidebarContent(pageWidth: max(proxy.size.width, 1))
-        }
+        sidebarContent
         .background {
-            ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
+            if isSwipeEnabled {
+                ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
+            }
         }
         .scrollDisabled(isTabListScrollDisabled)
         .onChange(of: sourceSpaceID) { _, _ in
@@ -26,14 +28,14 @@ struct ShellSidebarView: View {
         }
     }
 
-    private func sidebarContent(pageWidth: CGFloat) -> some View {
+    private var sidebarContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             commandLauncher
                 .padding(.horizontal, ShellSidebarMetrics.edgeInset)
                 .padding(.bottom, 10)
-            spaceLabelRow(pageWidth: pageWidth)
+            spaceLabelRow
                 .padding(.bottom, 2)
-            tabSection(pageWidth: pageWidth)
+            tabSection
             spaceDock
                 .padding(.horizontal, ShellSidebarMetrics.edgeInset)
                 .padding(.top, 10)
@@ -43,11 +45,10 @@ struct ShellSidebarView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private func spaceLabelRow(pageWidth: CGFloat) -> some View {
-        ShellSidebarSpaceHeaderPager(
+    private var spaceLabelRow: some View {
+        ShellSidebarSpaceHeader(
             host: host,
-            transition: activeTransition,
-            pageWidth: pageWidth
+            spaceID: sourceSpaceID
         )
         .frame(maxWidth: .infinity)
         .frame(height: 28)
@@ -90,26 +91,13 @@ struct ShellSidebarView: View {
         ShellPalette.sidebarMutedInk.opacity(isCommandLauncherHovered ? 0.92 : 0.80)
     }
 
-    private func tabSection(pageWidth: CGFloat) -> some View {
+    private var tabSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            GeometryReader { proxy in
-                ZStack(alignment: .topLeading) {
-                    tabListPage(for: sourceSpaceID)
-                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
-                        .offset(x: sourceOffset(in: pageWidth))
-
-                    if let targetSpaceID = activeTransition?.targetSpaceID {
-                        tabListPage(for: targetSpaceID)
-                            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
-                            .offset(x: targetOffset(in: pageWidth))
-                            .allowsHitTesting(false)
-                    }
-                }
-                .clipped()
+            tabListPage(for: sourceSpaceID)
                 .overlay(alignment: .top) {
                     ShellSidebarScrollBoundary(progress: tabListBoundaryProgress)
                 }
-            }
+                .clipped()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -131,7 +119,7 @@ struct ShellSidebarView: View {
                             title: "New Tab",
                             systemImage: "plus",
                             action: {
-                                _ = host.openTerminalTab()
+                                _ = host.openTerminalTab(in: space.spaceID)
                             }
                         )
                         .help("Create a tab in this space")
@@ -176,7 +164,7 @@ struct ShellSidebarView: View {
                                 attention: space.attention,
                                 tabCount: space.tabs.count,
                                 isSelected: host.selectedSpace?.spaceID == space.spaceID,
-                                isPreviewed: activeTransition?.targetSpaceID == space.spaceID,
+                                isPreviewed: previewedSpaceID == space.spaceID,
                                 isHovered: hoveredSpaceID == space.spaceID
                             )
                         }
@@ -216,29 +204,12 @@ struct ShellSidebarView: View {
         _ = host.createTerminalSpace()
     }
 
-    private var activeTransition: ShellSpaceTransition? {
-        guard let spaceTransition,
-              spaceTransition.sourceSpaceID == host.selectedSpace?.spaceID
-        else {
-            return nil
-        }
-        return spaceTransition
-    }
-
     private var isTabListScrollDisabled: Bool {
-        isSpaceSwipeGestureLocked || activeTransition != nil
+        isSpaceSwipeGestureLocked
     }
 
     private var sourceSpaceID: String? {
-        activeTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
-    }
-
-    private func sourceOffset(in width: CGFloat) -> CGFloat {
-        activeTransition?.sourceOffset(in: width) ?? 0
-    }
-
-    private func targetOffset(in width: CGFloat) -> CGFloat {
-        activeTransition?.targetOffset(in: width) ?? 0
+        displaySpaceID ?? host.selectedSpace?.spaceID
     }
 
     private var tabListBoundaryProgress: CGFloat {
@@ -282,6 +253,7 @@ struct ShellSidebarView: View {
             attention: strongestAttention(for: tab),
             showsAlanMarker: showsAlanMarker(for: tab),
             splitSummary: splitSummary(for: tab),
+            isPinned: host.isTabPinned(tabID: tab.tabID),
             isSelected: isSelected,
             isHovered: isHovered,
             showsCloseAffordance: isHovered,
@@ -306,6 +278,19 @@ struct ShellSidebarView: View {
             }
             Button("Open in alan") {
                 _ = host.openAlanTab()
+            }
+            Divider()
+            if host.isTabPinned(tabID: tab.tabID) {
+                Button("Update Pin") {
+                    _ = host.updatePinnedTabSnapshot(tabID: tab.tabID)
+                }
+                Button("Unpin Tab") {
+                    _ = host.unpinTab(tabID: tab.tabID)
+                }
+            } else {
+                Button("Pin Tab") {
+                    _ = host.pinTab(tabID: tab.tabID)
+                }
             }
             Divider()
             Button("Close Tab", role: .destructive) {
@@ -483,40 +468,14 @@ private struct ShellSidebarScrollBoundary: View {
     }
 }
 
-private struct ShellSidebarSpaceHeaderPager: View {
+private struct ShellSidebarSpaceHeader: View {
     @ObservedObject var host: ShellHostController
-    let transition: ShellSpaceTransition?
-    let pageWidth: CGFloat
+    let spaceID: String?
 
     var body: some View {
-        GeometryReader { proxy in
-            ZStack(alignment: .leading) {
-                headerPage(for: sourceSpaceID)
-                    .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
-                    .offset(x: sourceOffset(in: pageWidth))
-
-                if let targetSpaceID = activeTransition?.targetSpaceID {
-                    headerPage(for: targetSpaceID)
-                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
-                        .offset(x: targetOffset(in: pageWidth))
-                }
-            }
-            .clipped()
-        }
+        headerPage(for: spaceID)
+            .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 26)
-    }
-
-    private var activeTransition: ShellSpaceTransition? {
-        guard let transition,
-              transition.sourceSpaceID == host.selectedSpace?.spaceID
-        else {
-            return nil
-        }
-        return transition
-    }
-
-    private var sourceSpaceID: String? {
-        activeTransition?.sourceSpaceID ?? host.selectedSpace?.spaceID
     }
 
     private func headerPage(for spaceID: String?) -> some View {
@@ -537,14 +496,6 @@ private struct ShellSidebarSpaceHeaderPager: View {
         .padding(.leading, ShellSidebarMetrics.edgeInset)
         .padding(.trailing, ShellSidebarMetrics.edgeInset)
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func sourceOffset(in width: CGFloat) -> CGFloat {
-        activeTransition?.sourceOffset(in: width) ?? 0
-    }
-
-    private func targetOffset(in width: CGFloat) -> CGFloat {
-        activeTransition?.targetOffset(in: width) ?? 0
     }
 
     private func space(for spaceID: String?) -> ShellSpace? {
@@ -731,6 +682,7 @@ private struct ShellTabSidebarRow: View {
     let attention: ShellAttentionState?
     let showsAlanMarker: Bool
     let splitSummary: ShellTabSplitSummary?
+    let isPinned: Bool
     let isSelected: Bool
     let isHovered: Bool
     let showsCloseAffordance: Bool
@@ -757,6 +709,13 @@ private struct ShellTabSidebarRow: View {
                             Image(systemName: "sparkles")
                                 .font(.system(size: 9, weight: .bold))
                                 .foregroundStyle(ShellPalette.accent)
+                        }
+
+                        if isPinned {
+                            Image(systemName: "pin.fill")
+                                .font(.system(size: 8.5, weight: .bold))
+                                .foregroundStyle(ShellPalette.accent.opacity(isSelected ? 0.84 : 0.64))
+                                .help("Pinned tab")
                         }
                     }
 
@@ -853,6 +812,9 @@ private struct ShellTabSidebarRow: View {
         }
         if let splitSummary {
             parts.append("\(splitSummary.paneCount) panes")
+        }
+        if isPinned {
+            parts.append("pinned")
         }
         return parts.joined(separator: ", ")
     }

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -3,16 +3,69 @@ import SwiftUI
 #if os(macOS)
 struct ShellWorkspaceView: View {
     @ObservedObject var host: ShellHostController
-    let hasExpandedSidebar: Bool
+    let expandedSidebarProgress: CGFloat
+    let spaceID: String?
+    let selectedPaneID: String?
+
+    init(
+        host: ShellHostController,
+        expandedSidebarProgress: CGFloat,
+        spaceID: String? = nil,
+        selectedPaneID: String? = nil
+    ) {
+        self.host = host
+        self.expandedSidebarProgress = expandedSidebarProgress
+        self.spaceID = spaceID
+        self.selectedPaneID = selectedPaneID
+    }
 
     var body: some View {
         TerminalPaneView(
             host: host,
+            tab: displayTab,
+            spaceID: displaySpace?.spaceID,
+            selectedPaneID: displaySelectedPaneID,
             terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
-                hasExpandedSidebar: hasExpandedSidebar
+                expandedSidebarProgress: expandedSidebarProgress
             )
         )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var displaySpace: ShellSpace? {
+        guard let spaceID else { return host.selectedSpace }
+        return host.spaces.first { $0.spaceID == spaceID }
+    }
+
+    private var displayTab: ShellTab? {
+        guard let displaySpace else { return host.selectedTab }
+        if displaySpace.spaceID == host.selectedSpace?.spaceID,
+           let selectedTab = host.selectedTab,
+           displaySpace.tabs.contains(where: { $0.tabID == selectedTab.tabID })
+        {
+            return selectedTab
+        }
+        if let selectedPaneID,
+           let tab = displaySpace.tabs.first(where: { $0.contains(paneID: selectedPaneID) })
+        {
+            return tab
+        }
+        return displaySpace.tabs.first
+    }
+
+    private var displaySelectedPaneID: String? {
+        if let selectedPaneID,
+           displayTab?.contains(paneID: selectedPaneID) == true
+        {
+            return selectedPaneID
+        }
+        if displayTab?.tabID == host.selectedTab?.tabID,
+           let selectedPaneID = host.selectedPane?.paneID,
+           displayTab?.contains(paneID: selectedPaneID) == true
+        {
+            return selectedPaneID
+        }
+        return displayTab?.paneTree.paneIDs.first
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -239,6 +239,36 @@ require_pattern \
     "shell runtime tests must prove sidebar status prioritizes exit and renderer health"
 
 require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
+    "shell-workspace-" \
+    "workspace restore authority must use the ShellWorkspaceManifest store filename"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "case \\.workspaceManifest:" \
+    "shell host startup must have a workspace-manifest restore path"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "ShellWorkspaceMaterializer\\.materialize" \
+    "workspace-manifest startup must materialize shell state from the manifest"
+
+require_pattern \
+    "clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift" \
+    "startupMode: \\.workspaceManifest" \
+    "primary macOS shell must start from the workspace manifest"
+
+reject_pattern \
+    "clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift" \
+    "startupMode: \\.fresh|startupMode: \\.restorePrevious|restoreShellState|ShellStatePersistenceStore" \
+    "primary macOS shell must not restore workspace identity from ShellStateSnapshot"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-workspace-manifest.swift" \
+    "verifiesMissingManifestCreatesDefaultWithoutMigratingShellState" \
+    "workspace manifest tests must prove legacy ShellStateSnapshot is not migrated"
+
+require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.sh" \
     "TerminalSurfaceController.swift" \
     "surface controller behavior tests must compile the controller boundary"
@@ -565,13 +595,23 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
-    "ShellWorkspaceView\\(host: host, hasExpandedSidebar: !isSidebarCollapsed\\)" \
-    "mac shell root must pass expanded sidebar state into workspace spacing"
+    "pinnedSidebarPresentationProgress" \
+    "pinned sidebar collapse must be driven by continuous presentation progress"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "hasExpandedSidebar: Bool" \
-    "workspace view must expose sidebar-aware terminal surface spacing"
+    "expandedSidebarProgress" \
+    "workspace view must expose continuous sidebar progress for terminal surface spacing"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "frame\\(width: sidebarPinnedVisibleWidth" \
+    "pinned sidebar must stay mounted while visible width animates"
+
+reject_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "if !isSidebarCollapsed \\{" \
+    "pinned sidebar must not be conditionally inserted or removed"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
@@ -590,8 +630,63 @@ reject_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
-    "terminalSurfaceInsets\\(hasExpandedSidebar" \
-    "terminal workspace surface insets must account for expanded sidebar adjacency"
+    "terminalSurfaceInsets\\(expandedSidebarProgress" \
+    "terminal workspace surface insets must support continuous sidebar progress"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "struct ShellSpacePagerState" \
+    "space swipes must use a root pager state instead of a sidebar-only transition"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "sourceIndex" \
+    "space pager state must track the authoritative source space index"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "targetIndex" \
+    "space pager state must track the adjacent target space index"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "settlementPhase" \
+    "space pager state must model drag, commit, and cancel settlement phases"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "spacePager" \
+    "mac shell root must own space pager state for sidebar and workspace motion"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "spacePage\\(index:" \
+    "mac shell root must render whole space pages from the shared pager offset"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
+    "spaceID: String\\?" \
+    "workspace view must accept an explicit space for pager preview pages"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "selectedPaneID: String\\?" \
+    "terminal pane view must render preview pages without borrowing selected-pane state"
+
+reject_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "ShellSpaceTransition" \
+    "space swipe support must not reintroduce the sidebar-only transition model"
+
+reject_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "ShellSpaceTransition|spaceTransition" \
+    "mac shell root must use shared space pager state instead of sidebar-only transition state"
+
+reject_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "ShellSidebarSpaceHeaderPager|activeTransition|sourceOffset\\(|targetOffset\\(" \
+    "sidebar view must not own independent header/tab-list pager semantics"
 
 require_pattern \
     "clients/apple/scripts/test-shell-window-placement.swift" \
@@ -717,6 +812,31 @@ require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \
     "weak var activationDelegate" \
     "registry-owned terminal host views must not strongly retain activation owners"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "targetPaneID\\(forSpaceID: spaceID\\)" \
+    "sidebar space selection must resolve a target pane before committing selection"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "targetPaneID\\(forTabID: tabID, in: selectedSpace\\)" \
+    "sidebar tab selection must resolve a target pane before committing selection"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "terminalRuntimeRegistry\\.requestFocus\\(for: paneID\\)" \
+    "committed sidebar selection must request terminal focus through the runtime registry"
+
+reject_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "selectedSpaceID = spaceID" \
+    "sidebar space selection must not be view-local-only"
+
+reject_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "selectedTabID = tabID" \
+    "sidebar tab selection must not be view-local-only"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -10,6 +10,7 @@ protocol TerminalHostActivationDelegate: AnyObject {
 @MainActor
 final class AlanTerminalHostNSView: NSView {
     private(set) var teardownCount = 0
+    private(set) var focusCount = 0
 
     func configure(
         pane: ShellPane?,
@@ -41,6 +42,8 @@ final class AlanTerminalHostNSView: NSView {
 
     func dismissFindInteraction(refocusTerminal: Bool = true) {}
 
-    func focusTerminal() {}
+    func focusTerminal() {
+        focusCount += 1
+    }
 }
 #endif

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -15,6 +15,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellClipboardWriter.swift" \
@@ -26,6 +27,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalSurfaceController.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -772,6 +772,29 @@ private enum ShellRuntimeMetadataTests {
             "exited metadata must override foreground active-task projection"
         )
 
+        let activeOnlyURL = manifestURL("active_only")
+        let activeOnlyController = makeController(
+            windowID: "active_only_\(UUID().uuidString)",
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: activeOnlyURL),
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: "window_main",
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 64)
+            )
+        )
+        activeOnlyController.updateTerminalMetadata(
+            activeOnlyMetadata(activeTaskState: .inactive),
+            for: "pane_1"
+        )
+        activeOnlyController.updateTerminalMetadata(
+            activeOnlyMetadata(activeTaskState: .unknown),
+            for: "pane_1"
+        )
+        expect(
+            activeTask(in: activeOnlyURL) == .unknown,
+            "active-task-only metadata changes must persist the manifest"
+        )
+
         let alanPendingURL = manifestURL("active_alan_pending")
         let alanPendingWindowID = "active_alan_pending_\(UUID().uuidString)"
         let alanPendingController = makeController(
@@ -909,6 +932,21 @@ private enum ShellRuntimeMetadataTests {
             processExited: processExited,
             lastCommandExitCode: nil,
             lastUpdatedAt: Date(timeIntervalSince1970: 3_000),
+            activeTaskState: activeTaskState
+        )
+    }
+
+    private static func activeOnlyMetadata(
+        activeTaskState: ShellTabActiveTaskState
+    ) -> TerminalPaneMetadataSnapshot {
+        TerminalPaneMetadataSnapshot(
+            title: nil,
+            workingDirectory: nil,
+            summary: nil,
+            attention: .idle,
+            processExited: false,
+            lastCommandExitCode: nil,
+            lastUpdatedAt: nil,
             activeTaskState: activeTaskState
         )
     }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -727,6 +727,10 @@ private enum ShellRuntimeMetadataTests {
             for: "pane_1"
         )
         expect(activeTask(in: foregroundURL) == .foregroundCommand, "foreground command must protect tab")
+        expect(
+            foregroundController.shellState.panes.first?.context?.processState == "foreground_command",
+            "foreground command metadata must project into pane process state"
+        )
 
         let idleURL = manifestURL("active_idle")
         let idleController = makeController(
@@ -743,6 +747,10 @@ private enum ShellRuntimeMetadataTests {
             for: "pane_1"
         )
         expect(activeTask(in: idleURL) == .inactive, "idle shell must be eligible for retirement")
+        expect(
+            idleController.shellState.panes.first?.context?.processState == "running",
+            "idle shell metadata must remain running but not foreground"
+        )
 
         let exitedURL = manifestURL("active_exited")
         let exitedController = makeController(
@@ -759,6 +767,10 @@ private enum ShellRuntimeMetadataTests {
             for: "pane_1"
         )
         expect(activeTask(in: exitedURL) == .inactive, "exited terminal must not protect tab")
+        expect(
+            exitedController.shellState.panes.first?.context?.processState == "exited",
+            "exited metadata must override foreground active-task projection"
+        )
 
         let alanPendingURL = manifestURL("active_alan_pending")
         let alanPendingWindowID = "active_alan_pending_\(UUID().uuidString)"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -21,6 +21,15 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarFallbackOrdering()
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
+        verifiesClosingTabReleasesTerminalRuntime()
+        verifiesTabSelectionCommitsAuthoritativeFocus()
+        verifiesSpaceSelectionCommitsAuthoritativeFocus()
+        verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout()
+        verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
+        verifiesClosingLastTabLeavesSelectedSpaceEmptyAndPersistsManifest()
+        verifiesExplicitSpaceDeletionRemovesManifestSpace()
+        verifiesPinSnapshotIsExplicitAndDoesNotTrackTransientChanges()
+        verifiesManifestActiveTaskProjection()
         print("Shell runtime metadata tests passed.")
     }
 
@@ -408,8 +417,371 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
-    private static func makeController() -> ShellHostController {
-        let windowID = "metadata_test_\(UUID().uuidString)"
+    private static func verifiesClosingTabReleasesTerminalRuntime() {
+        let controller = makeController()
+        guard let pane = controller.selectedPane else {
+            fail("test setup must expose selected pane")
+        }
+        _ = controller.terminalRuntimeRegistry.surfaceHandle(for: pane, bootProfile: nil)
+
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.contains(pane.paneID),
+            "test setup must register selected pane runtime"
+        )
+
+        _ = controller.closeTab(tabID: pane.tabID)
+
+        expect(
+            !controller.terminalRuntimeRegistry.registeredPaneIDs.contains(pane.paneID),
+            "closing a tab must release its terminal runtime through the registry"
+        )
+    }
+
+    private static func verifiesTabSelectionCommitsAuthoritativeFocus() {
+        let controller = makeController()
+        _ = controller.openTerminalTab()
+        controller.focus(paneID: "pane_1")
+
+        guard let targetPane = controller.pane(paneID: "pane_2") else {
+            fail("test setup must create second tab pane")
+        }
+        let targetHostView = controller.terminalRuntimeRegistry.hostView(
+            for: targetPane,
+            bootProfile: controller.bootProfile(for: targetPane),
+            isSelected: false,
+            activationDelegate: nil,
+            onWorkspaceCommand: nil,
+            onCommandInput: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+
+        controller.select(tabID: "tab_2")
+        controller.updateTerminalMetadata(
+            metadata(title: "old focused pane updated"),
+            for: "pane_1"
+        )
+
+        expect(
+            controller.shellState.focusedPaneID == "pane_2",
+            "tab selection must update authoritative focused pane"
+        )
+        expect(controller.selectedTabID == "tab_2", "runtime metadata must not revert selected tab")
+        expect(controller.selectedPane?.paneID == "pane_2", "selected pane must follow selected tab focus")
+        expect(
+            targetHostView.focusCount == 1,
+            "tab selection must request focus for the target terminal runtime"
+        )
+    }
+
+    private static func verifiesSpaceSelectionCommitsAuthoritativeFocus() {
+        let controller = makeController()
+        _ = controller.createTerminalSpace(title: "Second", workingDirectory: "/tmp")
+        controller.focus(paneID: "pane_1")
+
+        guard let targetPane = controller.pane(paneID: "pane_2") else {
+            fail("test setup must create second space pane")
+        }
+        let targetHostView = controller.terminalRuntimeRegistry.hostView(
+            for: targetPane,
+            bootProfile: controller.bootProfile(for: targetPane),
+            isSelected: false,
+            activationDelegate: nil,
+            onWorkspaceCommand: nil,
+            onCommandInput: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+
+        controller.select(spaceID: "space_2")
+        controller.updateTerminalMetadata(
+            metadata(title: "old focused pane updated"),
+            for: "pane_1"
+        )
+
+        expect(
+            controller.shellState.focusedSpaceID == "space_2",
+            "space selection must update focused space"
+        )
+        expect(controller.shellState.focusedTabID == "tab_2", "space selection must update focused tab")
+        expect(
+            controller.shellState.focusedPaneID == "pane_2",
+            "space selection must update authoritative focused pane"
+        )
+        expect(controller.selectedSpaceID == "space_2", "runtime metadata must not revert selected space")
+        expect(controller.selectedTabID == "tab_2", "runtime metadata must not revert selected space tab")
+        expect(
+            targetHostView.focusCount == 1,
+            "space selection must request focus for the target terminal runtime"
+        )
+    }
+
+    private static func verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let splitTreeBefore = controller.shellState.tab(tabID: "tab_main")?.paneTree
+        _ = controller.openTerminalTab()
+
+        controller.select(tabID: "tab_main")
+
+        let splitTreeAfter = controller.shellState.tab(tabID: "tab_main")?.paneTree
+        expect(
+            controller.shellState.focusedPaneID == "pane_1",
+            "split-tab selection must choose a stable pane from the tab tree"
+        )
+        expect(
+            splitTreeAfter == splitTreeBefore,
+            "split-tab selection must not rewrite split tree or divider ratios"
+        )
+    }
+
+    private static func verifiesWorkspaceManifestStartupRestoresPinnedSnapshot() {
+        let windowID = "manifest_startup_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-workspace.json")
+        let context = ShellWindowContext.make(windowID: windowID)
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let manifest = ShellWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            windowID: windowID,
+            selectedSpaceID: "space_main",
+            selectedTabID: "tab_main",
+            spaces: [
+                ShellWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Main",
+                    order: 0,
+                    createdAt: Date(timeIntervalSince1970: 10),
+                    updatedAt: Date(timeIntervalSince1970: 10),
+                    tabs: [
+                        ShellWorkspaceTabRecord(
+                            tabID: "tab_main",
+                            title: "Pinned",
+                            kind: .terminal,
+                            createdAt: Date(timeIntervalSince1970: 10),
+                            lastActivatedAt: Date(timeIntervalSince1970: 10),
+                            lastActivityAt: Date(timeIntervalSince1970: 10),
+                            isPinned: true,
+                            pinSnapshot: restoreSnapshot(tabID: "tab_main", paneID: "pane_1", cwd: "/pinned"),
+                            liveSnapshot: restoreSnapshot(tabID: "tab_main", paneID: "pane_1", cwd: "/live"),
+                            activeTask: .inactive
+                        )
+                    ]
+                )
+            ]
+        )
+
+        do {
+            try store.save(manifest)
+        } catch {
+            fail("failed to write test manifest: \(error)")
+        }
+
+        let controller = ShellHostController.live(
+            windowContext: context,
+            startupMode: .workspaceManifest,
+            workspaceManifestURL: manifestURL,
+            defaultWorkingDirectory: "/fallback",
+            now: Date(timeIntervalSince1970: 20)
+        )
+
+        expect(controller.selectedPane?.cwd == "/pinned", "workspace manifest startup must use pinned cwd")
+        expect(
+            controller.shellState.focusedSpaceID == "space_main",
+            "workspace manifest startup must preserve selected space"
+        )
+        expect(
+            controller.shellState.focusedTabID == "tab_main",
+            "workspace manifest startup must preserve selected tab"
+        )
+    }
+
+    private static func verifiesClosingLastTabLeavesSelectedSpaceEmptyAndPersistsManifest() {
+        let windowID = "manifest_close_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-workspace.json")
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 30)
+            )
+        )
+
+        let result = controller.closeTab(tabID: "tab_main")
+
+        expect(result == .closed, "closing the last tab in a space must succeed")
+        expect(controller.shellState.spaces.count == 1, "closing the last tab must keep its space")
+        expect(
+            controller.shellState.spaces.first?.tabs.isEmpty == true,
+            "closing the last tab must leave the selected space empty"
+        )
+        expect(controller.shellState.panes.isEmpty, "closing the last tab must remove its panes")
+        expect(controller.selectedSpaceID == "space_main", "empty selected space must stay selected")
+        expect(controller.selectedTabID == nil, "empty selected space must clear selected tab")
+
+        guard let savedManifest = decodeManifest(at: manifestURL) else {
+            fail("closing the last tab must persist workspace manifest")
+        }
+        expect(savedManifest.spaces.count == 1, "persisted manifest must keep empty space")
+        expect(savedManifest.spaces.first?.tabs.isEmpty == true, "persisted manifest must keep space tabless")
+        expect(savedManifest.selectedSpaceID == "space_main", "persisted manifest must keep selected space")
+        expect(savedManifest.selectedTabID == nil, "persisted manifest must clear selected tab")
+    }
+
+    private static func verifiesExplicitSpaceDeletionRemovesManifestSpace() {
+        let windowID = "manifest_delete_space_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-workspace.json")
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 40)
+            )
+        )
+        _ = controller.createTerminalSpace(title: "Delete Me", workingDirectory: "/delete-me")
+
+        expect(controller.deleteSpace(spaceID: "space_2"), "explicit delete-space must be accepted")
+        expect(controller.shellState.space(spaceID: "space_2") == nil, "deleted space must leave shell state")
+
+        guard let savedManifest = decodeManifest(at: manifestURL) else {
+            fail("delete-space must persist workspace manifest")
+        }
+        expect(savedManifest.spaces.map(\.spaceID) == ["space_main"], "deleted space must leave manifest")
+        expect(
+            savedManifest.spaces.flatMap(\.tabs).allSatisfy { $0.tabID != "tab_2" },
+            "delete-space must remove deleted space tabs from manifest"
+        )
+    }
+
+    private static func verifiesPinSnapshotIsExplicitAndDoesNotTrackTransientChanges() {
+        let windowID = "manifest_pin_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-workspace.json")
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 50)
+            )
+        )
+
+        controller.updateTerminalMetadata(metadata(title: "Pinned", cwd: "/pinned"), for: "pane_1")
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        expect(controller.pinTab(tabID: "tab_main"), "pin-tab must be accepted")
+
+        controller.updateTerminalMetadata(metadata(title: "Moved", cwd: "/moved"), for: "pane_1")
+        _ = controller.splitPane(paneID: "pane_1", placement: .down)
+
+        guard let savedManifest = decodeManifest(at: manifestURL),
+              let tab = savedManifest.spaces.flatMap(\.tabs).first(where: { $0.tabID == "tab_main" })
+        else {
+            fail("pin-tab must persist manifest tab")
+        }
+
+        expect(tab.isPinned, "pin-tab must mark the tab as pinned")
+        expect(tab.pinSnapshot?.paneTree.paneIDs.count == 2, "pin snapshot must preserve split layout at pin time")
+        expect(tab.liveSnapshot?.paneTree.paneIDs.count == 3, "live snapshot must track later transient split changes")
+        expect(
+            tab.pinSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/pinned",
+            "pin snapshot must keep cwd from pin time"
+        )
+        expect(
+            tab.liveSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/moved",
+            "live snapshot must track later cwd changes without mutating pin snapshot"
+        )
+
+        expect(controller.updatePinnedTabSnapshot(tabID: "tab_main"), "update-pin must be accepted")
+        let updatedManifest = decodeManifest(at: manifestURL)
+        let updatedTab = updatedManifest?.spaces.flatMap(\.tabs).first { $0.tabID == "tab_main" }
+        expect(updatedTab?.pinSnapshot?.paneTree.paneIDs.count == 3, "update-pin must replace pin split snapshot")
+        expect(
+            updatedTab?.pinSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/moved",
+            "update-pin must replace pin cwd snapshot"
+        )
+    }
+
+    private static func verifiesManifestActiveTaskProjection() {
+        let foregroundURL = manifestURL("active_foreground")
+        let foregroundController = makeController(
+            windowID: "active_foreground_\(UUID().uuidString)",
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: foregroundURL),
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: "window_main",
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 60)
+            )
+        )
+        foregroundController.updateTerminalMetadata(
+            metadata(title: "make test", activeTaskState: .foregroundCommand),
+            for: "pane_1"
+        )
+        expect(activeTask(in: foregroundURL) == .foregroundCommand, "foreground command must protect tab")
+
+        let idleURL = manifestURL("active_idle")
+        let idleController = makeController(
+            windowID: "active_idle_\(UUID().uuidString)",
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: idleURL),
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: "window_main",
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 61)
+            )
+        )
+        idleController.updateTerminalMetadata(
+            metadata(title: "zsh", activeTaskState: .inactive),
+            for: "pane_1"
+        )
+        expect(activeTask(in: idleURL) == .inactive, "idle shell must be eligible for retirement")
+
+        let exitedURL = manifestURL("active_exited")
+        let exitedController = makeController(
+            windowID: "active_exited_\(UUID().uuidString)",
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: exitedURL),
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: "window_main",
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 62)
+            )
+        )
+        exitedController.updateTerminalMetadata(
+            metadata(title: "done", processExited: true, activeTaskState: .foregroundCommand),
+            for: "pane_1"
+        )
+        expect(activeTask(in: exitedURL) == .inactive, "exited terminal must not protect tab")
+
+        let alanPendingURL = manifestURL("active_alan_pending")
+        let alanPendingWindowID = "active_alan_pending_\(UUID().uuidString)"
+        let alanPendingController = makeController(
+            windowID: alanPendingWindowID,
+            shellState: stateWithAlanBinding(windowID: alanPendingWindowID, pendingYield: true),
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: alanPendingURL),
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: alanPendingWindowID,
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 63)
+            )
+        )
+        _ = alanPendingController.setAttention(.awaitingUser, for: "pane_1")
+        expect(activeTask(in: alanPendingURL) == .alanPendingYield, "alan pending yield must protect tab")
+    }
+
+    private static func makeController(
+        windowID: String = "metadata_test_\(UUID().uuidString)",
+        shellState: ShellStateSnapshot? = nil,
+        workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
+        workspaceManifest: ShellWorkspaceManifest? = nil
+    ) -> ShellHostController {
         let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
         let context = ShellWindowContext.make(
             windowID: windowID,
@@ -418,11 +790,49 @@ private enum ShellRuntimeMetadataTests {
         let persistenceURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(windowID).json")
         return ShellHostController(
-            shellState: .bootstrapDefault(windowID: windowID),
+            shellState: shellState ?? .bootstrapDefault(windowID: windowID),
             windowContext: context,
             persistenceURL: persistenceURL,
-            terminalRuntimeRegistry: registry
+            terminalRuntimeRegistry: registry,
+            workspaceManifestStore: workspaceManifestStore,
+            workspaceManifest: workspaceManifest
         )
+    }
+
+    private static func manifestURL(_ prefix: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)-workspace.json")
+    }
+
+    private static func restoreSnapshot(
+        tabID: String,
+        paneID: String,
+        cwd: String
+    ) -> ShellTabRestoreSnapshot {
+        ShellTabRestoreSnapshot(
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            ),
+            panes: [
+                ShellPaneRestoreRecord(
+                    paneID: paneID,
+                    launchTarget: .shell,
+                    cwd: cwd,
+                    title: tabID
+                )
+            ]
+        )
+    }
+
+    private static func decodeManifest(at url: URL) -> ShellWorkspaceManifest? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(ShellWorkspaceManifest.self, from: data)
     }
 
     private static func pane(
@@ -471,6 +881,93 @@ private enum ShellRuntimeMetadataTests {
             lastMetadataAt: nil,
             lastCommandExitCode: lastCommandExitCode
         )
+    }
+
+    private static func metadata(
+        title: String,
+        cwd: String = "/Users/morris/Developer/Alan",
+        processExited: Bool = false,
+        activeTaskState: ShellTabActiveTaskState? = nil
+    ) -> TerminalPaneMetadataSnapshot {
+        TerminalPaneMetadataSnapshot(
+            title: title,
+            workingDirectory: cwd,
+            summary: nil,
+            attention: .idle,
+            processExited: processExited,
+            lastCommandExitCode: nil,
+            lastUpdatedAt: Date(timeIntervalSince1970: 3_000),
+            activeTaskState: activeTaskState
+        )
+    }
+
+    private static func stateWithAlanBinding(
+        windowID: String,
+        pendingYield: Bool
+    ) -> ShellStateSnapshot {
+        let pane = ShellPane(
+            paneID: "pane_1",
+            tabID: "tab_main",
+            spaceID: "space_main",
+            launchTarget: .alan,
+            cwd: "/tmp",
+            process: ShellProcessBinding(program: "alan", argvPreview: ["alan", "chat"]),
+            attention: pendingYield ? .awaitingUser : .active,
+            context: ShellContextSnapshot(
+                workingDirectoryName: "tmp",
+                repositoryRoot: nil,
+                gitBranch: nil,
+                controlPath: "/tmp/control",
+                alanBindingFile: "/tmp/binding",
+                launchStrategy: "login_shell",
+                shellIntegrationSource: "ghostty_shell_integration",
+                processState: "running",
+                lastMetadataAt: nil,
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            alanBinding: ShellAlanBinding(
+                sessionID: "session_1",
+                runStatus: pendingYield ? "yielded" : "running",
+                pendingYield: pendingYield,
+                source: "test",
+                lastProjectedAt: nil
+            )
+        )
+
+        return ShellStateSnapshot(
+            contractVersion: "0.1",
+            windowID: windowID,
+            focusedSpaceID: "space_main",
+            focusedTabID: "tab_main",
+            focusedPaneID: "pane_1",
+            spaces: [
+                ShellSpace(
+                    spaceID: "space_main",
+                    title: "Main",
+                    attention: pane.attention,
+                    tabs: [
+                        ShellTab(
+                            tabID: "tab_main",
+                            kind: .terminal,
+                            title: "alan",
+                            paneTree: ShellPaneTreeNode(
+                                nodeID: "node_pane_1",
+                                kind: .pane,
+                                direction: nil,
+                                paneID: "pane_1",
+                                children: nil
+                            )
+                        )
+                    ]
+                )
+            ],
+            panes: [pane]
+        )
+    }
+
+    private static func activeTask(in url: URL) -> ShellTabActiveTaskState? {
+        decodeManifest(at: url)?.spaces.first?.tabs.first?.activeTask
     }
 
     private static func expect(

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
@@ -16,6 +16,12 @@ private enum ShellSidebarSwipeMonitorTests {
         verifiesPhaseLessVerticalGestureResetsAfterIdle()
         verifiesPhaseLessUndecidedGestureResetsAfterIdle()
         verifiesPhaseLessHorizontalGestureStillEndsAfterIdle()
+        verifiesPhasefulHorizontalGestureEndsOnRelease()
+        verifiesPhasefulHorizontalGestureCancelsOnCancelPhase()
+        verifiesFastFlickUsesTerminalDelta()
+        verifiesPagerOffsetsPagesFromSharedDragOffset()
+        verifiesPagerEdgeResistanceDoesNotRenderWrappedTarget()
+        verifiesPagerSettlementPhaseExposesCommitAndCancelState()
         print("Shell sidebar swipe monitor tests passed.")
     }
 
@@ -82,6 +88,129 @@ private enum ShellSidebarSwipeMonitorTests {
         harness.uninstall()
     }
 
+    private static func verifiesPhasefulHorizontalGestureEndsOnRelease() {
+        let harness = MonitorHarness()
+
+        let beganEvent = harness.event(deltaX: 8, deltaY: 0, phase: .began)
+        let beganResult = harness.coordinator.handleForTesting(beganEvent)
+        expect(beganResult == nil, "phaseful horizontal input must be consumed")
+
+        let endedEvent = harness.event(deltaX: 0, deltaY: 0, phase: .ended)
+        let endedResult = harness.coordinator.handleForTesting(endedEvent)
+        expect(endedResult == nil, "phaseful horizontal release must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed, .ended],
+            "phaseful horizontal release must emit began, changed, and ended"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func verifiesPhasefulHorizontalGestureCancelsOnCancelPhase() {
+        let harness = MonitorHarness()
+
+        _ = harness.coordinator.handleForTesting(
+            harness.event(deltaX: 8, deltaY: 0, phase: .began)
+        )
+        let cancelledResult = harness.coordinator.handleForTesting(
+            harness.event(deltaX: 0, deltaY: 0, phase: .cancelled)
+        )
+
+        expect(cancelledResult == nil, "phaseful horizontal cancel must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed, .cancelled],
+            "phaseful horizontal cancel must emit a cancel update"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func verifiesFastFlickUsesTerminalDelta() {
+        let harness = MonitorHarness()
+
+        let flickEvent = harness.event(deltaX: 8, deltaY: 0, phase: .ended)
+        let flickResult = harness.coordinator.handleForTesting(flickEvent)
+
+        expect(flickResult == nil, "terminal horizontal flick input must be consumed")
+        expect(
+            harness.updates.map(\.phase) == [.began, .changed, .ended],
+            "terminal horizontal flick must begin, change, and end from one terminal delta"
+        )
+
+        harness.uninstall()
+    }
+
+    private static func verifiesPagerOffsetsPagesFromSharedDragOffset() {
+        let pager = ShellSpacePagerState(
+            sourceIndex: 1,
+            targetIndex: 2,
+            dragOffset: -120,
+            pageWidth: 500,
+            settlementPhase: .dragging
+        )
+
+        expect(
+            pager.offset(for: 1).isApproximately(-120),
+            "source page must move directly with finger translation"
+        )
+        expect(
+            pager.offset(for: 2).isApproximately(380),
+            "target page must share the same drag offset from the adjacent page position"
+        )
+        expect(
+            pager.pageIndicesForRendering == [1, 2],
+            "pager must render source and adjacent target pages together"
+        )
+    }
+
+    private static func verifiesPagerEdgeResistanceDoesNotRenderWrappedTarget() {
+        let pager = ShellSpacePagerState(
+            sourceIndex: 0,
+            targetIndex: nil,
+            dragOffset: 42,
+            pageWidth: 500,
+            settlementPhase: .dragging
+        )
+
+        expect(pager.isEdgeResistance, "edge gestures without a target must enter resistance mode")
+        expect(
+            pager.pageIndicesForRendering == [0],
+            "edge resistance must not synthesize or wrap to a target page"
+        )
+        expect(
+            pager.offset(for: 0).isApproximately(42),
+            "edge source page must still move with the bounded resisted offset"
+        )
+    }
+
+    private static func verifiesPagerSettlementPhaseExposesCommitAndCancelState() {
+        let committing = ShellSpacePagerState(
+            sourceIndex: 1,
+            targetIndex: 2,
+            dragOffset: -500,
+            pageWidth: 500,
+            settlementPhase: .settlingToTarget
+        )
+        let cancelling = ShellSpacePagerState(
+            sourceIndex: 1,
+            targetIndex: 2,
+            dragOffset: 0,
+            pageWidth: 500,
+            settlementPhase: .settlingToSource
+        )
+
+        expect(committing.isSettling, "target settlement must report an active settling phase")
+        expect(
+            committing.committedTargetIndex == 2,
+            "target settlement must expose the committed target index"
+        )
+        expect(cancelling.isSettling, "source settlement must report an active settling phase")
+        expect(
+            cancelling.committedTargetIndex == nil,
+            "cancelled settlement must not expose a committed target"
+        )
+    }
+
     private static func drainMainQueue() {
         RunLoop.current.run(until: Date().addingTimeInterval(0.24))
     }
@@ -94,6 +223,12 @@ private enum ShellSidebarSwipeMonitorTests {
             fputs("error: \(message)\n", stderr)
             exit(1)
         }
+    }
+}
+
+private extension CGFloat {
+    func isApproximately(_ other: CGFloat, tolerance: CGFloat = 0.001) -> Bool {
+        abs(self - other) <= tolerance
     }
 }
 
@@ -128,13 +263,20 @@ private final class MonitorHarness {
         coordinator.install(for: view)
     }
 
-    func event(deltaX: CGFloat, deltaY: CGFloat) -> NSEvent {
+    func event(
+        deltaX: CGFloat,
+        deltaY: CGFloat,
+        phase: NSEvent.Phase = [],
+        momentumPhase: NSEvent.Phase = []
+    ) -> NSEvent {
         eventTime += 0.016
         return RecordingSidebarScrollWheelEvent(
             window: window,
             locationInWindow: NSPoint(x: 120, y: 240),
             deltaX: deltaX,
             deltaY: deltaY,
+            phase: phase,
+            momentumPhase: momentumPhase,
             timestamp: eventTime
         )
     }
@@ -154,6 +296,8 @@ private final class RecordingSidebarScrollWheelEvent: NSEvent {
     private let recordedLocationInWindow: NSPoint
     private let recordedDeltaX: CGFloat
     private let recordedDeltaY: CGFloat
+    private let recordedPhase: NSEvent.Phase
+    private let recordedMomentumPhase: NSEvent.Phase
     private let recordedTimestamp: TimeInterval
 
     init(
@@ -161,12 +305,16 @@ private final class RecordingSidebarScrollWheelEvent: NSEvent {
         locationInWindow: NSPoint,
         deltaX: CGFloat,
         deltaY: CGFloat,
+        phase: NSEvent.Phase = [],
+        momentumPhase: NSEvent.Phase = [],
         timestamp: TimeInterval
     ) {
         recordedWindow = window
         recordedLocationInWindow = locationInWindow
         recordedDeltaX = deltaX
         recordedDeltaY = deltaY
+        recordedPhase = phase
+        recordedMomentumPhase = momentumPhase
         recordedTimestamp = timestamp
         super.init()
     }
@@ -180,8 +328,8 @@ private final class RecordingSidebarScrollWheelEvent: NSEvent {
     override var scrollingDeltaX: CGFloat { recordedDeltaX }
     override var scrollingDeltaY: CGFloat { recordedDeltaY }
     override var hasPreciseScrollingDeltas: Bool { true }
-    override var phase: NSEvent.Phase { [] }
-    override var momentumPhase: NSEvent.Phase { [] }
+    override var phase: NSEvent.Phase { recordedPhase }
+    override var momentumPhase: NSEvent.Phase { recordedMomentumPhase }
     override var timestamp: TimeInterval { recordedTimestamp }
 }
 #endif

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -19,7 +19,7 @@ private enum ShellSplitModelTests {
         try verifiesPaneScopedCloseRemovesSelectedPane()
         try verifiesPaneScopedCloseKeepsInactivePaneTargeting()
         try verifiesPaneScopedCloseClosesSinglePaneTab()
-        try verifiesPaneScopedClosePreservesFinalPane()
+        try verifiesPaneScopedCloseLeavesFinalSpaceEmpty()
         try verifiesPaneAllocationSkipsReservedRuntimeIDs()
         try verifiesSplitDecodeRequiresPersistedRatio()
         print("Shell split model tests passed.")
@@ -215,15 +215,18 @@ private enum ShellSplitModelTests {
         expect(result.state.focusedPaneID == "pane_1", "single-pane tab close must focus a remaining pane")
     }
 
-    private static func verifiesPaneScopedClosePreservesFinalPane() throws {
+    private static func verifiesPaneScopedCloseLeavesFinalSpaceEmpty() throws {
         let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
 
-        do {
-            _ = try state.closingPane("pane_1")
-            expect(false, "closing the final pane in the final tab must throw")
-        } catch ShellStateMutationError.lastTab {
-            // Expected.
-        }
+        let result = try state.closingPane("pane_1")
+
+        expect(result.state.spaces.count == 1, "closing the final pane must keep the space")
+        expect(result.state.spaces.first?.spaceID == "space_main", "closing the final pane must keep space identity")
+        expect(result.state.spaces.first?.tabs.isEmpty == true, "closing the final pane must leave the space empty")
+        expect(result.state.panes.isEmpty, "closing the final pane must remove the pane")
+        expect(result.state.focusedSpaceID == "space_main", "closing the final pane must keep the empty space focused")
+        expect(result.state.focusedTabID == nil, "closing the final pane must clear tab focus")
+        expect(result.state.focusedPaneID == nil, "closing the final pane must clear pane focus")
     }
 
     private static func verifiesPaneAllocationSkipsReservedRuntimeIDs() throws {

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -14,10 +14,12 @@ private enum ShellWindowPlacementTests {
         try verifiesDefaultFrameFitsSmallVisibleRegions()
         try verifiesZoomFrameUsesEntireVisibleRegion()
         try verifiesApproximateZoomFrameMatching()
+        try verifiesWorkspaceInsetFollowsPinnedSidebarProgress()
         try verifiesTitlebarToolsMoveToLeadingEdgeWhenTrafficLightsAreHidden()
         try verifiesFullscreenChromeMetricsHideTrafficLightReservation()
         try verifiesHiddenSidebarSurfaceHidesTrafficLights()
         try verifiesFloatingSidebarSurfaceRevealsTrafficLightsAtSurfaceOrigin()
+        try verifiesPinnedSidebarMotionMovesTrafficLightsWithSurfaceOrigin()
         try verifiesPendingFloatingSidebarRevealHidesTrafficLightsButReservesLayout()
         try verifiesFloatingSidebarRevealAfterPendingHiddenStateUsesSurfaceOrigin()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
@@ -79,6 +81,28 @@ private enum ShellWindowPlacementTests {
         expect(
             !ShellWindowSizing.frame(notZoomed, approximatelyMatches: visibleFrame),
             "zoom frame matching must reject clearly different frames"
+        )
+    }
+
+    private static func verifiesWorkspaceInsetFollowsPinnedSidebarProgress() throws {
+        let expandedInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+            expandedSidebarProgress: 1
+        )
+        let midTransitionInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+            expandedSidebarProgress: 0.5
+        )
+        let collapsedInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+            expandedSidebarProgress: 0
+        )
+
+        expect(expandedInsets.leading == 0, "expanded sidebar must remove terminal leading inset")
+        expect(
+            midTransitionInsets.leading == ShellWorkspaceMetrics.terminalSurfaceInset / 2,
+            "workspace leading inset must move continuously with pinned sidebar progress"
+        )
+        expect(
+            collapsedInsets.leading == ShellWorkspaceMetrics.terminalSurfaceInset,
+            "collapsed pinned sidebar must restore terminal leading inset"
         )
     }
 
@@ -165,6 +189,38 @@ private enum ShellWindowPlacementTests {
                 ShellSidebarMetrics.trafficLightTopInset
             ),
             "published chrome metrics must not include the floating surface offset; actual \(metrics.trafficLightGroupFrame.minY), expected \(ShellSidebarMetrics.trafficLightTopInset)"
+        )
+    }
+
+    private static func verifiesPinnedSidebarMotionMovesTrafficLightsWithSurfaceOrigin() throws {
+        let window = makeTestWindow()
+        let surfaceOrigin = CGPoint(x: -132, y: 0)
+
+        let metrics = AlanShellWindowPlacement.synchronizeChrome(
+            for: window,
+            chromeSurface: ShellWindowChromeSurface(
+                isVisible: true,
+                origin: surfaceOrigin,
+                width: 264
+            )
+        )
+        let actualFrame = actualTrafficLightFrame(in: window)
+
+        expect(
+            standardWindowButtons(in: window).allSatisfy { !$0.isHidden },
+            "pinned sidebar motion must keep native traffic lights visible until the surface is hidden"
+        )
+        expect(
+            actualFrame.minX.isApproximately(
+                ShellSidebarMetrics.trafficLightLeadingInset + surfaceOrigin.x
+            ),
+            "pinned sidebar traffic lights must move with the surface origin"
+        )
+        expect(
+            metrics.trafficLightGroupFrame.minX.isApproximately(
+                ShellSidebarMetrics.trafficLightLeadingInset
+            ),
+            "published pinned chrome metrics must remain local to the moving sidebar surface"
         )
     }
 

--- a/clients/apple/scripts/test-shell-workspace-manifest.sh
+++ b/clients/apple/scripts/test-shell-workspace-manifest.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-workspace-manifest-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-workspace-manifest-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-workspace-manifest.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -1,0 +1,428 @@
+import Foundation
+
+@main
+struct ShellWorkspaceManifestTestRunner {
+    static func main() throws {
+        try ShellWorkspaceManifestTests.run()
+    }
+}
+
+private enum ShellWorkspaceManifestTests {
+    private static let referenceDate = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let twelveHours: TimeInterval = 12 * 60 * 60
+
+    static func run() throws {
+        try verifiesMissingManifestCreatesDefaultWithoutMigratingShellState()
+        try verifiesCorruptManifestIsQuarantined()
+        try verifiesMaterializerPreservesEmptySelectedSpace()
+        try verifiesPinnedSnapshotWinsOverLaterLiveSnapshot()
+        try verifiesPinnedSplitSnapshotRestoresSplitTree()
+        try verifiesUnpinnedTabPruningUsesTtlAndActiveTask()
+        try verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty()
+        print("Shell workspace manifest tests passed.")
+    }
+
+    private static func verifiesMissingManifestCreatesDefaultWithoutMigratingShellState() throws {
+        let fileManager = FileManager.default
+        let tempDirectory = try makeTempDirectory()
+        let manifestURL = tempDirectory.appendingPathComponent("shell-workspace-window_main.json")
+        let legacyStateURL = tempDirectory.appendingPathComponent("shell-state-window_main.json")
+        let legacyState = ShellStateSnapshot.bootstrapDefault(
+            windowID: "window_main",
+            workingDirectory: "/legacy/project"
+        )
+
+        try JSONEncoder().encode(legacyState).write(to: legacyStateURL)
+
+        let store = ShellWorkspaceManifestStore(fileManager: fileManager, manifestURL: manifestURL)
+        let result = try store.loadOrCreateDefault(
+            windowID: "window_main",
+            defaultWorkingDirectory: "/fresh/project",
+            now: referenceDate
+        )
+
+        expect(result.recovery == .createdDefault, "missing manifest must report default creation")
+        expect(fileManager.fileExists(atPath: manifestURL.path), "missing manifest must write a new manifest")
+
+        let tab = try requireOnlyTab(in: result.manifest)
+        let pane = try requireOnlyPane(in: tab.liveSnapshot)
+        expect(
+            pane.cwd == "/fresh/project",
+            "default manifest must use the requested working directory"
+        )
+
+        let persistedManifestText = try String(contentsOf: manifestURL, encoding: .utf8)
+        expect(
+            !persistedManifestText.contains("/legacy/project"),
+            "workspace manifest startup must not migrate legacy ShellStateSnapshot data"
+        )
+    }
+
+    private static func verifiesCorruptManifestIsQuarantined() throws {
+        let fileManager = FileManager.default
+        let tempDirectory = try makeTempDirectory()
+        let manifestURL = tempDirectory.appendingPathComponent("shell-workspace-window_main.json")
+        try "not json".write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        let store = ShellWorkspaceManifestStore(fileManager: fileManager, manifestURL: manifestURL)
+        let result = try store.loadOrCreateDefault(
+            windowID: "window_main",
+            defaultWorkingDirectory: "/fresh/project",
+            now: referenceDate
+        )
+
+        guard case .quarantinedCorruptFile(let corruptURL) = result.recovery else {
+            throw TestFailure("corrupt manifest must report a quarantine URL")
+        }
+
+        expect(fileManager.fileExists(atPath: corruptURL.path), "corrupt manifest must be preserved")
+        expect(fileManager.fileExists(atPath: manifestURL.path), "corrupt manifest recovery must write a replacement")
+        let quarantinedText = try String(contentsOf: corruptURL, encoding: .utf8)
+        expect(
+            quarantinedText == "not json",
+            "quarantined corrupt file must keep the unreadable payload"
+        )
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        _ = try decoder.decode(
+            ShellWorkspaceManifest.self,
+            from: Data(contentsOf: manifestURL)
+        )
+    }
+
+    private static func verifiesMaterializerPreservesEmptySelectedSpace() throws {
+        let manifest = ShellWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_empty",
+            selectedTabID: nil,
+            spaces: [
+                ShellWorkspaceSpaceRecord(
+                    spaceID: "space_empty",
+                    title: "Empty",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    tabs: []
+                )
+            ]
+        )
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: manifest,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(state.spaces.count == 1, "materializer must preserve empty spaces")
+        expect(state.focusedSpaceID == "space_empty", "selected empty space must remain selected")
+        expect(state.focusedTabID == nil, "selected empty space must not fabricate a tab selection")
+        expect(state.focusedPaneID == nil, "selected empty space must not fabricate a pane selection")
+        expect(state.panes.isEmpty, "selected empty space must not fabricate panes")
+    }
+
+    private static func verifiesPinnedSnapshotWinsOverLaterLiveSnapshot() throws {
+        let tab = makeTab(
+            tabID: "tab_pinned",
+            title: "Pinned",
+            isPinned: true,
+            pinCwd: "/pinned/project",
+            liveCwd: "/later/project",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: manifest,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        let pane = try requirePane("pane_tab_pinned", in: state)
+        expect(
+            pane.cwd == "/pinned/project",
+            "pinned restore must use the explicit pin snapshot, not later live cwd"
+        )
+    }
+
+    private static func verifiesPinnedSplitSnapshotRestoresSplitTree() throws {
+        var tab = makeTab(
+            tabID: "tab_split",
+            title: "Pinned Split",
+            isPinned: true,
+            pinCwd: nil,
+            liveCwd: "/live/single",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        tab.pinSnapshot = makeSplitSnapshot(tabID: tab.tabID)
+        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: manifest,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        let restoredTab = try requireTab("tab_split", in: state)
+        expect(restoredTab.paneTree.paneIDs == ["pane_tab_split_left", "pane_tab_split_right"], "pinned split restore must keep the split pane order")
+        expect(state.panes(in: "tab_split").count == 2, "pinned split restore must restore both panes")
+        expect(
+            state.pane(paneID: "pane_tab_split_left")?.cwd == "/pinned/left",
+            "pinned split restore must keep left pane cwd"
+        )
+        expect(
+            state.pane(paneID: "pane_tab_split_right")?.cwd == "/pinned/right",
+            "pinned split restore must keep right pane cwd"
+        )
+    }
+
+    private static func verifiesUnpinnedTabPruningUsesTtlAndActiveTask() throws {
+        let expiredAt = referenceDate.addingTimeInterval(-(twelveHours + 60))
+        let recentAt = referenceDate.addingTimeInterval(-60)
+        let expiredInactive = makeTab(
+            tabID: "tab_expired",
+            title: "Expired",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/expired",
+            lastActivatedAt: expiredAt,
+            lastActivityAt: expiredAt,
+            activeTask: .inactive
+        )
+        let expiredActive = makeTab(
+            tabID: "tab_active",
+            title: "Active",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/active",
+            lastActivatedAt: expiredAt,
+            lastActivityAt: expiredAt,
+            activeTask: .foregroundCommand
+        )
+        let recentInactive = makeTab(
+            tabID: "tab_recent",
+            title: "Recent",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/recent",
+            lastActivatedAt: recentAt,
+            lastActivityAt: recentAt,
+            activeTask: .inactive
+        )
+        let manifest = makeManifest(
+            selectedTabID: expiredInactive.tabID,
+            tabs: [expiredInactive, expiredActive, recentInactive]
+        )
+
+        let pruned = manifest.pruningExpiredTabs(now: referenceDate, ttl: twelveHours)
+
+        expect(findTab("tab_expired", in: pruned) == nil, "expired inactive unpinned tab must be pruned")
+        expect(findTab("tab_active", in: pruned) != nil, "active unpinned tab must survive TTL pruning")
+        expect(findTab("tab_recent", in: pruned) != nil, "recent unpinned tab must survive TTL pruning")
+        expect(pruned.selectedTabID == "tab_active", "selected pruned tab must repair to first retained tab")
+    }
+
+    private static func verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty() throws {
+        let expiredAt = referenceDate.addingTimeInterval(-(twelveHours + 60))
+        let expiredInactive = makeTab(
+            tabID: "tab_expired",
+            title: "Expired",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/expired",
+            lastActivatedAt: expiredAt,
+            lastActivityAt: expiredAt,
+            activeTask: .inactive
+        )
+        let manifest = makeManifest(selectedTabID: expiredInactive.tabID, tabs: [expiredInactive])
+
+        let pruned = manifest.pruningExpiredTabs(now: referenceDate, ttl: twelveHours)
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: pruned,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(pruned.spaces.first?.tabs.isEmpty == true, "pruning must keep the selected space even when empty")
+        expect(pruned.selectedSpaceID == "space_main", "pruning must preserve selected space")
+        expect(pruned.selectedTabID == nil, "pruning all tabs in a selected space must clear selected tab")
+        expect(state.focusedSpaceID == "space_main", "materializer must keep the empty selected space focused")
+        expect(state.focusedTabID == nil, "materializer must keep empty selected space tabless")
+    }
+
+    private static func makeManifest(
+        selectedTabID: String?,
+        tabs: [ShellWorkspaceTabRecord]
+    ) -> ShellWorkspaceManifest {
+        ShellWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_main",
+            selectedTabID: selectedTabID,
+            spaces: [
+                ShellWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Main",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    tabs: tabs
+                )
+            ]
+        )
+    }
+
+    private static func makeTab(
+        tabID: String,
+        title: String,
+        isPinned: Bool,
+        pinCwd: String?,
+        liveCwd: String?,
+        lastActivatedAt: Date,
+        lastActivityAt: Date,
+        activeTask: ShellTabActiveTaskState
+    ) -> ShellWorkspaceTabRecord {
+        ShellWorkspaceTabRecord(
+            tabID: tabID,
+            title: title,
+            kind: .terminal,
+            createdAt: referenceDate,
+            lastActivatedAt: lastActivatedAt,
+            lastActivityAt: lastActivityAt,
+            isPinned: isPinned,
+            pinSnapshot: pinCwd.map { makeSnapshot(tabID: tabID, cwd: $0) },
+            liveSnapshot: liveCwd.map { makeSnapshot(tabID: tabID, cwd: $0) },
+            activeTask: activeTask
+        )
+    }
+
+    private static func makeSnapshot(tabID: String, cwd: String) -> ShellTabRestoreSnapshot {
+        let paneID = "pane_\(tabID)"
+        return ShellTabRestoreSnapshot(
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            ),
+            panes: [
+                ShellPaneRestoreRecord(
+                    paneID: paneID,
+                    launchTarget: .shell,
+                    cwd: cwd,
+                    title: nil
+                )
+            ]
+        )
+    }
+
+    private static func makeSplitSnapshot(tabID: String) -> ShellTabRestoreSnapshot {
+        let leftPaneID = "pane_\(tabID)_left"
+        let rightPaneID = "pane_\(tabID)_right"
+        return ShellTabRestoreSnapshot(
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(tabID)_split",
+                kind: .split,
+                direction: .vertical,
+                ratio: 0.5,
+                paneID: nil,
+                children: [
+                    ShellPaneTreeNode(
+                        nodeID: "node_\(leftPaneID)",
+                        kind: .pane,
+                        direction: nil,
+                        paneID: leftPaneID,
+                        children: nil
+                    ),
+                    ShellPaneTreeNode(
+                        nodeID: "node_\(rightPaneID)",
+                        kind: .pane,
+                        direction: nil,
+                        paneID: rightPaneID,
+                        children: nil
+                    ),
+                ]
+            ),
+            panes: [
+                ShellPaneRestoreRecord(
+                    paneID: leftPaneID,
+                    launchTarget: .shell,
+                    cwd: "/pinned/left",
+                    title: nil
+                ),
+                ShellPaneRestoreRecord(
+                    paneID: rightPaneID,
+                    launchTarget: .shell,
+                    cwd: "/pinned/right",
+                    title: nil
+                ),
+            ]
+        )
+    }
+
+    private static func findTab(
+        _ tabID: String,
+        in manifest: ShellWorkspaceManifest
+    ) -> ShellWorkspaceTabRecord? {
+        manifest.spaces.flatMap(\.tabs).first { $0.tabID == tabID }
+    }
+
+    private static func requireOnlyTab(in manifest: ShellWorkspaceManifest) throws -> ShellWorkspaceTabRecord {
+        let tabs = manifest.spaces.flatMap(\.tabs)
+        guard tabs.count == 1, let tab = tabs.first else {
+            throw TestFailure("expected exactly one tab")
+        }
+        return tab
+    }
+
+    private static func requireOnlyPane(in snapshot: ShellTabRestoreSnapshot?) throws -> ShellPaneRestoreRecord {
+        guard let snapshot, snapshot.panes.count == 1, let pane = snapshot.panes.first else {
+            throw TestFailure("expected exactly one restore pane")
+        }
+        return pane
+    }
+
+    private static func requirePane(_ paneID: String, in state: ShellStateSnapshot) throws -> ShellPane {
+        guard let pane = state.pane(paneID: paneID) else {
+            throw TestFailure("missing pane \(paneID)")
+        }
+        return pane
+    }
+
+    private static func requireTab(_ tabID: String, in state: ShellStateSnapshot) throws -> ShellTab {
+        guard let tab = state.tab(tabID: tabID) else {
+            throw TestFailure("missing tab \(tabID)")
+        }
+        return tab
+    }
+
+    private static func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-shell-workspace-manifest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        guard condition() else {
+            fputs("error: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/openspec/changes/persist-macos-shell-workspaces/.openspec.yaml
+++ b/openspec/changes/persist-macos-shell-workspaces/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/persist-macos-shell-workspaces/design.md
+++ b/openspec/changes/persist-macos-shell-workspaces/design.md
@@ -1,0 +1,110 @@
+## Context
+
+当前 macOS shell 有两类状态被混在一个 `ShellStateSnapshot` 里：
+
+- 用户工作区意图：Space / Tab / split 结构、选择状态、cwd。
+- 当前运行态投影：terminal runtime metadata、renderer readiness、attention、alan binding、control-plane state file。
+
+`ShellStatePersistenceStore` 已经能把 `ShellStateSnapshot` 写到 Application Support，但主窗口启动仍然使用 fresh bootstrap；即使切换成 restore，现有快照也不能表达 Pinned Tab、Unpinned Tab TTL、Space 永久存在、active-task 回收保护等产品语义。
+
+本 change 将持久 workspace intent 从运行态快照里拆出来。`ShellWorkspaceManifest` 成为恢复 Space / Tab 的权威，`ShellStateSnapshot` 继续作为当前 UI、control plane、runtime projection 的可发布快照。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Space 创建后长期存在，直到用户显式删除。
+- Tab 支持 pin/unpin；Pinned Tab 按 pin 时刻快照恢复。
+- 未 pin Tab 在 12 小时内跨 App 重启恢复显示，超过 TTL 且 inactive 时自动回收。
+- 回收判断使用 terminal-aware active-task 信号，而不是简单使用 child process 是否仍未退出。
+- 允许空 Space，并在 UI 中保留可见的 Space 入口。
+- 使用 versioned Codable JSON manifest，不引入 SwiftData、Core Data、SQLite 或 daemon-owned store。
+- manifest 损坏时可恢复启动：旁路坏文件并创建 fresh default workspace。
+
+**Non-Goals:**
+
+- 不恢复退出前的 terminal 进程、scrollback 或 OS process；重启恢复只创建新的 terminal runtime。
+- 不迁移旧 `shell-state-window_main.json` 到 workspace manifest。
+- 不实现跨设备同步、多窗口 workspace 合并或 daemon/CLI 直接编辑 manifest。
+- 不在本 change 中完成通用 content-container v0.2；但本设计需要避免阻塞后续 content-container state model。
+
+## Decisions
+
+1. **新增 `ShellWorkspaceManifest` 作为持久化权威。**
+
+   Manifest 存放在 `Application Support/alan-macos/shell-workspace-window_main.json`，包含 `schemaVersion`、`windowID`、`selectedSpaceID`、`selectedTabID` 和 ordered spaces。它只表达用户希望长期保留的 workspace 结构，不保存 terminal renderer/runtime 对象。
+
+   备选方案：继续持久化 `ShellStateSnapshot`。这改动最小，但会继续让 runtime projection、control-plane snapshot 和用户意图区分不清，后续 Pinned Tab 与 TTL 会在同一个模型里互相污染。
+
+2. **Manifest 缺失或损坏不从旧 shell-state 迁移。**
+
+   Manifest 不存在时创建默认 workspace：一个默认 Space 和一个默认 unpinned terminal Tab。Decode 失败时，将坏文件移动或复制为 `.corrupt-<timestamp>.json` 后创建 fresh default manifest。旧 `shell-state-window_main.json` 可以继续作为 control-plane/runtime 诊断输出，但不作为 workspace restore 输入。
+
+   备选方案：从旧 `shell-state` 迁移。这个方案看似保留更多状态，但当前产品仍是 early development，且旧状态缺少 pin/TTL/lifecycle 字段；强迁移容易把 runtime 快照误解释为长期用户意图。
+
+3. **Pin 是显式 restore snapshot，不是自动持续同步。**
+
+   `pinSnapshot` 在用户 pin 或 update pin 时写入。pin 时是单 pane，就保存单 cwd 和 launch target；pin 时是 split，就保存当时 split tree 和每个 leaf pane 的 cwd/launch target。pin 之后的 cwd 变化、临时 split、pane move 不自动更新 pin snapshot。用户想持久化新的 split layout 时，需要重新 pin 或执行 update pin。
+
+   备选方案：Pinned Tab 的布局永远跟随当前 tab。它适合“长期工作台”，但会把临时 split 也永久化，和用户确认的“要持久化 split 就重新 pin”语义不一致。
+
+4. **Unpinned Tab 恢复用 live snapshot，生命周期由 TTL 管理。**
+
+   未 pin Tab 持有 `liveSnapshot`，用于记录最近 cwd、launch target、可恢复 split layout 和最近标题。重启时，只要未超过 TTL 且 inactive，就 materialize 成新的 terminal pane/runtime。回收 anchor 是 `max(lastActivatedAt, lastActivityAt)`；超过 12 小时且没有 active task 才回收。
+
+   备选方案：重启只恢复 pinned tabs。实现更简单，但不符合已确认的 Arc-like 行为，也会让用户短期工作上下文在重开 App 后消失。
+
+5. **Active task 是 terminal-aware lifecycle 信号。**
+
+   `processExited == false` 不能阻止回收，因为 idle login shell 也会一直未退出。需要引入或投影一个更精确的 active-task state：
+
+   - foreground command running：active。
+   - alan session running / pending / waiting for input：active。
+   - idle prompt shell：inactive。
+   - exited terminal：inactive。
+
+   这个 state 可以先作为 pane/tab projection 写入 manifest，再由 prune 使用。实现可从 Ghostty shell integration metadata、alan binding、surface state 和 command lifecycle signal 组合得出。
+
+   备选方案：所有未退出 process 都算 active。它会让 Unpinned Tab TTL 基本失效。
+
+6. **Materializer 负责从 manifest 生成当前 shell state。**
+
+   启动顺序：
+
+   ```text
+   load manifest
+   -> create fresh default if missing/corrupt
+   -> prune expired inactive unpinned tabs
+   -> materialize ShellStateSnapshot
+   -> publish control-plane state
+   ```
+
+   如果 selected tab 被 prune，materializer 选择当前 Space 的第一个 remaining tab；如果 Space 为空，则保留 selected Space，`selectedTabID = nil`，workspace UI 显示空状态。
+
+7. **与 content-container change 解耦。**
+
+   `generalize-macos-shell-content-containers` 会把当前 shell display/runtime state 从 pane-keyed terminal model 迁到 content-container model。这个 change 不等待它，也不把 workspace manifest 塞进那个大迁移里。Manifest 中的 restore snapshot 应通过小型 adapter materialize 到当前 shell state；如果 content-container 先落地，adapter 输出 v0.2 content state；如果本 change 先落地，adapter 输出当前 v0.1 terminal pane state。
+
+## Risks / Trade-offs
+
+- **Risk: manifest 与 runtime projection drift。** -> 只把用户意图和 lifecycle metadata 写入 manifest；runtime-only renderer/readiness/debug state 不进入 manifest。
+- **Risk: active-task 信号不准确导致误清理。** -> 在 active-task 未能判定时默认保守保留，并用 tests 明确 idle shell 不应被误判为 active。
+- **Risk: 空 Space UI 显得像 bug。** -> Sidebar 保留 Space 行；workspace 内容区提供 restrained empty state 和 new tab action。
+- **Risk: 两套持久文件令人困惑。** -> 命名区分：`shell-workspace-*` 是 restore 权威；`shell-state-*` 是当前 control-plane/runtime snapshot。
+- **Risk: content-container 后续迁移重复做 adapter。** -> Manifest restore snapshot 使用 content-neutral shape，避免把 terminal-only `ShellPane` 当作长期 schema。
+
+## Migration Plan
+
+1. 引入 manifest value types、store、corrupt-file handling 和 default manifest creation。
+2. 引入 manifest materializer，把 manifest 输出为当前 `ShellStateSnapshot`。
+3. 将 macOS primary shell startup 改为从 manifest restore，而不是 fresh `ShellStateSnapshot` bootstrap。
+4. 将 Space/Tab 创建、选择、关闭、pin/unpin/update pin、runtime activity projection 同步到 manifest。
+5. 添加 TTL prune 和 active-task protection。
+6. 更新 UI 以支持空 Space 和 pin affordance。
+7. 保留旧 `shell-state-window_main.json` 写入路径用于 control-plane/runtime diagnostics，直到后续 change 明确删除或替代它。
+
+Rollback 是源代码级：移除 manifest startup path 后，App 可回到 fresh bootstrap 或旧 shell-state restore 行为。已创建的 manifest 文件保留在 Application Support 中，不需要 destructive migration。
+
+## Open Questions
+
+无。已确认：Unpinned Tab 采用 12 小时 Arc-like 恢复语义；Pinned Tab 是显式快照；Space 可为空；manifest 损坏时旁路并创建 fresh workspace；不迁移旧 shell-state。

--- a/openspec/changes/persist-macos-shell-workspaces/proposal.md
+++ b/openspec/changes/persist-macos-shell-workspaces/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+alan 的 macOS shell 现在有 `shell-state-window_main.json` 形式的运行快照持久化，但主窗口启动仍然走 fresh bootstrap，且现有模型没有表达 Space 永久存在、Pinned Tab、未 pin Tab 的 12 小时生命周期，导致 App 退出再打开后用户组织好的 Space 和 Tab 不会作为产品状态恢复。
+
+这个 change 将 workspace 持久化从运行态快照中拆出来：Space / Tab 的长期意图由一个版本化 manifest 表达，terminal runtime 仍然由当前进程内 runtime service 管理。
+
+## What Changes
+
+- 新增 `ShellWorkspaceManifest` 作为 macOS shell workspace 的持久化权威，存储 Space、Tab、最后选择状态、pin 快照、TTL 元数据和 active-task 摘要。
+- 启动时从 manifest materialize 当前 `ShellStateSnapshot`；manifest 缺失时创建默认 workspace，manifest 损坏时旁路坏文件并创建默认 workspace。
+- Space 成为长期对象：创建后一直存在，自动回收 Tab 或关闭最后一个 Tab 不会删除 Space；只有显式删除 Space 才移除。
+- 引入 Pinned Tab 快照语义：pin 时是单 pane 就保存 cwd；pin 时是 split 就保存当时 split layout 和每个 pane cwd；pin 后的临时 split/cwd 改动不会自动更新 pin 快照。
+- 引入 Unpinned Tab 生命周期：未 pin Tab 跨 App 重启恢复显示，直到超过 12 小时且没有 active task 后自动回收；恢复是新 terminal/runtime，不是旧进程恢复。
+- 增加 terminal-aware active-task 信号：前台命令或 alan session active/pending 阻止回收，idle shell 不阻止回收；`processExited == false` 不能单独代表 active task。
+- 保持存储后端为 Application Support 下的 versioned Codable JSON，不引入 SwiftData、Core Data 或 SQLite。
+- 不迁移旧 `shell-state-window_main.json` 到 manifest；首次没有 manifest 时创建 fresh default workspace。
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-shell-workspace-persistence`: 定义 macOS shell workspace manifest、Space/Tab 持久化、Pinned Tab 快照、Unpinned Tab TTL、active-task 回收保护和损坏 manifest 恢复行为。
+
+### Modified Capabilities
+
+- `macos-shell-terminal-lifecycle`: 明确 terminal runtime 连续性只覆盖当前进程内仍属于 shell state 的 runtime；workspace manifest 恢复会启动新 terminal runtime，且 inactive unpinned Tab 的 lifecycle retirement 可以关闭对应 runtime。
+- `macos-shell-build-test-contract`: 增加 manifest 创建/损坏恢复、Space 空状态、Pinned Tab 快照恢复、Unpinned Tab TTL 回收和 active-task 阻止回收的验证要求。
+
+## Impact
+
+- Apple client model/store: 新增 workspace manifest value types、manifest persistence store、manifest-to-shell-state materializer、TTL pruning 和 pin snapshot helpers。
+- Apple client controller: `ShellHostController` 需要把 Space/Tab 创建、选择、关闭、pin/update pin、runtime activity metadata 同步到 manifest。
+- Apple client UI: sidebar 需要显示空 Space，提供创建 Tab 入口，并提供 pin/unpin 或 update pin affordance。
+- Terminal runtime metadata: 需要补充 terminal-aware active-task 信号，区分 foreground command / alan active session / idle shell。
+- Existing shell state persistence: `ShellStateSnapshot` 继续服务当前 UI/control-plane/runtime 快照和诊断，但不再作为 workspace restore 权威。
+- Tests/scripts: 需要增加 focused Swift tests 和 shell contract checks 覆盖 manifest lifecycle 与 terminal active-task 回收边界。

--- a/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Workspace persistence verification covers Tab lifecycle
+Changes to macOS shell workspace persistence SHALL include focused verification for manifest startup, Space retention, Pinned Tab restore snapshots, Unpinned Tab TTL retirement, and active-task retirement protection.
+
+#### Scenario: Manifest startup behavior is tested
+- **WHEN** workspace persistence changes are implemented
+- **THEN** focused tests cover missing manifest default creation and corrupt manifest quarantine with fresh default startup
+
+#### Scenario: Space retention is tested
+- **WHEN** tab close or lifecycle retirement can leave a Space without Tabs
+- **THEN** focused tests or manual notes verify the Space remains visible and selected with an empty workspace state
+
+#### Scenario: Pinned Tab restore is tested
+- **WHEN** Pinned Tab persistence is implemented
+- **THEN** focused tests cover single-pane cwd restoration, split layout restoration, and the fact that post-pin transient split/cwd changes do not update the pin snapshot without an explicit update-pin action
+
+#### Scenario: Unpinned Tab TTL is tested
+- **WHEN** Unpinned Tab lifecycle pruning is implemented
+- **THEN** focused tests cover retained Tabs inside the 12 hour TTL, retired inactive Tabs after the TTL, and selection repair when the selected Tab is retired
+
+#### Scenario: Active tasks are tested
+- **WHEN** terminal-aware active-task metadata is used for pruning
+- **THEN** focused tests cover foreground command protection, alan pending/yield protection, and idle shell eligibility for retirement

--- a/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal runtimes survive view selection changes
+The macOS shell host SHALL keep a tab's terminal process, renderer surface,
+runtime metadata, and buffered control state owned by the shell model or a
+dedicated runtime registry rather than by the transient SwiftUI/AppKit view that
+happens to be visible. Runtime continuity applies while the Tab remains part of
+the current shell state; explicit close operations and workspace lifecycle
+retirement of inactive unpinned Tabs SHALL finalize the affected terminal
+runtimes through the runtime service boundary.
+
+#### Scenario: Switching away from a tab
+- **WHEN** a user switches from one tab to another and the first tab is no longer rendered
+- **THEN** the first tab's terminal process and runtime record remain alive unless the tab or pane is explicitly closed or the Tab is later retired by the workspace lifecycle contract
+
+#### Scenario: Switching back to a tab
+- **WHEN** a user returns to a previously selected tab
+- **THEN** the host reattaches the visible view to the existing terminal runtime instead of booting a new shell process
+
+#### Scenario: Closing a tab
+- **WHEN** a tab is explicitly closed
+- **THEN** all terminal runtimes owned by that tab are torn down exactly once and their final state is reflected in shell state
+
+#### Scenario: Retiring an inactive unpinned Tab
+- **WHEN** workspace lifecycle pruning retires an inactive unpinned Tab
+- **THEN** terminal runtimes owned by that Tab are finalized through the same runtime service ownership boundary used by explicit close operations
+
+#### Scenario: Restoring a Tab after app restart
+- **WHEN** alan restores a Pinned Tab or retained Unpinned Tab from the workspace manifest after app restart
+- **THEN** alan creates new terminal runtimes from the restore snapshot instead of claiming continuity with processes from the prior app instance

--- a/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Workspace manifest is the restore authority
+The macOS shell SHALL use a versioned workspace manifest as the authoritative source for restoring Spaces, Tabs, pin snapshots, Tab lifecycle metadata, and the last selected Space/Tab across app restarts.
+
+#### Scenario: Manifest is present
+- **WHEN** alan for macOS starts and a valid workspace manifest exists for `window_main`
+- **THEN** alan loads Spaces, Tabs, pin snapshots, lifecycle metadata, and the last selected Space/Tab from that manifest
+- **AND** alan materializes the current shell state from the manifest rather than bootstrapping a fresh default state
+
+#### Scenario: Manifest is missing
+- **WHEN** alan for macOS starts and no workspace manifest exists for `window_main`
+- **THEN** alan creates a default manifest with one default Space and one default unpinned terminal Tab
+- **AND** alan uses that manifest as the restore authority for the launched shell state
+
+#### Scenario: Legacy shell state exists without manifest
+- **WHEN** `shell-state-window_main.json` exists but no workspace manifest exists
+- **THEN** alan does not migrate that legacy shell state into the workspace manifest
+- **AND** alan creates a default manifest instead
+
+### Requirement: Corrupt workspace manifests fail open safely
+The macOS shell SHALL preserve evidence of a malformed workspace manifest and start with a default workspace rather than failing to launch or silently overwriting the only copy.
+
+#### Scenario: Manifest cannot be decoded
+- **WHEN** alan for macOS starts and the workspace manifest cannot be decoded
+- **THEN** alan preserves the bad manifest as a timestamped corrupt file
+- **AND** alan creates a fresh default manifest
+- **AND** alan starts with the default workspace
+
+#### Scenario: Fresh manifest is written after corruption
+- **WHEN** alan creates a default manifest after detecting corruption
+- **THEN** future workspace mutations write to the fresh manifest path
+- **AND** the corrupt file remains available for diagnostics
+
+### Requirement: Spaces persist until explicit deletion
+The macOS shell SHALL treat Spaces as durable user-created containers that remain visible until the user explicitly deletes the Space.
+
+#### Scenario: Empty Space remains visible
+- **WHEN** the last Tab in a Space is closed or retired
+- **THEN** alan keeps the Space in the workspace manifest
+- **AND** the sidebar continues to show that Space
+- **AND** selecting that Space shows an empty workspace state instead of deleting the Space
+
+#### Scenario: Tab retirement does not delete Space
+- **WHEN** automatic Tab lifecycle retirement removes every Tab from a Space
+- **THEN** alan keeps the Space record and its ordering in the workspace manifest
+
+#### Scenario: Space is explicitly deleted
+- **WHEN** the user invokes a delete-space action for a Space
+- **THEN** alan removes that Space and its Tabs from the workspace manifest
+- **AND** alan chooses a remaining Space or creates a default Space if no Spaces remain
+
+### Requirement: Pinned Tabs restore from explicit snapshots
+The macOS shell SHALL persist Pinned Tabs by saving an explicit restore snapshot at pin or update-pin time, and SHALL restore from that snapshot rather than from later transient Tab mutations.
+
+#### Scenario: Single-pane Tab is pinned
+- **WHEN** the user pins a Tab that contains one terminal pane
+- **THEN** alan saves a pin snapshot with that pane's cwd, launch target, title, and Tab identity
+- **AND** future app launches restore that Pinned Tab as a new terminal pane at the pinned cwd
+
+#### Scenario: Split Tab is pinned
+- **WHEN** the user pins a Tab that contains a split layout
+- **THEN** alan saves the split tree and each leaf pane's cwd and launch target in the pin snapshot
+- **AND** future app launches restore the Pinned Tab with that split layout and pane cwd mapping
+
+#### Scenario: Pinned Tab changes after pinning
+- **WHEN** a Pinned Tab is split, moved, resized, or cd'd after the pin snapshot was saved
+- **THEN** alan does not update the pin snapshot automatically
+- **AND** future app launches restore the Tab from the saved pin snapshot
+
+#### Scenario: User updates the pin snapshot
+- **WHEN** the user explicitly updates or re-applies pinning for an already Pinned Tab
+- **THEN** alan replaces the prior pin snapshot with the Tab's current restorable layout and cwd state
+
+### Requirement: Unpinned Tabs restore until inactive TTL expiry
+The macOS shell SHALL retain Unpinned Tabs across app restarts until they are inactive and older than the configured lifecycle TTL.
+
+#### Scenario: Unpinned Tab is inside TTL
+- **WHEN** an Unpinned Tab has `max(lastActivatedAt, lastActivityAt)` within 12 hours
+- **THEN** alan keeps that Tab in the workspace manifest
+- **AND** app restart restores it as a new terminal runtime at its latest restorable cwd or layout
+
+#### Scenario: Unpinned Tab expires while inactive
+- **WHEN** an Unpinned Tab is not pinned
+- **AND** it has no active task
+- **AND** `now - max(lastActivatedAt, lastActivityAt)` is greater than 12 hours
+- **THEN** alan retires that Tab from the workspace manifest during lifecycle pruning
+
+#### Scenario: Selected Tab expires
+- **WHEN** the selected Tab is retired during startup pruning
+- **THEN** alan selects the first remaining Tab in the selected Space
+- **AND** if the selected Space has no remaining Tabs, alan keeps the Space selected with no selected Tab
+
+### Requirement: Active tasks prevent unpinned Tab retirement
+The macOS shell SHALL protect Unpinned Tabs from lifecycle retirement when terminal-aware metadata indicates that user work is actively running or waiting for input.
+
+#### Scenario: Foreground command is running
+- **WHEN** an Unpinned Tab contains a terminal pane with an active foreground command
+- **THEN** alan treats that Tab as having an active task
+- **AND** lifecycle pruning does not retire it solely because its TTL anchor is older than 12 hours
+
+#### Scenario: alan session is active
+- **WHEN** an Unpinned Tab contains an alan session that is running, waiting for input, or pending yield
+- **THEN** alan treats that Tab as having an active task
+- **AND** lifecycle pruning does not retire it solely because its TTL anchor is older than 12 hours
+
+#### Scenario: Shell is idle
+- **WHEN** an Unpinned Tab contains only an idle shell prompt
+- **THEN** alan does not treat `processExited == false` by itself as an active task
+- **AND** the Tab can be retired after TTL expiry
+
+### Requirement: Shell state remains a runtime snapshot
+The macOS shell SHALL keep `ShellStateSnapshot` as the current UI/control-plane/runtime projection while using the workspace manifest as the durable restore authority.
+
+#### Scenario: Runtime metadata changes
+- **WHEN** terminal title, cwd, renderer state, attention, or alan binding metadata changes
+- **THEN** alan updates current shell state for UI and control-plane publication
+- **AND** alan writes only restorable workspace intent and lifecycle metadata back to the manifest
+
+#### Scenario: App restarts
+- **WHEN** alan for macOS restarts after publishing a shell state file in the previous process
+- **THEN** alan restores Spaces and Tabs from the workspace manifest
+- **AND** terminal runtimes are newly created rather than restored from the old shell state process snapshot

--- a/openspec/changes/persist-macos-shell-workspaces/tasks.md
+++ b/openspec/changes/persist-macos-shell-workspaces/tasks.md
@@ -1,0 +1,41 @@
+## 1. Manifest Model And Store
+
+- [x] 1.1 Add `ShellWorkspaceManifest`, Space record, Tab record, pin snapshot, live snapshot, and active-task value types with `Codable` schema versioning.
+- [x] 1.2 Add a manifest persistence store under Application Support using `shell-workspace-window_main.json`, atomic writes, sorted/pretty JSON, and timestamped corrupt-file quarantine.
+- [x] 1.3 Add default manifest creation for a missing manifest without reading or migrating `shell-state-window_main.json`.
+- [x] 1.4 Add focused model/store tests for missing manifest startup and corrupt manifest quarantine.
+
+## 2. Materialization And Lifecycle Pruning
+
+- [x] 2.1 Add a manifest materializer that converts retained manifest Spaces/Tabs into the current `ShellStateSnapshot` shape and preserves empty Space selection.
+- [x] 2.2 Implement Unpinned Tab pruning using `now - max(lastActivatedAt, lastActivityAt) > 12h` and active-task protection.
+- [x] 2.3 Implement selection repair when the selected Tab is pruned, including selected empty Space with `selectedTabID = nil`.
+- [x] 2.4 Keep the materializer adapter small enough to swap from current pane-shaped state to future content-container state without changing manifest semantics.
+
+## 3. Controller And Runtime Synchronization
+
+- [x] 3.1 Change primary macOS shell startup to load the workspace manifest and materialize shell state instead of forcing fresh bootstrap.
+- [x] 3.2 Sync Space creation, explicit Space deletion, Tab creation, Tab close, Tab selection, and Space selection from `ShellHostController` into the manifest.
+- [x] 3.3 Add pin, unpin, and update-pin controller mutations that write explicit restore snapshots without auto-updating snapshots on later transient changes.
+- [x] 3.4 Project terminal cwd/title/activity metadata into manifest live snapshots and `lastActivityAt` without storing runtime-only renderer/debug state.
+- [x] 3.5 Add terminal-aware active-task projection for foreground command activity, alan active/pending/yield states, idle shell, and exited terminal states.
+- [x] 3.6 Ensure lifecycle retirement finalizes affected terminal runtimes through the runtime service path used by close operations.
+
+## 4. UI And Control Surfaces
+
+- [x] 4.1 Update sidebar/workspace rendering so empty Spaces remain visible and show a restrained empty state with a new-tab action.
+- [x] 4.2 Add pin/unpin/update-pin affordances in the existing Arc-like sidebar/tab interaction model without adding dashboard-style chrome.
+- [x] 4.3 Update close-tab behavior so closing the last Tab in a Space leaves the Space empty rather than deleting it.
+- [x] 4.4 Update shell events or diagnostics where useful so manifest load failures, corrupt-file quarantine, lifecycle retirement, and pin updates are inspectable.
+
+## 5. Verification And Archive Readiness
+
+- [x] 5.1 Add focused Swift tests for Pinned Tab single-pane restore, Pinned Tab split restore, and post-pin transient changes not mutating the pin snapshot.
+- [x] 5.2 Add focused Swift tests for retained Unpinned Tabs inside TTL, retired inactive Unpinned Tabs after TTL, and selected-tab pruning repair.
+- [x] 5.3 Add focused Swift tests for active-task protection: foreground command, alan pending/yield, and idle shell eligibility for retirement.
+- [x] 5.4 Update shell contract checks to prevent `ShellStateSnapshot` from becoming the workspace restore authority again.
+- [x] 5.5 Run focused Apple shell scripts affected by manifest, metadata, and lifecycle changes.
+- [x] 5.6 Run the macOS app build or document the exact local dependency blocker.
+- [x] 5.7 Validate `persist-macos-shell-workspaces` with `openspec validate persist-macos-shell-workspaces --strict`.
+- [x] 5.8 Run `openspec validate --all --strict` and `git diff --check`.
+- [ ] 5.9 After implementation is merged, sync accepted requirements into `openspec/specs/` and prepare archive-readiness notes.

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Selection And Focus Convergence
 
-- [ ] 1.1 Add shell-controller helpers that resolve a target pane for a selected tab or space, preferring an existing focused pane in that tab and otherwise using a stable pane from the tab tree.
-- [ ] 1.2 Change `select(spaceID:)`, `select(tabID:)`, indexed space selection, adjacent space selection, and sidebar click paths so committed sidebar selection updates authoritative `shellState.focusedPaneID` through the shell focus mutation path.
-- [ ] 1.3 Ensure committed sidebar selection requests terminal focus for the selected pane when a runtime is available, without stealing focus during transient preview-only gestures.
-- [ ] 1.4 Add focused tests proving tab clicks and space clicks are not reverted by immediate terminal runtime metadata or control-plane state publication.
-- [ ] 1.5 Add split-tab coverage proving sidebar selection chooses a stable pane without changing split trees or divider ratios.
+- [x] 1.1 Add shell-controller helpers that resolve a target pane for a selected tab or space, preferring an existing focused pane in that tab and otherwise using a stable pane from the tab tree.
+- [x] 1.2 Change `select(spaceID:)`, `select(tabID:)`, indexed space selection, adjacent space selection, and sidebar click paths so committed sidebar selection updates authoritative `shellState.focusedPaneID` through the shell focus mutation path.
+- [x] 1.3 Ensure committed sidebar selection requests terminal focus for the selected pane when a runtime is available, without stealing focus during transient preview-only gestures.
+- [x] 1.4 Add focused tests proving tab clicks and space clicks are not reverted by immediate terminal runtime metadata or control-plane state publication.
+- [x] 1.5 Add split-tab coverage proving sidebar selection chooses a stable pane without changing split trees or divider ratios.
 
 ## 2. Coordinated Sidebar And Window Chrome Motion
 
-- [ ] 2.1 Replace pinned-sidebar conditional insertion/removal with a mounted sidebar presentation state that drives visible width, content opacity or offset, and workspace leading inset.
-- [ ] 2.2 Tune pinned collapse and expansion timing to be short and crisp in normal motion and non-springy under reduced motion.
-- [ ] 2.3 Extend the window chrome bridge so standard macOS traffic-light controls move with the sidebar/titlebar-control motion and settle to corrected final AppKit frames.
-- [ ] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
-- [ ] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
+- [x] 2.1 Replace pinned-sidebar conditional insertion/removal with a mounted sidebar presentation state that drives visible width, content opacity or offset, and workspace leading inset.
+- [x] 2.2 Tune pinned collapse and expansion timing to be short and crisp in normal motion and non-springy under reduced motion.
+- [x] 2.3 Extend the window chrome bridge so standard macOS traffic-light controls move with the sidebar/titlebar-control motion and settle to corrected final AppKit frames.
+- [x] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
+- [x] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
 
 ## 3. Continuous Space Pager
 
-- [ ] 3.1 Replace the sidebar-only `ShellSpaceTransition` model with a pager state that tracks source index, target index, drag offset, page width, commit/cancel state, and settlement phase.
-- [ ] 3.2 Preserve gesture axis arbitration in `ShellSidebarSwipeMonitor`, including undecided buffering, vertical scroll pass-through, phaseful release, phase-less idle release, momentum handoff, and fast flick velocity.
-- [ ] 3.3 Render current and adjacent space pages from the same pager offset so users can see the target space edge while dragging.
-- [ ] 3.4 Include sidebar header, sidebar tab list, and terminal workspace surface in the pager page motion while preserving terminal runtime identities.
-- [ ] 3.5 Apply bounded edge resistance at the first and last spaces and prevent accidental wraparound.
-- [ ] 3.6 Commit the target space through the authoritative selection/focus path at the transition point so concurrent runtime updates cannot snap the UI back during settlement.
-- [ ] 3.7 Cancel below-threshold gestures back to the source page without changing selected space, selected tab, focused pane, split tree, or divider ratios.
+- [x] 3.1 Replace the sidebar-only `ShellSpaceTransition` model with a pager state that tracks source index, target index, drag offset, page width, commit/cancel state, and settlement phase.
+- [x] 3.2 Preserve gesture axis arbitration in `ShellSidebarSwipeMonitor`, including undecided buffering, vertical scroll pass-through, phaseful release, phase-less idle release, momentum handoff, and fast flick velocity.
+- [x] 3.3 Render current and adjacent space pages from the same pager offset so users can see the target space edge while dragging.
+- [x] 3.4 Include sidebar header, sidebar tab list, and terminal workspace surface in the pager page motion while preserving terminal runtime identities.
+- [x] 3.5 Apply bounded edge resistance at the first and last spaces and prevent accidental wraparound.
+- [x] 3.6 Commit the target space through the authoritative selection/focus path at the transition point so concurrent runtime updates cannot snap the UI back during settlement.
+- [x] 3.7 Cancel below-threshold gestures back to the source page without changing selected space, selected tab, focused pane, split tree, or divider ratios.
 
 ## 4. Verification
 
-- [ ] 4.1 Extend focused shell tests for sidebar selection/focus convergence and runtime-update race coverage.
-- [ ] 4.2 Extend sidebar swipe monitor or pager tests for horizontal, vertical, undecided, edge, cancel, commit, phaseful, phase-less, and fast-flick cases.
-- [ ] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or sidebar-only space swipe semantics.
-- [ ] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 4.1 Extend focused shell tests for sidebar selection/focus convergence and runtime-update race coverage.
+- [x] 4.2 Extend sidebar swipe monitor or pager tests for horizontal, vertical, undecided, edge, cancel, commit, phaseful, phase-less, and fast-flick cases.
+- [x] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or sidebar-only space swipe semantics.
+- [x] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
 
 ## 5. OpenSpec And Review Readiness
 
-- [ ] 5.1 Keep `proposal.md`, `design.md`, `tasks.md`, and all delta specs aligned if implementation discoveries change the contract.
-- [ ] 5.2 Run `openspec validate refine-macos-sidebar-interactions --strict` after spec edits and after implementation.
-- [ ] 5.3 Run `openspec validate --all --strict` before opening or updating a PR.
+- [x] 5.1 Keep `proposal.md`, `design.md`, `tasks.md`, and all delta specs aligned if implementation discoveries change the contract.
+- [x] 5.2 Run `openspec validate refine-macos-sidebar-interactions --strict` after spec edits and after implementation.
+- [x] 5.3 Run `openspec validate --all --strict` before opening or updating a PR.
 - [ ] 5.4 Prepare archive readiness notes after implementation so the delta specs can be synced into `openspec/specs/` before archiving.


### PR DESCRIPTION
## Summary

- add `ShellWorkspaceManifest` and an Application Support store as the durable Space/Tab restore authority
- restore the primary macOS shell from the manifest, preserve empty Spaces, and sync Space/Tab selection, close, delete, pin, unpin, and update-pin mutations
- add active-task-aware Unpinned Tab pruning, pin/live snapshots, sidebar pin affordances, empty-space new-tab UI, and contract guards against restoring workspace identity from `ShellStateSnapshot`

This is stacked on #405 (`refine-macos-sidebar-interactions`). The untracked `generalize-macos-shell-content-containers` change is intentionally not included.

## Verification

- `bash clients/apple/scripts/test-shell-workspace-manifest.sh`
- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
- `bash clients/apple/scripts/test-shell-split-model.sh`
- `bash clients/apple/scripts/test-terminal-surface-controller.sh`
- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -destination 'platform=macOS' -configuration Debug -derivedDataPath /private/tmp/alan-macos-derived-data build CODE_SIGNING_ALLOWED=NO`
- `openspec validate persist-macos-shell-workspaces --strict`
- `openspec validate --all --strict`
- `git diff --check`
