### PR TITLE
Spec: generalize macOS shell content containers

### DIFF
--- a/openspec/changes/complete-macos-shell-advanced-splits/design.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/design.md
@@ -8,7 +8,10 @@ ownership can lose terminal continuity or steal terminal input.
 
 The main constraints are:
 
-- Terminal runtime identity must remain pane-keyed and service-owned.
+- Terminal runtime identity must remain service-owned and, after
+  `generalize-macos-shell-content-containers`, terminal ContentInstance-keyed;
+  pane or PaneSlot identity is the layout/focus placement boundary, not the
+  terminal runtime owner.
 - Terminal text selection and terminal app input must not be compromised by
   drag/drop or shortcut handling.
 - Native menu, keyboard, command UI, context menu, and control-plane commands
@@ -49,8 +52,9 @@ The main constraints are:
 2. Implement explicit move commands before enabling drag/drop by default.
 
    Controller-owned move commands can validate source/target tabs and preserve
-   runtime identity before gesture complexity is introduced. Drag/drop can then
-   call the same command path once terminal selection behavior is proven.
+   PaneSlot placement and mounted terminal content runtime identity before
+   gesture complexity is introduced. Drag/drop can then call the same command
+   path once terminal selection behavior is proven.
 
    Alternative considered: start with direct drag/drop. That would make it
    harder to separate model bugs from hit-testing and terminal-selection bugs.
@@ -58,8 +62,9 @@ The main constraints are:
 3. Route native commands through a command target resolver.
 
    Copy, paste, search, zoom, focus, and movement need a consistent target:
-   selected terminal host, focused pane, selected tab, or command UI row. A
-   resolver keeps menu, keyboard, and command UI behavior aligned.
+   selected terminal host, focused PaneSlot, mounted terminal ContentInstance,
+   selected tab, or command UI row. A resolver keeps menu, keyboard, and command
+   UI behavior aligned.
 
    Alternative considered: let each surface decide locally. That repeats the
    old hidden-button problem and makes terminal-host ownership ambiguous.

--- a/openspec/changes/complete-macos-shell-advanced-splits/proposal.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/proposal.md
@@ -8,9 +8,10 @@ does not disappear inside an archived change.
 ## What Changes
 
 - Add split zoom and unzoom as a tab-scoped view state that preserves sibling
-  pane runtimes and restores the previous split layout.
+  terminal ContentInstance runtimes and restores the previous split layout.
 - Add explicit in-tab pane movement and optional drag/drop movement once it can
-  preserve runtime identity without compromising terminal text selection.
+  preserve PaneSlot placement and terminal ContentInstance runtime identity without
+  compromising terminal text selection.
 - Extend control-plane commands for split resize, equalize, zoom/unzoom, and
   spatial focus with authoritative result semantics.
 - Complete command ownership for copy, paste, and terminal search so native
@@ -32,9 +33,9 @@ None.
 - `macos-shell-control-plane-reliability`: Adds authoritative control-plane
   result semantics for resize, equalize, zoom/unzoom, spatial focus, and
   movement commands.
-- `macos-shell-terminal-lifecycle`: Clarifies runtime identity preservation for
-  zoom/unzoom, in-tab movement, drag/drop movement, and search/copy/paste target
-  routing.
+- `macos-shell-terminal-lifecycle`: Clarifies terminal ContentInstance runtime
+  identity preservation for zoom/unzoom, in-tab movement, drag/drop movement,
+  and search/copy/paste target routing.
 - `macos-shell-ui-ux-conformance`: Adds UI requirements for zoom affordances,
   movement affordances, drag/drop quality gates, and search/copy/paste command
   surfaces without toolbar bloat.

--- a/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-control-plane-reliability/spec.md
@@ -6,7 +6,7 @@ resize, equalize, zoom, unzoom, and spatial focus commands.
 
 #### Scenario: Resize command succeeds
 - **WHEN** a control client requests a valid split ratio change
-- **THEN** the response reports `applied: true` and includes the resulting ratio and affected split or pane IDs
+- **THEN** the response reports `applied: true` and includes the resulting ratio and affected split or PaneSlot IDs
 
 #### Scenario: Equalize command succeeds
 - **WHEN** a control client requests equalize for a tab with split branches
@@ -14,7 +14,7 @@ resize, equalize, zoom, unzoom, and spatial focus commands.
 
 #### Scenario: Zoom command succeeds
 - **WHEN** a control client zooms or unzooms a valid pane
-- **THEN** the response reports `applied: true`, the pane ID, and the tab zoom state
+- **THEN** the response reports `applied: true`, the `pane_slot_id`, and the tab zoom state
 
 #### Scenario: Spatial focus has no target
 - **WHEN** a control client requests spatial focus and no adjacent pane exists
@@ -25,8 +25,8 @@ Pane move commands SHALL report enough source and destination detail for agents
 to observe layout changes without inferring them from raw shell snapshots.
 
 #### Scenario: In-tab move succeeds
-- **WHEN** a control client moves a pane within a tab
-- **THEN** the response reports the pane ID, source tab, destination tab, direction or position, and preserved runtime identity
+- **WHEN** a control client moves a PaneSlot within a tab
+- **THEN** the response reports the `pane_slot_id`, source tab, destination tab, direction or position, and preserved mounted ContentInstance identity
 
 #### Scenario: Drag-backed move succeeds
 - **WHEN** a drag/drop affordance completes through the control-plane movement path

--- a/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-terminal-lifecycle/spec.md
@@ -2,40 +2,43 @@
 
 ### Requirement: Zoom preserves sibling runtimes
 The macOS shell host SHALL implement split zoom as view state that does not
-close, recreate, or detach sibling pane runtimes unnecessarily.
+close, recreate, or detach sibling terminal ContentInstance runtimes unnecessarily.
 
 #### Scenario: Zoom hides siblings
-- **WHEN** a pane is zoomed
-- **THEN** sibling panes remain registered in the terminal runtime service and keep their scrollback, title, cwd, and pending delivery state
+- **WHEN** a PaneSlot with terminal content is zoomed
+- **THEN** sibling terminal ContentInstances remain registered in the terminal runtime service and keep their scrollback, title, cwd, and pending delivery state
 
 #### Scenario: Unzoom reattaches siblings
 - **WHEN** the user exits zoom
-- **THEN** sibling panes reappear by reattaching to their existing runtime handles
+- **THEN** sibling PaneSlots reappear by reattaching terminal views to their existing terminal ContentInstance runtime handles
 
 ### Requirement: Pane movement preserves runtime continuity
-In-tab pane movement and drag/drop-backed movement SHALL move pane placement
-without replacing the pane runtime identity.
+In-tab pane movement and drag/drop-backed movement SHALL move PaneSlot placement
+without replacing the mounted ContentInstance identity or any terminal ContentInstance
+runtime identity.
 
 #### Scenario: In-tab movement
-- **WHEN** a pane moves to another split position in the same tab
-- **THEN** the pane keeps its runtime handle, scrollback, title, cwd, and pending delivery state
+- **WHEN** a PaneSlot moves to another split position in the same tab
+- **THEN** the PaneSlot keeps its mounted ContentInstance
+- **AND** terminal content keeps its runtime handle, scrollback, title, cwd, and pending delivery state
 
 #### Scenario: Drag/drop movement
-- **WHEN** a pane moves through an enabled drag/drop affordance
-- **THEN** the pane keeps the same runtime identity as the equivalent explicit move command
+- **WHEN** a PaneSlot moves through an enabled drag/drop affordance
+- **THEN** the PaneSlot and mounted ContentInstance keep the same identities as the equivalent explicit move command
 
 ### Requirement: Terminal commands target the runtime owner
-Copy, paste, and terminal search SHALL be delivered to the focused pane's
-terminal runtime or host surface rather than to transient shell chrome.
+Copy, paste, and terminal search SHALL resolve the focused PaneSlot to mounted
+terminal content and deliver to that terminal ContentInstance runtime or host
+surface rather than to transient shell chrome.
 
 #### Scenario: Copy terminal selection
 - **WHEN** Copy is invoked and the focused terminal host owns a selection
-- **THEN** the terminal host handles the copy operation without changing pane runtime state
+- **THEN** the terminal host handles the copy operation without changing terminal ContentInstance runtime state
 
 #### Scenario: Paste terminal input
-- **WHEN** Paste is invoked for the focused terminal pane
-- **THEN** the paste operation is delivered through that pane's terminal input path
+- **WHEN** Paste is invoked for a focused PaneSlot that mounts terminal content
+- **THEN** the paste operation is delivered through that terminal ContentInstance input path
 
 #### Scenario: Search terminal content
-- **WHEN** terminal search is invoked for the focused pane
-- **THEN** search state follows that pane's runtime identity across view reconstruction
+- **WHEN** terminal search is invoked for a focused PaneSlot that mounts terminal content
+- **THEN** search state follows that terminal ContentInstance runtime identity across view reconstruction

--- a/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-ui-ux-conformance/spec.md
@@ -5,7 +5,7 @@ Split zoom UI SHALL make the zoomed state and escape path clear without adding a
 persistent pane-management toolbar.
 
 #### Scenario: Pane zoomed
-- **WHEN** a pane is zoomed
+- **WHEN** a PaneSlot is zoomed
 - **THEN** the UI provides a compact way to unzoom while keeping the terminal content dominant
 
 #### Scenario: Toolbar remains restrained
@@ -25,7 +25,7 @@ terminal text selection reliable.
 - **THEN** the movement affordance is visually distinct from terminal text selection regions
 
 ### Requirement: Copy paste and search surfaces are native and pane scoped
-Copy, paste, and search command UI SHALL feel native, target the focused pane,
+Copy, paste, and search command UI SHALL feel native, target the focused PaneSlot,
 and avoid displacing the sidebar, toolbar, or split layout.
 
 #### Scenario: Search opens
@@ -33,5 +33,5 @@ and avoid displacing the sidebar, toolbar, or split layout.
 - **THEN** the search UI appears as a compact pane-scoped terminal tool
 
 #### Scenario: Copy paste available
-- **WHEN** the focused terminal pane can copy or paste
-- **THEN** native menu and keyboard commands target that pane without exposing debug routing details
+- **WHEN** the focused PaneSlot mounts terminal content that can copy or paste
+- **THEN** native menu and keyboard commands target that terminal content without exposing debug routing details

--- a/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/specs/macos-shell-workspace-interactions/spec.md
@@ -1,27 +1,27 @@
 ## ADDED Requirements
 
 ### Requirement: Split zoom is reversible
-The macOS shell SHALL let users zoom and unzoom the focused pane without
-mutating the canonical split tree or closing sibling panes.
+The macOS shell SHALL let users zoom and unzoom the focused PaneSlot without
+mutating the canonical split tree or closing sibling PaneSlots or terminal content.
 
 #### Scenario: Zoom focused pane
-- **WHEN** the user zooms a focused split pane
-- **THEN** the focused pane fills the terminal content area and sibling panes remain alive and restorable
+- **WHEN** the user zooms a focused split PaneSlot
+- **THEN** the focused PaneSlot fills the shell content area and sibling PaneSlots remain alive and restorable
 
 #### Scenario: Unzoom focused pane
 - **WHEN** the user exits zoom
-- **THEN** the previous split layout, divider ratios, and pane runtime identities are restored
+- **THEN** the previous split layout, divider ratios, PaneSlot identities, and mounted ContentInstance identities are restored
 
 ### Requirement: In-tab pane movement is explicit and reversible
-The macOS shell SHALL support explicit pane movement within the same tab while
-preserving pane identity and keeping the split tree valid.
+The macOS shell SHALL support explicit PaneSlot movement within the same tab while
+preserving PaneSlot identity, mounted ContentInstance identity, and split tree validity.
 
 #### Scenario: Move pane within current tab
-- **WHEN** the user moves a pane to a valid position in the current tab
-- **THEN** alan updates the split-tree placement and keeps the moved pane's runtime identity
+- **WHEN** the user moves a PaneSlot to a valid position in the current tab
+- **THEN** alan updates the split-tree placement and keeps the moved PaneSlot and mounted ContentInstance identities
 
 #### Scenario: Move target invalid
-- **WHEN** the requested in-tab move would create an invalid split tree or move a pane onto itself
+- **WHEN** the requested in-tab move would create an invalid split tree or move a PaneSlot onto itself
 - **THEN** alan rejects the move with a stable reason and leaves the current layout unchanged
 
 ### Requirement: Drag/drop movement has a terminal-selection quality gate
@@ -33,7 +33,7 @@ mutation path as explicit moves and preserves terminal text selection behavior.
 - **THEN** alan treats the drag as terminal selection or terminal input rather than pane movement
 
 #### Scenario: Drag uses a movement affordance
-- **WHEN** the user drags a supported pane movement affordance to another valid target
+- **WHEN** the user drags a supported PaneSlot movement affordance to another valid target
 - **THEN** alan runs the same move mutation used by explicit move commands
 
 ### Requirement: Copy paste and search commands route consistently
@@ -41,13 +41,13 @@ Copy, paste, and terminal search SHALL resolve the same focused terminal target
 across native menus, keyboard shortcuts, command UI, and terminal host surfaces.
 
 #### Scenario: Copy focused terminal selection
-- **WHEN** the user invokes Copy while a terminal pane owns a selection
+- **WHEN** the user invokes Copy while focused terminal content owns a selection
 - **THEN** the command is delivered to that terminal host rather than to shell debug text
 
 #### Scenario: Paste into focused terminal
-- **WHEN** the user invokes Paste while a terminal pane is focused
-- **THEN** the command is delivered to that pane's terminal host
+- **WHEN** the user invokes Paste while a PaneSlot that mounts terminal content is focused
+- **THEN** the command is delivered to that terminal ContentInstance host
 
 #### Scenario: Search focused terminal
 - **WHEN** the user invokes terminal search from a native command surface
-- **THEN** the search UI is scoped to the focused terminal pane
+- **THEN** the search UI is scoped to the focused terminal ContentInstance

--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Split Zoom
 
 - [ ] 1.1 Add tab-scoped zoom state that leaves the canonical split tree unchanged.
-- [ ] 1.2 Render zoomed panes full-area while keeping sibling runtimes registered and restorable.
+- [ ] 1.2 Render zoomed PaneSlots full-area while keeping sibling terminal ContentInstance runtimes registered and restorable.
 - [ ] 1.3 Add menu, keyboard, command UI, and compact visible affordances for zoom and unzoom.
 - [ ] 1.4 Add model/UI tests for zoom, unzoom, disappearing panes, and selected-tab changes.
 
@@ -10,7 +10,7 @@
 - [ ] 2.1 Add explicit in-tab pane move operations with stable validation and tree repair.
 - [ ] 2.2 Route pane movement commands through the shared shell controller mutation path.
 - [ ] 2.3 Add drag/drop movement only after proving terminal text selection remains reliable.
-- [ ] 2.4 Add tests for in-tab movement, invalid movement, drag-backed movement routing, and runtime identity preservation.
+- [ ] 2.4 Add tests for in-tab movement, invalid movement, drag-backed movement routing, and PaneSlot / mounted ContentInstance identity preservation.
 
 ## 3. Control Plane
 
@@ -23,7 +23,7 @@
 
 - [ ] 4.1 Add a shared command target resolver for native menu, keyboard, command UI, context menu, and terminal host paths.
 - [ ] 4.2 Route Copy and Paste to the focused terminal host when terminal selection or input owns the command.
-- [ ] 4.3 Route terminal search to a pane-scoped UI owned by the focused terminal runtime identity.
+- [ ] 4.3 Route terminal search to a terminal-content-scoped UI owned by the focused terminal ContentInstance runtime identity.
 - [ ] 4.4 Add tests for command routing precedence and terminal-host ownership.
 
 ## 5. Verification And Archive Readiness

--- a/openspec/changes/generalize-macos-shell-content-containers/.openspec.yaml
+++ b/openspec/changes/generalize-macos-shell-content-containers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/generalize-macos-shell-content-containers/design.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/design.md
@@ -1,0 +1,155 @@
+## Context
+
+当前 macOS shell 的用户模型已经是 Space / Tab / Split / Pane，但实现模型仍然把
+Pane 视为 terminal runtime 的承载点。`ShellTab.kind` 已有 `terminal`、`scratch`、
+`log` 等枚举空间，但真实渲染路径仍然是 `ShellTab.paneTree -> ShellPane ->
+TerminalHostView`。`ShellPane` 同时承担布局身份、terminal 进程、cwd、runtime metadata、
+alan binding、viewport 摘要和 attention 状态。
+
+这个耦合在 terminal-only 阶段是可接受的，但当 Tab 需要承载 markdown、alan 设置页、
+embedded browser 或未来 agent-native 工具面板时，会产生三个问题：
+
+- split/focus/move/close 本质是容器操作，却被 terminal lifecycle 语义污染。
+- 非 terminal 内容如果绕过 shell tab，会形成第二套导航和窗口模型。
+- 如果只是继续扩展 `ShellTabKind`，混合 split tab 仍然无法自然表达。
+
+约束是：现有 terminal runtime continuity 必须保留；默认 UI 仍然 terminal-first、Arc-like、
+轻量 material；control plane 仍然需要给 agent 返回可观察、稳定的 mutation 结果。
+
+本设计选择一步到位的模型拆分：旧 `ShellPane` 不再作为新状态的核心实体，而是迁移为
+`ShellPaneSlot` 加 `ShellContentInstance`。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 将 Space / Tab / Pane 建模为通用导航和布局容器。
+- 允许一个 split tab 内混合不同 content。
+- 将 terminal runtime identity 绑定到 terminal content，而不是绑定到布局 pane。
+- 给 markdown 和 settings 定义 v1 content contract，同时让模型能在后续 change 中承载 browser。
+- 让 UI、control plane、persistence、event stream 都能表达 content kind 和 content capability。
+- 支持从 `persist-macos-shell-workspaces` 落地后的 terminal-only workspace manifest
+  一次性迁移到 content-container state。
+
+**Non-Goals:**
+
+- 不在这个 change 中实现完整 markdown 编辑器、浏览器安全模型、下载管理、cookie/profile 管理或扩展系统。
+- 不在这个 change 中实现 browser content kind、browser renderer、WKWebView 集成、浏览器安全策略、下载管理、cookie/profile 管理或扩展系统。
+- 不重做 Space / sidebar 信息架构，也不引入第二套 window/tab model。
+- 不改变 terminal app input ownership、Ghostty rendering 或现有 terminal search 细节，除非为了迁移到 content boundary 必须调整调用位置。
+- 不把 alan 设置页做成 dashboard；settings 只是 shell content 的一种。
+
+## Decisions
+
+1. **Tab 和 PaneSlot 作为容器，ContentInstance 作为内容实体。**
+
+   目标模型是 `Space -> Tab -> PaneLayoutTree -> PaneSlot -> ContentInstance`。PaneSlot
+   拥有 split/focus/selection/close/move 的身份；ContentInstance 拥有 kind、title、icon、
+   capabilities、renderer state、生命周期和持久化 payload。`ShellPaneTreeNode` 的 leaf
+   指向 `pane_slot_id`，不再指向 terminal-shaped `pane_id`。
+
+   v0.2 状态形态：
+
+   ```json
+   {
+     "contract_version": "0.2",
+     "focused_pane_slot_id": "slot_1",
+     "spaces": [],
+     "tabs": [],
+     "pane_slots": [],
+     "contents": []
+   }
+   ```
+
+   Alternative considered: 继续扩展 `ShellTabKind`。这能快速打开 settings tab，但 split leaf
+   仍然只能是 terminal pane，未来 terminal + markdown 混合布局还要再拆一次。
+
+2. **Terminal runtime service 迁移为 content-keyed。**
+
+   terminal 的进程、surface、metadata、pending delivery 和 teardown keyed by stable
+   `content_id`。PaneSlot 只是 terminal content 当前挂载的位置。移动 terminal pane slot 到
+   另一个 tab 时，slot 和 content 的绑定保持连续；未来如果支持 content detach/reattach，也不需要
+   重写 terminal runtime identity。
+
+   Alternative considered: v1 继续 pane-keyed runtime，只在 `ShellPane` 上增加 `content` 字段。
+   这会降低短期迁移成本，但会长期保留“Pane 到底是布局位置还是 terminal runtime”的歧义，不符合
+   一步到位目标。
+
+3. **Content capability 决定命令合法性。**
+
+   通用 pane 命令包括 split、focus、move、close、open content tab。content-specific 命令必须先
+   通过 capability 检查。terminal input command 应改为 terminal-specific surface，例如
+   `terminal.send_text`；该命令可以接受 `pane_slot_id` 作为便捷目标，但执行前必须解析到承载
+   `terminal` kind 的 ContentInstance，并以 `content_id` 调用 runtime。
+
+   Alternative considered: 让每个 renderer 自己忽略不支持的命令。那会让 agent 看到
+   `applied: true` 但没有效果，违背当前 control-plane truthfulness 合约。
+
+4. **首批非 terminal content 是 markdown viewer 和 settings。**
+
+   v1 需要能表达并打开 markdown viewer 和 alan settings。markdown 先做 read-only viewer；
+   settings 先承载 alan app 设置。Browser 不进入 v1 implementation，也不要求 browser
+   ContentInstance descriptor；完整 webview 安全策略和 browser content kind 后续单独 change 细化。
+
+   Alternative considered: v1 加入 browser host boundary。它能提前验证外部资源和嵌入式 host
+   边界，但会把 scope 拉到 webview、安全策略、profile/cookie、下载和导航权限，不适合与模型拆分同批完成。
+
+5. **Persisted state 采用 v0.2 单模型加 v0.1 迁移输入。**
+
+   本 change 在 `persist-macos-shell-workspaces` 之后执行，因此 durable restore 的主要输入是
+   `ShellWorkspaceManifest` 中的 terminal-only `pinSnapshot` / `liveSnapshot`，而不是旧的
+   `shell-state-window_main.json`。Manifest 迁移时，每个 terminal restore leaf 迁移成
+   `ShellPaneSlot` + `ShellContentInstance(kind: terminal)`，并保留 Space/Tab identity、ordering、
+   selected state、pin 状态、TTL anchor 和 active-task metadata。
+
+   旧的 `ShellPane` decode compatibility 仍然保留为 v0.1 shell-state/runtime projection 的
+   诊断或兼容输入，但不能重新成为 workspace restore authority。旧字段如 cwd、process、context、
+   viewport、alan binding 映射到 terminal content payload 或 projection。新 manifest 和新 shell
+   state 只 encode v0.2，不长期 dual-write v0.1。迁移失败时进入可诊断 fallback，不能静默丢失
+   terminal tabs、slots 或 contents。
+
+   Alternative considered: 重置所有旧 persisted state。实现最简单，但会破坏当前 shell restore
+   行为，也不利于验证 terminal continuity。
+
+6. **UI 继续由 shell chrome 统一承载。**
+
+   Sidebar tab rows、toolbar title、pane title bars 和 command UI 显示 content title/kind/capability
+   的用户语言。非 terminal content 不拥有新的 page header、dashboard 卡片或独立导航 chrome。
+
+   Alternative considered: 给 settings/browser 单独完整页面 shell。那会让 Tab 看似统一，实际
+   交互层级割裂，违背 terminal-first 工作区方向。
+
+## Risks / Trade-offs
+
+- **Risk: 模型迁移范围较大。** -> 先引入兼容 descriptor 和 adapter，让 terminal 通过 adapter
+  运行，再迁移 call sites；保留 v0.1 decode 路径，但新写入只使用 v0.2。
+- **Risk: 泛化后 terminal 体验退化。** -> terminal continuity、send_text、search、focus 和
+  close teardown 的现有 tests 必须继续通过，并新增 content-keyed runtime 回归测试。
+- **Risk: control plane 命令语义膨胀。** -> 将命令分为 pane mutation、content creation、
+  content-specific runtime command 三类，并为不支持的 content 返回稳定 unsupported code。
+- **Risk: browser scope 过大。** -> browser 不进入 v1；只保留模型扩展性，browser content kind
+  和 webview 策略后续单独设计。
+- **Risk: settings 变成 dashboard。** -> UI spec 明确 settings 是 tab content，继承 shell
+  chrome，只显示设置本身，不引入营销式页面布局。
+
+## Migration Plan
+
+1. 在 `persist-macos-shell-workspaces` 归档后的 accepted specs 上实现本 change，先读取已落地的
+   `ShellWorkspaceManifest` schema 和 materializer 边界。
+2. 增加 v0.2 content-container model，同时保留旧 `ShellPane` decode compatibility。
+3. 将 workspace manifest 的 terminal-only restore snapshot 迁移为 content-aware restore
+   snapshot；新写入只使用 PaneSlot / ContentInstance shape，不写回 terminal-only snapshot。
+4. 将现有 terminal leaf 渲染包成 `TerminalContentRenderer`，并将 runtime registry keyed by
+   `content_id`。
+5. 将 split/focus/move/close mutation 改为操作 PaneSlot，并由 terminal adapter 处理 terminal
+   content teardown。
+6. 增加 markdown/settings 的最小 renderer 和 content descriptors。
+7. 扩展 control plane DTO 和命令结果，暴露 pane slots、content kind、capabilities、
+   `content_id` 和 unsupported-command 语义。
+8. 添加 manifest 迁移、mixed split、terminal continuity、non-terminal command rejection 和 UI
+   evidence 验证。
+9. 旧状态迁移稳定后，再移除不再需要的 v0.1-only projection helpers。
+
+## Open Questions
+
+无。当前已确认：一个 split tab 内可以混合不同 content。

--- a/openspec/changes/generalize-macos-shell-content-containers/proposal.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+alan 的 macOS shell 现在把 Tab、Pane、Split 和 Terminal runtime 绑定在一起：
+用户看到的是通用工作区结构，但模型和渲染路径事实上只支持 terminal 这一种内容。随着
+markdown 文件、alan 设置页、浏览器内核和其他原生工具面板进入同一个工作区，Tab 和
+Pane 需要成为通用内容容器，而 Terminal 需要降级为一种 Content surface。
+
+这个 change 采用一步到位的真分离模型，而不是在现有 `ShellPane` 上追加
+`content` 字段后继续保留 terminal 历史语义。
+
+## Sequencing
+
+本 change 以 `persist-macos-shell-workspaces` 先完成并归档为前提。完成顺序很重要：
+workspace restore authority 先由 `ShellWorkspaceManifest` 接管；随后本 change 将该 manifest
+的 terminal-only restore snapshot 升级为 content-container restore snapshot。实现时不得重新把
+`shell-state-window_main.json` 或 `ShellStateSnapshot` 作为 workspace restore authority。
+
+## What Changes
+
+- **BREAKING**: 将 macOS shell state 升级为 `contract_version = "0.2"`，新状态以
+  `pane_slots` 和 `contents` 分离表达布局与内容；`persist-macos-shell-workspaces` 产生的
+  terminal-only manifest snapshot 和旧 `panes: [ShellPane]` 只作为迁移输入。
+- 引入通用 content-container 合约：Space / Tab / PaneSlot 负责导航、布局、焦点、移动和关闭；
+  ContentInstance 负责具体内容类型、生命周期、标题、图标、命令能力、渲染和安全边界。
+- 允许一个 split tab 内混合不同 content，例如左侧 terminal、右侧 markdown 或 settings。
+- 将 terminal runtime identity 从 pane-keyed 迁移为 content-keyed：`terminal` content 是
+  runtime owner，PaneSlot 只是当前承载位置。
+- 为首批非 terminal content 定义 v1 范围：markdown viewer 和 alan settings；browser 作为
+  后续 change 单独设计。
+- 区分通用 pane/control-plane 命令和 content-specific 命令：split、focus、move、close 是
+  PaneSlot 命令；terminal input 使用 terminal-specific command，并先解析到 `terminal`
+  ContentInstance。
+- 更新 UI 合约，要求非 terminal content 仍然出现在 Arc-like shell 工作区内，不能退化成
+  dashboard/page chrome 或第二套导航模型。
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-shell-content-containers`: 定义 macOS shell 的通用内容容器、PaneSlot /
+  ContentInstance 分离、content kind、content 生命周期、能力声明和首批非 terminal
+  surface 行为。
+
+### Modified Capabilities
+
+- `macos-shell-workspace-interactions`: 将 split、focus、pane lift、cross-tab move 等交互从
+  terminal-only pane 扩展为 content-agnostic PaneSlot 操作。
+- `macos-shell-terminal-lifecycle`: 明确 terminal lifecycle 只适用于 terminal ContentInstance，
+  并将 terminal runtime 连续性绑定到 `content_id`。
+- `macos-shell-control-plane-reliability`: 区分通用 pane mutation、content creation 和
+  content-specific runtime commands 的结果语义，并更新 text delivery command 的目标模型。
+- `macos-shell-ui-ux-conformance`: 约束 markdown、settings 等非 terminal content
+  在默认 shell 中的视觉层级和 progressive disclosure。
+- `macos-shell-workspace-persistence`: 将 workspace manifest 的 pin/live restore snapshot
+  从 terminal-only pane shape 升级为 content-aware PaneSlot / ContentInstance restore shape。
+- `macos-shell-build-test-contract`: 增加通用 content-container 模型、渲染注册和混合 split
+  场景的验证要求。
+
+## Impact
+
+- Affected Swift model code: `ShellTab`, new `ShellPaneSlot`, new `ShellContentInstance`,
+  `ShellPaneTreeNode`, `ShellStateSnapshot`, state mutation helpers, persistence migration,
+  and sidebar projections.
+- Affected Swift rendering code: `ShellWorkspaceView`, `TerminalPaneView`, split layout leaves,
+  terminal host attachment, and markdown/settings host views.
+- Affected runtime/control plane code: shell DTOs, local/socket command handling, event projection,
+  command result codes, terminal-only command validation, and legacy v0.1 state migration.
+- Affected tests/scripts: shell model mutation tests, terminal runtime continuity checks,
+  control-plane contract tests, and screenshot/manual verification for mixed content tabs.

--- a/openspec/changes/generalize-macos-shell-content-containers/proposal.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/proposal.md
@@ -53,6 +53,8 @@ workspace restore authority 先由 `ShellWorkspaceManifest` 接管；随后本 c
   在默认 shell 中的视觉层级和 progressive disclosure。
 - `macos-shell-workspace-persistence`: 将 workspace manifest 的 pin/live restore snapshot
   从 terminal-only pane shape 升级为 content-aware PaneSlot / ContentInstance restore shape。
+- `macos-terminal-runtime-foundation`: 将 terminal runtime service、surface handle、metadata
+  projection 和 text delivery 从 pane-keyed 迁移为 terminal ContentInstance keyed。
 - `macos-shell-build-test-contract`: 增加通用 content-container 模型、渲染注册和混合 split
   场景的验证要求。
 
@@ -65,5 +67,6 @@ workspace restore authority 先由 `ShellWorkspaceManifest` 接管；随后本 c
   terminal host attachment, and markdown/settings host views.
 - Affected runtime/control plane code: shell DTOs, local/socket command handling, event projection,
   command result codes, terminal-only command validation, and legacy v0.1 state migration.
-- Affected tests/scripts: shell model mutation tests, terminal runtime continuity checks,
-  control-plane contract tests, and screenshot/manual verification for mixed content tabs.
+- Affected tests/scripts: shell model mutation tests, fake terminal runtime service tests,
+  terminal runtime continuity checks, control-plane contract tests, and screenshot/manual
+  verification for mixed content tabs.

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
@@ -1,3 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal host boundary is testable
+The terminal host SHALL expose a testable boundary for runtime attachment,
+teardown, and text delivery without requiring the real Ghostty library in every
+test.
+
+#### Scenario: Mock runtime accepts text
+- **WHEN** a test runtime is registered for terminal content and `terminal.send_text` is issued
+- **THEN** the test verifies the text reaches the runtime and the control response reports accepted bytes with the terminal `content_id`
+
+#### Scenario: Mock runtime unavailable
+- **WHEN** no runtime is registered for terminal content and `terminal.send_text` is issued
+- **THEN** the test verifies the response reports failure or durable queueing according to the delivery contract
+
+### Requirement: Runtime service ownership has focused tests
+The Apple client SHALL include focused tests for process bootstrap, window
+runtime service ownership, terminal ContentInstance handle creation, reattachment,
+text delivery, and teardown using fake Ghostty adapters where possible.
+
+#### Scenario: Fake runtime reattaches view
+- **WHEN** a test creates a terminal ContentInstance handle, detaches the host view, and attaches a replacement host view
+- **THEN** the test verifies that the `content_id` handle identity and runtime metadata remain unchanged
+
+#### Scenario: Fake runtime tears down once
+- **WHEN** a test closes a terminal ContentInstance, PaneSlot, tab, or window through shell actions
+- **THEN** the fake runtime observes exactly one teardown call per affected terminal ContentInstance
+
+### Requirement: Control-plane runtime tests use the service boundary
+Control-plane tests SHALL exercise runtime-dependent mutations through the same
+terminal runtime service boundary used by production code.
+
+#### Scenario: Service accepts text
+- **WHEN** a control-plane test sends text to fake live terminal content with `terminal.send_text`
+- **THEN** the command response reports accepted bytes from the fake service and shell diagnostics remain clean
+
+#### Scenario: Service reports runtime missing
+- **WHEN** a control-plane test sends text to terminal content whose service handle is absent
+- **THEN** the command response reports a stable runtime-missing error
+
 ## ADDED Requirements
 
 ### Requirement: Content container model has focused tests

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Content container model has focused tests
+Apple client SHALL 为 v0.2 content-container model、旧状态迁移、mixed split、content-aware
+command validation 和 content-keyed terminal runtime continuity 提供 focused 自动化测试或明确的人工验证记录。
+
+#### Scenario: Old terminal state migrates
+- **WHEN** 测试加载 `persist-macos-shell-workspaces` 产生的 terminal-only workspace manifest
+- **THEN** shell model 迁移出 PaneSlot 和 terminal ContentInstance
+- **AND** focused space、focused tab、focused PaneSlot、pin/live snapshot 和 terminal metadata projection 保持一致
+
+#### Scenario: Legacy shell state is not restored as workspace authority
+- **WHEN** 测试环境同时存在旧 `shell-state-window_main.json` 和 workspace manifest
+- **THEN** app restore 使用 workspace manifest materializer
+- **AND** 旧 shell-state 只作为 runtime/control-plane projection 或诊断输入存在
+
+#### Scenario: Mixed split mutates safely
+- **WHEN** 测试创建 terminal + markdown + settings 的 mixed split tab
+- **THEN** split、focus、move、close 和 equalize 操作保持 split tree 有效
+- **AND** terminal runtime identity 不因非 terminal PaneSlot 操作重建
+
+#### Scenario: Non-terminal command rejection tested
+- **WHEN** control-plane 测试向 markdown 或 settings PaneSlot 发送 `terminal.send_text`
+- **THEN** response 使用 stable unsupported-content error
+- **AND** fake terminal runtime service 没有收到 delivery
+
+#### Scenario: Terminal content identity survives movement
+- **WHEN** 测试将 terminal ContentInstance 所在 PaneSlot 移动到另一个 tab 或重新 attach 视图
+- **THEN** terminal runtime handle、scrollback、metadata 和 pending delivery 仍绑定到同一个 `content_id`
+
+#### Scenario: Content rendering registry verified
+- **WHEN** renderer registry 收到 terminal、markdown 和 settings content descriptor
+- **THEN** 测试或 review checklist 确认每个 kind 路由到对应 renderer 或 bounded unavailable surface
+
+#### Scenario: Visual evidence covers mixed content
+- **WHEN** content-container UI implementation 标记完成
+- **THEN** maintainers 可以检查 running-app screenshot 或记录，确认 light-mode shell 中存在混合 content tab/split，且 sidebar、toolbar、pane title bar 和 terminal-first chrome 保持一致

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-build-test-contract/spec.md
@@ -28,6 +28,11 @@ command validation 和 content-keyed terminal runtime continuity 提供 focused 
 - **WHEN** 测试将 terminal ContentInstance 所在 PaneSlot 移动到另一个 tab 或重新 attach 视图
 - **THEN** terminal runtime handle、scrollback、metadata 和 pending delivery 仍绑定到同一个 `content_id`
 
+#### Scenario: Retired unpinned tab finalizes terminal content
+- **WHEN** workspace lifecycle pruning retires an inactive unpinned Tab that contains terminal ContentInstances
+- **THEN** focused tests verify those terminal runtimes are finalized through the runtime service
+- **AND** retired PaneSlots and terminal ContentInstances cannot receive later `terminal.send_text` delivery
+
 #### Scenario: Content rendering registry verified
 - **WHEN** renderer registry 收到 terminal、markdown 和 settings content descriptor
 - **THEN** 测试或 review checklist 确认每个 kind 路由到对应 renderer 或 bounded unavailable surface

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-content-containers/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-content-containers/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Shell containers separate layout from content
+alan 的 macOS shell SHALL 将 Space、Tab、PaneSlot 作为通用导航和布局容器，将 terminal、
+markdown、settings 等具体内容作为 ContentInstance 挂载在 PaneSlot 上。新状态
+MUST 使用 `contract_version = "0.2"`，并以 `pane_slots` 和 `contents` 分离表达布局与内容。
+
+#### Scenario: Existing terminal tab is represented as terminal content
+- **WHEN** alan 读取一个只包含 terminal 的现有 shell tab
+- **THEN** 该 tab 以通用 pane layout tree 表达
+- **AND** 每个 terminal leaf 以 PaneSlot 加 `terminal` ContentInstance 表达，而不是把 terminal 字段作为所有 pane 的默认形态
+- **AND** pane layout leaf 引用 `pane_slot_id`，terminal runtime 引用 `content_id`
+
+#### Scenario: Mixed split tab is represented
+- **WHEN** 一个 tab 左侧包含 terminal content、右侧包含 markdown 或 settings content
+- **THEN** 两个 leaf 共用同一个 tab 的 split layout tree
+- **AND** 每个 leaf 保持独立 PaneSlot identity、ContentInstance identity、content kind、title、capabilities 和 lifecycle state
+
+#### Scenario: Non-terminal pane receives focus
+- **WHEN** 用户聚焦 markdown 或 settings pane
+- **THEN** shell focus SHALL 指向该 pane slot
+- **AND** alan MUST NOT 为该 pane 创建 terminal runtime，除非 content kind 是 `terminal`
+
+### Requirement: PaneSlot and ContentInstance identities are distinct
+alan 的 macOS shell SHALL 使用独立的 `pane_slot_id` 和 `content_id`。`pane_slot_id` 表示当前
+layout/focus 位置，`content_id` 表示内容实例及其 runtime/persistence identity。
+
+#### Scenario: Content moves with a slot
+- **WHEN** 用户将承载 terminal、markdown 或 settings content 的 PaneSlot 移动到另一个 tab
+- **THEN** 该 PaneSlot 保持同一个 `pane_slot_id`
+- **AND** 挂载的 ContentInstance 保持同一个 `content_id`
+
+#### Scenario: Content is replaced in a slot
+- **WHEN** alan 在现有 PaneSlot 中用 markdown content 替换 terminal content
+- **THEN** PaneSlot 保持同一个 `pane_slot_id`
+- **AND** old terminal ContentInstance lifecycle 进入 closed/finalized
+- **AND** new markdown ContentInstance 获得新的 `content_id`
+
+#### Scenario: Future multi-view content is not implied
+- **WHEN** v0.2 state 中一个 ContentInstance 被挂载
+- **THEN** alan SHALL treat it as attached to one active PaneSlot unless a future capability explicitly introduces multi-view attachment
+
+### Requirement: Content descriptors declare identity and capabilities
+每个 shell ContentInstance SHALL 暴露稳定 `content_id`、content kind、用户可见标题、可选图标、
+capabilities、持久化 payload、lifecycle state 和 renderer state。
+
+#### Scenario: Terminal content declares terminal capabilities
+- **WHEN** control plane 或 UI 查询 terminal content
+- **THEN** response 包含 `content_id`、terminal content kind 和可用能力，例如 terminal input、terminal search、paste 和 runtime metadata
+
+#### Scenario: Markdown content declares viewer capabilities
+- **WHEN** alan 打开 markdown 文件 content
+- **THEN** content descriptor 包含文件 URL 或授权引用、用户可见文件名和 read-only viewer capability
+- **AND** terminal-only capabilities 不出现在该 content descriptor 中
+
+#### Scenario: Settings content declares settings capabilities
+- **WHEN** alan 打开 settings content
+- **THEN** content descriptor 表达设置 surface identity 和设置页标题
+- **AND** settings content 的可用命令通过 settings-specific capabilities 暴露
+
+### Requirement: Content lifecycle is pane-slot aware
+ContentInstance SHALL 在 PaneSlot 创建、移动、关闭和恢复时保持明确生命周期，并且不得让
+content-specific cleanup 破坏通用 shell layout。
+
+#### Scenario: Pane with non-terminal content closes
+- **WHEN** 用户关闭承载 markdown 或 settings content 的 PaneSlot
+- **THEN** alan 移除该 PaneSlot 并 finalize 对应 ContentInstance
+- **AND** terminal runtime finalizer MUST NOT 被错误调用
+
+#### Scenario: Pane with terminal content moves
+- **WHEN** 用户将 terminal ContentInstance 所在的 PaneSlot 移动到另一个 tab
+- **THEN** PaneSlot identity、ContentInstance identity 和 terminal runtime identity 保持连续
+- **AND** ContentInstance descriptor 跟随该 PaneSlot 的新 tab/space membership
+
+#### Scenario: Pane with markdown content moves
+- **WHEN** 用户将 markdown ContentInstance 所在的 PaneSlot 移动到另一个 tab
+- **THEN** markdown content 的文件引用、scroll/viewer state 和用户可见标题保持连续
+- **AND** 目标 tab split tree 保持有效
+
+### Requirement: Content state persists across app restore
+alan SHALL 通过 workspace manifest 持久化通用 container state、PaneSlots 和 ContentInstances，
+使 app restore 后能恢复 tab、split 和 content kind，而不会把非 terminal content 误恢复为 terminal。
+
+#### Scenario: App restores mixed content tab
+- **WHEN** alan 重新打开之前包含 terminal、markdown 和 settings pane 的窗口
+- **THEN** shell state 恢复同一 tab、split tree、PaneSlot IDs 和每个 ContentInstance 的 kind
+- **AND** terminal content 从 manifest 中的 terminal restore payload 创建新的 terminal runtime，而不是恢复上一轮 app 进程中的 OS process
+- **AND** markdown/settings content 恢复为各自的 viewer/settings surface
+
+#### Scenario: Terminal-only workspace manifest is migrated
+- **WHEN** alan 读取 `persist-macos-shell-workspaces` 产生的 terminal-only workspace manifest
+- **THEN** alan 将每个 terminal restore leaf 迁移为 PaneSlot 加 `terminal` ContentInstance
+- **AND** Space/Tab identity、ordering、selected state、pin 状态、TTL anchor 和 active-task metadata 保持一致
+- **AND** 如果迁移失败，alan 记录可诊断错误而不是静默丢失 tab、pane slot 或 content
+
+#### Scenario: Legacy shell state remains non-authoritative
+- **WHEN** `shell-state-window_main.json` 仍以旧 terminal-only shell-state shape 存在
+- **THEN** alan MAY decode it for diagnostics or compatibility checks
+- **AND** alan MUST NOT use it as the workspace restore authority once a workspace manifest exists
+
+### Requirement: V1 non-terminal surfaces are bounded
+V1 content-container implementation SHALL 支持 terminal、read-only markdown viewer、alan settings
+surface；超出边界的编辑器、browser content、浏览器权限和扩展能力 SHALL 留给后续 change。
+
+#### Scenario: Markdown file opens in shell tab
+- **WHEN** 用户或 control client 请求打开 markdown 文件
+- **THEN** alan 在当前 space 中创建或聚焦一个 markdown content tab/pane
+- **AND** 该 surface 以 read-only viewer 呈现文件内容
+
+#### Scenario: Settings opens in shell tab
+- **WHEN** 用户打开 alan app 设置
+- **THEN** alan 将设置页作为 shell tab content 呈现
+- **AND** 设置页继承 shell sidebar、toolbar 和 tab selection 模型

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-control-plane-reliability/spec.md
@@ -55,6 +55,35 @@ PaneSlot focus commands after the mutation is accepted or rejected.
 - **WHEN** a control client closes a PaneSlot
 - **THEN** the response reflects both shell model removal and the remaining focused PaneSlot
 
+### Requirement: Pane focus commands are observable
+Direct pane focus commands SHALL report whether focus changed to the requested
+PaneSlot or why the target could not be focused.
+
+#### Scenario: Direct focus changes
+- **WHEN** a control client requests focus for an existing PaneSlot
+- **THEN** the response reports `applied: true` and the requested `pane_slot_id`
+
+#### Scenario: Direct focus target missing
+- **WHEN** a control client requests focus for a missing PaneSlot
+- **THEN** the response reports `applied: false` with a stable missing-pane error and preserves existing focus
+
+### Requirement: Workspace mutation events are observable
+Workspace mutations SHALL emit shell events with enough detail for agents to
+observe PaneSlot creation, closure, movement, content creation/closure,
+terminal metadata changes, attention changes, and focus changes.
+
+#### Scenario: Split creates a pane
+- **WHEN** the user or a control client creates a split
+- **THEN** the shell event stream records the created PaneSlot, mounted ContentInstance, and tab
+
+#### Scenario: Move changes a pane tab
+- **WHEN** the user or a control client moves a PaneSlot to another tab
+- **THEN** the shell event stream records the previous and current tab or space identity for the moved PaneSlot
+
+#### Scenario: Focus changes
+- **WHEN** the user or a control client changes focused pane
+- **THEN** the shell event stream records the previous and current focused PaneSlot IDs
+
 ## ADDED Requirements
 
 ### Requirement: Control plane separates pane and content commands

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-control-plane-reliability/spec.md
@@ -1,0 +1,92 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime-dependent commands use service state
+The macOS shell control plane SHALL derive runtime-dependent terminal command
+results from the terminal content runtime service after resolving the target
+window, PaneSlot, and ContentInstance.
+
+#### Scenario: Text delivery succeeds through runtime service
+- **WHEN** `terminal.send_text` targets a terminal ContentInstance whose service-owned surface accepts the bytes
+- **THEN** the response reports `applied: true`, the accepted byte count, the `content_id`, and the terminal runtime phase observed by the service
+
+#### Scenario: Target slot has no terminal content
+- **WHEN** a runtime-dependent terminal command targets a PaneSlot that shell state lists but that PaneSlot is empty or contains non-terminal content
+- **THEN** the response reports `applied: false` with a stable unsupported-content error and does not claim delivery
+
+#### Scenario: Target terminal content has no service handle
+- **WHEN** a runtime-dependent terminal command targets a terminal ContentInstance that shell state still lists but the runtime service cannot resolve
+- **THEN** the response reports `applied: false` with a stable runtime-missing error and does not claim delivery
+
+### Requirement: Pending delivery is pane scoped and observable
+If the runtime service supports queued text delivery, the queue SHALL be scoped
+to one terminal ContentInstance and observable through shell diagnostics or
+command responses.
+
+#### Scenario: Text is queued for an attachable terminal content
+- **WHEN** `terminal.send_text` targets an attachable terminal ContentInstance whose surface is not currently ready to accept text
+- **THEN** the response reports queued state with the `content_id`, queued byte count, and delivery policy
+
+#### Scenario: Queued text is flushed
+- **WHEN** the terminal content surface becomes ready after text was queued
+- **THEN** the runtime service flushes the content-specific queue and records whether the bytes were accepted or rejected
+
+#### Scenario: Terminal content closes with queued text
+- **WHEN** a terminal ContentInstance closes while text remains queued
+- **THEN** the runtime service drops or fails that queue with a diagnostic tied to the closed `content_id`
+
+### Requirement: Pane workspace mutation commands report authoritative results
+The macOS shell control plane SHALL return authoritative results for PaneSlot
+split, PaneSlot close, PaneSlot lift, cross-tab PaneSlot move, and direct
+PaneSlot focus commands after the mutation is accepted or rejected.
+
+#### Scenario: Split command succeeds
+- **WHEN** a control client requests a valid directional PaneSlot split
+- **THEN** the response reports `applied: true` and includes the resulting focused `pane_slot_id`
+
+#### Scenario: Split command invalid
+- **WHEN** a control client requests a PaneSlot split against a missing slot or without a direction
+- **THEN** the response reports `applied: false` with a stable error code and leaves shell state unchanged
+
+#### Scenario: Move command succeeds
+- **WHEN** a control client moves a PaneSlot to a valid destination tab in the same window
+- **THEN** the response reports `applied: true` and the resulting focused `pane_slot_id` while preserving the PaneSlot and ContentInstance identities
+
+#### Scenario: Close command succeeds
+- **WHEN** a control client closes a PaneSlot
+- **THEN** the response reflects both shell model removal and the remaining focused PaneSlot
+
+## ADDED Requirements
+
+### Requirement: Control plane separates pane and content commands
+macOS shell control plane SHALL 区分通用 pane mutation、content creation 和 content-specific
+runtime command，并从 authoritative shell/content/runtime state 返回结果。
+
+#### Scenario: Pane split creates requested content
+- **WHEN** control client 请求在目标 pane 旁创建 split，并指定 `markdown` content intent
+- **THEN** response 报告 `applied: true`
+- **AND** response 包含新 `pane_slot_id`、tab ID、`content_id`、content kind 和 resulting shell state
+
+#### Scenario: Terminal text targets terminal content
+- **WHEN** `terminal.send_text` 目标 PaneSlot 承载 `terminal` ContentInstance 且 runtime 接受 bytes
+- **THEN** response 报告 `applied: true`、`content_id`、accepted byte count 和 terminal runtime phase
+
+#### Scenario: Terminal text targets non-terminal content
+- **WHEN** `terminal.send_text` 目标 PaneSlot 承载 markdown 或 settings content
+- **THEN** response 报告 `applied: false`
+- **AND** response 使用 stable unsupported-content error code
+- **AND** alan 不声明 accepted bytes、不创建 terminal runtime、不改变 content state
+
+### Requirement: Shell state exposes content descriptors
+Control-plane shell state responses SHALL 为每个 PaneSlot 暴露 `pane_slot_id`、挂载的
+`content_id`、content kind、用户可见 title、capabilities 和必要的安全引用，使 agent 可以判断哪些命令合法。
+
+#### Scenario: Agent reads mixed shell state
+- **WHEN** agent 查询 shell state
+- **THEN** response 中包含 `pane_slots` 和 `contents`
+- **AND** 每个 PaneSlot 可以解析到当前挂载的 ContentInstance
+- **AND** terminal-only runtime metadata 只出现在 terminal content projection 中
+
+#### Scenario: Unsupported command is inspectable
+- **WHEN** agent 对不支持的 content 执行 content-specific command
+- **THEN** response 包含稳定错误码和目标 content kind
+- **AND** event/diagnostic surface 可以显示该 rejected command

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
@@ -4,6 +4,9 @@
 The macOS shell host SHALL keep terminal process, renderer surface, runtime metadata,
 and buffered control state owned by terminal ContentInstances through the terminal
 runtime service rather than by the transient SwiftUI/AppKit view that happens to be visible.
+Runtime continuity applies while the Tab remains part of current shell state; explicit
+close operations and workspace lifecycle retirement of inactive unpinned Tabs SHALL
+finalize affected terminal ContentInstances through the runtime service boundary.
 
 #### Scenario: Switching away from a tab
 - **WHEN** a user switches from one tab to another and the first tab is no longer rendered
@@ -16,6 +19,17 @@ runtime service rather than by the transient SwiftUI/AppKit view that happens to
 #### Scenario: Closing a tab
 - **WHEN** a tab is explicitly closed
 - **THEN** all terminal ContentInstances owned by that tab are finalized exactly once through the runtime service and their final state is reflected in shell state
+
+#### Scenario: Retiring an inactive unpinned Tab
+- **WHEN** workspace lifecycle pruning retires an inactive unpinned Tab
+- **THEN** all terminal ContentInstances owned by that Tab are finalized through the same runtime service ownership boundary used by explicit close operations
+- **AND** non-terminal ContentInstances in that Tab follow their content-specific finalization path without invoking terminal runtime finalizers
+- **AND** retired PaneSlots and terminal ContentInstances are no longer valid terminal delivery targets
+
+#### Scenario: Restoring a Tab after app restart
+- **WHEN** alan restores a Pinned Tab or retained Unpinned Tab from the workspace manifest after app restart
+- **THEN** alan materializes terminal ContentInstances from the restore snapshot
+- **AND** alan creates new terminal runtimes for those ContentInstances instead of claiming continuity with processes from the prior app instance
 
 ### Requirement: Pane text delivery is truthful
 The macOS shell host SHALL only acknowledge terminal text delivery as applied when the

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Terminal lifecycle is scoped to terminal content
+macOS shell 的 terminal runtime lifecycle SHALL 只适用于 `terminal` ContentInstance。非 terminal
+ContentInstance MUST NOT 分配 terminal runtime、shell process、Ghostty surface 或 terminal delivery queue。
+
+#### Scenario: Settings pane becomes visible
+- **WHEN** 用户选择承载 settings content 的 pane
+- **THEN** alan 渲染 settings surface
+- **AND** terminal runtime registry 不为该 PaneSlot 或 ContentInstance 创建 shell process 或 Ghostty host
+
+#### Scenario: Markdown pane receives terminal text command
+- **WHEN** terminal text command 的目标 PaneSlot 承载 markdown content
+- **THEN** terminal lifecycle 不接收该 delivery
+- **AND** control response 报告 stable unsupported-content error
+
+#### Scenario: Live terminal pane remains continuous after model migration
+- **WHEN** 当前进程内仍属于 shell state 的 terminal pane 从旧 terminal-only model 迁移到 content-container model
+- **THEN** 该 terminal ContentInstance 的 process、scrollback、metadata、pending delivery 和 reattachment 语义保持连续
+- **AND** runtime continuity 绑定到 `content_id`
+
+#### Scenario: Terminal content restored from workspace manifest
+- **WHEN** alan after app restart 从 workspace manifest materialize 出 terminal ContentInstance
+- **THEN** terminal lifecycle 创建新的 terminal runtime 和 renderer surface
+- **AND** alan MUST NOT 声称恢复上一轮 app 进程中的 terminal process、scrollback 或 delivery queue
+- **AND** runtime continuity 从本轮 materialization 之后开始绑定到该 `content_id`
+
+### Requirement: Terminal adapter owns terminal-specific projection
+Terminal content adapter SHALL 负责将 terminal runtime metadata 投影为 shell-visible title、cwd、
+attention、surface readiness、alan binding 和 terminal command capabilities，并以 `content_id`
+作为 runtime identity。
+
+#### Scenario: Background terminal metadata updates
+- **WHEN** 后台 terminal content 报告 cwd、title、attention 或 process status 变化
+- **THEN** terminal adapter 更新该 content/pane 的 shell projection
+- **AND** 用户当前聚焦的非 terminal pane 不被抢占
+
+#### Scenario: Terminal content closes
+- **WHEN** 用户关闭承载 terminal content 的 pane
+- **THEN** terminal adapter 以 `content_id` 调用 terminal runtime finalizer
+- **AND** shell layout 删除该 PaneSlot 后不保留可投递 terminal target
+
+#### Scenario: Terminal content moves between pane slots
+- **WHEN** terminal ContentInstance 从一个 PaneSlot 移动或重挂到另一个 PaneSlot
+- **THEN** terminal runtime handle、scrollback、pending delivery 和 metadata 保持绑定到同一个 `content_id`
+- **AND** terminal host focus 解析到新的 PaneSlot 位置

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,3 +1,199 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal runtimes survive view selection changes
+The macOS shell host SHALL keep terminal process, renderer surface, runtime metadata,
+and buffered control state owned by terminal ContentInstances through the terminal
+runtime service rather than by the transient SwiftUI/AppKit view that happens to be visible.
+
+#### Scenario: Switching away from a tab
+- **WHEN** a user switches from one tab to another and the first tab is no longer rendered
+- **THEN** each terminal ContentInstance in the first tab remains alive unless its PaneSlot, content, tab, or workspace lifecycle is explicitly closed or retired
+
+#### Scenario: Switching back to a tab
+- **WHEN** a user returns to a previously selected tab
+- **THEN** the host reattaches visible terminal views to existing terminal ContentInstance runtimes instead of booting new shell processes
+
+#### Scenario: Closing a tab
+- **WHEN** a tab is explicitly closed
+- **THEN** all terminal ContentInstances owned by that tab are finalized exactly once through the runtime service and their final state is reflected in shell state
+
+### Requirement: Pane text delivery is truthful
+The macOS shell host SHALL only acknowledge terminal text delivery as applied when the
+target terminal ContentInstance runtime accepts the text or queues it in a durable
+content-specific delivery buffer that will be flushed when the runtime is attached.
+
+#### Scenario: Visible terminal content accepts text
+- **WHEN** `terminal.send_text` targets a visible PaneSlot with attached terminal content and a ready runtime
+- **THEN** the response reports `applied: true`, includes the accepted byte count, and identifies the terminal `content_id`
+
+#### Scenario: Background terminal content accepts text
+- **WHEN** `terminal.send_text` targets a background PaneSlot with existing terminal content and runtime state
+- **THEN** the text is delivered to that terminal ContentInstance without requiring the tab to become visible
+
+#### Scenario: Target slot cannot accept text
+- **WHEN** `terminal.send_text` targets a missing, closed, non-terminal, or not-yet-bootable PaneSlot or ContentInstance
+- **THEN** the response reports `applied: false` with a specific error code and does not claim accepted bytes
+
+### Requirement: Focus and metadata follow runtime identity
+The macOS shell host SHALL associate cwd, title, process status, attention,
+renderer phase, and last-command metadata with stable terminal ContentInstance IDs,
+while shell focus remains associated with stable PaneSlot IDs.
+
+#### Scenario: Runtime metadata arrives for a background terminal content
+- **WHEN** a background terminal ContentInstance reports cwd, title, process, or attention changes
+- **THEN** the shell state for that content updates without changing the user's selected tab or focused PaneSlot
+
+#### Scenario: Visible focus changes
+- **WHEN** the user focuses a visible PaneSlot
+- **THEN** shell state updates the focused PaneSlot while preserving runtime records for all terminal ContentInstances
+- **AND** terminal focus side effects run only when the focused PaneSlot mounts terminal content
+
+### Requirement: Host fallback state is user-safe
+The macOS shell host SHALL make unavailable Ghostty or failed terminal runtime
+states explicit and actionable without presenting a fake usable terminal.
+
+#### Scenario: Ghostty is unavailable
+- **WHEN** the app launches without a linked or loadable Ghostty runtime
+- **THEN** each affected terminal ContentInstance reports a non-ready terminal state and the UI provides setup/debug information without accepting terminal input as if it succeeded
+
+#### Scenario: Surface creation fails
+- **WHEN** a terminal surface cannot be created for a terminal ContentInstance
+- **THEN** the content records the failure reason and control-plane mutations against that terminal content fail or queue according to the delivery contract
+
+### Requirement: Surface readiness is lifecycle metadata
+The macOS shell host SHALL track surface readiness, input readiness, renderer
+health, child process status, readonly state, and terminal mode as runtime
+metadata associated with stable terminal ContentInstance IDs.
+
+#### Scenario: Surface becomes input ready
+- **WHEN** a terminal content surface finishes creation and can accept terminal input
+- **THEN** terminal lifecycle metadata records input-ready state and pending delivery may flush according to the delivery contract
+
+#### Scenario: Renderer becomes unhealthy
+- **WHEN** a terminal renderer reports degraded or failed health
+- **THEN** terminal content lifecycle metadata records that state and terminal input/delivery responses remain truthful
+
+#### Scenario: Child exits
+- **WHEN** the terminal child process exits
+- **THEN** terminal content lifecycle metadata records exit status and later text delivery does not claim success unless a new runtime is explicitly started
+
+### Requirement: Terminal mode changes survive view changes
+The macOS shell host SHALL keep terminal mode metadata such as alternate screen,
+mouse reporting, search state, and readonly state with terminal ContentInstance
+runtime identity rather than with transient host views or PaneSlot layout identity.
+
+#### Scenario: View recreated during alternate screen
+- **WHEN** a terminal view is recreated while an alternate-screen application is active
+- **THEN** the replacement view reflects the terminal ContentInstance's current terminal mode rather than reverting to normal-buffer assumptions
+
+#### Scenario: Background terminal exits readonly mode
+- **WHEN** background terminal content changes readonly or input readiness state
+- **THEN** terminal content metadata updates without selecting that tab
+
+### Requirement: Terminal lifecycle ownership is service backed
+The macOS shell host SHALL route terminal process, renderer surface, runtime
+metadata, pending delivery buffer, and teardown ownership through the terminal
+runtime service keyed by terminal ContentInstance identity rather than through
+transient host views or PaneSlot layout identity.
+
+#### Scenario: Runtime survives SwiftUI reconstruction
+- **WHEN** SwiftUI reconstructs the shell content view while terminal content remains mounted in shell state
+- **THEN** the terminal runtime service keeps the terminal content surface alive and the new view attaches to the same `content_id` runtime identity
+
+#### Scenario: Runtime no longer exists
+- **WHEN** shell state references terminal content whose runtime has irrecoverably failed or closed
+- **THEN** lifecycle metadata reports the non-ready state and the UI/control plane do not treat that terminal content as ready
+
+### Requirement: Pane close finalizes runtime identity
+The macOS shell host SHALL make PaneSlot, content, tab, and window close operations
+call the runtime service finalizer for each affected terminal ContentInstance before
+the terminal content is removed from authoritative runtime state.
+
+#### Scenario: Closing a split pane
+- **WHEN** a user closes one PaneSlot in a split tab
+- **THEN** the runtime service finalizes the mounted terminal ContentInstance only if that PaneSlot contains terminal content
+- **AND** remaining terminal ContentInstances keep their runtime identities
+
+#### Scenario: Closing a window
+- **WHEN** a shell window closes
+- **THEN** every terminal ContentInstance runtime owned by that window transitions to closing or closed state before the window control identity is released
+
+### Requirement: Reattachment preserves terminal continuity
+Visible terminal views SHALL reattach to existing terminal ContentInstance runtime
+handles and MUST NOT restart shell processes, clear scrollback, or reset terminal
+metadata solely because selection, split layout, PaneSlot mounting, or window visibility changed.
+
+#### Scenario: Tab selection changes repeatedly
+- **WHEN** a user switches between terminal tabs several times
+- **THEN** each terminal ContentInstance keeps its existing terminal process, scrollback, title, cwd, and runtime phase
+
+#### Scenario: Split layout changes
+- **WHEN** a PaneSlot with terminal content is moved, resized, or temporarily hidden by split zoom
+- **THEN** its terminal ContentInstance runtime handle remains continuous and reattaches when visible again
+
+### Requirement: Terminal-area events are owned by the terminal host
+The macOS shell host SHALL route mouse events that occur inside terminal pixels
+through the terminal ContentInstance's AppKit terminal host rather than through
+SwiftUI tap gesture wrappers around the terminal view.
+
+#### Scenario: First click activates and reaches the terminal
+- **WHEN** a user clicks a visible terminal PaneSlot that is not currently selected
+- **THEN** the shell selects that PaneSlot, makes its terminal host first responder, and forwards the same mouse-down event to the terminal renderer
+
+#### Scenario: Terminal text selection starts on first drag
+- **WHEN** a user begins a drag inside a visible terminal PaneSlot
+- **THEN** the drag is handled by the terminal host and can start terminal text selection without requiring a prior selection-only click
+
+#### Scenario: Terminal host lifetime remains content-keyed
+- **WHEN** SwiftUI recreates the terminal leaf view for an existing terminal ContentInstance
+- **THEN** the registry reuses the content-keyed terminal host and refreshes its weak activation boundary for the current PaneSlot without transferring terminal event ownership to the SwiftUI view
+
+### Requirement: Terminal activation does not retain shell controllers
+Registry-owned terminal host views SHALL use a weak activation boundary when
+requesting PaneSlot selection from the shell controller.
+
+#### Scenario: Host requests activation
+- **WHEN** a terminal host receives a mouse-down event for terminal content mounted in a stable PaneSlot
+- **THEN** it calls the weak activation boundary for that PaneSlot before requesting terminal focus
+
+#### Scenario: Activation boundary is unavailable
+- **WHEN** a terminal host has no activation delegate available
+- **THEN** terminal input handling remains local to the host and the host does not keep a strong closure that can retain the shell controller
+
+### Requirement: Split workspace mutations preserve live runtimes
+The macOS shell host SHALL preserve terminal ContentInstance runtime identity across
+split resize, equalize, focus, pane lift, and cross-tab PaneSlot move operations unless
+the operation explicitly closes or replaces that terminal content.
+
+#### Scenario: Resize split
+- **WHEN** the user resizes a split divider
+- **THEN** all terminal ContentInstances in the tab keep their existing runtime handles and metadata
+
+#### Scenario: Equalize splits
+- **WHEN** the user equalizes splits in a tab
+- **THEN** all terminal ContentInstances in the tab keep their existing runtime handles and metadata
+
+#### Scenario: Lift pane
+- **WHEN** the user lifts a PaneSlot with terminal content to its own tab
+- **THEN** the terminal ContentInstance keeps its runtime handle, scrollback, title, cwd, and pending delivery state
+
+#### Scenario: Move pane to another tab
+- **WHEN** the user moves a PaneSlot with terminal content to another tab within the same window
+- **THEN** the terminal ContentInstance keeps its runtime handle, scrollback, title, cwd, and pending delivery state
+
+### Requirement: Split close operations define runtime finalization
+The macOS shell host SHALL define explicit terminal runtime finalization
+semantics for close PaneSlot, close tab, close window, pane lift, and PaneSlot move
+operations that empty containers.
+
+#### Scenario: Close focused pane
+- **WHEN** the user invokes close pane
+- **THEN** alan finalizes exactly the terminal ContentInstance mounted in that PaneSlot, if any, and repairs the split tree around the removed leaf
+
+#### Scenario: Close tab after moving last pane
+- **WHEN** a move operation leaves the source tab empty and alan closes that tab
+- **THEN** alan does not finalize the moved terminal ContentInstance runtime as part of source tab cleanup
+
 ## ADDED Requirements
 
 ### Requirement: Terminal lifecycle is scoped to terminal content

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Non-terminal content stays inside shell workspace chrome
+Markdown、settings 和未来 content surface SHALL 继承 alan macOS shell 的 sidebar、
+toolbar、tab selection、split layout 和 restrained material 视觉系统，而不是引入第二套 page
+chrome、dashboard 布局或营销式页面结构。
+
+#### Scenario: Markdown tab is active
+- **WHEN** 用户选择 markdown content tab
+- **THEN** 主区域显示 markdown viewer
+- **AND** sidebar、toolbar 和 tab row 仍保持默认 shell chrome
+- **AND** UI 不显示 terminal-specific debug labels 或 raw content IDs
+
+#### Scenario: Settings tab is active
+- **WHEN** 用户选择 alan settings content tab
+- **THEN** 设置内容呈现在 shell content area 中
+- **AND** 默认 UI 不增加 page-like hero、card-heavy dashboard 或独立 settings navigation shell
+
+### Requirement: Content labels are user-facing
+默认 UI SHALL 使用 content title、file name、settings section 或未来 content title 等用户可见信息
+展示 tab/pane，不得把 implementation IDs 作为主要标签。
+
+#### Scenario: Mixed split pane title bars render
+- **WHEN** 一个 split tab 同时显示 terminal、markdown 和 settings panes
+- **THEN** 每个 pane title bar 显示对应用户可见标题和必要的 compact status
+- **AND** terminal-only 状态只出现在 terminal pane 上
+
+#### Scenario: Command results include non-terminal content
+- **WHEN** command input 列出 markdown 或 settings target
+- **THEN** 结果使用用户可见 content title 和 type hint
+- **AND** 不以 raw pane ID、content ID 或 renderer class name 作为 primary label

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-interactions/spec.md
@@ -1,3 +1,91 @@
+## MODIFIED Requirements
+
+### Requirement: Split layout stores durable ratios
+alan's macOS shell SHALL store split branch direction, child PaneSlot identity, and
+divider ratio in the shell model so split layouts survive rendering changes and
+app state persistence.
+
+#### Scenario: Existing equal split loads
+- **WHEN** a tab with an older equal split tree is loaded
+- **THEN** the shell model interprets each branch as equal ratios and preserves stable structural identity
+
+#### Scenario: Divider is resized
+- **WHEN** the user drags a split divider
+- **THEN** the branch ratio updates within usable minimum bounds and terminal ContentInstances keep their runtime identities
+
+#### Scenario: Window resizes
+- **WHEN** the window size changes after ratios were set
+- **THEN** pane frames are recalculated from stored ratios without resetting the split tree
+
+### Requirement: Split operations are native and reversible
+The macOS shell SHALL provide native split operations for creating directional
+PaneSlots, closing PaneSlots, resizing panes, and equalizing panes.
+
+#### Scenario: Create directional split
+- **WHEN** the user invokes split right, left, up, or down from a menu, shortcut, command UI, or control command
+- **THEN** alan inserts a new PaneSlot in the requested direction and focuses the intended PaneSlot according to the command semantics
+
+#### Scenario: Equalize splits
+- **WHEN** the user invokes equalize for a tab
+- **THEN** all split branches in that tab return to equal usable ratios without restarting terminal runtimes
+
+#### Scenario: Close focused pane
+- **WHEN** the user invokes close pane while a tab has multiple panes
+- **THEN** alan removes the focused PaneSlot, repairs the split tree, and keeps remaining terminal ContentInstance runtimes alive
+
+### Requirement: Spatial focus is first class
+The macOS shell SHALL allow users to move focus spatially between visible PaneSlots
+using left, right, up, and down directions.
+
+#### Scenario: Focus adjacent pane
+- **WHEN** the user invokes focus right from a focused PaneSlot with a visible neighbor to the right
+- **THEN** shell focus moves to that neighboring PaneSlot
+- **AND** terminal focus follows only when the neighboring PaneSlot mounts terminal content
+
+#### Scenario: Preserve perpendicular position
+- **WHEN** a tab contains a two-by-two split layout and the lower-left PaneSlot is focused
+- **THEN** invoking focus right selects the lower-right PaneSlot rather than the upper-right PaneSlot
+
+#### Scenario: No adjacent pane
+- **WHEN** a spatial focus command has no valid target in the requested direction
+- **THEN** focus remains unchanged and the command reports a no-target result where a response is required
+
+### Requirement: Pane lift and cross-tab moves preserve runtime identity
+alan's macOS shell SHALL support PaneSlot lift and cross-tab PaneSlot move operations
+that preserve PaneSlot identity, mounted ContentInstance identity, and any terminal
+runtime handle, scrollback, metadata, and pending delivery state owned by terminal content.
+
+#### Scenario: Lift pane to a new tab
+- **WHEN** the user lifts a PaneSlot out of a split tab
+- **THEN** alan creates a new tab for that PaneSlot and the mounted ContentInstance keeps the same identity
+- **AND** terminal runtime identity remains continuous when the mounted content is terminal
+
+#### Scenario: Move pane to another tab in the same window
+- **WHEN** the user moves a PaneSlot to another tab in the same shell window
+- **THEN** the PaneSlot and mounted ContentInstance keep their identities and the source and target tab split trees remain valid
+
+#### Scenario: Move would empty a tab
+- **WHEN** a PaneSlot move would leave a tab without panes
+- **THEN** alan either closes the empty tab through normal tab-close semantics or rejects the move with a stable reason
+
+### Requirement: Sidebar split indicators can focus panes
+Split topology indicators in the macOS sidebar SHALL route PaneSlot focus through
+the same shell controller focus model used by split interactions.
+
+#### Scenario: Two-pane segment clicked
+- **WHEN** a user clicks a segment in a two-pane tab row split indicator
+- **THEN** alan selects that PaneSlot
+- **AND** terminal focus follows only if the selected PaneSlot mounts terminal content
+- **AND** the action does not change the split tree or divider ratios
+
+#### Scenario: Complex split indicator clicked
+- **WHEN** a user clicks a compact indicator for a tab with three or more panes
+- **THEN** alan performs a predictable PaneSlot-focus action or opens a compact pane picker, and the action does not mutate the split tree
+
+#### Scenario: Split indicator keyboard access
+- **WHEN** a split tab row or its split indicator has keyboard focus
+- **THEN** keyboard or accessibility activation can focus PaneSlots without relying on pointer-only interaction
+
 ## ADDED Requirements
 
 ### Requirement: Pane layout operations are content-agnostic

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Pane layout operations are content-agnostic
+The macOS shell SHALL treat split, focus, resize, equalize, pane lift, cross-tab move, and close pane as PaneSlot operations over the split layout tree, not as terminal-only operations.
+
+#### Scenario: Split terminal pane with markdown target
+- **WHEN** 用户在 terminal pane 旁创建 markdown split
+- **THEN** alan 在同一个 tab 中插入新的 pane slot
+- **AND** 新 PaneSlot 承载 markdown ContentInstance
+- **AND** 原 terminal ContentInstance 的 runtime identity 保持连续
+
+#### Scenario: Focus moves from terminal to settings pane
+- **WHEN** 用户从 terminal pane 空间聚焦到同一 tab 内的 settings pane
+- **THEN** shell focus 更新到 settings PaneSlot
+- **AND** terminal runtime 保持后台存活，不接收 settings pane 的键盘输入
+
+#### Scenario: Move mixed pane between tabs
+- **WHEN** 用户将 markdown 或 settings pane 移动到另一个 tab
+- **THEN** alan 保持该 PaneSlot 和 ContentInstance identity 连续
+- **AND** source 和 target tab 的 split tree 都保持有效
+
+### Requirement: Tab creation accepts content intent
+创建 tab 或 split pane 时，macOS shell SHALL 接受 content intent，并在 intent 缺省时保持现有
+terminal tab 行为。
+
+#### Scenario: New terminal tab remains default
+- **WHEN** 用户执行现有 New Terminal Tab 行为
+- **THEN** alan 创建承载 `terminal` ContentInstance 的 tab
+- **AND** 现有 keyboard/menu/command 行为保持兼容
+
+#### Scenario: New settings tab opens
+- **WHEN** 用户执行 Open Settings in Tab 行为
+- **THEN** alan 在当前 space 创建或聚焦承载 canonical `settings` ContentInstance 的 tab
+- **AND** sidebar tab row 使用用户可见设置标题，而不是 raw content ID
+
+#### Scenario: New markdown tab opens
+- **WHEN** 用户请求打开 markdown 文件为 tab
+- **THEN** alan 创建承载 `markdown` ContentInstance 的 tab
+- **AND** tab title 从文件名或 content title 派生
+
+#### Scenario: Settings tab is singleton
+- **WHEN** 用户再次执行 Open Settings in Tab 行为
+- **THEN** alan 聚焦已存在的 settings ContentInstance 所在 PaneSlot
+- **AND** alan MUST NOT 创建重复 settings tabs，除非未来 capability 明确引入多实例 settings
+
+### Requirement: Sidebar and command routing understand content kind
+Sidebar、toolbar、command input 和 menu routing SHALL 使用 content kind、title 和 capabilities
+来展示和执行 tab/pane 操作，而不是把所有 PaneSlots 视为 terminal target。
+
+#### Scenario: Sidebar lists mixed content tabs
+- **WHEN** 一个 space 中存在 terminal、markdown 和 settings tabs
+- **THEN** sidebar 使用各自用户可见标题和 restrained content affordance
+- **AND** 默认 UI 不暴露 raw pane IDs、content IDs 或 renderer implementation names
+
+#### Scenario: Command input resolves content-aware target
+- **WHEN** 用户通过 command input 跳转到 markdown 或 settings pane
+- **THEN** alan 聚焦对应 PaneSlot
+- **AND** 不执行 terminal-specific focus side effect，例如请求 terminal host first responder

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Workspace manifest stores content-container restore snapshots
+After `generalize-macos-shell-content-containers`, the macOS shell workspace manifest SHALL
+remain the workspace restore authority and SHALL store restorable PaneSlot / ContentInstance
+snapshots instead of terminal-only pane snapshots.
+
+#### Scenario: Terminal-only manifest upgrades to content-container shape
+- **WHEN** alan 读取 `persist-macos-shell-workspaces` 产生的 terminal-only workspace manifest
+- **THEN** alan 将每个 terminal restore leaf 升级为 PaneSlot 加 `terminal` ContentInstance restore payload
+- **AND** Space/Tab IDs、ordering、selected Space/Tab、pin 状态、TTL anchor 和 active-task metadata 保持一致
+- **AND** 后续 manifest 写入只使用 content-container restore shape
+
+#### Scenario: Pinned mixed tab snapshot is saved
+- **WHEN** 用户 pin 或 update-pin 一个包含 terminal、markdown 或 settings content 的 split tab
+- **THEN** workspace manifest 保存 split tree、PaneSlot restore identity、ContentInstance kind 和每个 content 的 restorable payload
+- **AND** terminal payload 保存 cwd、launch target 和用户可见 title
+- **AND** markdown/settings payload 保存对应文件引用或 settings surface identity
+- **AND** manifest 不保存 terminal process、renderer object、scrollback 或 delivery queue
+
+#### Scenario: Unpinned mixed tab live snapshot is saved
+- **WHEN** 未 pin tab 包含 terminal、markdown 或 settings content 且仍在 TTL 内
+- **THEN** workspace manifest 的 live snapshot 保存 content-aware restore state
+- **AND** lifecycle pruning 继续使用原有 `max(lastActivatedAt, lastActivityAt)`、pin 状态和 active-task metadata
+- **AND** 非 terminal content 不会被误判为 terminal active task
+
+#### Scenario: ShellStateSnapshot stays a runtime projection
+- **WHEN** content-container migration 已经完成且 app 重新启动
+- **THEN** alan 从 workspace manifest materialize v0.2 shell state
+- **AND** `ShellStateSnapshot` 只发布当前 UI、control-plane 和 runtime projection
+- **AND** `shell-state-window_main.json` 不重新成为 workspace restore authority

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime services are window scoped
+Each macOS shell window SHALL own a terminal runtime service that maps stable
+terminal ContentInstance IDs to terminal surface handles for that window only.
+PaneSlot IDs MAY be accepted as convenience targets, but runtime lookup SHALL
+resolve them to mounted terminal ContentInstances before touching terminal state.
+
+#### Scenario: Terminal content lookup in one window
+- **WHEN** a control-plane command targets a terminal ContentInstance in a shell window
+- **THEN** the command resolves that terminal content through the terminal runtime service for the same window
+- **AND** the runtime service uses `content_id` as the terminal runtime identity
+
+#### Scenario: PaneSlot convenience target resolves to terminal content
+- **WHEN** `terminal.send_text` targets a PaneSlot that mounts terminal content
+- **THEN** alan resolves the PaneSlot to the mounted terminal ContentInstance before invoking the runtime service
+- **AND** the terminal runtime service does not key delivery by PaneSlot identity
+
+#### Scenario: Content ID collision across windows
+- **WHEN** two windows contain terminal ContentInstances with identical local IDs or restored IDs
+- **THEN** each window runtime service resolves and mutates only its own terminal content handle
+
+### Requirement: Pane surfaces have stable handles
+A terminal ContentInstance SHALL be represented by a stable surface handle that
+outlives SwiftUI/AppKit view creation and stores lifecycle phase, text delivery
+state, metadata, and teardown state.
+
+#### Scenario: View is recreated
+- **WHEN** SwiftUI recreates the terminal host view for an existing terminal ContentInstance
+- **THEN** the new view attaches to the existing surface handle without starting a new shell process
+
+#### Scenario: Background terminal content receives text
+- **WHEN** a background terminal ContentInstance has a live surface handle and receives `terminal.send_text`
+- **THEN** the runtime service delivers text through that handle without requiring the PaneSlot or tab to become visible
+
+#### Scenario: Surface handle is closing
+- **WHEN** text delivery targets terminal content whose surface handle is closing or closed
+- **THEN** the runtime service rejects or queues the command according to the terminal content's delivery policy and reports that state explicitly
+
+### Requirement: Host views are runtime adapters
+`AlanTerminalHostNSView` and related SwiftUI wrappers SHALL act as adapters for
+focus, display metrics, occlusion, frame changes, and input forwarding, and MUST
+NOT own Ghostty app lifetime or terminal ContentInstance runtime truth.
+
+#### Scenario: Host view attaches
+- **WHEN** a terminal host view is mounted for a terminal ContentInstance
+- **THEN** it receives an existing surface handle from the runtime service and reports view metrics to that handle
+
+#### Scenario: Host view detaches
+- **WHEN** a terminal host view is removed because selection or layout changed
+- **THEN** the terminal content surface handle remains alive unless the content, PaneSlot, tab, window, or app is closing
+
+### Requirement: Runtime metadata is projected by pane identity
+The runtime service SHALL project terminal title, cwd, process status,
+attention, renderer phase, readiness, and delivery diagnostics into alan shell
+state using stable terminal ContentInstance IDs; PaneSlot projection SHALL be
+derived from the content currently mounted in that slot.
+
+#### Scenario: Metadata event from background terminal content
+- **WHEN** background terminal content emits a title, cwd, process, attention, or renderer-state event
+- **THEN** shell state updates the matching ContentInstance record without changing user focus
+- **AND** any PaneSlot currently mounting that content reflects the updated terminal projection
+
+#### Scenario: Metadata event after content close
+- **WHEN** a terminal callback arrives after its ContentInstance has reached closed state
+- **THEN** the runtime service ignores or records it as late diagnostics without resurrecting the content or its former PaneSlot
+
+### Requirement: Runtime cleanup is deterministic
+Content, PaneSlot, tab, window, and app close paths SHALL transition terminal
+ContentInstance surface handles through closing and closed states and release
+Ghostty resources exactly once.
+
+#### Scenario: Closing one terminal pane
+- **WHEN** a user closes a split PaneSlot that mounts terminal content
+- **THEN** the runtime service tears down that terminal ContentInstance surface exactly once and preserves other terminal content handles in the same tab
+
+#### Scenario: Closing a tab
+- **WHEN** a user closes a tab with multiple terminal ContentInstances
+- **THEN** the runtime service tears down every terminal ContentInstance surface in that tab exactly once and publishes final closed state
+
+#### Scenario: App terminates
+- **WHEN** the app terminates while terminal ContentInstances are live
+- **THEN** the runtime service performs best-effort teardown and records closed or interrupted terminal state for persisted diagnostics

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -1,0 +1,53 @@
+## 1. Model And Migration
+
+- [ ] 1.1 Rebase this change after `persist-macos-shell-workspaces` is archived, and read the accepted `ShellWorkspaceManifest` schema/materializer before implementation.
+- [ ] 1.2 Introduce v0.2 shell state value types: `ShellPaneSlot`, `ShellContentInstance`, content kind, content capabilities, and content payloads for terminal, markdown, and settings surfaces.
+- [ ] 1.3 Change pane layout leaves to reference `pane_slot_id` and change shell focus state to use `focused_pane_slot_id`.
+- [ ] 1.4 Replace new-state `panes: [ShellPane]` persistence with `pane_slots` and `contents`; keep v0.1 `ShellPane` decoding only as diagnostics/compatibility input, not as workspace restore authority.
+- [ ] 1.5 Add one-time manifest migration that turns terminal-only workspace restore snapshots into PaneSlot plus terminal ContentInstance restore snapshots while preserving Space/Tab IDs, selection, pin state, TTL anchors, and active-task metadata.
+- [ ] 1.6 Update shell state projection helpers so focused space, focused tab, focused PaneSlot, attention, titles, and sidebar rows derive from content-aware descriptors.
+
+## 2. Terminal Adapter
+
+- [ ] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
+- [ ] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
+- [ ] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
+- [ ] 2.4 Ensure close PaneSlot, close tab, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
+- [ ] 2.5 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
+
+## 3. Non-Terminal Content Surfaces
+
+- [ ] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
+- [ ] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
+- [ ] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
+- [ ] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.
+
+## 4. Workspace Mutations And Control Plane
+
+- [ ] 4.1 Update tab and split creation paths to accept content intent while keeping New Terminal Tab as the default behavior.
+- [ ] 4.2 Update split, focus, resize, equalize, PaneSlot lift, PaneSlot move, close PaneSlot, and close tab mutations to operate on content-agnostic PaneSlots.
+- [ ] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
+- [ ] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
+- [ ] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
+- [ ] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.
+- [ ] 4.7 Ensure workspace manifest updates for pin/live snapshots write content-aware restore payloads and do not dual-write terminal-only snapshots.
+
+## 5. UI Integration
+
+- [ ] 5.1 Update `ShellWorkspaceView` / pane layout leaf rendering so mixed content panes share split geometry and focus treatment.
+- [ ] 5.2 Update sidebar tab rows, toolbar titles, pane title bars, and command input labels to use user-facing content titles and type hints.
+- [ ] 5.3 Keep terminal-only status, search, and input affordances visible only on terminal content panes.
+- [ ] 5.4 Make settings content a singleton tab target in v1 so repeated Open Settings focuses the existing ContentInstance.
+- [ ] 5.5 Capture running-app visual evidence for light-mode mixed content tabs and split panes.
+
+## 6. Verification And Archive Readiness
+
+- [ ] 6.1 Add focused shell model tests for v0.1-to-v0.2 migration, mixed content split mutation, and content-aware focus behavior.
+- [ ] 6.2 Add terminal runtime tests proving runtime continuity is keyed by `content_id` across PaneSlot move, tab move, and view reattachment.
+- [ ] 6.3 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
+- [ ] 6.4 Add workspace manifest migration tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, and the rule that `shell-state-window_main.json` is not restore authority.
+- [ ] 6.5 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
+- [ ] 6.6 Run the macOS app build or document any local dependency blocker with the exact failing command.
+- [ ] 6.7 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.
+- [ ] 6.8 Run `openspec validate --all --strict` after `persist-macos-shell-workspaces` is archived or while both active changes validate together.
+- [ ] 6.9 After implementation is merged, sync accepted requirements into `openspec/specs/` and confirm the change is archive-ready.

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -12,7 +12,7 @@
 - [ ] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
 - [ ] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
 - [ ] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
-- [ ] 2.4 Ensure close PaneSlot, close tab, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
+- [ ] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
 - [ ] 2.5 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
 
 ## 3. Non-Terminal Content Surfaces
@@ -43,9 +43,9 @@
 ## 6. Verification And Archive Readiness
 
 - [ ] 6.1 Add focused shell model tests for v0.1-to-v0.2 migration, mixed content split mutation, and content-aware focus behavior.
-- [ ] 6.2 Add terminal runtime tests proving runtime continuity is keyed by `content_id` across PaneSlot move, tab move, and view reattachment.
+- [ ] 6.2 Add terminal runtime tests proving runtime continuity is keyed by `content_id` across PaneSlot move, tab move, view reattachment, and new-runtime creation after manifest restore.
 - [ ] 6.3 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
-- [ ] 6.4 Add workspace manifest migration tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, and the rule that `shell-state-window_main.json` is not restore authority.
+- [ ] 6.4 Add workspace manifest migration and lifecycle tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, inactive unpinned Tab retirement finalization, and the rule that `shell-state-window_main.json` is not restore authority.
 - [ ] 6.5 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
 - [ ] 6.6 Run the macOS app build or document any local dependency blocker with the exact failing command.
 - [ ] 6.7 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -13,7 +13,8 @@
 - [ ] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
 - [ ] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
 - [ ] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
-- [ ] 2.5 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
+- [ ] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
+- [ ] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
 
 ## 3. Non-Terminal Content Surfaces
 
@@ -44,10 +45,11 @@
 
 - [ ] 6.1 Add focused shell model tests for v0.1-to-v0.2 migration, mixed content split mutation, and content-aware focus behavior.
 - [ ] 6.2 Add terminal runtime tests proving runtime continuity is keyed by `content_id` across PaneSlot move, tab move, view reattachment, and new-runtime creation after manifest restore.
-- [ ] 6.3 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
-- [ ] 6.4 Add workspace manifest migration and lifecycle tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, inactive unpinned Tab retirement finalization, and the rule that `shell-state-window_main.json` is not restore authority.
-- [ ] 6.5 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
-- [ ] 6.6 Run the macOS app build or document any local dependency blocker with the exact failing command.
-- [ ] 6.7 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.
-- [ ] 6.8 Run `openspec validate --all --strict` after `persist-macos-shell-workspaces` is archived or while both active changes validate together.
-- [ ] 6.9 After implementation is merged, sync accepted requirements into `openspec/specs/` and confirm the change is archive-ready.
+- [ ] 6.3 Add fake runtime service tests for `terminal.send_text`, `content_id` delivery, missing runtime errors, and queued delivery diagnostics.
+- [ ] 6.4 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
+- [ ] 6.5 Add workspace manifest migration and lifecycle tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, inactive unpinned Tab retirement finalization, and the rule that `shell-state-window_main.json` is not restore authority.
+- [ ] 6.6 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
+- [ ] 6.7 Run the macOS app build or document any local dependency blocker with the exact failing command.
+- [ ] 6.8 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.
+- [ ] 6.9 Run `openspec validate --all --strict` after `persist-macos-shell-workspaces` is archived or while both active changes validate together.
+- [ ] 6.10 After implementation is merged, sync accepted requirements into `openspec/specs/` and confirm the change is archive-ready.


### PR DESCRIPTION
## Summary
- Add OpenSpec change for true PaneSlot / ContentInstance separation in the macOS shell
- Scope v1 to terminal, read-only markdown, and settings content; keep browser deferred
- Align the content-container migration with persist-macos-shell-workspaces by upgrading ShellWorkspaceManifest restore snapshots instead of using shell-state as restore authority

## Validation
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict