### PR TITLE
Fix sidebar-local macOS space swipe

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */; };
 		000000000000000000000039 /* ShellWorkspaceManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000139 /* ShellWorkspaceManifest.swift */; };
 		00000000000000000000003A /* ShellWorkspaceManifestStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013A /* ShellWorkspaceManifestStore.swift */; };
+		00000000000000000000003B /* ShellSidebarSpaceContentPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -127,6 +128,7 @@
 		000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSwipeMonitor.swift; sourceTree = "<group>"; };
 		000000000000000000000139 /* ShellWorkspaceManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellWorkspaceManifest.swift; sourceTree = "<group>"; };
 		00000000000000000000013A /* ShellWorkspaceManifestStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellWorkspaceManifestStore.swift; sourceTree = "<group>"; };
+		00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceContentPager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,6 +204,7 @@
 				000000000000000000000118 /* ShellDesignTokens.swift */,
 				000000000000000000000136 /* ConsoleAdaptiveColor.swift */,
 				000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */,
+				00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */,
 				000000000000000000000119 /* ShellWindowPlacement.swift */,
 				00000000000000000000011D /* ShellVoiceCommandController.swift */,
 			);
@@ -463,6 +466,7 @@
 				000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */,
 				000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */,
 				000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */,
+				00000000000000000000003B /* ShellSidebarSpaceContentPager.swift in Sources */,
 				000000000000000000000039 /* ShellWorkspaceManifest.swift in Sources */,
 				00000000000000000000003A /* ShellWorkspaceManifestStore.swift in Sources */,
 			);

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -11,12 +11,7 @@ struct MacShellRootView: View {
     @State private var areFloatingSidebarTrafficLightsVisible = false
     @State private var sidebarRevealToken = 0
     @State private var floatingSidebarTrafficLightRevealToken = 0
-    @State private var isSpaceSwipeGestureLocked = false
     @State private var pinnedSidebarPresentationProgress: CGFloat
-    @State private var spacePager: ShellSidebarSpaceContentPagerState?
-    @State private var spacePagerToken = 0
-    @State private var spacePagerPageWidth: CGFloat = 1
-    @State private var spacePagerPageSelectedPaneIDs: [Int: String] = [:]
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
     @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
     private let sidebarWidth: CGFloat = 264
@@ -58,191 +53,6 @@ struct MacShellRootView: View {
         DispatchQueue.main.async {
             host.refocusSelectedTerminalPane()
         }
-    }
-
-    private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
-        switch update.phase {
-        case .began:
-            guard spacePager?.isSettling != true else { return }
-            isSpaceSwipeGestureLocked = true
-            beginSpacePager()
-        case .changed:
-            guard spacePager?.isSettling != true else { return }
-            isSpaceSwipeGestureLocked = true
-            updateSpacePager(translationX: update.translationX)
-        case .ended:
-            finishSpacePager(velocityX: update.velocityX)
-        case .cancelled:
-            settleSpacePager(committing: false)
-        }
-    }
-
-    private func beginSpacePager() {
-        guard let sourceIndex = selectedSpaceIndex else { return }
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            spacePagerPageSelectedPaneIDs = [
-                sourceIndex: host.selectedPane?.paneID,
-            ].compactMapValues { $0 }
-            spacePager = ShellSidebarSpaceContentPagerState(
-                sourceIndex: sourceIndex,
-                targetIndex: nil,
-                dragOffset: 0,
-                pageWidth: sidebarSwipePageWidth,
-                settlementPhase: .dragging
-            )
-        }
-    }
-
-    private func updateSpacePager(translationX: CGFloat) {
-        guard abs(translationX) > 0.5 else { return }
-        guard let sourceIndex = spacePager?.sourceIndex ?? selectedSpaceIndex else { return }
-
-        let direction = translationX < 0 ? 1 : -1
-        let targetIndex = adjacentSpaceIndex(from: sourceIndex, direction: direction)
-        let dragOffset = targetIndex == nil ? resistedEdgeOffset(for: translationX) : translationX
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            if let targetIndex {
-                spacePagerPageSelectedPaneIDs[targetIndex] =
-                    spacePagerPageSelectedPaneIDs[targetIndex]
-                    ?? firstPaneID(forSpaceAt: targetIndex)
-            }
-            spacePager = ShellSidebarSpaceContentPagerState(
-                sourceIndex: sourceIndex,
-                targetIndex: targetIndex,
-                dragOffset: dragOffset,
-                pageWidth: sidebarSwipePageWidth,
-                settlementPhase: .dragging
-            )
-        }
-    }
-
-    private func finishSpacePager(velocityX: CGFloat) {
-        guard let pager = spacePager else {
-            isSpaceSwipeGestureLocked = false
-            return
-        }
-        guard pager.targetIndex != nil else {
-            settleSpacePager(committing: false)
-            return
-        }
-
-        let velocityDirection = velocityX < 0 ? 1 : -1
-        let fastEnough = abs(velocityX) >= 120 && velocityDirection == pager.direction
-        let farEnough = pager.progress >= 0.28
-        settleSpacePager(committing: farEnough || fastEnough)
-    }
-
-    private func settleSpacePager(committing: Bool) {
-        guard var pager = spacePager else {
-            isSpaceSwipeGestureLocked = false
-            return
-        }
-        let targetIndex = pager.targetIndex
-        if committing,
-           let targetIndex,
-           host.spaces.indices.contains(targetIndex)
-        {
-            host.select(spaceID: host.spaces[targetIndex].spaceID)
-        }
-
-        pager.settlementPhase = committing ? .settlingToTarget : .settlingToSource
-        pager.pageWidth = sidebarSwipePageWidth
-        pager.dragOffset = committing ? -CGFloat(pager.direction) * sidebarSwipePageWidth : 0
-        spacePagerToken += 1
-        let token = spacePagerToken
-        let duration = reduceMotion ? 0.12 : 0.28
-
-        withAnimation(settleAnimation) {
-            spacePager = pager
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-            guard spacePagerToken == token else { return }
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                spacePager = nil
-                spacePagerPageSelectedPaneIDs = [:]
-                isSpaceSwipeGestureLocked = false
-            }
-        }
-    }
-
-    private var settleAnimation: Animation {
-        if reduceMotion {
-            return .easeOut(duration: 0.12)
-        }
-        return .interactiveSpring(response: 0.28, dampingFraction: 0.86, blendDuration: 0.04)
-    }
-
-    private var sidebarSwipePageWidth: CGFloat {
-        max(spacePagerPageWidth, 1)
-    }
-
-    private func resistedEdgeOffset(for translationX: CGFloat) -> CGFloat {
-        let edgeLimit = sidebarSwipePageWidth * 0.18
-        let distance = abs(translationX)
-        let resistedDistance = edgeLimit * distance / (distance + edgeLimit)
-        return translationX < 0 ? -resistedDistance : resistedDistance
-    }
-
-    private func adjacentSpaceIndex(from sourceIndex: Int, direction: Int) -> Int? {
-        let targetIndex = sourceIndex + direction
-        guard host.spaces.indices.contains(targetIndex) else { return nil }
-        return targetIndex
-    }
-
-    private var selectedSpaceIndex: Int? {
-        guard let selectedSpaceID = host.selectedSpace?.spaceID else { return nil }
-        return host.spaces.firstIndex { $0.spaceID == selectedSpaceID }
-    }
-
-    private var previewedSpaceID: String? {
-        guard let targetIndex = spacePager?.targetIndex else { return nil }
-        return spaceID(forSpaceAt: targetIndex)
-    }
-
-    private var swipeEnabledSpaceIndex: Int? {
-        spacePager?.sourceIndex ?? selectedSpaceIndex
-    }
-
-    private var floatingSidebarDisplaySpaceID: String? {
-        if let sourceIndex = spacePager?.sourceIndex {
-            return spaceID(forSpaceAt: sourceIndex)
-        }
-        return host.selectedSpace?.spaceID
-    }
-
-    private func spaceID(forSpaceAt index: Int) -> String? {
-        guard host.spaces.indices.contains(index) else { return nil }
-        return host.spaces[index].spaceID
-    }
-
-    private func firstPaneID(forSpaceAt index: Int) -> String? {
-        guard host.spaces.indices.contains(index) else { return nil }
-        let space = host.spaces[index]
-        return space.tabs
-            .flatMap(\.paneTree.paneIDs)
-            .first { paneID in
-                host.shellState.panes.contains { $0.paneID == paneID }
-            }
-    }
-
-    private func selectedPaneID(forSpaceAt index: Int) -> String? {
-        if let paneID = spacePagerPageSelectedPaneIDs[index] {
-            return paneID
-        }
-        if index == selectedSpaceIndex,
-           let paneID = host.selectedPane?.paneID
-        {
-            return paneID
-        }
-        return firstPaneID(forSpaceAt: index)
     }
 
     private var isSidebarSurfaceVisible: Bool {
@@ -399,11 +209,20 @@ struct MacShellRootView: View {
             ShellMaterialBackgroundView(.windowBackdrop)
                 .ignoresSafeArea()
 
-            spacePagerPages
-                .frame(
-                    minWidth: ShellWindowSizing.minimumSize.width,
-                    minHeight: ShellWindowSizing.minimumSize.height
+            HStack(spacing: 0) {
+                pinnedSidebarSurface()
+
+                ShellWorkspaceView(
+                    host: host,
+                    expandedSidebarProgress: clampedPinnedSidebarPresentationProgress
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .ignoresSafeArea(edges: .top)
+            }
+            .frame(
+                minWidth: ShellWindowSizing.minimumSize.width,
+                minHeight: ShellWindowSizing.minimumSize.height
+            )
 
             if isSidebarCollapsed && isPinnedSidebarFullyCollapsed {
                 collapsedSidebarRevealZone
@@ -464,82 +283,8 @@ struct MacShellRootView: View {
         )
     }
 
-    private var spacePagerPages: some View {
-        GeometryReader { proxy in
-            let pageWidth = max(proxy.size.width, 1)
-            ZStack(alignment: .leading) {
-                ForEach(spacePageIndices, id: \.self) { index in
-                    spacePage(index: index, pageWidth: pageWidth)
-                        .frame(width: pageWidth, height: proxy.size.height, alignment: .topLeading)
-                        .offset(x: spacePageOffset(for: index, pageWidth: pageWidth))
-                        .allowsHitTesting(spacePager == nil && index == selectedSpaceIndex)
-                }
-            }
-            .clipped()
-            .onAppear {
-                updateSpacePagerPageWidth(pageWidth)
-            }
-            .onChange(of: proxy.size.width) { _, width in
-                updateSpacePagerPageWidth(max(width, 1))
-            }
-        }
-    }
-
-    private var spacePageIndices: [Int] {
-        guard let spacePager else {
-            return selectedSpaceIndex.map { [$0] } ?? []
-        }
-        return spacePager.pageIndicesForRendering.filter { host.spaces.indices.contains($0) }
-    }
-
-    private func spacePage(index: Int, pageWidth: CGFloat) -> some View {
-        HStack(spacing: 0) {
-            pinnedSidebarSurface(
-                displaySpaceID: spaceID(forSpaceAt: index),
-                previewedSpaceID: previewedSpaceID,
-                isSwipeEnabled: index == swipeEnabledSpaceIndex
-            )
-
-            ShellWorkspaceView(
-                host: host,
-                expandedSidebarProgress: clampedPinnedSidebarPresentationProgress,
-                spaceID: spaceID(forSpaceAt: index),
-                selectedPaneID: selectedPaneID(forSpaceAt: index)
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .ignoresSafeArea(edges: .top)
-        }
-        .frame(width: pageWidth, alignment: .leading)
-    }
-
-    private func spacePageOffset(for index: Int, pageWidth: CGFloat) -> CGFloat {
-        guard var spacePager else { return 0 }
-        spacePager.pageWidth = pageWidth
-        return spacePager.offset(for: index)
-    }
-
-    private func updateSpacePagerPageWidth(_ pageWidth: CGFloat) {
-        let clampedPageWidth = max(pageWidth, 1)
-        spacePagerPageWidth = clampedPageWidth
-        guard var spacePager,
-              spacePager.pageWidth != clampedPageWidth
-        else {
-            return
-        }
-        spacePager.pageWidth = clampedPageWidth
-        self.spacePager = spacePager
-    }
-
-    private func pinnedSidebarSurface(
-        displaySpaceID: String?,
-        previewedSpaceID: String?,
-        isSwipeEnabled: Bool
-    ) -> some View {
-        sidebarContent(
-            displaySpaceID: displaySpaceID,
-            previewedSpaceID: previewedSpaceID,
-            isSwipeEnabled: isSwipeEnabled
-        )
+    private func pinnedSidebarSurface() -> some View {
+        sidebarContent(isSwipeEnabled: true)
             .frame(width: sidebarWidth)
             .offset(x: sidebarPinnedChromeOffsetX)
             .opacity(sidebarPinnedContentOpacity)
@@ -562,19 +307,12 @@ struct MacShellRootView: View {
         }
     }
 
-    private func sidebarContent(
-        displaySpaceID: String? = nil,
-        previewedSpaceID: String? = nil,
-        isSwipeEnabled: Bool = true
-    ) -> some View {
+    private func sidebarContent(isSwipeEnabled: Bool = true) -> some View {
         ShellSidebarView(
             host: host,
             chromeMetrics: windowChromeMetrics,
-            displaySpaceID: displaySpaceID,
-            previewedSpaceID: previewedSpaceID,
-            isSpaceSwipeGestureLocked: isSpaceSwipeGestureLocked,
-            isSwipeEnabled: isSwipeEnabled,
-            onSpaceSwipe: handleSpaceSwipe
+            displaySpaceID: nil,
+            isSwipeEnabled: isSwipeEnabled
         ) {
             presentCommandInput()
         }
@@ -609,11 +347,7 @@ struct MacShellRootView: View {
                         .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
                 }
 
-            sidebarContent(
-                displaySpaceID: floatingSidebarDisplaySpaceID,
-                previewedSpaceID: previewedSpaceID,
-                isSwipeEnabled: true
-            )
+            sidebarContent(isSwipeEnabled: true)
                 .clipShape(
                     RoundedRectangle(
                         cornerRadius: ShellRadii.floatingSidebarPanel,

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -13,7 +13,7 @@ struct MacShellRootView: View {
     @State private var floatingSidebarTrafficLightRevealToken = 0
     @State private var isSpaceSwipeGestureLocked = false
     @State private var pinnedSidebarPresentationProgress: CGFloat
-    @State private var spacePager: ShellSpacePagerState?
+    @State private var spacePager: ShellSidebarSpaceContentPagerState?
     @State private var spacePagerToken = 0
     @State private var spacePagerPageWidth: CGFloat = 1
     @State private var spacePagerPageSelectedPaneIDs: [Int: String] = [:]
@@ -85,7 +85,7 @@ struct MacShellRootView: View {
             spacePagerPageSelectedPaneIDs = [
                 sourceIndex: host.selectedPane?.paneID,
             ].compactMapValues { $0 }
-            spacePager = ShellSpacePagerState(
+            spacePager = ShellSidebarSpaceContentPagerState(
                 sourceIndex: sourceIndex,
                 targetIndex: nil,
                 dragOffset: 0,
@@ -111,7 +111,7 @@ struct MacShellRootView: View {
                     spacePagerPageSelectedPaneIDs[targetIndex]
                     ?? firstPaneID(forSpaceAt: targetIndex)
             }
-            spacePager = ShellSpacePagerState(
+            spacePager = ShellSidebarSpaceContentPagerState(
                 sourceIndex: sourceIndex,
                 targetIndex: targetIndex,
                 dragOffset: dragOffset,

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+#if os(macOS)
+enum ShellSidebarSpaceContentPagerSettlementPhase: Equatable {
+    case dragging
+    case settlingToSource
+    case settlingToTarget
+}
+
+struct ShellSidebarSpaceContentPagerState: Equatable {
+    let sourceIndex: Int
+    var targetIndex: Int?
+    var dragOffset: CGFloat
+    var pageWidth: CGFloat
+    var settlementPhase: ShellSidebarSpaceContentPagerSettlementPhase
+
+    var isSettling: Bool {
+        settlementPhase != .dragging
+    }
+
+    var isEdgeResistance: Bool {
+        targetIndex == nil
+    }
+
+    var committedTargetIndex: Int? {
+        guard settlementPhase == .settlingToTarget else { return nil }
+        return targetIndex
+    }
+
+    var direction: Int {
+        guard let targetIndex else {
+            return dragOffset < 0 ? 1 : -1
+        }
+        return targetIndex >= sourceIndex ? 1 : -1
+    }
+
+    var progress: CGFloat {
+        let width = max(pageWidth, 1)
+        return min(abs(dragOffset) / width, 0.98)
+    }
+
+    var pageIndicesForRendering: [Int] {
+        guard let targetIndex, targetIndex != sourceIndex else {
+            return [sourceIndex]
+        }
+        return [sourceIndex, targetIndex]
+    }
+
+    func offset(for index: Int) -> CGFloat {
+        CGFloat(index - sourceIndex) * max(pageWidth, 1) + dragOffset
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift
@@ -16,56 +16,6 @@ struct ShellSidebarSwipeUpdate {
     let velocityX: CGFloat
 }
 
-enum ShellSpacePagerSettlementPhase: Equatable {
-    case dragging
-    case settlingToSource
-    case settlingToTarget
-}
-
-struct ShellSpacePagerState: Equatable {
-    let sourceIndex: Int
-    var targetIndex: Int?
-    var dragOffset: CGFloat
-    var pageWidth: CGFloat
-    var settlementPhase: ShellSpacePagerSettlementPhase
-
-    var isSettling: Bool {
-        settlementPhase != .dragging
-    }
-
-    var isEdgeResistance: Bool {
-        targetIndex == nil
-    }
-
-    var committedTargetIndex: Int? {
-        guard settlementPhase == .settlingToTarget else { return nil }
-        return targetIndex
-    }
-
-    var direction: Int {
-        guard let targetIndex else {
-            return dragOffset < 0 ? 1 : -1
-        }
-        return targetIndex >= sourceIndex ? 1 : -1
-    }
-
-    var progress: CGFloat {
-        let width = max(pageWidth, 1)
-        return min(abs(dragOffset) / width, 0.98)
-    }
-
-    var pageIndicesForRendering: [Int] {
-        guard let targetIndex, targetIndex != sourceIndex else {
-            return [sourceIndex]
-        }
-        return [sourceIndex, targetIndex]
-    }
-
-    func offset(for index: Int) -> CGFloat {
-        CGFloat(index - sourceIndex) * max(pageWidth, 1) + dragOffset
-    }
-}
-
 struct ShellSidebarSwipeMonitor: NSViewRepresentable {
     let onUpdate: (ShellSidebarSwipeUpdate) -> Void
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -2,24 +2,45 @@ import SwiftUI
 
 #if os(macOS)
 struct ShellSidebarView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var host: ShellHostController
     let chromeMetrics: ShellWindowChromeMetrics
     let displaySpaceID: String?
-    let previewedSpaceID: String?
-    let isSpaceSwipeGestureLocked: Bool
     let isSwipeEnabled: Bool
-    let onSpaceSwipe: (ShellSidebarSwipeUpdate) -> Void
     let openCommandTab: () -> Void
+    @State private var spacePager: ShellSidebarSpaceContentPagerState?
+    @State private var spacePagerToken = 0
+    @State private var spacePagerPageWidth: CGFloat = 1
     @State private var hoveredTabID: String?
     @State private var hoveredSpaceID: String?
     @State private var isCommandLauncherHovered = false
     @State private var tabListScrollOffsetY: CGFloat = 0
 
+    init(
+        host: ShellHostController,
+        chromeMetrics: ShellWindowChromeMetrics,
+        displaySpaceID: String?,
+        previewedSpaceID: String? = nil,
+        isSpaceSwipeGestureLocked: Bool = false,
+        isSwipeEnabled: Bool,
+        onSpaceSwipe: @escaping (ShellSidebarSwipeUpdate) -> Void = { _ in },
+        openCommandTab: @escaping () -> Void
+    ) {
+        self.host = host
+        self.chromeMetrics = chromeMetrics
+        self.displaySpaceID = displaySpaceID
+        self.isSwipeEnabled = isSwipeEnabled
+        self.openCommandTab = openCommandTab
+        _ = previewedSpaceID
+        _ = isSpaceSwipeGestureLocked
+        _ = onSpaceSwipe
+    }
+
     var body: some View {
         sidebarContent
         .background {
             if isSwipeEnabled {
-                ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
+                ShellSidebarSwipeMonitor(onUpdate: handleSpaceSwipe)
             }
         }
         .scrollDisabled(isTabListScrollDisabled)
@@ -33,9 +54,7 @@ struct ShellSidebarView: View {
             commandLauncher
                 .padding(.horizontal, ShellSidebarMetrics.edgeInset)
                 .padding(.bottom, 10)
-            spaceLabelRow
-                .padding(.bottom, 2)
-            tabSection
+            spaceContentPager
             spaceDock
                 .padding(.horizontal, ShellSidebarMetrics.edgeInset)
                 .padding(.top, 10)
@@ -45,10 +64,36 @@ struct ShellSidebarView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private var spaceLabelRow: some View {
+    private var spaceContentPager: some View {
+        GeometryReader { proxy in
+            let pageWidth = max(proxy.size.width, 1)
+            ZStack(alignment: .leading) {
+                ForEach(spacePageIndices, id: \.self) { index in
+                    VStack(alignment: .leading, spacing: 0) {
+                        spaceLabelRow(for: spaceID(forSpaceAt: index))
+                            .padding(.bottom, 2)
+                        tabSection(for: spaceID(forSpaceAt: index))
+                    }
+                    .frame(width: pageWidth, height: proxy.size.height, alignment: .topLeading)
+                    .offset(x: spacePageOffset(for: index, pageWidth: pageWidth))
+                    .allowsHitTesting(spacePager == nil && index == selectedSpaceIndex)
+                }
+            }
+            .clipped()
+            .onAppear {
+                updateSpacePagerPageWidth(pageWidth)
+            }
+            .onChange(of: proxy.size.width) { _, width in
+                updateSpacePagerPageWidth(max(width, 1))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func spaceLabelRow(for spaceID: String?) -> some View {
         ShellSidebarSpaceHeader(
             host: host,
-            spaceID: sourceSpaceID
+            spaceID: spaceID
         )
         .frame(maxWidth: .infinity)
         .frame(height: 28)
@@ -91,11 +136,13 @@ struct ShellSidebarView: View {
         ShellPalette.sidebarMutedInk.opacity(isCommandLauncherHovered ? 0.92 : 0.80)
     }
 
-    private var tabSection: some View {
+    private func tabSection(for spaceID: String?) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            tabListPage(for: sourceSpaceID)
+            tabListPage(for: spaceID)
                 .overlay(alignment: .top) {
-                    ShellSidebarScrollBoundary(progress: tabListBoundaryProgress)
+                    if spaceID == sourceSpaceID {
+                        ShellSidebarScrollBoundary(progress: tabListBoundaryProgress)
+                    }
                 }
                 .clipped()
         }
@@ -204,8 +251,166 @@ struct ShellSidebarView: View {
         _ = host.createTerminalSpace()
     }
 
+    private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
+        switch update.phase {
+        case .began:
+            guard spacePager?.isSettling != true else { return }
+            beginSpacePager()
+        case .changed:
+            guard spacePager?.isSettling != true else { return }
+            updateSpacePager(translationX: update.translationX)
+        case .ended:
+            finishSpacePager(velocityX: update.velocityX)
+        case .cancelled:
+            settleSpacePager(committing: false)
+        }
+    }
+
+    private func beginSpacePager() {
+        guard let sourceIndex = selectedSpaceIndex else { return }
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            spacePager = ShellSidebarSpaceContentPagerState(
+                sourceIndex: sourceIndex,
+                targetIndex: nil,
+                dragOffset: 0,
+                pageWidth: sidebarSwipePageWidth,
+                settlementPhase: .dragging
+            )
+        }
+    }
+
+    private func updateSpacePager(translationX: CGFloat) {
+        guard abs(translationX) > 0.5 else { return }
+        guard let sourceIndex = spacePager?.sourceIndex ?? selectedSpaceIndex else { return }
+        let direction = translationX < 0 ? 1 : -1
+        let targetIndex = adjacentSpaceIndex(from: sourceIndex, direction: direction)
+        let dragOffset = targetIndex == nil ? resistedEdgeOffset(for: translationX) : translationX
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            spacePager = ShellSidebarSpaceContentPagerState(
+                sourceIndex: sourceIndex,
+                targetIndex: targetIndex,
+                dragOffset: dragOffset,
+                pageWidth: sidebarSwipePageWidth,
+                settlementPhase: .dragging
+            )
+        }
+    }
+
+    private func finishSpacePager(velocityX: CGFloat) {
+        guard let pager = spacePager else { return }
+        guard pager.targetIndex != nil else {
+            settleSpacePager(committing: false)
+            return
+        }
+
+        let velocityDirection = velocityX < 0 ? 1 : -1
+        let fastEnough = abs(velocityX) >= 120 && velocityDirection == pager.direction
+        let farEnough = pager.progress >= 0.28
+        settleSpacePager(committing: farEnough || fastEnough)
+    }
+
+    private func settleSpacePager(committing: Bool) {
+        guard var pager = spacePager else { return }
+        let targetIndex = pager.targetIndex
+        if committing,
+           let targetIndex,
+           host.spaces.indices.contains(targetIndex)
+        {
+            host.select(spaceID: host.spaces[targetIndex].spaceID)
+        }
+
+        pager.settlementPhase = committing ? .settlingToTarget : .settlingToSource
+        pager.pageWidth = sidebarSwipePageWidth
+        pager.dragOffset = committing ? -CGFloat(pager.direction) * sidebarSwipePageWidth : 0
+        spacePagerToken += 1
+        let token = spacePagerToken
+        let duration = reduceMotion ? 0.12 : 0.28
+
+        withAnimation(settleAnimation) {
+            spacePager = pager
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+            guard spacePagerToken == token else { return }
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                spacePager = nil
+            }
+        }
+    }
+
+    private var settleAnimation: Animation {
+        if reduceMotion {
+            return .easeOut(duration: 0.12)
+        }
+        return .interactiveSpring(response: 0.28, dampingFraction: 0.86, blendDuration: 0.04)
+    }
+
+    private var sidebarSwipePageWidth: CGFloat {
+        max(spacePagerPageWidth, 1)
+    }
+
+    private func resistedEdgeOffset(for translationX: CGFloat) -> CGFloat {
+        let edgeLimit = sidebarSwipePageWidth * 0.18
+        let distance = abs(translationX)
+        let resistedDistance = edgeLimit * distance / (distance + edgeLimit)
+        return translationX < 0 ? -resistedDistance : resistedDistance
+    }
+
+    private func adjacentSpaceIndex(from sourceIndex: Int, direction: Int) -> Int? {
+        let targetIndex = sourceIndex + direction
+        guard host.spaces.indices.contains(targetIndex) else { return nil }
+        return targetIndex
+    }
+
+    private var selectedSpaceIndex: Int? {
+        guard let selectedSpaceID = host.selectedSpace?.spaceID else { return nil }
+        return host.spaces.firstIndex { $0.spaceID == selectedSpaceID }
+    }
+
+    private var previewedSpaceID: String? {
+        guard let targetIndex = spacePager?.targetIndex else { return nil }
+        return spaceID(forSpaceAt: targetIndex)
+    }
+
+    private func spaceID(forSpaceAt index: Int) -> String? {
+        guard host.spaces.indices.contains(index) else { return nil }
+        return host.spaces[index].spaceID
+    }
+
     private var isTabListScrollDisabled: Bool {
-        isSpaceSwipeGestureLocked
+        spacePager != nil
+    }
+
+    private var spacePageIndices: [Int] {
+        guard let spacePager else {
+            return selectedSpaceIndex.map { [$0] } ?? []
+        }
+        return spacePager.pageIndicesForRendering.filter { host.spaces.indices.contains($0) }
+    }
+
+    private func spacePageOffset(for index: Int, pageWidth: CGFloat) -> CGFloat {
+        guard var spacePager else { return 0 }
+        spacePager.pageWidth = pageWidth
+        return spacePager.offset(for: index)
+    }
+
+    private func updateSpacePagerPageWidth(_ pageWidth: CGFloat) {
+        let clampedPageWidth = max(pageWidth, 1)
+        spacePagerPageWidth = clampedPageWidth
+        guard var spacePager,
+              spacePager.pageWidth != clampedPageWidth
+        else {
+            return
+        }
+        spacePager.pageWidth = clampedPageWidth
+        self.spacePager = spacePager
     }
 
     private var sourceSpaceID: String? {

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -4,68 +4,18 @@ import SwiftUI
 struct ShellWorkspaceView: View {
     @ObservedObject var host: ShellHostController
     let expandedSidebarProgress: CGFloat
-    let spaceID: String?
-    let selectedPaneID: String?
-
-    init(
-        host: ShellHostController,
-        expandedSidebarProgress: CGFloat,
-        spaceID: String? = nil,
-        selectedPaneID: String? = nil
-    ) {
-        self.host = host
-        self.expandedSidebarProgress = expandedSidebarProgress
-        self.spaceID = spaceID
-        self.selectedPaneID = selectedPaneID
-    }
 
     var body: some View {
         TerminalPaneView(
             host: host,
-            tab: displayTab,
-            spaceID: displaySpace?.spaceID,
-            selectedPaneID: displaySelectedPaneID,
+            tab: host.selectedTab,
+            spaceID: host.selectedSpace?.spaceID,
+            selectedPaneID: host.selectedPane?.paneID,
             terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
                 expandedSidebarProgress: expandedSidebarProgress
             )
         )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var displaySpace: ShellSpace? {
-        guard let spaceID else { return host.selectedSpace }
-        return host.spaces.first { $0.spaceID == spaceID }
-    }
-
-    private var displayTab: ShellTab? {
-        guard let displaySpace else { return host.selectedTab }
-        if displaySpace.spaceID == host.selectedSpace?.spaceID,
-           let selectedTab = host.selectedTab,
-           displaySpace.tabs.contains(where: { $0.tabID == selectedTab.tabID })
-        {
-            return selectedTab
-        }
-        if let selectedPaneID,
-           let tab = displaySpace.tabs.first(where: { $0.contains(paneID: selectedPaneID) })
-        {
-            return tab
-        }
-        return displaySpace.tabs.first
-    }
-
-    private var displaySelectedPaneID: String? {
-        if let selectedPaneID,
-           displayTab?.contains(paneID: selectedPaneID) == true
-        {
-            return selectedPaneID
-        }
-        if displayTab?.tabID == host.selectedTab?.tabID,
-           let selectedPaneID = host.selectedPane?.paneID,
-           displayTab?.contains(paneID: selectedPaneID) == true
-        {
-            return selectedPaneID
-        }
-        return displayTab?.paneTree.paneIDs.first
     }
 }
 

--- a/clients/apple/scripts/check-brand-identity.sh
+++ b/clients/apple/scripts/check-brand-identity.sh
@@ -65,7 +65,8 @@ while IFS= read -r line; do
     printf 'error: non-canonical alan brand occurrence: %s\n' "$rel" >&2
     violations=$((violations + 1))
 done < <(
-    rg -n --pcre2 "$PATTERN" "$REPO_ROOT" \
+    cd "$REPO_ROOT"
+    rg -n --pcre2 "$PATTERN" \
         --glob '!target/**' \
         --glob '!.git/**' \
         --glob '!plans/**' \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -664,19 +664,59 @@ require_pattern \
     "space pager state must model drag, commit, and cancel settlement phases"
 
 require_pattern \
-    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "spacePager" \
-    "mac shell root must own space pager state for sidebar and workspace motion"
+    "sidebar view must own sidebar-local space pager state"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "ShellSidebarSwipeMonitor\\(onUpdate: handleSpaceSwipe\\)" \
+    "sidebar view must install the sidebar swipe monitor as its input adapter"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "spaceContentPager" \
+    "sidebar view must render sidebar-local space content pager pages"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "commandLauncher" \
+    "sidebar-local pager motion must keep the command launcher owned by the sidebar"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "spaceDock" \
+    "sidebar-local pager motion must keep the bottom space dock owned by the sidebar"
+
+reject_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "spacePager|spacePagerPages|spacePage\\(index:" \
+    "mac shell root must not reintroduce root full-window space pager semantics"
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
-    "spacePage\\(index:" \
-    "mac shell root must render whole space pages from the shared pager offset"
+    "HStack\\(spacing: 0\\)" \
+    "mac shell root must keep a stable sidebar/workspace HStack layout"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "ShellWorkspaceView\\(" \
+    "mac shell root must render the committed workspace surface"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "spaceID: String\\?" \
-    "workspace view must accept an explicit space for pager preview pages"
+    "tab: host\\.selectedTab" \
+    "workspace view must render committed host tab selection"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
+    "spaceID: host\\.selectedSpace\\?\\.spaceID" \
+    "workspace view must render committed host space selection"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
+    "selectedPaneID: host\\.selectedPane\\?\\.paneID" \
+    "workspace view must render committed host pane selection"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -635,21 +635,31 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
-    "struct ShellSpacePagerState" \
-    "space swipes must use a root pager state instead of a sidebar-only transition"
+    "struct ShellSidebarSwipeMonitor" \
+    "sidebar swipe monitor must remain the input adapter"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "struct ShellSidebarSwipeUpdate" \
+    "sidebar swipe monitor must emit swipe input updates"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
+    "struct ShellSidebarSpaceContentPagerState" \
+    "space swipes must use sidebar content pager state"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
     "sourceIndex" \
     "space pager state must track the authoritative source space index"
 
 require_pattern \
-    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
     "targetIndex" \
     "space pager state must track the adjacent target space index"
 
 require_pattern \
-    "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
     "settlementPhase" \
     "space pager state must model drag, commit, and cancel settlement phases"
 

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
@@ -12,6 +12,7 @@ mkdir -p "$MODULE_CACHE_DIR"
 CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     -D ALAN_TESTING \
     "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift" \
     -o "$TEST_BINARY"
 

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
@@ -141,30 +141,30 @@ private enum ShellSidebarSwipeMonitorTests {
     }
 
     private static func verifiesPagerOffsetsPagesFromSharedDragOffset() {
-        let pager = ShellSpacePagerState(
+        let pager = ShellSidebarSpaceContentPagerState(
             sourceIndex: 1,
             targetIndex: 2,
-            dragOffset: -120,
-            pageWidth: 500,
+            dragOffset: -72,
+            pageWidth: 240,
             settlementPhase: .dragging
         )
 
         expect(
-            pager.offset(for: 1).isApproximately(-120),
-            "source page must move directly with finger translation"
+            pager.offset(for: 1).isApproximately(-72),
+            "source sidebar content page must move directly with finger translation"
         )
         expect(
-            pager.offset(for: 2).isApproximately(380),
-            "target page must share the same drag offset from the adjacent page position"
+            pager.offset(for: 2).isApproximately(168),
+            "target sidebar content page must share the same drag offset from the adjacent page position"
         )
         expect(
             pager.pageIndicesForRendering == [1, 2],
-            "pager must render source and adjacent target pages together"
+            "sidebar content pager must render source and adjacent target pages together"
         )
     }
 
     private static func verifiesPagerEdgeResistanceDoesNotRenderWrappedTarget() {
-        let pager = ShellSpacePagerState(
+        let pager = ShellSidebarSpaceContentPagerState(
             sourceIndex: 0,
             targetIndex: nil,
             dragOffset: 42,
@@ -184,14 +184,14 @@ private enum ShellSidebarSwipeMonitorTests {
     }
 
     private static func verifiesPagerSettlementPhaseExposesCommitAndCancelState() {
-        let committing = ShellSpacePagerState(
+        let committing = ShellSidebarSpaceContentPagerState(
             sourceIndex: 1,
             targetIndex: 2,
             dragOffset: -500,
             pageWidth: 500,
             settlementPhase: .settlingToTarget
         )
-        let cancelling = ShellSpacePagerState(
+        let cancelling = ShellSidebarSpaceContentPagerState(
             sourceIndex: 1,
             targetIndex: 2,
             dragOffset: 0,

--- a/docs/superpowers/plans/2026-05-15-sidebar-local-space-swipe.md
+++ b/docs/superpowers/plans/2026-05-15-sidebar-local-space-swipe.md
@@ -1,0 +1,916 @@
+# Sidebar-local Space Swipe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore macOS space swipe to a sidebar-local, finger-tracked content pager that leaves the terminal workspace and fixed sidebar controls stable until commit.
+
+**Architecture:** `MacShellRootView` returns to a stable shell layout with one sidebar surface and one committed `ShellWorkspaceView`. `ShellSidebarView` owns the space content pager for only the active space header and tab list. `ShellSidebarSwipeMonitor` remains an input adapter; committed selection still flows through `ShellHostController`.
+
+**Tech Stack:** SwiftUI, AppKit scroll event monitoring, OpenSpec, shell Swift script tests, Xcode macOS build.
+
+---
+
+### Task 1: Correct The Active OpenSpec Delta
+
+**Files:**
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/proposal.md`
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/design.md`
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md`
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md`
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/tasks.md`
+
+- [ ] **Step 1: Replace the incorrect full-window pager language in the design**
+
+  In `openspec/changes/refine-macos-sidebar-interactions/design.md`, replace Decision 4 with this text:
+
+  ```markdown
+  4. **Space swipe is a sidebar-local content pager.**
+
+     The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`,
+     `pageWidth`, and settlement phase for the sidebar's active-space content
+     area. The moving page includes only the active space title/header and the
+     active space tab list. Command input, the bottom space switcher, sidebar
+     material/chrome, traffic lights, and the terminal workspace surface remain
+     visually fixed while dragging. Commit and cancel use the same pager model,
+     but shell selection and terminal focus change only when the gesture commits
+     to a target space.
+
+     Alternative considered: make the entire shell content area a continuous
+     space pager. That breaks the accepted terminal-first layout because the
+     terminal workspace slides, duplicates, and exposes artifacts during a
+     sidebar navigation gesture.
+  ```
+
+  Also update the Goals section so the swipe goal reads:
+
+  ```markdown
+  - Replace discontinuous sidebar space swipe behavior with a continuous,
+    sidebar-local content pager over the ordered `ShellSpace` sequence.
+  ```
+
+- [ ] **Step 2: Fix the workspace interaction delta spec**
+
+  In `openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md`:
+
+  - Remove the `REMOVED Requirements` section that removes `Sidebar swipe previews spaces without moving the workspace`.
+  - Remove the `Requirement: Space switching uses a continuous pager` block.
+  - Add this `MODIFIED Requirements` block after the existing `ADDED Requirements` block for authoritative selection, or make it the first section if there is no `MODIFIED Requirements` section:
+
+  ```markdown
+  ## MODIFIED Requirements
+
+  ### Requirement: Sidebar swipe previews spaces without moving the workspace
+  Horizontal swipe gestures that originate inside the macOS sidebar SHALL drive
+  a sidebar-local, finger-tracked space content pager. The moving page SHALL
+  include only the sidebar's active-space header and active-space tab list. The
+  command input, bottom space switcher, sidebar material surface, sidebar chrome,
+  macOS traffic-light placement, and workspace terminal surface SHALL remain
+  visually fixed while the gesture is active. Alan SHALL avoid mutating durable
+  shell selection until the gesture commits.
+
+  #### Scenario: Gesture-tracked sidebar content pager
+  - **WHEN** a user horizontally swipes inside the sidebar and an adjacent space exists
+  - **THEN** the current sidebar space header and tab list move with the gesture while the adjacent space content previews from the side
+  - **AND** the space header and tab list use the same full sidebar content page width for horizontal offsets
+  - **AND** the preview movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+  - **AND** the command input remains fixed
+  - **AND** the bottom space switcher remains fixed as the stable space navigation control
+  - **AND** the workspace terminal surface remains visually stable on the original selected space
+  - **AND** visible terminal panes keep their runtime identities instead of being restarted, duplicated, or horizontally offset as a side effect of the drag
+  - **AND** vertical tab-list scrolling does not move while horizontal intent is locked
+
+  #### Scenario: Undecided axis buffers mixed deltas
+  - **WHEN** a sidebar scroll gesture has not yet crossed the horizontal or vertical intent threshold
+  - **THEN** alan buffers the initial mixed deltas instead of applying partial vertical tab-list scrolling or horizontal pager movement
+  - **AND** the gesture is routed only after horizontal or vertical intent is locked
+
+  #### Scenario: Content pager reaches sequence edge
+  - **WHEN** a user swipes past the first or last available space
+  - **THEN** alan applies bounded edge resistance to the moving sidebar content rather than wrapping unexpectedly or showing a nonexistent space page
+  - **AND** releasing before a valid target is selected returns the content pager to the current space
+
+  #### Scenario: Commit updates focus at the authoritative transition point
+  - **WHEN** the user releases a space swipe past the commit threshold or with sufficient release velocity toward an adjacent space
+  - **THEN** alan commits the target space through the shell controller selection and focus path
+  - **AND** the sidebar content pager settles smoothly to the committed space without being reverted by concurrent runtime updates
+  - **AND** the workspace terminal surface and terminal focus follow the committed space after shell selection commits
+
+  #### Scenario: Cancel preserves focus and layout
+  - **WHEN** the user releases a space swipe before the commit threshold
+  - **THEN** alan animates the sidebar content pager back to the original space
+  - **AND** selected space, selected tab, terminal focus, split tree, and divider ratios remain unchanged
+
+  #### Scenario: Phaseful gesture waits for real release
+  - **WHEN** a user pauses a phaseful horizontal trackpad swipe while their fingers remain on the trackpad
+  - **THEN** alan keeps the sidebar content pager at the current drag offset
+  - **AND** alan does not commit or cancel until the gesture ends, is cancelled, or enters momentum
+
+  #### Scenario: Release uses last effective velocity
+  - **WHEN** a phaseful horizontal trackpad swipe ends or enters momentum
+  - **THEN** alan evaluates commit using current pager progress and the last effective finger velocity before release
+  - **AND** alan does not replace that velocity with a zero-delta ended event
+
+  #### Scenario: Fast flick can commit
+  - **WHEN** a user performs a fast horizontal flick inside the sidebar
+  - **THEN** alan recognizes the dominant horizontal release or momentum handoff as a space switch
+  - **AND** alan may commit from velocity even when the gesture produced only a short visible translation before release
+
+  #### Scenario: Phase-less gesture settles
+  - **WHEN** a horizontal sidebar swipe comes from a scroll device that does not provide gesture phases
+  - **THEN** alan may treat a short idle gap as release to avoid leaving the content pager stuck
+  - **AND** shell selection follows the same commit threshold as other sidebar swipes
+
+  #### Scenario: Vertical scroll is not captured
+  - **WHEN** a user's gesture is primarily vertical in the sidebar tab list
+  - **THEN** the native vertical tab-list scroll receives the gesture and the workspace space transition does not begin
+  - **AND** horizontal sidebar content pager movement is not applied while vertical intent is locked
+  ```
+
+- [ ] **Step 3: Update build-test wording**
+
+  In `openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md`, make the space gesture scenario require fixed terminal/sidebar regions:
+
+  ```markdown
+  #### Scenario: Sidebar-local space pager gesture tested
+  - **WHEN** horizontal space swipe behavior changes
+  - **THEN** focused tests cover undecided-axis buffering, horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
+  - **AND** verification confirms only the sidebar active-space header and tab list move during the gesture
+  - **AND** verification confirms the command input, bottom space switcher, sidebar chrome, traffic lights, and workspace terminal surface remain fixed during the gesture
+  ```
+
+- [ ] **Step 4: Update tasks terminology**
+
+  In `openspec/changes/refine-macos-sidebar-interactions/tasks.md`, rename section `## 3. Continuous Space Pager` to:
+
+  ```markdown
+  ## 3. Sidebar-local Space Content Pager
+  ```
+
+  Replace tasks 3.1 and 3.3 with:
+
+  ```markdown
+  - [ ] 3.1 Replace the root-level `ShellSpacePagerState` usage with a sidebar-local pager state that tracks source index, target index, drag offset, sidebar content page width, commit/cancel state, and settlement phase.
+  - [ ] 3.3 Render current and adjacent sidebar active-space content pages from the same pager offset so users can see the target space edge while dragging, without moving command input, the bottom space switcher, sidebar chrome, or the terminal workspace surface.
+  ```
+
+- [ ] **Step 5: Validate the spec change**
+
+  Run:
+
+  ```bash
+  openspec validate refine-macos-sidebar-interactions --strict
+  ```
+
+  Expected: exits `0` with no validation errors.
+
+- [ ] **Step 6: Commit the spec correction**
+
+  Run:
+
+  ```bash
+  git add openspec/changes/refine-macos-sidebar-interactions
+  git commit -m "Spec sidebar-local space swipe"
+  ```
+
+### Task 2: Extract Sidebar Content Pager State And Tests
+
+**Files:**
+- Create: `clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift`
+- Modify: `clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift`
+- Modify: `clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift`
+- Modify: `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`
+- Modify: `clients/apple/alan-macos.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Add failing pager-state expectations**
+
+  In `clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift`, rename the pager tests to the sidebar-local type before the implementation exists:
+
+  ```swift
+  private static func verifiesPagerOffsetsPagesFromSharedDragOffset() {
+      let pager = ShellSidebarSpaceContentPagerState(
+          sourceIndex: 1,
+          targetIndex: 2,
+          dragOffset: -72,
+          pageWidth: 240,
+          settlementPhase: .dragging
+      )
+
+      expect(
+          pager.offset(for: 1).isApproximately(-72),
+          "source sidebar content page must move directly with finger translation"
+      )
+      expect(
+          pager.offset(for: 2).isApproximately(168),
+          "target sidebar content page must share the same drag offset from the adjacent page position"
+      )
+      expect(
+          pager.pageIndicesForRendering == [1, 2],
+          "sidebar content pager must render source and adjacent target pages together"
+      )
+  }
+  ```
+
+  Also change the edge and settlement tests to use `ShellSidebarSpaceContentPagerState`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+  Run:
+
+  ```bash
+  clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
+  ```
+
+  Expected: compile failure mentioning `cannot find 'ShellSidebarSpaceContentPagerState' in scope`.
+
+- [ ] **Step 3: Create the sidebar-local pager state file**
+
+  Add `clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift`:
+
+  ```swift
+  import SwiftUI
+
+  #if os(macOS)
+  enum ShellSidebarSpaceContentPagerSettlementPhase: Equatable {
+      case dragging
+      case settlingToSource
+      case settlingToTarget
+  }
+
+  struct ShellSidebarSpaceContentPagerState: Equatable {
+      let sourceIndex: Int
+      var targetIndex: Int?
+      var dragOffset: CGFloat
+      var pageWidth: CGFloat
+      var settlementPhase: ShellSidebarSpaceContentPagerSettlementPhase
+
+      var isSettling: Bool {
+          settlementPhase != .dragging
+      }
+
+      var isEdgeResistance: Bool {
+          targetIndex == nil
+      }
+
+      var committedTargetIndex: Int? {
+          guard settlementPhase == .settlingToTarget else { return nil }
+          return targetIndex
+      }
+
+      var direction: Int {
+          guard let targetIndex else {
+              return dragOffset < 0 ? 1 : -1
+          }
+          return targetIndex >= sourceIndex ? 1 : -1
+      }
+
+      var progress: CGFloat {
+          let width = max(pageWidth, 1)
+          return min(abs(dragOffset) / width, 0.98)
+      }
+
+      var pageIndicesForRendering: [Int] {
+          guard let targetIndex, targetIndex != sourceIndex else {
+              return [sourceIndex]
+          }
+          return [sourceIndex, targetIndex]
+      }
+
+      func offset(for index: Int) -> CGFloat {
+          CGFloat(index - sourceIndex) * max(pageWidth, 1) + dragOffset
+      }
+  }
+  #endif
+  ```
+
+- [ ] **Step 4: Remove pager state from the monitor file**
+
+  In `clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift`, delete the
+  existing `ShellSpacePagerSettlementPhase` enum and the existing
+  `ShellSpacePagerState` struct. After this edit the file should still define
+  only the swipe input types and monitor:
+
+  ```swift
+  enum ShellSidebarSwipePhase {
+      case began
+      case changed
+      case ended
+      case cancelled
+  }
+
+  struct ShellSidebarSwipeUpdate {
+      let phase: ShellSidebarSwipePhase
+      let translationX: CGFloat
+      let velocityX: CGFloat
+  }
+
+  struct ShellSidebarSwipeMonitor: NSViewRepresentable {
+      let onUpdate: (ShellSidebarSwipeUpdate) -> Void
+  }
+  ```
+
+  Keep `ShellSidebarSwipePhase`, `ShellSidebarSwipeUpdate`, and `ShellSidebarSwipeMonitor` unchanged.
+
+- [ ] **Step 5: Compile the new file in the script test**
+
+  In `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, add the new Swift file before the test file:
+
+  ```bash
+  CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+      -D ALAN_TESTING \
+      "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
+      "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
+      "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift" \
+      -o "$TEST_BINARY"
+  ```
+
+- [ ] **Step 6: Add the new Swift source to the Xcode project**
+
+  In `clients/apple/alan-macos.xcodeproj/project.pbxproj`, add a build file, file reference, group child, and Sources entry for:
+
+  ```text
+  ShellSidebarSpaceContentPager.swift
+  ```
+
+  Follow the existing pattern for `ShellSidebarSwipeMonitor.swift`:
+
+  ```text
+  00000000000000000000003B /* ShellSidebarSpaceContentPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */; };
+  00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceContentPager.swift; sourceTree = "<group>"; };
+  ```
+
+  Add `00000000000000000000013B` to the main group children near `ShellSidebarSwipeMonitor.swift`, and add `00000000000000000000003B` to the app target `PBXSourcesBuildPhase`.
+
+- [ ] **Step 7: Run the focused test**
+
+  Run:
+
+  ```bash
+  clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
+  ```
+
+  Expected output includes:
+
+  ```text
+  Shell sidebar swipe monitor tests passed.
+  ```
+
+- [ ] **Step 8: Commit pager state extraction**
+
+  Run:
+
+  ```bash
+  git add clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh clients/apple/alan-macos.xcodeproj/project.pbxproj
+  git commit -m "Extract sidebar space content pager state"
+  ```
+
+### Task 3: Move Space Swipe Ownership Into ShellSidebarView
+
+**Files:**
+- Modify: `clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift`
+
+- [ ] **Step 1: Add local pager state**
+
+  In `ShellSidebarView`, add these properties:
+
+  ```swift
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var spacePager: ShellSidebarSpaceContentPagerState?
+  @State private var spacePagerToken = 0
+  @State private var spacePagerPageWidth: CGFloat = 1
+  ```
+
+  Remove these stored inputs:
+
+  ```swift
+  let previewedSpaceID: String?
+  let isSpaceSwipeGestureLocked: Bool
+  let onSpaceSwipe: (ShellSidebarSwipeUpdate) -> Void
+  ```
+
+- [ ] **Step 2: Handle swipe updates locally**
+
+  Add these methods inside `ShellSidebarView`:
+
+  ```swift
+  private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
+      switch update.phase {
+      case .began:
+          guard spacePager?.isSettling != true else { return }
+          beginSpacePager()
+      case .changed:
+          guard spacePager?.isSettling != true else { return }
+          updateSpacePager(translationX: update.translationX)
+      case .ended:
+          finishSpacePager(velocityX: update.velocityX)
+      case .cancelled:
+          settleSpacePager(committing: false)
+      }
+  }
+
+  private func beginSpacePager() {
+      guard let sourceIndex = selectedSpaceIndex else { return }
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+          spacePager = ShellSidebarSpaceContentPagerState(
+              sourceIndex: sourceIndex,
+              targetIndex: nil,
+              dragOffset: 0,
+              pageWidth: sidebarSwipePageWidth,
+              settlementPhase: .dragging
+          )
+      }
+  }
+
+  private func updateSpacePager(translationX: CGFloat) {
+      guard abs(translationX) > 0.5 else { return }
+      guard let sourceIndex = spacePager?.sourceIndex ?? selectedSpaceIndex else { return }
+      let direction = translationX < 0 ? 1 : -1
+      let targetIndex = adjacentSpaceIndex(from: sourceIndex, direction: direction)
+      let dragOffset = targetIndex == nil ? resistedEdgeOffset(for: translationX) : translationX
+
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+          spacePager = ShellSidebarSpaceContentPagerState(
+              sourceIndex: sourceIndex,
+              targetIndex: targetIndex,
+              dragOffset: dragOffset,
+              pageWidth: sidebarSwipePageWidth,
+              settlementPhase: .dragging
+          )
+      }
+  }
+
+  private func finishSpacePager(velocityX: CGFloat) {
+      guard let pager = spacePager else { return }
+      guard pager.targetIndex != nil else {
+          settleSpacePager(committing: false)
+          return
+      }
+
+      let velocityDirection = velocityX < 0 ? 1 : -1
+      let fastEnough = abs(velocityX) >= 120 && velocityDirection == pager.direction
+      let farEnough = pager.progress >= 0.28
+      settleSpacePager(committing: farEnough || fastEnough)
+  }
+
+  private func settleSpacePager(committing: Bool) {
+      guard var pager = spacePager else { return }
+      let targetIndex = pager.targetIndex
+      if committing,
+         let targetIndex,
+         host.spaces.indices.contains(targetIndex)
+      {
+          host.select(spaceID: host.spaces[targetIndex].spaceID)
+      }
+
+      pager.settlementPhase = committing ? .settlingToTarget : .settlingToSource
+      pager.pageWidth = sidebarSwipePageWidth
+      pager.dragOffset = committing ? -CGFloat(pager.direction) * sidebarSwipePageWidth : 0
+      spacePagerToken += 1
+      let token = spacePagerToken
+      let duration = reduceMotion ? 0.12 : 0.28
+
+      withAnimation(settleAnimation) {
+          spacePager = pager
+      }
+
+      DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+          guard spacePagerToken == token else { return }
+          var transaction = Transaction()
+          transaction.disablesAnimations = true
+          withTransaction(transaction) {
+              spacePager = nil
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 3: Add local pager helpers**
+
+  Add these helpers inside `ShellSidebarView`:
+
+  ```swift
+  private var settleAnimation: Animation {
+      if reduceMotion {
+          return .easeOut(duration: 0.12)
+      }
+      return .interactiveSpring(response: 0.28, dampingFraction: 0.86, blendDuration: 0.04)
+  }
+
+  private var sidebarSwipePageWidth: CGFloat {
+      max(spacePagerPageWidth, 1)
+  }
+
+  private func resistedEdgeOffset(for translationX: CGFloat) -> CGFloat {
+      let edgeLimit = sidebarSwipePageWidth * 0.18
+      let distance = abs(translationX)
+      let resistedDistance = edgeLimit * distance / (distance + edgeLimit)
+      return translationX < 0 ? -resistedDistance : resistedDistance
+  }
+
+  private func adjacentSpaceIndex(from sourceIndex: Int, direction: Int) -> Int? {
+      let targetIndex = sourceIndex + direction
+      guard host.spaces.indices.contains(targetIndex) else { return nil }
+      return targetIndex
+  }
+
+  private var selectedSpaceIndex: Int? {
+      guard let selectedSpaceID = host.selectedSpace?.spaceID else { return nil }
+      return host.spaces.firstIndex { $0.spaceID == selectedSpaceID }
+  }
+
+  private var previewedSpaceID: String? {
+      guard let targetIndex = spacePager?.targetIndex else { return nil }
+      return spaceID(forSpaceAt: targetIndex)
+  }
+
+  private func spaceID(forSpaceAt index: Int) -> String? {
+      guard host.spaces.indices.contains(index) else { return nil }
+      return host.spaces[index].spaceID
+  }
+
+  private var isTabListScrollDisabled: Bool {
+      spacePager != nil
+  }
+  ```
+
+- [ ] **Step 4: Replace the static header/list with a content pager**
+
+  Replace `spaceLabelRow` plus `tabSection` in `sidebarContent` with:
+
+  ```swift
+  spaceContentPager
+  ```
+
+  Add this view:
+
+  ```swift
+  private var spaceContentPager: some View {
+      GeometryReader { proxy in
+          let pageWidth = max(proxy.size.width, 1)
+          ZStack(alignment: .leading) {
+              ForEach(spacePageIndices, id: \.self) { index in
+                  VStack(alignment: .leading, spacing: 0) {
+                      spaceLabelRow(for: spaceID(forSpaceAt: index))
+                          .padding(.bottom, 2)
+                      tabSection(for: spaceID(forSpaceAt: index))
+                  }
+                  .frame(width: pageWidth, height: proxy.size.height, alignment: .topLeading)
+                  .offset(x: spacePageOffset(for: index, pageWidth: pageWidth))
+                  .allowsHitTesting(spacePager == nil && index == selectedSpaceIndex)
+              }
+          }
+          .clipped()
+          .onAppear {
+              updateSpacePagerPageWidth(pageWidth)
+          }
+          .onChange(of: proxy.size.width) { _, width in
+              updateSpacePagerPageWidth(max(width, 1))
+          }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+  ```
+
+- [ ] **Step 5: Parameterize header and tab list by space id**
+
+  Change:
+
+  ```swift
+  private var spaceLabelRow: some View
+  private var tabSection: some View
+  ```
+
+  to:
+
+  ```swift
+  private func spaceLabelRow(for spaceID: String?) -> some View {
+      ShellSidebarSpaceHeader(
+          host: host,
+          spaceID: spaceID
+      )
+      .frame(maxWidth: .infinity)
+      .frame(height: 28)
+  }
+
+  private func tabSection(for spaceID: String?) -> some View {
+      VStack(alignment: .leading, spacing: 0) {
+          tabListPage(for: spaceID)
+              .overlay(alignment: .top) {
+                  if spaceID == sourceSpaceID {
+                      ShellSidebarScrollBoundary(progress: tabListBoundaryProgress)
+                  }
+              }
+              .clipped()
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+  ```
+
+- [ ] **Step 6: Add page index and offset helpers**
+
+  Add:
+
+  ```swift
+  private var spacePageIndices: [Int] {
+      guard let spacePager else {
+          return selectedSpaceIndex.map { [$0] } ?? []
+      }
+      return spacePager.pageIndicesForRendering.filter { host.spaces.indices.contains($0) }
+  }
+
+  private func spacePageOffset(for index: Int, pageWidth: CGFloat) -> CGFloat {
+      guard var spacePager else { return 0 }
+      spacePager.pageWidth = pageWidth
+      return spacePager.offset(for: index)
+  }
+
+  private func updateSpacePagerPageWidth(_ pageWidth: CGFloat) {
+      let clampedPageWidth = max(pageWidth, 1)
+      spacePagerPageWidth = clampedPageWidth
+      guard var spacePager,
+            spacePager.pageWidth != clampedPageWidth
+      else {
+          return
+      }
+      spacePager.pageWidth = clampedPageWidth
+      self.spacePager = spacePager
+  }
+  ```
+
+- [ ] **Step 7: Wire the monitor locally**
+
+  In `body`, replace:
+
+  ```swift
+  ShellSidebarSwipeMonitor(onUpdate: onSpaceSwipe)
+  ```
+
+  with:
+
+  ```swift
+  ShellSidebarSwipeMonitor(onUpdate: handleSpaceSwipe)
+  ```
+
+- [ ] **Step 8: Commit the sidebar pager move**
+
+  Run:
+
+  ```bash
+  git add clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+  git commit -m "Move space swipe pager into sidebar"
+  ```
+
+### Task 4: Restore Stable Root Shell Layout
+
+**Files:**
+- Modify: `clients/apple/alan-macos/MacShellRootView.swift`
+- Modify: `clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift`
+
+- [ ] **Step 1: Remove root pager state and functions**
+
+  In `MacShellRootView.swift`, remove these state properties:
+
+  ```swift
+  @State private var isSpaceSwipeGestureLocked = false
+  @State private var spacePager: ShellSpacePagerState?
+  @State private var spacePagerToken = 0
+  @State private var spacePagerPageWidth: CGFloat = 1
+  @State private var spacePagerPageSelectedPaneIDs: [Int: String] = [:]
+  ```
+
+  Remove the root-level functions and computed properties that only support full-window paging:
+
+  ```swift
+  handleSpaceSwipe(_:)
+  beginSpacePager()
+  updateSpacePager(translationX:)
+  finishSpacePager(velocityX:)
+  settleSpacePager(committing:)
+  sidebarSwipePageWidth
+  resistedEdgeOffset(for:)
+  adjacentSpaceIndex(from:direction:)
+  selectedSpaceIndex
+  previewedSpaceID
+  swipeEnabledSpaceIndex
+  floatingSidebarDisplaySpaceID
+  spaceID(forSpaceAt:)
+  firstPaneID(forSpaceAt:)
+  selectedPaneID(forSpaceAt:)
+  spacePagerPages
+  spacePageIndices
+  spacePage(index:pageWidth:)
+  spacePageOffset(for:pageWidth:)
+  updateSpacePagerPageWidth(_:)
+  ```
+
+- [ ] **Step 2: Replace full-window pages with stable HStack layout**
+
+  In `body`, replace:
+
+  ```swift
+  spacePagerPages
+      .frame(
+          minWidth: ShellWindowSizing.minimumSize.width,
+          minHeight: ShellWindowSizing.minimumSize.height
+      )
+  ```
+
+  with:
+
+  ```swift
+  HStack(spacing: 0) {
+      pinnedSidebarSurface()
+
+      ShellWorkspaceView(
+          host: host,
+          expandedSidebarProgress: clampedPinnedSidebarPresentationProgress
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .ignoresSafeArea(edges: .top)
+  }
+  .frame(
+      minWidth: ShellWindowSizing.minimumSize.width,
+      minHeight: ShellWindowSizing.minimumSize.height
+  )
+  ```
+
+- [ ] **Step 3: Simplify sidebar surface calls**
+
+  Change:
+
+  ```swift
+  private func pinnedSidebarSurface(
+      displaySpaceID: String?,
+      previewedSpaceID: String?,
+      isSwipeEnabled: Bool
+  ) -> some View
+  ```
+
+  to:
+
+  ```swift
+  private func pinnedSidebarSurface() -> some View
+  ```
+
+  Its body should call:
+
+  ```swift
+  sidebarContent(isSwipeEnabled: true)
+  ```
+
+  Change `floatingSidebarPanel` so it calls:
+
+  ```swift
+  sidebarContent(isSwipeEnabled: true)
+  ```
+
+  Remove `displaySpaceID` and `previewedSpaceID` arguments from `sidebarContent`.
+
+- [ ] **Step 4: Simplify ShellSidebarView construction**
+
+  In `sidebarContent`, construct:
+
+  ```swift
+  ShellSidebarView(
+      host: host,
+      chromeMetrics: windowChromeMetrics,
+      displaySpaceID: nil,
+      isSwipeEnabled: isSwipeEnabled
+  ) {
+      presentCommandInput()
+  }
+  ```
+
+- [ ] **Step 5: Simplify ShellWorkspaceView if no longer needed**
+
+  If `ShellWorkspaceView` no longer has call sites that pass `spaceID` or
+  `selectedPaneID`, remove those parameters and keep:
+
+  ```swift
+  struct ShellWorkspaceView: View {
+      @ObservedObject var host: ShellHostController
+      let expandedSidebarProgress: CGFloat
+
+      var body: some View {
+          TerminalPaneView(
+              host: host,
+              tab: host.selectedTab,
+              spaceID: host.selectedSpace?.spaceID,
+              selectedPaneID: host.selectedPane?.paneID,
+              terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
+                  expandedSidebarProgress: expandedSidebarProgress
+              )
+          )
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+  }
+  ```
+
+- [ ] **Step 6: Build to catch SwiftUI signature drift**
+
+  Run:
+
+  ```bash
+  xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan -configuration Debug -destination 'platform=macOS' build
+  ```
+
+  Expected: exits `0`.
+
+- [ ] **Step 7: Commit root layout restoration**
+
+  Run:
+
+  ```bash
+  git add clients/apple/alan-macos/MacShellRootView.swift clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+  git commit -m "Restore stable shell layout during space swipe"
+  ```
+
+### Task 5: Validate The Full Change
+
+**Files:**
+- Read: `clients/apple/scripts/check-shell-contracts.sh`
+- Modify: `openspec/changes/refine-macos-sidebar-interactions/tasks.md`
+
+- [ ] **Step 1: Run the sidebar swipe test**
+
+  Run:
+
+  ```bash
+  clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
+  ```
+
+  Expected output includes:
+
+  ```text
+  Shell sidebar swipe monitor tests passed.
+  ```
+
+- [ ] **Step 2: Run shell contract checks**
+
+  Run:
+
+  ```bash
+  clients/apple/scripts/check-shell-contracts.sh
+  ```
+
+  Expected: exits `0`.
+
+- [ ] **Step 3: Validate OpenSpec**
+
+  Run:
+
+  ```bash
+  openspec validate refine-macos-sidebar-interactions --strict
+  openspec validate --all --strict
+  ```
+
+  Expected: both commands exit `0`.
+
+- [ ] **Step 4: Build the macOS app**
+
+  Run:
+
+  ```bash
+  xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan -configuration Debug -destination 'platform=macOS' build
+  ```
+
+  Expected: exits `0`.
+
+- [ ] **Step 5: Manually verify the running app**
+
+  Launch or reuse the local app, then verify:
+
+  ```text
+  - horizontal swipe starts only from inside the sidebar;
+  - only the space title/header and active tab list move with the finger;
+  - command input stays fixed;
+  - bottom space switcher stays fixed;
+  - sidebar chrome and traffic lights stay fixed;
+  - terminal workspace does not move, duplicate, or expose top-edge artifacts during drag;
+  - release past threshold commits to the adjacent space;
+  - release below threshold cancels back to the original space;
+  - fast flick can commit from velocity;
+  - vertical scrolling still works when the gesture is vertical.
+  ```
+
+- [ ] **Step 6: Update task completion state**
+
+  In `openspec/changes/refine-macos-sidebar-interactions/tasks.md`, check off the updated pager and verification tasks that were completed in this implementation pass.
+
+- [ ] **Step 7: Commit validation task updates**
+
+  Run:
+
+  ```bash
+  git add openspec/changes/refine-macos-sidebar-interactions/tasks.md
+  git commit -m "Mark sidebar swipe validation tasks complete"
+  ```
+
+### Self-review Notes
+
+- Spec coverage: Task 1 fixes the incorrect OpenSpec abstraction; Tasks 2-4 implement the sidebar-local content pager and root layout stability; Task 5 covers automated and manual validation.
+- Placeholder scan: this plan has no unresolved markers or unspecified test commands.
+- Type consistency: the plan uses `ShellSidebarSpaceContentPagerState` and `ShellSidebarSpaceContentPagerSettlementPhase` consistently after extraction.

--- a/docs/superpowers/plans/2026-05-15-sidebar-local-space-swipe.md
+++ b/docs/superpowers/plans/2026-05-15-sidebar-local-space-swipe.md
@@ -65,7 +65,7 @@
   include only the sidebar's active-space header and active-space tab list. The
   command input, bottom space switcher, sidebar material surface, sidebar chrome,
   macOS traffic-light placement, and workspace terminal surface SHALL remain
-  visually fixed while the gesture is active. Alan SHALL avoid mutating durable
+  visually fixed while the gesture is active. alan SHALL avoid mutating durable
   shell selection until the gesture commits.
 
   #### Scenario: Gesture-tracked sidebar content pager

--- a/docs/superpowers/specs/2026-05-15-sidebar-local-space-swipe-design.md
+++ b/docs/superpowers/specs/2026-05-15-sidebar-local-space-swipe-design.md
@@ -1,0 +1,157 @@
+# Sidebar-local Space Swipe Design
+
+## Context
+
+`refine-macos-sidebar-interactions` intended to improve the existing sidebar
+space swipe interaction. The correct product model is not a full-window space
+pager. The existing macOS sidebar already supports left/right swipe, but the
+interaction is not continuous enough: the user should be able to drag the
+active space content directly, then have the UI settle to the source or adjacent
+target space based on distance, velocity, momentum, and edge constraints.
+
+The earlier `refine-macos-sidebar-interactions` spec incorrectly moved the
+abstraction from sidebar-local space navigation to full shell paging. That made
+the right-side terminal workspace participate in the swipe, which breaks the
+terminal-first layout and causes visible artifacts at the terminal surface.
+
+## Goals
+
+- Keep space swipe scoped to the sidebar.
+- Make the swipe continuous and finger-tracked.
+- Move only the active-space content inside the sidebar: the space title/header
+  and the active space tab list.
+- Keep the command input, bottom space switcher, sidebar material surface,
+  sidebar chrome, traffic lights, and right-side terminal workspace fixed during
+  the drag.
+- Commit shell selection and terminal focus only after the gesture settles to a
+  target space.
+
+## Non-goals
+
+- Do not make the whole app window or terminal workspace a horizontal pager.
+- Do not redesign the sidebar information architecture.
+- Do not change terminal runtime identity, terminal input ownership, split
+  layout, or pane lifecycle semantics.
+- Do not make the bottom space switcher part of the moving page; it is a fixed
+  navigation control.
+
+## Architecture
+
+`MacShellRootView` should own the stable shell layout:
+
+```text
+MacShellRootView
+  -> pinned/floating sidebar surface
+  -> ShellWorkspaceView
+```
+
+It should not wrap the whole shell in a space pager. `ShellWorkspaceView`
+renders the currently committed selected space only.
+
+`ShellSidebarView` should own the sidebar-local swipe presentation. Inside the
+sidebar, introduce a focused content pager such as
+`ShellSidebarSpaceContentPager`. That pager wraps only:
+
+- active space title/header
+- active space tab list
+
+The following remain outside the pager and visually fixed:
+
+- command input
+- bottom space switcher
+- sidebar background/material
+- pinned and floating sidebar chrome controls
+- macOS traffic-light placement
+- right-side terminal workspace
+
+## Responsibilities
+
+`ShellSidebarSwipeMonitor` should be an input adapter. It converts macOS
+trackpad/scroll events into gesture signals:
+
+- horizontal/vertical intent lock
+- accumulated horizontal translation
+- latest effective horizontal velocity
+- phaseful release, cancellation, momentum handoff, and phaseless idle release
+
+It should not know which UI elements move, and it should not directly call shell
+selection APIs.
+
+`ShellSidebarSpaceContentPager` should be the physical/visual state machine. It
+tracks:
+
+- source space index
+- adjacent target space index, when one exists
+- direct drag offset from finger translation
+- sidebar content page width
+- settlement phase: dragging, settling to source, or settling to target
+
+`ShellHostController` remains the owner of committed shell selection and focus.
+The pager calls the controller selection/focus path only when the release should
+commit to a target space.
+
+## Gesture Semantics
+
+During drag:
+
+- horizontal movement maps directly to the sidebar content offset;
+- the current and adjacent space content pages move from the same translation;
+- edge swipes apply resistance instead of wrapping or showing nonexistent
+  spaces;
+- vertical tab-list scrolling is disabled only after horizontal intent locks;
+- terminal workspace, terminal focus, selected space, selected tab, split tree,
+  and divider ratios remain unchanged.
+
+On release:
+
+- if distance or velocity crosses the commit threshold and an adjacent target
+  exists, the pager settles to the target and commits shell selection through
+  the controller path;
+- if the threshold is not met, the pager settles back to the source and leaves
+  shell selection unchanged;
+- release handling should use the last effective finger velocity rather than a
+  zero-delta ended event;
+- phaseless input may use a short idle timeout to avoid leaving the pager stuck.
+
+The core boundary is:
+
+```text
+preview = sidebar presentation state
+selection = committed shell state
+```
+
+## Spec Correction
+
+`refine-macos-sidebar-interactions` should restore the sidebar-local contract
+from the accepted `streamline-macos-sidebar-ia` direction, while keeping the
+improved gesture physics and authoritative commit path.
+
+The spec should remove language that says a space page includes the terminal
+workspace surface. It should instead require that the workspace terminal surface
+stays visually stable during the swipe and updates only after the switch
+commits.
+
+## Testing
+
+Focused tests should cover:
+
+- horizontal intent lock and direct translation mapping;
+- vertical scroll pass-through before horizontal lock;
+- no vertical tab-list movement after horizontal lock;
+- edge resistance at the first and last spaces;
+- commit by distance threshold;
+- commit by release velocity or momentum handoff;
+- cancel below threshold;
+- phaseful release using the last effective velocity;
+- phaseless idle settlement;
+- root layout stability: terminal workspace and fixed sidebar regions do not
+  move during sidebar swipe.
+
+Manual verification should include a running macOS app check confirming that:
+
+- only the space title/header and active tab list move with the gesture;
+- command input and bottom space switcher remain fixed;
+- the right-side terminal surface does not slide, duplicate, or expose top-edge
+  artifacts;
+- after commit, terminal focus follows the selected pane for the committed
+  space.

--- a/openspec/changes/refine-macos-sidebar-interactions/design.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/design.md
@@ -4,7 +4,7 @@ The current macOS shell sidebar has three related interaction problems:
 
 - Sidebar tab and space clicks update `selectedSpaceID` / `selectedTabID` without updating the authoritative `shellState.focusedPaneID`. Later runtime metadata or state publication calls `synchronizeSelection()` and restores selection from the old focused pane.
 - Pinned-sidebar collapse is expressed as conditional SwiftUI insertion/removal, while titlebar controls and AppKit traffic-light placement are synchronized through a separate bridge. This produces uncoordinated motion and can make collapse appear instantaneous.
-- Horizontal space swipe is represented as a sidebar-local source/target transition. It previews the sidebar header and tab list only, commits after settle, and does not model spaces as a continuous sequence.
+- Horizontal space swipe is represented as a discontinuous sidebar-local source/target transition. It previews the sidebar header and tab list only, commits after settle, and does not model the ordered space sequence as a continuous sidebar-local content pager.
 
 The implementation must preserve alan's terminal-first layout, native material sidebar, hidden-titlebar window behavior, and terminal event ownership boundaries.
 
@@ -14,7 +14,8 @@ The implementation must preserve alan's terminal-first layout, native material s
 
 - Make sidebar tab and space selection persist by routing selection through authoritative shell focus.
 - Give pinned sidebar collapse and expansion one coordinated motion model across sidebar width, terminal content inset, sidebar toolbar controls, and standard macOS traffic lights.
-- Replace sidebar-only swipe semantics with a continuous pager over the ordered `ShellSpace` sequence.
+- Replace discontinuous sidebar space swipe behavior with a continuous,
+  sidebar-local content pager over the ordered `ShellSpace` sequence.
 - Keep collapsed floating sidebar reveal transient: it must not resize terminal content, and it must retain the narrow edge/titlebar-control hover behavior.
 - Add focused automated and contract verification for the new interaction guarantees.
 
@@ -45,28 +46,38 @@ The implementation must preserve alan's terminal-first layout, native material s
 
    Alternative considered: draw custom traffic-light replicas in SwiftUI. That would break native macOS traffic-light behavior and conflicts with the existing hidden-titlebar contract.
 
-4. **Space swipe is a pager over the ordered space sequence.**
+4. **Space swipe is a sidebar-local content pager.**
 
-   The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`, `pageWidth`, and settlement phase. Adjacent pages are rendered from the same offset so the user can see the next or previous space edge while dragging. The visible space page includes the sidebar navigation content and the terminal workspace surface for the source and adjacent target spaces, while preserving terminal runtime identity. Commit and cancel use the same pager model rather than a sidebar-only source/target transition.
+   The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`,
+   `pageWidth`, and settlement phase for the sidebar's active-space content
+   area. The moving page includes only the active space title/header and the
+   active space tab list. Command input, the bottom space switcher, sidebar
+   material/chrome, traffic lights, and the terminal workspace surface remain
+   visually fixed while dragging. Commit and cancel use the same pager model,
+   but shell selection and terminal focus change only when the gesture commits
+   to a target space.
 
-   Alternative considered: keep sidebar-only preview and only fix commit timing. That would solve some failures but would not match the virtual-desktop physical model requested for spaces.
+   Alternative considered: make the entire shell content area a continuous
+   space pager. That breaks the accepted terminal-first layout because the
+   terminal workspace slides, duplicates, and exposes artifacts during a
+   sidebar navigation gesture.
 
 5. **Commit focus is applied at the authoritative transition point.**
 
-   When a pager commit is selected, shell focus should update through the controller selection path before or at the start of the settle-to-target phase, while visual transition state keeps rendering the old and new pages until animation completion. This prevents runtime metadata updates from snapping the UI back during the settle animation.
+   When a pager commit is selected, shell focus should update through the controller selection path before or at the start of the settle-to-target phase, while sidebar content pager state keeps rendering the old and new sidebar pages until animation completion. This prevents runtime metadata updates from snapping the UI back during the settle animation.
 
    Alternative considered: wait until animation completion before changing shell state. That is the current source of race-prone behavior because unrelated runtime updates can arrive while the visual transition is in flight.
 
 ## Risks / Trade-offs
 
 - **Risk: traffic-light animation fights AppKit layout corrections.** → Keep the AppKit bridge as the only owner of standard button frames, coalesce chrome syncs, and ensure final frames are corrected without visible jumps.
-- **Risk: immediate focus commit changes terminal runtime focus while the old page is still visible during settle.** → Keep a short visual transition overlay/pager state that decouples rendering from the already-committed focus for the duration of settlement.
-- **Risk: continuous pager could create multiple live terminal hosts during drag.** → Reuse existing pane runtimes and render only the current and adjacent space pages needed for the gesture.
+- **Risk: immediate focus commit changes terminal runtime focus while the old sidebar page is still visible during settle.** → Keep a short sidebar content pager state that decouples rendering from the already-committed focus for the duration of settlement.
+- **Risk: sidebar-local pager accidentally moves fixed shell regions.** → Keep command input, the bottom space switcher, sidebar chrome, traffic lights, and the terminal workspace outside the moving page.
 - **Risk: gesture axis arbitration regresses vertical sidebar scrolling.** → Preserve the existing intent lock behavior and add tests for undecided, vertical, phaseful, phase-less, momentum, and fast flick paths.
 
 ## Migration Plan
 
-Implement in narrow stages: first selection/focus convergence, then pinned sidebar/chrome motion, then space pager refactor. Keep existing persisted shell state format unchanged. If a later stage regresses, it can be reverted independently because selection convergence does not require the pager implementation.
+Implement in narrow stages: first selection/focus convergence, then pinned sidebar/chrome motion, then sidebar-local content pager refactor. Keep existing persisted shell state format unchanged. If a later stage regresses, it can be reverted independently because selection convergence does not require the pager implementation.
 
 ## Open Questions
 

--- a/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
@@ -1,0 +1,28 @@
+# Manual Verification
+
+Date: 2026-05-15
+
+## Automated Verification
+
+- `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh` passed.
+- `bash clients/apple/scripts/check-brand-identity.sh` passed after the brand scan was run from the repository root so the existing relative exclusions apply.
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `openspec validate refine-macos-sidebar-interactions --strict` passed.
+- `openspec validate --all --strict` passed with `29 passed, 0 failed`.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' build` failed before compilation because the sandbox could not write the default DerivedData folder under `~/Library/Developer/Xcode/DerivedData`.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath target/xcode-derived build` passed. Xcode still printed CoreSimulator availability warnings, but the macOS build completed successfully.
+- `git diff --check` passed.
+
+## Manual Visual Verification Status
+
+- Pinned sidebar collapse/expand: not performed in this run.
+- Floating sidebar reveal/hide: not performed in this run.
+- Tab click persistence: not performed in this run.
+- Space click persistence: not performed in this run.
+- Sidebar-local space swipe pager motion: not performed in this run.
+
+The remaining human acceptance work is to launch the built app and visually verify those five interactions in the macOS shell. In particular, confirm that sidebar-local swipe motion moves only the active-space header and tab list while the command launcher, bottom space dock, sidebar chrome, traffic lights, and terminal workspace remain fixed.
+
+## Archive Readiness
+
+Before archiving, sync the active delta into the long-lived specs with the new sidebar-local swipe semantics. The archived contract should describe `ShellSidebarSwipeMonitor` as the sidebar input adapter, `ShellSidebarSpaceContentPagerState` as the local pager state, `ShellSidebarView` as the owner of pager rendering, and `MacShellRootView` as a stable sidebar/workspace layout without full-window space paging.

--- a/openspec/changes/refine-macos-sidebar-interactions/proposal.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-The macOS sidebar currently feels unreliable and physically inconsistent: tab and space selection can flash back to the previously focused terminal, pinned-sidebar collapse is not a coordinated motion, and horizontal space swipes are modeled as a sidebar-only preview instead of a continuous space sequence.
+The macOS sidebar currently feels unreliable and physically inconsistent: tab and space selection can flash back to the previously focused terminal, pinned-sidebar collapse is not a coordinated motion, and horizontal space swipes need a continuous sidebar-local content pager instead of discontinuous source/target preview behavior.
 
 This change formalizes a focused interaction pass so sidebar navigation, window chrome, and space switching share one authoritative focus and motion contract.
 
@@ -9,7 +9,7 @@ This change formalizes a focused interaction pass so sidebar navigation, window 
 - Make sidebar tab and space selection authoritative focus transitions: selecting a tab or space updates the shell focused pane through the same shell-state path used by terminal activation.
 - Replace pinned-sidebar insertion/removal with a continuous collapse and expand motion so the sidebar, terminal content inset, titlebar controls, and macOS traffic-light controls move together.
 - Refine collapsed/floating sidebar chrome timing so traffic lights do not jump, appear ahead of the panel, or linger on the bare window corner.
-- Replace the sidebar-only space swipe preview with a continuous pager model over the ordered space sequence, including edge preview, commit/cancel animation, and terminal focus handoff.
+- Replace discontinuous sidebar space swipe behavior with a continuous, sidebar-local content pager over the ordered `ShellSpace` sequence, including edge preview, commit/cancel animation, and terminal focus handoff only after commit.
 - Add focused tests and shell contract checks for selection persistence, sidebar/chrome animation invariants, and pager gesture behavior.
 
 ## Capabilities
@@ -21,8 +21,8 @@ This change formalizes a focused interaction pass so sidebar navigation, window 
 ### Modified Capabilities
 
 - `macos-shell-ui-ux-conformance`: clarify continuous sidebar chrome motion, pinned-sidebar collapse/expand behavior, and coordinated traffic-light/titlebar control movement.
-- `macos-shell-workspace-interactions`: replace sidebar-only space swipe preview semantics with authoritative focus selection and continuous space pager switching.
-- `macos-shell-build-test-contract`: require focused verification for selection/focus stability, space pager gestures, and coordinated sidebar/window-chrome behavior.
+- `macos-shell-workspace-interactions`: refine sidebar space swipe semantics with authoritative focus selection and a continuous sidebar-local content pager.
+- `macos-shell-build-test-contract`: require focused verification for selection/focus stability, sidebar-local space pager gestures, and coordinated sidebar/window-chrome behavior.
 
 ## Impact
 

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Sidebar interaction refinement has focused verification
 The Apple client SHALL include focused automated checks or documented manual
-verification for sidebar selection/focus convergence, continuous space pager
+verification for sidebar selection/focus convergence, sidebar-local space pager
 behavior, and coordinated sidebar/window-chrome motion when those interactions
 are changed.
 
@@ -11,9 +11,11 @@ are changed.
 - **THEN** focused tests verify that selecting a tab or space updates shell focused pane, selected tab, selected space, and terminal runtime focus consistently
 - **AND** tests or contract checks cover the case where runtime metadata arrives immediately after selection without reverting to the previous tab
 
-#### Scenario: Space pager gesture tested
+#### Scenario: Sidebar-local space pager gesture tested
 - **WHEN** horizontal space swipe behavior changes
 - **THEN** focused tests cover undecided-axis buffering, horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
+- **AND** verification confirms only the sidebar active-space header and tab list move during the gesture
+- **AND** verification confirms the command input, bottom space switcher, sidebar chrome, traffic lights, and workspace terminal surface remain fixed during the gesture
 
 #### Scenario: Pinned sidebar motion reviewed
 - **WHEN** pinned sidebar collapse or expansion behavior changes

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -33,7 +33,7 @@ a sidebar-local, finger-tracked space content pager. The moving page SHALL
 include only the sidebar's active-space header and active-space tab list. The
 command input, bottom space switcher, sidebar material surface, sidebar chrome,
 macOS traffic-light placement, and workspace terminal surface SHALL remain
-visually fixed while the gesture is active. Alan SHALL avoid mutating durable
+visually fixed while the gesture is active. alan SHALL avoid mutating durable
 shell selection until the gesture commits.
 
 #### Scenario: Gesture-tracked sidebar content pager

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -41,11 +41,14 @@ shell selection until the gesture commits.
 - **THEN** the current sidebar space header and tab list move with the gesture while the adjacent space content previews from the side
 - **AND** the space header and tab list use the same full sidebar content page width for horizontal offsets
 - **AND** movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+- **AND** the space header pager is not narrowed by row padding or trailing creation controls
+- **AND** the sidebar pager avoids static left or right padding gaps while pages move
 - **AND** the command input remains fixed
 - **AND** the bottom space switcher remains fixed as the stable space navigation control
 - **AND** the workspace terminal surface remains visually stable on the original selected space
 - **AND** visible terminal panes keep their runtime identities instead of being restarted, duplicated, or horizontally offset as a side effect of the drag
 - **AND** vertical tab-list scrolling does not move while horizontal intent is locked
+- **AND** later vertical finger movement during the same horizontal swipe does not move the tab list vertically
 
 #### Scenario: Undecided axis buffers mixed deltas
 - **WHEN** a sidebar scroll gesture has not yet crossed the horizontal or vertical intent threshold
@@ -62,11 +65,13 @@ shell selection until the gesture commits.
 - **THEN** alan commits the target space through the shell controller selection and focus path
 - **AND** the sidebar content pager settles smoothly to the committed space without being reverted by concurrent runtime updates
 - **AND** the workspace terminal surface and terminal focus follow the committed space after shell selection commits
+- **AND** release is honored even when the macOS ended or momentum-start event carries zero scroll delta
 
 #### Scenario: Cancel preserves focus and layout
 - **WHEN** the user releases a space swipe before the commit threshold
 - **THEN** alan animates the sidebar content pager back to the original space
 - **AND** selected space, selected tab, terminal focus, split tree, and divider ratios remain unchanged
+- **AND** release is honored even when the macOS ended or momentum-start event carries zero scroll delta
 
 #### Scenario: Phaseful gesture waits for real release
 - **WHEN** a user pauses a phaseful horizontal trackpad swipe while their fingers remain on the trackpad

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -1,10 +1,3 @@
-## REMOVED Requirements
-
-### Requirement: Sidebar swipe previews spaces without moving the workspace
-**Reason**: Sidebar-only previews make spaces feel like a local list animation rather than a continuous workspace sequence, and delaying shell selection until after settlement leaves room for runtime focus updates to snap the UI back to the previous tab or space.
-
-**Migration**: Use the new continuous space pager and authoritative sidebar selection requirements in this change.
-
 ## ADDED Requirements
 
 ### Requirement: Sidebar selection commits authoritative shell focus
@@ -32,21 +25,26 @@ runtime focus converge.
 - **WHEN** terminal runtime metadata or control-plane state publication occurs immediately after sidebar selection
 - **THEN** the committed sidebar selection remains on the selected tab and space because the shell focused pane already matches the selection
 
-### Requirement: Space switching uses a continuous pager
-Horizontal space switching SHALL model spaces as an ordered, continuous sequence
-with a current page index, adjacent page preview, drag offset, and commit/cancel
-settlement, so swiping behaves like a native carousel or virtual desktop. The
-space page SHALL include the sidebar navigation content and the terminal
-workspace surface for each visible source or adjacent target space while
-preserving terminal runtime identity.
+## MODIFIED Requirements
 
-#### Scenario: Gesture-tracked pager preview
+### Requirement: Sidebar swipe previews spaces without moving the workspace
+Horizontal swipe gestures that originate inside the macOS sidebar SHALL drive
+a sidebar-local, finger-tracked space content pager. The moving page SHALL
+include only the sidebar's active-space header and active-space tab list. The
+command input, bottom space switcher, sidebar material surface, sidebar chrome,
+macOS traffic-light placement, and workspace terminal surface SHALL remain
+visually fixed while the gesture is active. Alan SHALL avoid mutating durable
+shell selection until the gesture commits.
+
+#### Scenario: Gesture-tracked sidebar content pager
 - **WHEN** a user horizontally swipes inside the sidebar and an adjacent space exists
-- **THEN** alan renders the current and adjacent space pages from the same horizontal drag offset
-- **AND** the user can see the edge of the adjacent space while dragging toward it
-- **AND** the sidebar active-space header, sidebar tab list, and terminal workspace surface move as parts of the same space page
-- **AND** visible terminal panes keep their runtime identities instead of being restarted or recreated as a side effect of the drag
+- **THEN** the current sidebar space header and tab list move with the gesture while the adjacent space content previews from the side
+- **AND** the space header and tab list use the same full sidebar content page width for horizontal offsets
 - **AND** movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+- **AND** the command input remains fixed
+- **AND** the bottom space switcher remains fixed as the stable space navigation control
+- **AND** the workspace terminal surface remains visually stable on the original selected space
+- **AND** visible terminal panes keep their runtime identities instead of being restarted, duplicated, or horizontally offset as a side effect of the drag
 - **AND** vertical tab-list scrolling does not move while horizontal intent is locked
 
 #### Scenario: Undecided axis buffers mixed deltas
@@ -54,25 +52,25 @@ preserving terminal runtime identity.
 - **THEN** alan buffers the initial mixed deltas instead of applying partial vertical tab-list scrolling or horizontal pager movement
 - **AND** the gesture is routed only after horizontal or vertical intent is locked
 
-#### Scenario: Pager reaches sequence edge
+#### Scenario: Content pager reaches sequence edge
 - **WHEN** a user swipes past the first or last available space
-- **THEN** alan applies bounded edge resistance rather than wrapping unexpectedly or showing a nonexistent space page
-- **AND** releasing before a valid target is selected returns the pager to the current space
+- **THEN** alan applies bounded edge resistance to the moving sidebar content rather than wrapping unexpectedly or showing a nonexistent space page
+- **AND** releasing before a valid target is selected returns the content pager to the current space
 
 #### Scenario: Commit updates focus at the authoritative transition point
 - **WHEN** the user releases a space swipe past the commit threshold or with sufficient release velocity toward an adjacent space
 - **THEN** alan commits the target space through the shell controller selection and focus path
-- **AND** the visual pager settles smoothly to the committed space without being reverted by concurrent runtime updates
-- **AND** terminal focus follows the selected pane when the pane runtime is available
+- **AND** the sidebar content pager settles smoothly to the committed space without being reverted by concurrent runtime updates
+- **AND** the workspace terminal surface and terminal focus follow the committed space after shell selection commits
 
 #### Scenario: Cancel preserves focus and layout
 - **WHEN** the user releases a space swipe before the commit threshold
-- **THEN** alan animates the pager back to the original space
+- **THEN** alan animates the sidebar content pager back to the original space
 - **AND** selected space, selected tab, terminal focus, split tree, and divider ratios remain unchanged
 
 #### Scenario: Phaseful gesture waits for real release
 - **WHEN** a user pauses a phaseful horizontal trackpad swipe while their fingers remain on the trackpad
-- **THEN** alan keeps the pager at the current drag offset
+- **THEN** alan keeps the sidebar content pager at the current drag offset
 - **AND** alan does not commit or cancel until the gesture ends, is cancelled, or enters momentum
 
 #### Scenario: Release uses last effective velocity
@@ -87,10 +85,10 @@ preserving terminal runtime identity.
 
 #### Scenario: Phase-less gesture settles
 - **WHEN** a horizontal sidebar swipe comes from a scroll device that does not provide gesture phases
-- **THEN** alan may treat a short idle gap as release to avoid leaving the pager stuck
+- **THEN** alan may treat a short idle gap as release to avoid leaving the content pager stuck
 - **AND** shell selection follows the same commit threshold as other sidebar swipes
 
 #### Scenario: Vertical scroll is not captured
 - **WHEN** a user's gesture is primarily vertical in the sidebar tab list
 - **THEN** the native vertical tab-list scroll receives the gesture and the workspace space transition does not begin
-- **AND** horizontal pager movement is not applied while vertical intent is locked
+- **AND** horizontal sidebar content pager movement is not applied while vertical intent is locked

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -14,12 +14,12 @@
 - [x] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
 - [x] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
 
-## 3. Continuous Space Pager
+## 3. Sidebar-local Space Content Pager
 
-- [x] 3.1 Replace the sidebar-only `ShellSpaceTransition` model with a pager state that tracks source index, target index, drag offset, page width, commit/cancel state, and settlement phase.
+- [x] 3.1 Replace the root-level `ShellSpacePagerState` usage with a sidebar-local pager state that tracks source index, target index, drag offset, sidebar content page width, commit/cancel state, and settlement phase.
 - [x] 3.2 Preserve gesture axis arbitration in `ShellSidebarSwipeMonitor`, including undecided buffering, vertical scroll pass-through, phaseful release, phase-less idle release, momentum handoff, and fast flick velocity.
-- [x] 3.3 Render current and adjacent space pages from the same pager offset so users can see the target space edge while dragging.
-- [x] 3.4 Include sidebar header, sidebar tab list, and terminal workspace surface in the pager page motion while preserving terminal runtime identities.
+- [x] 3.3 Render current and adjacent sidebar active-space content pages from the same pager offset so users can see the target space edge while dragging, without moving command input, the bottom space switcher, sidebar chrome, or the terminal workspace surface.
+- [x] 3.4 Keep command input, the bottom space switcher, sidebar chrome, traffic lights, and the terminal workspace surface visually fixed during sidebar-local pager motion while preserving terminal runtime identities.
 - [x] 3.5 Apply bounded edge resistance at the first and last spaces and prevent accidental wraparound.
 - [x] 3.6 Commit the target space through the authoritative selection/focus path at the transition point so concurrent runtime updates cannot snap the UI back during settlement.
 - [x] 3.7 Cancel below-threshold gestures back to the source page without changing selected space, selected tab, focused pane, split tree, or divider ratios.
@@ -28,7 +28,7 @@
 
 - [x] 4.1 Extend focused shell tests for sidebar selection/focus convergence and runtime-update race coverage.
 - [x] 4.2 Extend sidebar swipe monitor or pager tests for horizontal, vertical, undecided, edge, cancel, commit, phaseful, phase-less, and fast-flick cases.
-- [x] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or sidebar-only space swipe semantics.
+- [x] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or full-window space pager semantics.
 - [x] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
 

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -31,10 +31,11 @@
 - [x] 4.3 Update shell contract checks so default shell code cannot reintroduce view-local-only sidebar selection or full-window space pager semantics.
 - [x] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
+  - 2026-05-15: macOS Debug build passed with project-local DerivedData and manual verification notes were added in `manual-verification.md`. Live visual interaction was not performed in this run, so this remains unchecked for human acceptance.
 
 ## 5. OpenSpec And Review Readiness
 
 - [x] 5.1 Keep `proposal.md`, `design.md`, `tasks.md`, and all delta specs aligned if implementation discoveries change the contract.
 - [x] 5.2 Run `openspec validate refine-macos-sidebar-interactions --strict` after spec edits and after implementation.
 - [x] 5.3 Run `openspec validate --all --strict` before opening or updating a PR.
-- [ ] 5.4 Prepare archive readiness notes after implementation so the delta specs can be synced into `openspec/specs/` before archiving.
+- [x] 5.4 Prepare archive readiness notes after implementation so the delta specs can be synced into `openspec/specs/` before archiving.


### PR DESCRIPTION
## Summary
- 修正 refine-macos-sidebar-interactions，把 space swipe 明确为 sidebar-local content pager，而不是 full-window pager。
- 将 pager state 提取到 ShellSidebarSpaceContentPagerState，由 ShellSidebarView 本地拥有手势与 preview；MacShellRootView 恢复为稳定 sidebar/workspace layout。
- 更新 shell contract、brand scan、manual/archive readiness notes，防止 root full-window pager 回归。

## Test Plan
- clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/check-brand-identity.sh
- openspec validate refine-macos-sidebar-interactions --strict
- openspec validate --all --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build

## Notes
- Live manual visual verification was not performed in this run; remaining checks are documented in openspec/changes/refine-macos-sidebar-interactions/manual-verification.md.