### PR TITLE
Fix collapsed sidebar hover at resize edge

### DIFF
--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -14,6 +14,7 @@ struct MacShellRootView: View {
     @State private var pinnedSidebarPresentationProgress: CGFloat
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
     @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
+    @State private var isCollapsedSidebarPointerRetained = false
     private let sidebarWidth: CGFloat = 264
     private let floatingSidebarInset: CGFloat = 6
     private let floatingSidebarTrafficLightRevealDelay: TimeInterval = 0.08
@@ -118,6 +119,10 @@ struct MacShellRootView: View {
         return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
     }
 
+    private var isCollapsedSidebarPointerRetentionActive: Bool {
+        isSidebarCollapsed && isPinnedSidebarFullyCollapsed && isSidebarPanelRevealed
+    }
+
     private func revealCollapsedSidebarPanel() {
         guard isSidebarCollapsed, isPinnedSidebarFullyCollapsed else { return }
         sidebarRevealToken += 1
@@ -138,6 +143,7 @@ struct MacShellRootView: View {
         let token = sidebarRevealToken
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
             guard sidebarRevealToken == token, isSidebarCollapsed else { return }
+            guard !isCollapsedSidebarPointerRetained else { return }
             areFloatingSidebarTrafficLightsVisible = false
             floatingSidebarTrafficLightRevealToken += 1
             withAnimation(sidebarPanelHideAnimation) {
@@ -172,6 +178,15 @@ struct MacShellRootView: View {
     private func handleCollapsedSidebarToolbarHover(_ hovering: Bool) {
         guard isSidebarCollapsed, isPinnedSidebarFullyCollapsed else { return }
         handleCollapsedSidebarHover(hovering)
+    }
+
+    private func handleCollapsedSidebarPointerRetention(_ retained: Bool) {
+        guard isCollapsedSidebarPointerRetentionActive else { return }
+        if retained {
+            sidebarRevealToken += 1
+        } else {
+            scheduleCollapsedSidebarHide()
+        }
     }
 
     private var sidebarPanelRevealAnimation: Animation? {
@@ -273,12 +288,17 @@ struct MacShellRootView: View {
         .onChange(of: host.commandInputRequestID) { _, _ in
             toggleCommandInput()
         }
+        .onChange(of: isCollapsedSidebarPointerRetained) { _, retained in
+            handleCollapsedSidebarPointerRetention(retained)
+        }
         .background(
             ShellWindowPlacementView(
                 metrics: $windowChromeMetrics,
                 appearanceMode: appearanceMode,
                 chromeSurface: windowChromeSurface,
-                systemColorScheme: $systemColorScheme
+                systemColorScheme: $systemColorScheme,
+                collapsedSidebarPointerRetentionEnabled: isCollapsedSidebarPointerRetentionActive,
+                collapsedSidebarPointerRetained: $isCollapsedSidebarPointerRetained
             )
         )
     }

--- a/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
+++ b/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
@@ -4,29 +4,57 @@ import SwiftUI
 import AppKit
 
 struct ShellWindowPlacementView: NSViewRepresentable {
-    @Binding var metrics: ShellWindowChromeMetrics
+    @Binding private var metrics: ShellWindowChromeMetrics
     let appearanceMode: ShellAppearanceMode
     var chromeSurface: ShellWindowChromeSurface = .visible
-    @Binding var systemColorScheme: ColorScheme
+    @Binding private var systemColorScheme: ColorScheme
+    var collapsedSidebarPointerRetentionEnabled = false
+    @Binding private var collapsedSidebarPointerRetained: Bool
+
+    init(
+        metrics: Binding<ShellWindowChromeMetrics>,
+        appearanceMode: ShellAppearanceMode,
+        chromeSurface: ShellWindowChromeSurface = .visible,
+        systemColorScheme: Binding<ColorScheme>,
+        collapsedSidebarPointerRetentionEnabled: Bool = false,
+        collapsedSidebarPointerRetained: Binding<Bool> = .constant(false)
+    ) {
+        _metrics = metrics
+        self.appearanceMode = appearanceMode
+        self.chromeSurface = chromeSurface
+        _systemColorScheme = systemColorScheme
+        self.collapsedSidebarPointerRetentionEnabled = collapsedSidebarPointerRetentionEnabled
+        _collapsedSidebarPointerRetained = collapsedSidebarPointerRetained
+    }
 
     func makeNSView(context: Context) -> ShellWindowPlacementNSView {
         let metricsBinding = _metrics
         let systemColorSchemeBinding = _systemColorScheme
+        let pointerRetentionBinding = _collapsedSidebarPointerRetained
         return ShellWindowPlacementNSView(
             appearanceMode: appearanceMode,
             chromeSurface: chromeSurface,
             metricsHandler: metricsHandler(metricsBinding),
-            systemAppearanceHandler: systemAppearanceHandler(systemColorSchemeBinding)
+            systemAppearanceHandler: systemAppearanceHandler(systemColorSchemeBinding),
+            collapsedSidebarPointerRetentionEnabled: collapsedSidebarPointerRetentionEnabled,
+            collapsedSidebarPointerRetentionHandler: pointerRetentionHandler(pointerRetentionBinding)
         )
     }
 
     func updateNSView(_ nsView: ShellWindowPlacementNSView, context: Context) {
         let metricsBinding = _metrics
         let systemColorSchemeBinding = _systemColorScheme
+        let pointerRetentionBinding = _collapsedSidebarPointerRetained
         nsView.updateAppearanceMode(appearanceMode)
         nsView.updateMetricsHandler(metricsHandler(metricsBinding))
         nsView.updateSystemAppearanceHandler(systemAppearanceHandler(systemColorSchemeBinding))
+        nsView.updateCollapsedSidebarPointerRetentionHandler(
+            pointerRetentionHandler(pointerRetentionBinding)
+        )
         nsView.updateChromeSurface(chromeSurface)
+        nsView.updateCollapsedSidebarPointerRetention(
+            enabled: collapsedSidebarPointerRetentionEnabled
+        )
         nsView.resolveWindowIfNeeded()
     }
 
@@ -48,6 +76,17 @@ struct ShellWindowPlacementView: NSViewRepresentable {
             DispatchQueue.main.async {
                 guard systemColorSchemeBinding.wrappedValue != colorScheme else { return }
                 systemColorSchemeBinding.wrappedValue = colorScheme
+            }
+        }
+    }
+
+    private func pointerRetentionHandler(
+        _ pointerRetentionBinding: Binding<Bool>
+    ) -> (Bool) -> Void {
+        { retained in
+            DispatchQueue.main.async {
+                guard pointerRetentionBinding.wrappedValue != retained else { return }
+                pointerRetentionBinding.wrappedValue = retained
             }
         }
     }
@@ -92,6 +131,63 @@ struct ShellWindowChromeMetrics: Equatable {
 
     var collapsedRevealHeaderHeight: CGFloat {
         commandLauncherTopInset + ShellSidebarMetrics.commandLauncherHeight + 8
+    }
+}
+
+enum ShellCollapsedSidebarPointerRetention {
+    static let leftResizeFrameWidth: CGFloat = 16
+
+    static func contains(
+        locationInWindow point: CGPoint,
+        windowSize: CGSize,
+        chromeSurface: ShellWindowChromeSurface
+    ) -> Bool {
+        contains(
+            locationInWindow: point,
+            windowSize: windowSize,
+            chromeSurface: chromeSurface,
+            edgeWidth: ShellSidebarMetrics.collapsedRevealEdgeWidth,
+            leftResizeFrameWidth: leftResizeFrameWidth
+        )
+    }
+
+    static func contains(
+        locationInWindow point: CGPoint,
+        windowSize: CGSize,
+        chromeSurface: ShellWindowChromeSurface,
+        edgeWidth: CGFloat,
+        leftResizeFrameWidth: CGFloat
+    ) -> Bool {
+        guard windowSize.width > 0, windowSize.height > 0 else { return false }
+
+        let verticalBounds = ClosedRange(
+            uncheckedBounds: (
+                lower: -leftResizeFrameWidth,
+                upper: windowSize.height + leftResizeFrameWidth
+            )
+        )
+        guard verticalBounds.contains(point.y) else { return false }
+
+        if point.x >= -leftResizeFrameWidth
+            && point.x <= max(edgeWidth, leftResizeFrameWidth) {
+            return true
+        }
+
+        guard chromeSurface.isVisible, let surfaceWidth = chromeSurface.width else {
+            return false
+        }
+
+        let surfaceMinX = chromeSurface.origin.x
+        let surfaceMaxX = surfaceMinX + surfaceWidth
+        if point.x >= surfaceMinX && point.x <= surfaceMaxX {
+            return true
+        }
+
+        return ShellWindowDoubleClickZoomHitTesting.isPointInSidebarChromeControls(
+            point,
+            windowSize: windowSize,
+            chromeSurface: chromeSurface
+        )
     }
 }
 
@@ -286,17 +382,25 @@ final class ShellWindowPlacementNSView: NSView {
     private var isSynchronizingChrome = false
     private var liveResizeChromeSyncTimer: Timer?
     private var nativeFullScreenOverride: Bool?
+    private var collapsedSidebarPointerRetentionEnabled = false
+    private var collapsedSidebarPointerRetained = false
+    private var collapsedSidebarPointerRetentionHandler: (Bool) -> Void
+    private var pointerRetentionEventMonitor: Any?
 
     init(
         appearanceMode: ShellAppearanceMode,
         chromeSurface: ShellWindowChromeSurface = .visible,
         metricsHandler: @escaping (ShellWindowChromeMetrics) -> Void,
-        systemAppearanceHandler: @escaping (ColorScheme) -> Void = { _ in }
+        systemAppearanceHandler: @escaping (ColorScheme) -> Void = { _ in },
+        collapsedSidebarPointerRetentionEnabled: Bool = false,
+        collapsedSidebarPointerRetentionHandler: @escaping (Bool) -> Void = { _ in }
     ) {
         self.appearanceMode = appearanceMode
         self.chromeSurface = chromeSurface
         self.metricsHandler = metricsHandler
         self.systemAppearanceHandler = systemAppearanceHandler
+        self.collapsedSidebarPointerRetentionEnabled = collapsedSidebarPointerRetentionEnabled
+        self.collapsedSidebarPointerRetentionHandler = collapsedSidebarPointerRetentionHandler
         super.init(frame: .zero)
     }
 
@@ -307,6 +411,7 @@ final class ShellWindowPlacementNSView: NSView {
 
     deinit {
         stopLiveResizeChromeSync()
+        removePointerRetentionEventMonitor()
         removeWindowObservers()
         removeTitlebarObservers()
     }
@@ -352,8 +457,30 @@ final class ShellWindowPlacementNSView: NSView {
     func updateChromeSurface(_ surface: ShellWindowChromeSurface) {
         let didChange = chromeSurface != surface
         chromeSurface = surface
+        updateCollapsedSidebarPointerRetentionState()
         guard didChange else { return }
         synchronizeChromeIfAttached()
+    }
+
+    func updateCollapsedSidebarPointerRetentionHandler(_ handler: @escaping (Bool) -> Void) {
+        collapsedSidebarPointerRetentionHandler = handler
+        collapsedSidebarPointerRetentionHandler(collapsedSidebarPointerRetained)
+    }
+
+    func updateCollapsedSidebarPointerRetention(enabled: Bool) {
+        let didChange = collapsedSidebarPointerRetentionEnabled != enabled
+        collapsedSidebarPointerRetentionEnabled = enabled
+
+        if enabled {
+            installPointerRetentionEventMonitorIfNeeded()
+            updateCollapsedSidebarPointerRetentionState()
+        } else {
+            removePointerRetentionEventMonitor()
+            publishCollapsedSidebarPointerRetained(false)
+        }
+
+        guard didChange else { return }
+        updateCollapsedSidebarPointerRetentionState()
     }
 
     func resolveWindowIfNeeded() {
@@ -384,6 +511,10 @@ final class ShellWindowPlacementNSView: NSView {
 
         removeWindowObservers()
         observedWindow = window
+        if collapsedSidebarPointerRetentionEnabled {
+            installPointerRetentionEventMonitorIfNeeded()
+            updateCollapsedSidebarPointerRetentionState()
+        }
 
         let center = NotificationCenter.default
         windowObservers = [
@@ -455,6 +586,7 @@ final class ShellWindowPlacementNSView: NSView {
 
     private func removeWindowObservers() {
         stopLiveResizeChromeSync()
+        removePointerRetentionEventMonitor()
         windowObservers.forEach(NotificationCenter.default.removeObserver)
         windowObservers.removeAll()
         observedWindow = nil
@@ -554,6 +686,62 @@ final class ShellWindowPlacementNSView: NSView {
         synchronizeChrome(for: window)
     }
 
+    private func installPointerRetentionEventMonitorIfNeeded() {
+        guard pointerRetentionEventMonitor == nil else { return }
+        let mask: NSEvent.EventTypeMask = [
+            .mouseMoved,
+            .leftMouseDragged,
+            .rightMouseDragged,
+            .otherMouseDragged,
+        ]
+        pointerRetentionEventMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) {
+            [weak self] event in
+            self?.handlePointerRetentionEvent(event)
+            return event
+        }
+    }
+
+    private func removePointerRetentionEventMonitor() {
+        guard let pointerRetentionEventMonitor else { return }
+        NSEvent.removeMonitor(pointerRetentionEventMonitor)
+        self.pointerRetentionEventMonitor = nil
+    }
+
+    private func handlePointerRetentionEvent(_ event: NSEvent) {
+        guard collapsedSidebarPointerRetentionEnabled else { return }
+        guard let window else {
+            publishCollapsedSidebarPointerRetained(false)
+            return
+        }
+
+        if let eventWindow = event.window, eventWindow !== window {
+            publishCollapsedSidebarPointerRetained(false)
+            return
+        }
+
+        updateCollapsedSidebarPointerRetentionState()
+    }
+
+    private func updateCollapsedSidebarPointerRetentionState() {
+        guard collapsedSidebarPointerRetentionEnabled, let window else {
+            publishCollapsedSidebarPointerRetained(false)
+            return
+        }
+
+        let retained = ShellCollapsedSidebarPointerRetention.contains(
+            locationInWindow: window.mouseLocationOutsideOfEventStream,
+            windowSize: window.frame.size,
+            chromeSurface: chromeSurface
+        )
+        publishCollapsedSidebarPointerRetained(retained)
+    }
+
+    private func publishCollapsedSidebarPointerRetained(_ retained: Bool) {
+        guard collapsedSidebarPointerRetained != retained else { return }
+        collapsedSidebarPointerRetained = retained
+        collapsedSidebarPointerRetentionHandler(retained)
+    }
+
     private func synchronizeChrome(for window: NSWindow) {
         guard !isSynchronizingChrome else { return }
         isSynchronizingChrome = true
@@ -570,6 +758,7 @@ final class ShellWindowPlacementNSView: NSView {
         )
         installDoubleClickZoomOverlayIfNeeded(in: titlebarView)
         publishEffectiveSystemColorScheme()
+        updateCollapsedSidebarPointerRetentionState()
         guard lastPublishedMetrics != metrics else { return }
         lastPublishedMetrics = metrics
         metricsHandler(metrics)

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -22,6 +22,7 @@ private enum ShellWindowPlacementTests {
         try verifiesPinnedSidebarMotionMovesTrafficLightsWithSurfaceOrigin()
         try verifiesPendingFloatingSidebarRevealHidesTrafficLightsButReservesLayout()
         try verifiesFloatingSidebarRevealAfterPendingHiddenStateUsesSurfaceOrigin()
+        try verifiesCollapsedSidebarRetentionIncludesLeftResizeFrame()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
         try verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom()
         try verifiesTrafficLightControlsDoNotTriggerDoubleClickZoom()
@@ -285,6 +286,40 @@ private enum ShellWindowPlacementTests {
                 ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y
             ),
             "floating sidebar traffic lights must not flash at the non-floating y position after pending reveal; actual \(actualFrame.minY), expected \(ShellSidebarMetrics.trafficLightTopInset + surfaceOrigin.y)"
+        )
+    }
+
+    private static func verifiesCollapsedSidebarRetentionIncludesLeftResizeFrame() throws {
+        let windowSize = CGSize(width: 1512, height: 889)
+        let chromeSurface = ShellWindowChromeSurface(
+            isVisible: true,
+            origin: CGPoint(x: 6, y: 6),
+            width: 264
+        )
+
+        expect(
+            ShellCollapsedSidebarPointerRetention.contains(
+                locationInWindow: CGPoint(x: -3, y: 420),
+                windowSize: windowSize,
+                chromeSurface: chromeSurface
+            ),
+            "collapsed sidebar retention must include the adjacent left resize frame"
+        )
+        expect(
+            ShellCollapsedSidebarPointerRetention.contains(
+                locationInWindow: CGPoint(x: 12, y: 420),
+                windowSize: windowSize,
+                chromeSurface: chromeSurface
+            ),
+            "collapsed sidebar retention must include the narrow edge reveal neighborhood"
+        )
+        expect(
+            !ShellCollapsedSidebarPointerRetention.contains(
+                locationInWindow: CGPoint(x: 420, y: 420),
+                windowSize: windowSize,
+                chromeSurface: chromeSurface
+            ),
+            "collapsed sidebar retention must end outside the related sidebar and resize regions"
         )
     }
 

--- a/openspec/changes/refine-macos-sidebar-interactions/design.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/design.md
@@ -4,6 +4,7 @@ The current macOS shell sidebar has three related interaction problems:
 
 - Sidebar tab and space clicks update `selectedSpaceID` / `selectedTabID` without updating the authoritative `shellState.focusedPaneID`. Later runtime metadata or state publication calls `synchronizeSelection()` and restores selection from the old focused pane.
 - Pinned-sidebar collapse is expressed as conditional SwiftUI insertion/removal, while titlebar controls and AppKit traffic-light placement are synchronized through a separate bridge. This produces uncoordinated motion and can make collapse appear instantaneous.
+- Collapsed floating-sidebar reveal is retained by SwiftUI view-local hover on the narrow reveal zone, the floating panel, and titlebar controls. After double-click visible-frame zoom, the left AppKit resize frame can take pointer ownership before the SwiftUI hover surfaces see the pointer as still inside the reveal neighborhood, so the sidebar schedules a hide even though the user is still intentionally working the left edge.
 - Horizontal space swipe is represented as a discontinuous sidebar-local source/target transition. It previews the sidebar header and tab list only, commits after settle, and does not model the ordered space sequence as a continuous sidebar-local content pager.
 
 The implementation must preserve alan's terminal-first layout, native material sidebar, hidden-titlebar window behavior, and terminal event ownership boundaries.
@@ -14,6 +15,7 @@ The implementation must preserve alan's terminal-first layout, native material s
 
 - Make sidebar tab and space selection persist by routing selection through authoritative shell focus.
 - Give pinned sidebar collapse and expansion one coordinated motion model across sidebar width, terminal content inset, sidebar toolbar controls, and standard macOS traffic lights.
+- Keep collapsed floating-sidebar reveal stable across AppKit window-frame hit testing, including the left resize cursor region after visible-frame zoom.
 - Replace discontinuous sidebar space swipe behavior with a continuous,
   sidebar-local content pager over the ordered `ShellSpace` sequence.
 - Keep collapsed floating sidebar reveal transient: it must not resize terminal content, and it must retain the narrow edge/titlebar-control hover behavior.
@@ -46,7 +48,28 @@ The implementation must preserve alan's terminal-first layout, native material s
 
    Alternative considered: draw custom traffic-light replicas in SwiftUI. That would break native macOS traffic-light behavior and conflicts with the existing hidden-titlebar contract.
 
-4. **Space swipe is a sidebar-local content pager.**
+4. **Collapsed reveal retention is a window-level pointer judgment.**
+
+   The collapsed floating sidebar should still use a narrow edge trigger, but
+   once revealed the retention decision should be made against a window-level
+   set of related regions: the edge trigger neighborhood, the floating sidebar
+   surface, collapsed titlebar controls, and the adjacent left window resize
+   frame. The retention path should observe pointer location in window/screen
+   coordinates rather than relying only on SwiftUI `onHover(false)` from
+   individual transparent views.
+
+   This keeps the Arc-like behavior when a visible-frame-zoomed window is flush
+   with the screen's left usable boundary. Moving the pointer through the
+   resize-cursor strip should not count as leaving the sidebar reveal intent.
+   Native resize must remain owned by AppKit; the sidebar logic should only
+   decide whether to cancel a pending hide, not steal mouse-down/drag behavior
+   from the resize frame.
+
+   Alternative considered: widen the SwiftUI edge hot zone. That may mask the
+   failure on some displays, but it still loses to AppKit frame hit-testing and
+   makes the collapsed trigger less intentional.
+
+5. **Space swipe is a sidebar-local content pager.**
 
    The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`,
    `pageWidth`, and settlement phase for the sidebar's active-space content
@@ -62,7 +85,7 @@ The implementation must preserve alan's terminal-first layout, native material s
    terminal workspace slides, duplicates, and exposes artifacts during a
    sidebar navigation gesture.
 
-5. **Commit focus is applied at the authoritative transition point.**
+6. **Commit focus is applied at the authoritative transition point.**
 
    When a pager commit is selected, shell focus should update through the controller selection path before or at the start of the settle-to-target phase, while sidebar content pager state keeps rendering the old and new sidebar pages until animation completion. This prevents runtime metadata updates from snapping the UI back during the settle animation.
 
@@ -71,6 +94,7 @@ The implementation must preserve alan's terminal-first layout, native material s
 ## Risks / Trade-offs
 
 - **Risk: traffic-light animation fights AppKit layout corrections.** → Keep the AppKit bridge as the only owner of standard button frames, coalesce chrome syncs, and ensure final frames are corrected without visible jumps.
+- **Risk: window-level pointer retention blocks native resizing.** → Keep AppKit as the owner of resize hit-testing and only use pointer location to keep or cancel the sidebar hide timer; do not install a mouse-down-consuming overlay on the resize frame.
 - **Risk: immediate focus commit changes terminal runtime focus while the old sidebar page is still visible during settle.** → Keep a short sidebar content pager state that decouples rendering from the already-committed focus for the duration of settlement.
 - **Risk: sidebar-local pager accidentally moves fixed shell regions.** → Keep command input, the bottom space switcher, sidebar chrome, traffic lights, and the terminal workspace outside the moving page.
 - **Risk: gesture axis arbitration regresses vertical sidebar scrolling.** → Preserve the existing intent lock behavior and add tests for undecided, vertical, phaseful, phase-less, momentum, and fast flick paths.

--- a/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
@@ -4,6 +4,7 @@ Date: 2026-05-15
 
 ## Automated Verification
 
+- `clients/apple/scripts/test-shell-window-placement.sh` passed with focused coverage for collapsed-sidebar pointer retention across the adjacent left resize frame.
 - `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh` passed.
 - `bash clients/apple/scripts/check-brand-identity.sh` passed after the brand scan was run from the repository root so the existing relative exclusions apply.
 - `bash clients/apple/scripts/check-shell-contracts.sh` passed.
@@ -20,6 +21,7 @@ Date: 2026-05-15
 - Tab click persistence: not performed in this run.
 - Space click persistence: not performed in this run.
 - Sidebar-local space swipe pager motion: not performed in this run.
+- Visible-frame-zoomed collapsed-sidebar left-edge retention: covered by focused AppKit geometry tests; live visual verification not performed in this run.
 
 The remaining human acceptance work is to launch the built app and visually verify those five interactions in the macOS shell. In particular, confirm that sidebar-local swipe motion moves only the active-space header and tab list while the command launcher, bottom space dock, sidebar chrome, traffic lights, and terminal workspace remain fixed.
 

--- a/openspec/changes/refine-macos-sidebar-interactions/proposal.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/proposal.md
@@ -9,6 +9,7 @@ This change formalizes a focused interaction pass so sidebar navigation, window 
 - Make sidebar tab and space selection authoritative focus transitions: selecting a tab or space updates the shell focused pane through the same shell-state path used by terminal activation.
 - Replace pinned-sidebar insertion/removal with a continuous collapse and expand motion so the sidebar, terminal content inset, titlebar controls, and macOS traffic-light controls move together.
 - Refine collapsed/floating sidebar chrome timing so traffic lights do not jump, appear ahead of the panel, or linger on the bare window corner.
+- Promote collapsed-sidebar reveal retention from view-local SwiftUI hover to a window-level pointer judgment so a revealed floating sidebar does not hide when the pointer crosses the left resize frame after visible-frame zoom.
 - Replace discontinuous sidebar space swipe behavior with a continuous, sidebar-local content pager over the ordered `ShellSpace` sequence, including edge preview, commit/cancel animation, and terminal focus handoff only after commit.
 - Add focused tests and shell contract checks for selection persistence, sidebar/chrome animation invariants, and pager gesture behavior.
 
@@ -22,7 +23,7 @@ This change formalizes a focused interaction pass so sidebar navigation, window 
 
 - `macos-shell-ui-ux-conformance`: clarify continuous sidebar chrome motion, pinned-sidebar collapse/expand behavior, and coordinated traffic-light/titlebar control movement.
 - `macos-shell-workspace-interactions`: refine sidebar space swipe semantics with authoritative focus selection and a continuous sidebar-local content pager.
-- `macos-shell-build-test-contract`: require focused verification for selection/focus stability, sidebar-local space pager gestures, and coordinated sidebar/window-chrome behavior.
+- `macos-shell-build-test-contract`: require focused verification for selection/focus stability, sidebar-local space pager gestures, window-level collapsed-sidebar reveal retention, and coordinated sidebar/window-chrome behavior.
 
 ## Impact
 

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -23,4 +23,6 @@ are changed.
 
 #### Scenario: Floating sidebar chrome reviewed
 - **WHEN** collapsed floating-sidebar reveal or hide behavior changes
-- **THEN** focused checks or manual notes verify narrow edge hover, hover retention, stable terminal workspace geometry, native traffic-light behavior, and no visible traffic-light jump from the non-floating corner
+- **THEN** focused checks or manual notes verify narrow edge hover, window-level hover retention, stable terminal workspace geometry, native traffic-light behavior, and no visible traffic-light jump from the non-floating corner
+- **AND** verification covers a visible-frame-zoomed window where the pointer moves through the left window resize frame without causing the revealed floating sidebar to auto-hide
+- **AND** verification confirms that native window resizing still works from the left resize frame

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
@@ -13,6 +13,17 @@ hover, while keeping the terminal workspace stable.
 - **WHEN** the pointer moves from the edge hot zone onto the floating sidebar panel or collapsed titlebar controls
 - **THEN** the floating panel remains revealed until the pointer leaves those related surfaces
 
+#### Scenario: Window-edge hover retention
+- **WHEN** the sidebar is collapsed, the floating panel is revealed, and the pointer crosses from the edge hot zone or floating panel into the left window resize frame
+- **THEN** alan treats that pointer position as part of the collapsed-sidebar reveal neighborhood and keeps the floating panel revealed
+- **AND** alan does not schedule a hide merely because AppKit has switched the cursor or hit-test state to a window-resize affordance
+- **AND** native window resizing remains available if the user presses and drags in the resize frame
+
+#### Scenario: Visible-frame zoom edge retention
+- **WHEN** the shell window has been double-click zoomed to the current screen's visible work area and its left edge is flush with the usable screen boundary
+- **AND** the sidebar is collapsed and revealed from the left edge
+- **THEN** moving the pointer along the left edge or through the resize-cursor strip does not cause the floating sidebar to auto-hide while the pointer remains in the window-level reveal neighborhood
+
 #### Scenario: Floating panel owns traffic lights
 - **WHEN** the sidebar is collapsed and the floating panel is hidden
 - **THEN** the standard macOS traffic-light controls are hidden with the sidebar surface instead of remaining on the bare window corner

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -13,6 +13,7 @@
 - [x] 2.3 Extend the window chrome bridge so standard macOS traffic-light controls move with the sidebar/titlebar-control motion and settle to corrected final AppKit frames.
 - [x] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
 - [x] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
+- [x] 2.6 Promote collapsed floating-sidebar hide retention to a window-level pointer-region check that includes the left resize frame while preserving native AppKit resize hit-testing.
 
 ## 3. Sidebar-local Space Content Pager
 
@@ -32,6 +33,7 @@
 - [x] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
   - 2026-05-15: macOS Debug build passed with project-local DerivedData and manual verification notes were added in `manual-verification.md`. Live visual interaction was not performed in this run, so this remains unchecked for human acceptance.
+- [x] 4.6 Verify the visible-frame-zoomed collapsed-sidebar case manually or with focused AppKit coverage: reveal the sidebar, move the pointer into the left resize cursor region, confirm the panel remains visible, and confirm native resizing still works.
 
 ## 5. OpenSpec And Review Readiness
 


### PR DESCRIPTION
Summary: Retains the collapsed macOS sidebar while the pointer crosses the left resize frame after visible-frame zoom; updates OpenSpec and shell placement tests. Tests: clients/apple/scripts/test-shell-window-placement.sh; openspec validate refine-macos-sidebar-interactions --strict.