### PR TITLE
Add OpenSpec for Rust inline TUI

### DIFF
--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/.openspec.yaml
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
@@ -1,0 +1,185 @@
+## Context
+
+alan currently has a Rust CLI/daemon binary and a separate TypeScript/Bun/Ink
+terminal UI under `clients/tui`. The CLI exposes multiple overlapping
+interactive entrypoints (`alan`, `alan chat`, and `alan ask`) and release
+packaging embeds a standalone `alan-tui` executable.
+
+Codex's terminal UX demonstrates a stronger model for alan's target workflow: a
+Rust terminal application with explicit terminal-mode ownership, typed transcript
+cells, inline viewport rendering, real terminal scrollback integration, a bottom
+composer, event-loop coalescing, and terminal behavior tests. alan should borrow
+that interaction architecture while staying inside alan's existing daemon/session
+boundary.
+
+The user-facing target is intentionally breaking: the old TUI, old command
+surface, and fallback paths are removed rather than preserved.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship one command-line executable: `alan`.
+- Launch the terminal UI from bare `alan`.
+- Implement the TUI in Rust and organize it as a crate that is linked into the
+  existing `alan` binary.
+- Delete the TypeScript/Bun/Ink TUI and all production fallback paths to it.
+- Remove `alan chat` and `alan ask`.
+- Match Codex's first-order terminal interaction patterns closely enough that
+  the first Rust version feels like the same class of tool.
+- Keep runtime execution, persistence, tool policy, and session management
+  behind the alan daemon/session APIs for V1.
+- Replace TypeScript-TUI-specific daemon helper requirements with a Rust-friendly
+  shared contract.
+
+**Non-Goals:**
+
+- Do not embed the runtime directly into the TUI process in V1.
+- Do not preserve a compatibility wrapper for `alan-tui`, `alan chat`, or
+  `alan ask`.
+- Do not attempt to copy Codex-specific product features unrelated to alan's
+  daemon/session protocol.
+- Do not keep the existing Ink UI design, key model, rendering model, or command
+  structure as a migration target.
+
+## Decisions
+
+### Decision: Rust TUI crate, single shipped binary
+
+The new TUI will live in a Rust workspace crate such as `crates/tui`, but that
+crate will expose a library entrypoint consumed by `crates/alan`. The release
+artifact remains the single `alan` binary.
+
+Alternatives considered:
+
+- Keep a separate `alan-tui` Rust binary. Rejected because the desired
+  distribution and mental model is one command, and a second binary preserves the
+  packaging split we are trying to remove.
+- Keep the TypeScript TUI as fallback. Rejected because it keeps the old UI,
+  old runtime constraints, and fallback complexity alive.
+
+### Decision: Bare `alan` is the TUI entrypoint
+
+The CLI parser will treat no subcommand as "launch the TUI". Existing management
+subcommands remain explicit subcommands. `alan chat` and `alan ask` are removed.
+
+Alternatives considered:
+
+- Keep `alan chat` as a compatibility alias. Rejected because the command surface
+  should be reset now instead of carrying ambiguous entrypoints.
+- Recreate `alan ask` as a one-shot mode. Rejected for V1; scripted/noninteractive
+  use can be reintroduced later with a clearer contract if needed.
+
+### Decision: Daemon-backed TUI for V1
+
+The Rust TUI will talk to the daemon through alan's session APIs:
+
+```text
+alan
+  explicit subcommand -> existing CLI command
+  no subcommand       -> alan_tui::run()
+                         -> daemon client
+                         -> session create/read/events/submit/resume/interrupt
+```
+
+The TUI owns presentation and terminal interaction. The daemon owns runtime
+startup, workspace resolution, connection profiles, governance, event
+persistence, and session lifecycle.
+
+Alternatives considered:
+
+- Embed `alan-runtime` directly in the TUI. Rejected for V1 because it would
+  duplicate daemon orchestration and change more runtime boundaries than needed
+  for the UI reset.
+- Keep a direct HTTP-only polling TUI. Rejected because the terminal UI needs
+  streaming events and reconnection behavior that should use the existing
+  event/WebSocket surfaces.
+
+### Decision: Copy Codex interaction architecture, not Codex internals wholesale
+
+alan should mirror the Codex TUI architecture at the interaction level:
+
+- crossterm/ratatui terminal backend;
+- explicit raw-mode, alternate-screen, paste, and stdin ownership;
+- an internal `AppEvent` bus;
+- a main event loop selecting over terminal input, daemon events, app events, and
+  background completions;
+- typed history cells for assistant text, thinking, tool calls, plans, warnings,
+  errors, and pending yields;
+- inline viewport plus terminal scrollback insertion;
+- bottom composer with multiline editing, slash commands, and pending input
+  modes;
+- terminal snapshots and vt100-style behavior tests.
+
+alan should not import large Codex modules verbatim as an architectural rule.
+Codex has very large UI files; alan should keep module boundaries smaller while
+preserving the same UX primitives.
+
+### Decision: Language-neutral daemon client contract
+
+The current daemon API spec names generated TypeScript helpers because the
+deleted TUI was TypeScript. The new contract should require shared endpoint and
+payload drift protection for shipped daemon clients without making TypeScript the
+authoritative TUI surface.
+
+The Rust TUI can satisfy this through Rust endpoint builders, schema snapshots,
+contract tests, or generated Rust helpers. The important invariant is that the
+Rust TUI does not hand-write canonical `/api/v1/...` paths or silently drift from
+daemon payloads.
+
+### Decision: Packaging removes `alan-tui`
+
+Release app assembly, signing, validation, direct app installs, and future cask
+metadata must embed/link only `alan`. The active `package-alan-app-distribution`
+change currently describes embedded CLI/TUI binaries; implementation of this
+change must update or supersede those requirements before archiving either
+change.
+
+## Risks / Trade-offs
+
+- [Risk] Removing `alan chat` and `alan ask` breaks existing scripts or habits.
+  -> Mitigation: treat this as an intentional breaking change and update docs,
+  shell integration, and tests in the same implementation.
+- [Risk] A Codex-like TUI can grow into large hard-to-maintain files.
+  -> Mitigation: define module ownership up front: terminal, app loop, daemon
+  client, session reducer, history cells, bottom pane, and tests.
+- [Risk] Replacing the TUI and command surface in one change is broad.
+  -> Mitigation: keep runtime semantics daemon-backed and avoid changing session
+  APIs except where Rust-client contract helpers require it.
+- [Risk] Terminal behavior regressions are hard to catch with unit tests alone.
+  -> Mitigation: add vt100/snapshot-style terminal tests for scrollback, resize,
+  streaming deltas, composer behavior, and pending yield surfaces.
+- [Risk] Active OpenSpec changes can conflict over `alan-tui` packaging.
+  -> Mitigation: update `package-alan-app-distribution` during implementation so
+  its app distribution contract is single-binary before it is archived.
+
+## Migration Plan
+
+1. Add the Rust TUI crate as a library and wire no-subcommand `alan` to it behind
+   a minimal compiling shell.
+2. Add the daemon client boundary and session reducer before building detailed UI
+   components.
+3. Implement terminal infrastructure, history cells, bottom composer, and pending
+   input surfaces with focused terminal tests.
+4. Remove the TypeScript TUI, Bun build paths, `ALAN_TUI_PATH`, `alan-tui`
+   packaging, and `alan chat`/`alan ask`.
+5. Update macOS shell launch paths, app release scripts, install validation, and
+   documentation to the single-binary contract.
+6. Update the active `package-alan-app-distribution` OpenSpec artifacts to remove
+   `alan-tui` assumptions before archiving.
+
+Rollback is intentionally source-level only: before release, revert this change
+or restore the deleted TypeScript TUI from version control. After release, there
+is no runtime fallback to `alan-tui`.
+
+## Open Questions
+
+- Which exact Rust helper shape should daemon endpoint construction use:
+  hand-maintained Rust builders from the existing registry, generated Rust code,
+  or schema snapshot tests around the registry?
+- Should the first Rust TUI include a minimal connection/profile picker, or is it
+  enough to surface daemon connection errors and rely on `alan connection`
+  subcommands for setup?
+- Which Codex interactions are required in the first implementation versus later
+  parity work: transcript search, image/file attachments, command palette depth,
+  resume picker, or advanced session list management?

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
@@ -100,7 +100,7 @@ Alternatives considered:
 alan should mirror the Codex TUI architecture at the interaction level:
 
 - crossterm/ratatui terminal backend;
-- explicit raw-mode, alternate-screen, paste, and stdin ownership;
+- explicit raw-mode, paste, and stdin ownership for the primary scrollback mode;
 - an internal `AppEvent` bus;
 - a main event loop selecting over terminal input, daemon events, app events, and
   background completions;
@@ -130,10 +130,10 @@ daemon payloads.
 ### Decision: Packaging removes `alan-tui`
 
 Release app assembly, signing, validation, direct app installs, and future cask
-metadata must embed/link only `alan`. The active `package-alan-app-distribution`
-change currently describes embedded CLI/TUI binaries; implementation of this
-change must update or supersede those requirements before archiving either
-change.
+metadata must embed/link only `alan`. If another active app-distribution
+OpenSpec change or release-script implementation still describes embedded
+CLI/TUI binaries, implementation of this change must update or supersede those
+requirements before archiving.
 
 ## Risks / Trade-offs
 
@@ -149,9 +149,11 @@ change.
 - [Risk] Terminal behavior regressions are hard to catch with unit tests alone.
   -> Mitigation: add vt100/snapshot-style terminal tests for scrollback, resize,
   streaming deltas, composer behavior, and pending yield surfaces.
-- [Risk] Active OpenSpec changes can conflict over `alan-tui` packaging.
-  -> Mitigation: update `package-alan-app-distribution` during implementation so
-  its app distribution contract is single-binary before it is archived.
+- [Risk] Active or future app-distribution work can conflict over `alan-tui`
+  packaging.
+  -> Mitigation: audit release OpenSpec artifacts, release scripts, and install
+  docs during implementation so the app distribution contract is single-binary
+  before related changes are archived.
 
 ## Migration Plan
 
@@ -165,8 +167,8 @@ change.
    packaging, and `alan chat`/`alan ask`.
 5. Update macOS shell launch paths, app release scripts, install validation, and
    documentation to the single-binary contract.
-6. Update the active `package-alan-app-distribution` OpenSpec artifacts to remove
-   `alan-tui` assumptions before archiving.
+6. Update any active app-distribution OpenSpec artifacts, release scripts, and
+   install docs to remove `alan-tui` assumptions before archiving.
 
 Rollback is intentionally source-level only: before release, revert this change
 or restore the deleted TypeScript TUI from version control. After release, there

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/design.md
@@ -78,6 +78,8 @@ The Rust TUI will talk to the daemon through alan's session APIs:
 alan
   explicit subcommand -> existing CLI command
   no subcommand       -> alan_tui::run()
+                         -> resolve daemon URL / local lifecycle
+                         -> health check or auto-start
                          -> daemon client
                          -> session create/read/events/submit/resume/interrupt
 ```
@@ -85,6 +87,14 @@ alan
 The TUI owns presentation and terminal interaction. The daemon owns runtime
 startup, workspace resolution, connection profiles, governance, event
 persistence, and session lifecycle.
+
+Bare `alan` must preserve the existing interactive startup behavior before it
+uses session APIs. For a default or local daemon URL, the TUI first checks
+`/health`, starts the local daemon when it is not already reachable, waits for
+readiness, and then creates or attaches to a session. For an explicit remote
+daemon URL such as `ALAN_AGENTD_URL`, the TUI treats that daemon as externally
+managed: it performs health/connect checks against the configured remote and
+does not spawn or stop a local daemon.
 
 Alternatives considered:
 
@@ -159,8 +169,9 @@ requirements before archiving.
 
 1. Add the Rust TUI crate as a library and wire no-subcommand `alan` to it behind
    a minimal compiling shell.
-2. Add the daemon client boundary and session reducer before building detailed UI
-   components.
+2. Add daemon URL resolution, local daemon health/auto-start, remote override
+   handling, the daemon client boundary, and the session reducer before building
+   detailed UI components.
 3. Implement terminal infrastructure, history cells, bottom composer, and pending
    input surfaces with focused terminal tests.
 4. Remove the TypeScript TUI, Bun build paths, `ALAN_TUI_PATH`, `alan-tui`

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
@@ -32,6 +32,9 @@ only shipped `alan` binary.
 - Keep the TUI daemon-backed for V1: the UI owns terminal interaction and
   presentation, while sessions, tools, runtime execution, and persistence stay
   behind the existing alan daemon/session APIs.
+- Preserve bare-`alan` startup ergonomics: local daemon health check,
+  auto-start/readiness wait when needed, existing daemon reuse, and explicit
+  remote daemon override behavior before any session API call.
 - Update release packaging, app install, Homebrew cask expectations, and Apple
   shell launch paths so the only embedded and linked command-line executable is
   `alan`.

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
@@ -35,10 +35,10 @@ only shipped `alan` binary.
 - Update release packaging, app install, Homebrew cask expectations, and Apple
   shell launch paths so the only embedded and linked command-line executable is
   `alan`.
-- Fold the active `package-alan-app-distribution` TUI-binary assumptions into
-  this change during implementation: any requirement that embeds, signs,
-  validates, links, or installs `alan-tui` is superseded by the single-binary
-  contract here.
+- Fold any active or future app-distribution OpenSpec artifacts and release
+  scripts into the single-binary contract during implementation: any requirement
+  that embeds, signs, validates, links, or installs `alan-tui` is superseded by
+  this change.
 
 ## Capabilities
 
@@ -87,4 +87,4 @@ only shipped `alan` binary.
   - `README.md`
   - `AGENTS.md`
   - `clients/apple/README.md`
-  - related OpenSpec changes, especially `package-alan-app-distribution`
+  - related OpenSpec changes or release docs that still describe `alan-tui`

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+alan's interactive terminal experience is currently split across the Rust `alan`
+binary and a separate Bun/TypeScript/Ink TUI executable. That split now creates
+both product and distribution problems:
+
+- the primary terminal experience lags far behind Codex's Rust TUI interaction
+  model;
+- macOS packaging, signing, and local install paths must carry a second
+  `alan-tui` executable with its own runtime constraints;
+- `alan chat`, `alan ask`, bare `alan`, and `ALAN_TUI_PATH` create multiple
+  overlapping entrypoints for what should be one product surface;
+- the existing TypeScript TUI UI and interaction model are not a foundation we
+  want to evolve.
+
+alan should make the Rust terminal UI the primary default experience inside the
+only shipped `alan` binary.
+
+## What Changes
+
+- Add a Rust TUI as a workspace crate consumed by the existing `alan` binary.
+  The crate may be independently organized and tested, but it MUST NOT ship a
+  separate `alan-tui` binary.
+- Change bare `alan` with no subcommand to launch the Rust TUI.
+- **BREAKING**: remove `alan chat` and `alan ask` as public commands.
+- **BREAKING**: delete the Bun/TypeScript/Ink TUI and remove all production
+  fallback paths to it, including `ALAN_TUI_PATH`.
+- Base the first Rust TUI version on Codex's terminal interaction model:
+  crossterm/ratatui rendering, inline viewport, terminal scrollback transcript,
+  bottom composer, typed history cells, pending approval/input surfaces,
+  resize reflow, and terminal-focused snapshot/vt100 verification.
+- Keep the TUI daemon-backed for V1: the UI owns terminal interaction and
+  presentation, while sessions, tools, runtime execution, and persistence stay
+  behind the existing alan daemon/session APIs.
+- Update release packaging, app install, Homebrew cask expectations, and Apple
+  shell launch paths so the only embedded and linked command-line executable is
+  `alan`.
+- Fold the active `package-alan-app-distribution` TUI-binary assumptions into
+  this change during implementation: any requirement that embeds, signs,
+  validates, links, or installs `alan-tui` is superseded by the single-binary
+  contract here.
+
+## Capabilities
+
+### New Capabilities
+
+- `rust-inline-tui`: defines the Rust terminal UI as the default bare-`alan`
+  experience, embedded in the only shipped `alan` binary, with a Codex-like
+  terminal interaction baseline and daemon-backed session contract.
+
+### Modified Capabilities
+
+- `daemon-api-contract`: replace TypeScript-TUI-specific generated helper and
+  drift-check requirements with language-neutral/Rust-client requirements that
+  support the new Rust TUI without making TypeScript the authoritative TUI
+  protocol surface.
+- `macos-shell-build-test-contract`: require build, packaging, install, and
+  Apple shell checks to enforce the single `alan` binary contract and prevent
+  reintroducing the TypeScript TUI, `alan-tui`, or legacy command entrypoints.
+
+## Impact
+
+- New Rust TUI crate and tests:
+  - `crates/tui/**`
+  - `Cargo.toml`
+  - Rust terminal snapshot/vt100-style test fixtures
+- CLI entrypoint changes:
+  - `crates/alan/src/main.rs`
+  - `crates/alan/src/cli/mod.rs`
+  - removal of `crates/alan/src/cli/chat.rs`
+  - removal of `crates/alan/src/cli/ask.rs`
+- TypeScript TUI deletion:
+  - `clients/tui/**`
+  - Bun/Ink-specific scripts, generated client files, package metadata, and
+    tests used only by the deleted TUI
+- Packaging and install changes:
+  - `justfile`
+  - `scripts/install.sh`
+  - `scripts/assemble-release-app.sh`
+  - `scripts/validate-release-app.sh`
+  - release signing/notarization helpers
+  - Homebrew cask metadata or future cask contract text
+- Apple shell integration:
+  - shell launch commands and contract checks that currently expect `alan chat`
+    or `alan-tui`
+- Documentation:
+  - `README.md`
+  - `AGENTS.md`
+  - `clients/apple/README.md`
+  - related OpenSpec changes, especially `package-alan-app-distribution`

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/daemon-api-contract/spec.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/daemon-api-contract/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Generated Client Endpoint Helpers
+The repository SHALL generate, expose, or verify client endpoint helpers from
+the daemon endpoint contract for shipped daemon clients. The Rust TUI daemon
+client SHALL use the shared Rust endpoint contract or generated Rust helpers for
+API path construction instead of embedding raw canonical daemon route strings.
+TypeScript helper generation MAY remain only for non-deleted TypeScript clients;
+it MUST NOT be the authoritative TUI protocol surface.
+
+#### Scenario: generated endpoint helper is current
+- **WHEN** the daemon endpoint contract changes
+- **THEN** generated endpoint helpers or contract snapshots for shipped daemon
+  clients change deterministically or a drift check fails
+
+#### Scenario: Rust TUI client avoids raw daemon route construction
+- **WHEN** the Rust TUI daemon client calls a supported API endpoint
+- **THEN** it constructs the path through the Rust endpoint contract/helper
+  surface rather than embedding a raw `/api/v1/...` string
+
+#### Scenario: TypeScript TUI helper is removed
+- **WHEN** the TypeScript TUI is deleted
+- **THEN** no production TUI build, test, or runtime path requires generated
+  TypeScript endpoint helpers
+- **AND** any remaining TypeScript helper checks are scoped to actual remaining
+  TypeScript clients
+
+### Requirement: Protocol And Payload Drift Checks
+The repository SHALL keep protocol event types and selected daemon API payloads
+schema-checked or generated for shipped daemon clients, including the Rust TUI.
+The drift surface SHALL be based on alan's Rust protocol and daemon API
+contracts, not on static hand-written TypeScript files for the removed TUI.
+
+#### Scenario: protocol event list drifts
+- **WHEN** the Rust protocol event enum adds, removes, or renames a serialized
+  event type used by shipped daemon clients
+- **THEN** the generated, schema-checked, or snapshot-checked client protocol
+  surface detects the difference
+
+#### Scenario: selected daemon payload drifts
+- **WHEN** a selected daemon API response shape used by the Rust TUI changes in
+  Rust
+- **THEN** the Rust TUI client contract checks or generated payload surface
+  detects the difference
+
+#### Scenario: removed TypeScript protocol files are not authoritative
+- **WHEN** `clients/tui` and its static generated TypeScript protocol files are
+  removed
+- **THEN** daemon API verification still covers shipped clients through Rust
+  contract helpers, schema checks, or generated Rust surfaces
+
+## ADDED Requirements
+
+### Requirement: Rust TUI client preserves session API compatibility
+The daemon API contract SHALL support the Rust TUI as a first-party daemon
+client without changing existing public session, event, connection, skill,
+relay, WebSocket, and health route paths unless a separate breaking route change
+explicitly updates migration notes.
+
+#### Scenario: TUI migration keeps route paths stable
+- **WHEN** the TypeScript TUI is replaced by the Rust TUI
+- **THEN** existing public daemon route paths used for session lifecycle,
+  event streaming, submissions, reconnect snapshots, history reads, connection
+  queries, and skill catalog reads continue to resolve
+
+#### Scenario: Rust TUI submits protocol operations
+- **WHEN** the Rust TUI sends turns, follow-up input, resume data, interrupts,
+  rollback requests, or compaction requests
+- **THEN** the daemon accepts the same protocol operation shapes exposed by the
+  existing public session submit APIs

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Single alan binary distribution is verified
+The Apple client and release packaging checks SHALL verify that terminal
+distribution uses one command-line executable, `alan`, and SHALL reject
+reintroducing `alan-tui` as an embedded, signed, linked, installed, or launched
+binary.
+
+#### Scenario: Release app layout is checked
+- **WHEN** release packaging implementation is ready for review
+- **THEN** focused checks verify `alan.app` contains the app executable and the
+  embedded command-line `alan` executable required by the distribution contract
+- **AND** focused checks fail if `alan.app` contains an embedded
+  `Contents/Resources/bin/alan-tui` executable
+
+#### Scenario: Signatures are checked
+- **WHEN** release signing checks inspect embedded command-line tools
+- **THEN** they verify the embedded `alan` binary is signed according to the
+  release signing contract
+- **AND** they do not require or accept a separately signed `alan-tui` binary as
+  part of the release package
+
+#### Scenario: Command-line links are checked
+- **WHEN** direct app install scripts or future Homebrew cask metadata are
+  inspected
+- **THEN** they link or install only `alan` from the app bundle
+- **AND** they fail if they link, install, or document `alan-tui`
+
+### Requirement: Legacy TypeScript TUI build paths are blocked
+The Apple client build/test contract SHALL include focused validation that
+prevents production packaging, install, and shell launch flows from depending on
+the deleted TypeScript/Bun/Ink TUI.
+
+#### Scenario: Bun TUI build is reintroduced
+- **WHEN** release packaging or local install scripts are inspected
+- **THEN** focused checks fail if they build, bundle, sign, or launch
+  `clients/tui`, Bun, Ink, or a standalone TypeScript TUI artifact
+
+#### Scenario: TUI path override is reintroduced
+- **WHEN** command-line launch or app shell scripts are inspected
+- **THEN** focused checks fail if production code uses `ALAN_TUI_PATH` as a
+  fallback path for the terminal UI
+
+#### Scenario: Legacy TUI dependency remains
+- **WHEN** package metadata and install scripts are inspected after migration
+- **THEN** no required production build or install step depends on the deleted
+  TypeScript TUI package
+
+### Requirement: Apple shell launches bare alan
+The Apple shell SHALL launch the command-line terminal experience through bare
+`alan` and SHALL NOT launch `alan chat`, `alan ask`, or `alan-tui` for the
+default alan terminal tab.
+
+#### Scenario: Default alan tab command is inspected
+- **WHEN** shell contract checks inspect the default alan terminal launch command
+- **THEN** the command resolves to bare `alan`
+- **AND** it does not include `chat`, `ask`, or `alan-tui`
+
+#### Scenario: Legacy commands are reintroduced
+- **WHEN** Apple shell scripts, control paths, or documentation reintroduce
+  `alan chat`, `alan ask`, or `alan-tui` as the default terminal launch path
+- **THEN** focused shell contract checks fail with a message pointing to the
+  single-binary Rust TUI contract

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/rust-inline-tui/spec.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/rust-inline-tui/spec.md
@@ -45,6 +45,33 @@ The Rust TUI SHALL use alan daemon/session APIs for workspace resolution,
 connection profile resolution, session lifecycle, event streaming, submissions,
 resume operations, interrupts, compaction, rollback, and persisted history.
 
+#### Scenario: Local daemon starts before session APIs
+- **WHEN** a user runs bare `alan` with the default local daemon configuration
+  and no healthy daemon is reachable
+- **THEN** the Rust TUI starts the local daemon before creating or attaching to a
+  session
+- **AND** it waits for the daemon health endpoint to report readiness before
+  calling session APIs
+
+#### Scenario: Existing local daemon is reused
+- **WHEN** a user runs bare `alan` and the configured local daemon is already
+  healthy
+- **THEN** the Rust TUI reuses that daemon
+- **AND** it does not stop the daemon on exit unless the TUI started that daemon
+  instance for this run
+
+#### Scenario: Remote daemon override is respected
+- **WHEN** a user runs bare `alan` with an explicit remote daemon URL such as
+  `ALAN_AGENTD_URL`
+- **THEN** the Rust TUI connects to that configured daemon
+- **AND** it does not start, stop, or otherwise manage a local daemon process
+
+#### Scenario: Daemon startup failure is actionable
+- **WHEN** the configured local daemon cannot be started or does not become
+  healthy before the startup timeout
+- **THEN** the Rust TUI reports an actionable startup error before attempting to
+  create or attach to a session
+
 #### Scenario: Session starts through daemon APIs
 - **WHEN** the Rust TUI starts a new conversation for a workspace
 - **THEN** it creates or attaches to a daemon-backed session using the public

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/rust-inline-tui/spec.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/rust-inline-tui/spec.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### Requirement: Bare alan launches the Rust terminal UI
+The `alan` binary SHALL launch the Rust terminal UI when invoked without an
+explicit subcommand, and this terminal UI SHALL be linked into the `alan` binary
+rather than shipped as a separate executable.
+
+#### Scenario: Bare command enters TUI
+- **WHEN** a user runs `alan` in an interactive terminal
+- **THEN** alan starts the Rust terminal UI
+- **AND** no `alan-tui` executable is required on `PATH`
+
+#### Scenario: Explicit subcommands remain available
+- **WHEN** a user runs an explicit supported management subcommand such as
+  `alan connection list` or `alan daemon status`
+- **THEN** alan runs that subcommand instead of starting the TUI
+
+#### Scenario: Noninteractive terminal is rejected truthfully
+- **WHEN** a user runs bare `alan` without an interactive terminal
+- **THEN** alan exits with a clear terminal capability error
+- **AND** it does not attempt to launch a TypeScript or `alan-tui` fallback
+
+### Requirement: Legacy TUI entrypoints are removed
+alan SHALL remove the TypeScript/Bun/Ink TUI, the `alan-tui` shipped executable,
+the `ALAN_TUI_PATH` override, and the public `alan chat` and `alan ask`
+commands.
+
+#### Scenario: Legacy commands are unavailable
+- **WHEN** a user runs `alan chat` or `alan ask`
+- **THEN** alan reports the command as unsupported or unknown
+- **AND** it does not delegate to the old TypeScript TUI
+
+#### Scenario: Legacy TUI fallback is unavailable
+- **WHEN** `ALAN_TUI_PATH` is set in the environment
+- **THEN** bare `alan` ignores it or reports it as unsupported
+- **AND** no production code loads a TypeScript TUI bundle from that path
+
+#### Scenario: Release artifacts omit alan-tui
+- **WHEN** release artifacts are assembled
+- **THEN** they include the `alan` executable for terminal use
+- **AND** they do not include, sign, link, or install an `alan-tui` executable
+
+### Requirement: TUI remains daemon-backed
+The Rust TUI SHALL use alan daemon/session APIs for workspace resolution,
+connection profile resolution, session lifecycle, event streaming, submissions,
+resume operations, interrupts, compaction, rollback, and persisted history.
+
+#### Scenario: Session starts through daemon APIs
+- **WHEN** the Rust TUI starts a new conversation for a workspace
+- **THEN** it creates or attaches to a daemon-backed session using the public
+  session APIs
+- **AND** it renders the resolved profile, provider, model, and durability state
+  from daemon responses when those fields are available
+
+#### Scenario: Event stream resumes after reconnect
+- **WHEN** the TUI reconnects to an existing daemon-backed session
+- **THEN** it reads persisted history or reconnect snapshot state before
+  consuming new events
+- **AND** it detects event gaps using daemon cursor metadata
+
+#### Scenario: User input uses protocol operations
+- **WHEN** the user submits a message, approval response, structured input,
+  interrupt, rollback, or compaction request
+- **THEN** the TUI sends the corresponding alan protocol operation through the
+  daemon session APIs
+
+### Requirement: Codex-like terminal interaction baseline
+The first Rust TUI SHALL provide a Codex-like terminal interaction baseline:
+explicit terminal mode ownership, ratatui-style frame rendering, a bottom
+composer, inline viewport rendering, terminal scrollback transcript insertion,
+typed transcript cells, resize reflow, and frame coalescing.
+
+#### Scenario: Streaming assistant output renders incrementally
+- **WHEN** daemon events stream thinking, text, tool, plan, warning, or error
+  updates
+- **THEN** the TUI updates typed transcript cells without rebuilding the entire
+  transcript as plain strings
+- **AND** it coalesces redraws so high-frequency deltas do not overwhelm the
+  terminal
+
+#### Scenario: Completed content enters terminal scrollback
+- **WHEN** visible transcript content is committed beyond the active viewport
+- **THEN** the TUI inserts committed lines into terminal scrollback
+- **AND** the active inline viewport remains focused on current interaction
+
+#### Scenario: Resize preserves readable state
+- **WHEN** the terminal is resized during a turn or while editing input
+- **THEN** transcript cells, the active viewport, and the bottom composer reflow
+  without corrupting input or losing streamed content
+
+### Requirement: Pending input surfaces are first-class
+The Rust TUI SHALL render runtime yields such as confirmation requests,
+structured user input, and recoverable interruptions as first-class terminal UI
+states rather than raw JSON or debug text.
+
+#### Scenario: Confirmation yield is shown
+- **WHEN** the runtime emits a confirmation yield
+- **THEN** the TUI presents a focused approval surface with the relevant action,
+  choices, and default keyboard behavior
+- **AND** the response is submitted as a protocol resume operation
+
+#### Scenario: Structured input yield is shown
+- **WHEN** the runtime emits a structured input yield
+- **THEN** the TUI presents fields or choices that match the yielded schema
+- **AND** it validates the response before submitting it to the daemon
+
+#### Scenario: Recoverable runtime error is shown
+- **WHEN** the daemon reports a recoverable session or stream error
+- **THEN** the TUI renders a concise user-facing state with available recovery
+  actions
+- **AND** raw diagnostic details remain behind an explicit debug surface
+
+### Requirement: Terminal behavior has focused verification
+The Rust TUI SHALL include focused automated verification for terminal behavior,
+including snapshots or vt100-style tests for transcript rendering, scrollback,
+resize, composer editing, streaming deltas, pending yield surfaces, and
+noninteractive startup failures.
+
+#### Scenario: Terminal snapshots cover core cells
+- **WHEN** typed transcript cell rendering changes
+- **THEN** snapshot tests cover assistant text, thinking, tool calls, plans,
+  warnings, errors, and pending yields
+
+#### Scenario: Scrollback behavior is tested
+- **WHEN** transcript viewport or scrollback insertion behavior changes
+- **THEN** terminal behavior tests verify committed history, active viewport
+  content, and resize reflow
+
+#### Scenario: Legacy fallback cannot pass tests
+- **WHEN** a production fallback path to `clients/tui`, Bun, Ink, or `alan-tui`
+  is reintroduced
+- **THEN** focused TUI or packaging contract checks fail

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
@@ -1,0 +1,120 @@
+## 1. OpenSpec And Contract Alignment
+
+- [ ] 1.1 Update the active `package-alan-app-distribution` change so its
+  proposal, design, specs, and tasks no longer require embedding, signing,
+  linking, installing, or validating `alan-tui`.
+- [ ] 1.2 Confirm long-lived specs affected by this change will archive cleanly:
+  `rust-inline-tui`, `daemon-api-contract`, and
+  `macos-shell-build-test-contract`.
+- [ ] 1.3 Add migration notes in documentation for the intentional removal of
+  `alan chat`, `alan ask`, `alan-tui`, and `ALAN_TUI_PATH`.
+
+## 2. Rust TUI Crate Setup
+
+- [ ] 2.1 Add a Rust workspace crate for the TUI as a library crate linked by
+  the existing `alan` binary, without adding a shipped `alan-tui` binary target.
+- [ ] 2.2 Add TUI dependencies such as crossterm, ratatui, terminal snapshot
+  support, and vt100-style test utilities using versions consistent with the
+  workspace.
+- [ ] 2.3 Add a minimal `alan_tui::run` entrypoint that initializes terminal
+  mode, restores terminal state on exit, and returns structured errors.
+- [ ] 2.4 Add initial TUI unit/snapshot test scaffolding that runs through Cargo.
+
+## 3. CLI Entrypoint Migration
+
+- [ ] 3.1 Change bare `alan` with no subcommand to launch `alan_tui::run` in an
+  interactive terminal.
+- [ ] 3.2 Preserve explicit management subcommands such as daemon, connection,
+  workspace, skills, shell, and init.
+- [ ] 3.3 Remove `alan chat` and `alan ask` from clap definitions, modules,
+  help text, docs, and tests.
+- [ ] 3.4 Remove `ALAN_TUI_PATH` handling and any production code that launches
+  or locates a standalone TUI bundle.
+- [ ] 3.5 Add noninteractive startup behavior that fails clearly without falling
+  back to the deleted TUI.
+
+## 4. Daemon Client Contract
+
+- [ ] 4.1 Add or expose Rust endpoint helpers for session lifecycle, event
+  streaming, reconnect snapshot/history reads, submissions, connection queries,
+  and skill catalog reads.
+- [ ] 4.2 Refactor the Rust TUI daemon client to use endpoint helpers instead of
+  raw canonical `/api/v1/...` route strings.
+- [ ] 4.3 Add contract checks or snapshots that detect drift in protocol event
+  names and selected daemon payloads used by the Rust TUI.
+- [ ] 4.4 Preserve public daemon route paths while replacing the TypeScript TUI
+  client.
+
+## 5. TUI Application Core
+
+- [ ] 5.1 Implement the internal `AppEvent` bus and main event loop selecting
+  over terminal input, daemon events, app events, and background completions.
+- [ ] 5.2 Implement daemon-backed session create/attach, history/reconnect
+  hydration, event streaming, gap detection, and reconnect behavior.
+- [ ] 5.3 Implement protocol submissions for turns, follow-up input, resume
+  data, interrupt, rollback, and compaction.
+- [ ] 5.4 Implement session reducers that translate `EventEnvelope` streams into
+  TUI state without leaking raw daemon JSON into default UI.
+
+## 6. Codex-Like Terminal Interaction
+
+- [ ] 6.1 Implement terminal mode ownership for raw mode, paste handling,
+  keyboard/mouse events, resize events, and terminal restoration on panic or
+  normal exit.
+- [ ] 6.2 Implement typed history cells for assistant text, thinking, tool calls,
+  plans, warnings, errors, compaction/memory events, and pending yields.
+- [ ] 6.3 Implement inline viewport rendering with committed transcript
+  insertion into terminal scrollback.
+- [ ] 6.4 Implement a bottom composer with multiline editing, submit behavior,
+  basic slash-command surface, and stable layout under resize.
+- [ ] 6.5 Implement frame coalescing/rate limiting so streaming deltas redraw
+  smoothly without overwhelming the terminal.
+- [ ] 6.6 Implement pending confirmation, structured input, recoverable error,
+  and interrupt states as first-class TUI surfaces.
+
+## 7. TypeScript TUI Removal
+
+- [ ] 7.1 Delete `clients/tui` and its Bun/Ink package metadata, generated files,
+  tests, and build scripts.
+- [ ] 7.2 Remove `alan-tui` build, bundle, sign, install, and validation steps
+  from `justfile` and release scripts.
+- [ ] 7.3 Remove TypeScript-TUI-only generated helper requirements while keeping
+  daemon contract checks for remaining shipped clients.
+- [ ] 7.4 Remove stale documentation, examples, shell snippets, and environment
+  variable references that point to the deleted TUI.
+
+## 8. macOS Packaging And Shell Integration
+
+- [ ] 8.1 Update release app assembly so `alan.app` embeds only the `alan`
+  command-line executable under the supported Resources/bin layout.
+- [ ] 8.2 Update signing/notarization validation so it verifies the embedded
+  `alan` binary and fails if `alan-tui` is present.
+- [ ] 8.3 Update direct app install and future cask metadata expectations so
+  only `alan` is linked or installed.
+- [ ] 8.4 Update Apple shell launch paths so the default alan terminal tab runs
+  bare `alan` and never `alan chat`, `alan ask`, or `alan-tui`.
+- [ ] 8.5 Update focused shell contract checks to reject legacy TUI launch paths
+  and TypeScript/Bun TUI packaging dependencies.
+
+## 9. Verification
+
+- [ ] 9.1 Run `cargo fmt --all`.
+- [ ] 9.2 Run `cargo test -p alan-tui` or the final TUI crate package name.
+- [ ] 9.3 Run `cargo test -p alan`.
+- [ ] 9.4 Run daemon API contract checks that cover endpoint helpers and payload
+  drift for the Rust TUI.
+- [ ] 9.5 Run Apple shell/package contract checks that cover single-binary
+  packaging and bare-`alan` launch.
+- [ ] 9.6 Run `openspec validate --all --strict`.
+- [ ] 9.7 Run `git diff --check`.
+
+## 10. Review And Archive Readiness
+
+- [ ] 10.1 Review the final diff for accidental fallback paths to the deleted
+  TypeScript TUI.
+- [ ] 10.2 Verify release artifacts and docs present one command-line binary:
+  `alan`.
+- [ ] 10.3 Prepare PR/review notes that call out the intentional breaking
+  changes and validation evidence.
+- [ ] 10.4 After implementation is merged, sync accepted delta specs into
+  `openspec/specs/` and archive this change.

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
@@ -1,8 +1,8 @@
 ## 1. OpenSpec And Contract Alignment
 
-- [ ] 1.1 Update the active `package-alan-app-distribution` change so its
-  proposal, design, specs, and tasks no longer require embedding, signing,
-  linking, installing, or validating `alan-tui`.
+- [ ] 1.1 Audit active app-distribution OpenSpec artifacts, release scripts,
+  install scripts, cask metadata, and docs, then remove or supersede any
+  requirement to embed, sign, link, install, launch, or validate `alan-tui`.
 - [ ] 1.2 Confirm long-lived specs affected by this change will archive cleanly:
   `rust-inline-tui`, `daemon-api-contract`, and
   `macos-shell-build-test-contract`.

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
@@ -35,22 +35,28 @@
 
 ## 4. Daemon Client Contract
 
-- [ ] 4.1 Add or expose Rust endpoint helpers for session lifecycle, event
+- [ ] 4.1 Implement daemon URL resolution for default local configuration,
+  host-configured URLs, and explicit remote overrides such as `ALAN_AGENTD_URL`.
+- [ ] 4.2 Implement local daemon health checks, auto-start, readiness wait,
+  existing-daemon reuse, and startup failure reporting before any session API
+  call.
+- [ ] 4.3 Add or expose Rust endpoint helpers for session lifecycle, event
   streaming, reconnect snapshot/history reads, submissions, connection queries,
   and skill catalog reads.
-- [ ] 4.2 Refactor the Rust TUI daemon client to use endpoint helpers instead of
+- [ ] 4.4 Refactor the Rust TUI daemon client to use endpoint helpers instead of
   raw canonical `/api/v1/...` route strings.
-- [ ] 4.3 Add contract checks or snapshots that detect drift in protocol event
+- [ ] 4.5 Add contract checks or snapshots that detect drift in protocol event
   names and selected daemon payloads used by the Rust TUI.
-- [ ] 4.4 Preserve public daemon route paths while replacing the TypeScript TUI
+- [ ] 4.6 Preserve public daemon route paths while replacing the TypeScript TUI
   client.
 
 ## 5. TUI Application Core
 
 - [ ] 5.1 Implement the internal `AppEvent` bus and main event loop selecting
   over terminal input, daemon events, app events, and background completions.
-- [ ] 5.2 Implement daemon-backed session create/attach, history/reconnect
-  hydration, event streaming, gap detection, and reconnect behavior.
+- [ ] 5.2 Implement daemon-backed session create/attach after daemon readiness,
+  history/reconnect hydration, event streaming, gap detection, and reconnect
+  behavior.
 - [ ] 5.3 Implement protocol submissions for turns, follow-up input, resume
   data, interrupt, rollback, and compaction.
 - [ ] 5.4 Implement session reducers that translate `EventEnvelope` streams into
@@ -101,12 +107,14 @@
 - [ ] 9.1 Run `cargo fmt --all`.
 - [ ] 9.2 Run `cargo test -p alan-tui` or the final TUI crate package name.
 - [ ] 9.3 Run `cargo test -p alan`.
-- [ ] 9.4 Run daemon API contract checks that cover endpoint helpers and payload
+- [ ] 9.4 Run TUI daemon-lifecycle checks covering local auto-start,
+  existing-daemon reuse, remote override behavior, and startup failure reporting.
+- [ ] 9.5 Run daemon API contract checks that cover endpoint helpers and payload
   drift for the Rust TUI.
-- [ ] 9.5 Run Apple shell/package contract checks that cover single-binary
+- [ ] 9.6 Run Apple shell/package contract checks that cover single-binary
   packaging and bare-`alan` launch.
-- [ ] 9.6 Run `openspec validate --all --strict`.
-- [ ] 9.7 Run `git diff --check`.
+- [ ] 9.7 Run `openspec validate --all --strict`.
+- [ ] 9.8 Run `git diff --check`.
 
 ## 10. Review And Archive Readiness
 


### PR DESCRIPTION
## Summary

- Add OpenSpec change `replace-typescript-tui-with-rust-inline-tui`.
- Define the breaking single-binary direction: bare `alan` launches the Rust TUI; no shipped `alan-tui` binary.
- Specify deletion of the TypeScript/Bun/Ink TUI, `alan chat`, `alan ask`, and `ALAN_TUI_PATH` fallback.
- Add design, capability deltas, and implementation tasks for a Codex-like daemon-backed Rust TUI.

## Validation

- `openspec validate replace-typescript-tui-with-rust-inline-tui --strict`
- `openspec validate --all --strict`
- `git diff --check`

## Notes

This PR intentionally contains only the OpenSpec change. Existing local macOS/package worktree changes were left out so the PR boundary stays narrow.
