### PR TITLE
Refine macOS sidebar space swipe

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		00000000000000000000003A /* ShellWorkspaceManifestStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013A /* ShellWorkspaceManifestStore.swift */; };
 		00000000000000000000003B /* ShellSidebarSpaceContentPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */; };
 		00000000000000000000003C /* AlanCommandLineToolInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013C /* AlanCommandLineToolInstaller.swift */; };
+		00000000000000000000003D /* ShellSidebarPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013D /* ShellSidebarPresentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -131,6 +132,7 @@
 		00000000000000000000013A /* ShellWorkspaceManifestStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellWorkspaceManifestStore.swift; sourceTree = "<group>"; };
 		00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceContentPager.swift; sourceTree = "<group>"; };
 		00000000000000000000013C /* AlanCommandLineToolInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/AlanCommandLineToolInstaller.swift; sourceTree = "<group>"; };
+		00000000000000000000013D /* ShellSidebarPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarPresentation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,6 +209,7 @@
 				00000000000000000000013C /* AlanCommandLineToolInstaller.swift */,
 				000000000000000000000136 /* ConsoleAdaptiveColor.swift */,
 				000000000000000000000138 /* ShellSidebarSwipeMonitor.swift */,
+				00000000000000000000013D /* ShellSidebarPresentation.swift */,
 				00000000000000000000013B /* ShellSidebarSpaceContentPager.swift */,
 				000000000000000000000119 /* ShellWindowPlacement.swift */,
 				00000000000000000000011D /* ShellVoiceCommandController.swift */,
@@ -469,6 +472,7 @@
 				000000000000000000000036 /* ConsoleAdaptiveColor.swift in Sources */,
 				000000000000000000000037 /* ShellHostControlCommandHandling.swift in Sources */,
 				000000000000000000000038 /* ShellSidebarSwipeMonitor.swift in Sources */,
+				00000000000000000000003D /* ShellSidebarPresentation.swift in Sources */,
 				00000000000000000000003B /* ShellSidebarSpaceContentPager.swift in Sources */,
 				00000000000000000000003C /* AlanCommandLineToolInstaller.swift in Sources */,
 				000000000000000000000039 /* ShellWorkspaceManifest.swift in Sources */,

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -292,10 +292,15 @@ struct MacShellRootView: View {
             handleCollapsedSidebarPointerRetention(retained)
         }
         .background(
-            ShellWindowPlacementView(
+            ShellWindowPlacementAnimationSyncView(
                 metrics: $windowChromeMetrics,
                 appearanceMode: appearanceMode,
-                chromeSurface: windowChromeSurface,
+                pinnedSidebarPresentationProgress: pinnedSidebarPresentationProgress,
+                isSidebarCollapsed: isSidebarCollapsed,
+                isSidebarPanelRevealed: isSidebarPanelRevealed,
+                areFloatingSidebarTrafficLightsVisible: areFloatingSidebarTrafficLightsVisible,
+                sidebarWidth: sidebarWidth,
+                floatingSidebarInset: floatingSidebarInset,
                 systemColorScheme: $systemColorScheme,
                 collapsedSidebarPointerRetentionEnabled: isCollapsedSidebarPointerRetentionActive,
                 collapsedSidebarPointerRetained: $isCollapsedSidebarPointerRetained
@@ -421,6 +426,75 @@ struct MacShellRootView: View {
         }
         .ignoresSafeArea(edges: .top)
         .zIndex(30)
+    }
+}
+
+private struct ShellWindowPlacementAnimationSyncView: View, Animatable {
+    @Binding var metrics: ShellWindowChromeMetrics
+    let appearanceMode: ShellAppearanceMode
+    var pinnedSidebarPresentationProgress: CGFloat
+    let isSidebarCollapsed: Bool
+    let isSidebarPanelRevealed: Bool
+    let areFloatingSidebarTrafficLightsVisible: Bool
+    let sidebarWidth: CGFloat
+    let floatingSidebarInset: CGFloat
+    @Binding var systemColorScheme: ColorScheme
+    let collapsedSidebarPointerRetentionEnabled: Bool
+    @Binding var collapsedSidebarPointerRetained: Bool
+
+    var animatableData: CGFloat {
+        get { pinnedSidebarPresentationProgress }
+        set { pinnedSidebarPresentationProgress = newValue }
+    }
+
+    var body: some View {
+        ShellWindowPlacementView(
+            metrics: $metrics,
+            appearanceMode: appearanceMode,
+            chromeSurface: windowChromeSurface,
+            systemColorScheme: $systemColorScheme,
+            collapsedSidebarPointerRetentionEnabled: collapsedSidebarPointerRetentionEnabled,
+            collapsedSidebarPointerRetained: $collapsedSidebarPointerRetained
+        )
+    }
+
+    private var windowChromeSurface: ShellWindowChromeSurface {
+        ShellWindowChromeSurface(
+            isVisible: isSidebarSurfaceVisible,
+            origin: sidebarChromeSurfaceOrigin,
+            width: sidebarWidth,
+            showsStandardTrafficLights: shouldShowStandardTrafficLights
+        )
+    }
+
+    private var isSidebarSurfaceVisible: Bool {
+        isPinnedSidebarSurfaceActive || isSidebarPanelRevealed
+    }
+
+    private var isPinnedSidebarSurfaceActive: Bool {
+        !isSidebarCollapsed || clampedPinnedSidebarPresentationProgress > 0.001
+    }
+
+    private var clampedPinnedSidebarPresentationProgress: CGFloat {
+        min(max(pinnedSidebarPresentationProgress, 0), 1)
+    }
+
+    private var sidebarChromeSurfaceOrigin: CGPoint {
+        if isSidebarPanelRevealed {
+            return CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
+        }
+        guard isPinnedSidebarSurfaceActive else {
+            return .zero
+        }
+        return CGPoint(x: -sidebarWidth * (1 - clampedPinnedSidebarPresentationProgress), y: 0)
+    }
+
+    private var shouldShowStandardTrafficLights: Bool {
+        if isPinnedSidebarSurfaceActive {
+            return true
+        }
+        guard isSidebarCollapsed else { return true }
+        return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
     }
 }
 

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -11,13 +11,17 @@ struct MacShellRootView: View {
     @State private var areFloatingSidebarTrafficLightsVisible = false
     @State private var sidebarRevealToken = 0
     @State private var floatingSidebarTrafficLightRevealToken = 0
+    @State private var sidebarPinMorphToken = 0
+    @State private var isSidebarPinMorphActive = false
     @State private var pinnedSidebarPresentationProgress: CGFloat
+    @State private var sidebarPinMorphProgress: CGFloat = 1
     @State private var windowChromeMetrics = ShellWindowChromeMetrics()
     @State private var systemColorScheme = ShellAppearanceMode.currentSystemColorScheme
     @State private var isCollapsedSidebarPointerRetained = false
     private let sidebarWidth: CGFloat = 264
     private let floatingSidebarInset: CGFloat = 6
     private let floatingSidebarTrafficLightRevealDelay: TimeInterval = 0.08
+    private let sidebarPinMorphDuration: TimeInterval = 0.18
     private let hiddenCommandInputOpacity = 0.001
 
     init(
@@ -57,41 +61,58 @@ struct MacShellRootView: View {
     }
 
     private var isSidebarSurfaceVisible: Bool {
-        isPinnedSidebarSurfaceActive || isSidebarPanelRevealed
-    }
-
-    private var isPinnedSidebarSurfaceActive: Bool {
-        !isSidebarCollapsed || pinnedSidebarPresentationProgress > 0.001
+        sidebarPresentation.isSurfaceVisible
     }
 
     private var isPinnedSidebarFullyCollapsed: Bool {
-        pinnedSidebarPresentationProgress <= 0.001
+        pinnedSidebarPresentationProgress <= ShellSidebarPresentationSnapshot.visibilityEpsilon
+            && !isSidebarPinMorphActive
     }
 
     private var sidebarPinnedVisibleWidth: CGFloat {
-        sidebarWidth * clampedPinnedSidebarPresentationProgress
+        sidebarPresentation.layoutWidth
     }
 
-    private var sidebarPinnedChromeOffsetX: CGFloat {
-        -sidebarWidth * (1 - clampedPinnedSidebarPresentationProgress)
+    private var sidebarPinnedContentOffsetX: CGFloat {
+        sidebarPresentation.contentOffsetX
     }
 
     private var sidebarPinnedContentOpacity: Double {
-        Double(clampedPinnedSidebarPresentationProgress)
+        sidebarPresentation.contentOpacity
     }
 
     private var clampedPinnedSidebarPresentationProgress: CGFloat {
-        min(max(pinnedSidebarPresentationProgress, 0), 1)
+        sidebarPresentation.layoutProgress
     }
 
     private var sidebarChromeSurfaceOrigin: CGPoint {
-        if isSidebarPanelRevealed {
-            return CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
-        }
-        guard isPinnedSidebarSurfaceActive else {
-            return .zero
-        }
-        return CGPoint(x: sidebarPinnedChromeOffsetX, y: 0)
+        sidebarPresentation.surfaceOrigin
+    }
+
+    private var sidebarPresentationConfiguration: ShellSidebarPresentationConfiguration {
+        ShellSidebarPresentationConfiguration(
+            sidebarWidth: sidebarWidth,
+            floatingSidebarInset: floatingSidebarInset,
+            floatingCornerRadius: ShellRadii.floatingSidebarPanel
+        )
+    }
+
+    private var sidebarPresentationPhase: ShellSidebarPresentationPhase {
+        ShellSidebarPresentationPhase.resolved(
+            isSidebarCollapsed: isSidebarCollapsed,
+            pinnedProgress: pinnedSidebarPresentationProgress,
+            isFloatingPanelRevealed: isSidebarPanelRevealed,
+            showsFloatingTrafficLights: areFloatingSidebarTrafficLightsVisible,
+            isFloatingToPinnedMorphActive: isSidebarPinMorphActive,
+            floatingToPinnedMorphProgress: sidebarPinMorphProgress
+        )
+    }
+
+    private var sidebarPresentation: ShellSidebarPresentationSnapshot {
+        ShellSidebarPresentationSnapshot(
+            phase: sidebarPresentationPhase,
+            configuration: sidebarPresentationConfiguration
+        )
     }
 
     private var commandInputOpacity: Double {
@@ -102,25 +123,11 @@ struct MacShellRootView: View {
         reduceMotion ? nil : .easeOut(duration: 0.14)
     }
 
-    private var windowChromeSurface: ShellWindowChromeSurface {
-        ShellWindowChromeSurface(
-            isVisible: isSidebarSurfaceVisible,
-            origin: sidebarChromeSurfaceOrigin,
-            width: sidebarWidth,
-            showsStandardTrafficLights: shouldShowStandardTrafficLights
-        )
-    }
-
-    private var shouldShowStandardTrafficLights: Bool {
-        if isPinnedSidebarSurfaceActive {
-            return true
-        }
-        guard isSidebarCollapsed else { return true }
-        return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
-    }
-
     private var isCollapsedSidebarPointerRetentionActive: Bool {
-        isSidebarCollapsed && isPinnedSidebarFullyCollapsed && isSidebarPanelRevealed
+        isSidebarCollapsed
+            && isPinnedSidebarFullyCollapsed
+            && isSidebarPanelRevealed
+            && !isSidebarPinMorphActive
     }
 
     private func revealCollapsedSidebarPanel() {
@@ -203,17 +210,86 @@ struct MacShellRootView: View {
         reduceMotion ? nil : .easeOut(duration: 0.16)
     }
 
+    private var sidebarPinMorphAnimation: Animation? {
+        reduceMotion ? nil : .easeOut(duration: sidebarPinMorphDuration)
+    }
+
     private var resolvedAppearanceColorScheme: ColorScheme {
         appearanceMode.resolvedColorScheme(systemColorScheme: systemColorScheme)
     }
 
     private func updateSidebarCollapsed(_ collapsed: Bool) {
+        if collapsed {
+            collapsePinnedSidebar()
+        } else if shouldMorphFloatingSidebarToPinned {
+            morphFloatingSidebarToPinned()
+        } else {
+            expandPinnedSidebar()
+        }
+    }
+
+    private var shouldMorphFloatingSidebarToPinned: Bool {
+        isSidebarCollapsed && isPinnedSidebarFullyCollapsed && isSidebarPanelRevealed
+    }
+
+    private func collapsePinnedSidebar() {
+        sidebarPinMorphToken += 1
+        isSidebarPinMorphActive = false
+        sidebarPinMorphProgress = 1
         withAnimation(sidebarPinnedStateAnimation) {
-            isSidebarCollapsed = collapsed
-            pinnedSidebarPresentationProgress = collapsed ? 0 : 1
+            isSidebarCollapsed = true
+            pinnedSidebarPresentationProgress = 0
             isSidebarPanelRevealed = false
             areFloatingSidebarTrafficLightsVisible = false
             floatingSidebarTrafficLightRevealToken += 1
+        }
+    }
+
+    private func expandPinnedSidebar() {
+        sidebarPinMorphToken += 1
+        isSidebarPinMorphActive = false
+        sidebarPinMorphProgress = 1
+        withAnimation(sidebarPinnedStateAnimation) {
+            isSidebarCollapsed = false
+            pinnedSidebarPresentationProgress = 1
+            isSidebarPanelRevealed = false
+            areFloatingSidebarTrafficLightsVisible = false
+            floatingSidebarTrafficLightRevealToken += 1
+        }
+    }
+
+    private func morphFloatingSidebarToPinned() {
+        sidebarRevealToken += 1
+        floatingSidebarTrafficLightRevealToken += 1
+        sidebarPinMorphToken += 1
+        let token = sidebarPinMorphToken
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            isSidebarCollapsed = false
+            isSidebarPinMorphActive = true
+            sidebarPinMorphProgress = 0
+            pinnedSidebarPresentationProgress = 0
+            areFloatingSidebarTrafficLightsVisible = true
+        }
+
+        withAnimation(sidebarPinMorphAnimation) {
+            sidebarPinMorphProgress = 1
+            pinnedSidebarPresentationProgress = 1
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + sidebarPinMorphDuration) {
+            guard sidebarPinMorphToken == token, isSidebarPinMorphActive else { return }
+            var completionTransaction = Transaction()
+            completionTransaction.disablesAnimations = true
+            withTransaction(completionTransaction) {
+                isSidebarPanelRevealed = false
+                isSidebarPinMorphActive = false
+                sidebarPinMorphProgress = 1
+                pinnedSidebarPresentationProgress = 1
+                areFloatingSidebarTrafficLightsVisible = false
+            }
         }
     }
 
@@ -241,11 +317,11 @@ struct MacShellRootView: View {
 
             if isSidebarCollapsed && isPinnedSidebarFullyCollapsed {
                 collapsedSidebarRevealZone
+            }
 
-                if isSidebarPanelRevealed {
-                    floatingSidebarPanel
-                        .transition(floatingSidebarPanelTransition)
-                }
+            if sidebarPresentation.showsOverlaySurface {
+                sidebarOverlaySurface
+                    .transition(floatingSidebarPanelTransition)
             }
 
             if isSidebarSurfaceVisible {
@@ -281,8 +357,11 @@ struct MacShellRootView: View {
         .environment(\.colorScheme, resolvedAppearanceColorScheme)
         .onAppear {
             pinnedSidebarPresentationProgress = isSidebarCollapsed ? 0 : 1
+            sidebarPinMorphProgress = 1
+            isSidebarPinMorphActive = false
         }
         .onChange(of: isSidebarCollapsed) { _, collapsed in
+            guard !isSidebarPinMorphActive else { return }
             synchronizePinnedSidebarPresentation(collapsed: collapsed)
         }
         .onChange(of: host.commandInputRequestID) { _, _ in
@@ -296,11 +375,14 @@ struct MacShellRootView: View {
                 metrics: $windowChromeMetrics,
                 appearanceMode: appearanceMode,
                 pinnedSidebarPresentationProgress: pinnedSidebarPresentationProgress,
+                sidebarPinMorphProgress: sidebarPinMorphProgress,
                 isSidebarCollapsed: isSidebarCollapsed,
                 isSidebarPanelRevealed: isSidebarPanelRevealed,
                 areFloatingSidebarTrafficLightsVisible: areFloatingSidebarTrafficLightsVisible,
+                isSidebarPinMorphActive: isSidebarPinMorphActive,
                 sidebarWidth: sidebarWidth,
                 floatingSidebarInset: floatingSidebarInset,
+                floatingCornerRadius: ShellRadii.floatingSidebarPanel,
                 systemColorScheme: $systemColorScheme,
                 collapsedSidebarPointerRetentionEnabled: isCollapsedSidebarPointerRetentionActive,
                 collapsedSidebarPointerRetained: $isCollapsedSidebarPointerRetained
@@ -308,15 +390,23 @@ struct MacShellRootView: View {
         )
     }
 
+    @ViewBuilder
     private func pinnedSidebarSurface() -> some View {
-        sidebarContent(isSwipeEnabled: true)
-            .frame(width: sidebarWidth)
-            .offset(x: sidebarPinnedChromeOffsetX)
-            .opacity(sidebarPinnedContentOpacity)
-            .allowsHitTesting(!isSidebarCollapsed)
-            .frame(width: sidebarPinnedVisibleWidth, alignment: .leading)
-            .clipped()
-            .ignoresSafeArea(edges: .top)
+        if sidebarPresentation.showsPinnedSurfaceContent {
+            sidebarContent(isSwipeEnabled: true)
+                .frame(width: sidebarWidth)
+                .offset(x: sidebarPinnedContentOffsetX)
+                .opacity(sidebarPinnedContentOpacity)
+                .allowsHitTesting(!isSidebarCollapsed)
+                .frame(width: sidebarPinnedVisibleWidth, alignment: .leading)
+                .clipped()
+                .ignoresSafeArea(edges: .top)
+        } else {
+            Color.clear
+                .frame(width: sidebarPinnedVisibleWidth)
+                .allowsHitTesting(false)
+                .ignoresSafeArea(edges: .top)
+        }
     }
 
     private func synchronizePinnedSidebarPresentation(collapsed: Bool) {
@@ -354,39 +444,33 @@ struct MacShellRootView: View {
             .zIndex(10)
     }
 
-    private var floatingSidebarPanel: some View {
-        ZStack(alignment: .topLeading) {
-            RoundedRectangle(cornerRadius: ShellRadii.floatingSidebarPanel, style: .continuous)
+    private var sidebarOverlaySurface: some View {
+        let presentation = sidebarPresentation
+        let shape = RoundedRectangle(cornerRadius: presentation.cornerRadius, style: .continuous)
+
+        return ZStack(alignment: .topLeading) {
+            shape
                 .fill(.clear)
                 .background {
                     ShellMaterialBackgroundView(.sidebarGlass)
-                        .clipShape(
-                            RoundedRectangle(
-                                cornerRadius: ShellRadii.floatingSidebarPanel,
-                                style: .continuous
-                            )
-                        )
+                        .clipShape(shape)
                 }
                 .overlay {
-                    RoundedRectangle(cornerRadius: ShellRadii.floatingSidebarPanel, style: .continuous)
+                    shape
                         .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
+                        .opacity(Double(presentation.floatingTreatmentProgress))
                 }
 
             sidebarContent(isSwipeEnabled: true)
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: ShellRadii.floatingSidebarPanel,
-                        style: .continuous
-                    )
-                )
+                .clipShape(shape)
         }
         .frame(width: sidebarWidth, alignment: .topLeading)
         .frame(maxHeight: .infinity, alignment: .topLeading)
-        .padding(.leading, floatingSidebarInset)
-        .padding(.top, floatingSidebarInset)
-        .padding(.bottom, floatingSidebarInset)
-        .shellShadow(ShellShadows.floatingPanel)
+        .padding(.bottom, presentation.overlayBottomInset)
+        .offset(x: presentation.surfaceOrigin.x, y: presentation.surfaceOrigin.y)
+        .shellShadow(presentation.showsFloatingShadow ? ShellShadows.floatingPanel : ShellShadows.none)
         .onHover(perform: handleCollapsedSidebarHover)
+        .allowsHitTesting(presentation.hitTestingRole != .morphingFloatingToPinned)
         .ignoresSafeArea(edges: [.top, .bottom])
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .zIndex(20)
@@ -433,18 +517,26 @@ private struct ShellWindowPlacementAnimationSyncView: View, Animatable {
     @Binding var metrics: ShellWindowChromeMetrics
     let appearanceMode: ShellAppearanceMode
     var pinnedSidebarPresentationProgress: CGFloat
+    var sidebarPinMorphProgress: CGFloat
     let isSidebarCollapsed: Bool
     let isSidebarPanelRevealed: Bool
     let areFloatingSidebarTrafficLightsVisible: Bool
+    let isSidebarPinMorphActive: Bool
     let sidebarWidth: CGFloat
     let floatingSidebarInset: CGFloat
+    let floatingCornerRadius: CGFloat
     @Binding var systemColorScheme: ColorScheme
     let collapsedSidebarPointerRetentionEnabled: Bool
     @Binding var collapsedSidebarPointerRetained: Bool
 
-    var animatableData: CGFloat {
-        get { pinnedSidebarPresentationProgress }
-        set { pinnedSidebarPresentationProgress = newValue }
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get {
+            AnimatablePair(pinnedSidebarPresentationProgress, sidebarPinMorphProgress)
+        }
+        set {
+            pinnedSidebarPresentationProgress = newValue.first
+            sidebarPinMorphProgress = newValue.second
+        }
     }
 
     var body: some View {
@@ -459,42 +551,29 @@ private struct ShellWindowPlacementAnimationSyncView: View, Animatable {
     }
 
     private var windowChromeSurface: ShellWindowChromeSurface {
-        ShellWindowChromeSurface(
-            isVisible: isSidebarSurfaceVisible,
-            origin: sidebarChromeSurfaceOrigin,
-            width: sidebarWidth,
-            showsStandardTrafficLights: shouldShowStandardTrafficLights
+        sidebarPresentation.chromeSurface
+    }
+
+    private var sidebarPresentation: ShellSidebarPresentationSnapshot {
+        ShellSidebarPresentationSnapshot(
+            phase: sidebarPresentationPhase,
+            configuration: ShellSidebarPresentationConfiguration(
+                sidebarWidth: sidebarWidth,
+                floatingSidebarInset: floatingSidebarInset,
+                floatingCornerRadius: floatingCornerRadius
+            )
         )
     }
 
-    private var isSidebarSurfaceVisible: Bool {
-        isPinnedSidebarSurfaceActive || isSidebarPanelRevealed
-    }
-
-    private var isPinnedSidebarSurfaceActive: Bool {
-        !isSidebarCollapsed || clampedPinnedSidebarPresentationProgress > 0.001
-    }
-
-    private var clampedPinnedSidebarPresentationProgress: CGFloat {
-        min(max(pinnedSidebarPresentationProgress, 0), 1)
-    }
-
-    private var sidebarChromeSurfaceOrigin: CGPoint {
-        if isSidebarPanelRevealed {
-            return CGPoint(x: floatingSidebarInset, y: floatingSidebarInset)
-        }
-        guard isPinnedSidebarSurfaceActive else {
-            return .zero
-        }
-        return CGPoint(x: -sidebarWidth * (1 - clampedPinnedSidebarPresentationProgress), y: 0)
-    }
-
-    private var shouldShowStandardTrafficLights: Bool {
-        if isPinnedSidebarSurfaceActive {
-            return true
-        }
-        guard isSidebarCollapsed else { return true }
-        return isSidebarPanelRevealed && areFloatingSidebarTrafficLightsVisible
+    private var sidebarPresentationPhase: ShellSidebarPresentationPhase {
+        ShellSidebarPresentationPhase.resolved(
+            isSidebarCollapsed: isSidebarCollapsed,
+            pinnedProgress: pinnedSidebarPresentationProgress,
+            isFloatingPanelRevealed: isSidebarPanelRevealed,
+            showsFloatingTrafficLights: areFloatingSidebarTrafficLightsVisible,
+            isFloatingToPinnedMorphActive: isSidebarPinMorphActive,
+            floatingToPinnedMorphProgress: sidebarPinMorphProgress
+        )
     }
 }
 

--- a/clients/apple/alan-macos/Support/ShellSidebarPresentation.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarPresentation.swift
@@ -1,0 +1,178 @@
+import CoreGraphics
+
+#if os(macOS)
+enum ShellSidebarPresentationHitTestingRole: Equatable {
+    case none
+    case pinned
+    case floating
+    case morphingFloatingToPinned
+}
+
+struct ShellSidebarPresentationConfiguration: Equatable {
+    let sidebarWidth: CGFloat
+    let floatingSidebarInset: CGFloat
+    let floatingCornerRadius: CGFloat
+}
+
+enum ShellSidebarPresentationPhase: Equatable {
+    case pinned(progress: CGFloat)
+    case collapsedHidden
+    case floatingRevealed(showsTrafficLights: Bool)
+    case morphingFloatingToPinned(progress: CGFloat)
+
+    static func resolved(
+        isSidebarCollapsed: Bool,
+        pinnedProgress: CGFloat,
+        isFloatingPanelRevealed: Bool,
+        showsFloatingTrafficLights: Bool,
+        isFloatingToPinnedMorphActive: Bool,
+        floatingToPinnedMorphProgress: CGFloat
+    ) -> ShellSidebarPresentationPhase {
+        if isFloatingToPinnedMorphActive {
+            return .morphingFloatingToPinned(progress: floatingToPinnedMorphProgress)
+        }
+
+        if isFloatingPanelRevealed {
+            return .floatingRevealed(showsTrafficLights: showsFloatingTrafficLights)
+        }
+
+        if !isSidebarCollapsed || pinnedProgress > ShellSidebarPresentationSnapshot.visibilityEpsilon {
+            return .pinned(progress: pinnedProgress)
+        }
+
+        return .collapsedHidden
+    }
+}
+
+struct ShellSidebarPresentationSnapshot: Equatable {
+    static let visibilityEpsilon: CGFloat = 0.001
+
+    let phase: ShellSidebarPresentationPhase
+    let layoutProgress: CGFloat
+    let surfaceOrigin: CGPoint
+    let surfaceWidth: CGFloat
+    let contentOffsetX: CGFloat
+    let contentOpacity: Double
+    let floatingTreatmentProgress: CGFloat
+    let cornerRadius: CGFloat
+    let overlayBottomInset: CGFloat
+    let hitTestingRole: ShellSidebarPresentationHitTestingRole
+    let chromeSurface: ShellWindowChromeSurface
+    let showsOverlaySurface: Bool
+    let showsPinnedSurfaceContent: Bool
+
+    init(
+        phase: ShellSidebarPresentationPhase,
+        configuration: ShellSidebarPresentationConfiguration
+    ) {
+        self.phase = phase
+        surfaceWidth = configuration.sidebarWidth
+
+        switch phase {
+        case let .pinned(progress):
+            let progress = Self.clamp(progress)
+            layoutProgress = progress
+            surfaceOrigin = CGPoint(
+                x: -configuration.sidebarWidth * (1 - progress),
+                y: 0
+            )
+            contentOffsetX = surfaceOrigin.x
+            contentOpacity = Double(progress)
+            floatingTreatmentProgress = 0
+            cornerRadius = 0
+            overlayBottomInset = 0
+            showsOverlaySurface = false
+            showsPinnedSurfaceContent = progress > Self.visibilityEpsilon
+            hitTestingRole = showsPinnedSurfaceContent ? .pinned : .none
+            chromeSurface = ShellWindowChromeSurface(
+                isVisible: showsPinnedSurfaceContent,
+                origin: surfaceOrigin,
+                width: configuration.sidebarWidth,
+                showsStandardTrafficLights: showsPinnedSurfaceContent
+            )
+
+        case .collapsedHidden:
+            layoutProgress = 0
+            surfaceOrigin = .zero
+            contentOffsetX = 0
+            contentOpacity = 0
+            floatingTreatmentProgress = 0
+            cornerRadius = 0
+            overlayBottomInset = 0
+            showsOverlaySurface = false
+            showsPinnedSurfaceContent = false
+            hitTestingRole = .none
+            chromeSurface = ShellWindowChromeSurface(
+                isVisible: false,
+                origin: .zero,
+                width: configuration.sidebarWidth,
+                showsStandardTrafficLights: false
+            )
+
+        case let .floatingRevealed(showsTrafficLights):
+            layoutProgress = 0
+            surfaceOrigin = CGPoint(
+                x: configuration.floatingSidebarInset,
+                y: configuration.floatingSidebarInset
+            )
+            contentOffsetX = 0
+            contentOpacity = 1
+            floatingTreatmentProgress = 1
+            cornerRadius = configuration.floatingCornerRadius
+            overlayBottomInset = configuration.floatingSidebarInset
+            showsOverlaySurface = true
+            showsPinnedSurfaceContent = false
+            hitTestingRole = .floating
+            chromeSurface = ShellWindowChromeSurface(
+                isVisible: true,
+                origin: surfaceOrigin,
+                width: configuration.sidebarWidth,
+                showsStandardTrafficLights: showsTrafficLights
+            )
+
+        case let .morphingFloatingToPinned(progress):
+            let progress = Self.clamp(progress)
+            let floatingProgress = 1 - progress
+            layoutProgress = progress
+            surfaceOrigin = CGPoint(
+                x: configuration.floatingSidebarInset * floatingProgress,
+                y: configuration.floatingSidebarInset * floatingProgress
+            )
+            contentOffsetX = 0
+            contentOpacity = 1
+            floatingTreatmentProgress = floatingProgress
+            cornerRadius = configuration.floatingCornerRadius * floatingProgress
+            overlayBottomInset = configuration.floatingSidebarInset * floatingProgress
+            showsOverlaySurface = true
+            showsPinnedSurfaceContent = false
+            hitTestingRole = .morphingFloatingToPinned
+            chromeSurface = ShellWindowChromeSurface(
+                isVisible: true,
+                origin: surfaceOrigin,
+                width: configuration.sidebarWidth,
+                showsStandardTrafficLights: true
+            )
+        }
+    }
+
+    var isSurfaceVisible: Bool {
+        showsOverlaySurface || showsPinnedSurfaceContent
+    }
+
+    var layoutWidth: CGFloat {
+        surfaceWidth * layoutProgress
+    }
+
+    var showsFloatingShadow: Bool {
+        floatingTreatmentProgress > Self.visibilityEpsilon
+    }
+
+    var visibleSurfaceCount: Int {
+        (showsOverlaySurface ? 1 : 0) + (showsPinnedSurfaceContent ? 1 : 0)
+    }
+
+    private static func clamp(_ value: CGFloat) -> CGFloat {
+        min(max(value, 0), 1)
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift
@@ -8,6 +8,9 @@ enum ShellSidebarSpaceContentPagerSettlementPhase: Equatable {
 }
 
 struct ShellSidebarSpaceContentPagerState: Equatable {
+    static let renderRadius = 2
+    static let overdragGapRatio: CGFloat = 0.18
+
     let sourceIndex: Int
     var targetIndex: Int?
     var dragOffset: CGFloat
@@ -40,14 +43,22 @@ struct ShellSidebarSpaceContentPagerState: Equatable {
     }
 
     var pageIndicesForRendering: [Int] {
-        guard let targetIndex, targetIndex != sourceIndex else {
-            return [sourceIndex]
-        }
-        return [sourceIndex, targetIndex]
+        let lowerBound = sourceIndex - Self.renderRadius
+        let upperBound = sourceIndex + Self.renderRadius
+        return Array(lowerBound...upperBound)
+    }
+
+    func pageIndicesForRendering(validRange: Range<Int>) -> [Int] {
+        pageIndicesForRendering.filter { validRange.contains($0) }
     }
 
     func offset(for index: Int) -> CGFloat {
         CGFloat(index - sourceIndex) * max(pageWidth, 1) + dragOffset
+    }
+
+    static func clampedDragOffset(for translationX: CGFloat, pageWidth: CGFloat) -> CGFloat {
+        let limit = max(pageWidth, 1) * (1 + overdragGapRatio)
+        return min(max(translationX, -limit), limit)
     }
 }
 #endif

--- a/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
+++ b/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
@@ -886,7 +886,9 @@ enum AlanShellWindowPlacement {
             return metrics
         }
 
-        if chromeSurface.showsStandardTrafficLights {
+        let shouldPrimeInvisibleTrafficLights =
+            chromeSurface.showsStandardTrafficLights && standardWindowButtonsAreHidden(in: window)
+        if shouldPrimeInvisibleTrafficLights {
             setStandardWindowButtons(in: window, hidden: false, alphaValue: 0)
         }
 
@@ -935,6 +937,11 @@ enum AlanShellWindowPlacement {
                 button.isHidden = hidden
             }
         }
+    }
+
+    private static func standardWindowButtonsAreHidden(in window: NSWindow) -> Bool {
+        guard let group = standardWindowButtonGroup(in: window) else { return false }
+        return group.buttons.allSatisfy(\.isHidden)
     }
 
     private static func localTrafficLightGroupFrame(for frame: CGRect) -> CGRect {

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -284,9 +284,14 @@ struct ShellSidebarView: View {
     private func updateSpacePager(translationX: CGFloat) {
         guard abs(translationX) > 0.5 else { return }
         guard let sourceIndex = spacePager?.sourceIndex ?? selectedSpaceIndex else { return }
-        let direction = translationX < 0 ? 1 : -1
+        let clampedTranslationX = ShellSidebarSpaceContentPagerState.clampedDragOffset(
+            for: translationX,
+            pageWidth: sidebarSwipePageWidth
+        )
+        let direction = clampedTranslationX < 0 ? 1 : -1
         let targetIndex = adjacentSpaceIndex(from: sourceIndex, direction: direction)
-        let dragOffset = targetIndex == nil ? resistedEdgeOffset(for: translationX) : translationX
+        let dragOffset =
+            targetIndex == nil ? resistedEdgeOffset(for: clampedTranslationX) : clampedTranslationX
 
         var transaction = Transaction()
         transaction.disablesAnimations = true
@@ -392,7 +397,7 @@ struct ShellSidebarView: View {
         guard let spacePager else {
             return selectedSpaceIndex.map { [$0] } ?? []
         }
-        return spacePager.pageIndicesForRendering.filter { host.spaces.indices.contains($0) }
+        return spacePager.pageIndicesForRendering(validRange: host.spaces.indices)
     }
 
     private func spacePageOffset(for index: Int, pageWidth: CGFloat) -> CGFloat {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -599,6 +599,11 @@ require_pattern \
     "pinned sidebar collapse must be driven by continuous presentation progress"
 
 require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "ShellWindowPlacementAnimationSyncView: View, Animatable" \
+    "window chrome placement must receive animated pinned-sidebar progress instead of only final state"
+
+require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
     "expandedSidebarProgress" \
     "workspace view must expose continuous sidebar progress for terminal surface spacing"
@@ -662,6 +667,16 @@ require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
     "settlementPhase" \
     "space pager state must model drag, commit, and cancel settlement phases"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
+    "renderRadius = 2" \
+    "space pager must keep a five-page rendering window around the source"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceContentPager.swift" \
+    "clampedDragOffset" \
+    "space pager must clamp one gesture to one page plus overdrag"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
@@ -1020,8 +1035,13 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
-    "setStandardWindowButtons\\(in: window, hidden: false, alphaValue: 0\\)" \
-    "floating sidebar traffic lights must be made invisible before AppKit-visible repositioning"
+    "shouldPrimeInvisibleTrafficLights" \
+    "floating sidebar traffic lights must only be made invisible before repositioning when revealing from a hidden state"
+
+reject_pattern \
+    "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
+    "^        if chromeSurface\\.showsStandardTrafficLights \\{$" \
+    "visible pinned sidebar traffic-light movement must not unconditionally prime standard buttons to alpha zero"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -514,8 +514,8 @@ require_pattern \
     "collapsed sidebar chrome must publish its floating surface state to AppKit"
 
 require_pattern \
-    "clients/apple/alan-macos/MacShellRootView.swift" \
-    "isVisible: isSidebarSurfaceVisible" \
+    "clients/apple/alan-macos/Support/ShellSidebarPresentation.swift" \
+    "isVisible: false" \
     "traffic lights must hide when the collapsed sidebar surface is hidden"
 
 require_pattern \
@@ -599,9 +599,34 @@ require_pattern \
     "pinned sidebar collapse must be driven by continuous presentation progress"
 
 require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarPresentation.swift" \
+    "morphingFloatingToPinned" \
+    "sidebar presentation must model the floating-to-pinned morph explicitly"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarPresentation.swift" \
+    "visibleSurfaceCount" \
+    "sidebar presentation model must expose single-surface invariants for pin morph coverage"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "sidebarPresentation\\.chromeSurface" \
+    "mac shell root must derive window chrome from the unified sidebar presentation snapshot"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "morphFloatingSidebarToPinned" \
+    "pinning a revealed floating sidebar must use a dedicated morph path"
+
+require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
     "ShellWindowPlacementAnimationSyncView: View, Animatable" \
     "window chrome placement must receive animated pinned-sidebar progress instead of only final state"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "AnimatablePair<CGFloat, CGFloat>" \
+    "window chrome placement must animate both pinned layout progress and floating-to-pinned morph progress"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
@@ -612,6 +637,16 @@ require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
     "frame\\(width: sidebarPinnedVisibleWidth" \
     "pinned sidebar must stay mounted while visible width animates"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-presentation.swift" \
+    "verifiesFloatingToPinnedMorphKeepsOneVisibleSurface" \
+    "sidebar presentation tests must cover floating-to-pinned morph single-surface behavior"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-presentation.sh" \
+    "ShellSidebarPresentation\\.swift" \
+    "sidebar presentation tests must compile the shared presentation model"
 
 reject_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \

--- a/clients/apple/scripts/test-shell-sidebar-presentation.sh
+++ b/clients/apple/scripts/test-shell-sidebar-presentation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-sidebar-presentation-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-sidebar-presentation-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarPresentation.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-presentation.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-sidebar-presentation.swift
+++ b/clients/apple/scripts/test-shell-sidebar-presentation.swift
@@ -1,0 +1,152 @@
+import CoreGraphics
+import Foundation
+
+@main
+struct ShellSidebarPresentationTestRunner {
+    static func main() throws {
+        try ShellSidebarPresentationTests.run()
+    }
+}
+
+private enum ShellSidebarPresentationTests {
+    private static let configuration = ShellSidebarPresentationConfiguration(
+        sidebarWidth: 264,
+        floatingSidebarInset: 6,
+        floatingCornerRadius: 18
+    )
+
+    static func run() throws {
+        try verifiesCollapsedHiddenHasNoVisibleSurface()
+        try verifiesFloatingRevealUsesOverlaySurfaceWithoutLayoutReservation()
+        try verifiesFloatingToPinnedMorphKeepsOneVisibleSurface()
+        try verifiesPinnedPhaseUsesPinnedLayoutSurface()
+        print("Shell sidebar presentation tests passed.")
+    }
+
+    private static func verifiesCollapsedHiddenHasNoVisibleSurface() throws {
+        let snapshot = ShellSidebarPresentationSnapshot(
+            phase: .collapsedHidden,
+            configuration: configuration
+        )
+
+        expect(snapshot.layoutProgress == 0, "collapsed hidden state must not reserve sidebar layout")
+        expect(!snapshot.isSurfaceVisible, "collapsed hidden state must not render a sidebar surface")
+        expect(snapshot.visibleSurfaceCount == 0, "collapsed hidden state must render zero surfaces")
+        expect(!snapshot.chromeSurface.isVisible, "collapsed hidden state must hide window chrome")
+    }
+
+    private static func verifiesFloatingRevealUsesOverlaySurfaceWithoutLayoutReservation() throws {
+        let snapshot = ShellSidebarPresentationSnapshot(
+            phase: .floatingRevealed(showsTrafficLights: true),
+            configuration: configuration
+        )
+
+        expect(snapshot.layoutProgress == 0, "floating reveal must not resize terminal layout")
+        expect(snapshot.showsOverlaySurface, "floating reveal must render the overlay surface")
+        expect(!snapshot.showsPinnedSurfaceContent, "floating reveal must not render pinned content")
+        expect(snapshot.visibleSurfaceCount == 1, "floating reveal must render exactly one surface")
+        expect(
+            snapshot.surfaceOrigin.isApproximately(CGPoint(x: 6, y: 6)),
+            "floating reveal origin must use the floating inset"
+        )
+        expect(snapshot.floatingTreatmentProgress == 1, "floating reveal must use floating treatment")
+        expect(snapshot.chromeSurface.isVisible, "floating reveal must expose the sidebar chrome surface")
+        expect(
+            snapshot.chromeSurface.showsStandardTrafficLights,
+            "floating reveal must be able to show native traffic lights"
+        )
+    }
+
+    private static func verifiesFloatingToPinnedMorphKeepsOneVisibleSurface() throws {
+        let start = ShellSidebarPresentationSnapshot(
+            phase: .morphingFloatingToPinned(progress: 0),
+            configuration: configuration
+        )
+        let midpoint = ShellSidebarPresentationSnapshot(
+            phase: .morphingFloatingToPinned(progress: 0.5),
+            configuration: configuration
+        )
+        let end = ShellSidebarPresentationSnapshot(
+            phase: .morphingFloatingToPinned(progress: 1),
+            configuration: configuration
+        )
+
+        expect(start.visibleSurfaceCount == 1, "morph start must render exactly one surface")
+        expect(midpoint.visibleSurfaceCount == 1, "morph midpoint must render exactly one surface")
+        expect(end.visibleSurfaceCount == 1, "morph end must render exactly one surface")
+
+        expect(start.showsOverlaySurface, "morph must keep the visible overlay surface mounted")
+        expect(!start.showsPinnedSurfaceContent, "morph start must not duplicate pinned content")
+        expect(!midpoint.showsPinnedSurfaceContent, "morph midpoint must not duplicate pinned content")
+        expect(!end.showsPinnedSurfaceContent, "morph end must not duplicate pinned content before settlement")
+
+        expect(start.layoutProgress == 0, "morph start must not reserve pinned layout")
+        expect(midpoint.layoutProgress == 0.5, "morph midpoint must open layout continuously")
+        expect(end.layoutProgress == 1, "morph end must reserve full pinned layout")
+
+        expect(
+            start.surfaceOrigin.isApproximately(CGPoint(x: 6, y: 6)),
+            "morph start must begin at the floating origin"
+        )
+        expect(
+            midpoint.surfaceOrigin.isApproximately(CGPoint(x: 3, y: 3)),
+            "morph midpoint must interpolate surface origin"
+        )
+        expect(
+            end.surfaceOrigin.isApproximately(.zero),
+            "morph end must settle at the pinned origin"
+        )
+
+        expect(
+            start.floatingTreatmentProgress == 1,
+            "morph start must use floating visual treatment"
+        )
+        expect(
+            midpoint.floatingTreatmentProgress == 0.5,
+            "morph midpoint must fade floating treatment continuously"
+        )
+        expect(end.floatingTreatmentProgress == 0, "morph end must remove floating treatment")
+
+        expect(
+            midpoint.chromeSurface.origin.isApproximately(midpoint.surfaceOrigin),
+            "window chrome must use the same interpolated origin as the visible surface"
+        )
+        expect(
+            midpoint.chromeSurface.showsStandardTrafficLights,
+            "pin morph must preserve native traffic lights"
+        )
+    }
+
+    private static func verifiesPinnedPhaseUsesPinnedLayoutSurface() throws {
+        let snapshot = ShellSidebarPresentationSnapshot(
+            phase: .pinned(progress: 1),
+            configuration: configuration
+        )
+
+        expect(snapshot.layoutProgress == 1, "pinned state must reserve full sidebar layout")
+        expect(snapshot.showsPinnedSurfaceContent, "pinned state must render pinned content")
+        expect(!snapshot.showsOverlaySurface, "pinned state must not render an overlay surface")
+        expect(snapshot.visibleSurfaceCount == 1, "pinned state must render exactly one surface")
+        expect(snapshot.surfaceOrigin.isApproximately(.zero), "pinned state origin must be zero")
+        expect(snapshot.chromeSurface.isVisible, "pinned state must expose window chrome")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fatalError(message)
+        }
+    }
+}
+
+private extension CGFloat {
+    func isApproximately(_ other: CGFloat, tolerance: CGFloat = 0.001) -> Bool {
+        abs(self - other) <= tolerance
+    }
+}
+
+private extension CGPoint {
+    func isApproximately(_ other: CGPoint, tolerance: CGFloat = 0.001) -> Bool {
+        x.isApproximately(other.x, tolerance: tolerance)
+            && y.isApproximately(other.y, tolerance: tolerance)
+    }
+}

--- a/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
+++ b/clients/apple/scripts/test-shell-sidebar-swipe-monitor.swift
@@ -20,6 +20,8 @@ private enum ShellSidebarSwipeMonitorTests {
         verifiesPhasefulHorizontalGestureCancelsOnCancelPhase()
         verifiesFastFlickUsesTerminalDelta()
         verifiesPagerOffsetsPagesFromSharedDragOffset()
+        verifiesPagerRendersFivePageWindowAroundSource()
+        verifiesPagerClampsDragToOnePageWithOverdragGap()
         verifiesPagerEdgeResistanceDoesNotRenderWrappedTarget()
         verifiesPagerSettlementPhaseExposesCommitAndCancelState()
         print("Shell sidebar swipe monitor tests passed.")
@@ -158,8 +160,49 @@ private enum ShellSidebarSwipeMonitorTests {
             "target sidebar content page must share the same drag offset from the adjacent page position"
         )
         expect(
-            pager.pageIndicesForRendering == [1, 2],
-            "sidebar content pager must render source and adjacent target pages together"
+            pager.pageIndicesForRendering == [-1, 0, 1, 2, 3],
+            "sidebar content pager must render a stable five-page window around the source"
+        )
+    }
+
+    private static func verifiesPagerRendersFivePageWindowAroundSource() {
+        let pager = ShellSidebarSpaceContentPagerState(
+            sourceIndex: 2,
+            targetIndex: 3,
+            dragOffset: -310,
+            pageWidth: 300,
+            settlementPhase: .dragging
+        )
+
+        expect(
+            pager.pageIndicesForRendering == [0, 1, 2, 3, 4],
+            "sidebar content pager must keep previous two and next two pages mounted"
+        )
+        expect(
+            pager.offset(for: 4).isApproximately(290),
+            "overdrag past one page must be able to reveal a sliver of the second next page"
+        )
+    }
+
+    private static func verifiesPagerClampsDragToOnePageWithOverdragGap() {
+        let pageWidth: CGFloat = 300
+        let clampedLeft = ShellSidebarSpaceContentPagerState.clampedDragOffset(
+            for: -900,
+            pageWidth: pageWidth
+        )
+        let clampedRight = ShellSidebarSpaceContentPagerState.clampedDragOffset(
+            for: 900,
+            pageWidth: pageWidth
+        )
+        let expectedLimit = pageWidth * (1 + ShellSidebarSpaceContentPagerState.overdragGapRatio)
+
+        expect(
+            clampedLeft.isApproximately(-expectedLimit),
+            "left swipe drag offset must be limited to one page plus the overdrag gap"
+        )
+        expect(
+            clampedRight.isApproximately(expectedLimit),
+            "right swipe drag offset must be limited to one page plus the overdrag gap"
         )
     }
 
@@ -174,8 +217,8 @@ private enum ShellSidebarSwipeMonitorTests {
 
         expect(pager.isEdgeResistance, "edge gestures without a target must enter resistance mode")
         expect(
-            pager.pageIndicesForRendering == [0],
-            "edge resistance must not synthesize or wrap to a target page"
+            pager.pageIndicesForRendering(validRange: 0..<3) == [0, 1, 2],
+            "edge resistance must keep the valid centered page window without wrapping"
         )
         expect(
             pager.offset(for: 0).isApproximately(42),

--- a/docs/superpowers/specs/2026-05-15-sidebar-local-space-swipe-design.md
+++ b/docs/superpowers/specs/2026-05-15-sidebar-local-space-swipe-design.md
@@ -18,6 +18,8 @@ terminal-first layout and causes visible artifacts at the terminal surface.
 
 - Keep space swipe scoped to the sidebar.
 - Make the swipe continuous and finger-tracked.
+- Render a stable five-page window around the current space: previous two,
+  current, and next two when available.
 - Move only the active-space content inside the sidebar: the space title/header
   and the active space tab list.
 - Keep the command input, bottom space switcher, sidebar material surface,
@@ -34,6 +36,7 @@ terminal-first layout and causes visible artifacts at the terminal surface.
   layout, or pane lifecycle semantics.
 - Do not make the bottom space switcher part of the moving page; it is a fixed
   navigation control.
+- Do not allow one swipe to skip multiple spaces.
 
 ## Architecture
 
@@ -84,6 +87,8 @@ tracks:
 - adjacent target space index, when one exists
 - direct drag offset from finger translation
 - sidebar content page width
+- a stable rendering window centered on the source space, with up to two
+  previous and two next pages
 - settlement phase: dragging, settling to source, or settling to target
 
 `ShellHostController` remains the owner of committed shell selection and focus.
@@ -95,7 +100,10 @@ commit to a target space.
 During drag:
 
 - horizontal movement maps directly to the sidebar content offset;
-- the current and adjacent space content pages move from the same translation;
+- the previous two, current, and next two space content pages move from the same
+  translation when those pages exist;
+- drag distance is clamped to one page plus a small overdrag gap so fast input
+  can expose a sliver of the second adjacent page without skipping spaces;
 - edge swipes apply resistance instead of wrapping or showing nonexistent
   spaces;
 - vertical tab-list scrolling is disabled only after horizontal intent locks;
@@ -107,6 +115,8 @@ On release:
 - if distance or velocity crosses the commit threshold and an adjacent target
   exists, the pager settles to the target and commits shell selection through
   the controller path;
+- a single gesture can commit only the immediately adjacent previous or next
+  space;
 - if the threshold is not met, the pager settles back to the source and leaves
   shell selection unchanged;
 - release handling should use the last effective finger velocity rather than a

--- a/openspec/changes/refine-macos-sidebar-interactions/design.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/design.md
@@ -4,6 +4,7 @@ The current macOS shell sidebar has three related interaction problems:
 
 - Sidebar tab and space clicks update `selectedSpaceID` / `selectedTabID` without updating the authoritative `shellState.focusedPaneID`. Later runtime metadata or state publication calls `synchronizeSelection()` and restores selection from the old focused pane.
 - Pinned-sidebar collapse is expressed as conditional SwiftUI insertion/removal, while titlebar controls and AppKit traffic-light placement are synchronized through a separate bridge. This produces uncoordinated motion and can make collapse appear instantaneous.
+- Pinning from a revealed collapsed floating sidebar currently crosses two presentation paths: the floating overlay is removed, then the pinned sidebar expands from its collapsed/offscreen state. That can read as a brief hide-then-show instead of one Arc-like morph from the visible floating surface into the pinned layout.
 - Collapsed floating-sidebar reveal is retained by SwiftUI view-local hover on the narrow reveal zone, the floating panel, and titlebar controls. After double-click visible-frame zoom, the left AppKit resize frame can take pointer ownership before the SwiftUI hover surfaces see the pointer as still inside the reveal neighborhood, so the sidebar schedules a hide even though the user is still intentionally working the left edge.
 - Horizontal space swipe is represented as a discontinuous sidebar-local source/target transition. It previews the sidebar header and tab list only, commits after settle, and does not model the ordered space sequence as a continuous sidebar-local content pager.
 
@@ -14,11 +15,11 @@ The implementation must preserve alan's terminal-first layout, native material s
 **Goals:**
 
 - Make sidebar tab and space selection persist by routing selection through authoritative shell focus.
-- Give pinned sidebar collapse and expansion one coordinated motion model across sidebar width, terminal content inset, sidebar toolbar controls, and standard macOS traffic lights.
+- Give pinned sidebar collapse, expansion, and floating-to-pinned pinning one coordinated presentation model across sidebar width, terminal content inset, sidebar toolbar controls, and standard macOS traffic lights.
 - Keep collapsed floating-sidebar reveal stable across AppKit window-frame hit testing, including the left resize cursor region after visible-frame zoom.
 - Replace discontinuous sidebar space swipe behavior with a continuous,
   sidebar-local content pager over the ordered `ShellSpace` sequence.
-- Keep collapsed floating sidebar reveal transient: it must not resize terminal content, and it must retain the narrow edge/titlebar-control hover behavior.
+- Keep collapsed floating sidebar reveal transient: it must not resize terminal content except during an explicit user-initiated pin morph, and it must retain the narrow edge/titlebar-control hover behavior.
 - Add focused automated and contract verification for the new interaction guarantees.
 
 **Non-Goals:**
@@ -27,6 +28,7 @@ The implementation must preserve alan's terminal-first layout, native material s
 - Add new space types, workspace persistence formats, or cross-window space movement.
 - Rework terminal pane input ownership or Ghostty rendering.
 - Implement a full visual snapshot automation system beyond the focused checks needed for this change.
+- Reproduce Arc's exact animation physics, duration, or private implementation details.
 
 ## Decisions
 
@@ -36,11 +38,15 @@ The implementation must preserve alan's terminal-first layout, native material s
 
    Alternative considered: preserve a separate "preview selection" state and delay focus until terminal click. That matches passive preview behavior but keeps the current flashback failure mode and makes sidebar navigation feel unreliable.
 
-2. **Pinned sidebar motion uses a continuous presentation progress.**
+2. **Sidebar presentation uses one model, not separate pinned/floating surfaces.**
 
-   The pinned sidebar should remain mounted while its visible width, content opacity/offset, and workspace leading inset animate from expanded to collapsed. The same progress drives titlebar tool position and the `ShellWindowChromeSurface` origin/visibility passed to AppKit.
+   `MacShellRootView` should derive sidebar rendering and window chrome from one presentation snapshot rather than directly branching on booleans such as `isSidebarCollapsed`, `isSidebarPanelRevealed`, and `pinnedSidebarPresentationProgress`. The model should represent the durable modes (`pinned`, `collapsedHidden`, `floatingRevealed`) and the transient mode needed for pinning (`morphingFloatingToPinned`). Each snapshot should provide the layout reservation progress, visible surface origin, surface width, content opacity/offset, corner treatment, floating shadow, hit-testing role, titlebar tool position, and `ShellWindowChromeSurface` values.
+
+   The pinned sidebar should still remain mounted while its visible width, content opacity/offset, and workspace leading inset animate from expanded to collapsed. When a revealed floating sidebar is pinned, the visible surface should not be removed first. It should morph from the floating origin and floating treatment into the pinned origin and layout-reserved treatment, while the workspace leading inset opens continuously. Only after the morph settles should transient floating state be cleared.
 
    Alternative considered: tune the existing `.transition(.move(edge: .leading))`. This would not coordinate the HStack layout, titlebar overlay, and AppKit traffic lights because they still change through separate state paths.
+
+   Alternative considered: keep separate pinned and floating views and bridge them with `matchedGeometryEffect`. That still leaves AppKit traffic lights and window chrome outside the matched geometry system, so it risks two animations with different owners.
 
 3. **AppKit traffic lights are animated through the window chrome bridge.**
 
@@ -99,6 +105,8 @@ The implementation must preserve alan's terminal-first layout, native material s
 ## Risks / Trade-offs
 
 - **Risk: traffic-light animation fights AppKit layout corrections.** → Keep the AppKit bridge as the only owner of standard button frames, coalesce chrome syncs, and ensure final frames are corrected without visible jumps.
+- **Risk: a unified presentation model grows too broad.** → Keep it limited to shell chrome presentation data: surface origin, layout progress, treatment, visibility, hit-testing, and window chrome values. Sidebar content, space selection, and terminal runtime identity remain owned by their existing components.
+- **Risk: floating-to-pinned morph shows duplicate sidebar content.** → During the morph, render one visible sidebar surface for the active presentation. The pinned layout reservation may open underneath, but the user should not see both the floating panel and a second pinned sidebar copy.
 - **Risk: window-level pointer retention blocks native resizing.** → Keep AppKit as the owner of resize hit-testing and only use pointer location to keep or cancel the sidebar hide timer; do not install a mouse-down-consuming overlay on the resize frame.
 - **Risk: immediate focus commit changes terminal runtime focus while the old sidebar page is still visible during settle.** → Keep a short sidebar content pager state that decouples rendering from the already-committed focus for the duration of settlement.
 - **Risk: sidebar-local pager accidentally moves fixed shell regions.** → Keep command input, the bottom space switcher, sidebar chrome, traffic lights, and the terminal workspace outside the moving page.

--- a/openspec/changes/refine-macos-sidebar-interactions/design.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/design.md
@@ -69,16 +69,21 @@ The implementation must preserve alan's terminal-first layout, native material s
    failure on some displays, but it still loses to AppKit frame hit-testing and
    makes the collapsed trigger less intentional.
 
-5. **Space swipe is a sidebar-local content pager.**
+5. **Space swipe is a sidebar-local five-page content pager.**
 
    The gesture model should track `sourceIndex`, `targetIndex`, `dragOffset`,
    `pageWidth`, and settlement phase for the sidebar's active-space content
-   area. The moving page includes only the active space title/header and the
-   active space tab list. Command input, the bottom space switcher, sidebar
-   material/chrome, traffic lights, and the terminal workspace surface remain
-   visually fixed while dragging. Commit and cancel use the same pager model,
-   but shell selection and terminal focus change only when the gesture commits
-   to a target space.
+   area. The rendered strip should keep the current space at the center with up
+   to two previous and two next spaces mounted, so reversing direction during a
+   swipe does not replace the target page and overdrag can reveal a sliver of
+   the second adjacent page. The moving page includes only the active space
+   title/header and the active space tab list. Command input, the bottom space
+   switcher, sidebar material/chrome, traffic lights, and the terminal workspace
+   surface remain visually fixed while dragging. Commit and cancel use the same
+   pager model, but shell selection and terminal focus change only when the
+   gesture commits to a target space. A single gesture may commit at most one
+   adjacent space; any movement beyond one page is bounded to a small physical
+   overdrag gap for feel rather than multi-space navigation.
 
    Alternative considered: make the entire shell content area a continuous
    space pager. That breaks the accepted terminal-first layout because the
@@ -97,6 +102,7 @@ The implementation must preserve alan's terminal-first layout, native material s
 - **Risk: window-level pointer retention blocks native resizing.** → Keep AppKit as the owner of resize hit-testing and only use pointer location to keep or cancel the sidebar hide timer; do not install a mouse-down-consuming overlay on the resize frame.
 - **Risk: immediate focus commit changes terminal runtime focus while the old sidebar page is still visible during settle.** → Keep a short sidebar content pager state that decouples rendering from the already-committed focus for the duration of settlement.
 - **Risk: sidebar-local pager accidentally moves fixed shell regions.** → Keep command input, the bottom space switcher, sidebar chrome, traffic lights, and the terminal workspace outside the moving page.
+- **Risk: swipe velocity makes one gesture skip multiple spaces.** → Clamp visual drag to one page plus a small overdrag gap and keep commit targets limited to the immediate previous or next space.
 - **Risk: gesture axis arbitration regresses vertical sidebar scrolling.** → Preserve the existing intent lock behavior and add tests for undecided, vertical, phaseful, phase-less, momentum, and fast flick paths.
 
 ## Migration Plan

--- a/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/manual-verification.md
@@ -14,6 +14,18 @@ Date: 2026-05-15
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath target/xcode-derived build` passed. Xcode still printed CoreSimulator availability warnings, but the macOS build completed successfully.
 - `git diff --check` passed.
 
+Additional 2026-05-16 automated verification after adding the unified sidebar
+presentation model:
+
+- `clients/apple/scripts/test-shell-sidebar-presentation.sh` passed with focused coverage for pinned, collapsed, floating, and floating-to-pinned morph snapshots.
+- `clients/apple/scripts/test-shell-window-placement.sh` passed.
+- `clients/apple/scripts/test-shell-runtime-metadata.sh` passed.
+- `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh` passed.
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `openspec validate refine-macos-sidebar-interactions --strict` passed.
+- `git diff --check` passed.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath target/xcode-derived-sidebar-presentation CODE_SIGNING_ALLOWED=NO build` passed. Xcode still printed CoreSimulator availability warnings, but the macOS build completed successfully.
+
 ## Manual Visual Verification Status
 
 - Pinned sidebar collapse/expand: not performed in this run.
@@ -22,6 +34,7 @@ Date: 2026-05-15
 - Space click persistence: not performed in this run.
 - Sidebar-local space swipe pager motion: not performed in this run.
 - Visible-frame-zoomed collapsed-sidebar left-edge retention: covered by focused AppKit geometry tests; live visual verification not performed in this run.
+- Floating-to-pinned morph: covered by focused presentation-model tests for one visible surface and no hidden/offscreen/duplicated intermediate frame; live visual verification not performed in this run.
 
 The remaining human acceptance work is to launch the built app and visually verify those five interactions in the macOS shell. In particular, confirm that sidebar-local swipe motion moves only the active-space header and tab list while the command launcher, bottom space dock, sidebar chrome, traffic lights, and terminal workspace remain fixed.
 

--- a/openspec/changes/refine-macos-sidebar-interactions/proposal.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-The macOS sidebar currently feels unreliable and physically inconsistent: tab and space selection can flash back to the previously focused terminal, pinned-sidebar collapse is not a coordinated motion, and horizontal space swipes need a continuous sidebar-local content pager instead of discontinuous source/target preview behavior.
+The macOS sidebar currently feels unreliable and physically inconsistent: tab and space selection can flash back to the previously focused terminal, pinned-sidebar collapse is not a coordinated motion, pinning a revealed floating sidebar can appear to hide before expanding, and horizontal space swipes need a continuous sidebar-local content pager instead of discontinuous source/target preview behavior.
 
 This change formalizes a focused interaction pass so sidebar navigation, window chrome, and space switching share one authoritative focus and motion contract.
 
 ## What Changes
 
 - Make sidebar tab and space selection authoritative focus transitions: selecting a tab or space updates the shell focused pane through the same shell-state path used by terminal activation.
-- Replace pinned-sidebar insertion/removal with a continuous collapse and expand motion so the sidebar, terminal content inset, titlebar controls, and macOS traffic-light controls move together.
+- Replace pinned-sidebar insertion/removal with a unified sidebar presentation model so pinned, collapsed, floating, and floating-to-pinned morph states drive the sidebar surface, terminal content inset, titlebar controls, and macOS traffic-light controls together.
 - Refine collapsed/floating sidebar chrome timing so traffic lights do not jump, appear ahead of the panel, or linger on the bare window corner.
 - Promote collapsed-sidebar reveal retention from view-local SwiftUI hover to a window-level pointer judgment so a revealed floating sidebar does not hide when the pointer crosses the left resize frame after visible-frame zoom.
 - Replace discontinuous sidebar space swipe behavior with a continuous, sidebar-local content pager over the ordered `ShellSpace` sequence, including edge preview, commit/cancel animation, and terminal focus handoff only after commit.

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -20,6 +20,8 @@ are changed.
 #### Scenario: Pinned sidebar motion reviewed
 - **WHEN** pinned sidebar collapse or expansion behavior changes
 - **THEN** maintainers can inspect automated invariants, screenshots, or manual notes showing that the sidebar surface, workspace inset, titlebar controls, and standard macOS traffic-light controls move as one coordinated transition
+- **AND** verification covers the revealed-floating-sidebar to pinned-sidebar morph and confirms there is no intermediate hidden/offscreen/duplicated sidebar frame
+- **AND** focused checks or contract checks confirm the presentation model, not independent pinned/floating booleans alone, drives the sidebar surface and window chrome values used during that morph
 
 #### Scenario: Floating sidebar chrome reviewed
 - **WHEN** collapsed floating-sidebar reveal or hide behavior changes

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-build-test-contract/spec.md
@@ -13,7 +13,7 @@ are changed.
 
 #### Scenario: Sidebar-local space pager gesture tested
 - **WHEN** horizontal space swipe behavior changes
-- **THEN** focused tests cover undecided-axis buffering, horizontal intent lock, vertical scroll pass-through, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
+- **THEN** focused tests cover undecided-axis buffering, horizontal intent lock, vertical scroll pass-through, stable five-page rendering around the source space, one-page-plus-overdrag drag clamping, edge resistance, commit threshold, cancel threshold, phaseful release, phase-less idle release, and fast flick velocity commit
 - **AND** verification confirms only the sidebar active-space header and tab list move during the gesture
 - **AND** verification confirms the command input, bottom space switcher, sidebar chrome, traffic lights, and workspace terminal surface remain fixed during the gesture
 

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-ui-ux-conformance/spec.md
@@ -55,6 +55,10 @@ motion of the sidebar surface, workspace inset, lightweight sidebar titlebar
 controls, and standard macOS traffic-light controls rather than as independent
 insertions, removals, or frame jumps.
 
+The shell SHALL derive pinned, collapsed, floating, and floating-to-pinned
+sidebar presentation from one presentation model so the visible sidebar surface
+and window chrome share one transition state.
+
 #### Scenario: Sidebar collapses
 - **WHEN** the user hides the pinned sidebar and reduced motion is disabled
 - **THEN** the sidebar surface moves or narrows out with a short, crisp animation
@@ -65,6 +69,18 @@ insertions, removals, or frame jumps.
 - **WHEN** the user pins or expands the sidebar and reduced motion is disabled
 - **THEN** the sidebar surface, terminal workspace inset, lightweight sidebar titlebar controls, and standard macOS traffic-light controls move together with a short, non-dragging animation
 - **AND** the expanded state settles without delayed toolbar drift or terminal content relayout after the visual motion has completed
+
+#### Scenario: Revealed floating sidebar pins without hiding first
+- **WHEN** the sidebar is collapsed, the floating sidebar panel is revealed, and the user chooses Pin Sidebar from that visible panel
+- **THEN** alan morphs the visible floating surface into the pinned sidebar position instead of first hiding the floating panel and then expanding a separate pinned surface
+- **AND** no rendered frame shows the sidebar absent, offscreen, or duplicated between the floating panel and pinned surface
+- **AND** the terminal workspace inset opens continuously during the morph rather than jumping after the panel disappears
+
+#### Scenario: Unified presentation owns chrome during pin morph
+- **WHEN** a revealed floating sidebar is pinning into the pinned layout
+- **THEN** the lightweight titlebar controls and standard macOS traffic-light controls follow the same interpolated sidebar surface origin
+- **AND** traffic lights remain native AppKit controls rather than SwiftUI replicas
+- **AND** the final pinned state clears transient floating reveal state only after the visible morph has settled
 
 #### Scenario: Reduced motion collapse
 - **WHEN** reduced motion is enabled and the pinned sidebar is hidden or shown

--- a/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/specs/macos-shell-workspace-interactions/spec.md
@@ -34,13 +34,17 @@ include only the sidebar's active-space header and active-space tab list. The
 command input, bottom space switcher, sidebar material surface, sidebar chrome,
 macOS traffic-light placement, and workspace terminal surface SHALL remain
 visually fixed while the gesture is active. alan SHALL avoid mutating durable
-shell selection until the gesture commits.
+shell selection until the gesture commits. The pager SHALL keep the current
+space centered in a bounded five-page rendering window: up to two previous
+spaces, the current space, and up to two next spaces.
 
 #### Scenario: Gesture-tracked sidebar content pager
 - **WHEN** a user horizontally swipes inside the sidebar and an adjacent space exists
 - **THEN** the current sidebar space header and tab list move with the gesture while the adjacent space content previews from the side
 - **AND** the space header and tab list use the same full sidebar content page width for horizontal offsets
 - **AND** movement is rendered directly from horizontal finger translation instead of being amplified, quantized, or shaped by the commit threshold
+- **AND** the pager keeps previous, current, and next page slots stable while direction changes instead of replacing the rendered target page based only on current drag sign
+- **AND** visual drag is clamped to one page plus a small overdrag gap that can reveal part of the second adjacent page for physical feedback
 - **AND** the space header pager is not narrowed by row padding or trailing creation controls
 - **AND** the sidebar pager avoids static left or right padding gaps while pages move
 - **AND** the command input remains fixed
@@ -66,6 +70,7 @@ shell selection until the gesture commits.
 - **AND** the sidebar content pager settles smoothly to the committed space without being reverted by concurrent runtime updates
 - **AND** the workspace terminal surface and terminal focus follow the committed space after shell selection commits
 - **AND** release is honored even when the macOS ended or momentum-start event carries zero scroll delta
+- **AND** a single release commits at most the immediately adjacent previous or next space, never multiple spaces
 
 #### Scenario: Cancel preserves focus and layout
 - **WHEN** the user releases a space swipe before the commit threshold

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -14,6 +14,9 @@
 - [x] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
 - [x] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
 - [x] 2.6 Promote collapsed floating-sidebar hide retention to a window-level pointer-region check that includes the left resize frame while preserving native AppKit resize hit-testing.
+- [ ] 2.7 Replace direct boolean branching for pinned/floating sidebar chrome with a unified sidebar presentation model that emits layout progress, visible surface origin, surface treatment, hit-testing role, and `ShellWindowChromeSurface` values.
+- [ ] 2.8 Add a floating-to-pinned morph path so pinning from a revealed collapsed sidebar keeps one visible sidebar surface while opening the pinned layout reservation and moving titlebar/traffic-light chrome with the same presentation snapshot.
+- [ ] 2.9 Add focused model or window-placement coverage proving the floating-to-pinned path has no intermediate hidden, offscreen, or duplicated sidebar frame.
 
 ## 3. Sidebar-local Space Content Pager
 
@@ -34,6 +37,7 @@
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
   - 2026-05-15: macOS Debug build passed with project-local DerivedData and manual verification notes were added in `manual-verification.md`. Live visual interaction was not performed in this run, so this remains unchecked for human acceptance.
 - [x] 4.6 Verify the visible-frame-zoomed collapsed-sidebar case manually or with focused AppKit coverage: reveal the sidebar, move the pointer into the left resize cursor region, confirm the panel remains visible, and confirm native resizing still works.
+- [ ] 4.7 Visually verify or capture evidence that pinning from a revealed collapsed sidebar morphs into the pinned layout without a hide-then-show bounce.
 
 ## 5. OpenSpec And Review Readiness
 

--- a/openspec/changes/refine-macos-sidebar-interactions/tasks.md
+++ b/openspec/changes/refine-macos-sidebar-interactions/tasks.md
@@ -14,9 +14,9 @@
 - [x] 2.4 Preserve collapsed floating-sidebar reveal behavior: narrow edge hover, toolbar-hover retention, stable terminal workspace geometry, and no traffic-light appearance ahead of panel reveal.
 - [x] 2.5 Add or update focused window-placement tests for hidden traffic lights, floating surface origin, pinned motion final frames, and native traffic-light behavior.
 - [x] 2.6 Promote collapsed floating-sidebar hide retention to a window-level pointer-region check that includes the left resize frame while preserving native AppKit resize hit-testing.
-- [ ] 2.7 Replace direct boolean branching for pinned/floating sidebar chrome with a unified sidebar presentation model that emits layout progress, visible surface origin, surface treatment, hit-testing role, and `ShellWindowChromeSurface` values.
-- [ ] 2.8 Add a floating-to-pinned morph path so pinning from a revealed collapsed sidebar keeps one visible sidebar surface while opening the pinned layout reservation and moving titlebar/traffic-light chrome with the same presentation snapshot.
-- [ ] 2.9 Add focused model or window-placement coverage proving the floating-to-pinned path has no intermediate hidden, offscreen, or duplicated sidebar frame.
+- [x] 2.7 Replace direct boolean branching for pinned/floating sidebar chrome with a unified sidebar presentation model that emits layout progress, visible surface origin, surface treatment, hit-testing role, and `ShellWindowChromeSurface` values.
+- [x] 2.8 Add a floating-to-pinned morph path so pinning from a revealed collapsed sidebar keeps one visible sidebar surface while opening the pinned layout reservation and moving titlebar/traffic-light chrome with the same presentation snapshot.
+- [x] 2.9 Add focused model or window-placement coverage proving the floating-to-pinned path has no intermediate hidden, offscreen, or duplicated sidebar frame.
 
 ## 3. Sidebar-local Space Content Pager
 
@@ -36,8 +36,10 @@
 - [x] 4.4 Run focused Apple checks: `clients/apple/scripts/test-shell-runtime-metadata.sh`, `clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`, `clients/apple/scripts/test-shell-window-placement.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.5 Build or run the macOS app and capture manual verification notes or screenshots for pinned collapse/expand, floating reveal/hide, tab click persistence, space click persistence, and space swipe pager motion.
   - 2026-05-15: macOS Debug build passed with project-local DerivedData and manual verification notes were added in `manual-verification.md`. Live visual interaction was not performed in this run, so this remains unchecked for human acceptance.
+  - 2026-05-16: macOS Debug build passed again after adding the unified sidebar presentation model. Live visual interaction was still not performed, so this remains unchecked for human acceptance.
 - [x] 4.6 Verify the visible-frame-zoomed collapsed-sidebar case manually or with focused AppKit coverage: reveal the sidebar, move the pointer into the left resize cursor region, confirm the panel remains visible, and confirm native resizing still works.
 - [ ] 4.7 Visually verify or capture evidence that pinning from a revealed collapsed sidebar morphs into the pinned layout without a hide-then-show bounce.
+  - 2026-05-16: focused model coverage now verifies the morph keeps one visible surface and has no hidden/offscreen/duplicated intermediate frame. Live visual verification or captured evidence is still pending.
 
 ## 5. OpenSpec And Review Readiness
 


### PR DESCRIPTION
## Summary

- Refine the macOS sidebar space swipe into a stable five-page content pager.
- Clamp a single gesture to one page plus a small overdrag gap so it cannot skip multiple spaces.
- Keep window chrome / traffic-light placement synced with animated pinned-sidebar progress.
- Update focused swipe tests, shell contract checks, design notes, and OpenSpec deltas.

## Validation

- `openspec validate refine-macos-sidebar-interactions --strict`
- `openspec validate --all --strict`
- `bash clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `git diff --cached --check`
