### PR TITLE
Fix macOS terminal interaction regressions

### DIFF
--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -597,11 +597,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         title: String? = nil,
         workingDirectory: String? = nil
     ) -> String? {
-        openTab(
+        let resolvedWorkingDirectory = workingDirectory
+            ?? focusedPaneWorkingDirectory()
+        return openTab(
             launchTarget: .shell,
             in: spaceID,
             title: title,
-            workingDirectory: workingDirectory
+            workingDirectory: resolvedWorkingDirectory
         )
     }
 
@@ -805,6 +807,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 processExited: runtimeProcessExited,
                 for: paneID
             )
+            if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: runtimeProcessExited) {
+                return
+            }
             let projectedContext = paneProjection.projectedContext(
                 for: pane,
                 bootProfile: bootProfile,
@@ -865,6 +870,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             processExited: metadataProcessExited,
             for: paneID
         )
+        if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: metadataProcessExited) {
+            return
+        }
         let projectedContext = paneProjection.projectedContext(
             for: pane,
             bootProfile: bootProfile,
@@ -1485,6 +1493,29 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         } catch {
             return .paneNotFound
         }
+    }
+
+    private func focusedPaneWorkingDirectory() -> String? {
+        guard let pane = focusedPane ?? selectedPane else { return nil }
+        let runtimeCwd = runtime(for: pane.paneID).paneMetadata.workingDirectory
+        return nonEmptyWorkingDirectory(runtimeCwd)
+            ?? nonEmptyWorkingDirectory(pane.cwd)
+    }
+
+    private func nonEmptyWorkingDirectory(_ path: String?) -> String? {
+        guard let path else { return nil }
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    @discardableResult
+    private func closePaneAfterChildExitIfNeeded(
+        paneID: String,
+        processExited: Bool
+    ) -> Bool {
+        guard processExited else { return false }
+        guard pane(paneID: paneID) != nil else { return false }
+        return closePane(paneID: paneID) == .closed
     }
 
     func movePane(

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -791,6 +791,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         }
 
         requestTerminalFocus()
+        let inputRoutingDecision = surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event))
+        let shouldInterpretText: Bool
+        if case .terminalText = inputRoutingDecision {
+            shouldInterpretText = true
+        } else {
+            shouldInterpretText = false
+        }
 
         let translationModsGhostty =
             surfaceController.keyTranslationMods(for: modsFromEvent(event))
@@ -839,10 +846,15 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         defer { keyTextAccumulator = nil }
 
         let markedTextBefore = markedText.length > 0
-        interpretKeyEvents([translationEvent])
-        syncPreedit(clearIfNeeded: markedTextBefore)
+        if shouldInterpretText {
+            interpretKeyEvents([translationEvent])
+            syncPreedit(clearIfNeeded: markedTextBefore)
+        }
 
-        if let keyTextAccumulator, !keyTextAccumulator.isEmpty {
+        if shouldInterpretText,
+           let keyTextAccumulator,
+           !keyTextAccumulator.isEmpty
+        {
             keyTextAccumulator.forEach { surfaceController.sendText($0) }
             return
         }

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -870,6 +870,15 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     func updateHostRuntimeSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {}
 
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        guard !currentSnapshot.metadata.processExited else {
+            let result = TerminalRuntimeDeliveryResult.rejected(
+                errorCode: "terminal_child_exited",
+                errorMessage: "The terminal process has exited.",
+                runtimePhase: currentSnapshot.runtimePhase
+            )
+            updateSnapshot(lastDelivery: result)
+            return result
+        }
         deliveredText.append(text)
         let result = deliveryResult
             ?? .accepted(
@@ -878,6 +887,20 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             )
         updateSnapshot(lastDelivery: result)
         return result
+    }
+
+    func markProcessExited(exitCode: Int) {
+        let metadata = TerminalPaneMetadataSnapshot(
+            title: currentSnapshot.metadata.title,
+            workingDirectory: currentSnapshot.metadata.workingDirectory,
+            summary: "process exited",
+            attention: .awaitingUser,
+            processExited: true,
+            lastCommandExitCode: exitCode,
+            lastUpdatedAt: .now,
+            activeTaskState: .inactive
+        )
+        updateSnapshot(metadata: metadata)
     }
 
     @discardableResult
@@ -894,6 +917,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
 
     private func updateSnapshot(
         lifecyclePhase: AlanTerminalSurfaceLifecyclePhase? = nil,
+        metadata: TerminalPaneMetadataSnapshot? = nil,
         lastDelivery: TerminalRuntimeDeliveryResult? = nil,
         teardownStatus: AlanTerminalSurfaceTeardownStatus? = nil,
         attachedViewCount: Int? = nil
@@ -902,7 +926,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             paneID: paneID,
             lifecyclePhase: lifecyclePhase ?? currentSnapshot.lifecyclePhase,
             renderer: currentSnapshot.renderer,
-            metadata: currentSnapshot.metadata,
+            metadata: metadata ?? currentSnapshot.metadata,
             lastDelivery: lastDelivery ?? currentSnapshot.lastDelivery,
             teardownStatus: teardownStatus ?? currentSnapshot.teardownStatus,
             attachedViewCount: attachedViewCount ?? currentSnapshot.attachedViewCount,

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -295,7 +295,7 @@ final class AlanTerminalInputAdapter {
         }
 
         guard input.phase == .down else { return .terminalKey }
-        guard input.modifiers.subtracting([.shift, .option]).isEmpty else {
+        guard input.modifiers.subtracting([.shift]).isEmpty else {
             return .terminalKey
         }
         guard let characters = input.characters, !characters.isEmpty else { return .terminalKey }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -15,12 +15,18 @@ struct ShellRuntimeMetadataTestRunner {
 private enum ShellRuntimeMetadataTests {
     static func run() {
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
-        verifiesSurfaceExitOverridesRunningMetadata()
+        verifiesSurfaceExitClosesFinalPaneWithoutRestarting()
         verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth()
         verifiesPaneTitleBarPrefersTerminalTitle()
         verifiesPaneTitleBarFallbackOrdering()
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
+        verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
+        verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
+        verifiesOpeningTerminalTabHonorsExplicitCwd()
+        verifiesTerminalChildExitClosesSplitPane()
+        verifiesTerminalChildExitClosesSinglePaneTab()
+        verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
         verifiesClosingTabReleasesTerminalRuntime()
         verifiesTabSelectionCommitsAuthoritativeFocus()
         verifiesSpaceSelectionCommitsAuthoritativeFocus()
@@ -94,7 +100,7 @@ private enum ShellRuntimeMetadataTests {
         expect(controller.shellState.spaces.first?.attention == .notable, "space attention must track pane attention")
     }
 
-    private static func verifiesSurfaceExitOverridesRunningMetadata() {
+    private static func verifiesSurfaceExitClosesFinalPaneWithoutRestarting() {
         let controller = makeController()
         guard let pane = controller.selectedPane else {
             fail("bootstrap shell must expose a selected pane")
@@ -144,13 +150,15 @@ private enum ShellRuntimeMetadataTests {
             )
         )
 
-        let updated = controller.shellState.panes.first { $0.paneID == pane.paneID }
         expect(
-            updated?.context?.processState == "exited",
-            "surface child exit must override running metadata in pane context"
+            controller.shellState.pane(paneID: pane.paneID) == nil,
+            "surface child exit must close the owning final pane"
         )
-        expect(updated?.viewport?.summary == "Exited 7", "surface child exit must drive viewport status")
-        expect(updated?.attention == .awaitingUser, "surface child exit must drive pane attention")
+        expect(
+            controller.shellState.spaces.first?.tabs.isEmpty == true,
+            "surface child exit must leave the focused space empty instead of restarting a terminal"
+        )
+        expect(controller.shellState.focusedPaneID == nil, "surface child exit must clear pane focus")
     }
 
     private static func verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth() {
@@ -415,6 +423,78 @@ private enum ShellRuntimeMetadataTests {
             !registry.registeredPaneIDs.contains("pane_2"),
             "opening a tab must release stale runtime-only panes after adopting the new state"
         )
+    }
+
+    private static func verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd() {
+        let controller = makeController()
+        controller.updateTerminalMetadata(metadata(title: "cwd update", cwd: "/repo/app"), for: "pane_1")
+
+        _ = controller.openTerminalTab()
+
+        expect(
+            controller.selectedPane?.cwd == "/repo/app",
+            "new terminal tabs must inherit the focused pane runtime cwd"
+        )
+    }
+
+    private static func verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd() {
+        let windowID = "metadata_snapshot_cwd_\(UUID().uuidString)"
+        let controller = makeController(
+            windowID: windowID,
+            shellState: .bootstrapDefault(windowID: windowID, workingDirectory: "/snapshot/cwd")
+        )
+
+        _ = controller.openTerminalTab()
+
+        expect(
+            controller.selectedPane?.cwd == "/snapshot/cwd",
+            "new terminal tabs must fall back to the focused pane snapshot cwd"
+        )
+    }
+
+    private static func verifiesOpeningTerminalTabHonorsExplicitCwd() {
+        let controller = makeController()
+        controller.updateTerminalMetadata(metadata(title: "cwd update", cwd: "/repo/app"), for: "pane_1")
+
+        _ = controller.openTerminalTab(workingDirectory: "/explicit/cwd")
+
+        expect(
+            controller.selectedPane?.cwd == "/explicit/cwd",
+            "explicit new-tab cwd must override focused pane cwd"
+        )
+    }
+
+    private static func verifiesTerminalChildExitClosesSplitPane() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+
+        controller.updateTerminalMetadata(childExitMetadata(title: "fish", exitCode: 0), for: "pane_2")
+
+        expect(controller.pane(paneID: "pane_2") == nil, "child exit must close the owning split pane")
+        expect(controller.pane(paneID: "pane_1") != nil, "child exit must preserve sibling panes")
+        expect(controller.shellState.focusedPaneID == "pane_1", "child exit must focus the remaining sibling")
+    }
+
+    private static func verifiesTerminalChildExitClosesSinglePaneTab() {
+        let controller = makeController()
+        _ = controller.openTerminalTab(workingDirectory: "/second")
+
+        controller.updateTerminalMetadata(childExitMetadata(title: "fish", exitCode: 0), for: "pane_2")
+
+        expect(controller.shellState.tab(tabID: "tab_2") == nil, "child exit must close the owning single-pane tab")
+        expect(controller.pane(paneID: "pane_1") != nil, "child exit must preserve other tabs")
+        expect(controller.shellState.focusedPaneID == "pane_1", "child exit must move focus to the next valid pane")
+    }
+
+    private static func verifiesTerminalChildExitCanLeaveEmptyFocusedSpace() {
+        let controller = makeController()
+
+        controller.updateTerminalMetadata(childExitMetadata(title: "fish", exitCode: 0), for: "pane_1")
+
+        expect(controller.shellState.spaces.count == 1, "final child exit must keep the focused space")
+        expect(controller.shellState.spaces.first?.tabs.isEmpty == true, "final child exit may leave an empty space")
+        expect(controller.shellState.panes.isEmpty, "final child exit must not restart a replacement pane")
+        expect(controller.shellState.focusedPaneID == nil, "final child exit must clear focused pane")
     }
 
     private static func verifiesClosingTabReleasesTerminalRuntime() {
@@ -766,10 +846,13 @@ private enum ShellRuntimeMetadataTests {
             metadata(title: "done", processExited: true, activeTaskState: .foregroundCommand),
             for: "pane_1"
         )
-        expect(activeTask(in: exitedURL) == .inactive, "exited terminal must not protect tab")
         expect(
-            exitedController.shellState.panes.first?.context?.processState == "exited",
-            "exited metadata must override foreground active-task projection"
+            activeTask(in: exitedURL) == nil,
+            "exited terminal must not protect a tab after lifecycle close removes it"
+        )
+        expect(
+            exitedController.shellState.panes.isEmpty,
+            "exited metadata must close the pane instead of preserving foreground state"
         )
 
         let activeOnlyURL = manifestURL("active_only")
@@ -933,6 +1016,23 @@ private enum ShellRuntimeMetadataTests {
             lastCommandExitCode: nil,
             lastUpdatedAt: Date(timeIntervalSince1970: 3_000),
             activeTaskState: activeTaskState
+        )
+    }
+
+    private static func childExitMetadata(
+        title: String,
+        cwd: String = "/Users/morris/Developer/Alan",
+        exitCode: Int
+    ) -> TerminalPaneMetadataSnapshot {
+        TerminalPaneMetadataSnapshot(
+            title: title,
+            workingDirectory: cwd,
+            summary: "process exited",
+            attention: .awaitingUser,
+            processExited: true,
+            lastCommandExitCode: exitCode,
+            lastUpdatedAt: Date(timeIntervalSince1970: 3_100),
+            activeTaskState: .inactive
         )
     }
 

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -19,6 +19,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
         verifiesDeliveryAndMissingRuntimeResults()
+        verifiesDeliveryRejectsExitedRuntime()
         verifiesQueuedAndTimeoutDeliveryStates()
         verifiesControlResponseCarriesDeliveryDiagnostics()
         verifiesTeardownOnce()
@@ -131,6 +132,18 @@ private enum TerminalRuntimeServiceTests {
         let missing = service.sendText(to: "pane_missing", text: "hello")
         expect(missing.code == .missingTarget, "missing pane must report runtime-missing")
         expect(missing.applied == false, "missing pane must not report applied")
+    }
+
+    private static func verifiesDeliveryRejectsExitedRuntime() {
+        let service = FakeAlanTerminalRuntimeService()
+        let handle = service.surfaceHandle(for: "pane_1", bootProfile: nil) as! FakeAlanTerminalSurfaceHandle
+        handle.markProcessExited(exitCode: 0)
+
+        let rejected = service.sendText(to: "pane_1", text: "after exit")
+
+        expect(rejected.applied == false, "exited runtime delivery must not report applied")
+        expect(rejected.errorCode == "terminal_child_exited", "exited runtime delivery must use stable error code")
+        expect(handle.deliveredText.isEmpty, "exited runtime delivery must not reach the surface")
     }
 
     private static func verifiesQueuedAndTimeoutDeliveryStates() {

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -20,6 +20,7 @@ private enum TerminalSurfaceControllerTests {
         verifiesNativeScrollViewForwardsWheelEvents()
         verifiesNativeScrollViewForwardsMouseEvents()
         verifiesInputCommandRouting()
+        verifiesTUIKeyboardRoutingKeepsTerminalOwnedKeysInTerminal()
         verifiesPointerRoutingFollowsTerminalMouseModes()
         verifiesPointerButtonMappingMatchesGhostty()
         verifiesPaneScopedSearchState()
@@ -204,6 +205,76 @@ private enum TerminalSurfaceControllerTests {
             )
         )
         expect(focusRight == .focusRight, "command-control-right must route to shell focus right")
+    }
+
+    private static func verifiesTUIKeyboardRoutingKeepsTerminalOwnedKeysInTerminal() {
+        let adapter = AlanTerminalInputAdapter()
+
+        let controlWWorkspaceCommand = adapter.routeWorkspaceCommand(
+            AlanTerminalKeyInput(
+                characters: "w",
+                keyCode: 13,
+                modifiers: [.control],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(controlWWorkspaceCommand == nil, "control-w must not be consumed as a workspace command")
+
+        let controlW = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "\u{17}",
+                keyCode: 13,
+                modifiers: [.control],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(controlW == .terminalKey, "control-w must stay a terminal key for Vim split navigation")
+
+        let escape = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "\u{1B}",
+                keyCode: 53,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(escape == .terminalKey, "escape must stay a terminal key for TUI command mode")
+
+        let tab = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "\t",
+                keyCode: 48,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(tab == .terminalKey, "tab must stay a terminal key for TUI focus and completion")
+
+        let optionF = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "f",
+                keyCode: 3,
+                modifiers: [.option],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(optionF == .terminalKey, "option-modified keys must preserve modifier-aware terminal delivery")
+
+        let commandT = adapter.routeWorkspaceCommand(
+            AlanTerminalKeyInput(
+                characters: "t",
+                keyCode: 17,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(commandT == .newTerminalTab, "command-t must remain a native workspace shortcut")
     }
 
     private static func verifiesPointerRoutingFollowsTerminalMouseModes() {

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/.openspec.yaml
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
@@ -1,0 +1,65 @@
+## Context
+
+这次 change 处理的是 macOS shell 的 terminal-first 主路径，而不是新增 shell 功能。现状里相关行为分散在几层：
+
+- `TerminalHostView` 先处理 command input / workspace command / native command，再进入 Ghostty key binding 和 `keyDown` 转译。
+- `ShellHostController.performShellWorkspaceCommand(.newTerminalTab)` 当前直接调用 `openTerminalTab()`，没有把 focused pane 的运行时 cwd 传入。
+- `ShellStateSnapshot.openingTab(...)` 在 `workingDirectory == nil` 时回退到 `defaultShellWorkingDirectory()`，而 split pane 已经从原 pane 继承 cwd。
+- Ghostty 的 `GHOSTTY_ACTION_SHOW_CHILD_EXITED` 已经能把 `processExited` 写入 runtime metadata，但这个信号还没有被提升为用户可理解的 pane/tab 关闭语义。
+
+这三个问题应该作为终端交互回归一起处理，因为它们共享同一个产品边界：终端 host 是活动 pane 的输入和进程生命周期 owner，shell controller 只负责明确的 workspace mutation。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Vim、less、fzf、ssh 等 TUI 在 focused terminal pane 中能稳定接收非 app-reserved 的键盘快捷键。
+- 新建 terminal tab 默认继承当前 focused pane 的最新 cwd，和 split pane 行为一致。
+- shell child 正常退出时关闭对应 pane/tab，或者在不能关闭时进入明确 exited state；不能隐式清屏、重启、刷新成新 shell。
+- 给这三个回归补足 focused tests 或手工验证步骤，能在后续 terminal 改动中复用。
+
+**Non-Goals:**
+
+- 不重做 Ghostty 的键盘编码或 pty 协议。
+- 不改变全局 macOS app 级快捷键，例如 app quit、显式 command input 切换、菜单声明的 `Command-*` workspace 操作。
+- 不恢复旧终端进程；关闭/退出语义只处理当前进程内 runtime 和 shell state。
+- 不改变 workspace manifest 的长期持久化格式，除非实现时发现 cwd 继承需要记录新的 manifest 字段。
+
+## Decisions
+
+1. **终端输入优先走 terminal host，再让明确 app command 截获。**
+
+   Focused pane 的 `TerminalHostView` 应该把非 command-key 的控制键、Escape、Tab、Backspace、功能键、Option/Control 组合键和 Ghostty 识别为 terminal binding 的事件交给 terminal surface。Command input 可见时仍然优先处理自己的 Escape/Return/Command-P；`Command-T`、`Command-W` 等显式 app/workspace command 继续走 native command routing。
+
+   备选方案是继续先跑 workspace/native routing，再对缺失快捷键逐个开洞。这会把 Vim/TUI 支持变成无穷补丁列表，也容易再次截获 `Ctrl-*` 这类终端快捷键。
+
+2. **新建 Tab 的 cwd 由 shell controller 解析，不下沉到 model 的默认值。**
+
+   `ShellHostController` 应在 user/menu/keyboard/control command 的新建 tab 入口解析 cwd：优先使用 focused pane 的 runtime metadata `workingDirectory`，其次使用 pane snapshot `cwd`，最后才使用 workspace default/home。`ShellStateMutations.openingTab(...)` 继续保留显式 `workingDirectory` 和 default fallback，作为低层 mutation 的安全默认。
+
+   备选方案是在 `openingTab(...)` 内部直接读取 focused pane。这样会让纯 model mutation 同时承担 controller/runtime 语义，不利于单元测试，也会让控制平面显式传入 cwd 的行为更难判断。
+
+3. **child exit 是 lifecycle 事件，不是重启触发器。**
+
+   `GHOSTTY_ACTION_SHOW_CHILD_EXITED` 或等价 runtime metadata 应由 `ShellHostController` 观察并转成 pane/tab mutation：split tab 中关闭退出的 pane；单 pane tab 中关闭 tab；如果实现层不能安全关闭最后的可见 shell surface，则保留 exited state 并提供明确的新建/重启入口。任何路径都不能为了保持画面可输入而自动创建新的 shell runtime。
+
+   备选方案是只在 pane UI 上展示 “exited” 状态。它能解释状态，但不符合用户输入 `exit` 后退出当前 pane/tab 的预期；只适合作为最终 pane 或关闭失败时的 fallback。
+
+4. **验证以 fake runtime 和真实 app 手工清单结合。**
+
+   键盘路由可用 fake surface 捕获 normalized key/text delivery；cwd 和 close mutation 可用 shell model/controller 脚本验证；Vim 的真实快捷键和 macOS responder-chain 行为需要运行 app 手工确认，因为问题本身发生在 AppKit/Ghostty 交界。
+
+## Risks / Trade-offs
+
+- [Risk] 放宽 terminal input ownership 可能让部分 workspace 快捷键在 terminal focused 时不再触发。→ 保留显式 app-reserved Command shortcuts，并用测试覆盖 command input 和 terminal binding 的优先级。
+- [Risk] cwd 继承如果只看 stale pane snapshot，`cd` 后新建 tab 仍可能回到旧目录。→ controller 必须优先读取 runtime metadata，再 fallback 到 `ShellPane.cwd`。
+- [Risk] child exit 自动关闭 pane/tab 可能误关正在展示退出信息的任务。→ 只对 shell child exited 的 terminal lifecycle 信号生效；如果关闭会违反 final-pane 保护，则进入明确 exited state。
+- [Risk] 真实 Vim 行为很难完全自动化。→ 自动化覆盖 key routing contract，手工验证记录覆盖 `vim`/`nvim` 的实际交互。
+
+## Migration Plan
+
+这是运行时行为修复，不需要数据迁移。实现可以分三步提交：先修 keyboard routing，再修 tab cwd 继承，最后接 child exit lifecycle；每一步都更新 focused tests 或手工验证记录。
+
+## Open Questions
+
+- 最后一个 Pane/Tab 收到 `exit` 时，本次实现选择关闭 final pane 并保留 focused empty Space。现有 shell model 已支持 empty Space，因此不需要保留一个 exited pane 作为默认 fallback。

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/proposal.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+macOS shell 的终端现在还有几类基础交互回归：Vim 等全屏 TUI 无法稳定收到快捷键，新建 Tab 没有继承当前 Pane 的 cwd，shell 输入 `exit` 后也没有关闭对应 Pane 或 Tab。这些行为直接破坏 terminal-first 的主路径，需要用一个独立 OpenSpec change 追踪到可验证修复。
+
+## What Changes
+
+- 修复终端键盘输入透传，确保 Vim 常用快捷键、控制键、Escape/Tab/Backspace、组合修饰键和 IME 之外的原始按键由终端 host 路由到 Ghostty/pty，而不是被 SwiftUI、菜单命令或 command input 截获。
+- 新建 Tab 时继承当前 focused pane 的 cwd，和新建 split pane 的行为保持一致；如果 focused pane 没有有效 cwd，再回退到 workspace default/home。
+- 输入 `exit` 或 shell 子进程正常退出时，Pane/Tab 按用户可理解的终端生命周期关闭或进入明确的 exited 状态，而不是刷新成一个看似被 clear 的新终端。
+- 补充面向 macOS shell 的自动化/手工验证项，覆盖 Vim 快捷键、Tab cwd 继承、单 pane tab exit、split pane exit 和异常退出状态。
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-terminal-lifecycle`: 明确终端键盘事件归 terminal host 所有、shell child exit 必须驱动 pane/tab lifecycle，而不是隐式刷新或重启 runtime。
+- `macos-shell-workspace-interactions`: 明确新建 Tab 的 cwd 继承语义应和 split pane 一致，默认从当前 focused pane 继承。
+- `macos-shell-build-test-contract`: 增加 Vim/TUI 输入透传、Tab cwd 继承和 exit 生命周期的验证要求。
+
+## Impact
+
+- Apple client terminal host/runtime: `TerminalHostView.swift`, `TerminalHostRuntime.swift`, `GhosttyLiveHost.swift`, `TerminalRuntimeRegistry.swift`, `TerminalRuntimeService.swift`, `TerminalSurfaceController.swift`。
+- Apple client shell model/controller: `ShellHostController.swift`, `ShellStateMutations.swift`, `ShellTreeMutations.swift`, `ShellControlPlane.swift`, `ShellSocketServer.swift`。
+- Native command routing: `AlanMacShellCommands.swift`, command input routing, menu/keyboard responder-chain handling。
+- Tests/scripts: `clients/apple/scripts/check-shell-contracts.sh` and focused Swift shell/terminal scripts need覆盖这三个回归场景。

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Terminal interaction regressions have focused verification
+The Apple client SHALL include focused automated tests, shell contract checks,
+or documented manual verification for terminal keyboard delivery, tab cwd
+inheritance, and shell child-exit lifecycle changes.
+
+#### Scenario: TUI keyboard verification
+- **WHEN** terminal input routing is changed
+- **THEN** verification covers Vim or an equivalent TUI receiving Escape, Tab, Backspace, control-key navigation, printable input, and command-mode transitions in a focused terminal pane
+
+#### Scenario: Native command routing verification
+- **WHEN** terminal keyboard routing is changed
+- **THEN** verification covers app-reserved `Command` shortcuts and visible command-input keys so terminal input ownership does not break native macOS commands
+
+#### Scenario: New tab cwd verification
+- **WHEN** terminal tab creation is changed
+- **THEN** verification covers runtime cwd metadata, pane snapshot cwd fallback, explicit control-plane cwd, and default/home fallback
+
+#### Scenario: Exit lifecycle verification
+- **WHEN** child-exit handling is changed
+- **THEN** verification covers `exit` from a split pane, `exit` from a single-pane tab, final-pane fallback behavior, and rejection of later text delivery to an exited runtime

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Terminal keyboard input is terminal-host owned
+The macOS shell host SHALL route keyboard events for the focused terminal pane
+through the terminal host unless a visible alan command surface or an explicit
+app-reserved `Command` shortcut owns that key.
+
+#### Scenario: Vim control key reaches terminal
+- **WHEN** a focused terminal pane is running a TUI such as Vim and no alan command surface is visible
+- **THEN** non-`Command` terminal keys such as Escape, Tab, Backspace, `Control-[`, `Control-W`, `Control-F`, and `Control-B` are delivered to the terminal runtime
+- **AND** the shell workspace command router does not consume those keys as pane, tab, or command-input actions
+
+#### Scenario: Ghostty binding wins for focused terminal
+- **WHEN** Ghostty reports that a focused terminal key event is a terminal binding
+- **THEN** alan sends the key event to the terminal runtime instead of treating it as an unresolved native command
+
+#### Scenario: App-reserved command shortcut remains native
+- **WHEN** a focused terminal pane receives an explicit app or workspace `Command` shortcut such as New Terminal Tab or Close Tab
+- **THEN** alan executes the native workspace command and does not send that shortcut as terminal text
+
+#### Scenario: Visible command surface owns its own keys
+- **WHEN** alan's command input is visible while a terminal pane is focused
+- **THEN** command-input keys such as submit, dismiss, and command-input toggle are handled by that surface before terminal delivery
+
+### Requirement: Shell child exit drives pane lifecycle
+The macOS shell host SHALL treat terminal child-process exit as a lifecycle
+event for the owning pane rather than as a request to clear, refresh, or
+implicitly restart the terminal runtime.
+
+#### Scenario: Exit closes split pane
+- **WHEN** a pane in a split tab receives a normal shell child-exit signal from user input such as `exit`
+- **THEN** alan closes only that pane through the normal pane-close path
+- **AND** sibling panes keep their terminal runtime identities, scrollback, cwd, and focus eligibility
+
+#### Scenario: Exit closes single-pane tab
+- **WHEN** the only pane in a tab receives a normal shell child-exit signal and the tab can be closed
+- **THEN** alan closes that tab through the normal tab-close path
+- **AND** focus moves to the shell model's next valid tab or empty-space state
+
+#### Scenario: Final pane cannot close safely
+- **WHEN** the final visible terminal pane receives a shell child-exit signal and closing it would leave the shell in an unsupported state
+- **THEN** alan keeps an explicit exited pane state with terminal input disabled
+- **AND** alan does not create a replacement shell runtime unless the user explicitly starts one
+
+#### Scenario: Final pane closes into empty space
+- **WHEN** the final visible terminal pane receives a shell child-exit signal and the shell model supports an empty focused space
+- **THEN** alan closes the owning pane and tab through the normal close path
+- **AND** the focused space remains available without creating a replacement terminal runtime
+
+#### Scenario: Text delivery after exit is rejected
+- **WHEN** text delivery targets a pane whose child process has exited and no replacement runtime was explicitly started
+- **THEN** the runtime response reports failure with a stable child-exited reason

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: New terminal tabs inherit focused pane cwd
+The macOS shell SHALL create user-requested terminal tabs in the focused pane's
+current working directory unless the caller supplies an explicit working
+directory or no valid focused-pane cwd exists.
+
+#### Scenario: Runtime cwd is current
+- **WHEN** the user invokes New Terminal Tab from a focused pane whose runtime metadata reports cwd `/repo/app`
+- **THEN** the new tab's initial pane starts in `/repo/app`
+- **AND** the new tab's pane snapshot records `/repo/app` as its cwd
+
+#### Scenario: Snapshot cwd is fallback
+- **WHEN** the focused pane has no runtime cwd metadata but its shell pane snapshot records cwd `/repo/app`
+- **THEN** the new terminal tab starts in `/repo/app`
+
+#### Scenario: Explicit cwd wins
+- **WHEN** a control-plane or command path opens a new terminal tab with an explicit cwd `/tmp/work`
+- **THEN** alan starts the new tab in `/tmp/work` even if the focused pane has a different cwd
+
+#### Scenario: Missing focused cwd falls back
+- **WHEN** a new terminal tab is requested and alan cannot resolve a valid cwd from the focused pane or request
+- **THEN** alan falls back to the workspace default working directory or the user's home directory
+
+#### Scenario: Split and tab creation agree
+- **WHEN** a user creates a split pane and a new terminal tab from the same focused pane
+- **THEN** both new terminal runtimes use the same cwd resolution order

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
@@ -1,0 +1,36 @@
+## 1. Reproduction And Baseline
+
+- [ ] 1.1 在当前 macOS app 中复现 Vim 快捷键问题，记录被截获的具体按键、focused pane、command input 可见状态和相关日志。
+- [ ] 1.2 复现新建 split pane 会继承 cwd、New Terminal Tab 不继承 cwd 的差异，记录 runtime metadata cwd 和 `ShellPane.cwd`。
+- [ ] 1.3 复现输入 `exit` 后 pane/tab 未关闭且表现为刷新或 clear 的路径，确认收到的 Ghostty child-exit metadata。
+
+## 2. Terminal Keyboard Routing
+
+- [x] 2.1 梳理 `TerminalHostView` 的 `performKeyEquivalent`、`keyDown`、command input routing、workspace command routing 和 native command routing 优先级。
+- [x] 2.2 调整 focused terminal 的键盘路由，使非 app-reserved 的 Escape、Tab、Backspace、Control/Option 组合键和 Ghostty terminal binding 优先交给 terminal runtime。
+- [x] 2.3 保留 command input 可见时的 submit/dismiss/toggle 行为，以及 `Command-T`、`Command-W` 等明确 native workspace shortcut。
+- [x] 2.4 为 fake terminal surface 或 focused shell contract 增加键盘输入验证，覆盖 Vim/TUI 关键按键和 native command shortcut 非回归。
+
+## 3. New Tab Cwd Inheritance
+
+- [x] 3.1 在 `ShellHostController` 中增加 focused-pane cwd 解析路径，优先使用 runtime metadata `workingDirectory`，再 fallback 到 `ShellPane.cwd`。
+- [x] 3.2 让 user/menu/keyboard 发起的 New Terminal Tab 使用 resolved focused cwd；保留 control-plane 显式 cwd 覆盖语义。
+- [x] 3.3 确认 New alan Tab 是否应共享同一 cwd 解析 helper；本次只改 New Terminal Tab，New alan Tab 保持原行为。
+- [x] 3.4 增加 focused model/controller 测试，覆盖 runtime cwd、snapshot cwd、explicit cwd 和 default/home fallback。
+
+## 4. Child Exit Lifecycle
+
+- [x] 4.1 将 Ghostty child-exit metadata 或 runtime snapshot 更新接到 shell controller 的 pane lifecycle 处理路径。
+- [x] 4.2 实现 split pane 中 `exit` 后关闭 owning pane，且不影响 sibling pane runtime identity。
+- [x] 4.3 实现 single-pane tab 中 `exit` 后关闭 owning tab，并把 focus 移到下一个有效 tab 或 empty-space state。
+- [x] 4.4 实现 final-pane 安全行为：关闭 final pane 后保留 focused empty Space，并避免自动重启 runtime。
+- [x] 4.5 增加 text delivery after exit 的失败验证，确保 exited runtime 不再报告 delivery success。
+
+## 5. Verification And Handoff
+
+- [x] 5.1 运行并更新相关 Swift focused scripts 与 `clients/apple/scripts/check-shell-contracts.sh`。
+- [ ] 5.2 构建并运行 macOS app，手工验证 Vim/nvim 的插入、退出、移动、保存/退出等快捷键路径。
+- [ ] 5.3 手工验证同一 cwd 下 split pane 与 New Terminal Tab 的 cwd 一致性。
+- [ ] 5.4 手工验证 split pane、single-pane tab 和 final-pane/fallback 的 `exit` 行为。
+- [x] 5.5 更新实现说明或 verification notes，列出覆盖的按键、cwd 路径、exit 场景和任何剩余限制。
+- [ ] 5.6 实现合入后，将 delta specs 同步到 `openspec/specs/` 并准备 archive。

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
@@ -1,0 +1,28 @@
+## Automated Verification
+
+- `bash clients/apple/scripts/test-terminal-surface-controller.sh`
+  - 覆盖 Escape、Tab、Control-W、Option-F 作为 terminal-owned key 的 routing。
+  - 覆盖 `Command-T` 仍然走 native New Terminal Tab shortcut。
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+  - 覆盖 New Terminal Tab 继承 focused runtime cwd。
+  - 覆盖 snapshot cwd fallback。
+  - 覆盖 explicit cwd override。
+  - 覆盖 split pane child exit、single-pane tab child exit、final pane child exit into empty focused Space。
+- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
+  - 覆盖 exited runtime 的 text delivery 使用 `terminal_child_exited` 失败码，且不会把 text 送到 surface。
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+  - 覆盖 shell contract 静态检查。
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-derived-data build`
+  - Debug build succeeded. The first build attempt without `-derivedDataPath` failed because the sandbox could not write `~/Library/Developer/Xcode/DerivedData`.
+
+## Manual Verification Pending
+
+用户将自行验证当前运行中的 alan app：
+
+- Vim/nvim 中 Escape、Tab、Backspace、Control-W、Control-F、Control-B、Option-modified navigation 是否正常进入 terminal。
+- 在 pane 中 `cd` 后新建 Terminal Tab 是否继承当前 cwd。
+- split pane、single-pane tab、final pane 中输入 `exit` 后是否关闭 owning pane/tab，且不会 clear/restart 成新 terminal。
+
+## Implementation Boundary
+
+本次只改变 New Terminal Tab 的 cwd 继承。New alan Tab 暂时保持原行为，避免把 terminal bugfix 扩大为 agent tab 启动语义变更。


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for the macOS terminal interaction regressions.
- Route terminal-owned modifier keys through Ghostty instead of AppKit text interpretation so TUI/Vim shortcuts are preserved.
- Inherit focused terminal cwd for New Terminal Tab and convert terminal child-exit metadata into pane/tab close lifecycle.
- Extend focused Swift scripts for keyboard routing, cwd inheritance, child-exit lifecycle, and exited-runtime delivery rejection.

## Test Plan
- [x] openspec validate fix-macos-terminal-interaction-regressions --strict
- [x] bash clients/apple/scripts/test-terminal-surface-controller.sh
- [x] bash clients/apple/scripts/test-shell-runtime-metadata.sh
- [x] bash clients/apple/scripts/test-terminal-runtime-service.sh
- [x] bash clients/apple/scripts/check-shell-contracts.sh
- [x] xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-derived-data build

## Notes
- Live app verification for Vim/nvim, cwd inheritance, and exit behavior is left as manual follow-up after restarting Alan, per local handoff.