### PR TITLE
Fix macOS terminal lifecycle and IME routing

### DIFF
--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -9,6 +9,7 @@ import QuartzCore
 final class AlanGhosttyLiveHost: NSObject {
     var onDiagnosticsChange: ((TerminalRendererSnapshot) -> Void)?
     var onMetadataChange: ((TerminalPaneMetadataSnapshot) -> Void)?
+    var onCloseRequest: ((Bool) -> Void)?
     var onSearchUpdate: ((AlanTerminalSearchEngineUpdate) -> Void)?
     var onScrollbackUpdate: ((AlanTerminalScrollbackMetrics) -> Void)?
 
@@ -30,6 +31,7 @@ final class AlanGhosttyLiveHost: NSObject {
     private var diagnostics = TerminalRendererSnapshot.placeholder
     private var metadata = TerminalPaneMetadataSnapshot.placeholder
     private let terminalModeTracker = AlanTerminalModeTracker()
+    private var didEmitNonConfirmingCloseRequest = false
 
     private enum KeyCode {
         static let returnKey: UInt32 = 36
@@ -275,8 +277,9 @@ final class AlanGhosttyLiveHost: NSObject {
         runtimeConfig.write_clipboard_cb = { _, location, content, len, _ in
             AlanGhosttyLiveHost.writeClipboard(location: location, content: content, len: len)
         }
-        runtimeConfig.close_surface_cb = { userdata, _ in
-            AlanGhosttyLiveHost.from(userdata)?.teardownSurface()
+        runtimeConfig.close_surface_cb = { userdata, processAlive in
+            AlanGhosttyLiveHost.from(userdata)?
+                .handleSurfaceCloseRequest(processAlive: processAlive)
         }
 
         guard let primaryConfig = makePrimaryConfig() else {
@@ -354,6 +357,7 @@ final class AlanGhosttyLiveHost: NSObject {
 
         teardownSurface()
         didEmitFirstRefresh = false
+        didEmitNonConfirmingCloseRequest = false
         terminalModeTracker.reset()
 
         transition(
@@ -518,7 +522,30 @@ final class AlanGhosttyLiveHost: NSObject {
         tickScheduleLock.unlock()
     }
 
-    private func teardownSurface() {
+    private func handleSurfaceCloseRequest(processAlive: Bool) {
+        performOnMain {
+            self.updateMetadata(
+                summary: processAlive ? "surface close requested" : "process exited",
+                attention: .awaitingUser,
+                processExited: !processAlive,
+                activeTaskState: processAlive ? self.metadata.activeTaskState : .inactive
+            )
+            self.emitCloseRequest(requiresConfirmation: processAlive)
+
+            guard !processAlive else { return }
+            self.teardownSurface(preservingMetadata: true)
+        }
+    }
+
+    private func emitCloseRequest(requiresConfirmation: Bool) {
+        if !requiresConfirmation {
+            guard !didEmitNonConfirmingCloseRequest else { return }
+            didEmitNonConfirmingCloseRequest = true
+        }
+        onCloseRequest?(requiresConfirmation)
+    }
+
+    private func teardownSurface(preservingMetadata: Bool = false) {
         if let surface {
             ghostty_surface_free(surface)
             self.surface = nil
@@ -540,6 +567,7 @@ final class AlanGhosttyLiveHost: NSObject {
             )
         }
 
+        guard !preservingMetadata else { return }
         updateMetadata(
             summary: app == nil ? nil : "surface released",
             attention: .idle,

--- a/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
@@ -11,6 +11,7 @@ struct TerminalHostView: NSViewRepresentable {
     let activationDelegate: TerminalHostActivationDelegate?
     let onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?
     let onCommandInput: (() -> Void)?
+    let onCloseRequest: ((Bool) -> Void)?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
 
@@ -22,6 +23,7 @@ struct TerminalHostView: NSViewRepresentable {
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
             onCommandInput: onCommandInput,
+            onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
@@ -36,6 +38,7 @@ struct TerminalHostView: NSViewRepresentable {
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
             onCommandInput: onCommandInput,
+            onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -20,6 +20,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private weak var activationDelegate: TerminalHostActivationDelegate?
     private var workspaceCommandHandler: ((ShellWorkspaceCommand) -> Void)?
     private var commandInputHandler: (() -> Void)?
+    private var closeRequestHandler: ((Bool) -> Void)?
     private var runtimeObserver: ((TerminalHostRuntimeSnapshot) -> Void)?
     private var metadataObserver: ((TerminalPaneMetadataSnapshot) -> Void)?
     private var rendererSnapshot: TerminalRendererSnapshot = .placeholder
@@ -134,6 +135,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onCommandInput: (() -> Void)?,
+        onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
@@ -147,6 +149,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         self.activationDelegate = activationDelegate
         workspaceCommandHandler = onWorkspaceCommand
         commandInputHandler = onCommandInput
+        closeRequestHandler = onCloseRequest
         runtimeObserver = onRuntimeUpdate
         metadataObserver = onMetadataUpdate
 
@@ -305,9 +308,21 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
                 reportMetadataIfNeeded(snapshot)
                 syncOverlayVisibility()
                 publishRuntimeSnapshot()
+            },
+            onCloseRequest: { [weak self] requiresConfirmation in
+                self?.reportCloseRequest(requiresConfirmation: requiresConfirmation)
             }
         )
 #endif
+    }
+
+    private func reportCloseRequest(requiresConfirmation: Bool) {
+        guard let closeRequestHandler else { return }
+        let paneID = pane?.paneID
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.pane?.paneID == paneID else { return }
+            closeRequestHandler(requiresConfirmation)
+        }
     }
 
     private func syncNativeScrollback() {
@@ -792,12 +807,6 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         requestTerminalFocus()
         let inputRoutingDecision = surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event))
-        let shouldInterpretText: Bool
-        if case .terminalText = inputRoutingDecision {
-            shouldInterpretText = true
-        } else {
-            shouldInterpretText = false
-        }
 
         let translationModsGhostty =
             surfaceController.keyTranslationMods(for: modsFromEvent(event))
@@ -846,34 +855,61 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         defer { keyTextAccumulator = nil }
 
         let markedTextBefore = markedText.length > 0
+        let shouldInterpretText = surfaceController.inputAdapter.shouldInterpretTextInput(
+            inputRoutingDecision,
+            hasMarkedText: markedTextBefore
+        )
         if shouldInterpretText {
             interpretKeyEvents([translationEvent])
             syncPreedit(clearIfNeeded: markedTextBefore)
         }
+        let composing = markedText.length > 0 || markedTextBefore
+        let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         if shouldInterpretText,
            let keyTextAccumulator,
            !keyTextAccumulator.isEmpty
         {
-            keyTextAccumulator.forEach { surfaceController.sendText($0) }
+            for text in keyTextAccumulator {
+                guard !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+                    text,
+                    composing: composing
+                ) else {
+                    continue
+                }
+
+                if markedTextBefore {
+                    sendCommittedPreeditText(text, action: action)
+                } else {
+                    surfaceController.sendText(text)
+                }
+            }
+
+            if markedTextBefore, shouldReplayCommittedPreeditKey(translationEvent) {
+                sendGhosttyKeyEvent(
+                    for: event,
+                    action: action,
+                    translationMods: translationMods,
+                    composing: false
+                )
+            }
             return
         }
 
-        var keyEvent = ghosttyKeyEvent(
-            for: event,
-            action: event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS,
-            translationMods: translationMods
-        )
-        keyEvent.composing = markedText.length > 0 || markedTextBefore
-
-        if let text = textForKeyEvent(translationEvent), shouldSendText(text) {
-            text.withCString { cString in
-                keyEvent.text = cString
-                _ = surfaceController.sendKey(keyEvent)
-            }
-        } else {
-            _ = surfaceController.sendKey(keyEvent)
+        if AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+            event.characters,
+            composing: composing
+        ) {
+            return
         }
+
+        sendGhosttyKeyEvent(
+            for: event,
+            action: action,
+            translationMods: translationMods,
+            textEvent: translationEvent,
+            composing: composing
+        )
 #else
         super.keyDown(with: event)
 #endif
@@ -963,6 +999,64 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         keyEvent.composing = false
         keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
         return keyEvent
+    }
+
+    @discardableResult
+    private func sendGhosttyKeyEvent(
+        for event: NSEvent,
+        action: ghostty_input_action_e,
+        translationMods: NSEvent.ModifierFlags,
+        textEvent: NSEvent? = nil,
+        composing: Bool
+    ) -> Bool {
+        var keyEvent = ghosttyKeyEvent(
+            for: event,
+            action: action,
+            translationMods: translationMods
+        )
+        keyEvent.composing = composing
+
+        if let textEvent,
+           let text = textForKeyEvent(textEvent),
+           shouldSendText(text)
+        {
+            return text.withCString { cString in
+                keyEvent.text = cString
+                return surfaceController.sendKey(keyEvent)
+            }
+        }
+
+        return surfaceController.sendKey(keyEvent)
+    }
+
+    private func sendCommittedPreeditText(
+        _ text: String,
+        action: ghostty_input_action_e
+    ) {
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = action
+        keyEvent.keycode = 0
+        keyEvent.mods = GHOSTTY_MODS_NONE
+        keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+        keyEvent.text = nil
+        keyEvent.composing = false
+        keyEvent.unshifted_codepoint = 0
+
+        text.withCString { cString in
+            keyEvent.text = cString
+            _ = surfaceController.sendKey(keyEvent)
+        }
+    }
+
+    private func shouldReplayCommittedPreeditKey(_ event: NSEvent) -> Bool {
+        switch event.keyCode {
+        case 0x7C, 0x7D, 0x7E:
+            return true
+        case 0x7B:
+            return !event.modifierFlags.isDisjoint(with: [.shift, .control, .option, .command])
+        default:
+            return false
+        }
     }
 
     private func unshiftedCodepointFromEvent(_ event: NSEvent) -> UInt32 {
@@ -1102,7 +1196,12 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return
         }
 
+        let wasComposing = markedText.length > 0
         unmarkText()
+        guard !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+            characters,
+            composing: wasComposing
+        ) else { return }
 
         if var keyTextAccumulator {
             keyTextAccumulator.append(characters)

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -632,6 +632,10 @@ private struct ShellTerminalLeafView: View {
                     activationDelegate: activationDelegate,
                     onWorkspaceCommand: onWorkspaceCommand,
                     onCommandInput: onCommandInput,
+                    onCloseRequest: { requiresConfirmation in
+                        guard !requiresConfirmation else { return }
+                        onClosePane()
+                    },
                     onRuntimeUpdate: onRuntimeUpdate,
                     onMetadataUpdate: onMetadataUpdate
                 )

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -57,6 +57,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onCommandInput: (() -> Void)?,
+        onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
@@ -88,6 +89,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             activationDelegate: activationDelegate,
             onWorkspaceCommand: onWorkspaceCommand,
             onCommandInput: onCommandInput,
+            onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -297,7 +297,8 @@ protocol AlanTerminalSurfaceHandle: AnyObject {
         to canvasView: NSView,
         focused: Bool,
         onDiagnosticsChange: @escaping (TerminalRendererSnapshot) -> Void,
-        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void
+        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void,
+        onCloseRequest: @escaping (Bool) -> Void
     )
     func detach()
     func updateHostRuntimeSnapshot(_ snapshot: TerminalHostRuntimeSnapshot)
@@ -379,7 +380,8 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         to canvasView: NSView,
         focused: Bool,
         onDiagnosticsChange: @escaping (TerminalRendererSnapshot) -> Void,
-        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void
+        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void,
+        onCloseRequest: @escaping (Bool) -> Void
     ) {
         guard currentSnapshot.teardownStatus != .completed else {
             onDiagnosticsChange(currentSnapshot.renderer)
@@ -431,6 +433,9 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
             guard let self else { return }
             updateSnapshot(metadata: metadata)
             onMetadataChange(metadata)
+        }
+        liveHost.onCloseRequest = { requiresConfirmation in
+            onCloseRequest(requiresConfirmation)
         }
         liveHost.attach(to: canvasView, bootProfile: bootProfile, focused: focused)
         updateSnapshot(
@@ -830,6 +835,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     var ready = true
     private var searchUpdateHandler: ((AlanTerminalSearchEngineUpdate) -> Void)?
     private var scrollbackUpdateHandler: ((AlanTerminalScrollbackMetrics) -> Void)?
+    private var closeRequestHandler: ((Bool) -> Void)?
     private var currentSnapshot: AlanTerminalSurfaceSnapshot
 
     init(paneID: String) {
@@ -854,9 +860,11 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
         to canvasView: NSView,
         focused: Bool,
         onDiagnosticsChange: @escaping (TerminalRendererSnapshot) -> Void,
-        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void
+        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void,
+        onCloseRequest: @escaping (Bool) -> Void
     ) {
         attachCount += 1
+        closeRequestHandler = onCloseRequest
         updateSnapshot(lifecyclePhase: .attached, attachedViewCount: 1)
         onDiagnosticsChange(currentSnapshot.renderer)
         onMetadataChange(currentSnapshot.metadata)
@@ -864,6 +872,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
 
     func detach() {
         detachCount += 1
+        closeRequestHandler = nil
         updateSnapshot(attachedViewCount: 0)
     }
 
@@ -901,6 +910,10 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             activeTaskState: .inactive
         )
         updateSnapshot(metadata: metadata)
+    }
+
+    func requestClose(requiresConfirmation: Bool) {
+        closeRequestHandler?(requiresConfirmation)
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -223,6 +223,33 @@ enum AlanTerminalInputRoutingDecision: Equatable {
 
 @MainActor
 final class AlanTerminalInputAdapter {
+    func shouldInterpretTextInput(
+        _ decision: AlanTerminalInputRoutingDecision,
+        hasMarkedText: Bool
+    ) -> Bool {
+        switch decision {
+        case .terminalText:
+            return true
+        case .terminalKey:
+            return hasMarkedText
+        case .nativeCommand, .ignored:
+            return false
+        }
+    }
+
+    static func shouldSuppressComposingControlInput(
+        _ text: String?,
+        composing: Bool
+    ) -> Bool {
+        guard composing, let text else { return false }
+        let scalars = text.unicodeScalars
+        guard let scalar = scalars.first,
+              scalars.index(after: scalars.startIndex) == scalars.endIndex else {
+            return false
+        }
+        return scalar.value < 0x20 || scalar.value == 0x7F
+    }
+
     func routeWorkspaceCommand(_ input: AlanTerminalKeyInput) -> ShellWorkspaceCommand? {
         guard input.phase == .down, !input.isRepeat else { return nil }
 
@@ -309,6 +336,7 @@ final class AlanTerminalInputAdapter {
         }
         return .terminalText(characters)
     }
+
 }
 
 enum AlanTerminalPointerPhase: Equatable {
@@ -854,7 +882,8 @@ final class AlanTerminalSurfaceController {
         bootProfile: AlanShellBootProfile?,
         focused: Bool,
         onDiagnosticsChange: @escaping (TerminalRendererSnapshot) -> Void,
-        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void
+        onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void,
+        onCloseRequest: @escaping (Bool) -> Void
     ) {
         surfaceHandle?.configure(bootProfile: bootProfile)
         surfaceHandle?.attach(
@@ -869,7 +898,8 @@ final class AlanTerminalSurfaceController {
                 guard let self else { return }
                 latestMetadata = metadata
                 onMetadataChange(metadata)
-            }
+            },
+            onCloseRequest: onCloseRequest
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -20,6 +20,7 @@ final class AlanTerminalHostNSView: NSView {
         activationDelegate: TerminalHostActivationDelegate?,
         onWorkspaceCommand: ((ShellWorkspaceCommand) -> Void)?,
         onCommandInput: (() -> Void)?,
+        onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {}

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -532,6 +532,7 @@ private enum ShellRuntimeMetadataTests {
             activationDelegate: nil,
             onWorkspaceCommand: nil,
             onCommandInput: nil,
+            onCloseRequest: nil,
             onRuntimeUpdate: { _ in },
             onMetadataUpdate: { _ in }
         )
@@ -569,6 +570,7 @@ private enum ShellRuntimeMetadataTests {
             activationDelegate: nil,
             onWorkspaceCommand: nil,
             onCommandInput: nil,
+            onCloseRequest: nil,
             onRuntimeUpdate: { _ in },
             onMetadataUpdate: { _ in }
         )

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -21,12 +21,14 @@ private enum TerminalSurfaceControllerTests {
         verifiesNativeScrollViewForwardsMouseEvents()
         verifiesInputCommandRouting()
         verifiesTUIKeyboardRoutingKeepsTerminalOwnedKeysInTerminal()
+        verifiesTextInputInterpretationPolicyPreservesIMEMarkedText()
         verifiesPointerRoutingFollowsTerminalMouseModes()
         verifiesPointerButtonMappingMatchesGhostty()
         verifiesPaneScopedSearchState()
         verifiesSearchActionsReachSurfaceEngine()
         verifiesScrollbackActionsReachSurfaceEngine()
         verifiesBindClearsStaleScrollbackState()
+        verifiesSurfaceCloseRequestIsForwarded()
         verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
         verifiesClipboardDeliveryStates()
         verifiesSelectionCopyAndPasteUseController()
@@ -275,6 +277,79 @@ private enum TerminalSurfaceControllerTests {
             )
         )
         expect(commandT == .newTerminalTab, "command-t must remain a native workspace shortcut")
+    }
+
+    private static func verifiesTextInputInterpretationPolicyPreservesIMEMarkedText() {
+        let adapter = AlanTerminalInputAdapter()
+
+        let backspace = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "\u{7F}",
+                keyCode: 51,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(backspace == .terminalKey, "backspace must remain a terminal-owned key outside IME composition")
+        expect(
+            !adapter.shouldInterpretTextInput(backspace, hasMarkedText: false),
+            "backspace must not go through NSTextInput when no IME marked text exists"
+        )
+        expect(
+            adapter.shouldInterpretTextInput(backspace, hasMarkedText: true),
+            "backspace must go through NSTextInput while IME marked text exists"
+        )
+
+        let printable = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "a",
+                keyCode: 0,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(
+            adapter.shouldInterpretTextInput(printable, hasMarkedText: false),
+            "printable input must still go through NSTextInput"
+        )
+
+        let findCommand = adapter.routeKey(
+            AlanTerminalKeyInput(
+                characters: "f",
+                keyCode: 3,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            )
+        )
+        expect(
+            !adapter.shouldInterpretTextInput(findCommand, hasMarkedText: true),
+            "native command shortcuts must not be reinterpreted as IME text input"
+        )
+
+        expect(
+            AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+                "\u{08}",
+                composing: true
+            ),
+            "raw C0 control input must not leak to the terminal during composition"
+        )
+        expect(
+            AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+                "\u{7F}",
+                composing: true
+            ),
+            "backspace must not leak to the terminal during composition"
+        )
+        expect(
+            !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+                "\u{08}",
+                composing: false
+            ),
+            "raw C0 control input remains terminal-owned outside composition"
+        )
     }
 
     private static func verifiesPointerRoutingFollowsTerminalMouseModes() {
@@ -632,6 +707,28 @@ private enum TerminalSurfaceControllerTests {
             controller.surfaceStateSnapshot.rendererHealth != "failed",
             "rebinding to a new surface must clear stale renderer failure state"
         )
+    }
+
+    private static func verifiesSurfaceCloseRequestIsForwarded() {
+        let controller = AlanTerminalSurfaceController()
+        let handle = FakeAlanTerminalSurfaceHandle(paneID: "pane_1")
+        var closeRequests: [Bool] = []
+
+        controller.bind(surfaceHandle: handle, paneID: "pane_1")
+        controller.attach(
+            to: NSView(),
+            bootProfile: nil,
+            focused: true,
+            onDiagnosticsChange: { _ in },
+            onMetadataChange: { _ in },
+            onCloseRequest: { requiresConfirmation in
+                closeRequests.append(requiresConfirmation)
+            }
+        )
+
+        handle.requestClose(requiresConfirmation: false)
+
+        expect(closeRequests == [false], "surface close requests must be forwarded to the shell owner")
     }
 
     private static func verifiesSurfaceSnapshotEqualityIgnoresTimestamp() {

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
@@ -5,7 +5,7 @@
 - `TerminalHostView` 先处理 command input / workspace command / native command，再进入 Ghostty key binding 和 `keyDown` 转译。
 - `ShellHostController.performShellWorkspaceCommand(.newTerminalTab)` 当前直接调用 `openTerminalTab()`，没有把 focused pane 的运行时 cwd 传入。
 - `ShellStateSnapshot.openingTab(...)` 在 `workingDirectory == nil` 时回退到 `defaultShellWorkingDirectory()`，而 split pane 已经从原 pane 继承 cwd。
-- Ghostty 的 `GHOSTTY_ACTION_SHOW_CHILD_EXITED` 已经能把 `processExited` 写入 runtime metadata，但这个信号还没有被提升为用户可理解的 pane/tab 关闭语义。
+- Ghostty 的 `GHOSTTY_ACTION_SHOW_CHILD_EXITED` 已经能把 `processExited` 写入 runtime metadata，但 Ghostty macOS app 的正确 close 模型不是 metadata-only：`close_surface_cb` 发出 close request，terminal controller 直接从 surface tree 移除对应 node。alan 之前缺少这条从 embedded surface 到 shell controller 的直接 close-request 通道，导致 `exit` 只能依赖 metadata 旁路。
 
 这三个问题应该作为终端交互回归一起处理，因为它们共享同一个产品边界：终端 host 是活动 pane 的输入和进程生命周期 owner，shell controller 只负责明确的 workspace mutation。
 
@@ -29,7 +29,7 @@
 
 1. **终端输入优先走 terminal host，再让明确 app command 截获。**
 
-   Focused pane 的 `TerminalHostView` 应该把非 command-key 的控制键、Escape、Tab、Backspace、功能键、Option/Control 组合键和 Ghostty 识别为 terminal binding 的事件交给 terminal surface。Command input 可见时仍然优先处理自己的 Escape/Return/Command-P；`Command-T`、`Command-W` 等显式 app/workspace command 继续走 native command routing。
+   Focused pane 的 `TerminalHostView` 应该把非 command-key 的控制键、Escape、Tab、Backspace、功能键、Option/Control 组合键和 Ghostty 识别为 terminal binding 的事件交给 terminal surface。IME 组合输入是这个规则的输入法例外：当 AppKit `NSTextInputClient` 已有 marked text 时，Backspace/Ctrl-H 等 control input 必须先交给 `interpretKeyEvents` 更新 preedit，并抑制组合态控制字符漏到 terminal。Command input 可见时仍然优先处理自己的 Escape/Return/Command-P；`Command-T`、`Command-W` 等显式 app/workspace command 继续走 native command routing。
 
    备选方案是继续先跑 workspace/native routing，再对缺失快捷键逐个开洞。这会把 Vim/TUI 支持变成无穷补丁列表，也容易再次截获 `Ctrl-*` 这类终端快捷键。
 
@@ -41,7 +41,7 @@
 
 3. **child exit 是 lifecycle 事件，不是重启触发器。**
 
-   `GHOSTTY_ACTION_SHOW_CHILD_EXITED` 或等价 runtime metadata 应由 `ShellHostController` 观察并转成 pane/tab mutation：split tab 中关闭退出的 pane；单 pane tab 中关闭 tab；如果实现层不能安全关闭最后的可见 shell surface，则保留 exited state 并提供明确的新建/重启入口。任何路径都不能为了保持画面可输入而自动创建新的 shell runtime。
+   `GHOSTTY_ACTION_SHOW_CHILD_EXITED`、Ghostty `close_surface_cb` 中 child 已不活跃的 close request，或等价 runtime metadata 应由 `ShellHostController` 观察并转成 pane/tab mutation：split tab 中关闭退出的 pane；单 pane tab 中关闭 tab。实现应参考 Ghostty macOS 的 `ghosttyCloseSurface -> closeSurface(node, withConfirmation:) -> removeSurfaceNode/closeTab/closeWindow` 模型，让 non-confirming close request 直接驱动 shell close path，而不是只写 metadata 等间接观察。如果实现层不能安全关闭最后的可见 shell surface，则保留 exited state 并提供明确的新建/重启入口。任何路径都不能为了保持画面可输入而自动创建新的 shell runtime，也不能在 controller 观察前把 exited metadata 重置回 running。
 
    备选方案是只在 pane UI 上展示 “exited” 状态。它能解释状态，但不符合用户输入 `exit` 后退出当前 pane/tab 的预期；只适合作为最终 pane 或关闭失败时的 fallback。
 

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
@@ -19,4 +19,4 @@ inheritance, and shell child-exit lifecycle changes.
 
 #### Scenario: Exit lifecycle verification
 - **WHEN** child-exit handling is changed
-- **THEN** verification covers `exit` from a split pane, `exit` from a single-pane tab, final-pane fallback behavior, and rejection of later text delivery to an exited runtime
+- **THEN** verification covers `exit` from a split pane, `exit` from a single-pane tab, final-pane fallback behavior, direct surface close-request forwarding, and rejection of later text delivery to an exited runtime

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
@@ -10,6 +10,13 @@ app-reserved `Command` shortcut owns that key.
 - **THEN** non-`Command` terminal keys such as Escape, Tab, Backspace, `Control-[`, `Control-W`, `Control-F`, and `Control-B` are delivered to the terminal runtime
 - **AND** the shell workspace command router does not consume those keys as pane, tab, or command-input actions
 
+#### Scenario: IME marked text owns composing backspace
+- **WHEN** a focused terminal pane has active AppKit `NSTextInputClient` marked text from a Chinese/Japanese/Korean input method
+- **AND** the user presses Backspace or an equivalent composing control key
+- **THEN** alan lets AppKit `interpretKeyEvents` update or clear the marked text before terminal delivery
+- **AND** alan updates Ghostty preedit state from the resulting marked text
+- **AND** alan MUST NOT forward the composing control character to the terminal as a deletion of already-committed terminal input
+
 #### Scenario: Ghostty binding wins for focused terminal
 - **WHEN** Ghostty reports that a focused terminal key event is a terminal binding
 - **THEN** alan sends the key event to the terminal runtime instead of treating it as an unresolved native command
@@ -36,6 +43,13 @@ implicitly restart the terminal runtime.
 - **WHEN** the only pane in a tab receives a normal shell child-exit signal and the tab can be closed
 - **THEN** alan closes that tab through the normal tab-close path
 - **AND** focus moves to the shell model's next valid tab or empty-space state
+
+#### Scenario: Close-surface after child exit preserves exited metadata
+- **WHEN** Ghostty reports a close-surface callback for a terminal surface whose child process is no longer alive
+- **THEN** alan forwards a non-confirming close request from the surface host to the shell owner
+- **AND** the shell owner closes the owning pane or tab through the normal close path
+- **AND** alan preserves exited runtime metadata long enough for observers to see the terminal lifecycle transition
+- **AND** releasing the Ghostty surface MUST NOT rewrite the pane metadata back to a running state before the controller observes the exit
 
 #### Scenario: Final pane cannot close safely
 - **WHEN** the final visible terminal pane receives a shell child-exit signal and closing it would leave the shell in an unsupported state

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
@@ -8,8 +8,9 @@
 
 - [x] 2.1 梳理 `TerminalHostView` 的 `performKeyEquivalent`、`keyDown`、command input routing、workspace command routing 和 native command routing 优先级。
 - [x] 2.2 调整 focused terminal 的键盘路由，使非 app-reserved 的 Escape、Tab、Backspace、Control/Option 组合键和 Ghostty terminal binding 优先交给 terminal runtime。
-- [x] 2.3 保留 command input 可见时的 submit/dismiss/toggle 行为，以及 `Command-T`、`Command-W` 等明确 native workspace shortcut。
-- [x] 2.4 为 fake terminal surface 或 focused shell contract 增加键盘输入验证，覆盖 Vim/TUI 关键按键和 native command shortcut 非回归。
+- [x] 2.3 修复 IME marked text 场景：组合输入态下 Backspace/Ctrl-H 先进入 `interpretKeyEvents` 更新 preedit，并阻止组合态 control 字符删除已提交 terminal 内容。
+- [x] 2.4 保留 command input 可见时的 submit/dismiss/toggle 行为，以及 `Command-T`、`Command-W` 等明确 native workspace shortcut。
+- [x] 2.5 为 fake terminal surface 或 focused shell contract 增加键盘输入验证，覆盖 Vim/TUI 关键按键、IME composing Backspace 和 native command shortcut 非回归。
 
 ## 3. New Tab Cwd Inheritance
 
@@ -25,6 +26,7 @@
 - [x] 4.3 实现 single-pane tab 中 `exit` 后关闭 owning tab，并把 focus 移到下一个有效 tab 或 empty-space state。
 - [x] 4.4 实现 final-pane 安全行为：关闭 final pane 后保留 focused empty Space，并避免自动重启 runtime。
 - [x] 4.5 增加 text delivery after exit 的失败验证，确保 exited runtime 不再报告 delivery success。
+- [x] 4.6 参考 Ghostty macOS 的 close notification/controller 模型，新增 surface close-request 通道，让 non-confirming close request 直接关闭 owning pane/tab。
 
 ## 5. Verification And Handoff
 

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
@@ -3,6 +3,8 @@
 - `bash clients/apple/scripts/test-terminal-surface-controller.sh`
   - 覆盖 Escape、Tab、Control-W、Option-F 作为 terminal-owned key 的 routing。
   - 覆盖 `Command-T` 仍然走 native New Terminal Tab shortcut。
+  - 覆盖 Backspace 在非组合态仍是 terminal-owned key，但 IME marked text 存在时会进入 `NSTextInputClient`/`interpretKeyEvents`，并抑制组合态 Backspace/Ctrl-H control 字符漏到 terminal。
+  - 覆盖 surface handle 的 close request 会被 `TerminalSurfaceController` 转发给 shell owner。
 - `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
   - 覆盖 New Terminal Tab 继承 focused runtime cwd。
   - 覆盖 snapshot cwd fallback。
@@ -14,14 +16,18 @@
   - 覆盖 shell contract 静态检查。
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-derived-data build`
   - Debug build succeeded. The first build attempt without `-derivedDataPath` failed because the sandbox could not write `~/Library/Developer/Xcode/DerivedData`.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build`
+  - Debug build succeeded after the close-surface callback fix. Xcode still printed CoreSimulator/log-permission noise, but the macOS target completed with `BUILD SUCCEEDED`.
 
 ## Manual Verification Pending
 
 用户将自行验证当前运行中的 alan app：
 
 - Vim/nvim 中 Escape、Tab、Backspace、Control-W、Control-F、Control-B、Option-modified navigation 是否正常进入 terminal。
+- 中文/日文/韩文输入法组合输入中，Backspace 是否删除 marked text，而不是删除已提交 terminal 内容或无响应。
 - 在 pane 中 `cd` 后新建 Terminal Tab 是否继承当前 cwd。
 - split pane、single-pane tab、final pane 中输入 `exit` 后是否关闭 owning pane/tab，且不会 clear/restart 成新 terminal。
+- 如果旧运行中 app 仍表现为 clear/restart，重启到包含 Ghostty-style close-request 通道和 close-surface callback fix 的 build 后再验证；旧 build 只处理了 `SHOW_CHILD_EXITED`/runtime metadata 路径，漏掉了真实 close request 观测路径。
 
 ## Implementation Boundary
 


### PR DESCRIPTION
## 摘要
- 修复 IME 组合输入态下 Backspace/Ctrl-H 的路由：先交给 NSTextInput 更新 marked text，避免删除已提交的 terminal 内容。
- 参考 Ghostty macOS 的 close-surface 模型，新增 surface close-request 通道，让 `exit` 后的 non-confirming close request 直接关闭 owning pane/tab。
- 更新 OpenSpec change 和 Apple 侧测试，覆盖键盘路由、surface close request 转发、cwd/exit 生命周期合同。

## 验证
- [x] bash clients/apple/scripts/test-terminal-surface-controller.sh
- [x] bash clients/apple/scripts/test-terminal-runtime-service.sh
- [x] bash clients/apple/scripts/test-shell-runtime-metadata.sh
- [x] bash clients/apple/scripts/check-shell-contracts.sh
- [x] openspec validate fix-macos-terminal-interaction-regressions --strict
- [x] git diff --check
- [x] xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-macos-derived-data build
- [x] just install