### PR TITLE
Capitalize Alan macOS app brand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ just fmt         # Format code
 just lint        # Clippy lints
 just serve       # Run the daemon
 just build       # Release build
-just install     # Install signed release alan.app and PATH-visible CLI/TUI links
+just install     # Install signed release Alan.app and PATH-visible CLI/TUI links
 just release-check # Check release signing/notarization setup without building
 just release     # Build, sign, notarize, staple, and archive the public macOS release app
 just uninstall   # Remove the local app install and alan-owned CLI/TUI links
@@ -887,7 +887,7 @@ alan
 alan-tui
 ```
 
-The signed `alan.app` bundle embeds both command-line tools under
+The signed `Alan.app` bundle embeds both command-line tools under
 `Contents/Resources/bin`. Homebrew links those embedded tools into its prefix.
 For a direct app install, use **Tools > Install Command Line Tools...** in the
 app to create PATH-visible symlinks. `~/.alan/bin` is not a supported

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ just build
 
 ### Installation
 
-The supported macOS distribution is app-first. The signed `alan.app` bundle
+The supported macOS distribution is app-first. The signed `Alan.app` bundle
 contains the `alan` CLI and `alan-tui` executable under
 `Contents/Resources/bin`.
 
@@ -224,7 +224,7 @@ creates or refreshes the notary keychain profile automatically before
 submitting the release artifact.
 
 Homebrew links the embedded `alan` and `alan-tui` binaries into its prefix.
-When installing `alan.app` directly, use **Tools > Install Command Line
+When installing `Alan.app` directly, use **Tools > Install Command Line
 Tools...** in the app to create PATH-visible symlinks. `~/.alan/bin` is not a
 supported install location.
 

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -1,8 +1,8 @@
-# alan for macOS
+# Alan for macOS
 
 `clients/apple` is alan's native Apple client project, supporting macOS and iOS.
 
-The macOS path is alan for macOS: a real terminal workspace whose terminal
+The macOS path is Alan for macOS: a real terminal workspace whose terminal
 state is readable and operable by both humans and agents.
 
 ## System Requirements
@@ -119,7 +119,7 @@ surface uses the stable `window_main` identity, so reopen, activation, and New
 Window commands focus the existing alan window instead of creating another
 control plane. Older fixed `shell-state-v0.1.json` files are not loaded; the
 current persisted state file is scoped as `shell-state-window_main.json`.
-During the rename, alan for macOS reads existing shell state from the historical
+During the rename, Alan for macOS reads existing shell state from the historical
 `Application Support/AlanNative` directory when the new
 `Application Support/alan-macos` file is missing, then writes future state only
 to `Application Support/alan-macos`. No destructive migration is performed.
@@ -146,7 +146,7 @@ for your terminal on first use.
 
 ### Desktop (macOS)
 
-- alan for macOS root with Arc-like sidebar/workspace chrome
+- Alan for macOS root with Arc-like sidebar/workspace chrome
 - Local typed shell snapshot preview
 - Native AppKit terminal-host scaffold sized and focused by the shell host
 - Plain-shell-first boot profile projection for the selected pane, with alan as

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0000000000000000000000F1 /* alan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = alan.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0000000000000000000000F1 /* Alan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alan.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		000000000000000000000101 /* AlanApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlanApp.swift; sourceTree = "<group>"; };
 		000000000000000000000102 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ContentView.swift; sourceTree = "<group>"; };
 		000000000000000000000103 /* AlanAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Daemon/AlanAPIClient.swift; sourceTree = "<group>"; };
@@ -322,7 +322,7 @@
 		000000000000000000000303 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0000000000000000000000F1 /* alan.app */,
+				0000000000000000000000F1 /* Alan.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -345,7 +345,7 @@
 			);
 			name = alan-macos;
 			productName = alan-macos;
-			productReference = 0000000000000000000000F1 /* alan.app */;
+			productReference = 0000000000000000000000F1 /* Alan.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -533,8 +533,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = alan;
-				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = alan;
+				INFOPLIST_KEY_CFBundleDisplayName = Alan;
+				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = Alan;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -554,7 +554,7 @@
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.alanworks.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				"PRODUCT_NAME[sdk=macosx*]" = alan;
+				"PRODUCT_NAME[sdk=macosx*]" = Alan;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -570,8 +570,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = alan;
-				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = alan;
+				INFOPLIST_KEY_CFBundleDisplayName = Alan;
+				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = Alan;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -591,7 +591,7 @@
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.alanworks.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				"PRODUCT_NAME[sdk=macosx*]" = alan;
+				"PRODUCT_NAME[sdk=macosx*]" = Alan;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
+++ b/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
@@ -79,7 +79,7 @@ enum AlanCommandLineToolInstaller {
                         tool: tool,
                         sourcePath: source.path,
                         targetPath: target.path,
-                        status: .skipped("Existing file is not an alan.app command-line link.")
+                        status: .skipped("Existing file is not an Alan.app command-line link.")
                     )
                 }
                 try fileManager.removeItem(at: target)
@@ -119,7 +119,8 @@ enum AlanCommandLineToolInstaller {
             return false
         }
 
-        return destination.hasSuffix("/alan.app/Contents/Resources/bin/\(tool)")
+        return destination.hasSuffix("/Alan.app/Contents/Resources/bin/\(tool)")
+            || destination.hasSuffix("/alan.app/Contents/Resources/bin/\(tool)")
     }
 
     private static func isHomebrewPrefixTarget(

--- a/clients/apple/scripts/check-brand-identity.sh
+++ b/clients/apple/scripts/check-brand-identity.sh
@@ -4,13 +4,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-PATTERN='AlanNative|Alan Shell|Ask Alan|Open in Alan|New Alan|Alan Space|Alan App|alanterm|dev\.alan\.macos|dev\.alan\.native|com\.realmorrisliu\.AlanNative|\bAlan\b'
+PATTERN='AlanNative|Alan Shell|Ask Alan|Open in Alan|New Alan|Alan Space|Alan App|alanterm|dev\.alan\.macos|dev\.alan\.native|com\.realmorrisliu\.AlanNative|\balan\.app\b|\balan for macOS\b|CFBundleDisplayName = alan|"INFOPLIST_KEY_CFBundleDisplayName\[sdk=macosx\*\]" = alan|"PRODUCT_NAME\[sdk=macosx\*\]" = alan|path = alan\.app'
 
 is_allowed_occurrence() {
     local line="$1"
 
     case "$line" in
         openspec/changes/normalize-alan-branding-and-macos-app-name/*)
+            return 0
+            ;;
+        openspec/changes/capitalize-alan-macos-app-brand/*)
             return 0
             ;;
         openspec/specs/product-brand-identity/spec.md:*)
@@ -41,6 +44,18 @@ is_allowed_occurrence() {
             return 0
             ;;
         *"clients/apple/README.md:"*"Application Support/AlanNative"*)
+            return 0
+            ;;
+        *"scripts/install.sh:"*"LEGACY_APP_TARGET"*|*"scripts/install.sh:"*"/alan.app/Contents/Resources/bin/"*)
+            return 0
+            ;;
+        *"scripts/uninstall.sh:"*"LEGACY_APP_TARGET"*|*"scripts/uninstall.sh:"*"/alan.app/Contents/Resources/bin/"*)
+            return 0
+            ;;
+        *"AlanCommandLineToolInstaller.swift:"*"/alan.app/Contents/Resources/bin/"*)
+            return 0
+            ;;
+        *"clients/apple/scripts/test-command-line-tool-installer.swift:"*"/Applications/alan.app"*)
             return 0
             ;;
         *"clients/apple/scripts/check-brand-identity.sh:"*"PATTERN="*)
@@ -77,7 +92,7 @@ done < <(
 
 if (( violations > 0 )); then
     printf 'Brand identity check failed with %d violation(s).\n' "$violations" >&2
-    printf 'Use `alan`, `alan for macOS`, `alanworks.app`, and `app.alanworks.macos` unless the occurrence is an explicit compatibility or migration fixture.\n' >&2
+    printf 'Use `Alan`, `Alan for macOS`, `Alan.app`, `alanworks.app`, and `app.alanworks.macos` unless the occurrence is explicit command syntax, a machine identifier, or a migration fixture.\n' >&2
     exit 1
 fi
 

--- a/clients/apple/scripts/check-brand-identity.sh
+++ b/clients/apple/scripts/check-brand-identity.sh
@@ -52,6 +52,9 @@ is_allowed_occurrence() {
         *"scripts/uninstall.sh:"*"LEGACY_APP_TARGET"*|*"scripts/uninstall.sh:"*"/alan.app/Contents/Resources/bin/"*)
             return 0
             ;;
+        *"scripts/test-app-bundle-paths.sh:"*"alan.app"*)
+            return 0
+            ;;
         *"AlanCommandLineToolInstaller.swift:"*"/alan.app/Contents/Resources/bin/"*)
             return 0
             ;;

--- a/clients/apple/scripts/test-command-line-tool-installer.swift
+++ b/clients/apple/scripts/test-command-line-tool-installer.swift
@@ -27,7 +27,7 @@ private func temporaryDirectory(_ name: String) throws -> URL {
 }
 
 private func makeResourceRoot() throws -> URL {
-    let appRoot = try temporaryDirectory("alan.app")
+    let appRoot = try temporaryDirectory("Alan.app")
     let root = appRoot
         .appendingPathComponent("Contents", isDirectory: true)
         .appendingPathComponent("Resources", isDirectory: true)
@@ -136,6 +136,37 @@ private func testSkipsWhenHomebrewAlreadyManagesLinks() throws {
     }
 }
 
+private func testReplacesLegacyLowercaseAppLinks() throws {
+    let resourceRoot = try makeResourceRoot()
+    let targetDirectory = try temporaryDirectory("target")
+    try FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+
+    for tool in AlanCommandLineToolInstaller.toolNames {
+        let legacyDestination = URL(fileURLWithPath: "/Applications/alan.app")
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent(tool)
+        let link = targetDirectory.appendingPathComponent(tool)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: legacyDestination)
+    }
+
+    let records = try AlanCommandLineToolInstaller.install(
+        targetDirectory: targetDirectory,
+        resourceURL: resourceRoot
+    )
+
+    try require(records.count == 2, "installer must report both tools")
+    for tool in AlanCommandLineToolInstaller.toolNames {
+        let target = targetDirectory.appendingPathComponent(tool)
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: target.path)
+        try require(
+            destination.contains("/Alan.app/Contents/Resources/bin/\(tool)"),
+            "installer must replace legacy lowercase app links for \(tool)"
+        )
+    }
+}
+
 private func testRejectsAlanHomeBinTarget() throws {
     let resourceRoot = try makeResourceRoot()
     let targetDirectory = try temporaryDirectory("home")
@@ -161,6 +192,7 @@ private enum TestRunner {
         try testSkipsNonAlanFiles()
         try testRejectsHomebrewPrefixTarget()
         try testSkipsWhenHomebrewAlreadyManagesLinks()
+        try testReplacesLegacyLowercaseAppLinks()
         try testRejectsAlanHomeBinTarget()
     }
 }

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -25,7 +25,7 @@ brew install --cask alan
 just install
 ```
 
-The TUI is distributed as a standalone executable embedded in `alan.app` at
+The TUI is distributed as a standalone executable embedded in `Alan.app` at
 `Contents/Resources/bin/alan-tui`. Homebrew cask installs link that embedded
 tool automatically. For a direct app install, use **Tools > Install Command
 Line Tools...** in the macOS app.

--- a/docs/spec/alan_macos_shell_ui_ux.md
+++ b/docs/spec/alan_macos_shell_ui_ux.md
@@ -1,4 +1,4 @@
-# alan for macOS Terminal Workspace UI / UX Contract
+# Alan for macOS Terminal Workspace UI / UX Contract
 
 > Status: superseded bridge. The canonical current macOS terminal workspace UI/UX contract
 > lives in OpenSpec long-lived specs under `openspec/specs/`.

--- a/docs/spec/alan_shell_macos_contract.md
+++ b/docs/spec/alan_shell_macos_contract.md
@@ -1,6 +1,6 @@
-# alan for macOS Terminal Workspace Contract
+# Alan for macOS Terminal Workspace Contract
 
-> Status: VNext product contract for the alan for macOS terminal workspace host.
+> Status: VNext product contract for the Alan for macOS terminal workspace host.
 
 ## Goal
 

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ serve:
 build:
     cargo build --release
 
-# Install release alan.app plus CLI/TUI locally
+# Install release Alan.app plus CLI/TUI locally
 install:
     ./scripts/install.sh
 

--- a/openspec/changes/capitalize-alan-macos-app-brand/.openspec.yaml
+++ b/openspec/changes/capitalize-alan-macos-app-brand/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/capitalize-alan-macos-app-brand/design.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The previous branding pass intentionally made `alan` the canonical product
+brand everywhere, including the macOS bundle name and display metadata. That
+kept CLI and app naming consistent, but it makes the native app look like a
+command-line artifact in Finder, Dock, menu bar, and install flows.
+
+The new distinction is:
+
+- `Alan` is the user-visible product brand.
+- `Alan for macOS` is the platform label when disambiguation is useful.
+- `alan` remains the command/system identifier for CLI names, dot directories,
+  package names, bundle identifiers, and embedded command-line binaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the generated macOS app bundle and display metadata read as `Alan.app`
+  and `Alan`.
+- Update release/install/Homebrew paths that refer to the app bundle while
+  preserving embedded `Contents/Resources/bin/alan` and `alan-tui` CLI paths.
+- Update OpenSpec contracts and active distribution artifacts so future work
+  does not reintroduce lowercase app branding.
+- Update brand validation to distinguish user-visible app casing from
+  lowercase compatibility identifiers.
+
+**Non-Goals:**
+
+- Rename the Rust CLI binary, `alan-tui`, crate names, package names, or
+  `~/.alan` data paths.
+- Change the bundle identifier `app.alanworks.macos`.
+- Rebrand historical archive records.
+- Redesign app UI, app icon, release archive naming, or signing/notarization
+  behavior beyond path updates required by `Alan.app`.
+
+## Decisions
+
+### User-visible product brand
+
+Use `Alan` in app metadata, app menu, Dock/Finder names, headings, and visible
+copy. This follows macOS convention for app names while retaining the simple
+human-name brand. The lowercase form remains appropriate for shell commands and
+machine identifiers where users expect command syntax.
+
+Alternatives considered:
+
+- Keep `alan` everywhere: internally consistent, but the app reads as a CLI
+  artifact and feels less native in macOS app contexts.
+- Use `Alan for macOS` as the bundle name: explicit, but too long for Dock/menu
+  use and unnecessary when the product name alone is enough.
+
+### Bundle and executable layout
+
+Set the Xcode macOS product/display name to `Alan`, producing `Alan.app`. The
+app bundle's internal macOS executable may follow Xcode product naming, while
+the embedded CLI/TUI executables remain lowercase under
+`Contents/Resources/bin/alan` and `Contents/Resources/bin/alan-tui`.
+
+### Validation boundary
+
+Brand validation should no longer reject every `Alan` occurrence. It should
+reject obsolete identities (`AlanNative`, `Alan Shell`, `alanterm`,
+`dev.alan.native`) and lowercase app/platform branding in active user-visible
+surfaces, especially `alan.app`, `alan for macOS`, and lowercase generated app
+metadata.
+
+## Risks / Trade-offs
+
+- App path churn breaks install scripts -> Update release assembly, install,
+  uninstall, validation, Homebrew, and command-line link ownership checks
+  together.
+- Lowercase command identifiers get overcorrected -> Keep explicit tasks and
+  validation text preserving embedded CLI paths and `~/.alan`.
+- Active OpenSpec drift -> Update active distribution/change specs that still
+  say `alan.app` before marking this change complete.

--- a/openspec/changes/capitalize-alan-macos-app-brand/proposal.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The native macOS app currently presents itself as `alan`, which matches the CLI
+binary but looks out of place in Finder, Dock, menu bar, and installer contexts
+where app names normally read as product names. The brand contract should
+distinguish the user-visible macOS product name from lowercase command and
+system identifiers.
+
+## What Changes
+
+- Use `Alan` as the canonical user-visible product brand in app metadata,
+  menu/window copy, docs headings, onboarding text, release notes, and visible
+  command labels.
+- Use `Alan for macOS` when platform disambiguation is needed.
+- Keep lowercase `alan` for CLI commands, embedded CLI/TUI executable names,
+  dot directories, package names, storage namespaces, bundle identifiers, and
+  other compatibility-sensitive machine identifiers.
+- Update the generated macOS app product/display metadata from `alan.app` /
+  `alan` to `Alan.app` / `Alan`.
+- Update brand validation so uppercase `Alan` is required in user-visible brand
+  surfaces and lowercase `alan` remains allowed only for command/system
+  contexts.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `product-brand-identity`: Change the canonical user-visible standalone brand
+  from lowercase `alan` to `Alan`, while preserving lowercase machine
+  identifiers.
+- `macos-app-instance-lifecycle`: Change generated macOS app metadata to
+  `Alan.app` and `CFBundleDisplayName = Alan`.
+- `macos-shell-build-test-contract`: Update build and validation expectations
+  for the capitalized macOS app bundle and display name.
+- `macos-shell-ui-ux-conformance`: Update visible UI copy expectations so
+  app chrome uses `Alan` and `Alan for macOS`.
+- `macos-app-architecture-maintainability`: Update engineering identity
+  validation so the generated product is `Alan.app` while the project/scheme
+  remain `alan-macos`.
+
+## Impact
+
+- OpenSpec long-lived specs and active changes that reference `alan.app`,
+  lowercase-only app metadata, or lowercase-only platform labels.
+- Xcode project metadata for the macOS product name and bundle display name.
+- Release, install, uninstall, validation, and Homebrew cask helper scripts that
+  point at the built app bundle.
+- Brand validation rules and focused tests for command-line tool installation.

--- a/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-app-architecture-maintainability/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Apple client engineering identity is alan-macos
+The Apple client SHALL use `alan-macos` as the active engineering identity for
+the macOS app project, scheme, target-facing developer commands, source root,
+architecture checks, and script path references.
+
+#### Scenario: Developer builds the macOS app
+- **WHEN** a developer reads or runs the documented macOS app build command
+- **THEN** the command references `clients/apple/alan-macos.xcodeproj`
+- **AND** the selected scheme is `alan-macos`
+- **AND** the generated app product is `Alan.app`
+
+#### Scenario: Swift app entry is inspected
+- **WHEN** a developer inspects the Swift app entry point
+- **THEN** the type and file names do not contain `AlanNative`
+- **AND** any Swift identifiers that include `Alan` use Swift naming
+  conventions rather than command-facing lowercase casing
+
+#### Scenario: Architecture validation runs
+- **WHEN** Apple-client architecture validation scans source layout,
+  README/build commands, scripts, project metadata, and active OpenSpec work
+- **THEN** it recognizes `alan-macos` as the engineering identity and `Alan` as
+  the user-visible product brand
+- **AND** it rejects reintroduced `AlanNative` project, path, scheme, or target
+  identity unless the occurrence is an explicit compatibility or migration
+  fixture

--- a/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-app-instance-lifecycle/spec.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-app-instance-lifecycle/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Native macOS app identity uses alan for macOS naming
+The native macOS app SHALL align bundle, display, singleton, logging, capture,
+and persisted support identities with the `Alan` product brand and
+`Alan for macOS` platform label, while preserving lowercase command and machine
+identifiers where required for compatibility.
+
+#### Scenario: App metadata is generated
+- **WHEN** the macOS app bundle is built
+- **THEN** the generated app product is `Alan.app`
+- **AND** `CFBundleDisplayName` and macOS product name are `Alan`
+- **AND** the default bundle identifier is `app.alanworks.macos`
+
+#### Scenario: Singleton and support paths are created
+- **WHEN** singleton lock files or App Support persistence paths are created
+- **THEN** they use the current Alan for macOS identity
+- **AND** they do not create new paths named `AlanNative`
+
+#### Scenario: Logs and capture helpers identify the app
+- **WHEN** maintainers inspect logs, run capture helpers, or filter running app
+  instances by bundle identifier
+- **THEN** defaults use `app.alanworks.macos` and compatibility-safe lowercase
+  command/system identifiers where paths or process names require them
+- **AND** `com.realmorrisliu.AlanNative` and `dev.alan.native` are not active
+  defaults

--- a/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Branding and project identity checks run with Apple validation
+Apple-client validation SHALL include focused checks that protect the canonical
+`Alan` product brand, `Alan for macOS` platform label, and `alan-macos`
+engineering identity.
+
+#### Scenario: Brand scan runs
+- **WHEN** Apple-client validation runs for a branding or project rename change
+- **THEN** it scans active Apple source, scripts, docs, project metadata, and
+  active OpenSpec changes for non-allowlisted `AlanNative`, `Alan Shell`,
+  `alanterm`, `dev.alan.native`, `alan.app`, `alan for macOS`, and lowercase
+  generated app metadata occurrences
+- **AND** it reports the expected canonical replacement for each violation
+
+#### Scenario: Renamed Xcode build runs
+- **WHEN** implementation is ready for review
+- **THEN** the documented Xcode build command uses
+  `clients/apple/alan-macos.xcodeproj`, scheme `alan-macos`, configuration
+  `Debug`, destination `platform=macOS`, and the shared derived-data path
+- **AND** the build produces `Alan.app`
+
+#### Scenario: Focused scripts are updated
+- **WHEN** focused Apple shell scripts are run after the rename
+- **THEN** they read source files from `clients/apple/alan-macos`
+- **AND** script defaults such as bundle identifiers, capture helpers, and
+  architecture checks use the current app identity instead of `AlanNative` or
+  `dev.alan.native`

--- a/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Visible macOS app copy follows product brand identity
+The default macOS app UI SHALL render the public product brand as `Alan` and
+SHALL use `Alan for macOS` only where platform distinction is useful.
+
+#### Scenario: App chrome is visible
+- **WHEN** the Dock name, app menu, window title, toolbar labels, command
+  palette labels, sidebar buttons, help text, or accessibility labels name the
+  product
+- **THEN** they use `Alan`
+- **AND** they do not use lowercase `alan`, `AlanNative`, `alanterm`, or
+  `Alan Shell` as visible product names
+
+#### Scenario: Terminal app category is visible
+- **WHEN** the UI or docs explain the native app's category
+- **THEN** they call it a terminal emulator or terminal workspace
+- **AND** they do not call the product a shell

--- a/openspec/changes/capitalize-alan-macos-app-brand/specs/product-brand-identity/spec.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/specs/product-brand-identity/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Canonical product brand is Alan
+The product SHALL use `Alan` as the canonical standalone user-visible brand
+name in app display metadata, docs headings, onboarding text, accessibility
+labels, release notes, and visible command labels. Lowercase `alan` SHALL remain
+available for CLI commands, package identifiers, dot directories, bundle
+identifiers, storage namespaces, and other compatibility-sensitive machine
+identifiers.
+
+#### Scenario: Standalone brand is displayed
+- **WHEN** a user-visible surface names the product without platform
+  disambiguation
+- **THEN** the surface renders the product name as `Alan`
+- **AND** the surface does not render `alan`, `ALAN`, `AlanNative`, `alanterm`,
+  or `alan shell` as the standalone product name
+
+#### Scenario: Command or system identifier is displayed
+- **WHEN** docs, help text, scripts, tests, paths, package metadata, or terminal
+  output refer to literal command syntax or machine identifiers
+- **THEN** they may use lowercase identifiers such as `alan`, `alan-tui`,
+  `~/.alan`, `app.alanworks.macos`, and `alan-macos`
+- **AND** they do not imply those lowercase identifiers are the app's
+  user-visible brand spelling
+
+### Requirement: macOS platform label is Alan for macOS
+The native macOS app SHALL use `Alan for macOS` as the platform variant label
+when a surface needs to distinguish the macOS app from the CLI, runtime, docs,
+or other future clients.
+
+#### Scenario: Platform-specific copy is displayed
+- **WHEN** a README, release note, download page, architecture doc, or support
+  message distinguishes the native macOS app
+- **THEN** it uses `Alan for macOS` as the platform label
+- **AND** it does not introduce a second app brand such as `AlanNative` or
+  `alanterm`
+
+#### Scenario: Product name is enough
+- **WHEN** Dock, app menu, window title, or default app metadata only needs the
+  product name
+- **THEN** it uses `Alan` instead of `Alan for macOS`
+
+## MODIFIED Requirements
+
+### Requirement: Terminal category is separate from shell command syntax
+Alan's user-facing product category SHALL describe the macOS app as a terminal
+emulator or terminal workspace. The phrase `alan shell` MUST NOT be used as the
+product name, app name, or product category.
+
+#### Scenario: macOS app is described
+- **WHEN** docs or UI explain what the native app is
+- **THEN** they describe it as a terminal emulator or terminal workspace
+- **AND** they do not describe the app as `alan shell`
+
+#### Scenario: CLI syntax is documented
+- **WHEN** docs, help text, skills, scripts, or tests refer to the literal
+  `alan shell ...` command namespace
+- **THEN** that command syntax remains allowed
+- **AND** the surrounding copy makes clear it is a command/control namespace,
+  not the product or app name
+
+### Requirement: Historical AlanNative identity is removed from active surfaces
+The active repository MUST remove `AlanNative` as a product, project, target,
+source-root, bundle, logging, or storage identity across source, docs, specs,
+project metadata, scripts, generated app metadata, logs, persisted support
+paths, and tests.
+
+#### Scenario: Active repository is scanned
+- **WHEN** the active repository excluding archived OpenSpec history is scanned
+  for `AlanNative`
+- **THEN** only explicitly allowlisted historical migration notes or test
+  fixtures may match
+- **AND** no current path, project file, build command, generated product name,
+  source type, log subsystem, or app-support path depends on `AlanNative`
+
+#### Scenario: Local state from old app exists
+- **WHEN** local macOS state exists under the historical `AlanNative` support
+  path
+- **THEN** Alan for macOS performs a best-effort migration or fallback read
+  before writing future state only under the new canonical path
+
+### Requirement: Brand validation is explicit and allowlisted
+The repository SHALL include a focused brand validation step that rejects
+non-allowlisted uses of obsolete product names and incorrectly-cased
+user-visible app branding in active surfaces.
+
+#### Scenario: Obsolete brand name is introduced
+- **WHEN** a change introduces `AlanNative`, `alanterm`, or `Alan Shell` as an
+  active product/app name
+- **THEN** brand validation fails with an actionable message naming the
+  canonical replacement
+
+#### Scenario: Lowercase app brand is introduced
+- **WHEN** a change introduces `alan.app`, `alan for macOS`, or lowercase
+  generated app display metadata in an active user-visible app surface
+- **THEN** brand validation fails with an actionable message naming `Alan.app`,
+  `Alan for macOS`, or `Alan` as the canonical replacement
+
+#### Scenario: Compatibility-sensitive string is present
+- **WHEN** a compatibility-sensitive surface contains `alan shell` as literal
+  command syntax, lowercase `alan` as a CLI or path identifier, an archive
+  contains historical references, or Swift/Rust code uses idiomatic PascalCase
+  identifiers that are not user-visible brand copy
+- **THEN** brand validation allows the occurrence through an explicit allowlist
+  rather than requiring unsafe global replacement
+
+## REMOVED Requirements
+
+### Requirement: Canonical product brand is lowercase alan
+**Reason**: The macOS app should follow product-name casing in user-visible app
+contexts instead of presenting the CLI command spelling as the brand.
+**Migration**: Use `Alan` for user-visible brand surfaces and lowercase `alan`
+only for command/system identifiers.
+
+### Requirement: macOS platform label is alan for macOS
+**Reason**: The platform label should use the updated user-visible product
+brand.
+**Migration**: Use `Alan for macOS` in platform-specific copy.

--- a/openspec/changes/capitalize-alan-macos-app-brand/tasks.md
+++ b/openspec/changes/capitalize-alan-macos-app-brand/tasks.md
@@ -1,0 +1,15 @@
+## 1. Brand Metadata And Distribution Paths
+
+- [x] 1.1 Update Xcode macOS app metadata so the built app is `Alan.app` with `CFBundleDisplayName` and product name `Alan`.
+- [x] 1.2 Update release assembly, install, uninstall, validation, and Homebrew cask helper scripts to use `Alan.app` while preserving embedded CLI paths under `Contents/Resources/bin/alan` and `alan-tui`.
+- [x] 1.3 Update Apple command-line tool installer ownership checks and focused tests for the capitalized app bundle path.
+
+## 2. OpenSpec And Docs Alignment
+
+- [x] 2.1 Update active OpenSpec distribution artifacts and user-facing docs that still present the macOS app as `alan.app` or `alan for macOS`.
+- [x] 2.2 Preserve lowercase `alan` in CLI syntax, embedded binary paths, package names, bundle identifiers, and storage paths.
+
+## 3. Validation
+
+- [x] 3.1 Update brand validation so it rejects obsolete identities and lowercase app/platform branding, while allowing lowercase command/system identifiers.
+- [x] 3.2 Run focused validation for brand identity, release/homebrew scripts, command-line installer tests, and OpenSpec strict validation.

--- a/openspec/changes/package-alan-app-distribution/design.md
+++ b/openspec/changes/package-alan-app-distribution/design.md
@@ -5,12 +5,12 @@ The current repository has two separate local workflows:
 - `just install` builds the release Rust CLI and standalone TUI, then installs
   them under `~/.alan/bin`.
 - `just app` runs `clients/apple/scripts/run-alan-debug-app.sh`, which builds a
-  Debug `alan.app`, kills any running app process, waits for singleton release,
+  Debug `Alan.app`, kills any running app process, waits for singleton release,
   and launches the new build.
 
 That split is useful for early UI iteration, but it is the wrong shape for
 distribution. The desired long-term model is app-first: users install
-`alan.app`, and the CLI/TUI come from that same signed release package. Homebrew
+`Alan.app`, and the CLI/TUI come from that same signed release package. Homebrew
 cask can install the app and expose binaries from inside the app bundle, so the
 release artifact does not need a separate formula or a runtime download step.
 
@@ -21,9 +21,9 @@ should not preserve ad-hoc signing as a supported local install fallback.
 
 **Goals:**
 
-- Make `alan.app` the primary macOS distribution artifact.
+- Make `Alan.app` the primary macOS distribution artifact.
 - Embed release `alan` and `alan-tui` executables in
-  `alan.app/Contents/Resources/bin/`.
+  `Alan.app/Contents/Resources/bin/`.
 - Sign nested CLI/TUI binaries and the app bundle with Developer ID signing.
 - Require notarization and stapling for published Homebrew/download artifacts.
 - Make `just install` install the same release-shaped app/CLI/TUI package
@@ -34,7 +34,7 @@ should not preserve ad-hoc signing as a supported local install fallback.
 - Define the future Homebrew cask contract that installs the app and links the
   embedded CLI/TUI binaries.
 - Provide an explicit direct-app command-line tools install action for users who
-  download or drag-install `alan.app` without Homebrew.
+  download or drag-install `Alan.app` without Homebrew.
 
 **Non-Goals:**
 
@@ -53,8 +53,8 @@ should not preserve ad-hoc signing as a supported local install fallback.
 1. **Use app-first packaging with embedded CLI/TUI.**
 
    The release assembly will build `target/release/alan`, the standalone
-   `alan-tui`, and Release `alan.app`, then copy the CLI/TUI into
-   `alan.app/Contents/Resources/bin/`.
+   `alan-tui`, and Release `Alan.app`, then copy the CLI/TUI into
+   `Alan.app/Contents/Resources/bin/`.
 
    Alternative considered: publish separate app and CLI artifacts. That would
    force Homebrew users through a cask+formula coordination problem and create
@@ -104,12 +104,12 @@ should not preserve ad-hoc signing as a supported local install fallback.
 
 4. **Use Homebrew cask binary links from the app bundle.**
 
-   The cask should install `alan.app` and expose:
+   The cask should install `Alan.app` and expose:
 
    ```ruby
-   app "alan.app"
-   binary "#{appdir}/alan.app/Contents/Resources/bin/alan", target: "alan"
-   binary "#{appdir}/alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
+   app "Alan.app"
+   binary "#{appdir}/Alan.app/Contents/Resources/bin/alan", target: "alan"
+   binary "#{appdir}/Alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
    ```
 
    Documentation should use `brew install --cask alan` as the canonical command.
@@ -134,7 +134,7 @@ should not preserve ad-hoc signing as a supported local install fallback.
 6. **Turn `just install` into the local release install path.**
 
    `just install` should call the release assembly/install script, install the
-   signed app into a user-level app directory such as `~/Applications/alan.app`,
+   signed app into a user-level app directory such as `~/Applications/Alan.app`,
    and install or refresh CLI/TUI symlinks in a configurable PATH directory. It
    must not write to `~/.alan/bin`, kill, restart, or open the running app. If
    the app is running, it may warn that the new version takes effect after the
@@ -174,12 +174,12 @@ should not preserve ad-hoc signing as a supported local install fallback.
 1. Add a release assembly script that builds CLI/TUI/app, embeds CLI/TUI, signs
    nested binaries and app, and can optionally notarize/staple for publication.
 2. Update `scripts/install.sh` and `just install` to use the release assembly
-   path and install without killing or launching `alan.app`.
+   path and install without killing or launching `Alan.app`.
 3. Remove the `just app` recipe and the debug-runner script from the supported
    workflow. Update contract checks and docs so it is not reintroduced.
 4. Add app-side explicit CLI/TUI command-line tools install behavior for direct
    app installs.
-5. Add Homebrew cask metadata or a template that installs `alan.app` and links
+5. Add Homebrew cask metadata or a template that installs `Alan.app` and links
    the embedded binaries.
 6. Validate signing, nested binary layout, local install behavior, Homebrew cask
    structure, and docs/contract checks before implementation is considered

--- a/openspec/changes/package-alan-app-distribution/pr-notes.md
+++ b/openspec/changes/package-alan-app-distribution/pr-notes.md
@@ -2,7 +2,7 @@
 
 - Breaking change: `just app` and the force-kill debug app runner are removed.
 - `just install` is now the local release install path. It assembles signed
-  `alan.app`, embeds `alan` and `alan-tui`, installs the app, and links the
+  `Alan.app`, embeds `alan` and `alan-tui`, installs the app, and links the
   embedded tools into a configurable PATH directory without using `~/.alan/bin`.
 - Formal signing is required. Release assembly fails closed unless
   `ALAN_DEVELOPER_ID_APPLICATION` or `ALAN_SIGNING_IDENTITY` names a Developer
@@ -14,7 +14,7 @@
   including `ALAN_DEVELOPER_ID_APPLICATION` and Apple ID app-specific-password
   notarization settings.
 - Homebrew distribution is cask-first: `brew install --cask alan` installs
-  `alan.app` and links `Contents/Resources/bin/alan` plus
+  `Alan.app` and links `Contents/Resources/bin/alan` plus
   `Contents/Resources/bin/alan-tui`.
 - Direct `.app` installs can use the macOS **Tools > Install Command Line
   Tools...** action to create PATH-visible symlinks, while refusing Homebrew

--- a/openspec/changes/package-alan-app-distribution/proposal.md
+++ b/openspec/changes/package-alan-app-distribution/proposal.md
@@ -2,17 +2,17 @@
 
 alan currently has a split local installation story: `just install` installs the
 release CLI and TUI, while `just app` builds and force-restarts a debug
-`alan.app`. This does not match the intended user-facing distribution model,
-where `alan.app` is the primary signed artifact and the CLI/TUI are installed
+`Alan.app`. This does not match the intended user-facing distribution model,
+where `Alan.app` is the primary signed artifact and the CLI/TUI are installed
 from that same release package.
 
 ## What Changes
 
-- Introduce a signed release packaging contract where `alan.app` is the primary
+- Introduce a signed release packaging contract where `Alan.app` is the primary
   distribution artifact and embeds release `alan` and `alan-tui` executables.
 - Require Developer ID signing for the app bundle and nested CLI/TUI binaries;
   local ad-hoc signing is not an accepted distribution path for this change.
-- Define the future Homebrew cask shape: install `alan.app` and expose the
+- Define the future Homebrew cask shape: install `Alan.app` and expose the
   embedded `alan` and `alan-tui` binaries through Homebrew's `bin` directory.
 - Change the local developer install flow so `just install` builds and installs
   the release app and PATH-visible CLI/TUI symlinks without killing or launching
@@ -46,9 +46,9 @@ from that same release package.
     `clients/apple/scripts/`
 - Apple build outputs and signing:
   - `clients/apple/alan-macos.xcodeproj`
-  - `target/xcode-derived/Build/Products/Release/alan.app`
-  - `alan.app/Contents/Resources/bin/alan`
-  - `alan.app/Contents/Resources/bin/alan-tui`
+  - `target/xcode-derived/Build/Products/Release/Alan.app`
+  - `Alan.app/Contents/Resources/bin/alan`
+  - `Alan.app/Contents/Resources/bin/alan-tui`
 - Homebrew distribution metadata for the future `alan` cask.
 - Documentation and focused Apple validation scripts that currently assume
   `just app` or `clients/apple/scripts/run-alan-debug-app.sh` is the local app

--- a/openspec/changes/package-alan-app-distribution/specs/alan-app-distribution/spec.md
+++ b/openspec/changes/package-alan-app-distribution/specs/alan-app-distribution/spec.md
@@ -1,13 +1,13 @@
 ## ADDED Requirements
 
-### Requirement: alan.app is the primary macOS distribution artifact
-alan SHALL distribute macOS releases as an app-first package where `alan.app`
+### Requirement: Alan.app is the primary macOS distribution artifact
+Alan SHALL distribute macOS releases as an app-first package where `Alan.app`
 contains the GUI app executable plus release CLI/TUI executables embedded under
 `Contents/Resources/bin`.
 
 #### Scenario: Release app is assembled
 - **WHEN** a macOS release package is assembled
-- **THEN** the package contains `alan.app`
+- **THEN** the package contains `Alan.app`
 - **AND** the bundle contains the app executable at `Contents/MacOS/alan`
 - **AND** the bundle contains the CLI at `Contents/Resources/bin/alan`
 - **AND** the bundle contains the TUI at `Contents/Resources/bin/alan-tui`
@@ -54,7 +54,7 @@ notarized and stapled before publication.
 - **AND** the local install output states whether notarization was skipped or completed
 
 ### Requirement: Direct app installs can explicitly install CLI and TUI
-alan for macOS SHALL provide an explicit direct-install action that creates
+Alan for macOS SHALL provide an explicit direct-install action that creates
 PATH-visible `alan` and `alan-tui` entries from the embedded app resources when
 Homebrew has not already provided authoritative binary links.
 
@@ -77,19 +77,19 @@ Homebrew has not already provided authoritative binary links.
 - **AND** the app does not create duplicate direct-install links in another PATH directory
 
 #### Scenario: App launches directly
-- **WHEN** a user launches `alan.app` directly
+- **WHEN** a user launches `Alan.app` directly
 - **THEN** the app does not silently install CLI/TUI entries
 - **AND** the app remains usable even when command-line tools have not been installed
 
 ### Requirement: Homebrew cask installs app and binaries from one artifact
-The Homebrew distribution SHALL use a cask that installs `alan.app` and exposes
+The Homebrew distribution SHALL use a cask that installs `Alan.app` and exposes
 the embedded CLI/TUI binaries from inside the installed app bundle.
 
 #### Scenario: Cask installs alan
 - **WHEN** a user installs the Homebrew cask for alan
-- **THEN** Homebrew installs `alan.app`
-- **AND** Homebrew links `alan.app/Contents/Resources/bin/alan` as `alan`
-- **AND** Homebrew links `alan.app/Contents/Resources/bin/alan-tui` as `alan-tui`
+- **THEN** Homebrew installs `Alan.app`
+- **AND** Homebrew links `Alan.app/Contents/Resources/bin/alan` as `alan`
+- **AND** Homebrew links `Alan.app/Contents/Resources/bin/alan-tui` as `alan-tui`
 - **AND** the cask does not require a separate formula to provide the CLI or TUI
 
 #### Scenario: Cask documentation is shown
@@ -105,19 +105,19 @@ locally without killing, launching, or restarting the macOS app.
 - **WHEN** a developer runs `just install`
 - **THEN** the command builds the release CLI
 - **AND** the command builds the release standalone TUI
-- **AND** the command builds and assembles release `alan.app`
+- **AND** the command builds and assembles release `Alan.app`
 - **AND** the command installs the app into a user-level app directory
 - **AND** the command installs or refreshes CLI/TUI symlinks in a configurable PATH directory
 - **AND** the command does not install CLI/TUI entries under `~/.alan/bin`
 
 #### Scenario: App is already running
-- **WHEN** `just install` runs while `alan.app` is already running
+- **WHEN** `just install` runs while `Alan.app` is already running
 - **THEN** the install process does not kill the app
 - **AND** the install process does not launch or relaunch the app
 - **AND** the install process reports that the user should restart the app manually to use the newly installed version
 
 ### Requirement: ~/.alan/bin is not a distribution path
-alan SHALL NOT install, refresh, document, or resolve `alan` or `alan-tui`
+Alan SHALL NOT install, refresh, document, or resolve `alan` or `alan-tui`
 through `~/.alan/bin` as part of macOS app distribution, Homebrew cask
 distribution, direct app command-line tool installation, or `just install`.
 

--- a/openspec/changes/package-alan-app-distribution/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/package-alan-app-distribution/specs/macos-shell-build-test-contract/spec.md
@@ -14,7 +14,7 @@ the supported local app workflow. The repository MUST NOT require or preserve a
 #### Scenario: Legacy debug runner is removed
 - **WHEN** Apple client contract checks inspect app runner scripts
 - **THEN** they do not require `clients/apple/scripts/run-alan-debug-app.sh` as the supported app workflow
-- **AND** they fail if a default local app workflow kills a running `alan.app` process and immediately relaunches it
+- **AND** they fail if a default local app workflow kills a running `Alan.app` process and immediately relaunches it
 
 ### Requirement: Release packaging has focused validation
 The Apple client SHALL provide focused validation for the release app package,
@@ -23,7 +23,7 @@ when distribution packaging changes.
 
 #### Scenario: Release app layout is checked
 - **WHEN** release packaging implementation is ready for review
-- **THEN** focused checks verify `alan.app` was built in Release configuration
+- **THEN** focused checks verify `Alan.app` was built in Release configuration
 - **AND** focused checks verify embedded `Contents/Resources/bin/alan` and `Contents/Resources/bin/alan-tui` exist and are executable
 - **AND** focused checks verify the embedded binaries are the release binaries from the current build
 - **AND** focused checks verify the package manifest SHA-256 values are recorded after embedded binary signing and match the delivered embedded binaries

--- a/openspec/changes/package-alan-app-distribution/tasks.md
+++ b/openspec/changes/package-alan-app-distribution/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Release Assembly Pipeline
 
-- [x] 1.1 Add a release assembly script that builds `cargo build --release -p alan`, builds standalone `alan-tui`, and builds Release `alan.app` into the shared derived-data path.
-- [x] 1.2 Copy the release CLI and standalone TUI into `alan.app/Contents/Resources/bin/alan` and `alan.app/Contents/Resources/bin/alan-tui`.
+- [x] 1.1 Add a release assembly script that builds `cargo build --release -p alan`, builds standalone `alan-tui`, and builds Release `Alan.app` into the shared derived-data path.
+- [x] 1.2 Copy the release CLI and standalone TUI into `Alan.app/Contents/Resources/bin/alan` and `Alan.app/Contents/Resources/bin/alan-tui`.
 - [x] 1.3 Generate or record package metadata that proves the app, CLI, and TUI were assembled from the same source revision or release version.
 - [x] 1.4 Require a configured Developer ID Application signing identity and fail with an actionable message when it is missing.
-- [x] 1.5 Sign embedded `alan` and `alan-tui` first, then sign `alan.app` with hardened runtime and timestamp options.
+- [x] 1.5 Sign embedded `alan` and `alan-tui` first, then sign `Alan.app` with hardened runtime and timestamp options.
 - [x] 1.6 Add release publication mode that notarizes and staples artifacts intended for Homebrew cask or direct public download.
 - [x] 1.7 Add a shared release env loader for allowlisted local signing/notarization settings, including `ALAN_DEVELOPER_ID_APPLICATION` and Apple ID app-specific-password notarization variables.
 - [x] 1.8 Add one-command public release helpers: `just release-check` and `just release`.
@@ -12,10 +12,10 @@
 
 ## 2. Local Install Workflow
 
-- [x] 2.1 Update `scripts/install.sh` so `just install` uses the release assembly pipeline and installs `alan.app` into a user-level app directory.
+- [x] 2.1 Update `scripts/install.sh` so `just install` uses the release assembly pipeline and installs `Alan.app` into a user-level app directory.
 - [x] 2.2 Install or refresh CLI/TUI symlinks in a configurable PATH directory from the same release app bundle, without using `~/.alan/bin`.
-- [x] 2.3 Ensure `just install` does not kill, launch, or relaunch `alan.app`.
-- [x] 2.4 Detect a running `alan.app` during install and print a restart-needed message without terminating the app.
+- [x] 2.3 Ensure `just install` does not kill, launch, or relaunch `Alan.app`.
+- [x] 2.4 Detect a running `Alan.app` during install and print a restart-needed message without terminating the app.
 - [x] 2.5 Remove the `just app` recipe from the justfile.
 - [x] 2.6 Remove `clients/apple/scripts/run-alan-debug-app.sh` from the supported workflow, and do not add a replacement debug app runner recipe.
 - [x] 2.7 Update uninstall behavior to account for the installed app and PATH symlinks without deleting user data under `~/.alan`.
@@ -29,9 +29,9 @@
 
 ## 4. Homebrew Cask Distribution
 
-- [x] 4.1 Add a Homebrew cask template or tap metadata that installs `alan.app` from the signed and notarized release artifact.
-- [x] 4.2 Link embedded `alan.app/Contents/Resources/bin/alan` as `alan` through the cask `binary` artifact.
-- [x] 4.3 Link embedded `alan.app/Contents/Resources/bin/alan-tui` as `alan-tui` through the cask `binary` artifact.
+- [x] 4.1 Add a Homebrew cask template or tap metadata that installs `Alan.app` from the signed and notarized release artifact.
+- [x] 4.2 Link embedded `Alan.app/Contents/Resources/bin/alan` as `alan` through the cask `binary` artifact.
+- [x] 4.3 Link embedded `Alan.app/Contents/Resources/bin/alan-tui` as `alan-tui` through the cask `binary` artifact.
 - [x] 4.4 Document `brew install --cask alan` as the canonical Homebrew command and only mention `brew install alan` when token ambiguity is not present.
 - [x] 4.5 Record architecture and checksum handling for the release artifact so future cask updates are deterministic.
 
@@ -39,7 +39,7 @@
 
 - [x] 5.1 Update `README.md`, `AGENTS.md`, `clients/tui/README.md`, and `clients/apple/README.md` to describe the app-first install and remove `just app` guidance.
 - [x] 5.2 Update `clients/apple/scripts/check-shell-contracts.sh` so it rejects reintroducing `just app` or a default force-kill app runner.
-- [x] 5.3 Add focused package-layout validation for Release `alan.app`, embedded executable paths, executable bits, post-signing manifest SHA-256 checksums, and stale binary detection.
+- [x] 5.3 Add focused package-layout validation for Release `Alan.app`, embedded executable paths, executable bits, post-signing manifest SHA-256 checksums, and stale binary detection.
 - [x] 5.4 Add focused signature validation that fails on ad-hoc signatures and verifies nested binaries and app bundle signing order outcomes.
 - [x] 5.5 Add publication validation for notarization/stapling and Homebrew cask binary links.
 - [x] 5.6 Document the private release env loader and its supported local signing/notarization variables.
@@ -55,7 +55,7 @@ current keychain reports no valid Developer ID signing identities.
 - [x] 6.1 Run `just --list` and verify it includes `install` but not `app` or `app-debug-run`.
 - [ ] 6.1a Run `just release-check` with complete local signing and notarization credentials.
 - [ ] 6.2 Run the release assembly validation with a Developer ID signing identity configured.
-- [ ] 6.3 Run `just install` and verify it installs the signed app plus PATH symlinks without killing or launching `alan.app`.
+- [ ] 6.3 Run `just install` and verify it installs the signed app plus PATH symlinks without killing or launching `Alan.app`.
 - [x] 6.4 Verify direct app command-line tool install behavior for missing CLI/TUI entries, existing Homebrew links in any detected prefix, non-alan-owned target files, and no `~/.alan/bin` writes.
 - [x] 6.5 Run focused Apple checks including `clients/apple/scripts/check-shell-contracts.sh`, the direct installer test, and a macOS target build.
 - [x] 6.6 Validate Homebrew cask metadata locally against the generated release artifact or template.

--- a/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/persist-macos-shell-workspaces/specs/macos-shell-workspace-persistence/spec.md
@@ -4,12 +4,12 @@
 The macOS shell SHALL use a versioned workspace manifest as the authoritative source for restoring Spaces, Tabs, pin snapshots, Tab lifecycle metadata, and the last selected Space/Tab across app restarts.
 
 #### Scenario: Manifest is present
-- **WHEN** alan for macOS starts and a valid workspace manifest exists for `window_main`
+- **WHEN** Alan for macOS starts and a valid workspace manifest exists for `window_main`
 - **THEN** alan loads Spaces, Tabs, pin snapshots, lifecycle metadata, and the last selected Space/Tab from that manifest
 - **AND** alan materializes the current shell state from the manifest rather than bootstrapping a fresh default state
 
 #### Scenario: Manifest is missing
-- **WHEN** alan for macOS starts and no workspace manifest exists for `window_main`
+- **WHEN** Alan for macOS starts and no workspace manifest exists for `window_main`
 - **THEN** alan creates a default manifest with one default Space and one default unpinned terminal Tab
 - **AND** alan uses that manifest as the restore authority for the launched shell state
 
@@ -22,7 +22,7 @@ The macOS shell SHALL use a versioned workspace manifest as the authoritative so
 The macOS shell SHALL preserve evidence of a malformed workspace manifest and start with a default workspace rather than failing to launch or silently overwriting the only copy.
 
 #### Scenario: Manifest cannot be decoded
-- **WHEN** alan for macOS starts and the workspace manifest cannot be decoded
+- **WHEN** Alan for macOS starts and the workspace manifest cannot be decoded
 - **THEN** alan preserves the bad manifest as a timestamped corrupt file
 - **AND** alan creates a fresh default manifest
 - **AND** alan starts with the default workspace
@@ -118,6 +118,6 @@ The macOS shell SHALL keep `ShellStateSnapshot` as the current UI/control-plane/
 - **AND** alan writes only restorable workspace intent and lifecycle metadata back to the manifest
 
 #### Scenario: App restarts
-- **WHEN** alan for macOS restarts after publishing a shell state file in the previous process
+- **WHEN** Alan for macOS restarts after publishing a shell state file in the previous process
 - **THEN** alan restores Spaces and Tabs from the workspace manifest
 - **AND** terminal runtimes are newly created rather than restored from the old shell state process snapshot

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/specs/macos-shell-build-test-contract/spec.md
@@ -8,9 +8,9 @@ binary.
 
 #### Scenario: Release app layout is checked
 - **WHEN** release packaging implementation is ready for review
-- **THEN** focused checks verify `alan.app` contains the app executable and the
+- **THEN** focused checks verify `Alan.app` contains the app executable and the
   embedded command-line `alan` executable required by the distribution contract
-- **AND** focused checks fail if `alan.app` contains an embedded
+- **AND** focused checks fail if `Alan.app` contains an embedded
   `Contents/Resources/bin/alan-tui` executable
 
 #### Scenario: Signatures are checked

--- a/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
+++ b/openspec/changes/replace-typescript-tui-with-rust-inline-tui/tasks.md
@@ -91,7 +91,7 @@
 
 ## 8. macOS Packaging And Shell Integration
 
-- [ ] 8.1 Update release app assembly so `alan.app` embeds only the `alan`
+- [ ] 8.1 Update release app assembly so `Alan.app` embeds only the `alan`
   command-line executable under the supported Resources/bin layout.
 - [ ] 8.2 Update signing/notarization validation so it verifies the embedded
   `alan` binary and fails if `alan-tui` is present.

--- a/packaging/homebrew/Casks/alan.rb.template
+++ b/packaging/homebrew/Casks/alan.rb.template
@@ -4,13 +4,13 @@ cask "alan" do
 
   url "https://github.com/realmorrisliu/Alan/releases/download/v#{version}/alan-#{version}-macos.zip",
       verified: "github.com/realmorrisliu/Alan/"
-  name "alan"
+  name "Alan"
   desc "Native agent terminal workspace"
   homepage "https://github.com/realmorrisliu/Alan"
 
-  app "alan.app"
-  binary "#{appdir}/alan.app/Contents/Resources/bin/alan", target: "alan"
-  binary "#{appdir}/alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
+  app "Alan.app"
+  binary "#{appdir}/Alan.app/Contents/Resources/bin/alan", target: "alan"
+  binary "#{appdir}/Alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
 
   zap trash: [
     "~/Library/Application Support/alan-macos",

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,7 +1,7 @@
 # Homebrew Cask Packaging
 
-alan's Homebrew distribution is app-first. The cask installs the signed and
-notarized `alan.app` artifact, then exposes the CLI and TUI from inside the app
+Alan's Homebrew distribution is app-first. The cask installs the signed and
+notarized `Alan.app` artifact, then exposes the CLI and TUI from inside the app
 bundle through Homebrew's `bin` directory.
 
 Canonical install command:
@@ -13,9 +13,9 @@ brew install --cask alan
 The cask must link these embedded tools:
 
 ```ruby
-app "alan.app"
-binary "#{appdir}/alan.app/Contents/Resources/bin/alan", target: "alan"
-binary "#{appdir}/alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
+app "Alan.app"
+binary "#{appdir}/Alan.app/Contents/Resources/bin/alan", target: "alan"
+binary "#{appdir}/Alan.app/Contents/Resources/bin/alan-tui", target: "alan-tui"
 ```
 
 Update flow:

--- a/scripts/app-bundle-paths.sh
+++ b/scripts/app-bundle-paths.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+alan_path_exists() {
+    local path="$1"
+
+    [[ -e "$path" || -L "$path" ]]
+}
+
+alan_is_distinct_existing_path() {
+    local candidate="$1"
+    local reference="$2"
+
+    alan_path_exists "$candidate" || return 1
+    alan_path_exists "$reference" || return 0
+
+    [[ ! "$candidate" -ef "$reference" ]]
+}

--- a/scripts/assemble-release-app.sh
+++ b/scripts/assemble-release-app.sh
@@ -10,7 +10,7 @@ source "$SCRIPT_DIR/release-env.sh"
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$REPO_ROOT/target/xcode-derived}"
 ARTIFACT_DIR="${ALAN_RELEASE_ARTIFACT_DIR:-$REPO_ROOT/target/release-artifacts}"
 STAGING_DIR="$ARTIFACT_DIR/staging"
-APP_BUNDLE="$DERIVED_DATA/Build/Products/Release/alan.app"
+APP_BUNDLE="$DERIVED_DATA/Build/Products/Release/Alan.app"
 EMBEDDED_BIN_DIR="$APP_BUNDLE/Contents/Resources/bin"
 MANIFEST_PATH="$APP_BUNDLE/Contents/Resources/alan-package-manifest.json"
 TUI_ENTITLEMENTS="$REPO_ROOT/scripts/entitlements/alan-tui.entitlements"
@@ -107,11 +107,11 @@ printf 'Building standalone alan-tui...\n'
 chmod +x "$STAGING_DIR/alan-tui"
 
 if [[ -e "$APP_BUNDLE" ]]; then
-    printf 'Removing stale Release alan.app build product...\n'
+    printf 'Removing stale Release Alan.app build product...\n'
     rm -rf "$APP_BUNDLE"
 fi
 
-printf 'Building Release alan.app...\n'
+printf 'Building Release Alan.app...\n'
 xcodebuild \
     -project "$REPO_ROOT/clients/apple/alan-macos.xcodeproj" \
     -scheme alan-macos \
@@ -125,7 +125,7 @@ if [[ ! -d "$APP_BUNDLE" ]]; then
     fail "Release build did not produce $APP_BUNDLE"
 fi
 
-printf 'Embedding CLI and TUI into alan.app...\n'
+printf 'Embedding CLI and TUI into Alan.app...\n'
 mkdir -p "$EMBEDDED_BIN_DIR"
 cp "$REPO_ROOT/target/release/alan" "$EMBEDDED_BIN_DIR/alan"
 cp "$STAGING_DIR/alan-tui" "$EMBEDDED_BIN_DIR/alan-tui"
@@ -143,7 +143,7 @@ TUI_SHA="$(sha256 "$EMBEDDED_BIN_DIR/alan-tui")"
 cat >"$MANIFEST_PATH" <<EOF
 {
   "schema_version": 1,
-  "package": "alan.app",
+  "package": "Alan.app",
   "version": "$(json_escape "$VERSION")",
   "git_revision": "$(json_escape "$REVISION")",
   "git_dirty": $DIRTY,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,14 +8,16 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/release-env.sh"
 
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$PROJECT_ROOT/target/xcode-derived}"
-APP_SOURCE="$DERIVED_DATA/Build/Products/Release/alan.app"
+APP_SOURCE="$DERIVED_DATA/Build/Products/Release/Alan.app"
 APP_INSTALL_DIR="${ALAN_APP_INSTALL_DIR:-$HOME/Applications}"
-APP_TARGET="$APP_INSTALL_DIR/alan.app"
+APP_TARGET="$APP_INSTALL_DIR/Alan.app"
+LEGACY_APP_TARGET="$APP_INSTALL_DIR/alan.app"
 CLI_INSTALL_DIR="${ALAN_CLI_INSTALL_DIR:-/usr/local/bin}"
 APP_WAS_RUNNING=0
 
 is_app_running() {
-    pgrep -f "/alan\\.app/Contents/MacOS/alan" >/dev/null 2>&1
+    pgrep -f "/Alan\\.app/Contents/MacOS/Alan" >/dev/null 2>&1 ||
+        pgrep -f "/alan\\.app/Contents/MacOS/alan" >/dev/null 2>&1
 }
 
 is_alan_owned_link() {
@@ -28,7 +30,7 @@ is_alan_owned_link() {
 
     target="$(readlink "$path")"
     case "$target" in
-        *"/alan.app/Contents/Resources/bin/"*)
+        *"/Alan.app/Contents/Resources/bin/"*|*"/alan.app/Contents/Resources/bin/"*)
             return 0
             ;;
         *)
@@ -88,7 +90,7 @@ has_homebrew_managed_tool_links() {
             fi
             target="$(readlink "$link")"
             case "$target" in
-                *"/alan.app/Contents/Resources/bin/$tool")
+                *"/Alan.app/Contents/Resources/bin/$tool"|*"/alan.app/Contents/Resources/bin/$tool")
                     printf '%s\n' "$link"
                     return 0
                     ;;
@@ -135,10 +137,14 @@ if [[ ! -d "$APP_SOURCE" ]]; then
     exit 1
 fi
 
-printf 'Installing alan.app to %s...\n' "$APP_TARGET"
+printf 'Installing Alan.app to %s...\n' "$APP_TARGET"
 mkdir -p "$APP_INSTALL_DIR"
 rm -rf "$APP_TARGET"
 ditto "$APP_SOURCE" "$APP_TARGET"
+if [[ "$LEGACY_APP_TARGET" != "$APP_TARGET" && -d "$LEGACY_APP_TARGET" ]]; then
+    printf 'Removing legacy lowercase app bundle at %s...\n' "$LEGACY_APP_TARGET"
+    rm -rf "$LEGACY_APP_TARGET"
+fi
 
 printf 'Linking CLI and TUI into %s...\n' "$CLI_INSTALL_DIR"
 if is_homebrew_prefix_target "$CLI_INSTALL_DIR"; then
@@ -155,13 +161,13 @@ mkdir -p "$CLI_INSTALL_DIR"
 link_tool "alan"
 link_tool "alan-tui"
 
-printf '\nalan installed:\n'
+printf '\nAlan installed:\n'
 printf '  app: %s\n' "$APP_TARGET"
 printf '  cli: %s/alan -> %s/Contents/Resources/bin/alan\n' "$CLI_INSTALL_DIR" "$APP_TARGET"
 printf '  tui: %s/alan-tui -> %s/Contents/Resources/bin/alan-tui\n' "$CLI_INSTALL_DIR" "$APP_TARGET"
 
 if [[ "$APP_WAS_RUNNING" -eq 1 ]]; then
-    printf '\nalan.app was running during install. It was not stopped or relaunched; restart it manually to use the newly installed app.\n'
+    printf '\nAlan.app was running during install. It was not stopped or relaunched; restart it manually to use the newly installed app.\n'
 fi
 
 printf '\nEnsure %s is on PATH if you want shell access.\n' "$CLI_INSTALL_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=scripts/release-env.sh
 source "$SCRIPT_DIR/release-env.sh"
+# shellcheck source=scripts/app-bundle-paths.sh
+source "$SCRIPT_DIR/app-bundle-paths.sh"
 
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$PROJECT_ROOT/target/xcode-derived}"
 APP_SOURCE="$DERIVED_DATA/Build/Products/Release/Alan.app"
@@ -141,7 +143,7 @@ printf 'Installing Alan.app to %s...\n' "$APP_TARGET"
 mkdir -p "$APP_INSTALL_DIR"
 rm -rf "$APP_TARGET"
 ditto "$APP_SOURCE" "$APP_TARGET"
-if [[ "$LEGACY_APP_TARGET" != "$APP_TARGET" && -d "$LEGACY_APP_TARGET" ]]; then
+if alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
     printf 'Removing legacy lowercase app bundle at %s...\n' "$LEGACY_APP_TARGET"
     rm -rf "$LEGACY_APP_TARGET"
 fi

--- a/scripts/test-app-bundle-paths.sh
+++ b/scripts/test-app-bundle-paths.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/app-bundle-paths.sh
+source "$SCRIPT_DIR/app-bundle-paths.sh"
+
+fail() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/alan-app-bundle-paths.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir "$WORK_DIR/Alan.app"
+
+if alan_is_distinct_existing_path "$WORK_DIR/Alan.app" "$WORK_DIR/Alan.app"; then
+    fail "identical app bundle paths must not be distinct"
+fi
+
+if [[ -d "$WORK_DIR/alan.app" ]]; then
+    if alan_is_distinct_existing_path "$WORK_DIR/alan.app" "$WORK_DIR/Alan.app"; then
+        fail "case-insensitive aliases must not be treated as distinct bundles"
+    fi
+else
+    mkdir "$WORK_DIR/alan.app"
+    if ! alan_is_distinct_existing_path "$WORK_DIR/alan.app" "$WORK_DIR/Alan.app"; then
+        fail "case-sensitive lowercase app bundle must be treated as distinct"
+    fi
+fi
+
+if ! alan_is_distinct_existing_path "$WORK_DIR/alan.app" "$WORK_DIR/Missing.app"; then
+    fail "existing candidate must be distinct from a missing reference"
+fi
+
+printf 'App bundle path checks passed.\n'

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/app-bundle-paths.sh
+source "$SCRIPT_DIR/app-bundle-paths.sh"
+
 APP_INSTALL_DIR="${ALAN_APP_INSTALL_DIR:-$HOME/Applications}"
 APP_TARGET="$APP_INSTALL_DIR/Alan.app"
 LEGACY_APP_TARGET="$APP_INSTALL_DIR/alan.app"
@@ -26,7 +30,7 @@ remove_alan_link() {
 remove_alan_link "alan"
 remove_alan_link "alan-tui"
 rm -rf "$APP_TARGET"
-if [[ "$LEGACY_APP_TARGET" != "$APP_TARGET" ]]; then
+if alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
     rm -rf "$LEGACY_APP_TARGET"
 fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 APP_INSTALL_DIR="${ALAN_APP_INSTALL_DIR:-$HOME/Applications}"
-APP_TARGET="$APP_INSTALL_DIR/alan.app"
+APP_TARGET="$APP_INSTALL_DIR/Alan.app"
+LEGACY_APP_TARGET="$APP_INSTALL_DIR/alan.app"
 CLI_INSTALL_DIR="${ALAN_CLI_INSTALL_DIR:-/usr/local/bin}"
 
 remove_alan_link() {
@@ -16,7 +17,7 @@ remove_alan_link() {
 
     target="$(readlink "$path")"
     case "$target" in
-        *"/alan.app/Contents/Resources/bin/$tool")
+        *"/Alan.app/Contents/Resources/bin/$tool"|*"/alan.app/Contents/Resources/bin/$tool")
             rm -f "$path"
             ;;
     esac
@@ -25,6 +26,9 @@ remove_alan_link() {
 remove_alan_link "alan"
 remove_alan_link "alan-tui"
 rm -rf "$APP_TARGET"
+if [[ "$LEGACY_APP_TARGET" != "$APP_TARGET" ]]; then
+    rm -rf "$LEGACY_APP_TARGET"
+fi
 
-printf 'alan app and PATH symlinks were removed when owned by this install.\n'
+printf 'Alan app and PATH symlinks were removed when owned by this install.\n'
 printf 'User data under ~/.alan was left intact.\n'

--- a/scripts/validate-homebrew-cask.sh
+++ b/scripts/validate-homebrew-cask.sh
@@ -12,11 +12,13 @@ fail() {
 
 [[ -f "$CASK_PATH" ]] || fail "cask template not found: $CASK_PATH"
 
-grep -Eq '^[[:space:]]*app "alan\.app"' "$CASK_PATH" ||
-    fail "cask must install alan.app"
-grep -Eq 'Contents/Resources/bin/alan", target: "alan"' "$CASK_PATH" ||
+grep -Eq '^[[:space:]]*name "Alan"' "$CASK_PATH" ||
+    fail "cask display name must be Alan"
+grep -Eq '^[[:space:]]*app "Alan\.app"' "$CASK_PATH" ||
+    fail "cask must install Alan.app"
+grep -Eq 'Alan\.app/Contents/Resources/bin/alan", target: "alan"' "$CASK_PATH" ||
     fail "cask must link embedded alan binary"
-grep -Eq 'Contents/Resources/bin/alan-tui", target: "alan-tui"' "$CASK_PATH" ||
+grep -Eq 'Alan\.app/Contents/Resources/bin/alan-tui", target: "alan-tui"' "$CASK_PATH" ||
     fail "cask must link embedded alan-tui binary"
 grep -Eq 'brew install --cask alan|--cask alan' "$REPO_ROOT/packaging/homebrew/README.md" ||
     fail "Homebrew docs must use brew install --cask alan"

--- a/scripts/validate-release-app.sh
+++ b/scripts/validate-release-app.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$REPO_ROOT/target/xcode-derived}"
-APP_BUNDLE="${1:-$DERIVED_DATA/Build/Products/Release/alan.app}"
+APP_BUNDLE="${1:-$DERIVED_DATA/Build/Products/Release/Alan.app}"
 MANIFEST="$APP_BUNDLE/Contents/Resources/alan-package-manifest.json"
 ALAN_BIN="$APP_BUNDLE/Contents/Resources/bin/alan"
 TUI_BIN="$APP_BUNDLE/Contents/Resources/bin/alan-tui"
@@ -86,11 +86,13 @@ require_manifest_checksum() {
 }
 
 [[ -d "$APP_BUNDLE" ]] || fail "app bundle not found: $APP_BUNDLE"
-require_executable "$APP_BUNDLE/Contents/MacOS/alan"
+require_executable "$APP_BUNDLE/Contents/MacOS/Alan"
 require_executable "$ALAN_BIN"
 require_executable "$TUI_BIN"
 [[ -f "$MANIFEST" ]] || fail "package manifest not found: $MANIFEST"
 
+grep -q '"package": "Alan.app"' "$MANIFEST" ||
+    fail "manifest does not record Alan.app package name"
 grep -q '"path": "Contents/Resources/bin/alan"' "$MANIFEST" ||
     fail "manifest does not record embedded alan path"
 grep -q '"path": "Contents/Resources/bin/alan-tui"' "$MANIFEST" ||


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for the `Alan` / `Alan.app` macOS brand casing contract.
- Update Xcode app metadata, release/install/Homebrew paths, and CLI link ownership checks for `Alan.app`.
- Refresh brand validation and active docs/OpenSpec references while preserving lowercase CLI identifiers like `alan` and `alan-tui`.

## Test Plan
- `bash -n scripts/assemble-release-app.sh scripts/install.sh scripts/uninstall.sh scripts/validate-release-app.sh scripts/validate-homebrew-cask.sh clients/apple/scripts/check-brand-identity.sh clients/apple/scripts/test-command-line-tool-installer.sh`
- `bash clients/apple/scripts/check-brand-identity.sh`
- `bash scripts/validate-homebrew-cask.sh`
- `bash clients/apple/scripts/test-command-line-tool-installer.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `openspec validate capitalize-alan-macos-app-brand --strict`
- `openspec validate --all --strict`
- `git diff --check`
- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
- `plutil -p target/xcode-derived/Build/Products/Debug/Alan.app/Contents/Info.plist`