### PR TITLE
Fix floating sidebar bottom inset

### DIFF
--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -445,32 +445,39 @@ struct MacShellRootView: View {
     }
 
     private var sidebarOverlaySurface: some View {
-        let presentation = sidebarPresentation
-        let shape = RoundedRectangle(cornerRadius: presentation.cornerRadius, style: .continuous)
+        GeometryReader { proxy in
+            let presentation = sidebarPresentation
+            let surfaceFrame = presentation.visibleSurfaceFrame(in: proxy.size)
+            let shape = RoundedRectangle(
+                cornerRadius: presentation.cornerRadius,
+                style: .continuous
+            )
 
-        return ZStack(alignment: .topLeading) {
-            shape
-                .fill(.clear)
-                .background {
-                    ShellMaterialBackgroundView(.sidebarGlass)
-                        .clipShape(shape)
-                }
-                .overlay {
-                    shape
-                        .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
-                        .opacity(Double(presentation.floatingTreatmentProgress))
-                }
+            ZStack(alignment: .topLeading) {
+                shape
+                    .fill(.clear)
+                    .background {
+                        ShellMaterialBackgroundView(.sidebarGlass)
+                            .clipShape(shape)
+                    }
+                    .overlay {
+                        shape
+                            .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.8)
+                            .opacity(Double(presentation.floatingTreatmentProgress))
+                    }
 
-            sidebarContent(isSwipeEnabled: true)
-                .clipShape(shape)
+                sidebarContent(isSwipeEnabled: true)
+                    .clipShape(shape)
+            }
+            .frame(width: surfaceFrame.width, height: surfaceFrame.height, alignment: .topLeading)
+            .offset(x: surfaceFrame.minX, y: surfaceFrame.minY)
+            .shellShadow(
+                presentation.showsFloatingShadow ? ShellShadows.floatingPanel : ShellShadows.none
+            )
+            .onHover(perform: handleCollapsedSidebarHover)
+            .allowsHitTesting(presentation.hitTestingRole != .morphingFloatingToPinned)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .frame(width: sidebarWidth, alignment: .topLeading)
-        .frame(maxHeight: .infinity, alignment: .topLeading)
-        .padding(.bottom, presentation.overlayBottomInset)
-        .offset(x: presentation.surfaceOrigin.x, y: presentation.surfaceOrigin.y)
-        .shellShadow(presentation.showsFloatingShadow ? ShellShadows.floatingPanel : ShellShadows.none)
-        .onHover(perform: handleCollapsedSidebarHover)
-        .allowsHitTesting(presentation.hitTestingRole != .morphingFloatingToPinned)
         .ignoresSafeArea(edges: [.top, .bottom])
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .zIndex(20)

--- a/clients/apple/alan-macos/Support/ShellSidebarPresentation.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarPresentation.swift
@@ -171,6 +171,18 @@ struct ShellSidebarPresentationSnapshot: Equatable {
         (showsOverlaySurface ? 1 : 0) + (showsPinnedSurfaceContent ? 1 : 0)
     }
 
+    func visibleSurfaceFrame(in containerSize: CGSize) -> CGRect {
+        guard isSurfaceVisible else { return .zero }
+
+        let height = max(0, containerSize.height - surfaceOrigin.y - overlayBottomInset)
+        return CGRect(
+            x: surfaceOrigin.x,
+            y: surfaceOrigin.y,
+            width: surfaceWidth,
+            height: height
+        )
+    }
+
     private static func clamp(_ value: CGFloat) -> CGFloat {
         min(max(value, 0), 1)
     }

--- a/clients/apple/scripts/test-shell-sidebar-presentation.swift
+++ b/clients/apple/scripts/test-shell-sidebar-presentation.swift
@@ -18,6 +18,7 @@ private enum ShellSidebarPresentationTests {
     static func run() throws {
         try verifiesCollapsedHiddenHasNoVisibleSurface()
         try verifiesFloatingRevealUsesOverlaySurfaceWithoutLayoutReservation()
+        try verifiesFloatingRevealKeepsBalancedVerticalInsets()
         try verifiesFloatingToPinnedMorphKeepsOneVisibleSurface()
         try verifiesPinnedPhaseUsesPinnedLayoutSurface()
         print("Shell sidebar presentation tests passed.")
@@ -54,6 +55,42 @@ private enum ShellSidebarPresentationTests {
         expect(
             snapshot.chromeSurface.showsStandardTrafficLights,
             "floating reveal must be able to show native traffic lights"
+        )
+    }
+
+    private static func verifiesFloatingRevealKeepsBalancedVerticalInsets() throws {
+        let snapshot = ShellSidebarPresentationSnapshot(
+            phase: .floatingRevealed(showsTrafficLights: true),
+            configuration: configuration
+        )
+        let frame = snapshot.visibleSurfaceFrame(in: CGSize(width: 1200, height: 800))
+
+        expect(
+            frame.minY.isApproximately(6),
+            "floating reveal frame must start at the floating top inset"
+        )
+        expect(
+            frame.maxY.isApproximately(794),
+            "floating reveal frame must preserve the floating bottom inset"
+        )
+        expect(
+            frame.height.isApproximately(788),
+            "floating reveal frame height must subtract top and bottom insets"
+        )
+
+        let midpoint = ShellSidebarPresentationSnapshot(
+            phase: .morphingFloatingToPinned(progress: 0.5),
+            configuration: configuration
+        )
+        let midpointFrame = midpoint.visibleSurfaceFrame(in: CGSize(width: 1200, height: 800))
+
+        expect(
+            midpointFrame.minY.isApproximately(3),
+            "morph frame must interpolate the top inset"
+        )
+        expect(
+            midpointFrame.maxY.isApproximately(797),
+            "morph frame must interpolate the bottom inset"
         )
     }
 


### PR DESCRIPTION
## Summary
- model the floating sidebar visible surface frame from the presentation snapshot
- render the floating overlay with an explicit GeometryReader-backed height instead of full-height bottom padding
- add regression coverage for balanced top/bottom floating insets and morph interpolation

## Verification
- clients/apple/scripts/test-shell-sidebar-presentation.sh
- clients/apple/scripts/test-shell-window-placement.sh
- git diff --check -- clients/apple/alan-macos/MacShellRootView.swift clients/apple/alan-macos/Support/ShellSidebarPresentation.swift clients/apple/scripts/test-shell-sidebar-presentation.swift
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build (passed in the main checkout before packaging)

## Note
A fresh /private/tmp worktree could not complete xcodebuild because Xcode reported the local ignored GhosttyKit.xcframework artifact as missing under /tmp, even after setup-local-ghosttykit.sh --check passed. The focused Swift/AppKit tests passed in the clean PR worktree.