### PR TITLE
Add advanced terminal activity semantics draft

### DIFF
--- a/openspec/changes/add-advanced-terminal-activity-semantics/.openspec.yaml
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/add-advanced-terminal-activity-semantics/design.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/design.md
@@ -1,0 +1,350 @@
+## Context
+
+Alan's macOS shell already has the important foundations for this work:
+terminal panes have stable runtime handles, pane metadata projects title/cwd/
+attention/active-task state into shell state, pane title bars can host
+lightweight metadata accessories, and the sidebar is designed around compact
+space/tab scanning. The gap is that activity is still fragmented. Ghostty
+progress reports and command-finished actions arrive through the host, Alan
+runtime activity has its own state, and third-party CLI agent status is not yet
+modeled as terminal activity.
+
+The research target spans three related groups:
+
+- A: activity and attention, including Ghostty progress, command completion,
+  CLI coding-agent status, tab metadata, and notification policy.
+- B: semantic terminal behavior, including prompt/command boundaries, command
+  output ranges, prompt navigation, copy-last-output, and search/browse flows.
+- Quick terminal: a detached global Peak terminal that can be summoned from any
+  macOS Space while using the same shell and runtime contracts instead of a
+  separate terminal model.
+
+This change is intentionally a draft owner for all three groups. The first
+implementation-ready detail pass should focus on A.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a durable terminal activity model that can ingest Ghostty progress,
+  command completion, bell/attention, Alan session activity, and supported CLI
+  coding-agent lifecycle events.
+- Keep activity display terminal-first: pane title-bar accessories, sidebar row
+  metadata, accessibility, and optional notifications rather than dashboards or
+  bottom status strips.
+- Make sidebar tab rows denser and more useful as tab-level attention/identity
+  surfaces while keeping pane title bars responsible for pane-local detail.
+- Define semantic command-boundary behavior that can later power prompt
+  navigation, copy-last-output, and command-output browsing without adopting
+  full Warp-style blocks.
+- Define quick terminal behavior as a presentation and workspace interaction
+  over the existing terminal runtime service.
+- Split future work into phases so A can be refined and implemented before B
+  and quick terminal.
+
+**Non-Goals:**
+
+- Implement Warp blocks, Warp Agent View, code review panels, file trees, or
+  changes sidebars.
+- Solve remote SSH/mux/cloud terminal persistence in this change.
+- Require provider-specific CLI agent plugins for the first draft. Structured
+  plugin or hook support can be added per agent after the Alan-side contract is
+  stable.
+- Replace existing terminal title/cwd/search/scrollback contracts.
+
+## Decisions
+
+### 1. Use one normalized activity model above source-specific adapters
+
+Alan should introduce a normalized terminal activity snapshot owned by the
+macOS shell/runtime boundary. Source adapters translate Ghostty progress,
+command-finished actions, bells, Alan session state, and CLI agent events into
+that snapshot. UI and control-plane consumers read the normalized state, not
+source-specific structs.
+
+The model should carry enough normalized state to produce both pane-local and
+tab-level display projections:
+
+- source kind: Codex, Claude, OpenCode, Alan, shell, progress, command, process,
+  or unknown
+- status: needs input, failed, paused, progress, running, bell, exited, idle,
+  done, or stale
+- priority/attention: passive, active, notable, or awaiting user
+- progress value: absent, indeterminate, percent, paused, or failed
+- command metadata: exit code, duration when available, command boundary when
+  known, and last update time
+- agent metadata: agent kind, session id when available, project/cwd when
+  available, and status detail when safe to show
+- display labels: reliable source label when known, fallback source label,
+  state label, detail label, optional pane hint, and progress display
+- freshness: updated-at timestamp plus optional expiry/stale deadlines
+
+The normalized model should expose two display projections rather than making
+every UI surface repeat merge logic:
+
+- `paneActivityDisplay`: the pane-local activity and detail for pane title bars,
+  accessibility, and control surfaces
+- `tabActivityDisplay`: the highest-priority sidebar-worthy activity selected
+  across the tab's panes for sidebar rows and tab-level attention
+
+Alternative considered: add separate UI state for Ghostty progress, command
+completion, and agent notifications. That is quicker initially but would repeat
+the same sidebar/titlebar/notification decisions for every source.
+
+### 2. Treat A as the first implementation phase
+
+The first phase should focus on activity ingestion, priority, freshness,
+projection, and low-noise notification policy. B and quick terminal stay in the
+draft spec so the direction is not forgotten, but they should not block the A
+phase design.
+
+Alternative considered: implement semantic command boundaries first. That would
+help command-finished quality, but Alan already receives enough Ghostty and
+agent signals to build useful activity UI without waiting for full prompt
+semantics.
+
+### 3. Prefer structured CLI agent signals, with conservative fallback
+
+Alan should prefer structured agent events or documented notification hooks for
+Codex, Claude Code, OpenCode, and similar CLIs. The first implementation can
+start with the highest-confidence signals and an unknown-agent fallback. It
+should not depend on brittle screen scraping of agent TUI text.
+
+For unsupported or partially supported agents, Alan may show process-level
+activity such as foreground command running or command finished, but it should
+not claim precise "needs input" or "done" states without a reliable signal.
+
+Alternative considered: parse common TUI output for prompts and status. That is
+fragile across agent releases, localization, themes, terminal widths, and
+alternate-screen rendering.
+
+### 4. Keep semantic terminal behavior lighter than blocks
+
+Alan should model prompt marks, command start/end, command text, output ranges,
+exit status, and search ranges as semantic terminal metadata. It should expose
+focused actions such as jump previous/next prompt, copy last command output,
+and browse/search command output. It should not turn every command into a
+visible card or block by default.
+
+This preserves Alan's terminal-first UI while still making terminal output more
+usable by humans and agents.
+
+Alternative considered: copy Warp's command block model. That would make
+command-level interactions explicit, but it conflicts with Alan's current
+Arc-like shell direction and risks making the terminal feel like an IDE panel.
+
+The B-group MVP should be action-only. When reliable prompt or command boundary
+metadata exists, `Go to or Command...` can expose command-aware actions:
+
+- jump to previous prompt
+- jump to next prompt
+- copy last command output
+- search last command output
+
+When reliable boundary metadata is absent, Alan falls back to ordinary terminal
+behavior such as scrollback search, selection copy, and normal scrollback
+navigation. It must not keep showing precise "last command output" actions while
+guessing from screen text. The MVP does not add a command browser, visible
+command blocks, or terminal output segmentation. It may store recent
+`CommandSegment` metadata to support the actions, but that storage is pane-local
+runtime metadata for the current terminal session rather than a long-term
+command history database.
+
+### 5. Implement quick terminal as a detached global Peak over normal runtimes
+
+Quick terminal should be a detached, globally summonable macOS Peak window, not
+a child popover of Alan's main window. It hosts one global quick-terminal
+pane/runtime and uses the same lifecycle, metadata, activity, clipboard, search,
+and command-routing contracts as regular panes.
+
+The draft default shortcut is a configurable global toggle, initially
+`Option+Space`. When the quick terminal is hidden, invoking the toggle presents
+the same global instance on the current macOS Space and active display without
+forcing Alan's main window to the front. When it is visible, invoking the same
+toggle hides it. `Esc` must remain terminal input and must not dismiss the Peak
+by default. Losing focus also does not hide the Peak; hide is an explicit toggle
+or command.
+
+Hide and show preserve scrollback and process state unless the user explicitly
+closes the quick terminal. If the global quick instance already exists, Alan
+restores that instance and its cwd. If Alan must create a new quick terminal, it
+chooses the cwd from the currently focused Alan pane when available, otherwise
+the last quick-terminal cwd, otherwise the user's home directory.
+
+The Peak can be promoted into a normal Alan Space through an `Open in Space`
+affordance. Promotion moves the current quick-terminal runtime into the selected
+Space as a normal tab, hides the Peak, and clears the global quick slot. Alan
+does not copy the terminal process or display the same runtime simultaneously in
+the Peak and a tab.
+
+Alternative considered: create a separate AppKit terminal panel with its own
+runtime owner. That would ship faster but would duplicate lifecycle, focus, and
+metadata behavior.
+
+### 6. Sidebar tab rows are tab-level attention and identity surfaces
+
+Sidebar tab rows should become richer work rows, but their job is still quick
+location and attention triage, not pane inspection. A tab row shows:
+
+- a leading visual slot
+- a title line
+- one secondary line that shows activity when activity exists, otherwise
+  worktree/branch context
+- an optional progress rail only when the displayed activity owns progress
+
+The leading slot expresses how to enter the tab. Single-pane tabs use the
+semantic kind or agent icon. Split tabs replace that icon with split topology;
+clicking the topology cycles focus through visible panes in order. Agent or Alan
+identity inside a split tab appears in title/activity metadata, not by mixing
+another icon into the topology slot.
+
+Tab titles initially follow the focused or primary pane. This keeps the first
+implementation simple and makes focus cycling visible in the row. The
+tab-level activity line, however, is selected from the highest-priority activity
+across the entire tab. If that activity belongs to a non-focused pane, the row
+uses a short pane hint such as `Pane 2`.
+
+When no sidebar-worthy activity exists, the secondary line falls back to
+worktree/repository leaf and branch rather than full cwd. This keeps the tab
+recognizable without turning the sidebar into a pane inspector.
+
+Alternative considered: keep the existing icon/title/subtitle row and only
+replace the subtitle with activity. That would be smaller, but it preserves the
+current low-density feel and keeps forcing status, cwd, branch, and process to
+compete for one field.
+
+### 7. Pane title bars provide pane-local detail
+
+Pane title bars keep terminal title as the primary label and use accessories
+for pane-local activity, worktree/cwd, branch, process, and agent/Alan state.
+This separates the surfaces: the sidebar answers "which tab needs attention?",
+while the pane title bar answers "what is this pane specifically doing?".
+
+Pane-local accessories can show more detail than the sidebar, but they still
+avoid raw IDs, hook payloads, event names, and redundant labels. If activity
+already says `Codex · Running`, a separate Codex marker should not repeat the
+same information.
+
+Alternative considered: move cwd/branch/process into the sidebar as permanent
+context. That is useful for identification, but it duplicates common terminal
+titles and makes the tab row feel like a compact inspector instead of an
+attention surface.
+
+### 8. Activity priority is action-first, with progress above generic running
+
+Sidebar activity should be source-first in its copy, such as `Codex · Input
+needed`, `Build · 42%`, `Progress · 42%`, or `Shell · Command failed 1`.
+Reliable source labels are used when available; otherwise progress falls back
+to `Progress` rather than guessing from output text or cwd.
+
+The initial sidebar priority is:
+
+1. input needed, approval, or blocked
+2. failed, error, or command failed
+3. paused
+4. active progress
+5. running agent or long foreground command
+6. bell or exited
+7. no sidebar-worthy activity, so show worktree/branch context
+
+Successful commands and idle states do not become sidebar activity. They may be
+pane-local transient detail or disappear immediately. Progress rail is shown
+only when the displayed activity itself owns progress, so the row never shows a
+progress bar for one pane while the copy describes another pane.
+
+Initial freshness rules are intentionally simple:
+
+- Progress clears or becomes stale after 15 seconds without an update or clear.
+- Command failure remains sidebar-worthy until the user focuses the tab or for
+  about 30 seconds, whichever comes first.
+- Bell is brief, roughly 5-10 seconds, unless another source upgrades it.
+- Process exited remains visible until the user closes or restarts the pane.
+- Running agent remains while a reliable agent/process signal says it is active.
+- Needs-input, approval, blocked, failed, and error states remain until a newer
+  reliable state replaces them.
+
+These windows are defaults, not user-visible promises. They should be easy to
+tune after visual review.
+
+Alternative considered: generic running above progress. That emphasizes which
+agent is active, but it hides reliable progress and makes the progress rail less
+useful.
+
+### 9. UI projection stays compact and progressive
+
+Activity should surface through pane title-bar accessories, sidebar secondary
+line/rail, accessibility values, and optional notifications. The default UI
+must not add persistent bottom strips, debug labels, large attention buttons,
+notification dots for every background change, or dashboard sections.
+
+Close controls in sidebar tab rows should be hover/focus overlays that do not
+reserve a permanent trailing layout slot. The row content may use a subtle fade
+or material treatment under the overlay so text does not collide visually with
+the close button.
+
+Notifications should be reserved for actionable or out-of-view activity:
+agent needs input, agent error, long command finished while unfocused, or
+explicit user opt-in. Foreground progress should usually stay visual only.
+
+The first source adapters should be Ghostty progress, Ghostty command
+finished/failed, Alan binding/session state, and Codex. That slice covers the
+highest-confidence local signals and the initial CLI-agent notification use
+case before broadening to Claude Code or OpenCode.
+
+Default notification policy should notify for agent needs input, agent
+failed/error, long command failed or completed in background, and unexpected
+process exit. It should not notify for foreground progress, command success,
+idle, or generic running.
+
+Alternative considered: use a notification center panel as the primary surface.
+That can be useful later, but it would be the wrong default center of gravity
+for a terminal-first shell.
+
+## Risks / Trade-offs
+
+- Stale progress can linger after interrupted programs -> Activity snapshots
+  need source-specific freshness policies and timeout/clear semantics.
+- Notifications can become noisy -> Default policy must gate on focus,
+  severity, duration, and explicit user intent.
+- Richer sidebar rows can become mini dashboards -> Keep only title,
+  activity-or-context, optional rail, and leading topology/kind slot in the
+  default row.
+- Hover close overlays can obscure text -> Apply fade/material treatment under
+  the overlay and keep the row accessible through keyboard focus.
+- CLI agent protocols can change -> Keep per-agent adapters small and let
+  unsupported agents fall back to generic terminal activity.
+- Semantic prompt data can be missing inside tmux, ssh, or unsupported shells ->
+  Semantic actions must degrade to normal scrollback/search behavior.
+- Quick terminal can fight normal window focus -> It must not bring Alan's main
+  window forward on summon, must stay visible across focus changes until the
+  user toggles or closes it, and must avoid stealing input while hidden.
+- A broad draft can become too large to implement -> Tasks are split into A,
+  B, and quick-terminal phases, with A as the first refinement target.
+
+## Migration Plan
+
+1. Add the normalized activity types and projection paths without changing the
+   visible UI.
+2. Map existing Ghostty progress, command-finished, bell, child-exit, and active
+   task signals into the normalized activity model.
+3. Refactor sidebar tab row projection to the richer title plus
+   activity-or-context layout with hover-only close overlay and leading
+   topology/kind slot.
+4. Update pane title-bar projection to read pane-local normalized activity while
+   preserving terminal title as the primary label.
+5. Add CLI agent adapters incrementally behind focused tests.
+6. Add semantic command-boundary storage and actions after A is stable.
+7. Add the detached global quick terminal Peak after the shared
+   runtime/activity behavior is proven in regular panes.
+
+## Open Questions
+
+- Which CLI agent should be the first structured adapter: Codex, Claude Code,
+  or OpenCode? The current draft defaults to Codex unless implementation
+  evidence shows another adapter is materially lower risk.
+- What exact notification defaults should Alan use for foreground vs
+  background panes? The current draft defaults to notifying only actionable or
+  out-of-view states.
+- What exact visual size/placement should the Peak use on small displays and
+  external monitors? The current draft assumes current active display placement
+  with size clamped to the visible rect.

--- a/openspec/changes/add-advanced-terminal-activity-semantics/proposal.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Alan's macOS terminal already projects title, cwd, attention, active task, and
+surface state into pane metadata, but advanced terminal workflows now need a
+durable contract for richer activity, semantic command boundaries, and a global
+quick terminal Peak surface. Without a draft owner, Ghostty-style progress,
+Warp-style agent status, prompt navigation, command-output browsing, and
+summonable quick-terminal work can drift into unrelated UI fixes.
+
+## What Changes
+
+- Add a unified terminal activity contract for progress, command completion,
+  long-running foreground commands, CLI coding-agent lifecycle state, and
+  attention/notification policy.
+- Define how activity is projected into pane title-bar accessories, sidebar tab
+  metadata, accessibility, and optional system notifications without introducing
+  dashboard panels or notification-dot clutter.
+- Redesign sidebar tab rows as richer attention/identity rows that show a tab
+  title plus either the highest-priority tab activity or a worktree/branch
+  context fallback, with hover-only close controls.
+- Add semantic terminal requirements for prompt/command boundaries, current
+  command/output ranges, prompt navigation, copy-last-output, and search/browse
+  flows that build on shell integration and terminal surface state.
+- Add a quick terminal draft contract for a detached global macOS Peak window
+  that can be summoned from any macOS Space, reused as a single instance, and
+  promoted into Alan spaces/tabs without creating a second terminal runtime
+  model.
+- Keep full Warp-style blocks, Agent View, code review panels, and IDE-like file
+  sidebars out of this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-terminal-activity-semantics`: Owns terminal activity state, CLI
+  coding-agent status ingestion, semantic command boundaries, prompt navigation,
+  command-output actions, and quick terminal behavior.
+
+### Modified Capabilities
+
+- `macos-terminal-runtime-foundation`: Extends runtime metadata projection from
+  title/cwd/attention/readiness into structured activity, command, and agent
+  state keyed by stable pane identity.
+- `macos-terminal-surface-parity`: Extends terminal surface parity from
+  scrollback/search/clipboard into semantic command-output browsing and
+  prompt-scoped actions.
+- `macos-shell-ui-ux-conformance`: Adds UI constraints for lightweight activity
+  indicators, progress display, agent status, notification surfaces, semantic
+  terminal controls, and quick terminal presentation.
+- `macos-shell-workspace-interactions`: Adds quick terminal global
+  summon/dismiss, focus restoration, single-instance lifecycle, promotion into
+  tabs/spaces, and command ownership semantics.
+
+## Impact
+
+- Apple runtime and Ghostty bridge: `GhosttyLiveHost.swift`,
+  `TerminalHostRuntime.swift`, `TerminalRuntimeService.swift`,
+  `TerminalRuntimeRegistry.swift`, and metadata snapshot propagation.
+- Apple shell model/projection: `ShellModel.swift`, `ShellHostController.swift`,
+  `ShellPaneProjectionService.swift`, shell snapshots, persistence, and control
+  plane DTOs where activity state becomes observable.
+- Apple shell UI: `TerminalPaneView.swift`, `ShellSidebarView.swift`,
+  `MacShellRootView.swift`, native commands, notification routing, and quick
+  terminal window/panel ownership.
+- Tests and contracts: macOS shell contract scripts, focused Swift script tests,
+  screenshot/visual review notes for activity/sidebar/titlebar behavior, and
+  OpenSpec validation.

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,155 @@
+## ADDED Requirements
+
+### Requirement: Activity UI Is Compact And Terminal First
+Terminal activity UI SHALL use compact pane title-bar accessories, sidebar tab
+metadata, and accessibility values instead of dashboard panels, persistent
+bottom status strips, or debug labels in the default shell.
+
+#### Scenario: Pane reports progress
+- **WHEN** a pane reports determinate, indeterminate, paused, or failed
+  progress
+- **THEN** Alan presents that state as a lightweight pane title-bar accessory or
+  sidebar activity rail that does not resize the terminal canvas, toolbar
+  content, or split dividers
+
+#### Scenario: Pane reports agent status
+- **WHEN** a pane running a supported CLI coding agent reports running, needs
+  input, complete, or error state
+- **THEN** Alan presents a compact user-facing status in the pane title-bar and
+  sidebar row without exposing raw event names, hook payloads, session IDs, or
+  debug implementation details
+
+#### Scenario: No actionable activity exists
+- **WHEN** a tab has no active, notable, or user-actionable terminal activity
+- **THEN** the sidebar tab row shows worktree and branch context as its
+  secondary line instead of reserving empty activity chrome or showing idle or
+  success states
+
+### Requirement: Sidebar Tab Rows Are Attention-Oriented Work Rows
+Sidebar tab rows SHALL use a richer but restrained layout that helps users
+identify a tab and decide whether it needs attention.
+
+#### Scenario: Tab row default layout
+- **WHEN** Alan renders a sidebar tab row
+- **THEN** the row contains a leading topology or kind slot, a title line, one
+  secondary line that shows activity or worktree/branch context, and an
+  optional progress rail only when the displayed activity owns progress
+
+#### Scenario: Close affordance appears
+- **WHEN** a sidebar tab row is hovered, keyboard-focused, or otherwise
+  interaction-active
+- **THEN** the close affordance appears as a trailing overlay without reserving
+  a permanent layout slot in the row content
+
+#### Scenario: Close affordance is hidden
+- **WHEN** a sidebar tab row is not interaction-active
+- **THEN** title, secondary text, activity, and progress content may occupy the
+  full row width without leaving a fixed empty close-button column
+
+#### Scenario: Split tab leading slot
+- **WHEN** a tab contains multiple visible panes
+- **THEN** the leading slot shows split topology instead of the generic terminal
+  icon, and activating that topology cycles focus through panes in a stable
+  order
+
+#### Scenario: Single-pane leading slot
+- **WHEN** a tab contains one pane
+- **THEN** the leading slot shows the tab kind or supported agent icon rather
+  than a split topology indicator
+
+#### Scenario: Activity takes precedence over context
+- **WHEN** a tab has sidebar-worthy activity
+- **THEN** the secondary line shows the source-first activity copy instead of
+  worktree or branch context
+
+#### Scenario: No activity fallback
+- **WHEN** a tab has no sidebar-worthy activity
+- **THEN** the secondary line uses worktree or repository leaf plus branch when
+  available, with cwd leaf only as a fallback
+
+### Requirement: Pane Title Bars Own Pane Detail
+Pane title bars SHALL keep terminal title as the primary label and expose
+pane-local context through accessories.
+
+#### Scenario: Pane title bar with activity
+- **WHEN** a pane has pane-local activity, cwd or worktree context, branch,
+  process, or supported agent state
+- **THEN** the pane title bar presents that detail as compact accessories while
+  keeping the terminal title as the primary text
+
+#### Scenario: Sidebar and pane title differ
+- **WHEN** the sidebar tab row shows a tab-level activity from another pane
+- **THEN** the focused pane title bar still shows only the focused pane's own
+  local detail and does not mirror unrelated tab-level activity
+
+### Requirement: Activity Notifications Are Low Noise
+System and in-app notifications for terminal activity SHALL be reserved for
+actionable, out-of-view, or user-configured events.
+
+#### Scenario: Background agent needs input
+- **WHEN** a background or unfocused pane's supported coding agent needs user
+  input
+- **THEN** Alan may notify the user and mark the owning tab without stealing
+  focus or opening a new panel
+
+#### Scenario: Foreground progress updates
+- **WHEN** the focused visible pane emits progress updates
+- **THEN** Alan updates visible activity UI without sending system
+  notifications by default
+
+#### Scenario: Long command completes while unfocused
+- **WHEN** a long-running command completes in an unfocused pane and the event
+  meets the notification policy
+- **THEN** Alan may send a concise command-completion notification with success
+  or failure state
+
+#### Scenario: Foreground command succeeds
+- **WHEN** a command succeeds in the focused visible pane
+- **THEN** Alan does not send a system notification by default
+
+#### Scenario: Agent fails in background
+- **WHEN** a supported coding agent reports failure or error in a background or
+  unfocused pane
+- **THEN** Alan may send a concise notification and mark the owning tab
+
+### Requirement: Quick Terminal Presentation Is Native And Lightweight
+The quick terminal SHALL present as a detached, lightweight native macOS Peak
+window that preserves Alan's terminal-first shell design and avoids dashboard or
+floating-card composition.
+
+#### Scenario: Quick terminal appears
+- **WHEN** the quick terminal is summoned
+- **THEN** Alan presents a focused terminal surface with restrained native
+  material chrome, no inspector, no marketing-style header, and no duplicate
+  sidebar
+
+#### Scenario: Quick terminal appears outside the main window
+- **WHEN** the user summons the quick terminal from any macOS Space
+- **THEN** Alan presents the Peak on the current active display and Space
+  without requiring, attaching to, or raising Alan's main window
+
+#### Scenario: Quick terminal hides
+- **WHEN** the quick terminal is dismissed without closing the session
+- **THEN** Alan hides the presentation without changing regular shell sidebar,
+  tab, split, or terminal geometry
+
+#### Scenario: Terminal keys remain terminal keys
+- **WHEN** the quick terminal owns focus and the user presses `Esc`
+- **THEN** Alan sends the key to the terminal surface instead of hiding the Peak
+  by default
+
+#### Scenario: Focus changes outside the Peak
+- **WHEN** the quick terminal loses focus because the user clicks another app or
+  window
+- **THEN** Alan keeps the Peak visible until the user invokes the quick-terminal
+  toggle, hide command, close command, or promotion action
+
+#### Scenario: Quick terminal can become a normal tab
+- **WHEN** the user opens the Peak's `Open in Space` affordance
+- **THEN** Alan offers Alan Space destinations without duplicating sidebar
+  chrome inside the Peak
+
+#### Scenario: Quick terminal activity exists
+- **WHEN** the hidden quick terminal has user-actionable activity
+- **THEN** Alan surfaces that activity through the same compact activity and
+  notification policy used for regular terminal panes

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Quick Terminal Summon And Dismiss Are Shell Commands
+Quick terminal summon, dismiss, focus, and close operations SHALL route through
+Alan's shared shell command/controller paths so keyboard shortcuts, menu
+commands, command input, and control surfaces converge on the same behavior.
+Alan SHALL expose a configurable global toggle shortcut for quick terminal; the
+draft default shortcut is `Option+Space`.
+
+#### Scenario: Quick terminal command opens
+- **WHEN** the user invokes quick terminal from a keyboard shortcut, menu,
+  command input, or supported control command
+- **THEN** Alan summons the same quick terminal target through the shared shell
+  controller path and focuses terminal input
+
+#### Scenario: Quick terminal global shortcut toggles
+- **WHEN** the quick terminal is visible and the user invokes the quick terminal
+  toggle command again
+- **THEN** Alan hides the quick terminal presentation without closing the
+  underlying terminal runtime
+
+#### Scenario: Quick terminal does not use Escape as hide
+- **WHEN** the quick terminal owns focus and the user presses `Esc`
+- **THEN** Alan treats the key as terminal input unless an Alan-owned nested
+  quick-terminal menu or picker is currently open
+
+#### Scenario: Quick terminal close is explicit
+- **WHEN** the user invokes close while the quick terminal owns focus
+- **THEN** Alan distinguishes hiding the quick terminal presentation from
+  closing the underlying terminal session
+
+### Requirement: Quick Terminal Has One Global Instance
+The quick terminal SHALL have a deterministic relationship to Alan's spaces,
+tabs, focus, persistence, and runtime identity. Alan SHALL model the MVP as one
+global quick-terminal instance, not one instance per Alan Space or one instance
+per macOS Space.
+
+#### Scenario: Existing quick terminal is reused globally
+- **WHEN** Alan creates or restores the quick terminal
+- **THEN** Alan reuses the single global quick-terminal runtime when it is live
+  rather than creating another quick terminal for the current Alan Space or
+  macOS Space
+
+#### Scenario: Quick terminal appears in the current macOS context
+- **WHEN** the user summons the hidden global quick terminal from a different
+  macOS Space or display
+- **THEN** Alan presents the same quick-terminal instance on the current active
+  display and Space without changing its runtime identity
+
+#### Scenario: Regular workspace remains stable
+- **WHEN** the quick terminal appears or disappears
+- **THEN** selected space, selected tab, split tree, regular terminal focus, and
+  pane runtime identities remain stable unless the user explicitly moves focus
+  or closes a session
+
+#### Scenario: Quick terminal cwd is deterministic
+- **WHEN** Alan creates a new quick-terminal runtime because no live global
+  quick-terminal instance exists
+- **THEN** Alan chooses the working directory from the focused Alan pane when
+  available, otherwise from the last quick-terminal cwd when available,
+  otherwise from the user's home directory
+
+#### Scenario: Quick terminal promotes into a Space
+- **WHEN** the user chooses `Open in Space` for a target Alan Space
+- **THEN** Alan moves the quick-terminal runtime into that Space as a normal tab,
+  hides the Peak presentation, and clears the global quick-terminal slot
+
+#### Scenario: Quick terminal promotion is not copy or link
+- **WHEN** Alan promotes the quick terminal into a normal tab
+- **THEN** Alan does not copy the terminal process and does not keep the same
+  runtime visible in both the Peak and the target tab

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-activity-semantics/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-activity-semantics/spec.md
@@ -1,0 +1,280 @@
+## ADDED Requirements
+
+### Requirement: Terminal Activity Is Normalized
+Alan SHALL normalize terminal progress, foreground command state, command
+completion, bell attention, Alan session activity, and supported CLI
+coding-agent state into a pane-scoped terminal activity model before projecting
+that state into UI, accessibility, persistence, or control surfaces.
+
+#### Scenario: Ghostty progress is normalized
+- **WHEN** a terminal pane receives a Ghostty progress report
+- **THEN** Alan records a pane-scoped activity state with progress kind,
+  optional percentage, freshness timestamp, source kind, and attention priority
+
+#### Scenario: Command completion is normalized
+- **WHEN** a terminal pane receives a command-finished event with exit status or
+  duration metadata
+- **THEN** Alan records a command completion activity with success or failure
+  status, last command metadata when available, and a bounded freshness window
+
+#### Scenario: Agent state is normalized
+- **WHEN** a supported CLI coding agent emits a reliable running, blocked,
+  complete, or error signal
+- **THEN** Alan records agent activity using the same pane-scoped activity model
+  instead of introducing a separate sidebar or notification state path
+
+### Requirement: Activity Priority And Freshness Are Deterministic
+Alan SHALL compute the visible activity state for a pane from source priority,
+attention severity, freshness, focus, and user actionability so stale or
+low-priority signals do not mask newer actionable signals.
+
+#### Scenario: Progress becomes stale
+- **WHEN** a progress-producing command stops updating without clearing its
+  progress state
+- **THEN** Alan marks or clears the progress activity according to a bounded
+  freshness policy instead of showing permanent in-progress UI
+
+#### Scenario: Agent needs input while command progress exists
+- **WHEN** a pane has both command progress and a supported agent signal that
+  requires user input
+- **THEN** Alan surfaces the agent input-required state as the primary activity
+  while retaining progress metadata only as secondary context
+
+#### Scenario: Successful command completes in focused pane
+- **WHEN** a focused pane reports successful command completion
+- **THEN** Alan may update transient metadata but MUST NOT produce disruptive
+  attention UI or a system notification by default
+
+#### Scenario: Sidebar priority is computed
+- **WHEN** a tab has input-required, failed, paused, progress, running, bell,
+  exited, and idle activity candidates across its panes
+- **THEN** Alan chooses sidebar activity in that priority order and falls back
+  to worktree and branch context when no sidebar-worthy activity exists
+
+#### Scenario: Progress stops updating
+- **WHEN** a progress activity has not updated or cleared within the bounded
+  freshness window
+- **THEN** Alan marks it stale or removes it from sidebar-worthy activity
+
+#### Scenario: Command failure is acknowledged
+- **WHEN** a command failure is displayed in the sidebar and the user focuses
+  the owning tab
+- **THEN** Alan may demote the command failure from sidebar-worthy activity so
+  the tab can return to context display
+
+### Requirement: CLI Coding-Agent Status Is Ingested Conservatively
+Alan SHALL ingest CLI coding-agent lifecycle state from reliable structured
+signals, documented notification hooks, or explicit integration adapters, and
+SHALL fall back to generic terminal activity when no reliable agent signal is
+available.
+
+#### Scenario: Structured agent event arrives
+- **WHEN** a supported agent event identifies the agent kind, session, cwd or
+  project, and lifecycle transition
+- **THEN** Alan maps it to pane-scoped agent activity and records only
+  user-facing safe metadata in default UI surfaces
+
+#### Scenario: Agent support is partial
+- **WHEN** Alan can detect a likely coding agent process but cannot determine
+  whether it is running, blocked, complete, or errored
+- **THEN** Alan surfaces generic foreground-command or unknown-agent activity
+  rather than claiming a precise agent lifecycle state
+
+#### Scenario: Agent event is unsafe or malformed
+- **WHEN** an agent integration emits malformed, untrusted, or overly detailed
+  status payloads
+- **THEN** Alan drops or sanitizes the payload for default UI and keeps raw
+  diagnostics only in explicit debug surfaces
+
+#### Scenario: Initial Codex adapter
+- **WHEN** Codex emits a reliable notification or structured lifecycle signal
+- **THEN** Alan maps it into the same pane-scoped activity model used by
+  terminal, command, progress, and Alan session sources
+
+### Requirement: Activity Projects To Lightweight Terminal UI
+Alan SHALL surface terminal activity through compact pane title-bar
+accessories, sidebar tab metadata, accessibility values, and optional
+notifications while preserving terminal-first layout and input ownership.
+
+#### Scenario: Background agent needs input
+- **WHEN** a background pane's supported coding agent needs user input
+- **THEN** Alan marks the owning tab and pane with lightweight status metadata
+  and may issue a notification without stealing terminal focus
+
+#### Scenario: Progress is active in visible pane
+- **WHEN** a visible pane reports determinate or indeterminate progress
+- **THEN** Alan presents progress as a compact terminal accessory or thin
+  pane-local indicator without adding a persistent bottom strip or resizing the
+  terminal canvas
+
+#### Scenario: Activity clears
+- **WHEN** the primary activity reaches a terminal state or expires
+- **THEN** Alan removes or demotes the visible activity indicator without
+  changing pane, split, sidebar, or toolbar geometry
+
+### Requirement: Sidebar Activity Is Tab Level
+Alan SHALL compute sidebar tab activity from the highest-priority
+sidebar-worthy activity across every pane in the tab, while keeping the tab
+title derived from the focused or primary pane for the initial implementation.
+
+#### Scenario: Background pane needs input
+- **WHEN** a non-focused pane in a split tab reports a supported coding-agent
+  input-required state
+- **THEN** the sidebar tab row surfaces that input-required activity as the tab
+  activity and includes a short pane hint
+
+#### Scenario: Focused pane is idle and background pane has progress
+- **WHEN** the focused pane has no sidebar-worthy activity and another pane in
+  the same tab owns active progress
+- **THEN** the sidebar tab row surfaces the progress activity and progress rail
+  for the tab
+
+#### Scenario: No sidebar-worthy activity exists
+- **WHEN** every pane in a tab is idle or only has successful completion state
+- **THEN** the sidebar tab row falls back to worktree and branch context instead
+  of showing idle or success as activity
+
+### Requirement: Sidebar Activity Copy Is Source First
+Alan SHALL render sidebar activity copy with source-first labels and SHALL avoid
+guessing source labels from arbitrary terminal output.
+
+#### Scenario: Reliable source label exists
+- **WHEN** a tab activity has a reliable source label such as a supported agent,
+  command boundary label, or explicit task label
+- **THEN** the sidebar activity line renders source before state, such as
+  `Codex · Input needed` or `Build · 42%`
+
+#### Scenario: Progress label is unavailable
+- **WHEN** a progress activity has no reliable source label
+- **THEN** the sidebar activity line uses `Progress` as the source label rather
+  than parsing terminal output or cwd text
+
+#### Scenario: Activity comes from another pane
+- **WHEN** sidebar tab activity belongs to a pane that is not the focused or
+  primary pane
+- **THEN** the sidebar activity line includes a short pane hint before the
+  source-first activity copy
+
+#### Scenario: Success and idle are not sidebar activity
+- **WHEN** a pane reports successful command completion, idle shell state, title
+  update, or working-directory update
+- **THEN** Alan does not render that state as sidebar activity
+
+### Requirement: Sidebar Progress Rail Belongs To Displayed Activity
+Alan SHALL render a sidebar progress rail only when the sidebar activity being
+displayed owns progress.
+
+#### Scenario: Displayed activity owns progress
+- **WHEN** the highest-priority sidebar activity is determinate progress
+- **THEN** the sidebar row may render a compact progress rail using that
+  activity's progress value
+
+#### Scenario: Different pane owns progress
+- **WHEN** the displayed sidebar activity is input-required, failed, paused, or
+  another non-progress state and a different pane has active progress
+- **THEN** the sidebar row does not render the different pane's progress rail
+  alongside the displayed activity
+
+### Requirement: Pane Title Activity Is Pane Local
+Alan SHALL project pane title-bar activity from the pane's own normalized
+activity and SHALL allow pane title bars to show more pane-local context than
+sidebar tab rows.
+
+#### Scenario: Pane has local progress
+- **WHEN** a visible pane owns progress activity
+- **THEN** the pane title bar may show pane-local progress detail even when the
+  sidebar tab row is showing a higher-priority activity from another pane
+
+#### Scenario: Pane activity repeats agent marker
+- **WHEN** pane-local activity already identifies a supported agent or Alan state
+- **THEN** the pane title bar avoids repeating a separate marker that conveys
+  the same agent identity
+
+#### Scenario: Title already contains context
+- **WHEN** the terminal title already provides the same cwd or worktree context
+  that a pane title accessory would show
+- **THEN** Alan may suppress the redundant context accessory while preserving
+  branch, process, or activity accessories that add distinct information
+
+### Requirement: Semantic Command Boundaries Are Pane Scoped
+Alan SHALL model shell prompt marks, command start, command end, command text,
+output range, exit status, and timestamps as semantic metadata owned by the
+terminal pane when those signals are available.
+
+#### Scenario: Shell integration reports command boundary
+- **WHEN** shell integration or terminal protocol events identify a command
+  start and command end
+- **THEN** Alan records the command boundary and output range for the owning
+  pane without changing terminal rendering or scrollback ownership
+
+#### Scenario: Semantic data is unavailable
+- **WHEN** prompt marks or command boundaries are unavailable because of shell,
+  tmux, ssh, or application mode limitations
+- **THEN** Alan keeps normal terminal behavior and disables semantic-only
+  actions instead of guessing output ranges from screen text
+
+### Requirement: Semantic Terminal Actions Are Focused And Reversible
+Alan SHALL expose prompt navigation, copy-last-command-output, and
+command-output search or browse actions through pane-scoped command paths that
+do not mutate terminal process state.
+
+#### Scenario: User jumps between prompts
+- **WHEN** semantic prompt marks exist for the focused pane and the user invokes
+  previous or next prompt
+- **THEN** Alan scrolls the pane viewport to the target prompt without changing
+  shell focus, split layout, or command history
+
+#### Scenario: User copies last command output
+- **WHEN** a focused pane has a known last command output range and the user
+  invokes copy last output
+- **THEN** Alan copies that output to the system pasteboard without sending text
+  into the terminal application
+
+#### Scenario: User searches command output
+- **WHEN** a focused pane has command output ranges and the user invokes
+  command-output search or browse
+- **THEN** Alan scopes the interaction to that pane and returns focus to the
+  terminal after dismissal
+
+#### Scenario: Command-aware actions are command-menu actions
+- **WHEN** a focused pane has reliable command boundary metadata
+- **THEN** Alan exposes command-aware prompt navigation, copy-last-output, and
+  search-last-output actions through `Go to or Command...` without adding
+  persistent terminal chrome
+
+#### Scenario: Command boundaries are unavailable
+- **WHEN** a focused pane has no reliable command boundary metadata
+- **THEN** Alan falls back to ordinary scrollback search, selection copy, and
+  normal scrollback navigation rather than guessing command ranges from screen
+  text
+
+#### Scenario: No command browser in MVP
+- **WHEN** semantic terminal actions are available
+- **THEN** Alan does not render a command browser, visible command blocks, or
+  persistent command-output segmentation for the MVP
+
+### Requirement: Quick Terminal Uses Normal Terminal Runtime Ownership
+Alan SHALL implement quick terminal behavior as a detached global macOS Peak
+presentation over the existing shell model and terminal runtime service, not as
+an independent terminal runtime owner.
+
+#### Scenario: Quick terminal is summoned
+- **WHEN** the user invokes the quick terminal command
+- **THEN** Alan presents the single global quick-terminal instance using a
+  normal pane runtime, restores its scrollback and process state when available,
+  and focuses terminal input
+
+#### Scenario: Quick terminal is dismissed
+- **WHEN** the user dismisses the quick terminal without closing its terminal
+- **THEN** Alan hides the presentation, preserves the terminal runtime state,
+  and does not mutate normal tab or split runtime ownership
+
+#### Scenario: Quick terminal is closed
+- **WHEN** the user explicitly closes the quick terminal's terminal session
+- **THEN** Alan tears down the underlying pane runtime through the same lifecycle
+  path used by regular terminal panes
+
+#### Scenario: Quick terminal is promoted
+- **WHEN** the user promotes the quick terminal into an Alan Space
+- **THEN** Alan transfers ownership of the existing pane runtime into a normal
+  tab in that Space and clears the quick-terminal slot

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime metadata is projected by pane identity
+The runtime service SHALL project terminal title, cwd, process status,
+attention, renderer phase, readiness, delivery diagnostics, terminal activity,
+semantic command state, and CLI coding-agent status into alan shell state using
+stable pane IDs.
+
+#### Scenario: Metadata event from background pane
+- **WHEN** a background pane emits a title, cwd, process, attention,
+  renderer-state, activity, semantic command, or agent-status event
+- **THEN** shell state updates the matching pane record without changing user
+  focus
+
+#### Scenario: Progress event from background pane
+- **WHEN** a background pane emits terminal progress or command-completion
+  activity
+- **THEN** the runtime service projects that activity by pane ID so sidebar,
+  titlebar, accessibility, and control surfaces can read the same state
+
+#### Scenario: Agent event from background pane
+- **WHEN** a supported CLI coding agent emits a lifecycle event from a terminal
+  pane
+- **THEN** the runtime service associates the normalized agent activity with the
+  stable pane ID rather than with a transient host view
+
+#### Scenario: Metadata event after pane close
+- **WHEN** a terminal callback arrives after its pane has reached closed state
+- **THEN** the runtime service ignores or records it as late diagnostics without
+  resurrecting the pane

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-surface-parity/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-surface-parity/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Semantic Command Output Actions Are Pane Scoped
+The macOS terminal surface SHALL support semantic command-output actions only
+for the owning pane and only when command boundary metadata is available.
+
+#### Scenario: Copy known command output
+- **WHEN** the focused terminal pane has a known command output range and the
+  user invokes copy last command output
+- **THEN** the terminal surface copies that range from the pane buffer to the
+  pasteboard without sending printable input to the terminal process
+
+#### Scenario: Command output range is unknown
+- **WHEN** the focused terminal pane does not have a reliable command output
+  range
+- **THEN** Alan falls back to ordinary terminal selection, visible-range copy,
+  or scrollback behavior where appropriate without guessing a last-command
+  output range from visible screen text
+
+### Requirement: Prompt Navigation Respects Terminal Modes
+Prompt navigation SHALL operate on normal-buffer semantic prompt marks and
+SHALL avoid conflicting with alternate-screen or terminal mouse modes.
+
+#### Scenario: Normal buffer prompt navigation
+- **WHEN** the focused pane is in normal-buffer mode and semantic prompt marks
+  are available
+- **THEN** previous or next prompt navigation scrolls the terminal viewport to
+  the selected prompt mark
+
+#### Scenario: Alternate screen is active
+- **WHEN** an alternate-screen application owns the focused pane
+- **THEN** prompt navigation does not expose stale normal-buffer prompt marks as
+  active application state
+
+### Requirement: Command Output Browse Reuses Search Ownership
+Command-output browse and search flows SHALL reuse pane-scoped terminal search
+ownership instead of introducing a global search panel.
+
+#### Scenario: Browse command output
+- **WHEN** the user opens command-output browse or search for a focused pane
+- **THEN** Alan scopes the query, match navigation, and dismissal behavior to
+  that pane's terminal surface
+
+#### Scenario: Browse dismissed
+- **WHEN** the user dismisses command-output browse or search
+- **THEN** keyboard focus returns to the terminal pane that owned the
+  interaction when available
+
+#### Scenario: Search last output unavailable
+- **WHEN** reliable command output range metadata is unavailable
+- **THEN** search-last-output falls back to pane-scoped scrollback search rather
+  than presenting a fake command-scoped search range

--- a/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
@@ -1,0 +1,124 @@
+## 1. A-Group Refinement Gate
+
+- [ ] 1.1 Audit current terminal metadata sources in `GhosttyLiveHost`,
+  `TerminalHostRuntime`, `TerminalRuntimeService`, `ShellHostController`, and
+  `ShellPaneProjectionService`.
+- [ ] 1.2 Finalize normalized activity state names, source kinds, source-first
+  display labels, priority order, freshness rules, and user-facing labels for
+  progress, command, Alan, and CLI agent states.
+- [ ] 1.3 Finalize sidebar row projection details for title, activity-or-context
+  fallback, progress rail, leading topology/kind slot, and hover close overlay.
+- [ ] 1.4 Encode default notification policy for focused, visible, background,
+  unfocused, successful, failed, and user-input-required activity.
+- [ ] 1.5 Document Codex as the first CLI coding-agent adapter target unless
+  implementation evidence shows another adapter is lower risk.
+
+## 2. Activity Model And Projection
+
+- [ ] 2.1 Add pane-scoped terminal activity value types for source, status,
+  priority, progress, command outcome, agent metadata, freshness, timestamps,
+  and source-first display labels.
+- [ ] 2.2 Extend terminal metadata snapshots and shell projection paths to carry
+  normalized activity without removing existing title/cwd/attention fields.
+- [ ] 2.3 Add deterministic activity merge and priority logic for concurrent
+  progress, command completion, bell, Alan, and agent signals, including
+  tab-level highest-priority activity selection.
+- [ ] 2.4 Add unit/script coverage for activity merge order, stale progress,
+  focused successful command completion exclusion from sidebar activity,
+  progress-over-running priority, and user-input-required priority.
+- [ ] 2.5 Add freshness coverage for progress stale/clear, command failure
+  demotion after focus or timeout, brief bell, persistent exited state, and
+  persistent needs-input/error until replaced.
+
+## 3. Ghostty And Command Activity Sources
+
+- [ ] 3.1 Map `GHOSTTY_ACTION_PROGRESS_REPORT` into structured activity including
+  determinate, indeterminate, paused, error, clear, and stale states.
+- [ ] 3.2 Map `GHOSTTY_ACTION_COMMAND_FINISHED` into command-completion activity
+  with success/failure status and duration when available.
+- [ ] 3.3 Keep bell and child-exit attention compatible with the normalized
+  activity model without changing existing terminal overlay semantics.
+- [ ] 3.4 Add focused tests for progress update, progress clear, command success,
+  command failure, and stale-progress timeout behavior.
+
+## 4. CLI Coding-Agent Activity
+
+- [ ] 4.1 Add a small adapter boundary for reliable CLI agent events and unknown
+  agent fallback state.
+- [ ] 4.2 Implement the Codex adapter slice from task 1.5, or update the draft
+  with evidence if another first adapter is selected.
+- [ ] 4.3 Sanitize agent event payloads so default UI never exposes raw hook
+  payloads, raw session IDs, or implementation event names.
+- [ ] 4.4 Add tests for supported agent running, needs-input, complete, error,
+  malformed payload, and unsupported-agent fallback.
+
+## 5. Activity UI And Notifications
+
+- [ ] 5.1 Render normalized activity in pane title-bar accessories without
+  resizing pane title bars or terminal canvases.
+- [ ] 5.2 Refactor sidebar tab rows to show a leading topology/kind slot, title
+  line, activity-or-worktree/branch secondary line, optional same-source
+  progress rail, and hover-only close overlay.
+- [ ] 5.3 Move split topology into the leading slot for split tabs and make
+  activation cycle focus through panes in stable order.
+- [ ] 5.4 Keep single-pane tabs on semantic kind or supported agent icons in the
+  leading slot.
+- [ ] 5.5 Project pane title-bar accessories from pane-local detail: activity,
+  worktree/cwd, branch, process, and non-duplicated agent/Alan state.
+- [ ] 5.6 Add low-noise notification routing for user-input-required, error, and
+  long-command-complete events according to the task 1.4 policy.
+- [ ] 5.7 Add accessibility labels or values for activity state on pane and tab
+  affordances.
+- [ ] 5.8 Add visual review evidence for focused progress, background agent
+  needs-input, command failure, cleared activity showing worktree/branch
+  fallback, split leading topology, and hover close overlay.
+
+## 6. B-Group Semantic Terminal Draft Follow-Up
+
+- [ ] 6.1 Audit which command-boundary and prompt-mark signals are available from
+  the embedded Ghostty surface and existing shell integration.
+- [ ] 6.2 Define pane-scoped `CommandSegment` storage for prompt ranges, command
+  ranges, output ranges, command text, cwd, exit status, started/ended
+  timestamps, and reliable/unavailable boundary state.
+- [ ] 6.3 Expose command-aware actions through `Go to or Command...` only when
+  reliable boundaries exist: jump previous prompt, jump next prompt, copy last
+  command output, and search last command output.
+- [ ] 6.4 Fall back to ordinary scrollback search, selection copy, visible-range
+  copy, and normal scrollback navigation when reliable boundaries are missing.
+- [ ] 6.5 Keep the MVP action-only: no command browser, no visible command blocks,
+  no persistent output segmentation, and no long-term command history database.
+- [ ] 6.6 Reuse pane-scoped search ownership for search-last-output and fallback
+  scrollback search.
+
+## 7. Quick Terminal Draft Follow-Up
+
+- [ ] 7.1 Add a single global quick-terminal slot that reuses one terminal
+  runtime across hide/show and summons it onto the current macOS Space/display.
+- [ ] 7.2 Add shared shell command routing for the configurable global toggle
+  shortcut, draft default `Option+Space`, plus explicit show, hide, focus, close,
+  and promote commands.
+- [ ] 7.3 Present the quick terminal through a detached native macOS Peak window
+  that does not depend on or raise Alan's main window and that uses normal
+  terminal runtime service ownership.
+- [ ] 7.4 Preserve quick terminal runtime state across hide/show, keep `Esc`
+  routed to the terminal, avoid focus-loss auto-hide, and tear down the runtime
+  only through explicit close semantics.
+- [ ] 7.5 Apply quick-terminal cwd creation rules: existing instance cwd,
+  focused Alan pane cwd, last quick-terminal cwd, then home.
+- [ ] 7.6 Implement `Open in Space` promotion as a move into the selected Alan
+  Space/tab that hides the Peak and clears the global quick slot.
+- [ ] 7.7 Add focus, display/Space placement, hide/show, close, promote, and
+  hidden-activity notification tests.
+
+## 8. Verification And Archive Readiness
+
+- [ ] 8.1 Run focused Swift script tests for activity model, projection, Ghostty
+  source mapping, and CLI agent adapters.
+- [ ] 8.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 8.3 Run the relevant macOS app build command for the touched Apple client
+  targets.
+- [ ] 8.4 Run `git diff --check`.
+- [ ] 8.5 Run `openspec validate add-advanced-terminal-activity-semantics --type
+  change --strict --json`.
+- [ ] 8.6 Run `openspec validate --all --strict --json`.
+- [ ] 8.7 Sync accepted delta requirements into `openspec/specs/` before archive.


### PR DESCRIPTION
## Summary
- Add a draft OpenSpec change for advanced terminal activity semantics across Activity Model, semantic terminal boundaries, and Quick Terminal Peak.
- Specify sidebar tab row attention layout, pane title-bar activity projection, Ghostty progress/command-finished mapping, CLI agent status, and notification defaults.
- Capture Quick Terminal Peak as a detached global single-instance window with Option+Space toggle, no Escape dismissal, deterministic cwd, and Open in Space promotion semantics.

## Verification
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- openspec validate --all --strict --json
- git diff --check -- openspec/changes/add-advanced-terminal-activity-semantics