### PR TITLE
Implement terminal activity model foundation

### DIFF
--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -706,13 +706,18 @@ final class AlanGhosttyLiveHost: NSObject {
             } else {
                 summary = "command failed (\(exitCode))"
             }
+            let activity = exitCode >= 0
+                ? TerminalActivitySnapshot.commandCompletion(exitCode: Int(exitCode), now: .now)
+                : nil
             performOnMain {
                 self.updateMetadata(
                     summary: summary,
                     attention: exitCode == 0 ? .active : .notable,
                     processExited: false,
                     lastCommandExitCode: Int(exitCode),
-                    activeTaskState: .inactive
+                    activeTaskState: .inactive,
+                    activity: activity,
+                    clearActivity: exitCode < 0
                 )
             }
             return true
@@ -720,8 +725,14 @@ final class AlanGhosttyLiveHost: NSObject {
         case GHOSTTY_ACTION_PROGRESS_REPORT:
             let progress = action.action.progress_report
             let summary = progressSummary(progress)
+            let activity = progressActivity(progress)
             performOnMain {
-                self.updateMetadata(summary: summary, attention: .active)
+                self.updateMetadata(
+                    summary: summary,
+                    attention: .active,
+                    activity: activity,
+                    clearActivity: progress.state == GHOSTTY_PROGRESS_STATE_REMOVE
+                )
             }
             return true
 
@@ -796,6 +807,56 @@ final class AlanGhosttyLiveHost: NSObject {
         }
     }
 
+    private func progressActivity(
+        _ progress: ghostty_action_progress_report_s,
+        now: Date = .now
+    ) -> TerminalActivitySnapshot? {
+        switch progress.state {
+        case GHOSTTY_PROGRESS_STATE_REMOVE:
+            return nil
+        case GHOSTTY_PROGRESS_STATE_SET:
+            if progress.progress >= 0 {
+                return TerminalActivitySnapshot.progressActivity(
+                    percent: Int(progress.progress),
+                    now: now
+                )
+            }
+            return TerminalActivitySnapshot.progressActivity(
+                progress: .indeterminate,
+                status: .progress,
+                priority: .active,
+                stateLabel: "Running",
+                now: now
+            )
+        case GHOSTTY_PROGRESS_STATE_ERROR:
+            return TerminalActivitySnapshot.progressActivity(
+                progress: .failed,
+                status: .failed,
+                priority: .notable,
+                stateLabel: "Failed",
+                now: now
+            )
+        case GHOSTTY_PROGRESS_STATE_INDETERMINATE:
+            return TerminalActivitySnapshot.progressActivity(
+                progress: .indeterminate,
+                status: .progress,
+                priority: .active,
+                stateLabel: "Running",
+                now: now
+            )
+        case GHOSTTY_PROGRESS_STATE_PAUSE:
+            return TerminalActivitySnapshot.progressActivity(
+                progress: .paused,
+                status: .paused,
+                priority: .active,
+                stateLabel: "Paused",
+                now: now
+            )
+        default:
+            return nil
+        }
+    }
+
     private func clampedInt(_ value: UInt64) -> Int {
         value > UInt64(Int.max) ? Int.max : Int(value)
     }
@@ -807,7 +868,9 @@ final class AlanGhosttyLiveHost: NSObject {
         attention: ShellAttentionState? = nil,
         processExited: Bool? = nil,
         lastCommandExitCode: Int? = nil,
-        activeTaskState: ShellTabActiveTaskState? = nil
+        activeTaskState: ShellTabActiveTaskState? = nil,
+        activity: TerminalActivitySnapshot? = nil,
+        clearActivity: Bool = false
     ) {
         let nextTitle = title ?? metadata.title
         let nextWorkingDirectory = workingDirectory ?? metadata.workingDirectory
@@ -816,6 +879,7 @@ final class AlanGhosttyLiveHost: NSObject {
         let nextProcessExited = processExited ?? metadata.processExited
         let nextLastCommandExitCode = lastCommandExitCode ?? metadata.lastCommandExitCode
         let nextActiveTaskState = activeTaskState ?? metadata.activeTaskState
+        let nextActivity = clearActivity ? nil : (activity ?? metadata.activity)
 
         guard
             nextTitle != metadata.title
@@ -825,6 +889,7 @@ final class AlanGhosttyLiveHost: NSObject {
                 || nextProcessExited != metadata.processExited
                 || nextLastCommandExitCode != metadata.lastCommandExitCode
                 || nextActiveTaskState != metadata.activeTaskState
+                || nextActivity != metadata.activity
         else {
             return
         }
@@ -837,7 +902,8 @@ final class AlanGhosttyLiveHost: NSObject {
             processExited: nextProcessExited,
             lastCommandExitCode: nextLastCommandExitCode,
             lastUpdatedAt: .now,
-            activeTaskState: nextActiveTaskState
+            activeTaskState: nextActiveTaskState,
+            activity: nextActivity
         )
         metadata = snapshot
         onMetadataChange?(snapshot)

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -890,6 +890,7 @@ final class AlanGhosttyLiveHost: NSObject {
                 || nextLastCommandExitCode != metadata.lastCommandExitCode
                 || nextActiveTaskState != metadata.activeTaskState
                 || nextActivity != metadata.activity
+                || clearActivity
         else {
             return
         }
@@ -903,7 +904,8 @@ final class AlanGhosttyLiveHost: NSObject {
             lastCommandExitCode: nextLastCommandExitCode,
             lastUpdatedAt: .now,
             activeTaskState: nextActiveTaskState,
-            activity: nextActivity
+            activity: nextActivity,
+            clearsActivity: clearActivity
         )
         metadata = snapshot
         onMetadataChange?(snapshot)

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -40,9 +40,36 @@ struct ShellPane: Identifiable, Codable, Equatable {
     let attention: ShellAttentionState
     let context: ShellContextSnapshot?
     let viewport: ShellViewportSnapshot?
+    let activity: TerminalActivitySnapshot?
     let alanBinding: ShellAlanBinding?
 
     var id: String { paneID }
+
+    init(
+        paneID: String,
+        tabID: String,
+        spaceID: String,
+        launchTarget: ShellLaunchTarget?,
+        cwd: String?,
+        process: ShellProcessBinding?,
+        attention: ShellAttentionState,
+        context: ShellContextSnapshot?,
+        viewport: ShellViewportSnapshot?,
+        activity: TerminalActivitySnapshot? = nil,
+        alanBinding: ShellAlanBinding?
+    ) {
+        self.paneID = paneID
+        self.tabID = tabID
+        self.spaceID = spaceID
+        self.launchTarget = launchTarget
+        self.cwd = cwd
+        self.process = process
+        self.attention = attention
+        self.context = context
+        self.viewport = viewport
+        self.activity = activity
+        self.alanBinding = alanBinding
+    }
 
     private enum CodingKeys: String, CodingKey {
         case paneID = "pane_id"
@@ -54,6 +81,7 @@ struct ShellPane: Identifiable, Codable, Equatable {
         case attention
         case context
         case viewport
+        case activity
         case alanBinding = "alan_binding"
     }
 }

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -597,6 +597,7 @@ extension ShellStateSnapshot {
                     visibleExcerpt: current.viewport?.visibleExcerpt,
                     lastActivityAt: formatter.string(from: now)
                 ),
+                activity: current.activity,
                 alanBinding: current.alanBinding
             )
         }
@@ -713,6 +714,7 @@ extension ShellStateSnapshot {
                     visibleExcerpt: current.viewport?.visibleExcerpt,
                     lastActivityAt: formatter.string(from: now)
                 ),
+                activity: current.activity,
                 alanBinding: current.alanBinding
             )
         }
@@ -750,6 +752,7 @@ extension ShellStateSnapshot {
                 attention: attention,
                 context: current.context,
                 viewport: current.viewport,
+                activity: current.activity,
                 alanBinding: current.alanBinding
             )
         }

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -189,6 +189,12 @@ struct TerminalActivityCommandOutcome: Codable, Equatable {
     let exitCode: Int?
     let durationMilliseconds: Int?
     let commandText: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case exitCode = "exit_code"
+        case durationMilliseconds = "duration_milliseconds"
+        case commandText = "command_text"
+    }
 }
 
 struct TerminalActivityAgentMetadata: Codable, Equatable {
@@ -196,6 +202,13 @@ struct TerminalActivityAgentMetadata: Codable, Equatable {
     let safeSessionLabel: String?
     let projectLabel: String?
     let workingDirectory: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case safeSessionLabel = "safe_session_label"
+        case projectLabel = "project_label"
+        case workingDirectory = "working_directory"
+    }
 }
 
 struct TerminalActivityDisplay: Codable, Equatable {
@@ -212,12 +225,25 @@ struct TerminalActivityDisplay: Codable, Equatable {
             }
             .joined(separator: " · ")
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case sourceLabel = "source_label"
+        case stateLabel = "state_label"
+        case detailLabel = "detail_label"
+        case paneHint = "pane_hint"
+    }
 }
 
 struct TerminalActivityFreshness: Codable, Equatable {
     let updatedAt: String
     let staleAt: String?
     let expiresAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case updatedAt = "updated_at"
+        case staleAt = "stale_at"
+        case expiresAt = "expires_at"
+    }
 }
 
 struct TerminalActivitySnapshot: Codable, Equatable {

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -387,7 +387,7 @@ struct TerminalActivitySnapshot: Codable, Equatable {
             ),
             freshness: TerminalActivityFreshness(
                 updatedAt: Self.iso8601Formatter.string(from: now),
-                staleAt: succeeded ? nil : Self.iso8601Formatter.string(from: now.addingTimeInterval(30)),
+                staleAt: Self.iso8601Formatter.string(from: now.addingTimeInterval(succeeded ? 8 : 30)),
                 expiresAt: nil
             )
         )

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -123,6 +123,251 @@ enum ShellTabActiveTaskState: String, Codable, Equatable, CaseIterable {
     }
 }
 
+enum TerminalActivitySourceKind: String, Codable, Equatable, CaseIterable {
+    case codex
+    case claude
+    case openCode = "open_code"
+    case alan
+    case shell
+    case progress
+    case command
+    case process
+    case unknown
+}
+
+enum TerminalActivityStatus: String, Codable, Equatable, CaseIterable {
+    case needsInput = "needs_input"
+    case failed
+    case paused
+    case progress
+    case running
+    case bell
+    case exited
+    case idle
+    case done
+    case stale
+}
+
+enum TerminalActivityPriority: String, Codable, Equatable, CaseIterable {
+    case passive
+    case active
+    case notable
+    case awaitingUser = "awaiting_user"
+}
+
+enum TerminalActivityProgressKind: String, Codable, Equatable, CaseIterable {
+    case percent
+    case indeterminate
+    case paused
+    case failed
+}
+
+struct TerminalActivitySource: Codable, Equatable {
+    let kind: TerminalActivitySourceKind
+    let label: String?
+}
+
+struct TerminalActivityProgress: Codable, Equatable {
+    let kind: TerminalActivityProgressKind
+    let percent: Int?
+
+    init(kind: TerminalActivityProgressKind, percent: Int? = nil) {
+        self.kind = kind
+        self.percent = percent.map { min(max($0, 0), 100) }
+    }
+
+    static func percent(_ value: Int) -> TerminalActivityProgress {
+        TerminalActivityProgress(kind: .percent, percent: value)
+    }
+
+    static let indeterminate = TerminalActivityProgress(kind: .indeterminate)
+    static let paused = TerminalActivityProgress(kind: .paused)
+    static let failed = TerminalActivityProgress(kind: .failed)
+}
+
+struct TerminalActivityCommandOutcome: Codable, Equatable {
+    let exitCode: Int?
+    let durationMilliseconds: Int?
+    let commandText: String?
+}
+
+struct TerminalActivityAgentMetadata: Codable, Equatable {
+    let kind: TerminalActivitySourceKind
+    let safeSessionLabel: String?
+    let projectLabel: String?
+    let workingDirectory: String?
+}
+
+struct TerminalActivityDisplay: Codable, Equatable {
+    let sourceLabel: String
+    let stateLabel: String
+    let detailLabel: String?
+    let paneHint: String?
+
+    var sourceFirstLabel: String {
+        [paneHint, "\(sourceLabel) · \(stateLabel)"]
+            .compactMap { label -> String? in
+                guard let label, !label.isEmpty else { return nil }
+                return label
+            }
+            .joined(separator: " · ")
+    }
+}
+
+struct TerminalActivityFreshness: Codable, Equatable {
+    let updatedAt: String
+    let staleAt: String?
+    let expiresAt: String?
+}
+
+struct TerminalActivitySnapshot: Codable, Equatable {
+    private static let iso8601Formatter = ISO8601DateFormatter()
+
+    let source: TerminalActivitySource
+    let status: TerminalActivityStatus
+    let priority: TerminalActivityPriority
+    let progress: TerminalActivityProgress?
+    let command: TerminalActivityCommandOutcome?
+    let agent: TerminalActivityAgentMetadata?
+    let display: TerminalActivityDisplay
+    let freshness: TerminalActivityFreshness
+
+    var isSidebarWorthy: Bool {
+        switch status {
+        case .needsInput, .failed, .paused, .progress, .running, .bell, .exited:
+            return true
+        case .idle, .done, .stale:
+            return false
+        }
+    }
+
+    var sidebarPriorityRank: Int {
+        switch status {
+        case .needsInput:
+            return 70
+        case .failed:
+            return 60
+        case .paused:
+            return 50
+        case .progress:
+            return 40
+        case .running:
+            return 30
+        case .bell, .exited:
+            return 20
+        case .idle, .done, .stale:
+            return 0
+        }
+    }
+
+    func isFresh(at now: Date) -> Bool {
+        if let expiresAt = freshness.expiresAt.flatMap(Self.iso8601Formatter.date(from:)),
+           now >= expiresAt
+        {
+            return false
+        }
+
+        if let staleAt = freshness.staleAt.flatMap(Self.iso8601Formatter.date(from:)),
+           now >= staleAt
+        {
+            return false
+        }
+
+        return true
+    }
+
+    static func primarySidebarActivity(
+        _ activities: [TerminalActivitySnapshot]
+    ) -> TerminalActivitySnapshot? {
+        primarySidebarActivity(activities, now: nil)
+    }
+
+    static func primarySidebarActivity(
+        _ activities: [TerminalActivitySnapshot],
+        now: Date?
+    ) -> TerminalActivitySnapshot? {
+        activities
+            .filter { activity in
+                activity.isSidebarWorthy && now.map(activity.isFresh(at:)) != false
+            }
+            .max { lhs, rhs in
+                if lhs.sidebarPriorityRank == rhs.sidebarPriorityRank {
+                    return lhs.freshness.updatedAt < rhs.freshness.updatedAt
+                }
+                return lhs.sidebarPriorityRank < rhs.sidebarPriorityRank
+            }
+    }
+
+    static func progressActivity(percent: Int, now: Date) -> TerminalActivitySnapshot {
+        let boundedPercent = min(max(percent, 0), 100)
+        return progressActivity(
+            progress: .percent(boundedPercent),
+            status: .progress,
+            priority: .active,
+            stateLabel: "\(boundedPercent)%",
+            now: now
+        )
+    }
+
+    static func progressActivity(
+        progress: TerminalActivityProgress,
+        status: TerminalActivityStatus,
+        priority: TerminalActivityPriority,
+        stateLabel: String,
+        now: Date
+    ) -> TerminalActivitySnapshot {
+        return TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: .progress, label: "Progress"),
+            status: status,
+            priority: priority,
+            progress: progress,
+            command: nil,
+            agent: nil,
+            display: TerminalActivityDisplay(
+                sourceLabel: "Progress",
+                stateLabel: stateLabel,
+                detailLabel: nil,
+                paneHint: nil
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: Self.iso8601Formatter.string(from: now),
+                staleAt: Self.iso8601Formatter.string(from: now.addingTimeInterval(15)),
+                expiresAt: nil
+            )
+        )
+    }
+
+    static func commandCompletion(exitCode: Int, now: Date) -> TerminalActivitySnapshot {
+        let succeeded = exitCode == 0
+        let status: TerminalActivityStatus = succeeded ? .done : .failed
+        let priority: TerminalActivityPriority = succeeded ? .passive : .notable
+        let stateLabel = succeeded ? "Command succeeded" : "Command failed \(exitCode)"
+        return TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: .command, label: "Shell"),
+            status: status,
+            priority: priority,
+            progress: nil,
+            command: TerminalActivityCommandOutcome(
+                exitCode: exitCode,
+                durationMilliseconds: nil,
+                commandText: nil
+            ),
+            agent: nil,
+            display: TerminalActivityDisplay(
+                sourceLabel: "Shell",
+                stateLabel: stateLabel,
+                detailLabel: nil,
+                paneHint: nil
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: Self.iso8601Formatter.string(from: now),
+                staleAt: succeeded ? nil : Self.iso8601Formatter.string(from: now.addingTimeInterval(30)),
+                expiresAt: nil
+            )
+        )
+    }
+}
+
 struct ShellProcessBinding: Codable, Equatable {
     let program: String
     let argvPreview: [String]?

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -305,7 +305,7 @@ struct TerminalActivitySnapshot: Codable, Equatable {
     static func primarySidebarActivity(
         _ activities: [TerminalActivitySnapshot]
     ) -> TerminalActivitySnapshot? {
-        primarySidebarActivity(activities, now: nil)
+        primarySidebarActivity(activities, now: Date())
     }
 
     static func primarySidebarActivity(

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -56,6 +56,7 @@ enum AlanShellPublishedStateMerger {
             attention: incomingPane.attention,
             context: merge(authoritativeContext: authoritativePane.context, incomingContext: incomingPane.context),
             viewport: merge(authoritativeViewport: authoritativePane.viewport, incomingViewport: incomingPane.viewport),
+            activity: incomingPane.activity ?? authoritativePane.activity,
             alanBinding: incomingPane.alanBinding ?? authoritativePane.alanBinding
         )
     }

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -56,7 +56,7 @@ enum AlanShellPublishedStateMerger {
             attention: incomingPane.attention,
             context: merge(authoritativeContext: authoritativePane.context, incomingContext: incomingPane.context),
             viewport: merge(authoritativeViewport: authoritativePane.viewport, incomingViewport: incomingPane.viewport),
-            activity: incomingPane.activity ?? authoritativePane.activity,
+            activity: incomingPane.activity,
             alanBinding: incomingPane.alanBinding ?? authoritativePane.alanBinding
         )
     }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -848,7 +848,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     ),
                     context: projectedContext,
                     viewport: viewport,
-                    activity: runtime.paneMetadata.activity ?? current.activity,
+                    activity: runtime.paneMetadata.clearsActivity
+                        ? nil
+                        : (runtime.paneMetadata.activity ?? current.activity),
                     alanBinding: projectedBinding
                 )
             }
@@ -916,7 +918,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 ),
                 context: projectedContext,
                 viewport: viewport,
-                activity: metadata.activity ?? current.activity,
+                activity: metadata.clearsActivity ? nil : (metadata.activity ?? current.activity),
                 alanBinding: projectedBinding
             )
         }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -848,6 +848,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     ),
                     context: projectedContext,
                     viewport: viewport,
+                    activity: runtime.paneMetadata.activity ?? current.activity,
                     alanBinding: projectedBinding
                 )
             }
@@ -915,6 +916,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 ),
                 context: projectedContext,
                 viewport: viewport,
+                activity: metadata.activity ?? current.activity,
                 alanBinding: projectedBinding
             )
         }
@@ -975,6 +977,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 attention: projectedBinding?.pendingYield == true ? .awaitingUser : current.attention,
                 context: projectedContext,
                 viewport: viewport,
+                activity: current.activity,
                 alanBinding: projectedBinding
             )
         }
@@ -1016,6 +1019,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 attention: current.attention,
                 context: projectedContext,
                 viewport: current.viewport,
+                activity: current.activity,
                 alanBinding: projectedBinding
             )
         }
@@ -1158,6 +1162,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 attention: pane.attention,
                 context: projectedContext,
                 viewport: pane.viewport,
+                activity: pane.activity,
                 alanBinding: pane.alanBinding
             )
         }

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -624,6 +624,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
     let lastCommandExitCode: Int?
     let lastUpdatedAt: Date?
     let activeTaskState: ShellTabActiveTaskState?
+    let activity: TerminalActivitySnapshot?
 
     init(
         title: String?,
@@ -633,7 +634,8 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         processExited: Bool,
         lastCommandExitCode: Int?,
         lastUpdatedAt: Date?,
-        activeTaskState: ShellTabActiveTaskState? = .inactive
+        activeTaskState: ShellTabActiveTaskState? = .inactive,
+        activity: TerminalActivitySnapshot? = nil
     ) {
         self.title = title
         self.workingDirectory = workingDirectory
@@ -643,6 +645,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         self.lastCommandExitCode = lastCommandExitCode
         self.lastUpdatedAt = lastUpdatedAt
         self.activeTaskState = activeTaskState
+        self.activity = activity
     }
 
     static let placeholder = TerminalPaneMetadataSnapshot(
@@ -653,7 +656,8 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         processExited: false,
         lastCommandExitCode: nil,
         lastUpdatedAt: nil,
-        activeTaskState: .inactive
+        activeTaskState: .inactive,
+        activity: nil
     )
 }
 

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -625,6 +625,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
     let lastUpdatedAt: Date?
     let activeTaskState: ShellTabActiveTaskState?
     let activity: TerminalActivitySnapshot?
+    let clearsActivity: Bool
 
     init(
         title: String?,
@@ -635,7 +636,8 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         lastCommandExitCode: Int?,
         lastUpdatedAt: Date?,
         activeTaskState: ShellTabActiveTaskState? = .inactive,
-        activity: TerminalActivitySnapshot? = nil
+        activity: TerminalActivitySnapshot? = nil,
+        clearsActivity: Bool = false
     ) {
         self.title = title
         self.workingDirectory = workingDirectory
@@ -646,6 +648,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         self.lastUpdatedAt = lastUpdatedAt
         self.activeTaskState = activeTaskState
         self.activity = activity
+        self.clearsActivity = clearsActivity
     }
 
     static let placeholder = TerminalPaneMetadataSnapshot(
@@ -657,7 +660,8 @@ struct TerminalPaneMetadataSnapshot: Equatable {
         lastCommandExitCode: nil,
         lastUpdatedAt: nil,
         activeTaskState: .inactive,
-        activity: nil
+        activity: nil,
+        clearsActivity: false
     )
 }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -551,6 +551,14 @@ private enum ShellRuntimeMetadataTests {
 
         expect(success.status == .done, "zero exit code must produce done status")
         expect(!success.isSidebarWorthy, "successful commands must not be sidebar-worthy")
+        expect(
+            success.freshness.staleAt == "2026-05-17T09:00:08Z",
+            "successful command completion must get a short stale deadline"
+        )
+        expect(
+            !success.isFresh(at: now.addingTimeInterval(9)),
+            "successful command completion must become stale after its freshness window"
+        )
         expect(failure.status == .failed, "non-zero exit code must produce failed status")
         expect(failure.command?.exitCode == 2, "command completion must preserve exit code")
         expect(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -30,6 +30,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalActivityCodableUsesSnakeCase()
         verifiesTerminalActivitySidebarPriority()
         verifiesStaleProgressIsNotSidebarWorthy()
+        verifiesDefaultSidebarActivitySelectionHonorsFreshness()
         verifiesSuccessfulCommandIsNotSidebarWorthy()
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
@@ -557,7 +558,7 @@ private enum ShellRuntimeMetadataTests {
             "failed command copy must be source-first"
         )
         expect(
-            TerminalActivitySnapshot.primarySidebarActivity([success, failure]) == failure,
+            TerminalActivitySnapshot.primarySidebarActivity([success, failure], now: now) == failure,
             "failed command completion must outrank successful completion"
         )
     }
@@ -673,6 +674,19 @@ private enum ShellRuntimeMetadataTests {
         expect(
             TerminalActivitySnapshot.primarySidebarActivity([progress], now: now) == nil,
             "stale progress must not remain sidebar-worthy"
+        )
+    }
+
+    private static func verifiesDefaultSidebarActivitySelectionHonorsFreshness() {
+        let staleProgress = progressActivity(
+            percent: 42,
+            updatedAt: "2000-01-01T00:00:00Z",
+            staleAt: "2000-01-01T00:00:15Z"
+        )
+
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([staleProgress]) == nil,
+            "default sidebar activity selection must reject stale activity"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -24,6 +24,12 @@ private enum ShellRuntimeMetadataTests {
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
         verifiesOpeningTerminalTabHonorsExplicitCwd()
+        verifiesTerminalActivityProjectsByPaneID()
+        verifiesProgressActivityFactoryUsesSourceFirstDisplay()
+        verifiesCommandCompletionActivityFactory()
+        verifiesTerminalActivitySidebarPriority()
+        verifiesStaleProgressIsNotSidebarWorthy()
+        verifiesSuccessfulCommandIsNotSidebarWorthy()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -461,6 +467,126 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.cwd == "/explicit/cwd",
             "explicit new-tab cwd must override focused pane cwd"
+        )
+    }
+
+    private static func verifiesTerminalActivityProjectsByPaneID() {
+        let controller = makeController()
+        _ = controller.openTerminalTab(workingDirectory: "/background")
+        let activity = progressActivity(
+            percent: 42,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", activity: activity),
+            for: "pane_1"
+        )
+
+        let activePane = controller.pane(paneID: "pane_1")
+        let backgroundPane = controller.pane(paneID: "pane_2")
+        expect(
+            activePane?.activity == activity,
+            "terminal activity metadata must project onto the owning pane"
+        )
+        expect(
+            backgroundPane?.activity == nil,
+            "terminal activity metadata must not leak to other panes"
+        )
+    }
+
+    private static func verifiesTerminalActivitySidebarPriority() {
+        let running = activity(status: .running, source: .shell, sourceLabel: "Shell", stateLabel: "Running")
+        let progress = activity(
+            status: .progress,
+            source: .progress,
+            sourceLabel: "Progress",
+            stateLabel: "42%",
+            progress: .percent(42)
+        )
+        let needsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed"
+        )
+
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([running, progress]) == progress,
+            "progress must outrank generic running activity"
+        )
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([progress, needsInput]) == needsInput,
+            "user-input-required activity must outrank progress"
+        )
+    }
+
+    private static func verifiesProgressActivityFactoryUsesSourceFirstDisplay() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let activity = TerminalActivitySnapshot.progressActivity(percent: 42, now: now)
+
+        expect(activity.source.kind == .progress, "progress factory must label source as progress")
+        expect(activity.status == .progress, "determinate progress must use progress status")
+        expect(activity.progress == .percent(42), "determinate progress must carry bounded percent")
+        expect(
+            activity.display.sourceFirstLabel == "Progress · 42%",
+            "progress display copy must be source-first"
+        )
+        expect(
+            activity.freshness.staleAt == "2026-05-17T09:00:15Z",
+            "progress activity must get the default 15 second stale deadline"
+        )
+    }
+
+    private static func verifiesCommandCompletionActivityFactory() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let success = TerminalActivitySnapshot.commandCompletion(exitCode: 0, now: now)
+        let failure = TerminalActivitySnapshot.commandCompletion(exitCode: 2, now: now)
+
+        expect(success.status == .done, "zero exit code must produce done status")
+        expect(!success.isSidebarWorthy, "successful commands must not be sidebar-worthy")
+        expect(failure.status == .failed, "non-zero exit code must produce failed status")
+        expect(failure.command?.exitCode == 2, "command completion must preserve exit code")
+        expect(
+            failure.display.sourceFirstLabel == "Shell · Command failed 2",
+            "failed command copy must be source-first"
+        )
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([success, failure]) == failure,
+            "failed command completion must outrank successful completion"
+        )
+    }
+
+    private static func verifiesSuccessfulCommandIsNotSidebarWorthy() {
+        let success = activity(
+            status: .done,
+            source: .command,
+            sourceLabel: "Shell",
+            stateLabel: "Command succeeded"
+        )
+
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([success]) == nil,
+            "successful command completion must not become sidebar-worthy activity"
+        )
+    }
+
+    private static func verifiesStaleProgressIsNotSidebarWorthy() {
+        let progress = progressActivity(
+            percent: 42,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+        let now = Date(timeIntervalSince1970: 1_779_008_416)
+
+        expect(
+            !progress.isFresh(at: now),
+            "progress must become stale after its freshness deadline"
+        )
+        expect(
+            TerminalActivitySnapshot.primarySidebarActivity([progress], now: now) == nil,
+            "stale progress must not remain sidebar-worthy"
         )
     }
 
@@ -1007,7 +1133,8 @@ private enum ShellRuntimeMetadataTests {
         title: String,
         cwd: String = "/Users/morris/Developer/Alan",
         processExited: Bool = false,
-        activeTaskState: ShellTabActiveTaskState? = nil
+        activeTaskState: ShellTabActiveTaskState? = nil,
+        activity: TerminalActivitySnapshot? = nil
     ) -> TerminalPaneMetadataSnapshot {
         TerminalPaneMetadataSnapshot(
             title: title,
@@ -1017,8 +1144,68 @@ private enum ShellRuntimeMetadataTests {
             processExited: processExited,
             lastCommandExitCode: nil,
             lastUpdatedAt: Date(timeIntervalSince1970: 3_000),
-            activeTaskState: activeTaskState
+            activeTaskState: activeTaskState,
+            activity: activity
         )
+    }
+
+    private static func progressActivity(
+        percent: Int,
+        updatedAt: String,
+        staleAt: String
+    ) -> TerminalActivitySnapshot {
+        activity(
+            status: .progress,
+            source: .progress,
+            sourceLabel: "Progress",
+            stateLabel: "\(percent)%",
+            progress: .percent(percent),
+            updatedAt: updatedAt,
+            staleAt: staleAt
+        )
+    }
+
+    private static func activity(
+        status: TerminalActivityStatus,
+        source: TerminalActivitySourceKind,
+        sourceLabel: String,
+        stateLabel: String,
+        progress: TerminalActivityProgress? = nil,
+        updatedAt: String = "2026-05-17T09:00:00Z",
+        staleAt: String? = nil
+    ) -> TerminalActivitySnapshot {
+        TerminalActivitySnapshot(
+            source: .init(kind: source, label: sourceLabel),
+            status: status,
+            priority: priority(for: status),
+            progress: progress,
+            command: nil,
+            agent: nil,
+            display: TerminalActivityDisplay(
+                sourceLabel: sourceLabel,
+                stateLabel: stateLabel,
+                detailLabel: nil,
+                paneHint: nil
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: updatedAt,
+                staleAt: staleAt,
+                expiresAt: nil
+            )
+        )
+    }
+
+    private static func priority(for status: TerminalActivityStatus) -> TerminalActivityPriority {
+        switch status {
+        case .needsInput:
+            return .awaitingUser
+        case .failed, .exited:
+            return .notable
+        case .paused, .progress, .running, .bell:
+            return .active
+        case .idle, .done, .stale:
+            return .passive
+        }
     }
 
     private static func childExitMetadata(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -27,6 +27,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
+        verifiesTerminalActivityCodableUsesSnakeCase()
         verifiesTerminalActivitySidebarPriority()
         verifiesStaleProgressIsNotSidebarWorthy()
         verifiesSuccessfulCommandIsNotSidebarWorthy()
@@ -557,6 +558,88 @@ private enum ShellRuntimeMetadataTests {
             TerminalActivitySnapshot.primarySidebarActivity([success, failure]) == failure,
             "failed command completion must outrank successful completion"
         )
+    }
+
+    private static func verifiesTerminalActivityCodableUsesSnakeCase() {
+        let activity = TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: .codex, label: "Codex"),
+            status: .failed,
+            priority: .notable,
+            progress: nil,
+            command: TerminalActivityCommandOutcome(
+                exitCode: 2,
+                durationMilliseconds: 120_000,
+                commandText: "just check"
+            ),
+            agent: TerminalActivityAgentMetadata(
+                kind: .codex,
+                safeSessionLabel: "Codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            ),
+            display: TerminalActivityDisplay(
+                sourceLabel: "Codex",
+                stateLabel: "Failed",
+                detailLabel: "just check",
+                paneHint: "1"
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: "2026-05-17T09:00:00Z",
+                staleAt: "2026-05-17T09:00:30Z",
+                expiresAt: "2026-05-17T09:05:00Z"
+            )
+        )
+
+        do {
+            let data = try JSONEncoder().encode(activity)
+            guard
+                let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let command = root["command"] as? [String: Any],
+                let agent = root["agent"] as? [String: Any],
+                let display = root["display"] as? [String: Any],
+                let freshness = root["freshness"] as? [String: Any]
+            else {
+                fail("activity JSON must encode nested objects")
+            }
+
+            expect(command["exit_code"] as? Int == 2, "command JSON must use exit_code")
+            expect(
+                command["duration_milliseconds"] as? Int == 120_000,
+                "command JSON must use duration_milliseconds"
+            )
+            expect(command["command_text"] as? String == "just check", "command JSON must use command_text")
+            expect(!command.keys.contains("exitCode"), "command JSON must not use camelCase exitCode")
+            expect(
+                agent["safe_session_label"] as? String == "Codex",
+                "agent JSON must use safe_session_label"
+            )
+            expect(agent["project_label"] as? String == "alan", "agent JSON must use project_label")
+            expect(
+                agent["working_directory"] as? String == "/Users/morris/Developer/alan",
+                "agent JSON must use working_directory"
+            )
+            expect(display["source_label"] as? String == "Codex", "display JSON must use source_label")
+            expect(display["state_label"] as? String == "Failed", "display JSON must use state_label")
+            expect(display["detail_label"] as? String == "just check", "display JSON must use detail_label")
+            expect(display["pane_hint"] as? String == "1", "display JSON must use pane_hint")
+            expect(
+                freshness["updated_at"] as? String == "2026-05-17T09:00:00Z",
+                "freshness JSON must use updated_at"
+            )
+            expect(
+                freshness["stale_at"] as? String == "2026-05-17T09:00:30Z",
+                "freshness JSON must use stale_at"
+            )
+            expect(
+                freshness["expires_at"] as? String == "2026-05-17T09:05:00Z",
+                "freshness JSON must use expires_at"
+            )
+
+            let decoded = try JSONDecoder().decode(TerminalActivitySnapshot.self, from: data)
+            expect(decoded == activity, "activity JSON must round-trip through snake_case keys")
+        } catch {
+            fail("activity JSON contract failed: \(error)")
+        }
     }
 
     private static func verifiesSuccessfulCommandIsNotSidebarWorthy() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -32,6 +32,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesStaleProgressIsNotSidebarWorthy()
         verifiesSuccessfulCommandIsNotSidebarWorthy()
         verifiesClearingActivityRemovesPaneActivity()
+        verifiesPublishedStateMergeClearsActivity()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -701,6 +702,34 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesPublishedStateMergeClearsActivity() {
+        let progress = progressActivity(
+            percent: 42,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+        let authoritative = stateWithAlanBinding(
+            windowID: "window_activity_merge",
+            pendingYield: false,
+            activity: progress
+        )
+        let incoming = stateWithAlanBinding(
+            windowID: "window_activity_merge",
+            pendingYield: false,
+            activity: nil
+        )
+
+        let merged = AlanShellPublishedStateMerger.merge(
+            authoritative: authoritative,
+            incoming: incoming
+        )
+
+        expect(
+            merged.pane(paneID: "pane_1")?.activity == nil,
+            "published state merge must allow incoming nil activity to clear stale activity"
+        )
+    }
+
     private static func verifiesTerminalChildExitClosesSplitPane() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -1355,7 +1384,8 @@ private enum ShellRuntimeMetadataTests {
 
     private static func stateWithAlanBinding(
         windowID: String,
-        pendingYield: Bool
+        pendingYield: Bool,
+        activity: TerminalActivitySnapshot? = nil
     ) -> ShellStateSnapshot {
         let pane = ShellPane(
             paneID: "pane_1",
@@ -1378,6 +1408,7 @@ private enum ShellRuntimeMetadataTests {
                 lastCommandExitCode: nil
             ),
             viewport: nil,
+            activity: activity,
             alanBinding: ShellAlanBinding(
                 sessionID: "session_1",
                 runStatus: pendingYield ? "yielded" : "running",

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -33,6 +33,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesSuccessfulCommandIsNotSidebarWorthy()
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
+        verifiesPaneRebuildMutationsPreserveActivity()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -727,6 +728,53 @@ private enum ShellRuntimeMetadataTests {
         expect(
             merged.pane(paneID: "pane_1")?.activity == nil,
             "published state merge must allow incoming nil activity to clear stale activity"
+        )
+    }
+
+    private static func verifiesPaneRebuildMutationsPreserveActivity() {
+        let controller = makeController()
+        let progress = progressActivity(
+            percent: 42,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", activity: progress),
+            for: "pane_1"
+        )
+        expect(
+            controller.pane(paneID: "pane_1")?.activity == progress,
+            "test setup must project progress activity before pane rebuilds"
+        )
+
+        _ = controller.setAttention(.notable, for: "pane_1")
+        expect(
+            controller.pane(paneID: "pane_1")?.activity == progress,
+            "attention-only pane rebuild must preserve terminal activity"
+        )
+
+        guard let targetTabID = controller.openTerminalTab(workingDirectory: "/target") else {
+            fail("test setup must create a target tab")
+        }
+        expect(
+            controller.movePane(paneID: "pane_1", toTab: targetTabID, direction: .vertical),
+            "test setup must move pane into target tab"
+        )
+        expect(
+            controller.pane(paneID: "pane_1")?.activity == progress,
+            "pane move rebuild must preserve terminal activity"
+        )
+
+        switch controller.liftPaneToTab(paneID: "pane_1") {
+        case .lifted:
+            break
+        case .paneNotFound, .lastPane:
+            fail("test setup must lift moved pane into a new tab")
+        }
+        expect(
+            controller.pane(paneID: "pane_1")?.activity == progress,
+            "pane lift rebuild must preserve terminal activity"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -30,6 +30,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalActivitySidebarPriority()
         verifiesStaleProgressIsNotSidebarWorthy()
         verifiesSuccessfulCommandIsNotSidebarWorthy()
+        verifiesClearingActivityRemovesPaneActivity()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -590,6 +591,33 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesClearingActivityRemovesPaneActivity() {
+        let controller = makeController()
+        let progress = progressActivity(
+            percent: 64,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", activity: progress),
+            for: "pane_1"
+        )
+        expect(
+            controller.shellState.pane(paneID: "pane_1")?.activity == progress,
+            "test setup must project progress activity"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", clearsActivity: true),
+            for: "pane_1"
+        )
+        expect(
+            controller.shellState.pane(paneID: "pane_1")?.activity == nil,
+            "clear metadata must remove stale pane activity"
+        )
+    }
+
     private static func verifiesTerminalChildExitClosesSplitPane() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -1134,7 +1162,8 @@ private enum ShellRuntimeMetadataTests {
         cwd: String = "/Users/morris/Developer/Alan",
         processExited: Bool = false,
         activeTaskState: ShellTabActiveTaskState? = nil,
-        activity: TerminalActivitySnapshot? = nil
+        activity: TerminalActivitySnapshot? = nil,
+        clearsActivity: Bool = false
     ) -> TerminalPaneMetadataSnapshot {
         TerminalPaneMetadataSnapshot(
             title: title,
@@ -1145,7 +1174,8 @@ private enum ShellRuntimeMetadataTests {
             lastCommandExitCode: nil,
             lastUpdatedAt: Date(timeIntervalSince1970: 3_000),
             activeTaskState: activeTaskState,
-            activity: activity
+            activity: activity,
+            clearsActivity: clearsActivity
         )
     }
 

--- a/openspec/changes/add-advanced-terminal-activity-semantics/design.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/design.md
@@ -171,7 +171,7 @@ restores that instance and its cwd. If Alan must create a new quick terminal, it
 chooses the cwd from the currently focused Alan pane when available, otherwise
 the last quick-terminal cwd, otherwise the user's home directory.
 
-The Peak can be promoted into a normal Alan Space through an `Open in Space`
+The Peak can be promoted into a normal Alan space through an `Open in Space`
 affordance. Promotion moves the current quick-terminal runtime into the selected
 Space as a normal tab, hides the Peak, and clears the global quick slot. Alan
 does not copy the terminal process or display the same runtime simultaneously in

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-ui-ux-conformance/spec.md
@@ -146,7 +146,7 @@ floating-card composition.
 
 #### Scenario: Quick terminal can become a normal tab
 - **WHEN** the user opens the Peak's `Open in Space` affordance
-- **THEN** Alan offers Alan Space destinations without duplicating sidebar
+- **THEN** Alan offers Alan space destinations without duplicating sidebar
   chrome inside the Peak
 
 #### Scenario: Quick terminal activity exists

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-shell-workspace-interactions/spec.md
@@ -32,13 +32,13 @@ draft default shortcut is `Option+Space`.
 ### Requirement: Quick Terminal Has One Global Instance
 The quick terminal SHALL have a deterministic relationship to Alan's spaces,
 tabs, focus, persistence, and runtime identity. Alan SHALL model the MVP as one
-global quick-terminal instance, not one instance per Alan Space or one instance
+global quick-terminal instance, not one instance per Alan space or one instance
 per macOS Space.
 
 #### Scenario: Existing quick terminal is reused globally
 - **WHEN** Alan creates or restores the quick terminal
 - **THEN** Alan reuses the single global quick-terminal runtime when it is live
-  rather than creating another quick terminal for the current Alan Space or
+  rather than creating another quick terminal for the current Alan space or
   macOS Space
 
 #### Scenario: Quick terminal appears in the current macOS context
@@ -61,7 +61,7 @@ per macOS Space.
   otherwise from the user's home directory
 
 #### Scenario: Quick terminal promotes into a Space
-- **WHEN** the user chooses `Open in Space` for a target Alan Space
+- **WHEN** the user chooses `Open in Space` for a target Alan space
 - **THEN** Alan moves the quick-terminal runtime into that Space as a normal tab,
   hides the Peak presentation, and clears the global quick-terminal slot
 

--- a/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-activity-semantics/spec.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/specs/macos-terminal-activity-semantics/spec.md
@@ -275,6 +275,6 @@ an independent terminal runtime owner.
   path used by regular terminal panes
 
 #### Scenario: Quick terminal is promoted
-- **WHEN** the user promotes the quick terminal into an Alan Space
+- **WHEN** the user promotes the quick terminal into an Alan space
 - **THEN** Alan transfers ownership of the existing pane runtime into a normal
   tab in that Space and clears the quick-terminal slot

--- a/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
@@ -1,6 +1,6 @@
 ## 1. A-Group Refinement Gate
 
-- [ ] 1.1 Audit current terminal metadata sources in `GhosttyLiveHost`,
+- [x] 1.1 Audit current terminal metadata sources in `GhosttyLiveHost`,
   `TerminalHostRuntime`, `TerminalRuntimeService`, `ShellHostController`, and
   `ShellPaneProjectionService`.
 - [ ] 1.2 Finalize normalized activity state names, source kinds, source-first
@@ -15,10 +15,10 @@
 
 ## 2. Activity Model And Projection
 
-- [ ] 2.1 Add pane-scoped terminal activity value types for source, status,
+- [x] 2.1 Add pane-scoped terminal activity value types for source, status,
   priority, progress, command outcome, agent metadata, freshness, timestamps,
   and source-first display labels.
-- [ ] 2.2 Extend terminal metadata snapshots and shell projection paths to carry
+- [x] 2.2 Extend terminal metadata snapshots and shell projection paths to carry
   normalized activity without removing existing title/cwd/attention fields.
 - [ ] 2.3 Add deterministic activity merge and priority logic for concurrent
   progress, command completion, bell, Alan, and agent signals, including
@@ -32,9 +32,9 @@
 
 ## 3. Ghostty And Command Activity Sources
 
-- [ ] 3.1 Map `GHOSTTY_ACTION_PROGRESS_REPORT` into structured activity including
+- [x] 3.1 Map `GHOSTTY_ACTION_PROGRESS_REPORT` into structured activity including
   determinate, indeterminate, paused, error, clear, and stale states.
-- [ ] 3.2 Map `GHOSTTY_ACTION_COMMAND_FINISHED` into command-completion activity
+- [x] 3.2 Map `GHOSTTY_ACTION_COMMAND_FINISHED` into command-completion activity
   with success/failure status and duration when available.
 - [ ] 3.3 Keep bell and child-exit attention compatible with the normalized
   activity model without changing existing terminal overlay semantics.


### PR DESCRIPTION
## Summary
- Add normalized terminal activity value types for source, status, priority, progress, command outcome, agent metadata, display labels, and freshness.
- Project pane activity through terminal metadata into shell pane state without removing existing title/cwd/attention fields.
- Map Ghostty progress reports and command-finished events into normalized activity while preserving existing summaries and attention behavior.
- Mark the completed OpenSpec tasks for the first Activity Model foundation slice and fix Quick Terminal wording to satisfy brand checks.

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build

Notes: xcodebuild emitted existing CoreSimulator/Xcode environment warnings, but the macOS build completed with ** BUILD SUCCEEDED **.