### PR TITLE
Render terminal activity in sidebar and pane titles

### DIFF
--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -679,7 +679,11 @@ final class AlanGhosttyLiveHost: NSObject {
 
         case GHOSTTY_ACTION_RING_BELL:
             performOnMain {
-                self.updateMetadata(summary: "terminal bell", attention: .notable)
+                self.updateMetadata(
+                    summary: "terminal bell",
+                    attention: .notable,
+                    activity: TerminalActivitySnapshot.bellActivity(now: .now)
+                )
             }
             return true
 
@@ -691,7 +695,11 @@ final class AlanGhosttyLiveHost: NSObject {
                     attention: .awaitingUser,
                     processExited: true,
                     lastCommandExitCode: Int(exitCode),
-                    activeTaskState: .inactive
+                    activeTaskState: .inactive,
+                    activity: TerminalActivitySnapshot.processExitedActivity(
+                        exitCode: Int(exitCode),
+                        now: .now
+                    )
                 )
             }
             return true

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -82,20 +82,56 @@ extension ShellStateSnapshot {
 
 
     func focusingPane(_ paneID: String) throws -> ShellStateMutationResult {
-        guard pane(paneID: paneID) != nil else {
+        guard let targetPane = pane(paneID: paneID) else {
             throw ShellStateMutationError.paneNotFound
         }
 
+        let acknowledgedPanes = panesAcknowledgingCommandFailureActivities(
+            in: targetPane.tabID,
+            focusedPaneID: paneID
+        )
         return ShellStateMutationResult(
             state: replacing(
-                spaces: spaces,
-                panes: panes,
+                spaces: rebuildingAttention(in: spaces, panes: acknowledgedPanes),
+                panes: acknowledgedPanes,
                 focusedPaneID: paneID
             ),
-            spaceID: pane(paneID: paneID)?.spaceID,
-            tabID: pane(paneID: paneID)?.tabID,
+            spaceID: targetPane.spaceID,
+            tabID: targetPane.tabID,
             paneID: paneID
         )
+    }
+
+    private func panesAcknowledgingCommandFailureActivities(
+        in tabID: String,
+        focusedPaneID: String
+    ) -> [ShellPane] {
+        panes.map { current in
+            guard current.tabID == tabID,
+                  current.activity?.isCommandFailure == true
+            else { return current }
+
+            let acknowledgedAttention: ShellAttentionState
+            if current.attention == .notable {
+                acknowledgedAttention = current.paneID == focusedPaneID ? .active : .idle
+            } else {
+                acknowledgedAttention = current.attention
+            }
+
+            return ShellPane(
+                paneID: current.paneID,
+                tabID: current.tabID,
+                spaceID: current.spaceID,
+                launchTarget: current.launchTarget,
+                cwd: current.cwd,
+                process: current.process,
+                attention: acknowledgedAttention,
+                context: current.context,
+                viewport: current.viewport,
+                activity: nil,
+                alanBinding: current.alanBinding
+            )
+        }
     }
 
     func focusingAdjacentPane(_ direction: ShellSpatialFocusDirection) throws -> ShellStateMutationResult {

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -153,6 +153,19 @@ enum TerminalActivityPriority: String, Codable, Equatable, CaseIterable {
     case active
     case notable
     case awaitingUser = "awaiting_user"
+
+    var sidebarPriorityRank: Int {
+        switch self {
+        case .awaitingUser:
+            return 40
+        case .notable:
+            return 30
+        case .active:
+            return 20
+        case .passive:
+            return 10
+        }
+    }
 }
 
 enum TerminalActivityProgressKind: String, Codable, Equatable, CaseIterable {
@@ -259,6 +272,20 @@ struct TerminalActivitySnapshot: Codable, Equatable {
     let freshness: TerminalActivityFreshness
 
     var isSidebarWorthy: Bool {
+        isSidebarWorthy(at: nil, owningTabFocused: false)
+    }
+
+    func isSidebarWorthy(at now: Date?, owningTabFocused: Bool = false) -> Bool {
+        if let now, !isFresh(at: now) {
+            return false
+        }
+        if owningTabFocused,
+           source.kind == .command,
+           status == .failed
+        {
+            return false
+        }
+
         switch status {
         case .needsInput, .failed, .paused, .progress, .running, .bell, .exited:
             return true
@@ -302,6 +329,24 @@ struct TerminalActivitySnapshot: Codable, Equatable {
         return true
     }
 
+    func withPaneHint(_ paneHint: String?) -> TerminalActivitySnapshot {
+        TerminalActivitySnapshot(
+            source: source,
+            status: status,
+            priority: priority,
+            progress: progress,
+            command: command,
+            agent: agent,
+            display: TerminalActivityDisplay(
+                sourceLabel: display.sourceLabel,
+                stateLabel: display.stateLabel,
+                detailLabel: display.detailLabel,
+                paneHint: paneHint
+            ),
+            freshness: freshness
+        )
+    }
+
     static func primarySidebarActivity(
         _ activities: [TerminalActivitySnapshot]
     ) -> TerminalActivitySnapshot? {
@@ -314,11 +359,17 @@ struct TerminalActivitySnapshot: Codable, Equatable {
     ) -> TerminalActivitySnapshot? {
         activities
             .filter { activity in
-                activity.isSidebarWorthy && now.map(activity.isFresh(at:)) != false
+                activity.isSidebarWorthy(at: now)
             }
             .max { lhs, rhs in
                 if lhs.sidebarPriorityRank == rhs.sidebarPriorityRank {
-                    return lhs.freshness.updatedAt < rhs.freshness.updatedAt
+                    if lhs.priority.sidebarPriorityRank == rhs.priority.sidebarPriorityRank {
+                        if lhs.freshness.updatedAt == rhs.freshness.updatedAt {
+                            return lhs.source.kind.rawValue < rhs.source.kind.rawValue
+                        }
+                        return lhs.freshness.updatedAt < rhs.freshness.updatedAt
+                    }
+                    return lhs.priority.sidebarPriorityRank < rhs.priority.sidebarPriorityRank
                 }
                 return lhs.sidebarPriorityRank < rhs.sidebarPriorityRank
             }
@@ -388,6 +439,55 @@ struct TerminalActivitySnapshot: Codable, Equatable {
             freshness: TerminalActivityFreshness(
                 updatedAt: Self.iso8601Formatter.string(from: now),
                 staleAt: Self.iso8601Formatter.string(from: now.addingTimeInterval(succeeded ? 8 : 30)),
+                expiresAt: nil
+            )
+        )
+    }
+
+    static func bellActivity(now: Date) -> TerminalActivitySnapshot {
+        TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: .shell, label: "Shell"),
+            status: .bell,
+            priority: .active,
+            progress: nil,
+            command: nil,
+            agent: nil,
+            display: TerminalActivityDisplay(
+                sourceLabel: "Shell",
+                stateLabel: "Bell",
+                detailLabel: nil,
+                paneHint: nil
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: Self.iso8601Formatter.string(from: now),
+                staleAt: nil,
+                expiresAt: Self.iso8601Formatter.string(from: now.addingTimeInterval(8))
+            )
+        )
+    }
+
+    static func processExitedActivity(exitCode: Int?, now: Date) -> TerminalActivitySnapshot {
+        let stateLabel = exitCode.map { "Exited \($0)" } ?? "Exited"
+        return TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: .process, label: "Process"),
+            status: .exited,
+            priority: .notable,
+            progress: nil,
+            command: TerminalActivityCommandOutcome(
+                exitCode: exitCode,
+                durationMilliseconds: nil,
+                commandText: nil
+            ),
+            agent: nil,
+            display: TerminalActivityDisplay(
+                sourceLabel: "Process",
+                stateLabel: stateLabel,
+                detailLabel: nil,
+                paneHint: nil
+            ),
+            freshness: TerminalActivityFreshness(
+                updatedAt: Self.iso8601Formatter.string(from: now),
+                staleAt: nil,
                 expiresAt: nil
             )
         )

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -271,6 +271,10 @@ struct TerminalActivitySnapshot: Codable, Equatable {
     let display: TerminalActivityDisplay
     let freshness: TerminalActivityFreshness
 
+    var isCommandFailure: Bool {
+        source.kind == .command && status == .failed
+    }
+
     var isSidebarWorthy: Bool {
         isSidebarWorthy(at: nil, owningTabFocused: false)
     }
@@ -280,8 +284,7 @@ struct TerminalActivitySnapshot: Codable, Equatable {
             return false
         }
         if owningTabFocused,
-           source.kind == .command,
-           status == .failed
+           isCommandFailure
         {
             return false
         }

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -15,13 +15,19 @@ func shellUserFacingSummary(_ summary: String?) -> String? {
     guard !trimmed.isEmpty else { return nil }
 
     let internalOnlySummaries = [
+        "command finished",
+        "command succeeded",
         "title updated",
         "input committed",
+        "terminal bell",
         "terminal rendering",
         "window attached",
     ]
 
-    if internalOnlySummaries.contains(trimmed.lowercased()) {
+    let lowercasedSummary = trimmed.lowercased()
+    if internalOnlySummaries.contains(lowercasedSummary)
+        || lowercasedSummary.hasPrefix("command failed")
+    {
         return nil
     }
 
@@ -57,9 +63,11 @@ func shellTerminalStatusSummary(for pane: ShellPane) -> String? {
 
     switch pane.attention {
     case .awaitingUser:
-        return shellUserFacingSummary(pane.viewport?.summary) ?? "Needs attention"
+        guard let rawSummary = pane.viewport?.summary else { return "Needs attention" }
+        return shellUserFacingSummary(rawSummary)
     case .notable:
-        return shellUserFacingSummary(pane.viewport?.summary) ?? "Terminal bell"
+        guard let rawSummary = pane.viewport?.summary else { return "Terminal bell" }
+        return shellUserFacingSummary(rawSummary)
     case .active, .idle:
         return nil
     }

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+struct ShellSidebarTabProjection: Equatable {
+    let title: String
+    let secondaryLine: String
+    let activity: TerminalActivitySnapshot?
+    let progress: TerminalActivityProgress?
+    let accessibilityActivityLabel: String?
+}
+
 func shellUserFacingSummary(_ summary: String?) -> String? {
     guard let summary else { return nil }
 
@@ -169,4 +177,133 @@ func shellPaneTitleBarTitle(for pane: ShellPane) -> String {
     }
 
     return "Terminal"
+}
+
+func shellPaneActivityAccessoryLabel(for pane: ShellPane, now: Date? = nil) -> String? {
+    guard let activity = pane.activity else { return nil }
+    if let now, !activity.isFresh(at: now) {
+        return nil
+    }
+
+    switch activity.status {
+    case .idle, .stale:
+        return nil
+    case .done:
+        return activity.source.kind == .command ? nil : activity.display.sourceFirstLabel
+    case .needsInput, .failed, .paused, .progress, .running, .bell, .exited:
+        return activity.display.sourceFirstLabel
+    }
+}
+
+func shellSidebarTabProjection(
+    for tab: ShellTab,
+    panes allPanes: [ShellPane],
+    focusedPaneID: String?,
+    focusedTabID: String?,
+    now: Date? = nil
+) -> ShellSidebarTabProjection {
+    let panes = shellOrderedPanes(for: tab, panes: allPanes)
+    let primaryPane = shellPrimaryPane(in: panes, focusedPaneID: focusedPaneID)
+    let title = shellSidebarTabTitle(for: tab, primaryPane: primaryPane)
+    let isOwningTabFocused = focusedTabID == tab.tabID
+
+    let activityCandidates = panes.enumerated().compactMap { index, pane -> TerminalActivitySnapshot? in
+        guard let activity = pane.activity,
+              activity.isSidebarWorthy(at: now, owningTabFocused: isOwningTabFocused)
+        else { return nil }
+
+        let hint: String?
+        if panes.count > 1,
+           pane.paneID != primaryPane?.paneID
+        {
+            hint = "Pane \(index + 1)"
+        } else {
+            hint = nil
+        }
+        return activity.withPaneHint(hint)
+    }
+
+    if let activity = TerminalActivitySnapshot.primarySidebarActivity(activityCandidates, now: now) {
+        return ShellSidebarTabProjection(
+            title: title,
+            secondaryLine: activity.display.sourceFirstLabel,
+            activity: activity,
+            progress: activity.progress,
+            accessibilityActivityLabel: activity.display.sourceFirstLabel
+        )
+    }
+
+    let fallback = primaryPane.flatMap { shellSidebarContextLine(for: $0, title: title) }
+        ?? shellFallbackTitle(for: tab.kind)
+    return ShellSidebarTabProjection(
+        title: title,
+        secondaryLine: fallback,
+        activity: nil,
+        progress: nil,
+        accessibilityActivityLabel: nil
+    )
+}
+
+func shellOrderedPanes(for tab: ShellTab, panes allPanes: [ShellPane]) -> [ShellPane] {
+    let byID = Dictionary(uniqueKeysWithValues: allPanes.map { ($0.paneID, $0) })
+    let ordered = tab.paneTree.paneIDs.compactMap { byID[$0] }
+    if !ordered.isEmpty {
+        return ordered
+    }
+    return allPanes.filter { $0.tabID == tab.tabID }
+}
+
+private func shellPrimaryPane(in panes: [ShellPane], focusedPaneID: String?) -> ShellPane? {
+    if let focusedPaneID,
+       let focused = panes.first(where: { $0.paneID == focusedPaneID })
+    {
+        return focused
+    }
+    return panes.first
+}
+
+private func shellSidebarTabTitle(for tab: ShellTab, primaryPane: ShellPane?) -> String {
+    shellDisplayTitle(
+        rawTitle: tab.title ?? primaryPane?.viewport?.title,
+        workingDirectoryName: primaryPane?.context?.workingDirectoryName,
+        cwd: primaryPane?.cwd,
+        program: primaryPane?.process?.program,
+        launchTarget: primaryPane?.resolvedLaunchTarget ?? .shell,
+        fallback: shellFallbackTitle(for: tab.kind)
+    )
+}
+
+private func shellSidebarContextLine(for pane: ShellPane, title: String) -> String? {
+    let contextLabel = shellPathLeaf(pane.context?.repositoryRoot)
+        ?? shellVisibleLabel(pane.context?.workingDirectoryName)
+        ?? shellPathLeaf(pane.cwd)
+
+    if let branch = shellVisibleLabel(pane.context?.gitBranch) {
+        if let contextLabel, contextLabel != title {
+            return "\(contextLabel) · \(branch)"
+        }
+        return branch
+    }
+
+    if let contextLabel {
+        if contextLabel == title,
+           let program = shellVisibleLabel(pane.process?.program)
+        {
+            return program
+        }
+        return contextLabel
+    }
+
+    return shellVisibleLabel(pane.process?.program)
+}
+
+private func shellFallbackTitle(for kind: ShellTabKind) -> String {
+    switch kind {
+    case .terminal:
+        return "Terminal"
+    case .scratch:
+        return "Scratch"
+    case .log:
+        return "Logs"
+    }
 }

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -233,7 +233,8 @@ func shellSidebarTabProjection(
         )
     }
 
-    let fallback = primaryPane.flatMap { shellSidebarContextLine(for: $0, title: title) }
+    let fallback = primaryPane.flatMap(shellTerminalStatusSummary(for:))
+        ?? primaryPane.flatMap { shellSidebarContextLine(for: $0, title: title) }
         ?? shellFallbackTitle(for: tab.kind)
     return ShellSidebarTabProjection(
         title: title,

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -734,6 +734,19 @@ private struct ShellPaneTitleBarView: View {
     private var accessories: [ShellPaneTitleBarAccessory] {
         var items: [ShellPaneTitleBarAccessory] = []
 
+        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane) {
+            items.append(
+                ShellPaneTitleBarAccessory(
+                    id: "activity",
+                    icon: activityIcon,
+                    title: activityLabel,
+                    help: activityLabel,
+                    tint: activityTint,
+                    maxWidth: 140
+                )
+            )
+        }
+
         if let status = shellTerminalStatusSummary(for: pane) {
             items.append(
                 ShellPaneTitleBarAccessory(
@@ -759,7 +772,9 @@ private struct ShellPaneTitleBarView: View {
             )
         }
 
-        if let binding = pane.alanBinding {
+        if let binding = pane.alanBinding,
+           pane.activity?.source.kind != .alan
+        {
             let bindingTitle = binding.pendingYield ? "Input" : shellVisibleLabel(binding.runStatus)
             items.append(
                 ShellPaneTitleBarAccessory(
@@ -774,6 +789,40 @@ private struct ShellPaneTitleBarView: View {
         }
 
         return items
+    }
+
+    private var activityIcon: String {
+        switch pane.activity?.status {
+        case .needsInput:
+            return "person.crop.circle.badge.exclamationmark"
+        case .failed:
+            return "exclamationmark.triangle"
+        case .paused:
+            return "pause.circle"
+        case .progress:
+            return "progress.indicator"
+        case .running:
+            return "play.circle"
+        case .bell:
+            return "bell"
+        case .exited:
+            return "rectangle.portrait.and.arrow.right"
+        case .done:
+            return "checkmark.circle"
+        case .idle, .stale, nil:
+            return "info.circle"
+        }
+    }
+
+    private var activityTint: Color {
+        switch pane.activity?.priority {
+        case .awaitingUser, .notable:
+            return ShellPalette.attention
+        case .active:
+            return ShellPalette.accent
+        case .passive, nil:
+            return ShellPalette.mutedInk
+        }
     }
 
     private var statusIcon: String {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -681,6 +681,7 @@ private struct ShellPaneTitleBarView: View {
     let isSelected: Bool
     let onFocusPane: () -> Void
     let onClosePane: () -> Void
+    @State private var activityFreshnessNow = Date()
 
     var body: some View {
         HStack(spacing: 8) {
@@ -729,12 +730,53 @@ private struct ShellPaneTitleBarView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture(perform: onFocusPane)
+        .task(id: activityFreshnessRefreshID) {
+            await scheduleActivityFreshnessRefresh()
+        }
     }
+
+    private var activityFreshnessRefreshID: String {
+        nextActivityFreshnessExpiry(after: activityFreshnessNow)
+            .map { "\($0.timeIntervalSince1970)" } ?? "none"
+    }
+
+    private func scheduleActivityFreshnessRefresh() async {
+        guard let deadline = nextActivityFreshnessExpiry(after: activityFreshnessNow) else {
+            return
+        }
+
+        let delay = min(max(deadline.timeIntervalSinceNow, 0), 86_400)
+        if delay > 0 {
+            let nanoseconds = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        }
+
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+            activityFreshnessNow = Date()
+        }
+    }
+
+    private func nextActivityFreshnessExpiry(after now: Date) -> Date? {
+        guard let activity = pane.activity else { return nil }
+
+        return [
+            activity.freshness.staleAt,
+            activity.freshness.expiresAt,
+        ]
+        .compactMap { value in
+            value.flatMap(Self.activityFreshnessFormatter.date(from:))
+        }
+        .filter { $0 > now }
+        .min()
+    }
+
+    private static let activityFreshnessFormatter = ISO8601DateFormatter()
 
     private var accessories: [ShellPaneTitleBarAccessory] {
         var items: [ShellPaneTitleBarAccessory] = []
 
-        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane, now: Date()) {
+        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane, now: activityFreshnessNow) {
             items.append(
                 ShellPaneTitleBarAccessory(
                     id: "activity",

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -734,7 +734,7 @@ private struct ShellPaneTitleBarView: View {
     private var accessories: [ShellPaneTitleBarAccessory] {
         var items: [ShellPaneTitleBarAccessory] = []
 
-        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane) {
+        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane, now: Date()) {
             items.append(
                 ShellPaneTitleBarAccessory(
                     id: "activity",

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -455,21 +455,26 @@ struct ShellSidebarView: View {
     private func tabListRow(for tab: ShellTab) -> some View {
         let isSelected = host.selectedTab?.tabID == tab.tabID
         let isHovered = hoveredTabID == tab.tabID
+        let projection = shellSidebarTabProjection(
+            for: tab,
+            panes: host.shellState.panes,
+            focusedPaneID: host.shellState.focusedPaneID,
+            focusedTabID: host.selectedTab?.tabID,
+            now: Date()
+        )
 
         ShellTabSidebarRow(
-            title: tabTitle(for: tab),
-            subtitle: tabSubtitle(for: tab),
+            title: projection.title,
+            subtitle: projection.secondaryLine,
             iconName: tabIconName(for: tab),
+            progress: projection.progress,
             attention: strongestAttention(for: tab),
-            showsAlanMarker: showsAlanMarker(for: tab),
+            showsAlanMarker: showsAlanMarker(for: tab, activity: projection.activity),
             splitSummary: splitSummary(for: tab),
             isPinned: host.isTabPinned(tabID: tab.tabID),
             isSelected: isSelected,
             isHovered: isHovered,
             showsCloseAffordance: isHovered,
-            onFocusPane: { paneID in
-                focusPane(paneID, in: tab)
-            },
             onFocusNextSplitPane: { summary in
                 focusNextSplitPane(in: tab, summary: summary)
             },
@@ -624,8 +629,9 @@ struct ShellSidebarView: View {
         return "terminal"
     }
 
-    private func showsAlanMarker(for tab: ShellTab) -> Bool {
-        host.shellState.panes.contains { pane in
+    private func showsAlanMarker(for tab: ShellTab, activity: TerminalActivitySnapshot?) -> Bool {
+        guard activity?.source.kind != .alan else { return false }
+        return host.shellState.panes.contains { pane in
             pane.tabID == tab.tabID && pane.resolvedLaunchTarget == .alan
         }
     }
@@ -889,6 +895,7 @@ private struct ShellTabSidebarRow: View {
     let title: String
     let subtitle: String
     let iconName: String
+    let progress: TerminalActivityProgress?
     let attention: ShellAttentionState?
     let showsAlanMarker: Bool
     let splitSummary: ShellTabSplitSummary?
@@ -896,24 +903,22 @@ private struct ShellTabSidebarRow: View {
     let isSelected: Bool
     let isHovered: Bool
     let showsCloseAffordance: Bool
-    let onFocusPane: (String) -> Void
     let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
     let onClose: () -> Void
 
     var body: some View {
         ZStack(alignment: .trailing) {
-            HStack(spacing: 10) {
-                Image(systemName: iconName)
-                    .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
-                    .foregroundStyle(iconForeground)
-                    .frame(width: ShellSidebarMetrics.iconColumnWidth)
+            HStack(alignment: .top, spacing: 10) {
+                leadingSlot
+                    .frame(width: 24, height: 24, alignment: .center)
 
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: progress == nil ? 3 : 5) {
                     HStack(spacing: 6) {
                         Text(title)
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundStyle(titleForeground)
                             .lineLimit(1)
+                            .truncationMode(.middle)
 
                         if showsAlanMarker {
                             Image(systemName: "sparkles")
@@ -933,35 +938,49 @@ private struct ShellTabSidebarRow: View {
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(subtitleForeground)
                         .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    if let progress {
+                        ShellSidebarActivityProgressRail(progress: progress, isSelected: isSelected)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 Spacer(minLength: 8)
+            }
 
-                if let splitSummary {
-                    ShellSplitTopologyIndicator(
-                        summary: splitSummary,
-                        onFocusPane: onFocusPane,
-                        onFocusNextSplitPane: onFocusNextSplitPane
+            if showsCloseButton {
+                HStack(spacing: 0) {
+                    LinearGradient(
+                        colors: [
+                            closeOverlayFill.opacity(0),
+                            closeOverlayFill.opacity(0.96),
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
                     )
-                }
-            }
-            .padding(.trailing, 24)
+                    .frame(width: 28)
 
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9.5, weight: .bold))
-                    .foregroundStyle(closeForeground)
-                    .frame(width: 20, height: 20)
-                    .contentShape(Rectangle())
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9.5, weight: .bold))
+                            .foregroundStyle(closeForeground)
+                            .frame(width: 22, height: 22)
+                            .contentShape(Rectangle())
+                            .background {
+                                Circle()
+                                    .fill(closeOverlayFill.opacity(0.98))
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .help("Close tab")
+                    .accessibilityLabel("Close tab")
+                }
+                .transition(.opacity)
             }
-            .buttonStyle(.plain)
-            .opacity(showsCloseButton ? 1 : 0)
-            .allowsHitTesting(showsCloseButton)
-            .accessibilityHidden(!showsCloseButton)
-            .help("Close tab")
         }
         .padding(.horizontal, ShellSidebarMetrics.rowInset)
-        .padding(.vertical, 7)
+        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             ShellSidebarRowBackground(state: visualState)
@@ -993,7 +1012,22 @@ private struct ShellTabSidebarRow: View {
     }
 
     private var showsCloseButton: Bool {
-        isSelected || isInteractionActive
+        isInteractionActive
+    }
+
+    @ViewBuilder
+    private var leadingSlot: some View {
+        if let splitSummary {
+            ShellSplitTopologyIndicator(
+                summary: splitSummary,
+                onFocusNextSplitPane: onFocusNextSplitPane
+            )
+        } else {
+            Image(systemName: iconName)
+                .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
+                .foregroundStyle(iconForeground)
+                .frame(width: ShellSidebarMetrics.iconColumnWidth)
+        }
     }
 
     private var iconForeground: Color {
@@ -1010,6 +1044,10 @@ private struct ShellTabSidebarRow: View {
 
     private var closeForeground: Color {
         isSelected ? ShellPalette.sidebarInk.opacity(0.50) : ShellPalette.sidebarMutedInk.opacity(0.72)
+    }
+
+    private var closeOverlayFill: Color {
+        isSelected ? ShellPalette.sidebarRowSelected : ShellPalette.sidebarRowHover
     }
 
     private var accessibilityLabel: String {
@@ -1030,9 +1068,50 @@ private struct ShellTabSidebarRow: View {
     }
 }
 
+private struct ShellSidebarActivityProgressRail: View {
+    let progress: TerminalActivityProgress
+    let isSelected: Bool
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(ShellPalette.sidebarMutedInk.opacity(isSelected ? 0.16 : 0.12))
+
+                Capsule()
+                    .fill(fillColor)
+                    .frame(width: fillWidth(in: proxy.size.width))
+            }
+        }
+        .frame(height: 2)
+        .accessibilityHidden(true)
+    }
+
+    private var fillColor: Color {
+        switch progress.kind {
+        case .failed:
+            return ShellPalette.attention.opacity(isSelected ? 0.86 : 0.72)
+        case .paused:
+            return ShellPalette.sidebarMutedInk.opacity(isSelected ? 0.62 : 0.48)
+        case .percent, .indeterminate:
+            return ShellPalette.accent.opacity(isSelected ? 0.82 : 0.68)
+        }
+    }
+
+    private func fillWidth(in width: CGFloat) -> CGFloat {
+        switch progress.kind {
+        case .percent:
+            return width * CGFloat(progress.percent ?? 0) / 100
+        case .indeterminate:
+            return max(width * 0.36, 18)
+        case .paused, .failed:
+            return width
+        }
+    }
+}
+
 private struct ShellSplitTopologyIndicator: View {
     let summary: ShellTabSplitSummary
-    let onFocusPane: (String) -> Void
     let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
 
     var body: some View {
@@ -1047,22 +1126,27 @@ private struct ShellSplitTopologyIndicator: View {
         let panes = Array(summary.paneIDs.prefix(2).enumerated())
         let isVertical = summary.direction == .vertical
 
-        return Group {
-            if isVertical {
-                HStack(spacing: 2) {
-                    ForEach(panes, id: \.element) { index, paneID in
-                        segmentButton(index: index, paneID: paneID)
+        return Button {
+            onFocusNextSplitPane(summary)
+        } label: {
+            Group {
+                if isVertical {
+                    HStack(spacing: 2) {
+                        ForEach(panes, id: \.element) { _, paneID in
+                            segmentView(paneID: paneID)
+                        }
                     }
-                }
-            } else {
-                VStack(spacing: 2) {
-                    ForEach(panes, id: \.element) { index, paneID in
-                        segmentButton(index: index, paneID: paneID)
+                } else {
+                    VStack(spacing: 2) {
+                        ForEach(panes, id: \.element) { _, paneID in
+                            segmentView(paneID: paneID)
+                        }
                     }
                 }
             }
+            .frame(width: 22, height: 16)
         }
-        .frame(width: 25, height: 16)
+        .buttonStyle(.plain)
         .help("Focus split pane")
         .accessibilityLabel("Split tab, \(summary.paneCount) panes")
     }
@@ -1078,7 +1162,7 @@ private struct ShellSplitTopologyIndicator: View {
                     .font(.system(size: 8, weight: .bold, design: .monospaced))
             }
             .foregroundStyle(summary.focusedPaneID == nil ? .secondary : ShellPalette.accent)
-            .frame(width: 28, height: 18)
+            .frame(width: 24, height: 18)
             .background(
                 RoundedRectangle(cornerRadius: ShellRadii.badge, style: .continuous)
                     .fill(ShellPalette.canvas.opacity(0.55))
@@ -1089,17 +1173,11 @@ private struct ShellSplitTopologyIndicator: View {
         .accessibilityLabel("Split tab, \(summary.paneCount) panes")
     }
 
-    private func segmentButton(index: Int, paneID: String) -> some View {
+    private func segmentView(paneID: String) -> some View {
         let isFocused = summary.focusedPaneID == paneID
 
-        return Button {
-            onFocusPane(paneID)
-        } label: {
-            RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
-                .fill(isFocused ? ShellPalette.accent.opacity(0.9) : ShellPalette.mutedInk.opacity(0.24))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Focus pane \(index + 1)")
+        return RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
+            .fill(isFocused ? ShellPalette.accent.opacity(0.9) : ShellPalette.mutedInk.opacity(0.24))
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -15,6 +15,7 @@ struct ShellSidebarView: View {
     @State private var hoveredSpaceID: String?
     @State private var isCommandLauncherHovered = false
     @State private var tabListScrollOffsetY: CGFloat = 0
+    @State private var activityFreshnessNow = Date()
 
     init(
         host: ShellHostController,
@@ -46,6 +47,9 @@ struct ShellSidebarView: View {
         .scrollDisabled(isTabListScrollDisabled)
         .onChange(of: sourceSpaceID) { _, _ in
             tabListScrollOffsetY = 0
+        }
+        .task(id: activityFreshnessRefreshID) {
+            await scheduleActivityFreshnessRefresh()
         }
     }
 
@@ -430,6 +434,53 @@ struct ShellSidebarView: View {
         "ShellSidebarTabListScroll-\(spaceID ?? "none")"
     }
 
+    private var activityFreshnessRefreshID: String {
+        nextActivityFreshnessExpiry(after: activityFreshnessNow)
+            .map { "\($0.timeIntervalSince1970)" } ?? "none"
+    }
+
+    private func scheduleActivityFreshnessRefresh() async {
+        guard let deadline = nextActivityFreshnessExpiry(after: activityFreshnessNow) else {
+            return
+        }
+
+        let delay = min(max(deadline.timeIntervalSinceNow, 0), 86_400)
+        if delay > 0 {
+            let nanoseconds = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        }
+
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+            activityFreshnessNow = Date()
+        }
+    }
+
+    private func nextActivityFreshnessExpiry(after now: Date) -> Date? {
+        host.shellState.panes.compactMap { pane in
+            guard let activity = pane.activity else { return nil }
+            return nextActivityFreshnessExpiry(for: activity, after: now)
+        }
+        .min()
+    }
+
+    private func nextActivityFreshnessExpiry(
+        for activity: TerminalActivitySnapshot,
+        after now: Date
+    ) -> Date? {
+        [
+            activity.freshness.staleAt,
+            activity.freshness.expiresAt,
+        ]
+        .compactMap { value in
+            value.flatMap(Self.activityFreshnessFormatter.date(from:))
+        }
+        .filter { $0 > now }
+        .min()
+    }
+
+    private static let activityFreshnessFormatter = ISO8601DateFormatter()
+
     private func space(for spaceID: String?) -> ShellSpace? {
         guard let spaceID else { return host.selectedSpace }
         return host.spaces.first { $0.spaceID == spaceID }
@@ -460,7 +511,7 @@ struct ShellSidebarView: View {
             panes: host.shellState.panes,
             focusedPaneID: host.shellState.focusedPaneID,
             focusedTabID: host.selectedTab?.tabID,
-            now: Date()
+            now: activityFreshnessNow
         )
 
         ShellTabSidebarRow(
@@ -475,6 +526,9 @@ struct ShellSidebarView: View {
             isSelected: isSelected,
             isHovered: isHovered,
             showsCloseAffordance: isHovered,
+            onFocusSplitPane: { paneID in
+                focusPane(paneID, in: tab)
+            },
             onFocusNextSplitPane: { summary in
                 focusNextSplitPane(in: tab, summary: summary)
             },
@@ -903,6 +957,7 @@ private struct ShellTabSidebarRow: View {
     let isSelected: Bool
     let isHovered: Bool
     let showsCloseAffordance: Bool
+    let onFocusSplitPane: (String) -> Void
     let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
     let onClose: () -> Void
 
@@ -1020,6 +1075,7 @@ private struct ShellTabSidebarRow: View {
         if let splitSummary {
             ShellSplitTopologyIndicator(
                 summary: splitSummary,
+                onFocusSplitPane: onFocusSplitPane,
                 onFocusNextSplitPane: onFocusNextSplitPane
             )
         } else {
@@ -1112,6 +1168,7 @@ private struct ShellSidebarActivityProgressRail: View {
 
 private struct ShellSplitTopologyIndicator: View {
     let summary: ShellTabSplitSummary
+    let onFocusSplitPane: (String) -> Void
     let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
 
     var body: some View {
@@ -1123,30 +1180,25 @@ private struct ShellSplitTopologyIndicator: View {
     }
 
     private var twoPaneIndicator: some View {
-        let panes = Array(summary.paneIDs.prefix(2).enumerated())
+        let paneIDs = Array(summary.paneIDs.prefix(2))
         let isVertical = summary.direction == .vertical
 
-        return Button {
-            onFocusNextSplitPane(summary)
-        } label: {
-            Group {
-                if isVertical {
-                    HStack(spacing: 2) {
-                        ForEach(panes, id: \.element) { _, paneID in
-                            segmentView(paneID: paneID)
-                        }
+        return Group {
+            if isVertical {
+                HStack(spacing: 2) {
+                    ForEach(paneIDs, id: \.self) { paneID in
+                        segmentButton(paneID: paneID)
                     }
-                } else {
-                    VStack(spacing: 2) {
-                        ForEach(panes, id: \.element) { _, paneID in
-                            segmentView(paneID: paneID)
-                        }
+                }
+            } else {
+                VStack(spacing: 2) {
+                    ForEach(paneIDs, id: \.self) { paneID in
+                        segmentButton(paneID: paneID)
                     }
                 }
             }
-            .frame(width: 22, height: 16)
         }
-        .buttonStyle(.plain)
+        .frame(width: 22, height: 16)
         .help("Focus split pane")
         .accessibilityLabel("Split tab, \(summary.paneCount) panes")
     }
@@ -1171,6 +1223,19 @@ private struct ShellSplitTopologyIndicator: View {
         .buttonStyle(.plain)
         .help("Focus next split pane")
         .accessibilityLabel("Split tab, \(summary.paneCount) panes")
+    }
+
+    private func segmentButton(paneID: String) -> some View {
+        Button {
+            onFocusSplitPane(paneID)
+        } label: {
+            segmentView(paneID: paneID)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(summary.focusedPaneID == paneID ? "Focused split pane" : "Focus split pane")
+        .accessibilityLabel(summary.focusedPaneID == paneID ? "Focused split pane" : "Focus split pane")
     }
 
     private func segmentView(paneID: String) -> some View {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -928,6 +928,26 @@ require_pattern \
     "terminalRuntimeRegistry\\.requestFocus\\(for: paneID\\)" \
     "committed sidebar selection must request terminal focus through the runtime registry"
 
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "activityFreshnessNow" \
+    "sidebar activity freshness must be driven by state that can invalidate idle rows"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "task\\(id: activityFreshnessRefreshID\\)" \
+    "sidebar activity freshness must schedule refreshes for stale/expires deadlines"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "onFocusSplitPane: \\{ paneID in" \
+    "sidebar split indicators must preserve direct clicked-pane targeting"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "segmentButton\\(paneID: paneID\\)" \
+    "two-pane sidebar split indicators must render pane-specific actions"
+
 reject_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
     "selectedSpaceID = spaceID" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -939,6 +939,21 @@ require_pattern \
     "sidebar activity freshness must schedule refreshes for stale/expires deadlines"
 
 require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "activityFreshnessNow" \
+    "pane title activity freshness must be driven by state that can invalidate idle title bars"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "task\\(id: activityFreshnessRefreshID\\)" \
+    "pane title activity freshness must schedule refreshes for stale/expires deadlines"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "shellPaneActivityAccessoryLabel\\(for: pane, now: activityFreshnessNow\\)" \
+    "pane title activity labels must use the state-driven freshness clock"
+
+require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "onFocusSplitPane: \\{ paneID in" \
     "sidebar split indicators must preserve direct clicked-pane targeting"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -35,6 +35,12 @@ private enum ShellRuntimeMetadataTests {
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
         verifiesPaneRebuildMutationsPreserveActivity()
+        verifiesTabSidebarActivityProjectionUsesHighestPriorityPane()
+        verifiesTabSidebarProjectionFallsBackToRepositoryBranch()
+        verifiesSidebarProgressRailBelongsToDisplayedActivity()
+        verifiesFocusedCommandFailureDemotesFromSidebarProjection()
+        verifiesActivityFreshnessPolicies()
+        verifiesPaneTitleActivityAccessoryLabel()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -800,6 +806,236 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesTabSidebarActivityProjectionUsesHighestPriorityPane() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let progress = progressActivity(
+            percent: 42,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+        let needsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            updatedAt: "2026-05-17T09:00:01Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", activity: progress),
+            for: "pane_1"
+        )
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: needsInput),
+            for: "pane_2"
+        )
+
+        guard let tab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("test setup must keep the split tab")
+        }
+
+        let projection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_other",
+            now: now
+        )
+
+        expect(projection.activity?.status == .needsInput, "tab activity must pick the most actionable pane")
+        expect(
+            projection.secondaryLine == "Pane 2 · Codex · Input needed",
+            "background pane activity must include a short pane hint"
+        )
+        expect(projection.progress == nil, "non-progress displayed activity must not inherit another pane progress")
+    }
+
+    private static func verifiesTabSidebarProjectionFallsBackToRepositoryBranch() {
+        let tab = ShellTab(
+            tabID: "tab_1",
+            kind: .terminal,
+            title: nil,
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_pane_1",
+                kind: .pane,
+                direction: nil,
+                paneID: "pane_1",
+                children: nil
+            )
+        )
+        let testPane = pane(
+            context: context(
+                workingDirectoryName: "src",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            cwd: "/Users/morris/Developer/alan/crates/runtime",
+            attention: .idle
+        )
+
+        let projection = shellSidebarTabProjection(
+            for: tab,
+            panes: [testPane],
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_1",
+            now: nil
+        )
+
+        expect(projection.activity == nil, "idle panes must not produce tab activity")
+        expect(
+            projection.secondaryLine == "alan · main",
+            "sidebar context fallback must prefer repository/worktree leaf plus branch"
+        )
+    }
+
+    private static func verifiesSidebarProgressRailBelongsToDisplayedActivity() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let progress = progressActivity(
+            percent: 64,
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:15Z"
+        )
+        let failed = activity(
+            status: .failed,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Error",
+            updatedAt: "2026-05-17T09:00:01Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "build", cwd: "/repo/app", activity: progress),
+            for: "pane_1"
+        )
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: failed),
+            for: "pane_2"
+        )
+
+        guard let tab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("test setup must keep the split tab")
+        }
+
+        let failedProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_other",
+            now: now
+        )
+        expect(failedProjection.secondaryLine == "Pane 2 · Codex · Error", "failed activity must outrank progress")
+        expect(failedProjection.progress == nil, "progress rail must not be shown for a different pane's progress")
+
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", clearsActivity: true),
+            for: "pane_2"
+        )
+        let progressProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_other",
+            now: now
+        )
+        expect(progressProjection.secondaryLine == "Progress · 64%", "progress activity must become visible after failure clears")
+        expect(progressProjection.progress == .percent(64), "progress rail must use the displayed activity progress")
+    }
+
+    private static func verifiesFocusedCommandFailureDemotesFromSidebarProjection() {
+        let controller = makeController()
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let failure = TerminalActivitySnapshot.commandCompletion(exitCode: 2, now: now)
+        controller.updateTerminalMetadata(
+            metadata(title: "fish", cwd: "/Users/morris/Developer/alan", activity: failure),
+            for: "pane_1"
+        )
+
+        guard let tab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("test setup must keep the tab")
+        }
+
+        let focusedProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_main",
+            now: now
+        )
+        expect(focusedProjection.activity == nil, "focused command failure may demote from sidebar activity")
+
+        let backgroundProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_other",
+            now: now
+        )
+        expect(
+            backgroundProjection.secondaryLine == "Shell · Command failed 2",
+            "background command failure must remain sidebar-worthy"
+        )
+    }
+
+    private static func verifiesActivityFreshnessPolicies() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let bell = TerminalActivitySnapshot.bellActivity(now: now)
+        let exited = TerminalActivitySnapshot.processExitedActivity(exitCode: 2, now: now)
+        let needsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed"
+        )
+
+        expect(
+            bell.isFresh(at: now.addingTimeInterval(7)),
+            "bell activity must remain briefly visible"
+        )
+        expect(
+            !bell.isFresh(at: now.addingTimeInterval(9)),
+            "bell activity must expire after the brief visibility window"
+        )
+        expect(
+            exited.isFresh(at: now.addingTimeInterval(3_600)),
+            "process-exited activity must persist until the pane is closed or replaced"
+        )
+        expect(
+            needsInput.isFresh(at: now.addingTimeInterval(3_600)),
+            "needs-input activity must persist until replaced"
+        )
+    }
+
+    private static func verifiesPaneTitleActivityAccessoryLabel() {
+        let paneWithProgress = pane(
+            context: context(
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            attention: .idle,
+            activity: TerminalActivitySnapshot.progressActivity(
+                percent: 42,
+                now: Date(timeIntervalSince1970: 1_779_008_400)
+            )
+        )
+
+        expect(
+            shellPaneActivityAccessoryLabel(for: paneWithProgress) == "Progress · 42%",
+            "pane title activity accessory must expose source-first activity copy"
+        )
+    }
+
     private static func verifiesTerminalChildExitClosesSplitPane() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -1297,7 +1533,8 @@ private enum ShellRuntimeMetadataTests {
         cwd: String? = "/Users/morris/Developer/Alan",
         launchTarget: ShellLaunchTarget = .shell,
         process: ShellProcessBinding? = ShellProcessBinding(program: "fish", argvPreview: nil),
-        attention: ShellAttentionState
+        attention: ShellAttentionState,
+        activity: TerminalActivitySnapshot? = nil
     ) -> ShellPane {
         ShellPane(
             paneID: "pane_1",
@@ -1309,12 +1546,15 @@ private enum ShellRuntimeMetadataTests {
             attention: attention,
             context: context,
             viewport: viewport,
+            activity: activity,
             alanBinding: nil
         )
     }
 
     private static func context(
         workingDirectoryName: String? = "alan",
+        repositoryRoot: String? = nil,
+        gitBranch: String? = nil,
         processState: String,
         rendererHealth: String,
         surfaceReadiness: String,
@@ -1322,8 +1562,8 @@ private enum ShellRuntimeMetadataTests {
     ) -> ShellContextSnapshot {
         ShellContextSnapshot(
             workingDirectoryName: workingDirectoryName,
-            repositoryRoot: nil,
-            gitBranch: nil,
+            repositoryRoot: repositoryRoot,
+            gitBranch: gitBranch,
             controlPath: nil,
             alanBindingFile: nil,
             launchStrategy: nil,

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -1015,6 +1015,7 @@ private enum ShellRuntimeMetadataTests {
     }
 
     private static func verifiesPaneTitleActivityAccessoryLabel() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
         let paneWithProgress = pane(
             context: context(
                 processState: "running",
@@ -1026,13 +1027,17 @@ private enum ShellRuntimeMetadataTests {
             attention: .idle,
             activity: TerminalActivitySnapshot.progressActivity(
                 percent: 42,
-                now: Date(timeIntervalSince1970: 1_779_008_400)
+                now: now
             )
         )
 
         expect(
-            shellPaneActivityAccessoryLabel(for: paneWithProgress) == "Progress · 42%",
+            shellPaneActivityAccessoryLabel(for: paneWithProgress, now: now) == "Progress · 42%",
             "pane title activity accessory must expose source-first activity copy"
+        )
+        expect(
+            shellPaneActivityAccessoryLabel(for: paneWithProgress, now: now.addingTimeInterval(16)) == nil,
+            "pane title activity accessory must hide stale progress"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -38,6 +38,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTabSidebarActivityProjectionUsesHighestPriorityPane()
         verifiesTabSidebarProjectionFallsBackToRepositoryBranch()
         verifiesTabSidebarProjectionPreservesTerminalStatusBeforeContext()
+        verifiesTabSidebarProjectionDoesNotResurrectStaleCommandFailure()
         verifiesSidebarProgressRailBelongsToDisplayedActivity()
         verifiesFocusedCommandFailureDemotesFromSidebarProjection()
         verifiesActivityFreshnessPolicies()
@@ -960,6 +961,63 @@ private enum ShellRuntimeMetadataTests {
         expect(
             startingProjection.secondaryLine == "Starting",
             "sidebar fallback must preserve startup/input readiness before repository context"
+        )
+    }
+
+    private static func verifiesTabSidebarProjectionDoesNotResurrectStaleCommandFailure() {
+        let tab = ShellTab(
+            tabID: "tab_1",
+            kind: .terminal,
+            title: nil,
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_pane_1",
+                kind: .pane,
+                direction: nil,
+                paneID: "pane_1",
+                children: nil
+            )
+        )
+        let staleFailure = activity(
+            status: .failed,
+            source: .command,
+            sourceLabel: "Shell",
+            stateLabel: "Command failed 2",
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:30Z"
+        )
+        let testPane = pane(
+            context: context(
+                workingDirectoryName: "src",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: 2
+            ),
+            viewport: ShellViewportSnapshot(
+                title: "fish",
+                summary: "command failed (2)",
+                visibleExcerpt: nil,
+                lastActivityAt: nil
+            ),
+            cwd: "/Users/morris/Developer/alan/crates/runtime",
+            attention: .notable,
+            activity: staleFailure
+        )
+
+        let projection = shellSidebarTabProjection(
+            for: tab,
+            panes: [testPane],
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_1",
+            now: Date(timeIntervalSince1970: 1_779_008_431)
+        )
+
+        expect(projection.activity == nil, "stale command failure must not remain sidebar activity")
+        expect(
+            projection.secondaryLine == "alan · main",
+            "stale command failure summary must not hide repository context"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -37,6 +37,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneRebuildMutationsPreserveActivity()
         verifiesTabSidebarActivityProjectionUsesHighestPriorityPane()
         verifiesTabSidebarProjectionFallsBackToRepositoryBranch()
+        verifiesTabSidebarProjectionPreservesTerminalStatusBeforeContext()
         verifiesSidebarProgressRailBelongsToDisplayedActivity()
         verifiesFocusedCommandFailureDemotesFromSidebarProjection()
         verifiesActivityFreshnessPolicies()
@@ -892,6 +893,73 @@ private enum ShellRuntimeMetadataTests {
         expect(
             projection.secondaryLine == "alan · main",
             "sidebar context fallback must prefer repository/worktree leaf plus branch"
+        )
+    }
+
+    private static func verifiesTabSidebarProjectionPreservesTerminalStatusBeforeContext() {
+        let tab = ShellTab(
+            tabID: "tab_1",
+            kind: .terminal,
+            title: nil,
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_pane_1",
+                kind: .pane,
+                direction: nil,
+                paneID: "pane_1",
+                children: nil
+            )
+        )
+        let failedRenderer = pane(
+            context: context(
+                workingDirectoryName: "src",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "failed",
+                surfaceReadiness: "renderer_failed",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            cwd: "/Users/morris/Developer/alan/crates/runtime",
+            attention: .notable
+        )
+        let startingPane = pane(
+            context: context(
+                workingDirectoryName: "src",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "input_not_ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            cwd: "/Users/morris/Developer/alan/crates/runtime",
+            attention: .idle
+        )
+
+        let failedProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: [failedRenderer],
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_1",
+            now: nil
+        )
+        let startingProjection = shellSidebarTabProjection(
+            for: tab,
+            panes: [startingPane],
+            focusedPaneID: "pane_1",
+            focusedTabID: "tab_1",
+            now: nil
+        )
+
+        expect(
+            failedProjection.secondaryLine == "Renderer failed",
+            "sidebar fallback must preserve renderer failures before repository context"
+        )
+        expect(
+            startingProjection.secondaryLine == "Starting",
+            "sidebar fallback must preserve startup/input readiness before repository context"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -41,6 +41,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTabSidebarProjectionDoesNotResurrectStaleCommandFailure()
         verifiesSidebarProgressRailBelongsToDisplayedActivity()
         verifiesFocusedCommandFailureDemotesFromSidebarProjection()
+        verifiesCommandFailureAcknowledgementSticksAfterFocus()
         verifiesActivityFreshnessPolicies()
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesTerminalChildExitClosesSplitPane()
@@ -1108,6 +1109,63 @@ private enum ShellRuntimeMetadataTests {
         expect(
             backgroundProjection.secondaryLine == "Shell · Command failed 2",
             "background command failure must remain sidebar-worthy"
+        )
+    }
+
+    private static func verifiesCommandFailureAcknowledgementSticksAfterFocus() {
+        let controller = makeController()
+        _ = controller.openTerminalTab()
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let failure = TerminalActivitySnapshot.commandCompletion(exitCode: 2, now: now)
+
+        controller.updateTerminalMetadata(
+            metadata(title: "fish", cwd: "/Users/morris/Developer/alan", activity: failure),
+            for: "pane_1"
+        )
+
+        guard let backgroundTab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("test setup must keep the background tab")
+        }
+        let unacknowledgedProjection = shellSidebarTabProjection(
+            for: backgroundTab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_2",
+            focusedTabID: "tab_2",
+            now: now
+        )
+        expect(
+            unacknowledgedProjection.secondaryLine == "Shell · Command failed 2",
+            "background command failure must remain visible before focus acknowledgement"
+        )
+
+        controller.focus(paneID: "pane_1")
+        expect(
+            controller.pane(paneID: "pane_1")?.activity == nil,
+            "focusing the command-failure tab must acknowledge and clear the retained activity"
+        )
+        expect(
+            controller.pane(paneID: "pane_1")?.attention != .notable,
+            "acknowledged focused command failure must stop keeping the pane notable"
+        )
+
+        controller.focus(paneID: "pane_2")
+        guard let acknowledgedTab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("test setup must keep the acknowledged tab")
+        }
+        let acknowledgedProjection = shellSidebarTabProjection(
+            for: acknowledgedTab,
+            panes: controller.shellState.panes,
+            focusedPaneID: "pane_2",
+            focusedTabID: "tab_2",
+            now: now.addingTimeInterval(1)
+        )
+        expect(
+            acknowledgedProjection.activity == nil,
+            "acknowledged command failure must not become sidebar-worthy again after switching away"
+        )
+        expect(
+            acknowledgedProjection.secondaryLine != "Shell · Command failed 2",
+            "acknowledged command failure must fall back to tab context instead of resurfacing"
         )
     }
 

--- a/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
@@ -3,10 +3,10 @@
 - [x] 1.1 Audit current terminal metadata sources in `GhosttyLiveHost`,
   `TerminalHostRuntime`, `TerminalRuntimeService`, `ShellHostController`, and
   `ShellPaneProjectionService`.
-- [ ] 1.2 Finalize normalized activity state names, source kinds, source-first
+- [x] 1.2 Finalize normalized activity state names, source kinds, source-first
   display labels, priority order, freshness rules, and user-facing labels for
   progress, command, Alan, and CLI agent states.
-- [ ] 1.3 Finalize sidebar row projection details for title, activity-or-context
+- [x] 1.3 Finalize sidebar row projection details for title, activity-or-context
   fallback, progress rail, leading topology/kind slot, and hover close overlay.
 - [ ] 1.4 Encode default notification policy for focused, visible, background,
   unfocused, successful, failed, and user-input-required activity.
@@ -20,13 +20,13 @@
   and source-first display labels.
 - [x] 2.2 Extend terminal metadata snapshots and shell projection paths to carry
   normalized activity without removing existing title/cwd/attention fields.
-- [ ] 2.3 Add deterministic activity merge and priority logic for concurrent
+- [x] 2.3 Add deterministic activity merge and priority logic for concurrent
   progress, command completion, bell, Alan, and agent signals, including
   tab-level highest-priority activity selection.
-- [ ] 2.4 Add unit/script coverage for activity merge order, stale progress,
+- [x] 2.4 Add unit/script coverage for activity merge order, stale progress,
   focused successful command completion exclusion from sidebar activity,
   progress-over-running priority, and user-input-required priority.
-- [ ] 2.5 Add freshness coverage for progress stale/clear, command failure
+- [x] 2.5 Add freshness coverage for progress stale/clear, command failure
   demotion after focus or timeout, brief bell, persistent exited state, and
   persistent needs-input/error until replaced.
 
@@ -36,9 +36,9 @@
   determinate, indeterminate, paused, error, clear, and stale states.
 - [x] 3.2 Map `GHOSTTY_ACTION_COMMAND_FINISHED` into command-completion activity
   with success/failure status and duration when available.
-- [ ] 3.3 Keep bell and child-exit attention compatible with the normalized
+- [x] 3.3 Keep bell and child-exit attention compatible with the normalized
   activity model without changing existing terminal overlay semantics.
-- [ ] 3.4 Add focused tests for progress update, progress clear, command success,
+- [x] 3.4 Add focused tests for progress update, progress clear, command success,
   command failure, and stale-progress timeout behavior.
 
 ## 4. CLI Coding-Agent Activity
@@ -54,20 +54,20 @@
 
 ## 5. Activity UI And Notifications
 
-- [ ] 5.1 Render normalized activity in pane title-bar accessories without
+- [x] 5.1 Render normalized activity in pane title-bar accessories without
   resizing pane title bars or terminal canvases.
-- [ ] 5.2 Refactor sidebar tab rows to show a leading topology/kind slot, title
+- [x] 5.2 Refactor sidebar tab rows to show a leading topology/kind slot, title
   line, activity-or-worktree/branch secondary line, optional same-source
   progress rail, and hover-only close overlay.
-- [ ] 5.3 Move split topology into the leading slot for split tabs and make
+- [x] 5.3 Move split topology into the leading slot for split tabs and make
   activation cycle focus through panes in stable order.
-- [ ] 5.4 Keep single-pane tabs on semantic kind or supported agent icons in the
+- [x] 5.4 Keep single-pane tabs on semantic kind or supported agent icons in the
   leading slot.
 - [ ] 5.5 Project pane title-bar accessories from pane-local detail: activity,
   worktree/cwd, branch, process, and non-duplicated agent/Alan state.
 - [ ] 5.6 Add low-noise notification routing for user-input-required, error, and
   long-command-complete events according to the task 1.4 policy.
-- [ ] 5.7 Add accessibility labels or values for activity state on pane and tab
+- [x] 5.7 Add accessibility labels or values for activity state on pane and tab
   affordances.
 - [ ] 5.8 Add visual review evidence for focused progress, background agent
   needs-input, command failure, cleared activity showing worktree/branch


### PR DESCRIPTION
## Summary
- add tab-level activity projection with deterministic priority, freshness, pane hints, focused command-failure demotion, and context fallback
- render activity in sidebar tab rows and pane title-bar accessories, including same-source progress rails and hover-only close overlay
- carry activity clear semantics through terminal metadata and map Ghostty bell/child-exit into normalized activity

## OpenSpec
- change: add-advanced-terminal-activity-semantics
- completed tasks: 1.2, 1.3, 2.3, 2.4, 2.5, 3.3, 3.4, 5.1, 5.2, 5.3, 5.4, 5.7
- stacked on: #422 / impl/terminal-activity-model

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build