### PR TITLE
Add low-noise terminal activity notification routing

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -19,10 +19,12 @@ extension ShellHostController {
     func routingCandidates(preferredPaneID: String?) -> [AlanShellRoutingCandidate] {
         let preferredPane = preferredPaneID.flatMap { pane(paneID: $0) }
         let focusedPane = self.focusedPane
+        let now = Date()
 
         return shellState.panes.map { candidate in
             var score = 0.0
             var reasons: [String] = []
+            let attention = shellEffectiveAttention(for: candidate, now: now)
 
             if candidate.paneID == preferredPaneID {
                 score += 0.4
@@ -32,10 +34,10 @@ extension ShellHostController {
                 score += 0.3
                 reasons.append("focused")
             }
-            if candidate.attention == .awaitingUser {
+            if attention == .awaitingUser {
                 score += 0.25
                 reasons.append("attention:awaiting_user")
-            } else if candidate.attention == .notable {
+            } else if attention == .notable {
                 score += 0.12
                 reasons.append("attention:notable")
             }

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -124,6 +124,10 @@ final class AlanGhosttyLiveHost: NSObject {
 
     func sendText(_ text: String) {
         guard let surface, !text.isEmpty else { return }
+        let isCommandSubmission = isCommandSubmissionText(text)
+        if isCommandSubmission {
+            markForegroundCommandStarted()
+        }
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
         }
@@ -131,7 +135,7 @@ final class AlanGhosttyLiveHost: NSObject {
         updateMetadata(
             summary: "input committed",
             attention: .active,
-            activeTaskState: text.contains("\n") || text.contains("\r") ? .foregroundCommand : nil
+            activeTaskState: isCommandSubmission ? .foregroundCommand : nil
         )
     }
 
@@ -930,6 +934,10 @@ final class AlanGhosttyLiveHost: NSObject {
     private func isCommandSubmissionKey(_ keyEvent: ghostty_input_key_s) -> Bool {
         keyEvent.action == GHOSTTY_ACTION_PRESS
             && (keyEvent.keycode == KeyCode.returnKey || keyEvent.keycode == KeyCode.keypadEnter)
+    }
+
+    private func isCommandSubmissionText(_ text: String) -> Bool {
+        text.contains("\n") || text.contains("\r")
     }
 
     private func markForegroundCommandStarted() {

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -32,6 +32,7 @@ final class AlanGhosttyLiveHost: NSObject {
     private var metadata = TerminalPaneMetadataSnapshot.placeholder
     private let terminalModeTracker = AlanTerminalModeTracker()
     private var didEmitNonConfirmingCloseRequest = false
+    private var foregroundCommandStartedAt: Date?
 
     private enum KeyCode {
         static let returnKey: UInt32 = 36
@@ -706,6 +707,7 @@ final class AlanGhosttyLiveHost: NSObject {
 
         case GHOSTTY_ACTION_COMMAND_FINISHED:
             let exitCode = action.action.command_finished.exit_code
+            let finishedAt = Date()
             let summary: String
             if exitCode < 0 {
                 summary = "command finished"
@@ -714,10 +716,16 @@ final class AlanGhosttyLiveHost: NSObject {
             } else {
                 summary = "command failed (\(exitCode))"
             }
-            let activity = exitCode >= 0
-                ? TerminalActivitySnapshot.commandCompletion(exitCode: Int(exitCode), now: .now)
-                : nil
             performOnMain {
+                let durationMilliseconds = self.commandDurationMilliseconds(finishedAt: finishedAt)
+                self.foregroundCommandStartedAt = nil
+                let activity = exitCode >= 0
+                    ? TerminalActivitySnapshot.commandCompletion(
+                        exitCode: Int(exitCode),
+                        now: finishedAt,
+                        durationMilliseconds: durationMilliseconds
+                    )
+                    : nil
                 self.updateMetadata(
                     summary: summary,
                     attention: exitCode == 0 ? .active : .notable,
@@ -925,10 +933,19 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func markForegroundCommandStarted() {
+        foregroundCommandStartedAt = .now
         updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }
 
+    private func commandDurationMilliseconds(finishedAt: Date) -> Int? {
+        guard let foregroundCommandStartedAt else { return nil }
+        let duration = finishedAt.timeIntervalSince(foregroundCommandStartedAt)
+        guard duration >= 0 else { return nil }
+        return Int((duration * 1_000).rounded())
+    }
+
     private func resetMetadata() {
+        foregroundCommandStartedAt = nil
         guard metadata != .placeholder else { return }
         metadata = .placeholder
         onMetadataChange?(.placeholder)

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -33,6 +33,7 @@ final class AlanGhosttyLiveHost: NSObject {
     private let terminalModeTracker = AlanTerminalModeTracker()
     private var didEmitNonConfirmingCloseRequest = false
     private var foregroundCommandStartedAt: Date?
+    private var queuedForegroundCommandSubmissions = 0
 
     private enum KeyCode {
         static let returnKey: UInt32 = 36
@@ -112,7 +113,7 @@ final class AlanGhosttyLiveHost: NSObject {
         let handled = ghostty_surface_key(surface, keyEvent)
         ghostty_surface_refresh(surface)
         if handled, isCommandSubmissionKey(keyEvent) {
-            markForegroundCommandStarted()
+            markForegroundCommandStarted(commandCount: 1)
         }
         return handled
     }
@@ -126,7 +127,7 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let surface, !text.isEmpty else { return }
         let isCommandSubmission = isCommandSubmissionText(text)
         if isCommandSubmission {
-            markForegroundCommandStarted()
+            markForegroundCommandStarted(commandCount: commandSubmissionCount(in: text))
         }
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
@@ -722,7 +723,9 @@ final class AlanGhosttyLiveHost: NSObject {
             }
             performOnMain {
                 let durationMilliseconds = self.commandDurationMilliseconds(finishedAt: finishedAt)
-                self.foregroundCommandStartedAt = nil
+                let hasQueuedForegroundCommand = self.advanceForegroundCommandTracking(
+                    finishedAt: finishedAt
+                )
                 let activity = exitCode >= 0
                     ? TerminalActivitySnapshot.commandCompletion(
                         exitCode: Int(exitCode),
@@ -735,7 +738,7 @@ final class AlanGhosttyLiveHost: NSObject {
                     attention: exitCode == 0 ? .active : .notable,
                     processExited: false,
                     lastCommandExitCode: Int(exitCode),
-                    activeTaskState: .inactive,
+                    activeTaskState: hasQueuedForegroundCommand ? .foregroundCommand : .inactive,
                     activity: activity,
                     clearActivity: exitCode < 0
                 )
@@ -937,12 +940,32 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func isCommandSubmissionText(_ text: String) -> Bool {
-        text.contains("\n") || text.contains("\r")
+        commandSubmissionCount(in: text) > 0
     }
 
-    private func markForegroundCommandStarted() {
+    private func commandSubmissionCount(in text: String) -> Int {
+        var count = 0
+        var previousWasCarriageReturn = false
+        for character in text {
+            if character == "\r" {
+                count += 1
+                previousWasCarriageReturn = true
+            } else if character == "\n" {
+                if !previousWasCarriageReturn {
+                    count += 1
+                }
+                previousWasCarriageReturn = false
+            } else {
+                previousWasCarriageReturn = false
+            }
+        }
+        return count
+    }
+
+    private func markForegroundCommandStarted(commandCount: Int) {
         if foregroundCommandStartedAt == nil {
             foregroundCommandStartedAt = .now
+            queuedForegroundCommandSubmissions = max(commandCount, 1)
         }
         updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }
@@ -954,8 +977,20 @@ final class AlanGhosttyLiveHost: NSObject {
         return Int((duration * 1_000).rounded())
     }
 
+    private func advanceForegroundCommandTracking(finishedAt: Date) -> Bool {
+        if queuedForegroundCommandSubmissions > 1 {
+            queuedForegroundCommandSubmissions -= 1
+            foregroundCommandStartedAt = finishedAt
+            return true
+        }
+        queuedForegroundCommandSubmissions = 0
+        foregroundCommandStartedAt = nil
+        return false
+    }
+
     private func resetMetadata() {
         foregroundCommandStartedAt = nil
+        queuedForegroundCommandSubmissions = 0
         guard metadata != .placeholder else { return }
         metadata = .placeholder
         onMetadataChange?(.placeholder)

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -113,7 +113,7 @@ final class AlanGhosttyLiveHost: NSObject {
         let handled = ghostty_surface_key(surface, keyEvent)
         ghostty_surface_refresh(surface)
         if handled, isCommandSubmissionKey(keyEvent) {
-            markForegroundCommandStarted(commandCount: 1)
+            markForegroundCommandStarted(commandCount: 1, queuesWhileActive: false)
         }
         return handled
     }
@@ -127,7 +127,10 @@ final class AlanGhosttyLiveHost: NSObject {
         guard let surface, !text.isEmpty else { return }
         let isCommandSubmission = isCommandSubmissionText(text)
         if isCommandSubmission {
-            markForegroundCommandStarted(commandCount: commandSubmissionCount(in: text))
+            markForegroundCommandStarted(
+                commandCount: commandSubmissionCount(in: text),
+                queuesWhileActive: true
+            )
         }
         text.withCString { cString in
             ghostty_surface_text(surface, cString, UInt(strlen(cString)))
@@ -962,10 +965,13 @@ final class AlanGhosttyLiveHost: NSObject {
         return count
     }
 
-    private func markForegroundCommandStarted(commandCount: Int) {
+    private func markForegroundCommandStarted(commandCount: Int, queuesWhileActive: Bool) {
+        let commandCount = max(commandCount, 1)
         if foregroundCommandStartedAt == nil {
             foregroundCommandStartedAt = .now
-            queuedForegroundCommandSubmissions = max(commandCount, 1)
+            queuedForegroundCommandSubmissions = commandCount
+        } else if queuesWhileActive {
+            queuedForegroundCommandSubmissions += commandCount
         }
         updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -941,7 +941,9 @@ final class AlanGhosttyLiveHost: NSObject {
     }
 
     private func markForegroundCommandStarted() {
-        foregroundCommandStartedAt = .now
+        if foregroundCommandStartedAt == nil {
+            foregroundCommandStartedAt = .now
+        }
         updateMetadata(attention: .active, activeTaskState: .foregroundCommand)
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -417,7 +417,11 @@ struct TerminalActivitySnapshot: Codable, Equatable {
         )
     }
 
-    static func commandCompletion(exitCode: Int, now: Date) -> TerminalActivitySnapshot {
+    static func commandCompletion(
+        exitCode: Int,
+        now: Date,
+        durationMilliseconds: Int? = nil
+    ) -> TerminalActivitySnapshot {
         let succeeded = exitCode == 0
         let status: TerminalActivityStatus = succeeded ? .done : .failed
         let priority: TerminalActivityPriority = succeeded ? .passive : .notable
@@ -429,7 +433,7 @@ struct TerminalActivitySnapshot: Codable, Equatable {
             progress: nil,
             command: TerminalActivityCommandOutcome(
                 exitCode: exitCode,
-                durationMilliseconds: nil,
+                durationMilliseconds: durationMilliseconds,
                 commandText: nil
             ),
             agent: nil,

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -606,20 +606,23 @@ enum AlanShellLocalCommandExecutor {
 }
 
 private func attentionInboxItems(from state: ShellStateSnapshot) -> [AlanShellAttentionInboxItem] {
-    state.panes
+    let now = Date()
+    return state.panes
+        .map { (pane: $0, attention: shellEffectiveAttention(for: $0, now: now)) }
         .filter { $0.attention != .idle }
         .sorted {
             attentionRank(for: $0.attention) == attentionRank(for: $1.attention)
-                ? $0.paneID < $1.paneID
+                ? $0.pane.paneID < $1.pane.paneID
                 : attentionRank(for: $0.attention) > attentionRank(for: $1.attention)
         }
-        .map { pane in
-            AlanShellAttentionInboxItem(
+        .map { item in
+            let pane = item.pane
+            return AlanShellAttentionInboxItem(
                 itemID: "attn_\(pane.paneID)",
                 spaceID: pane.spaceID,
                 tabID: pane.tabID,
                 paneID: pane.paneID,
-                attention: pane.attention,
+                attention: item.attention,
                 summary: pane.viewport?.summary
                     ?? pane.alanBinding.map { $0.pendingYield ? "alan is waiting for user input" : "alan run status: \($0.runStatus)" }
                     ?? pane.process?.program
@@ -634,10 +637,12 @@ private func routingCandidates(
 ) -> [AlanShellRoutingCandidate] {
     let preferredPane = preferredPaneID.flatMap(state.pane(paneID:))
     let focusedPane = state.focusedPaneID.flatMap(state.pane(paneID:))
+    let now = Date()
 
     return state.panes.map { pane in
         var score = 0.0
         var reasons: [String] = []
+        let attention = shellEffectiveAttention(for: pane, now: now)
 
         if pane.paneID == preferredPaneID {
             score += 0.4
@@ -647,10 +652,10 @@ private func routingCandidates(
             score += 0.3
             reasons.append("focused")
         }
-        if pane.attention == .awaitingUser {
+        if attention == .awaitingUser {
             score += 0.25
             reasons.append("attention:awaiting_user")
-        } else if pane.attention == .notable {
+        } else if attention == .notable {
             score += 0.12
             reasons.append("attention:notable")
         }

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -20,19 +20,10 @@ struct ShellPaneProjectionService {
         metadataAttention: ShellAttentionState,
         processExited: Bool,
         binding: ShellAlanBinding?,
-        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil,
-        activity: TerminalActivitySnapshot? = nil,
-        now: Date = .now
+        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil
     ) -> ShellAttentionState {
         if binding?.pendingYield == true || processExited || surfaceState?.childExited == true {
             return .awaitingUser
-        }
-
-        let freshActivity = activity?.isFresh(at: now) == true ? activity : nil
-        if let activityAttention = freshActivity.flatMap(shellActivityAttention(for:)),
-           Self.attentionRank(for: activityAttention) > Self.attentionRank(for: metadataAttention)
-        {
-            return activityAttention
         }
 
         if surfaceState?.rendererHealth == "failed"
@@ -183,19 +174,6 @@ struct ShellPaneProjectionService {
         }
 
         return metadata.summary ?? fallback
-    }
-
-    private static func attentionRank(for attention: ShellAttentionState) -> Int {
-        switch attention {
-        case .idle:
-            return 0
-        case .active:
-            return 1
-        case .notable:
-            return 2
-        case .awaitingUser:
-            return 3
-        }
     }
 
     private func surfaceReadinessValue(_ readiness: AlanTerminalSurfaceReadiness) -> String {

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -21,13 +21,15 @@ struct ShellPaneProjectionService {
         processExited: Bool,
         binding: ShellAlanBinding?,
         surfaceState: AlanTerminalSurfaceStateSnapshot? = nil,
-        activity: TerminalActivitySnapshot? = nil
+        activity: TerminalActivitySnapshot? = nil,
+        now: Date = .now
     ) -> ShellAttentionState {
         if binding?.pendingYield == true || processExited || surfaceState?.childExited == true {
             return .awaitingUser
         }
 
-        if let activityAttention = activity.flatMap(shellActivityAttention(for:)),
+        let freshActivity = activity?.isFresh(at: now) == true ? activity : nil
+        if let activityAttention = freshActivity.flatMap(shellActivityAttention(for:)),
            Self.attentionRank(for: activityAttention) > Self.attentionRank(for: metadataAttention)
         {
             return activityAttention

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -20,10 +20,17 @@ struct ShellPaneProjectionService {
         metadataAttention: ShellAttentionState,
         processExited: Bool,
         binding: ShellAlanBinding?,
-        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil
+        surfaceState: AlanTerminalSurfaceStateSnapshot? = nil,
+        activity: TerminalActivitySnapshot? = nil
     ) -> ShellAttentionState {
         if binding?.pendingYield == true || processExited || surfaceState?.childExited == true {
             return .awaitingUser
+        }
+
+        if let activityAttention = activity.flatMap(shellActivityAttention(for:)),
+           Self.attentionRank(for: activityAttention) > Self.attentionRank(for: metadataAttention)
+        {
+            return activityAttention
         }
 
         if surfaceState?.rendererHealth == "failed"
@@ -174,6 +181,19 @@ struct ShellPaneProjectionService {
         }
 
         return metadata.summary ?? fallback
+    }
+
+    private static func attentionRank(for attention: ShellAttentionState) -> Int {
+        switch attention {
+        case .idle:
+            return 0
+        case .active:
+            return 1
+        case .notable:
+            return 2
+        case .awaitingUser:
+            return 3
+        }
     }
 
     private func surfaceReadinessValue(_ readiness: AlanTerminalSurfaceReadiness) -> String {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -809,6 +809,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 processExited: runtimeProcessExited,
                 for: paneID
             )
+            let projectedActivity = runtime.paneMetadata.clearsActivity
+                ? nil
+                : (runtime.paneMetadata.activity ?? pane.activity)
+            if runtimeProcessExited {
+                routeActivityNotificationIfNeeded(from: pane, nextActivity: projectedActivity)
+            }
             if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: runtimeProcessExited) {
                 return
             }
@@ -835,9 +841,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     metadata: runtime.paneMetadata,
                     runtime: runtime
                 )
-                let projectedActivity = runtime.paneMetadata.clearsActivity
-                    ? nil
-                    : (runtime.paneMetadata.activity ?? current.activity)
                 return ShellPane(
                     paneID: current.paneID,
                     tabID: current.tabID,
@@ -877,6 +880,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             processExited: metadataProcessExited,
             for: paneID
         )
+        let projectedActivity = metadata.clearsActivity ? nil : (metadata.activity ?? pane.activity)
+        if metadataProcessExited {
+            routeActivityNotificationIfNeeded(from: pane, nextActivity: projectedActivity)
+        }
         if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: metadataProcessExited) {
             return
         }
@@ -906,7 +913,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 metadata: metadata,
                 runtime: runtime
             )
-            let projectedActivity = metadata.clearsActivity ? nil : (metadata.activity ?? current.activity)
 
             return ShellPane(
                 paneID: current.paneID,
@@ -1076,6 +1082,24 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private func routeActivityNotificationIfNeeded(
         from existingPane: ShellPane,
+        nextActivity: TerminalActivitySnapshot?
+    ) {
+        guard existingPane.activity != nextActivity,
+              let activity = nextActivity,
+              let tab = shellState.tab(tabID: existingPane.tabID)
+        else {
+            return
+        }
+
+        routeActivityNotificationIfNeeded(
+            activity: activity,
+            pane: existingPane,
+            tab: tab
+        )
+    }
+
+    private func routeActivityNotificationIfNeeded(
+        from existingPane: ShellPane,
         to updatedPane: ShellPane
     ) {
         guard existingPane.activity != updatedPane.activity,
@@ -1085,13 +1109,25 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return
         }
 
-        let key = shellActivityNotificationKey(for: activity, paneID: updatedPane.paneID)
+        routeActivityNotificationIfNeeded(
+            activity: activity,
+            pane: updatedPane,
+            tab: tab
+        )
+    }
+
+    private func routeActivityNotificationIfNeeded(
+        activity: TerminalActivitySnapshot,
+        pane: ShellPane,
+        tab: ShellTab
+    ) {
+        let key = shellActivityNotificationKey(for: activity, paneID: pane.paneID)
         guard !routedActivityNotificationKeys.contains(key),
               let route = shellActivityNotificationRoute(
                   for: activity,
-                  pane: updatedPane,
+                  pane: pane,
                   tab: tab,
-                  visibility: activityNotificationVisibility(for: updatedPane),
+                  visibility: activityNotificationVisibility(for: pane),
                   now: .now
               )
         else {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -129,8 +129,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
     @Published private(set) var controlPlaneDiagnostics: [String] = []
     @Published private(set) var commandInputRequestID = 0
+    @Published private(set) var activityNotifications: [ShellActivityNotificationRoute] = []
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
+    private var routedActivityNotificationKeys: Set<String> = []
 
     init(
         shellState: ShellStateSnapshot,
@@ -833,6 +835,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     metadata: runtime.paneMetadata,
                     runtime: runtime
                 )
+                let projectedActivity = runtime.paneMetadata.clearsActivity
+                    ? nil
+                    : (runtime.paneMetadata.activity ?? current.activity)
                 return ShellPane(
                     paneID: current.paneID,
                     tabID: current.tabID,
@@ -844,13 +849,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                         metadataAttention: runtime.paneMetadata.attention,
                         processExited: runtimeProcessExited,
                         binding: projectedBinding,
-                        surfaceState: runtime.surfaceState
+                        surfaceState: runtime.surfaceState,
+                        activity: projectedActivity
                     ),
                     context: projectedContext,
                     viewport: viewport,
-                    activity: runtime.paneMetadata.clearsActivity
-                        ? nil
-                        : (runtime.paneMetadata.activity ?? current.activity),
+                    activity: projectedActivity,
                     alanBinding: projectedBinding
                 )
             }
@@ -902,6 +906,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 metadata: metadata,
                 runtime: runtime
             )
+            let projectedActivity = metadata.clearsActivity ? nil : (metadata.activity ?? current.activity)
 
             return ShellPane(
                 paneID: current.paneID,
@@ -914,11 +919,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     metadataAttention: metadata.attention,
                     processExited: metadataProcessExited,
                     binding: projectedBinding,
-                    surfaceState: runtime.surfaceState
+                    surfaceState: runtime.surfaceState,
+                    activity: projectedActivity
                 ),
                 context: projectedContext,
                 viewport: viewport,
-                activity: metadata.clearsActivity ? nil : (metadata.activity ?? current.activity),
+                activity: projectedActivity,
                 alanBinding: projectedBinding
             )
         }
@@ -1063,8 +1069,59 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             panes: updatedPanes
         )
         synchronizeSelection()
+        routeActivityNotificationIfNeeded(from: existingPane, to: transformedPane)
         publishControlPlaneState()
         return true
+    }
+
+    private func routeActivityNotificationIfNeeded(
+        from existingPane: ShellPane,
+        to updatedPane: ShellPane
+    ) {
+        guard existingPane.activity != updatedPane.activity,
+              let activity = updatedPane.activity,
+              let tab = shellState.tab(tabID: updatedPane.tabID)
+        else {
+            return
+        }
+
+        let key = shellActivityNotificationKey(for: activity, paneID: updatedPane.paneID)
+        guard !routedActivityNotificationKeys.contains(key),
+              let route = shellActivityNotificationRoute(
+                  for: activity,
+                  pane: updatedPane,
+                  tab: tab,
+                  visibility: activityNotificationVisibility(for: updatedPane),
+                  now: .now
+              )
+        else {
+            return
+        }
+
+        routedActivityNotificationKeys.insert(key)
+        activityNotifications.append(route)
+        if activityNotifications.count > 50 {
+            activityNotifications.removeFirst(activityNotifications.count - 50)
+        }
+    }
+
+    private func activityNotificationVisibility(
+        for pane: ShellPane
+    ) -> ShellActivityNotificationVisibility {
+        let isSelectedSpace = pane.spaceID == selectedSpace?.spaceID
+        let isSelectedTab = pane.tabID == selectedTab?.tabID
+        if isSelectedSpace,
+           isSelectedTab,
+           pane.paneID == shellState.focusedPaneID
+        {
+            return .focusedVisible
+        }
+
+        if isSelectedSpace, isSelectedTab {
+            return .visibleUnfocused
+        }
+
+        return .background
     }
 
     private func rebuildSpaces(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 #if os(macOS)
+import AppKit
 import SwiftUI
 
 struct ShellAttentionItem: Identifiable, Equatable {
@@ -132,6 +133,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var activityNotifications: [ShellActivityNotificationRoute] = []
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
+    private let appIsActiveProvider: @MainActor () -> Bool
     private var routedActivityNotificationKeys: Set<String> = []
 
     init(
@@ -141,7 +143,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         persistenceURL: URL? = nil,
         terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil,
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
-        workspaceManifest: ShellWorkspaceManifest? = nil
+        workspaceManifest: ShellWorkspaceManifest? = nil,
+        appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
         self.fileManager = fileManager
         self.paneProjection = ShellPaneProjectionService(fileManager: fileManager)
@@ -155,6 +158,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self.workspaceManifestStore = workspaceManifestStore
         self.workspaceManifest = workspaceManifest
         self.clipboardWriter = ShellClipboardWriter()
+        self.appIsActiveProvider = appIsActiveProvider
         self.shellState = shellState
         self.terminalRuntimeRegistry =
             terminalRuntimeRegistry
@@ -1146,6 +1150,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     ) -> ShellActivityNotificationVisibility {
         let isSelectedSpace = pane.spaceID == selectedSpace?.spaceID
         let isSelectedTab = pane.tabID == selectedTab?.tabID
+        guard appIsActiveProvider() else {
+            return .background
+        }
         if isSelectedSpace,
            isSelectedTab,
            pane.paneID == shellState.focusedPaneID

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -335,16 +335,18 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     var attentionItems: [ShellAttentionItem] {
-        shellState.panes
+        let now = Date()
+        return shellState.panes
             .compactMap { pane in
-                guard pane.attention != .idle else { return nil }
+                let attention = shellEffectiveAttention(for: pane, now: now)
+                guard attention != .idle else { return nil }
                 return ShellAttentionItem(
                     paneID: pane.paneID,
                     spaceID: pane.spaceID,
                     tabID: pane.tabID,
                     title: pane.viewport?.title ?? pane.process?.program ?? "Pane",
                     summary: pane.viewport?.summary ?? "Activity detected",
-                    attention: pane.attention
+                    attention: attention
                 )
             }
             .sorted {
@@ -856,8 +858,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                         metadataAttention: runtime.paneMetadata.attention,
                         processExited: runtimeProcessExited,
                         binding: projectedBinding,
-                        surfaceState: runtime.surfaceState,
-                        activity: projectedActivity
+                        surfaceState: runtime.surfaceState
                     ),
                     context: projectedContext,
                     viewport: viewport,
@@ -929,8 +930,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     metadataAttention: metadata.attention,
                     processExited: metadataProcessExited,
                     binding: projectedBinding,
-                    surfaceState: runtime.surfaceState,
-                    activity: projectedActivity
+                    surfaceState: runtime.surfaceState
                 ),
                 context: projectedContext,
                 viewport: viewport,
@@ -1664,8 +1664,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func strongestAttention(in panes: [ShellPane]) -> ShellAttentionState {
-        panes
-            .map(\.attention)
+        let now = Date()
+        return panes
+            .map { shellEffectiveAttention(for: $0, now: now) }
             .max(by: { Self.attentionRank(for: $0) < Self.attentionRank(for: $1) })
             ?? .idle
     }

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -236,7 +236,26 @@ func shellActivityNotificationKey(
         activity.source.kind.rawValue,
         activity.status.rawValue,
         activity.freshness.updatedAt,
+        shellActivityNotificationPayloadDiscriminator(for: activity),
     ].joined(separator: ":")
+}
+
+private func shellActivityNotificationPayloadDiscriminator(
+    for activity: TerminalActivitySnapshot
+) -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    if let data = try? encoder.encode(activity) {
+        return data.base64EncodedString()
+    }
+
+    return [
+        activity.source.label ?? "",
+        activity.priority.rawValue,
+        activity.display.sourceFirstLabel,
+        activity.freshness.staleAt ?? "",
+        activity.freshness.expiresAt ?? "",
+    ].joined(separator: "|")
 }
 
 func shellActivityAttention(for activity: TerminalActivitySnapshot) -> ShellAttentionState? {

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -8,6 +8,30 @@ struct ShellSidebarTabProjection: Equatable {
     let accessibilityActivityLabel: String?
 }
 
+enum ShellActivityNotificationVisibility: String, Equatable {
+    case focusedVisible
+    case visibleUnfocused
+    case background
+}
+
+enum ShellActivityNotificationKind: String, Equatable {
+    case needsInput = "needs_input"
+    case failed
+    case commandCompleted = "command_completed"
+    case processExited = "process_exited"
+}
+
+struct ShellActivityNotificationRoute: Equatable, Identifiable {
+    let id: String
+    let paneID: String
+    let tabID: String
+    let spaceID: String
+    let kind: ShellActivityNotificationKind
+    let title: String
+    let body: String
+    let attention: ShellAttentionState
+}
+
 func shellUserFacingSummary(_ summary: String?) -> String? {
     guard let summary else { return nil }
 
@@ -200,6 +224,98 @@ func shellPaneActivityAccessoryLabel(for pane: ShellPane, now: Date? = nil) -> S
         return activity.source.kind == .command ? nil : activity.display.sourceFirstLabel
     case .needsInput, .failed, .paused, .progress, .running, .bell, .exited:
         return activity.display.sourceFirstLabel
+    }
+}
+
+func shellActivityNotificationKey(
+    for activity: TerminalActivitySnapshot,
+    paneID: String
+) -> String {
+    [
+        paneID,
+        activity.source.kind.rawValue,
+        activity.status.rawValue,
+        activity.freshness.updatedAt,
+    ].joined(separator: ":")
+}
+
+func shellActivityAttention(for activity: TerminalActivitySnapshot) -> ShellAttentionState? {
+    switch activity.status {
+    case .needsInput, .exited:
+        return .awaitingUser
+    case .failed:
+        return .notable
+    case .paused, .progress, .running, .bell, .idle, .done, .stale:
+        return nil
+    }
+}
+
+func shellActivityNotificationRoute(
+    for activity: TerminalActivitySnapshot,
+    pane: ShellPane,
+    tab: ShellTab?,
+    visibility: ShellActivityNotificationVisibility,
+    now: Date? = nil,
+    longCommandThresholdMilliseconds: Int = 60_000
+) -> ShellActivityNotificationRoute? {
+    if let now, !activity.isFresh(at: now) {
+        return nil
+    }
+
+    guard visibility != .focusedVisible else {
+        return nil
+    }
+
+    let kind: ShellActivityNotificationKind
+    let attention: ShellAttentionState
+    switch activity.status {
+    case .needsInput where shellIsCodingAgentActivity(activity):
+        kind = .needsInput
+        attention = .awaitingUser
+    case .failed where shellIsCodingAgentActivity(activity):
+        kind = .failed
+        attention = .notable
+    case .done
+        where activity.source.kind == .command
+            && (activity.command?.durationMilliseconds ?? 0) >= longCommandThresholdMilliseconds,
+        .failed
+        where activity.source.kind == .command
+            && (activity.command?.durationMilliseconds ?? 0) >= longCommandThresholdMilliseconds:
+        kind = .commandCompleted
+        attention = .notable
+    case .exited:
+        kind = .processExited
+        attention = .awaitingUser
+    default:
+        return nil
+    }
+
+    let subject = shellDisplayTitle(
+        rawTitle: tab?.title ?? pane.viewport?.title,
+        workingDirectoryName: pane.context?.workingDirectoryName,
+        cwd: pane.cwd,
+        program: pane.process?.program,
+        launchTarget: pane.resolvedLaunchTarget,
+        fallback: shellFallbackTitle(for: tab?.kind ?? .terminal)
+    )
+    return ShellActivityNotificationRoute(
+        id: shellActivityNotificationKey(for: activity, paneID: pane.paneID),
+        paneID: pane.paneID,
+        tabID: pane.tabID,
+        spaceID: pane.spaceID,
+        kind: kind,
+        title: activity.display.sourceFirstLabel,
+        body: subject,
+        attention: attention
+    )
+}
+
+private func shellIsCodingAgentActivity(_ activity: TerminalActivitySnapshot) -> Bool {
+    switch activity.source.kind {
+    case .codex, .claude, .openCode, .alan:
+        return true
+    case .shell, .progress, .command, .process, .unknown:
+        return false
     }
 }
 

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -58,7 +58,7 @@ func shellUserFacingSummary(_ summary: String?) -> String? {
     return trimmed
 }
 
-func shellTerminalStatusSummary(for pane: ShellPane) -> String? {
+func shellTerminalStatusSummary(for pane: ShellPane, now: Date? = nil) -> String? {
     if pane.context?.processState == "exited"
         || pane.context?.surfaceReadiness == "child_exited"
     {
@@ -85,7 +85,7 @@ func shellTerminalStatusSummary(for pane: ShellPane) -> String? {
         return "Starting"
     }
 
-    switch pane.attention {
+    switch shellEffectiveAttention(for: pane, now: now) {
     case .awaitingUser:
         guard let rawSummary = pane.viewport?.summary else { return "Needs attention" }
         return shellUserFacingSummary(rawSummary)
@@ -269,6 +269,65 @@ func shellActivityAttention(for activity: TerminalActivitySnapshot) -> ShellAtte
     }
 }
 
+func shellEffectiveAttention(for pane: ShellPane, now: Date? = nil) -> ShellAttentionState {
+    let storedAttention = pane.attention
+    guard let activity = pane.activity else { return storedAttention }
+
+    if let now,
+       !activity.isFresh(at: now),
+       let activityAttention = shellActivityAttention(for: activity),
+       activityAttention == storedAttention
+    {
+        return shellPersistentAttention(for: pane)
+    }
+
+    if let now, !activity.isFresh(at: now) {
+        return storedAttention
+    }
+
+    guard let activityAttention = shellActivityAttention(for: activity),
+          shellAttentionRank(for: activityAttention) > shellAttentionRank(for: storedAttention)
+    else {
+        return storedAttention
+    }
+
+    return activityAttention
+}
+
+private func shellPersistentAttention(for pane: ShellPane) -> ShellAttentionState {
+    if pane.alanBinding?.pendingYield == true {
+        return .awaitingUser
+    }
+
+    if pane.context?.processState == "exited"
+        || pane.context?.surfaceReadiness == "child_exited"
+    {
+        return .awaitingUser
+    }
+
+    if pane.context?.rendererHealth == "failed"
+        || pane.context?.rendererPhase == "failed"
+        || pane.context?.surfaceReadiness == "renderer_failed"
+    {
+        return .notable
+    }
+
+    return .idle
+}
+
+private func shellAttentionRank(for attention: ShellAttentionState) -> Int {
+    switch attention {
+    case .idle:
+        return 0
+    case .active:
+        return 1
+    case .notable:
+        return 2
+    case .awaitingUser:
+        return 3
+    }
+}
+
 func shellActivityNotificationRoute(
     for activity: TerminalActivitySnapshot,
     pane: ShellPane,
@@ -376,7 +435,7 @@ func shellSidebarTabProjection(
         )
     }
 
-    let fallback = primaryPane.flatMap(shellTerminalStatusSummary(for:))
+    let fallback = primaryPane.flatMap { shellTerminalStatusSummary(for: $0, now: now) }
         ?? primaryPane.flatMap { shellSidebarContextLine(for: $0, title: title) }
         ?? shellFallbackTitle(for: tab.kind)
     return ShellSidebarTabProjection(

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -789,7 +789,7 @@ private struct ShellPaneTitleBarView: View {
             )
         }
 
-        if let status = shellTerminalStatusSummary(for: pane) {
+        if let status = shellTerminalStatusSummary(for: pane, now: activityFreshnessNow) {
             items.append(
                 ShellPaneTitleBarAccessory(
                     id: "status",
@@ -879,7 +879,8 @@ private struct ShellPaneTitleBarView: View {
         {
             return "exclamationmark.triangle"
         }
-        if pane.attention == .awaitingUser || pane.attention == .notable {
+        let attention = shellEffectiveAttention(for: pane, now: activityFreshnessNow)
+        if attention == .awaitingUser || attention == .notable {
             return "bell.badge"
         }
         return "info.circle"
@@ -889,7 +890,7 @@ private struct ShellPaneTitleBarView: View {
         if pane.context?.rendererHealth == "failed"
             || pane.context?.rendererPhase == "failed"
             || pane.context?.surfaceReadiness == "renderer_failed"
-            || pane.attention == .awaitingUser
+            || shellEffectiveAttention(for: pane, now: activityFreshnessNow) == .awaitingUser
         {
             return ShellPalette.attention
         }
@@ -897,7 +898,7 @@ private struct ShellPaneTitleBarView: View {
     }
 
     private func statusTitle(_ status: String) -> String? {
-        if pane.attention == .notable,
+        if shellEffectiveAttention(for: pane, now: activityFreshnessNow) == .notable,
            status == "Terminal bell"
         {
             return nil

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -212,7 +212,7 @@ struct ShellSidebarView: View {
                             ShellSpaceSwitcherItem(
                                 title: space.title,
                                 symbolName: spaceSymbol(for: space),
-                                attention: space.attention,
+                                attention: strongestAttention(for: space),
                                 tabCount: space.tabs.count,
                                 isSelected: host.selectedSpace?.spaceID == space.spaceID,
                                 isPreviewed: previewedSpaceID == space.spaceID,
@@ -631,7 +631,7 @@ struct ShellSidebarView: View {
         let title = tabTitle(for: tab)
 
         if let primaryPane,
-           let status = shellTerminalStatusSummary(for: primaryPane)
+           let status = shellTerminalStatusSummary(for: primaryPane, now: activityFreshnessNow)
         {
             return status
         }
@@ -662,9 +662,17 @@ struct ShellSidebarView: View {
     private func strongestAttention(for tab: ShellTab) -> ShellAttentionState? {
         host.shellState.panes
             .filter { $0.tabID == tab.tabID }
-            .map(\.attention)
+            .map { shellEffectiveAttention(for: $0, now: activityFreshnessNow) }
             .sorted { attentionRank(for: $0) > attentionRank(for: $1) }
             .first(where: { $0 != .idle })
+    }
+
+    private func strongestAttention(for space: ShellSpace) -> ShellAttentionState {
+        host.shellState.panes
+            .filter { $0.spaceID == space.spaceID }
+            .map { shellEffectiveAttention(for: $0, now: activityFreshnessNow) }
+            .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
+            ?? .idle
     }
 
     private func spaceSymbol(for space: ShellSpace) -> String {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -329,6 +329,26 @@ require_pattern \
     "foreground command duration tracking must preserve the original command start time"
 
 require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "private var queuedForegroundCommandSubmissions = 0" \
+    "foreground command duration tracking must retain queued pasted command submissions"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "private func commandSubmissionCount\\(in text: String\\)" \
+    "foreground command duration tracking must count newline-delimited pasted commands"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "advanceForegroundCommandTracking" \
+    "foreground command duration tracking must re-arm after queued command completion"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "hasQueuedForegroundCommand \\? \\.foregroundCommand : \\.inactive" \
+    "queued pasted commands must keep tab activity protected until the final completion"
+
+require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
     "\\.id\\(pane\\.paneID\\)" \
     "terminal host views must be keyed by stable pane identity"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -324,6 +324,11 @@ require_pattern \
     "foreground command detection must include pasted/control text submissions"
 
 require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "if foregroundCommandStartedAt == nil" \
+    "foreground command duration tracking must preserve the original command start time"
+
+require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
     "\\.id\\(pane\\.paneID\\)" \
     "terminal host views must be keyed by stable pane identity"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -314,6 +314,16 @@ require_pattern \
     "pane.send_text must use the registry delivery result"
 
 require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "let isCommandSubmission = isCommandSubmissionText\\(text\\)" \
+    "text-delivered terminal commands must start foreground command duration tracking"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "private func isCommandSubmissionText\\(_ text: String\\)" \
+    "foreground command detection must include pasted/control text submissions"
+
+require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
     "\\.id\\(pane\\.paneID\\)" \
     "terminal host views must be keyed by stable pane identity"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -330,6 +330,16 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "queuesWhileActive: true" \
+    "text-delivered queued commands must extend foreground command duration tracking while another command is active"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "queuedForegroundCommandSubmissions \\+= commandCount" \
+    "foreground command duration tracking must preserve split-submission queued command counts"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
     "private var queuedForegroundCommandSubmissions = 0" \
     "foreground command duration tracking must retain queued pasted command submissions"
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -43,7 +43,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesFocusedCommandFailureDemotesFromSidebarProjection()
         verifiesCommandFailureAcknowledgementSticksAfterFocus()
         verifiesActivityFreshnessPolicies()
-        verifiesStaleActivityDoesNotPromotePaneAttention()
+        verifiesActivityAttentionIsReadTimeOnly()
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
@@ -1214,7 +1214,7 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
-    private static func verifiesStaleActivityDoesNotPromotePaneAttention() {
+    private static func verifiesActivityAttentionIsReadTimeOnly() {
         let projection = ShellPaneProjectionService()
         let now = Date(timeIntervalSince1970: 1_779_008_400)
         let failure = activity(
@@ -1226,23 +1226,62 @@ private enum ShellRuntimeMetadataTests {
             staleAt: "2026-05-17T09:00:30Z"
         )
 
-        let freshAttention = projection.projectedAttention(
+        let persistedAttention = projection.projectedAttention(
             metadataAttention: .idle,
             processExited: false,
-            binding: nil,
-            activity: failure,
-            now: now.addingTimeInterval(10)
+            binding: nil
         )
-        let staleAttention = projection.projectedAttention(
-            metadataAttention: .idle,
-            processExited: false,
-            binding: nil,
-            activity: failure,
-            now: now.addingTimeInterval(31)
+        let freshPane = pane(
+            context: context(
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            attention: persistedAttention,
+            activity: failure
+        )
+        let legacyStalePane = pane(
+            context: context(
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            attention: .notable,
+            activity: failure
+        )
+        let rendererFailedPane = pane(
+            context: context(
+                processState: "running",
+                rendererHealth: "failed",
+                surfaceReadiness: "renderer_failed",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            attention: .notable,
+            activity: failure
         )
 
-        expect(freshAttention == .notable, "fresh failed activity may promote pane attention")
-        expect(staleAttention == .idle, "stale failed activity must not keep pane attention notable")
+        expect(persistedAttention == .idle, "activity attention must not be persisted into pane attention")
+        expect(
+            shellEffectiveAttention(for: freshPane, now: now.addingTimeInterval(10)) == .notable,
+            "fresh failed activity may overlay pane attention at read time"
+        )
+        expect(
+            shellEffectiveAttention(for: freshPane, now: now.addingTimeInterval(31)) == .idle,
+            "stale failed activity must not overlay pane attention"
+        )
+        expect(
+            shellEffectiveAttention(for: legacyStalePane, now: now.addingTimeInterval(31)) == .idle,
+            "legacy stale activity-derived pane attention must be ignored at read time"
+        )
+        expect(
+            shellEffectiveAttention(for: rendererFailedPane, now: now.addingTimeInterval(31)) == .notable,
+            "stale activity must not suppress persistent renderer attention"
+        )
     }
 
     private static func verifiesPaneTitleActivityAccessoryLabel() {
@@ -1444,8 +1483,14 @@ private enum ShellRuntimeMetadataTests {
             "controller notification must preserve the routed activity kind"
         )
         expect(
-            controller.shellState.pane(paneID: backgroundPane.paneID)?.attention == .awaitingUser,
-            "notification-worthy agent input must mark its pane awaiting user"
+            controller.shellState.pane(paneID: backgroundPane.paneID)?.attention == .idle,
+            "notification-worthy activity must not persist into pane attention"
+        )
+        expect(
+            controller.shellState.pane(paneID: backgroundPane.paneID).map {
+                shellEffectiveAttention(for: $0, now: Date())
+            } == .awaitingUser,
+            "notification-worthy agent input must overlay its pane awaiting user at read time"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -44,6 +44,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesCommandFailureAcknowledgementSticksAfterFocus()
         verifiesActivityFreshnessPolicies()
         verifiesPaneTitleActivityAccessoryLabel()
+        verifiesActivityNotificationPolicyIsLowNoise()
+        verifiesControllerRoutesActivityNotificationsOnce()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -1225,6 +1227,167 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesActivityNotificationPolicyIsLowNoise() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let testPane = pane(
+            context: context(
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            attention: .idle
+        )
+        let testTab = ShellTab(
+            tabID: "tab_1",
+            kind: .terminal,
+            title: "alan",
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_pane_1",
+                kind: .pane,
+                direction: nil,
+                paneID: "pane_1",
+                children: nil
+            )
+        )
+
+        let focusedProgress = TerminalActivitySnapshot.progressActivity(percent: 42, now: now)
+        expect(
+            shellActivityNotificationRoute(
+                for: focusedProgress,
+                pane: testPane,
+                tab: testTab,
+                visibility: .focusedVisible,
+                now: now
+            ) == nil,
+            "focused progress must stay visual-only"
+        )
+
+        let agentNeedsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            agent: .init(
+                kind: .codex,
+                safeSessionLabel: "codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            )
+        )
+        let needsInputRoute = shellActivityNotificationRoute(
+            for: agentNeedsInput,
+            pane: testPane,
+            tab: testTab,
+            visibility: .background,
+            now: now
+        )
+        expect(needsInputRoute?.kind == .needsInput, "background agent input must be notification-worthy")
+        expect(needsInputRoute?.attention == .awaitingUser, "agent input must mark tab as awaiting user")
+
+        let focusedSuccess = commandActivity(
+            exitCode: 0,
+            durationMilliseconds: 120_000,
+            updatedAt: "2026-05-17T09:00:00Z"
+        )
+        expect(
+            shellActivityNotificationRoute(
+                for: focusedSuccess,
+                pane: testPane,
+                tab: testTab,
+                visibility: .focusedVisible,
+                now: now
+            ) == nil,
+            "focused command success must not send a notification"
+        )
+
+        let shortBackgroundSuccess = commandActivity(
+            exitCode: 0,
+            durationMilliseconds: 5_000,
+            updatedAt: "2026-05-17T09:00:00Z"
+        )
+        expect(
+            shellActivityNotificationRoute(
+                for: shortBackgroundSuccess,
+                pane: testPane,
+                tab: testTab,
+                visibility: .background,
+                now: now
+            ) == nil,
+            "short background command success must remain quiet"
+        )
+
+        let longBackgroundSuccess = commandActivity(
+            exitCode: 0,
+            durationMilliseconds: 120_000,
+            updatedAt: "2026-05-17T09:00:00Z"
+        )
+        let longCommandRoute = shellActivityNotificationRoute(
+            for: longBackgroundSuccess,
+            pane: testPane,
+            tab: testTab,
+            visibility: .background,
+            now: now
+        )
+        expect(longCommandRoute?.kind == .commandCompleted, "long background command completion must route")
+        expect(longCommandRoute?.attention == .notable, "long command completion must mark the tab notable")
+
+        let exited = TerminalActivitySnapshot.processExitedActivity(exitCode: 9, now: now)
+        let exitedRoute = shellActivityNotificationRoute(
+            for: exited,
+            pane: testPane,
+            tab: testTab,
+            visibility: .background,
+            now: now
+        )
+        expect(exitedRoute?.kind == .processExited, "background process exit must route")
+        expect(exitedRoute?.attention == .awaitingUser, "process exit must mark the tab awaiting user")
+    }
+
+    private static func verifiesControllerRoutesActivityNotificationsOnce() {
+        let controller = makeController()
+        _ = controller.openTerminalTab()
+        guard let backgroundPane = controller.shellState.panes.first(where: { $0.paneID != "pane_1" }) else {
+            fail("test setup must create a background pane")
+        }
+        controller.focus(paneID: "pane_1")
+
+        let needsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            agent: .init(
+                kind: .codex,
+                safeSessionLabel: "codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            )
+        )
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: needsInput),
+            for: backgroundPane.paneID
+        )
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: needsInput),
+            for: backgroundPane.paneID
+        )
+
+        expect(
+            controller.activityNotifications.count == 1,
+            "controller must route one notification per activity update"
+        )
+        expect(
+            controller.activityNotifications.first?.kind == .needsInput,
+            "controller notification must preserve the routed activity kind"
+        )
+        expect(
+            controller.shellState.pane(paneID: backgroundPane.paneID)?.attention == .awaitingUser,
+            "notification-worthy agent input must mark its pane awaiting user"
+        )
+    }
+
     private static func verifiesTerminalChildExitClosesSplitPane() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -1812,6 +1975,8 @@ private enum ShellRuntimeMetadataTests {
         sourceLabel: String,
         stateLabel: String,
         progress: TerminalActivityProgress? = nil,
+        command: TerminalActivityCommandOutcome? = nil,
+        agent: TerminalActivityAgentMetadata? = nil,
         updatedAt: String = "2026-05-17T09:00:00Z",
         staleAt: String? = nil
     ) -> TerminalActivitySnapshot {
@@ -1820,8 +1985,8 @@ private enum ShellRuntimeMetadataTests {
             status: status,
             priority: priority(for: status),
             progress: progress,
-            command: nil,
-            agent: nil,
+            command: command,
+            agent: agent,
             display: TerminalActivityDisplay(
                 sourceLabel: sourceLabel,
                 stateLabel: stateLabel,
@@ -1833,6 +1998,26 @@ private enum ShellRuntimeMetadataTests {
                 staleAt: staleAt,
                 expiresAt: nil
             )
+        )
+    }
+
+    private static func commandActivity(
+        exitCode: Int,
+        durationMilliseconds: Int,
+        updatedAt: String
+    ) -> TerminalActivitySnapshot {
+        let succeeded = exitCode == 0
+        return activity(
+            status: succeeded ? .done : .failed,
+            source: .command,
+            sourceLabel: "Shell",
+            stateLabel: succeeded ? "Command succeeded" : "Command failed \(exitCode)",
+            command: TerminalActivityCommandOutcome(
+                exitCode: exitCode,
+                durationMilliseconds: durationMilliseconds,
+                commandText: nil
+            ),
+            updatedAt: updatedAt
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -43,6 +43,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesFocusedCommandFailureDemotesFromSidebarProjection()
         verifiesCommandFailureAcknowledgementSticksAfterFocus()
         verifiesActivityFreshnessPolicies()
+        verifiesStaleActivityDoesNotPromotePaneAttention()
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
@@ -1209,6 +1210,37 @@ private enum ShellRuntimeMetadataTests {
             needsInput.isFresh(at: now.addingTimeInterval(3_600)),
             "needs-input activity must persist until replaced"
         )
+    }
+
+    private static func verifiesStaleActivityDoesNotPromotePaneAttention() {
+        let projection = ShellPaneProjectionService()
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let failure = activity(
+            status: .failed,
+            source: .command,
+            sourceLabel: "Shell",
+            stateLabel: "Command failed 2",
+            updatedAt: "2026-05-17T09:00:00Z",
+            staleAt: "2026-05-17T09:00:30Z"
+        )
+
+        let freshAttention = projection.projectedAttention(
+            metadataAttention: .idle,
+            processExited: false,
+            binding: nil,
+            activity: failure,
+            now: now.addingTimeInterval(10)
+        )
+        let staleAttention = projection.projectedAttention(
+            metadataAttention: .idle,
+            processExited: false,
+            binding: nil,
+            activity: failure,
+            now: now.addingTimeInterval(31)
+        )
+
+        expect(freshAttention == .notable, "fresh failed activity may promote pane attention")
+        expect(staleAttention == .idle, "stale failed activity must not keep pane attention notable")
     }
 
     private static func verifiesPaneTitleActivityAccessoryLabel() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -47,6 +47,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
+        verifiesControllerRoutesDistinctActivityPayloadsInSameSecond()
         verifiesInactiveAppRoutesFocusedPaneNotifications()
         verifiesProcessExitNotificationRoutesBeforeAutoClose()
         verifiesProcessExitRuntimeNotificationRoutesBeforeAutoClose()
@@ -1448,6 +1449,62 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesControllerRoutesDistinctActivityPayloadsInSameSecond() {
+        let controller = makeController()
+        _ = controller.openTerminalTab()
+        guard let backgroundPane = controller.shellState.panes.first(where: { $0.paneID != "pane_1" }) else {
+            fail("test setup must create a background pane")
+        }
+        controller.focus(paneID: "pane_1")
+
+        let firstNeedsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            detailLabel: "Review plan",
+            agent: .init(
+                kind: .codex,
+                safeSessionLabel: "codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            ),
+            updatedAt: "2026-05-17T09:00:00Z"
+        )
+        let secondNeedsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            detailLabel: "Approve changes",
+            agent: .init(
+                kind: .codex,
+                safeSessionLabel: "codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            ),
+            updatedAt: "2026-05-17T09:00:00Z"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: firstNeedsInput),
+            for: backgroundPane.paneID
+        )
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: secondNeedsInput),
+            for: backgroundPane.paneID
+        )
+
+        expect(
+            controller.activityNotifications.count == 2,
+            "distinct same-second activity payloads must each route a notification"
+        )
+        expect(
+            controller.activityNotifications.first?.id != controller.activityNotifications.last?.id,
+            "notification ids must include a payload discriminator beyond the second-level timestamp"
+        )
+    }
+
     private static func verifiesInactiveAppRoutesFocusedPaneNotifications() {
         let controller = makeController(appIsActive: false)
         let needsInput = activity(
@@ -2160,6 +2217,7 @@ private enum ShellRuntimeMetadataTests {
         source: TerminalActivitySourceKind,
         sourceLabel: String,
         stateLabel: String,
+        detailLabel: String? = nil,
         progress: TerminalActivityProgress? = nil,
         command: TerminalActivityCommandOutcome? = nil,
         agent: TerminalActivityAgentMetadata? = nil,
@@ -2176,7 +2234,7 @@ private enum ShellRuntimeMetadataTests {
             display: TerminalActivityDisplay(
                 sourceLabel: sourceLabel,
                 stateLabel: stateLabel,
-                detailLabel: nil,
+                detailLabel: detailLabel,
                 paneHint: nil
             ),
             freshness: TerminalActivityFreshness(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -559,6 +559,11 @@ private enum ShellRuntimeMetadataTests {
         let now = Date(timeIntervalSince1970: 1_779_008_400)
         let success = TerminalActivitySnapshot.commandCompletion(exitCode: 0, now: now)
         let failure = TerminalActivitySnapshot.commandCompletion(exitCode: 2, now: now)
+        let longSuccess = TerminalActivitySnapshot.commandCompletion(
+            exitCode: 0,
+            now: now,
+            durationMilliseconds: 120_000
+        )
 
         expect(success.status == .done, "zero exit code must produce done status")
         expect(!success.isSidebarWorthy, "successful commands must not be sidebar-worthy")
@@ -569,6 +574,10 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !success.isFresh(at: now.addingTimeInterval(9)),
             "successful command completion must become stale after its freshness window"
+        )
+        expect(
+            longSuccess.command?.durationMilliseconds == 120_000,
+            "command completion must preserve measured duration"
         )
         expect(failure.status == .failed, "non-zero exit code must produce failed status")
         expect(failure.command?.exitCode == 2, "command completion must preserve exit code")
@@ -1332,6 +1341,22 @@ private enum ShellRuntimeMetadataTests {
         )
         expect(longCommandRoute?.kind == .commandCompleted, "long background command completion must route")
         expect(longCommandRoute?.attention == .notable, "long command completion must mark the tab notable")
+
+        let realFactoryLongSuccess = TerminalActivitySnapshot.commandCompletion(
+            exitCode: 0,
+            now: now,
+            durationMilliseconds: 120_000
+        )
+        expect(
+            shellActivityNotificationRoute(
+                for: realFactoryLongSuccess,
+                pane: testPane,
+                tab: testTab,
+                visibility: .background,
+                now: now
+            )?.kind == .commandCompleted,
+            "factory-produced long command completion must route"
+        )
 
         let exited = TerminalActivitySnapshot.processExitedActivity(exitCode: 9, now: now)
         let exitedRoute = shellActivityNotificationRoute(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -46,6 +46,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
+        verifiesProcessExitNotificationRoutesBeforeAutoClose()
+        verifiesProcessExitRuntimeNotificationRoutesBeforeAutoClose()
         verifiesTerminalChildExitClosesSplitPane()
         verifiesTerminalChildExitClosesSinglePaneTab()
         verifiesTerminalChildExitCanLeaveEmptyFocusedSpace()
@@ -1413,6 +1415,100 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesProcessExitNotificationRoutesBeforeAutoClose() {
+        let controller = makeController()
+        _ = controller.openTerminalTab(workingDirectory: "/second")
+        controller.focus(paneID: "pane_1")
+
+        let processExitActivity = TerminalActivitySnapshot.processExitedActivity(
+            exitCode: 0,
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+
+        controller.updateTerminalMetadata(
+            childExitMetadata(title: "fish", exitCode: 0, activity: processExitActivity),
+            for: "pane_2"
+        )
+
+        expect(controller.pane(paneID: "pane_2") == nil, "child exit must still close the pane")
+        expect(
+            controller.activityNotifications.count == 1,
+            "process-exit activity must route before auto-close removes the pane"
+        )
+        expect(
+            controller.activityNotifications.first?.kind == .processExited,
+            "auto-closed process exit must preserve the notification kind"
+        )
+        expect(
+            controller.activityNotifications.first?.paneID == "pane_2",
+            "auto-closed process exit notification must point at the exiting pane"
+        )
+    }
+
+    private static func verifiesProcessExitRuntimeNotificationRoutesBeforeAutoClose() {
+        let controller = makeController()
+        _ = controller.openTerminalTab(workingDirectory: "/second")
+        controller.focus(paneID: "pane_1")
+        guard let exitingPane = controller.pane(paneID: "pane_2") else {
+            fail("test setup must create a background pane")
+        }
+
+        let processExitActivity = TerminalActivitySnapshot.processExitedActivity(
+            exitCode: 130,
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+
+        controller.updateTerminalRuntime(
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                paneID: exitingPane.paneID,
+                tabID: exitingPane.tabID,
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: "Studio Display",
+                displayID: "display_1",
+                attachedWindowTitle: "alan",
+                isFocused: false,
+                renderer: TerminalRendererSnapshot(
+                    kind: .ghosttyLive,
+                    phase: .surfaceReady,
+                    summary: "surface ready",
+                    detail: nil,
+                    failureReason: nil,
+                    recentEvents: []
+                ),
+                paneMetadata: childExitMetadata(
+                    title: "fish",
+                    exitCode: 130,
+                    activity: processExitActivity
+                ),
+                surfaceState: AlanTerminalSurfaceStateSnapshot(
+                    readiness: .unready(reason: .childExited),
+                    terminalMode: .normalBuffer,
+                    scrollback: .empty,
+                    search: nil,
+                    readonly: false,
+                    secureInput: false,
+                    inputReady: false,
+                    rendererHealth: "surface_ready",
+                    childExited: true,
+                    lastUpdatedAt: Date(timeIntervalSince1970: 2_001)
+                ),
+                lastUpdatedAt: Date(timeIntervalSince1970: 2_002)
+            )
+        )
+
+        expect(controller.pane(paneID: "pane_2") == nil, "runtime child exit must still close the pane")
+        expect(
+            controller.activityNotifications.count == 1,
+            "runtime process-exit activity must route before auto-close removes the pane"
+        )
+        expect(
+            controller.activityNotifications.first?.kind == .processExited,
+            "runtime auto-closed process exit must preserve the notification kind"
+        )
+    }
+
     private static func verifiesTerminalChildExitClosesSplitPane() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -2062,7 +2158,8 @@ private enum ShellRuntimeMetadataTests {
     private static func childExitMetadata(
         title: String,
         cwd: String = "/Users/morris/Developer/Alan",
-        exitCode: Int
+        exitCode: Int,
+        activity: TerminalActivitySnapshot? = nil
     ) -> TerminalPaneMetadataSnapshot {
         TerminalPaneMetadataSnapshot(
             title: title,
@@ -2072,7 +2169,8 @@ private enum ShellRuntimeMetadataTests {
             processExited: true,
             lastCommandExitCode: exitCode,
             lastUpdatedAt: Date(timeIntervalSince1970: 3_100),
-            activeTaskState: .inactive
+            activeTaskState: .inactive,
+            activity: activity
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -47,6 +47,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
+        verifiesInactiveAppRoutesFocusedPaneNotifications()
         verifiesProcessExitNotificationRoutesBeforeAutoClose()
         verifiesProcessExitRuntimeNotificationRoutesBeforeAutoClose()
         verifiesTerminalChildExitClosesSplitPane()
@@ -1447,6 +1448,36 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesInactiveAppRoutesFocusedPaneNotifications() {
+        let controller = makeController(appIsActive: false)
+        let needsInput = activity(
+            status: .needsInput,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Input needed",
+            agent: .init(
+                kind: .codex,
+                safeSessionLabel: "codex",
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            )
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activity: needsInput),
+            for: "pane_1"
+        )
+
+        expect(
+            controller.activityNotifications.count == 1,
+            "inactive app must route focused pane activity because it is out of view"
+        )
+        expect(
+            controller.activityNotifications.first?.kind == .needsInput,
+            "inactive focused pane notification must preserve the routed activity kind"
+        )
+    }
+
     private static func verifiesProcessExitNotificationRoutesBeforeAutoClose() {
         let controller = makeController()
         _ = controller.openTerminalTab(workingDirectory: "/second")
@@ -1977,7 +2008,8 @@ private enum ShellRuntimeMetadataTests {
         windowID: String = "metadata_test_\(UUID().uuidString)",
         shellState: ShellStateSnapshot? = nil,
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
-        workspaceManifest: ShellWorkspaceManifest? = nil
+        workspaceManifest: ShellWorkspaceManifest? = nil,
+        appIsActive: Bool = true
     ) -> ShellHostController {
         let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
         let context = ShellWindowContext.make(
@@ -1992,7 +2024,8 @@ private enum ShellRuntimeMetadataTests {
             persistenceURL: persistenceURL,
             terminalRuntimeRegistry: registry,
             workspaceManifestStore: workspaceManifestStore,
-            workspaceManifest: workspaceManifest
+            workspaceManifest: workspaceManifest,
+            appIsActiveProvider: { appIsActive }
         )
     }
 

--- a/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
@@ -8,7 +8,7 @@
   progress, command, Alan, and CLI agent states.
 - [x] 1.3 Finalize sidebar row projection details for title, activity-or-context
   fallback, progress rail, leading topology/kind slot, and hover close overlay.
-- [ ] 1.4 Encode default notification policy for focused, visible, background,
+- [x] 1.4 Encode default notification policy for focused, visible, background,
   unfocused, successful, failed, and user-input-required activity.
 - [ ] 1.5 Document Codex as the first CLI coding-agent adapter target unless
   implementation evidence shows another adapter is lower risk.
@@ -65,7 +65,7 @@
   leading slot.
 - [ ] 5.5 Project pane title-bar accessories from pane-local detail: activity,
   worktree/cwd, branch, process, and non-duplicated agent/Alan state.
-- [ ] 5.6 Add low-noise notification routing for user-input-required, error, and
+- [x] 5.6 Add low-noise notification routing for user-input-required, error, and
   long-command-complete events according to the task 1.4 policy.
 - [x] 5.7 Add accessibility labels or values for activity state on pane and tab
   affordances.


### PR DESCRIPTION
## Summary
- add a low-noise activity notification policy for focused, visible-unfocused, and background terminal activity
- route notification-worthy activity through the shell host without stealing focus or introducing OS notification permissions yet
- project notification-worthy activity into pane attention and de-duplicate repeated activity updates

## OpenSpec
- change: add-advanced-terminal-activity-semantics
- completed tasks: 1.4, 5.6
- stacked on: #423 / impl/activity-sidebar-projection

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build