### PR TITLE
Complete terminal activity A-group

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -474,6 +474,58 @@ extension ShellHostController {
                 errorMessage: delivery.errorMessage
             )
 
+        case .agentActivity:
+            guard let paneID = command.paneID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
+                )
+            }
+            guard let targetPane = pane(paneID: paneID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+            guard let event = command.agentActivityEvent,
+                  let activity = TerminalAgentActivityAdapter.activity(from: event)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "invalid_agent_activity",
+                    errorMessage: "agent_kind and a supported agent_status are required."
+                )
+            }
+
+            updateTerminalMetadata(
+                TerminalPaneMetadataSnapshot(
+                    title: nil,
+                    workingDirectory: event.workingDirectory,
+                    summary: nil,
+                    attention: .idle,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(),
+                    activeTaskState: nil,
+                    activity: activity
+                ),
+                for: paneID
+            )
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: targetPane.spaceID,
+                tabID: targetPane.tabID,
+                paneID: paneID
+            )
+
         case .attentionInbox:
             return response(
                 requestID: command.requestID,

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -17,6 +17,7 @@ enum AlanShellControlCommandKind: String, Codable {
     case paneMove = "pane.move"
     case paneFocus = "pane.focus"
     case paneSendText = "pane.send_text"
+    case agentActivity = "agent.activity"
     case attentionInbox = "attention.inbox"
     case attentionSet = "attention.set"
     case routingCandidates = "routing.candidates"
@@ -34,6 +35,13 @@ struct AlanShellControlCommand: Codable {
     let cwd: String?
     let text: String?
     let attention: ShellAttentionState?
+    let agentKind: String?
+    let agentStatus: String?
+    let sessionLabel: String?
+    let projectLabel: String?
+    let workingDirectory: String?
+    let detail: String?
+    let updatedAt: String?
     let afterEventID: String?
     let limit: Int?
 
@@ -48,8 +56,30 @@ struct AlanShellControlCommand: Codable {
         case cwd
         case text
         case attention
+        case agentKind = "agent_kind"
+        case agentStatus = "agent_status"
+        case sessionLabel = "session_label"
+        case projectLabel = "project_label"
+        case workingDirectory = "working_directory"
+        case detail
+        case updatedAt = "updated_at"
         case afterEventID = "after_event_id"
         case limit
+    }
+}
+
+extension AlanShellControlCommand {
+    var agentActivityEvent: TerminalAgentActivityEvent? {
+        guard let agentKind, let agentStatus else { return nil }
+        return TerminalAgentActivityEvent(
+            agentKind: agentKind,
+            status: agentStatus,
+            sessionLabel: sessionLabel,
+            projectLabel: projectLabel,
+            workingDirectory: workingDirectory ?? cwd,
+            detail: detail,
+            updatedAt: updatedAt
+        )
     }
 }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -152,6 +152,44 @@ extension ShellStateSnapshot {
         return try focusingPane(targetPaneID)
     }
 
+    func applyingAgentActivity(
+        _ activity: TerminalActivitySnapshot,
+        to paneID: String,
+        workingDirectory: String?
+    ) throws -> ShellStateMutationResult {
+        guard let targetPane = pane(paneID: paneID) else {
+            throw ShellStateMutationError.paneNotFound
+        }
+
+        let updatedPanes = panes.map { current in
+            guard current.paneID == paneID else { return current }
+            return ShellPane(
+                paneID: current.paneID,
+                tabID: current.tabID,
+                spaceID: current.spaceID,
+                launchTarget: current.launchTarget,
+                cwd: workingDirectory ?? current.cwd,
+                process: current.process,
+                attention: current.attention,
+                context: current.context,
+                viewport: current.viewport,
+                activity: activity,
+                alanBinding: current.alanBinding
+            )
+        }
+        let nextSpaces = rebuildingAttention(in: spaces, panes: updatedPanes)
+        return ShellStateMutationResult(
+            state: replacing(
+                spaces: nextSpaces,
+                panes: updatedPanes,
+                focusedPaneID: focusedPaneID
+            ),
+            spaceID: targetPane.spaceID,
+            tabID: targetPane.tabID,
+            paneID: targetPane.paneID
+        )
+    }
+
     func creatingSpace(
         launchTarget: ShellLaunchTarget,
         title: String?,

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -224,6 +224,192 @@ struct TerminalActivityAgentMetadata: Codable, Equatable {
     }
 }
 
+struct TerminalAgentActivityEvent: Equatable {
+    let agentKind: String
+    let status: String
+    let sessionLabel: String?
+    let projectLabel: String?
+    let workingDirectory: String?
+    let detail: String?
+    let updatedAt: String?
+}
+
+enum TerminalAgentActivityAdapter {
+    private static let iso8601Formatter = ISO8601DateFormatter()
+
+    static func activity(
+        from event: TerminalAgentActivityEvent,
+        now: Date = Date()
+    ) -> TerminalActivitySnapshot? {
+        guard let sourceKind = sourceKind(for: event.agentKind) else { return nil }
+        guard let status = mappedStatus(for: event.status) else { return nil }
+
+        let updatedAtDate = event.updatedAt.flatMap(iso8601Formatter.date(from:)) ?? now
+        let updatedAt = iso8601Formatter.string(from: updatedAtDate)
+        let sourceLabel = sourceLabel(for: sourceKind)
+        let workingDirectory = sanitizedLabel(event.workingDirectory, maxLength: 240)
+        let projectLabel = sanitizedLabel(event.projectLabel, maxLength: 48)
+            ?? pathLeaf(from: workingDirectory)
+
+        return TerminalActivitySnapshot(
+            source: TerminalActivitySource(kind: sourceKind, label: sourceLabel),
+            status: status.status,
+            priority: status.priority,
+            progress: nil,
+            command: nil,
+            agent: TerminalActivityAgentMetadata(
+                kind: sourceKind,
+                safeSessionLabel: sanitizedSessionLabel(event.sessionLabel),
+                projectLabel: projectLabel,
+                workingDirectory: workingDirectory
+            ),
+            display: TerminalActivityDisplay(
+                sourceLabel: sourceLabel,
+                stateLabel: status.stateLabel,
+                detailLabel: sanitizedDetail(event.detail),
+                paneHint: nil
+            ),
+            freshness: freshness(for: status.status, updatedAt: updatedAtDate, updatedAtString: updatedAt)
+        )
+    }
+
+    private struct MappedStatus {
+        let status: TerminalActivityStatus
+        let priority: TerminalActivityPriority
+        let stateLabel: String
+    }
+
+    private static func sourceKind(for raw: String) -> TerminalActivitySourceKind? {
+        let token = normalizedToken(raw)
+        guard !token.isEmpty else { return nil }
+
+        switch token {
+        case "codex", "openaicodex":
+            return .codex
+        default:
+            return .unknown
+        }
+    }
+
+    private static func sourceLabel(for sourceKind: TerminalActivitySourceKind) -> String {
+        switch sourceKind {
+        case .codex:
+            return "Codex"
+        default:
+            return "Agent"
+        }
+    }
+
+    private static func mappedStatus(for raw: String) -> MappedStatus? {
+        switch normalizedToken(raw) {
+        case "running", "inprogress", "working", "thinking", "streaming", "toolrunning":
+            return MappedStatus(status: .running, priority: .active, stateLabel: "Running")
+        case "needsinput", "inputrequired", "waitingforinput", "requiresinput",
+             "approvalrequired", "requiresapproval", "blocked":
+            return MappedStatus(status: .needsInput, priority: .awaitingUser, stateLabel: "Input needed")
+        case "completed", "complete", "done", "success", "succeeded", "idle":
+            return MappedStatus(status: .done, priority: .passive, stateLabel: "Done")
+        case "failed", "failure", "error", "errored", "cancelled", "canceled":
+            return MappedStatus(status: .failed, priority: .notable, stateLabel: "Error")
+        case "paused":
+            return MappedStatus(status: .paused, priority: .active, stateLabel: "Paused")
+        default:
+            return nil
+        }
+    }
+
+    private static func freshness(
+        for status: TerminalActivityStatus,
+        updatedAt: Date,
+        updatedAtString: String
+    ) -> TerminalActivityFreshness {
+        switch status {
+        case .running:
+            return TerminalActivityFreshness(
+                updatedAt: updatedAtString,
+                staleAt: iso8601Formatter.string(from: updatedAt.addingTimeInterval(90)),
+                expiresAt: nil
+            )
+        case .done:
+            return TerminalActivityFreshness(
+                updatedAt: updatedAtString,
+                staleAt: nil,
+                expiresAt: iso8601Formatter.string(from: updatedAt.addingTimeInterval(8))
+            )
+        case .needsInput, .failed:
+            return TerminalActivityFreshness(updatedAt: updatedAtString, staleAt: nil, expiresAt: nil)
+        case .paused:
+            return TerminalActivityFreshness(
+                updatedAt: updatedAtString,
+                staleAt: iso8601Formatter.string(from: updatedAt.addingTimeInterval(90)),
+                expiresAt: nil
+            )
+        case .progress, .bell, .exited, .idle, .stale:
+            return TerminalActivityFreshness(updatedAt: updatedAtString, staleAt: nil, expiresAt: nil)
+        }
+    }
+
+    private static func sanitizedSessionLabel(_ raw: String?) -> String? {
+        guard let label = sanitizedLabel(raw, maxLength: 32) else { return nil }
+        let lowercased = label.lowercased()
+        guard !lowercased.contains("session"),
+              !lowercased.hasPrefix("sess"),
+              !looksLikeRawIdentifier(label)
+        else {
+            return nil
+        }
+        return label
+    }
+
+    private static func sanitizedDetail(_ raw: String?) -> String? {
+        guard let detail = sanitizedLabel(raw, maxLength: 80) else { return nil }
+        let lowercased = detail.lowercased()
+        guard !detail.hasPrefix("{"),
+              !detail.hasPrefix("["),
+              !lowercased.contains("event"),
+              !lowercased.contains("session_id")
+        else {
+            return nil
+        }
+        return detail
+    }
+
+    private static func sanitizedLabel(_ raw: String?, maxLength: Int) -> String? {
+        guard let raw else { return nil }
+        let cleaned = raw.unicodeScalars
+            .map { scalar in
+                CharacterSet.controlCharacters.contains(scalar) ? " " : String(scalar)
+            }
+            .joined()
+        let collapsed = cleaned
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard !collapsed.isEmpty else { return nil }
+
+        let clipped = String(collapsed.prefix(maxLength))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return clipped.isEmpty ? nil : clipped
+    }
+
+    private static func pathLeaf(from raw: String?) -> String? {
+        guard let raw, raw.contains("/") else { return nil }
+        let leaf = URL(fileURLWithPath: raw).lastPathComponent
+        return sanitizedLabel(leaf, maxLength: 48)
+    }
+
+    private static func looksLikeRawIdentifier(_ label: String) -> Bool {
+        let alphanumericCount = label.filter { $0.isLetter || $0.isNumber }.count
+        guard alphanumericCount >= 20 else { return false }
+        let hexCount = label.filter(\.isHexDigit).count
+        return Double(hexCount) / Double(alphanumericCount) > 0.7
+    }
+
+    private static func normalizedToken(_ raw: String) -> String {
+        raw.lowercased().filter { $0.isLetter || $0.isNumber }
+    }
+}
+
 struct TerminalActivityDisplay: Codable, Equatable {
     let sourceLabel: String
     let stateLabel: String

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -404,6 +404,76 @@ enum AlanShellLocalCommandExecutor {
         case .paneSendText:
             return nil
 
+        case .agentActivity:
+            guard let paneID = command.paneID else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "pane_required",
+                        errorMessage: "pane_id is required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            guard state.pane(paneID: paneID) != nil else {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(
+                        for: .paneNotFound,
+                        command: command,
+                        state: state
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            guard let event = command.agentActivityEvent,
+                  let activity = TerminalAgentActivityAdapter.activity(from: event)
+            else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        paneID: paneID,
+                        errorCode: "invalid_agent_activity",
+                        errorMessage: "agent_kind and a supported agent_status are required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+
+            do {
+                let result = try state.applyingAgentActivity(
+                    activity,
+                    to: paneID,
+                    workingDirectory: event.workingDirectory
+                )
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: result.state,
+                        applied: true,
+                        spaceID: result.spaceID,
+                        tabID: result.tabID,
+                        paneID: result.paneID
+                    ),
+                    updatedState: result.state,
+                    sideEffect: nil
+                )
+            } catch let error as ShellStateMutationError {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(for: error, command: command, state: state),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            } catch {
+                return nil
+            }
+
         case .attentionInbox:
             return AlanShellLocalCommandResult(
                 response: response(

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -351,7 +351,7 @@ final class AlanShellSocketServer {
     }
 
     func handleLocally(_ command: AlanShellControlCommand) -> AlanShellControlResponse? {
-        guard !command.command.allocatesPaneID else { return nil }
+        guard !command.command.requiresHostHandler else { return nil }
 
         let localResult: AlanShellLocalCommandResult? = {
             stateLock.lock()
@@ -397,9 +397,9 @@ final class AlanShellSocketServer {
 }
 
 private extension AlanShellControlCommandKind {
-    var allocatesPaneID: Bool {
+    var requiresHostHandler: Bool {
         switch self {
-        case .spaceCreate, .spaceOpenAlan, .tabOpen, .paneSplit:
+        case .spaceCreate, .spaceOpenAlan, .tabOpen, .paneSplit, .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -32,6 +32,12 @@ struct ShellActivityNotificationRoute: Equatable, Identifiable {
     let attention: ShellAttentionState
 }
 
+struct ShellPaneTitleBarDetailProjection: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let help: String
+}
+
 func shellUserFacingSummary(_ summary: String?) -> String? {
     guard let summary else { return nil }
 
@@ -225,6 +231,159 @@ func shellPaneActivityAccessoryLabel(for pane: ShellPane, now: Date? = nil) -> S
     case .needsInput, .failed, .paused, .progress, .running, .bell, .exited:
         return activity.display.sourceFirstLabel
     }
+}
+
+func shellPaneStatusAccessoryLabel(for pane: ShellPane, now: Date? = nil) -> String? {
+    guard let status = shellTerminalStatusSummary(for: pane, now: now) else { return nil }
+    if shellEffectiveAttention(for: pane, now: now) == .notable,
+       status == "Terminal bell"
+    {
+        return nil
+    }
+    return status
+}
+
+func shellPaneTitleBarDetailProjection(
+    for pane: ShellPane,
+    title: String,
+    now: Date? = nil
+) -> [ShellPaneTitleBarDetailProjection] {
+    var items: [ShellPaneTitleBarDetailProjection] = []
+
+    if let activityLabel = shellPaneActivityAccessoryLabel(for: pane, now: now) {
+        items.append(
+            ShellPaneTitleBarDetailProjection(
+                id: "activity",
+                title: activityLabel,
+                help: activityLabel
+            )
+        )
+    }
+
+    if let status = shellPaneStatusAccessoryLabel(for: pane, now: now) {
+        items.append(
+            ShellPaneTitleBarDetailProjection(
+                id: "status",
+                title: status,
+                help: status
+            )
+        )
+    }
+
+    if let context = shellPaneContextAccessoryProjection(for: pane, title: title) {
+        items.append(context)
+    }
+
+    if let branch = shellPaneBranchAccessoryProjection(for: pane, title: title) {
+        items.append(branch)
+    }
+
+    if let process = shellPaneProcessAccessoryProjection(for: pane, title: title) {
+        items.append(process)
+    }
+
+    if let alan = shellPaneAlanAccessoryProjection(for: pane) {
+        items.append(alan)
+    }
+
+    return items
+}
+
+private func shellPaneContextAccessoryProjection(
+    for pane: ShellPane,
+    title: String
+) -> ShellPaneTitleBarDetailProjection? {
+    let repositoryLabel = shellPathLeaf(pane.context?.repositoryRoot)
+    let cwdLabel = shellPathLeaf(pane.cwd)
+        ?? shellVisibleLabel(pane.context?.workingDirectoryName)
+    guard let label = repositoryLabel ?? cwdLabel,
+          !shellLabelsMatch(label, title)
+    else {
+        return nil
+    }
+
+    return ShellPaneTitleBarDetailProjection(
+        id: repositoryLabel == nil ? "cwd" : "worktree",
+        title: label,
+        help: repositoryLabel == nil ? "Directory \(label)" : "Worktree \(label)"
+    )
+}
+
+private func shellPaneBranchAccessoryProjection(
+    for pane: ShellPane,
+    title: String
+) -> ShellPaneTitleBarDetailProjection? {
+    guard let branch = shellVisibleLabel(pane.context?.gitBranch),
+          !shellLabelsMatch(branch, title)
+    else {
+        return nil
+    }
+
+    return ShellPaneTitleBarDetailProjection(
+        id: "branch",
+        title: branch,
+        help: "Git branch \(branch)"
+    )
+}
+
+private func shellPaneProcessAccessoryProjection(
+    for pane: ShellPane,
+    title: String
+) -> ShellPaneTitleBarDetailProjection? {
+    guard let program = shellVisibleLabel(pane.process?.program),
+          !shellLabelsMatch(program, title),
+          !shellProcessDuplicatesAgentOrAlan(program, pane: pane)
+    else {
+        return nil
+    }
+
+    return ShellPaneTitleBarDetailProjection(
+        id: "process",
+        title: program,
+        help: "Process \(program)"
+    )
+}
+
+private func shellPaneAlanAccessoryProjection(for pane: ShellPane) -> ShellPaneTitleBarDetailProjection? {
+    guard let binding = pane.alanBinding,
+          pane.activity?.source.kind != .alan
+    else {
+        return nil
+    }
+
+    let title = binding.pendingYield ? "Input" : shellVisibleLabel(binding.runStatus)
+    guard let title else { return nil }
+    return ShellPaneTitleBarDetailProjection(
+        id: "alan",
+        title: title,
+        help: "alan \(binding.runStatus)"
+    )
+}
+
+private func shellProcessDuplicatesAgentOrAlan(_ program: String, pane: ShellPane) -> Bool {
+    let lowercasedProgram = program.lowercased()
+    if pane.alanBinding != nil || pane.resolvedLaunchTarget == .alan {
+        return lowercasedProgram.contains("alan")
+    }
+
+    guard let activity = pane.activity else { return false }
+    switch activity.source.kind {
+    case .codex:
+        return lowercasedProgram.contains("codex")
+    case .claude:
+        return lowercasedProgram.contains("claude")
+    case .openCode:
+        return lowercasedProgram.contains("opencode") || lowercasedProgram.contains("open-code")
+    case .alan:
+        return lowercasedProgram.contains("alan")
+    case .shell, .progress, .command, .process, .unknown:
+        return false
+    }
+}
+
+private func shellLabelsMatch(_ lhs: String, _ rhs: String) -> Bool {
+    lhs.trimmingCharacters(in: .whitespacesAndNewlines)
+        .caseInsensitiveCompare(rhs.trimmingCharacters(in: .whitespacesAndNewlines)) == .orderedSame
 }
 
 func shellActivityNotificationKey(

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -774,63 +774,20 @@ private struct ShellPaneTitleBarView: View {
     private static let activityFreshnessFormatter = ISO8601DateFormatter()
 
     private var accessories: [ShellPaneTitleBarAccessory] {
-        var items: [ShellPaneTitleBarAccessory] = []
-
-        if let activityLabel = shellPaneActivityAccessoryLabel(for: pane, now: activityFreshnessNow) {
-            items.append(
-                ShellPaneTitleBarAccessory(
-                    id: "activity",
-                    icon: activityIcon,
-                    title: activityLabel,
-                    help: activityLabel,
-                    tint: activityTint,
-                    maxWidth: 140
-                )
+        shellPaneTitleBarDetailProjection(
+            for: pane,
+            title: title,
+            now: activityFreshnessNow
+        ).map { projection in
+            ShellPaneTitleBarAccessory(
+                id: projection.id,
+                icon: accessoryIcon(for: projection.id),
+                title: projection.title,
+                help: projection.help,
+                tint: accessoryTint(for: projection.id),
+                maxWidth: accessoryMaxWidth(for: projection.id)
             )
         }
-
-        if let status = shellTerminalStatusSummary(for: pane, now: activityFreshnessNow) {
-            items.append(
-                ShellPaneTitleBarAccessory(
-                    id: "status",
-                    icon: statusIcon,
-                    title: statusTitle(status),
-                    help: status,
-                    tint: statusTint
-                )
-            )
-        }
-
-        if let branch = shellVisibleLabel(pane.context?.gitBranch) {
-            items.append(
-                ShellPaneTitleBarAccessory(
-                    id: "branch",
-                    icon: "point.topleft.down.curvedto.point.bottomright.up",
-                    title: branch,
-                    help: "Git branch \(branch)",
-                    tint: ShellPalette.mutedInk,
-                    maxWidth: 120
-                )
-            )
-        }
-
-        if let binding = pane.alanBinding,
-           pane.activity?.source.kind != .alan
-        {
-            let bindingTitle = binding.pendingYield ? "Input" : shellVisibleLabel(binding.runStatus)
-            items.append(
-                ShellPaneTitleBarAccessory(
-                    id: "alan",
-                    icon: "sparkles",
-                    title: bindingTitle,
-                    help: "alan \(binding.runStatus)",
-                    tint: ShellPalette.accent,
-                    maxWidth: 72
-                )
-            )
-        }
-
-        return items
     }
 
     private var activityIcon: String {
@@ -897,13 +854,49 @@ private struct ShellPaneTitleBarView: View {
         return ShellPalette.mutedInk
     }
 
-    private func statusTitle(_ status: String) -> String? {
-        if shellEffectiveAttention(for: pane, now: activityFreshnessNow) == .notable,
-           status == "Terminal bell"
-        {
+    private func accessoryIcon(for id: String) -> String {
+        switch id {
+        case "activity":
+            return activityIcon
+        case "status":
+            return statusIcon
+        case "worktree", "cwd":
+            return "folder"
+        case "branch":
+            return "point.topleft.down.curvedto.point.bottomright.up"
+        case "process":
+            return "terminal"
+        case "alan":
+            return "sparkles"
+        default:
+            return "info.circle"
+        }
+    }
+
+    private func accessoryTint(for id: String) -> Color {
+        switch id {
+        case "activity":
+            return activityTint
+        case "status":
+            return statusTint
+        case "alan":
+            return ShellPalette.accent
+        default:
+            return ShellPalette.mutedInk
+        }
+    }
+
+    private func accessoryMaxWidth(for id: String) -> CGFloat? {
+        switch id {
+        case "activity":
+            return 140
+        case "branch", "worktree", "cwd":
+            return 120
+        case "process", "alan":
+            return 72
+        default:
             return nil
         }
-        return status
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -995,8 +995,13 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "shellPaneActivityAccessoryLabel\\(for: pane, now: activityFreshnessNow\\)" \
-    "pane title activity labels must use the state-driven freshness clock"
+    "shellPaneTitleBarDetailProjection\\(" \
+    "pane title detail projection must use the state-driven freshness clock"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "now: activityFreshnessNow" \
+    "pane title detail projection must pass the state-driven freshness clock"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -32,6 +32,10 @@ private enum ShellRuntimeMetadataTests {
         verifiesStaleProgressIsNotSidebarWorthy()
         verifiesDefaultSidebarActivitySelectionHonorsFreshness()
         verifiesSuccessfulCommandIsNotSidebarWorthy()
+        verifiesCodexAgentActivityAdapterMapsSupportedStates()
+        verifiesAgentActivityAdapterSanitizesDefaultUIPayload()
+        verifiesAgentActivityAdapterRejectsMalformedPayloadAndFallsBackForUnsupportedAgent()
+        verifiesAgentActivityControlCommandProjectsOntoPane()
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
         verifiesPaneRebuildMutationsPreserveActivity()
@@ -45,6 +49,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesActivityFreshnessPolicies()
         verifiesActivityAttentionIsReadTimeOnly()
         verifiesPaneTitleActivityAccessoryLabel()
+        verifiesPaneTitleDetailProjectionIncludesContextBranchAndProcess()
+        verifiesPaneTitleDetailProjectionAvoidsDuplicateAgentAndAlan()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
         verifiesControllerRoutesDistinctActivityPayloadsInSameSecond()
@@ -558,6 +564,162 @@ private enum ShellRuntimeMetadataTests {
             activity.freshness.staleAt == "2026-05-17T09:00:15Z",
             "progress activity must get the default 15 second stale deadline"
         )
+    }
+
+    private static func verifiesCodexAgentActivityAdapterMapsSupportedStates() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let updatedAt = "2026-05-17T09:00:00Z"
+        let running = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "running",
+                sessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: nil,
+                updatedAt: updatedAt
+            ),
+            now: now
+        )
+        let needsInput = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "approval_required",
+                sessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: nil,
+                updatedAt: updatedAt
+            ),
+            now: now
+        )
+        let complete = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "completed",
+                sessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: nil,
+                updatedAt: updatedAt
+            ),
+            now: now
+        )
+        let failed = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "error",
+                sessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: nil,
+                updatedAt: updatedAt
+            ),
+            now: now
+        )
+
+        expect(running?.source.kind == .codex, "Codex running activity must keep codex as source")
+        expect(running?.status == .running, "Codex running event must map to running")
+        expect(running?.display.sourceFirstLabel == "Codex · Running", "Codex running copy must be source-first")
+        expect(running?.freshness.staleAt == "2026-05-17T09:01:30Z", "running agent activity must have a bounded stale window")
+        expect(needsInput?.status == .needsInput, "Codex approval-required event must map to needs-input")
+        expect(needsInput?.priority == .awaitingUser, "Codex needs-input event must be awaiting-user priority")
+        expect(needsInput?.freshness.staleAt == nil, "Codex needs-input must persist until replaced")
+        expect(complete?.status == .done, "Codex completed event must map to done")
+        expect(complete?.freshness.expiresAt == "2026-05-17T09:00:08Z", "Codex done activity must be brief")
+        expect(failed?.status == .failed, "Codex error event must map to failed")
+        expect(failed?.display.sourceFirstLabel == "Codex · Error", "Codex error copy must hide implementation names")
+        expect(failed?.freshness.staleAt == nil, "Codex error must persist until replaced")
+    }
+
+    private static func verifiesAgentActivityAdapterSanitizesDefaultUIPayload() {
+        let activity = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "needs_input",
+                sessionLabel: "session-1234567890abcdef1234567890",
+                projectLabel: "alan\nworkspace",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: #"{"event":"codex.status","session_id":"session-1234567890abcdef1234567890"}"#,
+                updatedAt: "2026-05-17T09:00:00Z"
+            ),
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+
+        expect(activity?.agent?.safeSessionLabel == nil, "agent adapter must not expose raw session ids")
+        expect(activity?.agent?.projectLabel == "alan workspace", "agent adapter must collapse control characters in labels")
+        expect(activity?.display.detailLabel == nil, "agent adapter must not expose raw hook payloads in default UI detail")
+        if let activity {
+            do {
+                let data = try JSONEncoder().encode(activity)
+                let json = String(data: data, encoding: .utf8) ?? ""
+                expect(!json.contains("codex.status"), "serialized activity must not retain raw hook event names")
+                expect(!json.contains("1234567890abcdef"), "serialized activity must not retain raw session ids")
+            } catch {
+                fail("agent activity JSON encode failed: \(error)")
+            }
+        } else {
+            fail("valid Codex needs-input activity should adapt")
+        }
+    }
+
+    private static func verifiesAgentActivityAdapterRejectsMalformedPayloadAndFallsBackForUnsupportedAgent() {
+        let malformed = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "codex",
+                status: "tool_call_delta",
+                sessionLabel: nil,
+                projectLabel: nil,
+                workingDirectory: nil,
+                detail: nil,
+                updatedAt: "2026-05-17T09:00:00Z"
+            ),
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+        let unsupported = TerminalAgentActivityAdapter.activity(
+            from: TerminalAgentActivityEvent(
+                agentKind: "future-agent",
+                status: "running",
+                sessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan",
+                detail: nil,
+                updatedAt: "2026-05-17T09:00:00Z"
+            ),
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+
+        expect(malformed == nil, "unknown implementation event names must not create precise activity")
+        expect(unsupported?.source.kind == .unknown, "unsupported agents must fall back to unknown source")
+        expect(unsupported?.display.sourceFirstLabel == "Agent · Running", "unsupported agents must use generic UI copy")
+    }
+
+    private static func verifiesAgentActivityControlCommandProjectsOntoPane() {
+        let controller = makeController(appIsActive: false)
+        let json = """
+        {
+          "request_id": "agent-activity-1",
+          "command": "agent.activity",
+          "pane_id": "pane_1",
+          "agent_kind": "codex",
+          "agent_status": "needs_input",
+          "session_label": "session-1234567890abcdef1234567890",
+          "project_label": "alan",
+          "working_directory": "/Users/morris/Developer/alan",
+          "detail": "{\\"event\\":\\"codex.status\\"}",
+          "updated_at": "2026-05-17T09:00:00Z"
+        }
+        """
+        let command = decodeControlCommand(json)
+        let response = controller.handleControlPlaneCommand(command)
+        let paneActivity = controller.pane(paneID: "pane_1")?.activity
+
+        expect(response.applied == true, "agent activity command must be applied")
+        expect(response.paneID == "pane_1", "agent activity command must identify the updated pane")
+        expect(paneActivity?.source.kind == .codex, "agent activity command must project Codex source onto pane")
+        expect(paneActivity?.status == .needsInput, "agent activity command must project needs-input status")
+        expect(paneActivity?.agent?.safeSessionLabel == nil, "control command projection must not expose raw session ids")
+        expect(controller.activityNotifications.first?.kind == .needsInput, "agent command must reuse low-noise notification routing")
     }
 
     private static func verifiesCommandCompletionActivityFactory() {
@@ -1309,6 +1471,112 @@ private enum ShellRuntimeMetadataTests {
             shellPaneActivityAccessoryLabel(for: paneWithProgress, now: now.addingTimeInterval(16)) == nil,
             "pane title activity accessory must hide stale progress"
         )
+    }
+
+    private static func verifiesPaneTitleDetailProjectionIncludesContextBranchAndProcess() {
+        let testPane = pane(
+            context: context(
+                workingDirectoryName: "alan",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            cwd: "/Users/morris/Developer/alan",
+            process: ShellProcessBinding(program: "fish", argvPreview: nil),
+            attention: .idle
+        )
+        let details = shellPaneTitleBarDetailProjection(
+            for: testPane,
+            title: "Terminal",
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+
+        expect(
+            details.map(\.id) == ["worktree", "branch", "process"],
+            "pane title details must expose non-redundant worktree, branch, and process"
+        )
+        expect(details.map(\.title) == ["alan", "main", "fish"], "pane title details must use compact labels")
+    }
+
+    private static func verifiesPaneTitleDetailProjectionAvoidsDuplicateAgentAndAlan() {
+        let codexActivity = activity(
+            status: .running,
+            source: .codex,
+            sourceLabel: "Codex",
+            stateLabel: "Running",
+            agent: TerminalActivityAgentMetadata(
+                kind: .codex,
+                safeSessionLabel: nil,
+                projectLabel: "alan",
+                workingDirectory: "/Users/morris/Developer/alan"
+            )
+        )
+        let codexPane = pane(
+            context: context(
+                workingDirectoryName: "alan",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "main",
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            cwd: "/Users/morris/Developer/alan",
+            process: ShellProcessBinding(program: "codex", argvPreview: ["codex"]),
+            attention: .idle,
+            activity: codexActivity
+        )
+        let codexDetails = shellPaneTitleBarDetailProjection(
+            for: codexPane,
+            title: "alan",
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+        expect(codexDetails.map(\.id) == ["activity", "branch"], "Codex activity must not duplicate process")
+
+        let alanActivity = activity(
+            status: .running,
+            source: .alan,
+            sourceLabel: "alan",
+            stateLabel: "Running"
+        )
+        let alanPane = ShellPane(
+            paneID: "pane_1",
+            tabID: "tab_1",
+            spaceID: "space_1",
+            launchTarget: .alan,
+            cwd: "/Users/morris/Developer/alan",
+            process: ShellProcessBinding(program: "alan", argvPreview: ["alan", "chat"]),
+            attention: .active,
+            context: context(
+                workingDirectoryName: "alan",
+                repositoryRoot: nil,
+                gitBranch: nil,
+                processState: "running",
+                rendererHealth: "ready",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            activity: alanActivity,
+            alanBinding: ShellAlanBinding(
+                sessionID: "session_1",
+                runStatus: "running",
+                pendingYield: false,
+                source: "test",
+                lastProjectedAt: nil
+            )
+        )
+        let alanDetails = shellPaneTitleBarDetailProjection(
+            for: alanPane,
+            title: "alan",
+            now: Date(timeIntervalSince1970: 1_779_008_400)
+        )
+        expect(alanDetails.map(\.id) == ["activity"], "alan activity must not duplicate alan binding or process")
     }
 
     private static func verifiesActivityNotificationPolicyIsLowNoise() {
@@ -2426,6 +2694,15 @@ private enum ShellRuntimeMetadataTests {
 
     private static func activeTask(in url: URL) -> ShellTabActiveTaskState? {
         decodeManifest(at: url)?.spaces.first?.tabs.first?.activeTask
+    }
+
+    private static func decodeControlCommand(_ json: String) -> AlanShellControlCommand {
+        do {
+            let data = Data(json.utf8)
+            return try JSONDecoder().decode(AlanShellControlCommand.self, from: data)
+        } catch {
+            fail("failed to decode control command fixture: \(error)")
+        }
     }
 
     private static func expect(

--- a/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/tasks.md
@@ -10,7 +10,7 @@
   fallback, progress rail, leading topology/kind slot, and hover close overlay.
 - [x] 1.4 Encode default notification policy for focused, visible, background,
   unfocused, successful, failed, and user-input-required activity.
-- [ ] 1.5 Document Codex as the first CLI coding-agent adapter target unless
+- [x] 1.5 Document Codex as the first CLI coding-agent adapter target unless
   implementation evidence shows another adapter is lower risk.
 
 ## 2. Activity Model And Projection
@@ -43,13 +43,13 @@
 
 ## 4. CLI Coding-Agent Activity
 
-- [ ] 4.1 Add a small adapter boundary for reliable CLI agent events and unknown
+- [x] 4.1 Add a small adapter boundary for reliable CLI agent events and unknown
   agent fallback state.
-- [ ] 4.2 Implement the Codex adapter slice from task 1.5, or update the draft
+- [x] 4.2 Implement the Codex adapter slice from task 1.5, or update the draft
   with evidence if another first adapter is selected.
-- [ ] 4.3 Sanitize agent event payloads so default UI never exposes raw hook
+- [x] 4.3 Sanitize agent event payloads so default UI never exposes raw hook
   payloads, raw session IDs, or implementation event names.
-- [ ] 4.4 Add tests for supported agent running, needs-input, complete, error,
+- [x] 4.4 Add tests for supported agent running, needs-input, complete, error,
   malformed payload, and unsupported-agent fallback.
 
 ## 5. Activity UI And Notifications
@@ -63,13 +63,13 @@
   activation cycle focus through panes in stable order.
 - [x] 5.4 Keep single-pane tabs on semantic kind or supported agent icons in the
   leading slot.
-- [ ] 5.5 Project pane title-bar accessories from pane-local detail: activity,
+- [x] 5.5 Project pane title-bar accessories from pane-local detail: activity,
   worktree/cwd, branch, process, and non-duplicated agent/Alan state.
 - [x] 5.6 Add low-noise notification routing for user-input-required, error, and
   long-command-complete events according to the task 1.4 policy.
 - [x] 5.7 Add accessibility labels or values for activity state on pane and tab
   affordances.
-- [ ] 5.8 Add visual review evidence for focused progress, background agent
+- [x] 5.8 Add visual review evidence for focused progress, background agent
   needs-input, command failure, cleared activity showing worktree/branch
   fallback, split leading topology, and hover close overlay.
 
@@ -112,13 +112,13 @@
 
 ## 8. Verification And Archive Readiness
 
-- [ ] 8.1 Run focused Swift script tests for activity model, projection, Ghostty
+- [x] 8.1 Run focused Swift script tests for activity model, projection, Ghostty
   source mapping, and CLI agent adapters.
-- [ ] 8.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 8.3 Run the relevant macOS app build command for the touched Apple client
+- [x] 8.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 8.3 Run the relevant macOS app build command for the touched Apple client
   targets.
-- [ ] 8.4 Run `git diff --check`.
-- [ ] 8.5 Run `openspec validate add-advanced-terminal-activity-semantics --type
+- [x] 8.4 Run `git diff --check`.
+- [x] 8.5 Run `openspec validate add-advanced-terminal-activity-semantics --type
   change --strict --json`.
-- [ ] 8.6 Run `openspec validate --all --strict --json`.
+- [x] 8.6 Run `openspec validate --all --strict --json`.
 - [ ] 8.7 Sync accepted delta requirements into `openspec/specs/` before archive.

--- a/openspec/changes/add-advanced-terminal-activity-semantics/verification.md
+++ b/openspec/changes/add-advanced-terminal-activity-semantics/verification.md
@@ -1,0 +1,45 @@
+# Verification Notes
+
+Date: 2026-05-18
+
+## A-Group Visual Review Evidence
+
+This pass used focused projection tests and source-level UI review rather than a
+saved running-app screenshot. The debug macOS app build passed, so the SwiftUI
+surface compiles with the reviewed projections.
+
+- Focused progress: `verifiesPaneTitleActivityAccessoryLabel` covers pane-local
+  `Progress · 42%` title detail and freshness expiry without resizing title bars.
+- Background agent needs input: `verifiesAgentActivityControlCommandProjectsOntoPane`,
+  `verifiesTabSidebarActivityProjectionUsesHighestPriorityPane`, and
+  `verifiesControllerRoutesActivityNotificationsOnce` cover Codex
+  `Input needed` projection, tab-level selection, and notification routing.
+- Command failure: `verifiesFocusedCommandFailureDemotesFromSidebarProjection`
+  and `verifiesCommandFailureAcknowledgementSticksAfterFocus` cover failure
+  visibility and focus acknowledgement.
+- Cleared activity fallback: `verifiesClearingActivityRemovesPaneActivity` and
+  `verifiesTabSidebarProjectionFallsBackToRepositoryBranch` cover returning from
+  activity UI to worktree/branch context.
+- Split leading topology: `verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout`,
+  `bash clients/apple/scripts/test-shell-split-model.sh`, and the reviewed
+  `ShellSidebarTabRow` split-summary leading slot cover the compact topology
+  affordance and stable focus cycling.
+- Hover close overlay: reviewed `ShellSidebarTabRow` hover state in
+  `clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift`; the close
+  control remains an overlay in the trailing row area and does not reserve a
+  permanent text column.
+
+## Commands Run
+
+```bash
+bash clients/apple/scripts/test-shell-runtime-metadata.sh
+bash clients/apple/scripts/check-shell-contracts.sh
+bash clients/apple/scripts/test-shell-sidebar-presentation.sh
+bash clients/apple/scripts/test-shell-split-model.sh
+xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-activity build
+openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
+```
+
+The first xcodebuild attempt used `target/xcode-derived-activity` and failed
+before compilation because the local `target/` directory is owned by root. The
+same build passed with `/private/tmp/alan-xcode-derived-activity`.


### PR DESCRIPTION
## Summary
- add the Codex-first CLI agent activity adapter with conservative unknown-agent fallback and payload sanitization
- project agent activity through shell control commands and pane metadata without exposing raw hook payloads or session ids
- centralize pane title-bar detail projection for activity, worktree/cwd, branch, process, and non-duplicated agent/Alan state
- record A-group visual/verification evidence and update OpenSpec tasks while keeping B and Quick Terminal as draft follow-ups

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-sidebar-presentation.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-activity build
- git diff --check
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- openspec validate --all --strict --json