### PR TITLE
Polish terminal activity typography

### DIFF
--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -675,6 +675,21 @@ private struct ShellTerminalLeafView: View {
     }
 }
 
+private enum ShellPaneTitleTypography {
+    static let titleSize: CGFloat = 11
+    static let accessorySize: CGFloat = 10
+    static let closeSize: CGFloat = 9
+
+    static func titleWeight(isSelected: Bool) -> Font.Weight {
+        isSelected ? .medium : .regular
+    }
+
+    static let accessoryWeight: Font.Weight = .regular
+    static let emphasizedAccessoryWeight: Font.Weight = .medium
+    static let iconWeight: Font.Weight = .medium
+    static let closeWeight: Font.Weight = .semibold
+}
+
 private struct ShellPaneTitleBarView: View {
     let title: String
     let pane: ShellPane
@@ -686,7 +701,12 @@ private struct ShellPaneTitleBarView: View {
     var body: some View {
         HStack(spacing: 8) {
             Text(title)
-                .font(.system(size: 11, weight: isSelected ? .semibold : .medium))
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.titleSize,
+                        weight: ShellPaneTitleTypography.titleWeight(isSelected: isSelected)
+                    )
+                )
                 .foregroundStyle(isSelected ? ShellPalette.ink : ShellPalette.mutedInk)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -703,7 +723,12 @@ private struct ShellPaneTitleBarView: View {
 
             Button(action: onClosePane) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(
+                        .system(
+                            size: ShellPaneTitleTypography.closeSize,
+                            weight: ShellPaneTitleTypography.closeWeight
+                        )
+                    )
                     .foregroundStyle(ShellPalette.mutedInk)
                     .frame(width: 22, height: 22)
                     .contentShape(Rectangle())
@@ -785,6 +810,7 @@ private struct ShellPaneTitleBarView: View {
                 title: projection.title,
                 help: projection.help,
                 tint: accessoryTint(for: projection.id),
+                isEmphasized: accessoryIsEmphasized(projection.id),
                 maxWidth: accessoryMaxWidth(for: projection.id)
             )
         }
@@ -886,6 +912,20 @@ private struct ShellPaneTitleBarView: View {
         }
     }
 
+    private func accessoryIsEmphasized(_ id: String) -> Bool {
+        switch id {
+        case "activity":
+            return pane.activity?.priority == .awaitingUser || pane.activity?.priority == .notable
+        case "status":
+            return shellEffectiveAttention(for: pane, now: activityFreshnessNow) == .awaitingUser
+                || shellEffectiveAttention(for: pane, now: activityFreshnessNow) == .notable
+        case "alan":
+            return pane.alanBinding?.pendingYield == true
+        default:
+            return false
+        }
+    }
+
     private func accessoryMaxWidth(for id: String) -> CGFloat? {
         switch id {
         case "activity":
@@ -906,6 +946,7 @@ private struct ShellPaneTitleBarAccessory: Identifiable {
     let title: String?
     let help: String
     let tint: Color
+    let isEmphasized: Bool
     var maxWidth: CGFloat?
 }
 
@@ -916,11 +957,23 @@ private struct ShellPaneTitleBarAccessoryView: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: accessory.icon)
-                .font(.system(size: 10, weight: .semibold))
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.accessorySize,
+                        weight: ShellPaneTitleTypography.iconWeight
+                    )
+                )
 
             if let title = accessory.title {
                 Text(title)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(
+                        .system(
+                            size: ShellPaneTitleTypography.accessorySize,
+                            weight: accessory.isEmphasized
+                                ? ShellPaneTitleTypography.emphasizedAccessoryWeight
+                                : ShellPaneTitleTypography.accessoryWeight
+                        )
+                    )
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: accessory.maxWidth, alignment: .leading)

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -517,6 +517,7 @@ struct ShellSidebarView: View {
         ShellTabSidebarRow(
             title: projection.title,
             subtitle: projection.secondaryLine,
+            isActivitySubtitle: projection.activity != nil,
             iconName: tabIconName(for: tab),
             progress: projection.progress,
             attention: strongestAttention(for: tab),
@@ -951,11 +952,29 @@ private struct ShellSidebarRowBackground: View {
     }
 }
 
+private enum ShellSidebarTypography {
+    static let titleSize: CGFloat = 13
+    static let secondarySize: CGFloat = 11
+    static let markerSize: CGFloat = 9
+    static let pinSize: CGFloat = 8.5
+    static let closeSize: CGFloat = 9.5
+
+    static func titleWeight(isSelected: Bool) -> Font.Weight {
+        isSelected ? .medium : .regular
+    }
+
+    static let secondaryWeight: Font.Weight = .regular
+    static let secondaryEmphasisWeight: Font.Weight = .medium
+    static let iconWeight: Font.Weight = .medium
+    static let markerWeight: Font.Weight = .semibold
+}
+
 private struct ShellTabSidebarRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isKeyboardFocused: Bool
     let title: String
     let subtitle: String
+    let isActivitySubtitle: Bool
     let iconName: String
     let progress: TerminalActivityProgress?
     let attention: ShellAttentionState?
@@ -978,27 +997,41 @@ private struct ShellTabSidebarRow: View {
                 VStack(alignment: .leading, spacing: progress == nil ? 3 : 5) {
                     HStack(spacing: 6) {
                         Text(title)
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(
+                                .system(
+                                    size: ShellSidebarTypography.titleSize,
+                                    weight: ShellSidebarTypography.titleWeight(isSelected: isSelected)
+                                )
+                            )
                             .foregroundStyle(titleForeground)
                             .lineLimit(1)
                             .truncationMode(.middle)
 
                         if showsAlanMarker {
                             Image(systemName: "sparkles")
-                                .font(.system(size: 9, weight: .bold))
+                                .font(
+                                    .system(
+                                        size: ShellSidebarTypography.markerSize,
+                                        weight: ShellSidebarTypography.markerWeight
+                                    )
+                                )
                                 .foregroundStyle(ShellPalette.accent)
                         }
 
                         if isPinned {
                             Image(systemName: "pin.fill")
-                                .font(.system(size: 8.5, weight: .bold))
+                                .font(
+                                    .system(
+                                        size: ShellSidebarTypography.pinSize,
+                                        weight: ShellSidebarTypography.markerWeight
+                                    )
+                                )
                                 .foregroundStyle(ShellPalette.accent.opacity(isSelected ? 0.84 : 0.64))
                                 .help("Pinned tab")
                         }
                     }
 
-                    Text(subtitle)
-                        .font(.system(size: 11, weight: .medium))
+                    subtitleText
                         .foregroundStyle(subtitleForeground)
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -1026,7 +1059,12 @@ private struct ShellTabSidebarRow: View {
 
                     Button(action: onClose) {
                         Image(systemName: "xmark")
-                            .font(.system(size: 9.5, weight: .bold))
+                            .font(
+                                .system(
+                                    size: ShellSidebarTypography.closeSize,
+                                    weight: ShellSidebarTypography.markerWeight
+                                )
+                            )
                             .foregroundStyle(closeForeground)
                             .frame(width: 22, height: 22)
                             .contentShape(Rectangle())
@@ -1088,10 +1126,51 @@ private struct ShellTabSidebarRow: View {
             )
         } else {
             Image(systemName: iconName)
-                .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
+                .font(
+                    .system(
+                        size: ShellSidebarMetrics.iconPointSize,
+                        weight: ShellSidebarTypography.iconWeight
+                    )
+                )
                 .foregroundStyle(iconForeground)
                 .frame(width: ShellSidebarMetrics.iconColumnWidth)
         }
+    }
+
+    private var subtitleText: Text {
+        let parts = subtitle.components(separatedBy: " · ")
+        guard isActivitySubtitle, !parts.isEmpty else {
+            return Text(subtitle)
+                .font(
+                    .system(
+                        size: ShellSidebarTypography.secondarySize,
+                        weight: ShellSidebarTypography.secondaryWeight
+                    )
+                )
+        }
+
+        let emphasizedIndex = emphasizedSubtitleIndex(for: parts)
+        var attributedSubtitle = AttributedString()
+        for element in parts.enumerated() {
+            let (index, part) = element
+            let prefix = index == 0 ? "" : " · "
+            let weight = index == emphasizedIndex
+                ? ShellSidebarTypography.secondaryEmphasisWeight
+                : ShellSidebarTypography.secondaryWeight
+            var fragment = AttributedString(prefix + part)
+            fragment.font = .system(size: ShellSidebarTypography.secondarySize, weight: weight)
+            attributedSubtitle += fragment
+        }
+        return Text(attributedSubtitle)
+    }
+
+    private func emphasizedSubtitleIndex(for parts: [String]) -> Int {
+        if parts.count >= 3,
+           parts[0].hasPrefix("Pane ")
+        {
+            return 1
+        }
+        return 0
     }
 
     private var iconForeground: Color {

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1005,6 +1005,16 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "private enum ShellSidebarTypography" \
+    "sidebar tab typography must use role-based typography tokens"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "private enum ShellPaneTitleTypography" \
+    "pane title typography must use role-based typography tokens"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "onFocusSplitPane: \\{ paneID in" \
     "sidebar split indicators must preserve direct clicked-pane targeting"
 


### PR DESCRIPTION
## Summary
- Add role-based typography tokens for sidebar tab rows and pane title bars.
- Reduce blanket semibold usage so selected titles, inactive titles, secondary text, and activity emphasis have clearer hierarchy.
- Keep activity attention visible by emphasizing only the source/actionable segment instead of making the whole row heavy.

## Verification
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- git diff --check origin/main HEAD
- openspec validate add-advanced-terminal-activity-semantics --type change --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-typography build