### PR TITLE
Fix terminal input routing regressions

### DIFF
--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -123,7 +123,7 @@ final class AlanGhosttyLiveHost: NSObject {
         return ghostty_surface_key_is_binding(surface, keyEvent, flags)
     }
 
-    func sendText(_ text: String) {
+    func sendProgrammaticText(_ text: String) {
         guard let surface, !text.isEmpty else { return }
         let isCommandSubmission = isCommandSubmissionText(text)
         if isCommandSubmission {

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -1629,27 +1629,40 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 }
 
+private struct AlanTerminalInputTraceConfig {
+    let isEnabled: Bool
+    let fileURL: URL?
+}
+
 private final class AlanTerminalInputTrace {
-    private let fileURL: URL?
+    private let environment: [String: String]
+    private let defaults: UserDefaults
+    private let fileManager: FileManager
     private let lock = NSLock()
     private let timestampFormatter: ISO8601DateFormatter
+    private let configRefreshInterval: TimeInterval = 0.5
+    private var cachedConfig: AlanTerminalInputTraceConfig?
+    private var lastConfigRefresh = Date.distantPast
 
-    let isEnabled: Bool
+    var isEnabled: Bool {
+        currentConfig().isEnabled
+    }
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default
     ) {
-        isEnabled = Self.isTruthy(environment["ALAN_TERMINAL_INPUT_TRACE"])
-            || defaults.bool(forKey: "AlanTerminalInputTraceEnabled")
-        fileURL = Self.resolveFileURL(environment: environment, defaults: defaults, fileManager: fileManager)
+        self.environment = environment
+        self.defaults = defaults
+        self.fileManager = fileManager
         timestampFormatter = ISO8601DateFormatter()
         timestampFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     }
 
     func log(_ message: @autoclosure () -> String) {
-        guard isEnabled, let fileURL else { return }
+        let config = currentConfig()
+        guard config.isEnabled, let fileURL = config.fileURL else { return }
 
         let line = "\(timestampFormatter.string(from: Date())) \(message())\n"
         guard let data = line.data(using: .utf8) else { return }
@@ -1672,6 +1685,45 @@ private final class AlanTerminalInputTrace {
         } catch {
             // Tracing is diagnostic-only and must never affect terminal input delivery.
         }
+    }
+
+    private func currentConfig() -> AlanTerminalInputTraceConfig {
+        let now = Date()
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let cachedConfig,
+           now.timeIntervalSince(lastConfigRefresh) < configRefreshInterval
+        {
+            return cachedConfig
+        }
+
+        defaults.synchronize()
+        let config = Self.resolveConfig(
+            environment: environment,
+            defaults: defaults,
+            fileManager: fileManager
+        )
+        cachedConfig = config
+        lastConfigRefresh = now
+        return config
+    }
+
+    private static func resolveConfig(
+        environment: [String: String],
+        defaults: UserDefaults,
+        fileManager: FileManager
+    ) -> AlanTerminalInputTraceConfig {
+        AlanTerminalInputTraceConfig(
+            isEnabled: isTruthy(environment["ALAN_TERMINAL_INPUT_TRACE"])
+                || defaults.bool(forKey: "AlanTerminalInputTraceEnabled"),
+            fileURL: resolveFileURL(
+                environment: environment,
+                defaults: defaults,
+                fileManager: fileManager
+            )
+        )
     }
 
     private static func resolveFileURL(

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -618,6 +618,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func mouseDragged(with event: NSEvent) {
+        if focusClickAdapter.shouldSuppressLeftMouseDrag() {
+            return
+        }
         routePointer(terminalPointerInput(for: event, phase: .drag, button: .primary))
     }
 

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -9,11 +9,12 @@ import GhosttyKit
 #endif
 
 final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHandle {
+    private static let inputTrace = AlanTerminalInputTrace()
+
     private let canvasView = makeCanvasView()
     private let overlayPresenter = TerminalHostOverlayPresenter()
     private let surfaceController = AlanTerminalSurfaceController()
     private let keyEquivalentAdapter = AlanTerminalKeyEquivalentAdapter()
-    private let focusClickAdapter = AlanTerminalFocusClickAdapter()
     private let runtimeReporter = TerminalHostRuntimeReporter()
     private let windowObserver = TerminalHostWindowObserver()
 
@@ -114,7 +115,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
         if result {
-            focusClickAdapter.resetSuppression()
+            surfaceController.resetInputRouting()
             synchronizeLiveHost()
             publishRuntimeSnapshot()
         }
@@ -250,7 +251,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     private func localEventKeyUp(_ event: NSEvent) -> NSEvent? {
         guard event.modifierFlags.contains(.command) else { return event }
-        guard isFocused else { return event }
+        guard terminalInputIsActive else { return event }
         keyUp(with: event)
         return nil
     }
@@ -261,18 +262,31 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
               event.window == window,
               let contentView = window.contentView
         else {
+            traceTerminalInput(
+                "local-leftMouseDown ignored",
+                event: event,
+                details: "reason=window_mismatch"
+            )
             return event
         }
 
         let location = contentView.convert(event.locationInWindow, from: nil)
-        let hitOwnsTerminal = terminalHostOwnsHitTestView(contentView.hitTest(location))
-        switch focusClickAdapter.routeLeftMouseDown(
+        let hitView = contentView.hitTest(location)
+        let hitOwnsTerminal = terminalHostOwnsHitTestView(hitView)
+        let decision = surfaceController.routeLeftMouseDown(
             hitOwnsTerminal: hitOwnsTerminal,
             commandSurfaceVisible: false,
-            isFirstResponder: isFocused,
+            isFirstResponder: terminalInputIsActive,
             appIsActive: NSApp.isActive,
             windowIsKey: window.isKeyWindow
-        ) {
+        )
+        traceTerminalInput(
+            "local-leftMouseDown",
+            event: event,
+            details: "hitOwnsTerminal=\(hitOwnsTerminal) hitView=\(traceViewName(hitView)) decision=\(decision)"
+        )
+
+        switch decision {
         case .ignored, .deliverToTerminal:
             return event
         case .focusOnly:
@@ -342,7 +356,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         let stage: TerminalHostStage = {
             guard superview != nil else { return .scaffold }
             guard window != nil else { return .viewAttached }
-            return isFocused ? .focused : .windowAttached
+            return terminalInputIsActive ? .focused : .windowAttached
         }()
 
         let displayID = (screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)
@@ -357,7 +371,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             displayName: screen?.localizedName,
             displayID: displayID,
             attachedWindowTitle: window?.title,
-            isFocused: isFocused,
+            isFocused: terminalInputIsActive,
             renderer: rendererSnapshot,
             paneMetadata: paneMetadata,
             surfaceState: surfaceController.surfaceStateSnapshot,
@@ -372,7 +386,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         surfaceController.attach(
             to: canvasView,
             bootProfile: bootProfile,
-            focused: isFocused,
+            focused: terminalInputIsActive,
             onDiagnosticsChange: { [weak self] snapshot in
                 guard let self else { return }
                 rendererSnapshot = snapshot
@@ -455,6 +469,62 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         window?.firstResponder === self
     }
 
+    private var terminalInputIsActive: Bool {
+        isSelected && isFocused
+    }
+
+    private func traceTerminalInput(
+        _ eventName: String,
+        event: NSEvent? = nil,
+        details: @autoclosure () -> String = ""
+    ) {
+        guard Self.inputTrace.isEnabled else { return }
+        let paneID = pane?.paneID ?? "nil"
+        let firstResponder = traceResponderName(window?.firstResponder)
+        let windowKey = window?.isKeyWindow == true
+        let timestamp = event.map { String(format: "%.6f", $0.timestamp) } ?? "nil"
+        let point = event.map { tracePoint(localPoint(for: $0)) } ?? "nil"
+        let detailText = details()
+        let suffix = detailText.isEmpty ? "" : " \(detailText)"
+        Self.inputTrace.log(
+            "\(eventName) pane=\(paneID) selected=\(isSelected) firstResponderSelf=\(isFocused) active=\(terminalInputIsActive) appActive=\(NSApp.isActive) windowKey=\(windowKey) firstResponder=\(firstResponder) ts=\(timestamp) point=\(point)\(suffix)"
+        )
+    }
+
+    private func tracePointerInput(
+        _ eventName: String,
+        input: AlanTerminalPointerInput,
+        decision: AlanTerminalPointerRoutingDecision,
+        handled: Bool
+    ) {
+        guard Self.inputTrace.isEnabled else { return }
+        switch input.phase {
+        case .buttonDown, .buttonUp, .drag:
+            break
+        case .entered, .moved, .exited, .pressure:
+            return
+        }
+
+        let paneID = pane?.paneID ?? "nil"
+        Self.inputTrace.log(
+            "\(eventName) pane=\(paneID) selected=\(isSelected) firstResponderSelf=\(isFocused) active=\(terminalInputIsActive) phase=\(input.phase) button=\(input.normalizedButton.map { String(describing: $0) } ?? "nil") x=\(String(format: "%.1f", input.x)) y=\(String(format: "%.1f", input.y)) decision=\(decision) handled=\(handled)"
+        )
+    }
+
+    private func tracePoint(_ point: CGPoint) -> String {
+        "(\(String(format: "%.1f", point.x)),\(String(format: "%.1f", point.y)))"
+    }
+
+    private func traceResponderName(_ responder: NSResponder?) -> String {
+        guard let responder else { return "nil" }
+        return String(describing: type(of: responder))
+    }
+
+    private func traceViewName(_ view: NSView?) -> String {
+        guard let view else { return "nil" }
+        return String(describing: type(of: view))
+    }
+
     private func focusTerminalSoon() {
         guard isSelected, pane != nil else { return }
         guard window != nil else {
@@ -530,24 +600,51 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     @discardableResult
     private func routePointer(_ input: AlanTerminalPointerInput) -> Bool {
+        let decision = pointerDecision(for: input)
+        let handled = executePointerDecision(decision)
+        tracePointerInput("pointer-route", input: input, decision: decision, handled: handled)
+        return handled
+    }
+
+    private func pointerDecision(
+        for input: AlanTerminalPointerInput
+    ) -> AlanTerminalPointerRoutingDecision {
 #if canImport(GhosttyKit)
-        return deliverPointerDecision(surfaceController.routePointer(input))
+        return surfaceController.routePointer(input)
+#else
+        return .ignored
+#endif
+    }
+
+    @discardableResult
+    private func executePointerDecision(_ decision: AlanTerminalPointerRoutingDecision) -> Bool {
+#if canImport(GhosttyKit)
+        return deliverPointerDecision(decision)
 #else
         return false
 #endif
     }
 
     override func mouseDown(with event: NSEvent) {
+        traceTerminalInput("raw-leftMouseDown", event: event)
         activateTerminalHostForMouseEvent()
         routePointer(terminalPointerInput(for: event, phase: .buttonDown, button: .primary))
     }
 
     override func mouseUp(with event: NSEvent) {
-        if focusClickAdapter.consumeSuppressedLeftMouseUp() {
+        let buttonUpDecision = pointerDecision(
+            for: terminalPointerInput(for: event, phase: .buttonUp, button: .primary)
+        )
+        traceTerminalInput(
+            "raw-leftMouseUp",
+            event: event,
+            details: "decision=\(buttonUpDecision)"
+        )
+        if buttonUpDecision == .consumed {
             return
         }
         previousPressureStage = 0
-        routePointer(terminalPointerInput(for: event, phase: .buttonUp, button: .primary))
+        executePointerDecision(buttonUpDecision)
         routePointer(
             AlanTerminalPointerInput(
                 phase: .pressure,
@@ -618,9 +715,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     override func mouseDragged(with event: NSEvent) {
-        if focusClickAdapter.shouldSuppressLeftMouseDrag() {
-            return
-        }
+        traceTerminalInput("raw-leftMouseDragged", event: event)
         routePointer(terminalPointerInput(for: event, phase: .drag, button: .primary))
     }
 
@@ -645,6 +740,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     @discardableResult
     private func routeWrappedMouseEvent(_ routedEvent: AlanTerminalRoutedMouseEvent, _ event: NSEvent) -> Bool {
+        traceTerminalInput(
+            "wrapped-\(routedEvent)",
+            event: event,
+            details: "source=nativeScrollView"
+        )
         switch routedEvent {
         case .mouseDown:
             mouseDown(with: event)
@@ -758,6 +858,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
              .terminalSelection(let operation),
              .terminalHover(let operation):
             return deliverPointerOperation(operation)
+        case .consumed:
+            return true
         case .ignored:
             return false
         }
@@ -852,7 +954,9 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
 #if canImport(GhosttyKit)
         guard !isApplicationReservedKeyEquivalent(event) else { return false }
-        guard event.type == .keyDown, isFocused, surfaceController.isSurfaceReady == true else { return false }
+        guard event.type == .keyDown,
+              terminalInputIsActive,
+              surfaceController.isSurfaceReady == true else { return false }
 
         var keyEvent = ghosttyKeyEvent(for: event, action: GHOSTTY_ACTION_PRESS)
         var flags = ghostty_binding_flags_e(0)
@@ -864,7 +968,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         switch keyEquivalentAdapter.routeKeyEquivalent(
             terminalKeyEquivalentInput(for: event),
-            isFocused: isFocused,
+            isFocused: terminalInputIsActive,
             isTerminalBinding: isBinding
         ) {
         case .sendOriginal:
@@ -905,7 +1009,26 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         requestTerminalFocus()
         keyEquivalentAdapter.clearPendingRedispatch()
-        let inputRoutingDecision = surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event))
+        let keyboardDecision = surfaceController.routeKeyboard(
+            terminalKeyInput(for: event),
+            hasMarkedText: markedText.length > 0
+        )
+
+        switch keyboardDecision {
+        case .workspaceCommand(let command):
+            workspaceCommandHandler?(command)
+            return
+        case .nativeCommand("find"):
+            _ = beginFindInteraction()
+            return
+        case .nativeCommand("quit"):
+            NSApp.terminate(nil)
+            return
+        case .nativeCommand, .drop:
+            return
+        case .interpretTextInput, .terminalKey:
+            break
+        }
 
         let translationModsGhostty =
             surfaceController.keyTranslationMods(for: modsFromEvent(event))
@@ -954,10 +1077,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         defer { keyTextAccumulator = nil }
 
         let markedTextBefore = markedText.length > 0
-        let shouldInterpretText = surfaceController.inputAdapter.shouldInterpretTextInput(
-            inputRoutingDecision,
-            hasMarkedText: markedTextBefore
-        )
+        let shouldInterpretText = keyboardDecision == .interpretTextInput
         let keyboardIDBefore = !markedTextBefore && shouldInterpretText
             ? AlanKeyboardLayout.currentID
             : nil
@@ -976,7 +1096,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
            !keyTextAccumulator.isEmpty
         {
             for text in keyTextAccumulator {
-                guard !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+                guard !AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
                     text,
                     composing: composing
                 ) else {
@@ -986,7 +1106,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
                 if markedTextBefore {
                     sendCommittedPreeditText(text, action: action)
                 } else {
-                    surfaceController.sendText(text)
+                    sendGhosttyKeyEvent(
+                        for: event,
+                        action: action,
+                        translationMods: translationMods,
+                        textOverride: text,
+                        composing: false
+                    )
                 }
             }
 
@@ -1001,7 +1127,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return
         }
 
-        if AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+        if AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
             event.characters,
             composing: composing
         ) {
@@ -1145,6 +1271,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         action: ghostty_input_action_e,
         translationMods: NSEvent.ModifierFlags,
         textEvent: NSEvent? = nil,
+        textOverride: String? = nil,
         composing: Bool
     ) -> Bool {
         var keyEvent = ghosttyKeyEvent(
@@ -1154,10 +1281,8 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         )
         keyEvent.composing = composing
 
-        if let textEvent,
-           let text = textForKeyEvent(textEvent),
-           shouldSendText(text)
-        {
+        let text = textOverride ?? textEvent.flatMap { textForKeyEvent($0) }
+        if let text, shouldSendText(text) {
             return text.withCString { cString in
                 keyEvent.text = cString
                 return surfaceController.sendKey(keyEvent)
@@ -1237,19 +1362,23 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func routeNativeKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
-        switch surfaceController.inputAdapter.routeKey(terminalKeyInput(for: event)) {
+        switch surfaceController.routeKeyboard(
+            terminalKeyInput(for: event),
+            hasMarkedText: markedText.length > 0
+        ) {
         case .nativeCommand("find"):
             return beginFindInteraction()
         case .nativeCommand("quit"):
             return false
-        case .nativeCommand, .terminalText, .terminalKey, .ignored:
+        case .nativeCommand, .workspaceCommand, .terminalKey, .interpretTextInput, .drop:
             return false
         }
     }
 
     private func routeWorkspaceKeyCommandIfNeeded(_ event: NSEvent) -> Bool {
-        guard let command = surfaceController.inputAdapter.routeWorkspaceCommand(
-            terminalKeyInput(for: event)
+        guard case .workspaceCommand(let command) = surfaceController.routeKeyboard(
+            terminalKeyInput(for: event),
+            hasMarkedText: markedText.length > 0
         ) else {
             return false
         }
@@ -1365,7 +1494,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         let wasComposing = markedText.length > 0
         unmarkText()
-        guard !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+        guard !AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
             characters,
             composing: wasComposing
         ) else { return }
@@ -1375,7 +1504,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             self.keyTextAccumulator = keyTextAccumulator
         } else {
 #if canImport(GhosttyKit)
-            surfaceController.sendText(characters)
+            surfaceController.sendProgrammaticText(characters)
 #endif
         }
     }
@@ -1497,6 +1626,85 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         if refocusTerminal {
             requestTerminalFocus()
         }
+    }
+}
+
+private final class AlanTerminalInputTrace {
+    private let fileURL: URL?
+    private let lock = NSLock()
+    private let timestampFormatter: ISO8601DateFormatter
+
+    let isEnabled: Bool
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default
+    ) {
+        isEnabled = Self.isTruthy(environment["ALAN_TERMINAL_INPUT_TRACE"])
+            || defaults.bool(forKey: "AlanTerminalInputTraceEnabled")
+        fileURL = Self.resolveFileURL(environment: environment, defaults: defaults, fileManager: fileManager)
+        timestampFormatter = ISO8601DateFormatter()
+        timestampFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    }
+
+    func log(_ message: @autoclosure () -> String) {
+        guard isEnabled, let fileURL else { return }
+
+        let line = "\(timestampFormatter.string(from: Date())) \(message())\n"
+        guard let data = line.data(using: .utf8) else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: fileURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            // Tracing is diagnostic-only and must never affect terminal input delivery.
+        }
+    }
+
+    private static func resolveFileURL(
+        environment: [String: String],
+        defaults: UserDefaults,
+        fileManager: FileManager
+    ) -> URL? {
+        if let override = environment["ALAN_TERMINAL_INPUT_TRACE_PATH"],
+           !override.isEmpty {
+            return URL(fileURLWithPath: expandingHomeDirectory(in: override))
+        }
+        if let override = defaults.string(forKey: "AlanTerminalInputTracePath"),
+           !override.isEmpty {
+            return URL(fileURLWithPath: expandingHomeDirectory(in: override))
+        }
+
+        guard let libraryURL = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return libraryURL
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("Alan", isDirectory: true)
+            .appendingPathComponent("terminal-input-trace.log", isDirectory: false)
+    }
+
+    private static func expandingHomeDirectory(in path: String) -> String {
+        guard path == "~" || path.hasPrefix("~/") else { return path }
+        return NSHomeDirectory() + String(path.dropFirst())
+    }
+
+    private static func isTruthy(_ value: String?) -> Bool {
+        guard let value = value?.lowercased() else { return false }
+        return value == "1" || value == "true" || value == "yes" || value == "on"
     }
 }
 

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -321,7 +321,7 @@ protocol AlanGhosttyEventSurfaceHandle:
         _ keyEvent: ghostty_input_key_s,
         flags: UnsafeMutablePointer<ghostty_binding_flags_e>?
     ) -> Bool
-    func sendText(_ text: String)
+    func sendProgrammaticText(_ text: String)
     func sendPreedit(_ text: String?)
     func sendMousePosition(x: Double, y: Double, mods: ghostty_input_mods_e)
     func sendMouseButton(
@@ -513,7 +513,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         }
 
 #if canImport(GhosttyKit)
-        liveHost.sendText(text)
+        liveHost.sendProgrammaticText(text)
         return recordDelivery(
             .accepted(
                 byteCount: text.lengthOfBytes(using: .utf8),
@@ -608,8 +608,8 @@ extension AlanGhosttySurfaceHandle: AlanGhosttyEventSurfaceHandle {
         liveHost.keyIsBinding(keyEvent, flags: flags)
     }
 
-    func sendText(_ text: String) {
-        liveHost.sendText(text)
+    func sendProgrammaticText(_ text: String) {
+        liveHost.sendProgrammaticText(text)
     }
 
     func sendPreedit(_ text: String?) {

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -214,29 +214,15 @@ struct AlanTerminalKeyInput: Equatable {
     let isRepeat: Bool
 }
 
-enum AlanTerminalInputRoutingDecision: Equatable {
+enum AlanTerminalKeyboardRoutingDecision: Equatable {
     case nativeCommand(String)
-    case terminalText(String)
+    case workspaceCommand(ShellWorkspaceCommand)
     case terminalKey
-    case ignored
+    case interpretTextInput
+    case drop
 }
 
-@MainActor
-final class AlanTerminalInputAdapter {
-    func shouldInterpretTextInput(
-        _ decision: AlanTerminalInputRoutingDecision,
-        hasMarkedText: Bool
-    ) -> Bool {
-        switch decision {
-        case .terminalText:
-            return true
-        case .terminalKey:
-            return hasMarkedText
-        case .nativeCommand, .ignored:
-            return false
-        }
-    }
-
+enum AlanTerminalTextCompositionPolicy {
     static func shouldSuppressComposingControlInput(
         _ text: String?,
         composing: Bool
@@ -249,94 +235,6 @@ final class AlanTerminalInputAdapter {
         }
         return scalar.value < 0x20 || scalar.value == 0x7F
     }
-
-    func routeWorkspaceCommand(_ input: AlanTerminalKeyInput) -> ShellWorkspaceCommand? {
-        guard input.phase == .down, !input.isRepeat else { return nil }
-
-        let characters = input.characters?.lowercased()
-        switch input.modifiers {
-        case [.command]:
-            switch characters {
-            case "d":
-                return .splitRight
-            case "t":
-                return .newTerminalTab
-            case "w":
-                return .closeTab
-            default:
-                return nil
-            }
-        case [.command, .shift]:
-            switch characters {
-            case "d":
-                return .splitDown
-            case "w":
-                return .closePane
-            default:
-                return nil
-            }
-        case [.command, .option]:
-            switch characters {
-            case "d":
-                return .splitLeft
-            case "t":
-                return .newAlanTab
-            case "=" where input.keyCode == 0x18:
-                return .equalizeSplits
-            default:
-                return nil
-            }
-        case [.command, .option, .shift]:
-            return characters == "d" ? .splitUp : nil
-        case [.command, .control]:
-            switch input.keyCode {
-            case 0x7B:
-                return .focusLeft
-            case 0x7C:
-                return .focusRight
-            case 0x7E:
-                return .focusUp
-            case 0x7D:
-                return .focusDown
-            default:
-                return nil
-            }
-        default:
-            return nil
-        }
-    }
-
-    func routeKey(_ input: AlanTerminalKeyInput) -> AlanTerminalInputRoutingDecision {
-        if input.phase == .down,
-           input.modifiers == .command,
-           input.characters?.lowercased() == "q"
-        {
-            return .nativeCommand("quit")
-        }
-
-        if input.phase == .down,
-           input.modifiers == .command,
-           input.characters?.lowercased() == "f"
-        {
-            return .nativeCommand("find")
-        }
-
-        guard input.phase == .down else { return .terminalKey }
-        guard input.modifiers.subtracting([.shift]).isEmpty else {
-            return .terminalKey
-        }
-        guard let characters = input.characters, !characters.isEmpty else { return .terminalKey }
-        if characters.count == 1, let scalar = characters.unicodeScalars.first {
-            if scalar.value < 0x20 || scalar.value == 0x7F {
-                return .terminalKey
-            }
-            if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
-                return .terminalKey
-            }
-        }
-        return .terminalText(characters)
-    }
-
 }
 
 struct AlanTerminalKeyEquivalentInput: Equatable {
@@ -426,49 +324,6 @@ enum AlanTerminalLeftMouseDownRoutingDecision: Equatable {
 }
 
 @MainActor
-final class AlanTerminalFocusClickAdapter {
-    private var suppressNextLeftMouseUp = false
-
-    func routeLeftMouseDown(
-        hitOwnsTerminal: Bool,
-        commandSurfaceVisible: Bool,
-        isFirstResponder: Bool,
-        appIsActive: Bool,
-        windowIsKey: Bool
-    ) -> AlanTerminalLeftMouseDownRoutingDecision {
-        suppressNextLeftMouseUp = false
-
-        guard hitOwnsTerminal, !commandSurfaceVisible else {
-            return .ignored
-        }
-
-        guard !isFirstResponder else {
-            return .deliverToTerminal
-        }
-
-        if appIsActive && windowIsKey {
-            suppressNextLeftMouseUp = true
-            return .focusOnly
-        }
-
-        return .focusAndDeliver
-    }
-
-    func consumeSuppressedLeftMouseUp() -> Bool {
-        guard suppressNextLeftMouseUp else { return false }
-        suppressNextLeftMouseUp = false
-        return true
-    }
-
-    func shouldSuppressLeftMouseDrag() -> Bool {
-        suppressNextLeftMouseUp
-    }
-
-    func resetSuppression() {
-        suppressNextLeftMouseUp = false
-    }
-}
-
 enum AlanTerminalPointerPhase: Equatable {
     case entered
     case moved
@@ -563,6 +418,7 @@ enum AlanTerminalPointerRoutingDecision: Equatable {
     case terminalMouse(AlanTerminalPointerOperation)
     case terminalSelection(AlanTerminalPointerOperation)
     case terminalHover(AlanTerminalPointerOperation)
+    case consumed
     case ignored
 }
 
@@ -644,6 +500,176 @@ final class AlanTerminalPointerAdapter {
         case .alternateScreen, .mouseReporting:
             return .terminalMouse(operation)
         }
+    }
+}
+
+@MainActor
+final class AlanTerminalInputRouter {
+    private enum PrimaryButtonSequence {
+        case idle
+        case suppressingFocusTransfer
+    }
+
+    private let pointerAdapter = AlanTerminalPointerAdapter()
+    private var primaryButtonSequence = PrimaryButtonSequence.idle
+
+    func reset() {
+        primaryButtonSequence = .idle
+    }
+
+    func routeLeftMouseDown(
+        hitOwnsTerminal: Bool,
+        commandSurfaceVisible: Bool,
+        isFirstResponder: Bool,
+        appIsActive: Bool,
+        windowIsKey: Bool
+    ) -> AlanTerminalLeftMouseDownRoutingDecision {
+        primaryButtonSequence = .idle
+
+        guard hitOwnsTerminal, !commandSurfaceVisible else {
+            return .ignored
+        }
+
+        guard !isFirstResponder else {
+            return .deliverToTerminal
+        }
+
+        if appIsActive && windowIsKey {
+            primaryButtonSequence = .suppressingFocusTransfer
+            return .focusOnly
+        }
+
+        return .focusAndDeliver
+    }
+
+    func routeKeyboard(
+        _ input: AlanTerminalKeyInput,
+        hasMarkedText: Bool
+    ) -> AlanTerminalKeyboardRoutingDecision {
+        if let command = routeWorkspaceCommand(input) {
+            return .workspaceCommand(command)
+        }
+
+        if input.phase == .down,
+           input.modifiers == .command,
+           input.characters?.lowercased() == "q"
+        {
+            return .nativeCommand("quit")
+        }
+
+        if input.phase == .down,
+           input.modifiers == .command,
+           input.characters?.lowercased() == "f"
+        {
+            return .nativeCommand("find")
+        }
+
+        guard input.phase == .down else { return .terminalKey }
+
+        if hasMarkedText {
+            return .interpretTextInput
+        }
+
+        if shouldInterpretTextInput(input) {
+            return .interpretTextInput
+        }
+
+        return .terminalKey
+    }
+
+    private func shouldInterpretTextInput(_ input: AlanTerminalKeyInput) -> Bool {
+        guard input.modifiers.subtracting([.shift]).isEmpty else { return false }
+        guard let characters = input.characters, !characters.isEmpty else { return false }
+        if characters.count == 1, let scalar = characters.unicodeScalars.first {
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                return false
+            }
+            if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
+                return false
+            }
+        }
+        return true
+    }
+
+    func routeWorkspaceCommand(_ input: AlanTerminalKeyInput) -> ShellWorkspaceCommand? {
+        guard input.phase == .down, !input.isRepeat else { return nil }
+
+        let characters = input.characters?.lowercased()
+        switch input.modifiers {
+        case [.command]:
+            switch characters {
+            case "d":
+                return .splitRight
+            case "t":
+                return .newTerminalTab
+            case "w":
+                return .closeTab
+            default:
+                return nil
+            }
+        case [.command, .shift]:
+            switch characters {
+            case "d":
+                return .splitDown
+            case "w":
+                return .closePane
+            default:
+                return nil
+            }
+        case [.command, .option]:
+            switch characters {
+            case "d":
+                return .splitLeft
+            case "t":
+                return .newAlanTab
+            case "=" where input.keyCode == 0x18:
+                return .equalizeSplits
+            default:
+                return nil
+            }
+        case [.command, .option, .shift]:
+            return characters == "d" ? .splitUp : nil
+        case [.command, .control]:
+            switch input.keyCode {
+            case 0x7B:
+                return .focusLeft
+            case 0x7C:
+                return .focusRight
+            case 0x7E:
+                return .focusUp
+            case 0x7D:
+                return .focusDown
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+
+    func routePointer(
+        _ input: AlanTerminalPointerInput,
+        terminalMode: AlanTerminalMode,
+        surfaceReady: Bool
+    ) -> AlanTerminalPointerRoutingDecision {
+        if shouldConsumePrimaryFocusTransfer(input) {
+            if input.phase == .buttonUp {
+                primaryButtonSequence = .idle
+            }
+            return .consumed
+        }
+
+        return pointerAdapter.routePointer(
+            input,
+            terminalMode: terminalMode,
+            surfaceReady: surfaceReady
+        )
+    }
+
+    private func shouldConsumePrimaryFocusTransfer(_ input: AlanTerminalPointerInput) -> Bool {
+        guard primaryButtonSequence == .suppressingFocusTransfer else { return false }
+        guard input.normalizedButton == .primary else { return false }
+        return input.phase == .buttonDown || input.phase == .drag || input.phase == .buttonUp
     }
 }
 
@@ -928,8 +954,7 @@ final class AlanTerminalMetadataAdapter {
 
 @MainActor
 final class AlanTerminalSurfaceController {
-    let inputAdapter = AlanTerminalInputAdapter()
-    let pointerAdapter = AlanTerminalPointerAdapter()
+    let inputRouter = AlanTerminalInputRouter()
     let scrollbackAdapter = AlanTerminalScrollbackAdapter()
     let nativeScrollViewAdapter = AlanTerminalNativeScrollViewAdapter()
     let metadataAdapter = AlanTerminalMetadataAdapter()
@@ -1121,11 +1146,38 @@ final class AlanTerminalSurfaceController {
     }
 
     func routePointer(_ input: AlanTerminalPointerInput) -> AlanTerminalPointerRoutingDecision {
-        pointerAdapter.routePointer(
+        inputRouter.routePointer(
             input,
             terminalMode: scrollbackAdapter.state.metrics.mode,
             surfaceReady: isSurfaceReady
         )
+    }
+
+    func routeKeyboard(
+        _ input: AlanTerminalKeyInput,
+        hasMarkedText: Bool
+    ) -> AlanTerminalKeyboardRoutingDecision {
+        inputRouter.routeKeyboard(input, hasMarkedText: hasMarkedText)
+    }
+
+    func routeLeftMouseDown(
+        hitOwnsTerminal: Bool,
+        commandSurfaceVisible: Bool,
+        isFirstResponder: Bool,
+        appIsActive: Bool,
+        windowIsKey: Bool
+    ) -> AlanTerminalLeftMouseDownRoutingDecision {
+        inputRouter.routeLeftMouseDown(
+            hitOwnsTerminal: hitOwnsTerminal,
+            commandSurfaceVisible: commandSurfaceVisible,
+            isFirstResponder: isFirstResponder,
+            appIsActive: appIsActive,
+            windowIsKey: windowIsKey
+        )
+    }
+
+    func resetInputRouting() {
+        inputRouter.reset()
     }
 
     @discardableResult
@@ -1234,6 +1286,7 @@ final class AlanTerminalSurfaceController {
         let previousReadonly = readonly
         let previousSecureInput = secureInput
         scrollbackAdapter.reset()
+        inputRouter.reset()
         nativeScrollRowHeight = 1
         latestRenderer = .placeholder
         latestMetadata = .placeholder
@@ -1297,8 +1350,8 @@ extension AlanTerminalSurfaceController {
         ghosttySurfaceHandle?.keyIsBinding(keyEvent, flags: flags) ?? false
     }
 
-    func sendText(_ text: String) {
-        ghosttySurfaceHandle?.sendText(text)
+    func sendProgrammaticText(_ text: String) {
+        ghosttySurfaceHandle?.sendProgrammaticText(text)
     }
 
     func sendPreedit(_ text: String?) {

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -460,6 +460,10 @@ final class AlanTerminalFocusClickAdapter {
         return true
     }
 
+    func shouldSuppressLeftMouseDrag() -> Bool {
+        suppressNextLeftMouseUp
+    }
+
     func resetSuppression() {
         suppressNextLeftMouseUp = false
     }

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1085,6 +1085,11 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \
+    "shouldSuppressLeftMouseDrag" \
+    "terminal focus-only split clicks must suppress matching mouse drags"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
     "func insertText\\(_ string: Any, replacementRange: NSRange\\)" \
     "terminal IME text insertion must remain owned by the AppKit terminal host"
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -54,9 +54,55 @@ reject_active_shell_radius_drift() {
     fi
 }
 
+reject_ghosttykit_umbrella_modulemap() {
+    local modulemap
+    while IFS= read -r -d '' modulemap; do
+        if grep -q 'umbrella header "ghostty\.h"' "$modulemap"; then
+            printf 'error: GhosttyKit modulemap must use header "ghostty.h" instead of umbrella header "ghostty.h"\n' >&2
+            printf '       offending modulemap: %s\n' "$modulemap" >&2
+            exit 1
+        fi
+    done < <(find -L "$REPO_ROOT/clients/apple/GhosttyKit.xcframework" -name module.modulemap -type f -print0)
+}
+
+reject_keydown_programmatic_text_delivery() {
+    local file="$REPO_ROOT/clients/apple/alan-macos/TerminalHostView.swift"
+
+    if ! awk '
+        /override func keyDown\(with event: NSEvent\) \{/ {
+            in_keydown = 1
+            depth = 1
+            next
+        }
+
+        in_keydown {
+            if ($0 ~ /sendProgrammaticText[[:space:]]*\(/) {
+                print FILENAME ":" FNR ":" $0 > "/dev/stderr"
+                matched = 1
+            }
+
+            opens = gsub(/\{/, "{")
+            closes = gsub(/\}/, "}")
+            depth += opens - closes
+            if (depth <= 0) {
+                in_keydown = 0
+            }
+        }
+
+        END {
+            exit matched ? 1 : 0
+        }
+    ' "$file"; then
+        printf 'error: TerminalHostView.keyDown must not use programmatic text delivery\n' >&2
+        exit 1
+    fi
+}
+
 "$SCRIPT_DIR/setup-local-ghosttykit.sh" --check >/dev/null
 "$SCRIPT_DIR/check-architecture-maintainability.sh" >/dev/null
 reject_active_shell_radius_drift
+reject_ghosttykit_umbrella_modulemap
+reject_keydown_programmatic_text_delivery
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
@@ -120,8 +166,18 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalSurfaceController.swift" \
+    "enum AlanTerminalTextCompositionPolicy" \
+    "terminal IME composing control-character policy must have an explicit owner"
+
+reject_pattern \
+    "clients/apple/alan-macos/TerminalSurfaceController.swift" \
     "final class AlanTerminalInputAdapter" \
-    "terminal keyboard and IME behavior must be normalized through an input adapter"
+    "terminal input routing must not keep a stale input adapter boundary"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalSurfaceController.swift" \
+    "final class AlanTerminalInputRouter" \
+    "terminal focus and pointer sequence policy must be owned by a single input router"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalSurfaceController.swift" \
@@ -1080,13 +1136,58 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \
-    "consumeSuppressedLeftMouseUp" \
-    "terminal focus-only split clicks must suppress the matching mouse-up"
+    "private var terminalInputIsActive: Bool" \
+    "terminal focus-transfer routing must combine shell selection with AppKit first-responder state"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \
-    "shouldSuppressLeftMouseDrag" \
-    "terminal focus-only split clicks must suppress matching mouse drags"
+    "terminal-input-trace\\.log" \
+    "terminal input trace logs must write to a stable file by default"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "ALAN_TERMINAL_INPUT_TRACE" \
+    "terminal input trace logs must be opt-in by environment"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "ALAN_TERMINAL_INPUT_TRACE_PATH" \
+    "terminal input trace logs must support a file path override"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "AlanTerminalInputTraceEnabled" \
+    "terminal input trace logs must be opt-in by user defaults"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "local-leftMouseDown" \
+    "terminal focus-click diagnostics must log local monitor routing"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "isFirstResponder: terminalInputIsActive" \
+    "focus-only mouse routing must use active terminal input, not raw first-responder state"
+
+require_pattern \
+    "clients/apple/scripts/test-terminal-surface-controller.swift" \
+    "verifiesTerminalInputRouterOwnsFocusOnlyPointerSequence" \
+    "surface controller tests must prove the terminal input router owns focus-only pointer sequences"
+
+reject_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "FocusClickAdapter|focusClickAdapter|consumeSuppressedLeftMouseUp|shouldSuppressLeftMouseDrag" \
+    "focus-only pointer sequence state must not live in TerminalHostView"
+
+reject_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "surfaceController\\.sendText" \
+    "physical terminal keyboard code must not use a generic text delivery path"
+
+require_pattern \
+    "clients/apple/alan-macos/GhosttyLiveHost.swift" \
+    "func sendProgrammaticText" \
+    "Ghostty text injection must be named as programmatic text, not physical keyboard input"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1161,6 +1161,16 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalHostView.swift" \
+    "synchronize\\(\\)" \
+    "terminal input trace defaults must refresh without restarting alan"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
+    "configRefreshInterval" \
+    "terminal input trace must bound live default refresh overhead"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalHostView.swift" \
     "local-leftMouseDown" \
     "terminal focus-click diagnostics must log local monitor routing"
 

--- a/clients/apple/scripts/setup-local-ghosttykit.sh
+++ b/clients/apple/scripts/setup-local-ghosttykit.sh
@@ -52,6 +52,20 @@ link_output() {
     ln -sfn "$source" "$destination"
 }
 
+normalize_ghosttykit_modulemaps() {
+    local framework="$1"
+    local modulemap
+    local tmp
+
+    while IFS= read -r -d '' modulemap; do
+        if grep -q 'umbrella header "ghostty\.h"' "$modulemap"; then
+            tmp="$modulemap.tmp.$$"
+            sed 's/umbrella header "ghostty\.h"/header "ghostty.h"/' "$modulemap" > "$tmp"
+            mv "$tmp" "$modulemap"
+        fi
+    done < <(find -L "$framework" -name module.modulemap -type f -print0)
+}
+
 require_metal_toolchain() {
     if xcrun -sdk macosx --find metal >/dev/null 2>&1; then
         return 0
@@ -134,6 +148,7 @@ ensure_ghosttykit() {
 
     printf '==> Syncing %s -> %s\n' "$resolved" "$CACHE_XCFRAMEWORK"
     sync_path "$resolved" "$CACHE_XCFRAMEWORK"
+    normalize_ghosttykit_modulemaps "$CACHE_XCFRAMEWORK"
 
     printf '==> Linking %s -> %s\n' "$OUTPUT_XCFRAMEWORK" "$CACHE_XCFRAMEWORK"
     link_output "$CACHE_XCFRAMEWORK" "$OUTPUT_XCFRAMEWORK"

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -395,6 +395,26 @@ private enum TerminalSurfaceControllerTests {
             "left mouse-up suppression must be one-shot"
         )
 
+        _ = adapter.routeLeftMouseDown(
+            hitOwnsTerminal: true,
+            commandSurfaceVisible: false,
+            isFirstResponder: false,
+            appIsActive: true,
+            windowIsKey: true
+        )
+        expect(
+            adapter.shouldSuppressLeftMouseDrag(),
+            "focus-only mouse down must suppress matching left mouse drags"
+        )
+        expect(
+            adapter.consumeSuppressedLeftMouseUp(),
+            "focus-only drag suppression must keep suppressing until mouse up"
+        )
+        expect(
+            !adapter.shouldSuppressLeftMouseDrag(),
+            "left mouse-drag suppression must clear after mouse up"
+        )
+
         expect(
             adapter.routeLeftMouseDown(
                 hitOwnsTerminal: true,

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -21,8 +21,10 @@ private enum TerminalSurfaceControllerTests {
         verifiesNativeScrollViewForwardsMouseEvents()
         verifiesInputCommandRouting()
         verifiesTUIKeyboardRoutingKeepsTerminalOwnedKeysInTerminal()
+        verifiesKeyboardPipelineKeepsPhysicalKeysOnGhosttyKeyPath()
         verifiesGhosttyKeyEquivalentRedispatchContract()
         verifiesFocusOnlyClickSuppressionPolicy()
+        verifiesTerminalInputRouterOwnsFocusOnlyPointerSequence()
         verifiesTextInputInterpretationPolicyPreservesIMEMarkedText()
         verifiesPointerRoutingFollowsTerminalMouseModes()
         verifiesPointerButtonMappingMatchesGhostty()
@@ -143,78 +145,96 @@ private enum TerminalSurfaceControllerTests {
     }
 
     private static func verifiesInputCommandRouting() {
-        let adapter = AlanTerminalInputAdapter()
-        let command = adapter.routeKey(
+        let router = AlanTerminalInputRouter()
+        let command = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "q",
                 keyCode: 12,
                 modifiers: [.command],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(command == .nativeCommand("quit"), "command-q must route to the native app command")
 
-        let findCommand = adapter.routeKey(
+        let findCommand = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "f",
                 keyCode: 3,
                 modifiers: [.command],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(findCommand == .nativeCommand("find"), "command-f must route to pane search")
 
-        let printable = adapter.routeKey(
+        let printable = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "a",
                 keyCode: 0,
                 modifiers: [],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
-        expect(printable == .terminalText("a"), "printable key input must become terminal text")
+        expect(
+            printable == .interpretTextInput,
+            "printable key input must enter AppKit text interpretation so IME composition can start"
+        )
 
-        let splitDown = adapter.routeWorkspaceCommand(
+        let splitDown = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "d",
                 keyCode: 2,
                 modifiers: [.command, .shift],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
-        expect(splitDown == .splitDown, "command-shift-d must route to shell split down before terminal bindings")
+        expect(
+            splitDown == .workspaceCommand(.splitDown),
+            "command-shift-d must route to shell split down before terminal bindings"
+        )
 
-        let splitRight = adapter.routeWorkspaceCommand(
+        let splitRight = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "d",
                 keyCode: 2,
                 modifiers: [.command],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
-        expect(splitRight == .splitRight, "command-d must route to shell split right before terminal bindings")
+        expect(
+            splitRight == .workspaceCommand(.splitRight),
+            "command-d must route to shell split right before terminal bindings"
+        )
 
-        let focusRight = adapter.routeWorkspaceCommand(
+        let focusRight = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: nil,
                 keyCode: 0x7C,
                 modifiers: [.command, .control],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
-        expect(focusRight == .focusRight, "command-control-right must route to shell focus right")
+        expect(
+            focusRight == .workspaceCommand(.focusRight),
+            "command-control-right must route to shell focus right"
+        )
     }
 
     private static func verifiesTUIKeyboardRoutingKeepsTerminalOwnedKeysInTerminal() {
-        let adapter = AlanTerminalInputAdapter()
+        let router = AlanTerminalInputRouter()
 
-        let controlWWorkspaceCommand = adapter.routeWorkspaceCommand(
+        let controlWWorkspaceCommand = router.routeWorkspaceCommand(
             AlanTerminalKeyInput(
                 characters: "w",
                 keyCode: 13,
@@ -225,60 +245,174 @@ private enum TerminalSurfaceControllerTests {
         )
         expect(controlWWorkspaceCommand == nil, "control-w must not be consumed as a workspace command")
 
-        let controlW = adapter.routeKey(
+        let controlW = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "\u{17}",
                 keyCode: 13,
                 modifiers: [.control],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(controlW == .terminalKey, "control-w must stay a terminal key for Vim split navigation")
 
-        let escape = adapter.routeKey(
+        let escape = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "\u{1B}",
                 keyCode: 53,
                 modifiers: [],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(escape == .terminalKey, "escape must stay a terminal key for TUI command mode")
 
-        let tab = adapter.routeKey(
+        let tab = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "\t",
                 keyCode: 48,
                 modifiers: [],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(tab == .terminalKey, "tab must stay a terminal key for TUI focus and completion")
 
-        let optionF = adapter.routeKey(
+        let optionF = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "f",
                 keyCode: 3,
                 modifiers: [.option],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
         expect(optionF == .terminalKey, "option-modified keys must preserve modifier-aware terminal delivery")
 
-        let commandT = adapter.routeWorkspaceCommand(
+        let commandT = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "t",
                 keyCode: 17,
                 modifiers: [.command],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: false
         )
-        expect(commandT == .newTerminalTab, "command-t must remain a native workspace shortcut")
+        expect(
+            commandT == .workspaceCommand(.newTerminalTab),
+            "command-t must remain a native workspace shortcut"
+        )
+    }
+
+    private static func verifiesKeyboardPipelineKeepsPhysicalKeysOnGhosttyKeyPath() {
+        let router = AlanTerminalInputRouter()
+
+        let printable = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "a",
+                keyCode: 0,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            printable == .interpretTextInput,
+            "printable physical keys must enter AppKit text interpretation before Ghostty key delivery"
+        )
+
+        let colon = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: ":",
+                keyCode: 41,
+                modifiers: [.shift],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            colon == .interpretTextInput,
+            "shift-printable physical keys must enter AppKit text interpretation before Ghostty key delivery"
+        )
+
+        let escape = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "\u{1B}",
+                keyCode: 53,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            escape == .terminalKey,
+            "Escape must be delivered through Ghostty key events for Vim command mode"
+        )
+
+        let controlBracket = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "\u{1B}",
+                keyCode: 33,
+                modifiers: [.control],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(controlBracket == .terminalKey, "Control-[ must remain terminal-owned")
+
+        let controlW = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "\u{17}",
+                keyCode: 13,
+                modifiers: [.control],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            controlW == .terminalKey,
+            "Control-W must remain terminal-owned for Vim split navigation"
+        )
+
+        let commandT = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "t",
+                keyCode: 17,
+                modifiers: [.command],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            commandT == .workspaceCommand(.newTerminalTab),
+            "Command-T must remain an app workspace command"
+        )
+
+        let composingBackspace = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "\u{7F}",
+                keyCode: 51,
+                modifiers: [],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: true
+        )
+        expect(
+            composingBackspace == .interpretTextInput,
+            "IME marked text must keep control keys in AppKit text interpretation first"
+        )
     }
 
     private static func verifiesGhosttyKeyEquivalentRedispatchContract() {
@@ -374,10 +508,10 @@ private enum TerminalSurfaceControllerTests {
     }
 
     private static func verifiesFocusOnlyClickSuppressionPolicy() {
-        let adapter = AlanTerminalFocusClickAdapter()
+        let router = AlanTerminalInputRouter()
 
         expect(
-            adapter.routeLeftMouseDown(
+            router.routeLeftMouseDown(
                 hitOwnsTerminal: true,
                 commandSurfaceVisible: false,
                 isFirstResponder: false,
@@ -386,37 +520,66 @@ private enum TerminalSurfaceControllerTests {
             ) == .focusOnly,
             "active-window clicks into an unfocused terminal split must only transfer focus"
         )
-        expect(
-            adapter.consumeSuppressedLeftMouseUp(),
-            "focus-only mouse down must suppress the matching left mouse up"
+
+        let suppressedDown = router.routePointer(
+            primaryPointerInput(phase: .buttonDown),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
         )
         expect(
-            !adapter.consumeSuppressedLeftMouseUp(),
-            "left mouse-up suppression must be one-shot"
+            suppressedDown == .consumed,
+            "focus-only mouse down must suppress the matching terminal button press"
         )
 
-        _ = adapter.routeLeftMouseDown(
+        let suppressedUp = router.routePointer(
+            primaryPointerInput(phase: .buttonUp),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
+        expect(
+            suppressedUp == .consumed,
+            "focus-only mouse down must suppress the matching left mouse up"
+        )
+
+        _ = router.routeLeftMouseDown(
             hitOwnsTerminal: true,
             commandSurfaceVisible: false,
             isFirstResponder: false,
             appIsActive: true,
             windowIsKey: true
         )
+        let suppressedDrag = router.routePointer(
+            primaryPointerInput(phase: .drag),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
         expect(
-            adapter.shouldSuppressLeftMouseDrag(),
+            suppressedDrag == .consumed,
             "focus-only mouse down must suppress matching left mouse drags"
         )
-        expect(
-            adapter.consumeSuppressedLeftMouseUp(),
-            "focus-only drag suppression must keep suppressing until mouse up"
+        let dragSuppressionClosingUp = router.routePointer(
+            primaryPointerInput(phase: .buttonUp),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
         )
         expect(
-            !adapter.shouldSuppressLeftMouseDrag(),
+            dragSuppressionClosingUp == .consumed,
+            "focus-only drag suppression must keep suppressing until mouse up"
+        )
+        let postSuppressionDown = router.routePointer(
+            primaryPointerInput(phase: .buttonDown),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
+        expect(
+            postSuppressionDown == .terminalSelection(
+                .button(state: .press, button: .primary, x: 24, y: 48, modifiers: [])
+            ),
             "left mouse-drag suppression must clear after mouse up"
         )
 
         expect(
-            adapter.routeLeftMouseDown(
+            AlanTerminalInputRouter().routeLeftMouseDown(
                 hitOwnsTerminal: true,
                 commandSurfaceVisible: false,
                 isFirstResponder: true,
@@ -427,7 +590,7 @@ private enum TerminalSurfaceControllerTests {
         )
 
         expect(
-            adapter.routeLeftMouseDown(
+            AlanTerminalInputRouter().routeLeftMouseDown(
                 hitOwnsTerminal: true,
                 commandSurfaceVisible: false,
                 isFirstResponder: false,
@@ -438,72 +601,144 @@ private enum TerminalSurfaceControllerTests {
         )
     }
 
-    private static func verifiesTextInputInterpretationPolicyPreservesIMEMarkedText() {
-        let adapter = AlanTerminalInputAdapter()
+    private static func verifiesTerminalInputRouterOwnsFocusOnlyPointerSequence() {
+        let router = AlanTerminalInputRouter()
 
-        let backspace = adapter.routeKey(
-            AlanTerminalKeyInput(
-                characters: "\u{7F}",
-                keyCode: 51,
-                modifiers: [],
-                phase: .down,
-                isRepeat: false
-            )
-        )
-        expect(backspace == .terminalKey, "backspace must remain a terminal-owned key outside IME composition")
         expect(
-            !adapter.shouldInterpretTextInput(backspace, hasMarkedText: false),
-            "backspace must not go through NSTextInput when no IME marked text exists"
+            router.routeLeftMouseDown(
+                hitOwnsTerminal: true,
+                commandSurfaceVisible: false,
+                isFirstResponder: false,
+                appIsActive: true,
+                windowIsKey: true
+            ) == .focusOnly,
+            "active-window focus-transfer clicks must be identified by the terminal input router"
+        )
+
+        let suppressedDown = router.routePointer(
+            primaryPointerInput(phase: .buttonDown),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
         )
         expect(
-            adapter.shouldInterpretTextInput(backspace, hasMarkedText: true),
+            suppressedDown == .consumed,
+            "focus-transfer primary button-down must be consumed even if AppKit still dispatches it"
+        )
+
+        let suppressedDrag = router.routePointer(
+            primaryPointerInput(phase: .drag),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
+        expect(
+            suppressedDrag == .consumed,
+            "focus-transfer primary drags must be consumed by the same input router sequence"
+        )
+
+        let suppressedUp = router.routePointer(
+            primaryPointerInput(phase: .buttonUp),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
+        expect(
+            suppressedUp == .consumed,
+            "focus-transfer primary mouse-up must close the router-owned suppression sequence"
+        )
+
+        let nextPrimaryDown = router.routePointer(
+            primaryPointerInput(phase: .buttonDown),
+            terminalMode: .normalBuffer,
+            surfaceReady: true
+        )
+        expect(
+            nextPrimaryDown == .terminalSelection(
+                .button(state: .press, button: .primary, x: 24, y: 48, modifiers: [])
+            ),
+            "router suppression must end before the next primary button sequence"
+        )
+    }
+
+    private static func primaryPointerInput(
+        phase: AlanTerminalPointerPhase
+    ) -> AlanTerminalPointerInput {
+        AlanTerminalPointerInput(
+            phase: phase,
+            button: .primary,
+            buttonNumber: 0,
+            x: 24,
+            y: 48,
+            modifiers: [],
+            pressureStage: nil,
+            pressure: nil
+        )
+    }
+
+    private static func verifiesTextInputInterpretationPolicyPreservesIMEMarkedText() {
+        let router = AlanTerminalInputRouter()
+
+        let backspace = AlanTerminalKeyInput(
+            characters: "\u{7F}",
+            keyCode: 51,
+            modifiers: [],
+            phase: .down,
+            isRepeat: false
+        )
+        expect(
+            router.routeKeyboard(backspace, hasMarkedText: false) == .terminalKey,
+            "backspace must remain a terminal-owned key outside IME composition"
+        )
+        expect(
+            router.routeKeyboard(backspace, hasMarkedText: true) == .interpretTextInput,
             "backspace must go through NSTextInput while IME marked text exists"
         )
 
-        let printable = adapter.routeKey(
-            AlanTerminalKeyInput(
-                characters: "a",
-                keyCode: 0,
-                modifiers: [],
-                phase: .down,
-                isRepeat: false
-            )
+        let printable = AlanTerminalKeyInput(
+            characters: "a",
+            keyCode: 0,
+            modifiers: [],
+            phase: .down,
+            isRepeat: false
         )
         expect(
-            adapter.shouldInterpretTextInput(printable, hasMarkedText: false),
-            "printable input must still go through NSTextInput"
+            router.routeKeyboard(printable, hasMarkedText: false) == .interpretTextInput,
+            "printable physical input must enter AppKit text interpretation outside active preedit"
+        )
+        expect(
+            router.routeKeyboard(printable, hasMarkedText: true) == .interpretTextInput,
+            "printable input must still go through NSTextInput while IME marked text exists"
         )
 
-        let findCommand = adapter.routeKey(
+        let findCommand = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "f",
                 keyCode: 3,
                 modifiers: [.command],
                 phase: .down,
                 isRepeat: false
-            )
+            ),
+            hasMarkedText: true
         )
         expect(
-            !adapter.shouldInterpretTextInput(findCommand, hasMarkedText: true),
+            findCommand == .nativeCommand("find"),
             "native command shortcuts must not be reinterpreted as IME text input"
         )
 
         expect(
-            AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+            AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
                 "\u{08}",
                 composing: true
             ),
             "raw C0 control input must not leak to the terminal during composition"
         )
         expect(
-            AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+            AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
                 "\u{7F}",
                 composing: true
             ),
             "backspace must not leak to the terminal during composition"
         )
         expect(
-            !AlanTerminalInputAdapter.shouldSuppressComposingControlInput(
+            !AlanTerminalTextCompositionPolicy.shouldSuppressComposingControlInput(
                 "\u{08}",
                 composing: false
             ),

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/design.md
@@ -29,7 +29,7 @@
 
 1. **终端输入优先走 terminal host，再让明确 app command 截获。**
 
-   Focused pane 的 `TerminalHostView` 应该把非 command-key 的控制键、Escape、Tab、Backspace、功能键、Option/Control 组合键和 Ghostty 识别为 terminal binding 的事件交给 terminal surface。IME 组合输入是这个规则的输入法例外：当 AppKit `NSTextInputClient` 已有 marked text 时，Backspace/Ctrl-H 等 control input 必须先交给 `interpretKeyEvents` 更新 preedit，并抑制组合态控制字符漏到 terminal。Command input 可见时仍然优先处理自己的 Escape/Return/Command-P；`Command-T`、`Command-W` 等显式 app/workspace command 继续走 native command routing。
+   Focused pane 的 `TerminalHostView` 应该把非 command-key 的控制键、Escape、Tab、Backspace、功能键、Option/Control 组合键和 Ghostty 识别为 terminal binding 的事件交给 terminal surface。printable/Shift-printable 物理键仍需要先进入 AppKit `interpretKeyEvents`，让中文/日文/韩文 IME 能启动 composition；但最终 committed text 必须重新包成 Ghostty key event 发送，不能走 programmatic text injection。IME 组合输入是这个规则的输入法例外：当 AppKit `NSTextInputClient` 已有 marked text 时，Backspace/Ctrl-H 等 control input 必须先交给 `interpretKeyEvents` 更新 preedit，并抑制组合态控制字符漏到 terminal。Command input 可见时仍然优先处理自己的 Escape/Return/Command-P；`Command-T`、`Command-W` 等显式 app/workspace command 继续走 native command routing。
 
    备选方案是继续先跑 workspace/native routing，再对缺失快捷键逐个开洞。这会把 Vim/TUI 支持变成无穷补丁列表，也容易再次截获 `Ctrl-*` 这类终端快捷键。
 
@@ -57,6 +57,14 @@
 
    备选方案是在 `routeKey` 中继续追加 `Ctrl-*` 白名单。这个方案无法覆盖 AppKit 先调用 `performKeyEquivalent`/`doCommand` 的路径，也无法解释为什么 fake adapter 测试通过但真实 Vim 仍失败。
 
+6. **键盘、鼠标焦点、拖拽和 selection 策略收敛到单一 terminal input router。**
+
+   `TerminalHostView` 应只承担 AppKit 边界职责：把 `NSEvent`、shell selection 和 marked-text 状态归一化成 terminal input、执行 router 返回的 app command / terminal key / interpret text / consume / fallthrough 结果，并把 Ghostty delivery 保持在 host/surface boundary。物理键盘输入的最终 terminal delivery 必须走 Ghostty key event；`ghostty_surface_text` 只保留给 paste、control-plane 和非物理键盘的 programmatic text injection。焦点转移 click、primary button sequence、normal-buffer selection drag、alternate-screen/mouse-reporting delivery 等策略应由 `TerminalSurfaceController` 内的单一 input router 持有，而不是让 HostView 分别询问 focus-click adapter 和 pointer adapter。
+
+   这个 router 需要显式建模 focus-only primary button sequence：active/key window 中点击未成为 active terminal input 的 split pane 时，left mouse down 只转移 focus；同一 primary sequence 的 drag 和 mouse up 都被 consume；sequence 结束后再恢复正常 selection/mouse routing。Alan 的 active terminal input 必须同时满足 shell pane 被选中和 AppKit first responder 属于该 host，避免 stale first-responder 状态把 pane focus click 误判为 terminal selection drag。这样可以匹配 Ghostty 的用户可见行为，同时保留 alan 的 native scrollback、selection、pane focus 和 surface readiness 策略。
+
+   备选方案是继续保留独立 `FocusClickAdapter`，并在 HostView 的每个 mouse override 里补条件。这个方案短期代码少，但会让 sequence state 分散在 AppKit overrides 和 pointer policy 之间，后续很容易再次出现 “down 被吞掉，drag 仍被当成 selection” 这类跨层 bug。
+
 ## Risks / Trade-offs
 
 - [Risk] 放宽 terminal input ownership 可能让部分 workspace 快捷键在 terminal focused 时不再触发。→ 保留显式 app-reserved Command shortcuts，并用测试覆盖 command input 和 terminal binding 的优先级。
@@ -64,6 +72,7 @@
 - [Risk] child exit 自动关闭 pane/tab 可能误关正在展示退出信息的任务。→ 只对 shell child exited 的 terminal lifecycle 信号生效；如果关闭会违反 final-pane 保护，则进入明确 exited state。
 - [Risk] 真实 Vim 行为很难完全自动化。→ 自动化覆盖 key routing contract，手工验证记录覆盖 `vim`/`nvim` 的实际交互。
 - [Risk] local event monitor 可能在多个 pane host 间重复观察事件。→ monitor 只在 hit-tested owning host 或 focused host 上消费事件，并在 teardown 时移除。
+- [Risk] input router 合并后如果把 AppKit delivery 也一起吞进去，会让测试和 Ghostty bridge 变重。→ router 只返回 policy decision，不直接调用 Ghostty；HostView 继续执行 delivery。
 
 ## Migration Plan
 

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
@@ -9,6 +9,12 @@ inheritance, and shell child-exit lifecycle changes.
 - **WHEN** terminal input routing is changed
 - **THEN** verification covers Vim or an equivalent TUI receiving Escape, Tab, Backspace, control-key navigation, printable input, and command-mode transitions in a focused terminal pane
 
+#### Scenario: Physical keyboard and programmatic text stay separate
+- **WHEN** terminal input routing is changed
+- **THEN** verification proves printable physical keys can enter AppKit text interpretation for IME startup while Escape and Control keys remain terminal-owned
+- **AND** verification proves committed printable physical input uses terminal key-event delivery
+- **AND** static checks prevent `TerminalHostView.keyDown` from calling the programmatic text injection path
+
 #### Scenario: Native command routing verification
 - **WHEN** terminal keyboard routing is changed
 - **THEN** verification covers app-reserved `Command` shortcuts and visible command-input keys so terminal input ownership does not break native macOS commands
@@ -17,6 +23,12 @@ inheritance, and shell child-exit lifecycle changes.
 - **WHEN** terminal keyboard routing is changed
 - **THEN** verification covers `performKeyEquivalent`/`doCommand` redispatch for Control or Command key equivalents
 - **AND** verification covers Ghostty's special `Control-/` handling and focus-only split click/drag sequences that must not reach Vim mouse mode or terminal selection
+- **AND** verification covers the terminal input router as the single owner of primary pointer sequence policy instead of only testing separate focus-click or pointer helpers
+
+#### Scenario: GhosttyKit modulemap verification
+- **WHEN** local GhosttyKit artifacts are prepared for the Apple client build
+- **THEN** the setup script normalizes generated GhosttyKit module maps to use `header "ghostty.h"` instead of `umbrella header "ghostty.h"`
+- **AND** shell contract checks reject cached GhosttyKit module maps that would cause Clang umbrella-header warnings for internal `ghostty/vt/*` headers
 
 #### Scenario: New tab cwd verification
 - **WHEN** terminal tab creation is changed

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
@@ -16,7 +16,7 @@ inheritance, and shell child-exit lifecycle changes.
 #### Scenario: AppKit responder-chain verification
 - **WHEN** terminal keyboard routing is changed
 - **THEN** verification covers `performKeyEquivalent`/`doCommand` redispatch for Control or Command key equivalents
-- **AND** verification covers Ghostty's special `Control-/` handling and focus-only split clicks that must not reach Vim mouse mode
+- **AND** verification covers Ghostty's special `Control-/` handling and focus-only split click/drag sequences that must not reach Vim mouse mode or terminal selection
 
 #### Scenario: New tab cwd verification
 - **WHEN** terminal tab creation is changed

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-build-test-contract/spec.md
@@ -30,6 +30,11 @@ inheritance, and shell child-exit lifecycle changes.
 - **THEN** the setup script normalizes generated GhosttyKit module maps to use `header "ghostty.h"` instead of `umbrella header "ghostty.h"`
 - **AND** shell contract checks reject cached GhosttyKit module maps that would cause Clang umbrella-header warnings for internal `ghostty/vt/*` headers
 
+#### Scenario: Terminal input trace can be toggled live
+- **WHEN** terminal input routing diagnostics are enabled or disabled through user defaults
+- **THEN** alan refreshes the terminal input trace configuration while running without requiring an app restart
+- **AND** shell contract checks prevent the trace helper from caching the user-defaults enabled state for the whole process lifetime
+
 #### Scenario: New tab cwd verification
 - **WHEN** terminal tab creation is changed
 - **THEN** verification covers runtime cwd metadata, pane snapshot cwd fallback, explicit control-plane cwd, and default/home fallback

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
@@ -10,6 +10,18 @@ app-reserved `Command` shortcut owns that key.
 - **THEN** non-`Command` terminal keys such as Escape, Tab, Backspace, `Control-[`, `Control-W`, `Control-F`, and `Control-B` are delivered to the terminal runtime
 - **AND** the shell workspace command router does not consume those keys as pane, tab, or command-input actions
 
+#### Scenario: Printable physical keyboard input uses Ghostty key events
+- **WHEN** a focused terminal pane receives printable physical keyboard input such as `a` or `:`
+- **THEN** alan first lets AppKit text interpretation process the key so IME composition can start
+- **AND** alan delivers committed printable input through the Ghostty key-event path
+- **AND** alan does not bypass Ghostty's key encoder by sending that physical key through programmatic text injection
+
+#### Scenario: IME composition can start from printable input
+- **WHEN** a focused terminal pane uses a Chinese/Japanese/Korean input method
+- **AND** the user types the first printable key of a composition
+- **THEN** alan lets AppKit `interpretKeyEvents` create or update marked text
+- **AND** alan updates Ghostty preedit state from the resulting marked text
+
 #### Scenario: IME marked text owns composing backspace
 - **WHEN** a focused terminal pane has active AppKit `NSTextInputClient` marked text from a Chinese/Japanese/Korean input method
 - **AND** the user presses Backspace or an equivalent composing control key
@@ -48,6 +60,12 @@ app-reserved `Command` shortcut owns that key.
 - **AND** matching left mouse drags are suppressed until the focus-transfer mouse up
 - **AND** the matching left mouse up is suppressed
 - **AND** Vim mouse mode does not receive a stray click or selection drag from the focus transfer
+
+#### Scenario: Terminal input router owns primary pointer sequence policy
+- **WHEN** terminal pointer routing is evaluated for a focused or focus-transfer terminal pane
+- **THEN** the macOS terminal surface controller owns the sequence policy for focus-only primary button events, normal-buffer selection drags, alternate-screen mouse delivery, mouse-reporting delivery, and unready-surface ignores
+- **AND** the AppKit host view only normalizes events and executes the returned focus, deliver, consume, or fallthrough decision
+- **AND** focus-transfer suppression state MUST NOT be split between separate host-view drag guards and surface pointer routing
 
 #### Scenario: Modifier changes follow Ghostty semantics
 - **WHEN** modifier keys change while IME marked text is active

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/specs/macos-shell-terminal-lifecycle/spec.md
@@ -45,8 +45,9 @@ app-reserved `Command` shortcut owns that key.
 - **WHEN** the app and window are already active
 - **AND** the user clicks a terminal split pane that is selected in the shell model but is not the AppKit first responder
 - **THEN** alan focuses that terminal host and consumes the focus-transfer mouse down
+- **AND** matching left mouse drags are suppressed until the focus-transfer mouse up
 - **AND** the matching left mouse up is suppressed
-- **AND** Vim mouse mode does not receive a stray click from the focus transfer
+- **AND** Vim mouse mode does not receive a stray click or selection drag from the focus transfer
 
 #### Scenario: Modifier changes follow Ghostty semantics
 - **WHEN** modifier keys change while IME marked text is active

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
@@ -14,7 +14,7 @@
 - [x] 2.4 保留 command input 可见时的 submit/dismiss/toggle 行为，以及 `Command-T`、`Command-W` 等明确 native workspace shortcut。
 - [x] 2.5 为 fake terminal surface 或 focused shell contract 增加键盘输入验证，覆盖 Vim/TUI 关键按键、IME composing Backspace 和 native command shortcut 非回归。
 - [x] 2.6 按 Ghostty macOS `SurfaceView_AppKit` 补齐 `performKeyEquivalent`/`doCommand` timestamp redispatch，覆盖 `Control-/`、`Control-Return`、普通 Control/Command key equivalent 和 terminal binding。
-- [x] 2.7 补齐 focused terminal 的 local AppKit event monitor：Command keyUp release、active-window focus-only left click suppression、matching mouseUp suppression。
+- [x] 2.7 补齐 focused terminal 的 local AppKit event monitor：Command keyUp release、active-window focus-only left click suppression、matching mouseDrag/mouseUp suppression。
 - [x] 2.8 补齐 modifier event 语义：IME marked text 中不转发 `flagsChanged`，正常路径保留 caps/right-side modifier bits。
 - [x] 2.9 增加 focused tests 或 shell contract，证明 Ghostty-style key-equivalent state machine、focus-only click suppression 和 modifier event 语义不会回退。
 

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
@@ -17,6 +17,12 @@
 - [x] 2.7 补齐 focused terminal 的 local AppKit event monitor：Command keyUp release、active-window focus-only left click suppression、matching mouseDrag/mouseUp suppression。
 - [x] 2.8 补齐 modifier event 语义：IME marked text 中不转发 `flagsChanged`，正常路径保留 caps/right-side modifier bits。
 - [x] 2.9 增加 focused tests 或 shell contract，证明 Ghostty-style key-equivalent state machine、focus-only click suppression 和 modifier event 语义不会回退。
+- [x] 2.10 将 focus-only primary button sequence、normal-buffer selection drag、alternate-screen/mouse-reporting delivery 和 surface readiness 判断收敛到单一 terminal input router；`TerminalHostView` 只保留 AppKit event normalization 和 decision execution。
+- [x] 2.11 将物理键盘输入收敛到 terminal input router，并确保 printable keys、Escape、Control keys 最终通过 Ghostty key event delivery。
+- [x] 2.12 将 `ghostty_surface_text` 路径命名为 programmatic text delivery，保留给 paste/control-plane/非 keyDown text insertion，不作为物理键盘输入路径。
+- [x] 2.13 修复 printable key 直接绕过 AppKit text interpretation 导致中文 IME 无法启动 composition 的回归，同时保持 committed printable input 最终走 Ghostty key event。
+- [x] 2.14 修复 focus-only mouse routing 只看 AppKit first responder、不看 shell selection 导致 pane focus click 被误判为 terminal selection drag 的回归。
+- [x] 2.15 根据 terminal input trace 修复 focus-only click 的 primary buttonDown 泄漏：即使 AppKit 在 local monitor 判定 focus-only 后仍派发 native mouseDown，也由同一 input router 消费整段 primary down/drag/up 序列。
 
 ## 3. New Tab Cwd Inheritance
 
@@ -43,4 +49,6 @@
 - [x] 5.4 手工验证 split pane、single-pane tab 和 final-pane/fallback 的 `exit` 行为。
   - 2026-05-17: User confirmed exit behavior is OK.
 - [x] 5.5 更新实现说明或 verification notes，列出覆盖的按键、cwd 路径、exit 场景和任何剩余限制。
+- [x] 5.7 验证 terminal input router 收敛后的 focused tests、shell contract、OpenSpec strict validation 和 macOS build。
+- [x] 5.8 修复 GhosttyKit 本地 artifact modulemap 的 umbrella-header build warnings，并让 shell contract 拒绝回归。
 - [ ] 5.6 实现合入后，将 delta specs 同步到 `openspec/specs/` 并准备 archive。

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/tasks.md
@@ -23,6 +23,7 @@
 - [x] 2.13 修复 printable key 直接绕过 AppKit text interpretation 导致中文 IME 无法启动 composition 的回归，同时保持 committed printable input 最终走 Ghostty key event。
 - [x] 2.14 修复 focus-only mouse routing 只看 AppKit first responder、不看 shell selection 导致 pane focus click 被误判为 terminal selection drag 的回归。
 - [x] 2.15 根据 terminal input trace 修复 focus-only click 的 primary buttonDown 泄漏：即使 AppKit 在 local monitor 判定 focus-only 后仍派发 native mouseDown，也由同一 input router 消费整段 primary down/drag/up 序列。
+- [x] 2.16 让 terminal input trace 的 user-defaults 开关和路径在运行中按短刷新间隔重新读取，避免打开或关闭诊断日志必须重启 alan。
 
 ## 3. New Tab Cwd Inheritance
 

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
@@ -20,6 +20,7 @@
   - 覆盖 shell contract 静态检查，包括 `performKeyEquivalent`、`doCommand`、local AppKit event monitor、`AlanTerminalInputRouter` 存在，以及 `TerminalHostView` 不再持有 focus-click suppression state。
   - 覆盖 `TerminalHostView.keyDown` 不调用 programmatic text injection，物理键盘输入保持在 Ghostty key event path。
   - 覆盖 focus-only mouse routing 使用 `terminalInputIsActive`，也就是 shell selection 和 AppKit first-responder 同时成立，而不是只看 raw first-responder state。
+  - 覆盖 terminal input trace 的 user-defaults 开关会运行中 refresh，避免打开或关闭诊断日志必须重启 alan。
   - 覆盖 GhosttyKit modulemap contract：prepared local artifacts 不能继续使用 `umbrella header "ghostty.h"`，避免 Clang 对 `ghostty/vt/*` internal headers 产生 umbrella-header warnings。
 - `openspec validate fix-macos-terminal-interaction-regressions --strict`
   - Strict validation succeeded after adding the terminal input router requirements and build-test contract coverage.

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
@@ -4,7 +4,7 @@
   - 覆盖 Escape、Tab、Control-W、Option-F 作为 terminal-owned key 的 routing。
   - 覆盖 `Command-T` 仍然走 native New Terminal Tab shortcut。
   - 覆盖 Ghostty-style `performKeyEquivalent`/`doCommand` timestamp redispatch：terminal binding 直接进入 terminal，`Control-/` 归一化为 `Control-_`，普通 Command/Control key equivalent 先让 AppKit responder chain 处理，再在同一 timestamp 重新派发时只送入 terminal 一次。
-  - 覆盖 active/key window 中点击未 focused terminal split pane 的 focus-only 行为，以及 matching left mouse up 的一次性 suppression。
+  - 覆盖 active/key window 中点击未 focused terminal split pane 的 focus-only 行为，以及 matching left mouse drag / mouse up 的 suppression。
   - 覆盖 Backspace 在非组合态仍是 terminal-owned key，但 IME marked text 存在时会进入 `NSTextInputClient`/`interpretKeyEvents`，并抑制组合态 Backspace/Ctrl-H control 字符漏到 terminal。
   - 覆盖 surface handle 的 close request 会被 `TerminalSurfaceController` 转发给 shell owner。
 - `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
@@ -15,7 +15,7 @@
 - `bash clients/apple/scripts/test-terminal-runtime-service.sh`
   - 覆盖 exited runtime 的 text delivery 使用 `terminal_child_exited` 失败码，且不会把 text 送到 surface。
 - `bash clients/apple/scripts/check-shell-contracts.sh`
-  - 覆盖 shell contract 静态检查，包括 `performKeyEquivalent`、`doCommand`、local AppKit event monitor 和 focus-only mouse-up suppression 结构。
+  - 覆盖 shell contract 静态检查，包括 `performKeyEquivalent`、`doCommand`、local AppKit event monitor 和 focus-only mouse-drag / mouse-up suppression 结构。
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-derived-data build`
   - Debug build succeeded. The first build attempt without `-derivedDataPath` failed because the sandbox could not write `~/Library/Developer/Xcode/DerivedData`.
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build`
@@ -27,7 +27,7 @@
 
 - Vim/nvim 中 Escape、Tab、Backspace、Control-W、Control-F、Control-B、Control-]、Control-/, Control-Return、Command-modified terminal binding 和 Option-modified navigation 是否正常进入 terminal。
 - 中文/日文/韩文输入法组合输入中，Backspace 是否删除 marked text，而不是删除已提交 terminal 内容或无响应。
-- 同一窗口中从未 focused split pane 切换 focus 时，第一次 click 是否只聚焦、不注入 Vim mouse mode；窗口未激活时第一次 click 是否仍能按系统语义激活窗口。
+- 同一窗口中从未 focused split pane 切换 focus 时，第一次 click/drag 是否只聚焦、不注入 Vim mouse mode 或触发 terminal selection；窗口未激活时第一次 click 是否仍能按系统语义激活窗口。
 - 在 pane 中 `cd` 后新建 Terminal Tab 是否继承当前 cwd。
 - split pane、single-pane tab、final pane 中输入 `exit` 后是否关闭 owning pane/tab，且不会 clear/restart 成新 terminal。
 - 如果旧运行中 app 仍表现为 clear/restart，重启到包含 Ghostty-style close-request 通道和 close-surface callback fix 的 build 后再验证；旧 build 只处理了 `SHOW_CHILD_EXITED`/runtime metadata 路径，漏掉了真实 close request 观测路径。

--- a/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
+++ b/openspec/changes/fix-macos-terminal-interaction-regressions/verification.md
@@ -1,10 +1,12 @@
 ## Automated Verification
 
 - `bash clients/apple/scripts/test-terminal-surface-controller.sh`
+  - 覆盖 printable physical keys（包括 `a` 和 Vim command-mode `:`）先进入 AppKit text interpretation，让 IME composition 可以启动；HostView 最终仍应把 committed text 重新包成 Ghostty key event，而不是 programmatic text injection。
   - 覆盖 Escape、Tab、Control-W、Option-F 作为 terminal-owned key 的 routing。
   - 覆盖 `Command-T` 仍然走 native New Terminal Tab shortcut。
   - 覆盖 Ghostty-style `performKeyEquivalent`/`doCommand` timestamp redispatch：terminal binding 直接进入 terminal，`Control-/` 归一化为 `Control-_`，普通 Command/Control key equivalent 先让 AppKit responder chain 处理，再在同一 timestamp 重新派发时只送入 terminal 一次。
-  - 覆盖 active/key window 中点击未 focused terminal split pane 的 focus-only 行为，以及 matching left mouse drag / mouse up 的 suppression。
+  - 覆盖 active/key window 中点击未 focused terminal split pane 的 focus-only 行为，以及 matching left mouse down / drag / mouse up 的 suppression；即使 AppKit 在 local monitor 判定 focus-only 后仍派发 native mouseDown，也不会触发 terminal selection press。
+  - 覆盖 `AlanTerminalInputRouter` 是 focus-only primary button sequence、normal-buffer selection drag、alternate-screen/mouse-reporting delivery 和 surface readiness pointer policy 的单一 owner；`TerminalHostView` 只执行 router decision。
   - 覆盖 Backspace 在非组合态仍是 terminal-owned key，但 IME marked text 存在时会进入 `NSTextInputClient`/`interpretKeyEvents`，并抑制组合态 Backspace/Ctrl-H control 字符漏到 terminal。
   - 覆盖 surface handle 的 close request 会被 `TerminalSurfaceController` 转发给 shell owner。
 - `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
@@ -15,11 +17,29 @@
 - `bash clients/apple/scripts/test-terminal-runtime-service.sh`
   - 覆盖 exited runtime 的 text delivery 使用 `terminal_child_exited` 失败码，且不会把 text 送到 surface。
 - `bash clients/apple/scripts/check-shell-contracts.sh`
-  - 覆盖 shell contract 静态检查，包括 `performKeyEquivalent`、`doCommand`、local AppKit event monitor 和 focus-only mouse-drag / mouse-up suppression 结构。
+  - 覆盖 shell contract 静态检查，包括 `performKeyEquivalent`、`doCommand`、local AppKit event monitor、`AlanTerminalInputRouter` 存在，以及 `TerminalHostView` 不再持有 focus-click suppression state。
+  - 覆盖 `TerminalHostView.keyDown` 不调用 programmatic text injection，物理键盘输入保持在 Ghostty key event path。
+  - 覆盖 focus-only mouse routing 使用 `terminalInputIsActive`，也就是 shell selection 和 AppKit first-responder 同时成立，而不是只看 raw first-responder state。
+  - 覆盖 GhosttyKit modulemap contract：prepared local artifacts 不能继续使用 `umbrella header "ghostty.h"`，避免 Clang 对 `ghostty/vt/*` internal headers 产生 umbrella-header warnings。
+- `openspec validate fix-macos-terminal-interaction-regressions --strict`
+  - Strict validation succeeded after adding the terminal input router requirements and build-test contract coverage.
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-derived-data build`
   - Debug build succeeded. The first build attempt without `-derivedDataPath` failed because the sandbox could not write `~/Library/Developer/Xcode/DerivedData`.
 - `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath /private/tmp/alan-macos-derived-data build`
   - Debug build succeeded after the close-surface callback fix and Ghostty AppKit responder-contract implementation. Xcode still printed CoreSimulator/log-permission noise, but the macOS target completed with `BUILD SUCCEEDED`.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-input-router build`
+  - Debug build succeeded after the terminal input router refactor. Xcode still printed the existing CoreSimulator/log-permission noise and GhosttyKit umbrella-header warnings, but the macOS target completed with `BUILD SUCCEEDED`.
+- `bash clients/apple/scripts/setup-local-ghosttykit.sh`
+  - Refreshed local GhosttyKit artifacts and normalized all generated module maps to `header "ghostty.h"`.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /private/tmp/alan-xcode-derived-ghosttykit-modulemap build`
+  - Debug build succeeded after the GhosttyKit modulemap normalization.
+  - The previous `GhosttyKit` umbrella-header warnings did not reappear.
+  - The narrower destination removed the previous "Using the first of multiple matching destinations" warning.
+  - Xcode still printed CoreSimulator/cache/log-permission warnings from the local toolchain environment; those are not emitted by alan source or GhosttyKit module maps.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-generic-macos build`
+  - Debug build succeeded with a generic macOS destination, preserving the universal arm64/x86_64 build while avoiding the previous multiple matching destinations warning.
+  - The previous `GhosttyKit` umbrella-header warnings did not reappear.
+  - Xcode still printed CoreSimulator/cache/log-permission warnings from the local toolchain environment; simulator device support was not required for this macOS build.
 
 ## Manual Verification Pending
 


### PR DESCRIPTION
## Summary
- Centralize terminal keyboard and pointer routing in a single terminal input router.
- Keep printable physical keys IME-aware while delivering committed input through Ghostty key events instead of programmatic text injection.
- Consume focus-transfer primary button down/drag/up sequences and add opt-in terminal input trace logging for future AppKit routing debugging.
- Normalize local GhosttyKit module maps and add shell contract checks to prevent umbrella-header warnings from returning.

## Verification
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate fix-macos-terminal-interaction-regressions --strict
- git diff --cached --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-pr-terminal-input-router build

## Notes
- User manually verified the focus-click selection regression no longer reproduces after the trace-guided button-down suppression fix.