### PR TITLE
Polish pane title bar readability

### DIFF
--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -728,6 +728,7 @@ private struct ShellPaneTitleBarView: View {
         }
         .padding(.leading, ShellPaneTitleBarMetrics.horizontalLeadingPadding)
         .padding(.trailing, ShellPaneTitleBarMetrics.horizontalTrailingPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: ShellPaneTitleBarMetrics.height)
         .background(ShellPalette.terminal)
         .contentShape(Rectangle())

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -690,6 +690,28 @@ private enum ShellPaneTitleTypography {
     static let closeWeight: Font.Weight = .semibold
 }
 
+private enum ShellPaneTitleBarMetrics {
+    static let height: CGFloat = 28
+    static let minimumTitleWidth: CGFloat = 56
+    static let horizontalLeadingPadding: CGFloat = 10
+    static let horizontalTrailingPadding: CGFloat = 6
+    static let itemSpacing: CGFloat = 8
+    static let accessorySpacing: CGFloat = 8
+    static let accessoryInternalSpacing: CGFloat = 4
+    static let closeButtonSize: CGFloat = 22
+}
+
+private enum ShellPaneTitleBarPresentation {
+    case full
+    case compact
+    case minimal
+}
+
+private enum ShellPaneTitleBarAccessoryMode: Equatable {
+    case textAndIcon
+    case iconOnly
+}
+
 private struct ShellPaneTitleBarView: View {
     let title: String
     let pane: ShellPane
@@ -699,65 +721,82 @@ private struct ShellPaneTitleBarView: View {
     @State private var activityFreshnessNow = Date()
 
     var body: some View {
-        HStack(spacing: 8) {
-            Text(title)
-                .font(
-                    .system(
-                        size: ShellPaneTitleTypography.titleSize,
-                        weight: ShellPaneTitleTypography.titleWeight(isSelected: isSelected)
-                    )
-                )
-                .foregroundStyle(isSelected ? ShellPalette.ink : ShellPalette.mutedInk)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            if !accessories.isEmpty {
-                HStack(spacing: 10) {
-                    ForEach(accessories) { accessory in
-                        ShellPaneTitleBarAccessoryView(accessory: accessory, isSelected: isSelected)
-                    }
-                }
-                .layoutPriority(1)
-            }
-
-            Button(action: onClosePane) {
-                Image(systemName: "xmark")
-                    .font(
-                        .system(
-                            size: ShellPaneTitleTypography.closeSize,
-                            weight: ShellPaneTitleTypography.closeWeight
-                        )
-                    )
-                    .foregroundStyle(ShellPalette.mutedInk)
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help("Close pane")
-            .accessibilityLabel("Close pane")
+        ViewThatFits(in: .horizontal) {
+            titleBarContent(presentation: .full)
+            titleBarContent(presentation: .compact)
+            titleBarContent(presentation: .minimal)
         }
-        .padding(.leading, 10)
-        .padding(.trailing, 6)
-        .frame(height: 28)
-        .background(
-            Rectangle()
-                .fill(
-                    isSelected
-                        ? ShellMaterialRole.terminalChromeSelected.fill
-                        : ShellMaterialRole.terminalChrome.fill
-                )
-        )
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(ShellPalette.line.opacity(isSelected ? 0.18 : 0.12))
-                .frame(height: 1)
-        }
+        .padding(.leading, ShellPaneTitleBarMetrics.horizontalLeadingPadding)
+        .padding(.trailing, ShellPaneTitleBarMetrics.horizontalTrailingPadding)
+        .frame(height: ShellPaneTitleBarMetrics.height)
+        .background(ShellPalette.terminal)
         .contentShape(Rectangle())
         .onTapGesture(perform: onFocusPane)
         .task(id: activityFreshnessRefreshID) {
             await scheduleActivityFreshnessRefresh()
         }
+    }
+
+    private func titleBarContent(presentation: ShellPaneTitleBarPresentation) -> some View {
+        HStack(spacing: ShellPaneTitleBarMetrics.itemSpacing) {
+            titleView
+
+            let visibleAccessories = accessories(for: presentation)
+            if !visibleAccessories.isEmpty {
+                HStack(spacing: ShellPaneTitleBarMetrics.accessorySpacing) {
+                    ForEach(visibleAccessories) { accessory in
+                        ShellPaneTitleBarAccessoryView(
+                            accessory: accessory,
+                            isSelected: isSelected,
+                            mode: accessoryMode(for: accessory, presentation: presentation)
+                        )
+                    }
+                }
+                .fixedSize(horizontal: true, vertical: true)
+            }
+
+            closeButton
+        }
+    }
+
+    private var titleView: some View {
+        Text(title)
+            .font(
+                .system(
+                    size: ShellPaneTitleTypography.titleSize,
+                    weight: ShellPaneTitleTypography.titleWeight(isSelected: isSelected)
+                )
+            )
+            .foregroundStyle(Color.white.opacity(isSelected ? 0.94 : 0.78))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .layoutPriority(2)
+            .frame(
+                minWidth: ShellPaneTitleBarMetrics.minimumTitleWidth,
+                alignment: .leading
+            )
+    }
+
+    private var closeButton: some View {
+        Button(action: onClosePane) {
+            Image(systemName: "xmark")
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.closeSize,
+                        weight: ShellPaneTitleTypography.closeWeight
+                    )
+                )
+                .foregroundStyle(Color.white.opacity(isSelected ? 0.68 : 0.52))
+                .frame(
+                    width: ShellPaneTitleBarMetrics.closeButtonSize,
+                    height: ShellPaneTitleBarMetrics.closeButtonSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: true)
+        .help("Close pane")
+        .accessibilityLabel("Close pane")
     }
 
     private var activityFreshnessRefreshID: String {
@@ -810,9 +849,33 @@ private struct ShellPaneTitleBarView: View {
                 title: projection.title,
                 help: projection.help,
                 tint: accessoryTint(for: projection.id),
-                isEmphasized: accessoryIsEmphasized(projection.id),
-                maxWidth: accessoryMaxWidth(for: projection.id)
+                isEmphasized: accessoryIsEmphasized(projection.id)
             )
+        }
+    }
+
+    private func accessories(
+        for presentation: ShellPaneTitleBarPresentation
+    ) -> [ShellPaneTitleBarAccessory] {
+        switch presentation {
+        case .full, .compact:
+            return accessories
+        case .minimal:
+            return accessories.filter { $0.isPrimary || $0.isEmphasized }
+        }
+    }
+
+    private func accessoryMode(
+        for accessory: ShellPaneTitleBarAccessory,
+        presentation: ShellPaneTitleBarPresentation
+    ) -> ShellPaneTitleBarAccessoryMode {
+        switch presentation {
+        case .full:
+            return .textAndIcon
+        case .compact:
+            return accessory.isPrimary ? .textAndIcon : .iconOnly
+        case .minimal:
+            return .iconOnly
         }
     }
 
@@ -846,7 +909,7 @@ private struct ShellPaneTitleBarView: View {
         case .active:
             return ShellPalette.accent
         case .passive, nil:
-            return ShellPalette.mutedInk
+            return Color.white
         }
     }
 
@@ -877,7 +940,7 @@ private struct ShellPaneTitleBarView: View {
         {
             return ShellPalette.attention
         }
-        return ShellPalette.mutedInk
+        return Color.white
     }
 
     private func accessoryIcon(for id: String) -> String {
@@ -908,7 +971,7 @@ private struct ShellPaneTitleBarView: View {
         case "alan":
             return ShellPalette.accent
         default:
-            return ShellPalette.mutedInk
+            return Color.white
         }
     }
 
@@ -926,18 +989,6 @@ private struct ShellPaneTitleBarView: View {
         }
     }
 
-    private func accessoryMaxWidth(for id: String) -> CGFloat? {
-        switch id {
-        case "activity":
-            return 140
-        case "branch", "worktree", "cwd":
-            return 120
-        case "process", "alan":
-            return 72
-        default:
-            return nil
-        }
-    }
 }
 
 private struct ShellPaneTitleBarAccessory: Identifiable {
@@ -947,15 +998,19 @@ private struct ShellPaneTitleBarAccessory: Identifiable {
     let help: String
     let tint: Color
     let isEmphasized: Bool
-    var maxWidth: CGFloat?
+
+    var isPrimary: Bool {
+        id == "activity" || id == "status"
+    }
 }
 
 private struct ShellPaneTitleBarAccessoryView: View {
     let accessory: ShellPaneTitleBarAccessory
     let isSelected: Bool
+    let mode: ShellPaneTitleBarAccessoryMode
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: ShellPaneTitleBarMetrics.accessoryInternalSpacing) {
             Image(systemName: accessory.icon)
                 .font(
                     .system(
@@ -964,7 +1019,8 @@ private struct ShellPaneTitleBarAccessoryView: View {
                     )
                 )
 
-            if let title = accessory.title {
+            if mode == .textAndIcon,
+               let title = accessory.title {
                 Text(title)
                     .font(
                         .system(
@@ -976,13 +1032,20 @@ private struct ShellPaneTitleBarAccessoryView: View {
                     )
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .frame(maxWidth: accessory.maxWidth, alignment: .leading)
+                    .fixedSize(horizontal: true, vertical: false)
             }
         }
-        .foregroundStyle(accessory.tint.opacity(isSelected ? 0.86 : 0.58))
-        .fixedSize(horizontal: false, vertical: true)
+        .foregroundStyle(accessory.tint.opacity(accessoryOpacity))
+        .fixedSize(horizontal: true, vertical: true)
         .help(accessory.help)
         .accessibilityLabel(accessory.help)
+    }
+
+    private var accessoryOpacity: Double {
+        if accessory.isEmphasized {
+            return isSelected ? 0.96 : 0.82
+        }
+        return isSelected ? 0.78 : 0.62
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -98,11 +98,51 @@ reject_keydown_programmatic_text_delivery() {
     fi
 }
 
+require_title_bar_full_width_hit_area() {
+    local file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
+
+    if ! awk '
+        /private struct ShellPaneTitleBarView: View/ {
+            in_view = 1
+        }
+
+        in_view && /var body: some View/ {
+            in_body = 1
+        }
+
+        in_body && /ViewThatFits\(in: \.horizontal\)/ {
+            saw_responsive_layout = 1
+        }
+
+        in_body && /frame\(maxWidth: \.infinity, alignment: \.leading\)/ {
+            saw_full_width_frame = 1
+        }
+
+        in_body && /background\(ShellPalette\.terminal\)/ {
+            if (saw_responsive_layout && saw_full_width_frame) {
+                found = 1
+            }
+        }
+
+        in_body && /private func titleBarContent/ {
+            in_body = 0
+        }
+
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$file"; then
+        printf 'error: pane title-bar background and focus hit area must span full pane width\n' >&2
+        exit 1
+    fi
+}
+
 "$SCRIPT_DIR/setup-local-ghosttykit.sh" --check >/dev/null
 "$SCRIPT_DIR/check-architecture-maintainability.sh" >/dev/null
 reject_active_shell_radius_drift
 reject_ghosttykit_umbrella_modulemap
 reject_keydown_programmatic_text_delivery
+require_title_bar_full_width_hit_area
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1014,6 +1014,41 @@ require_pattern \
     "pane title typography must use role-based typography tokens"
 
 require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "ViewThatFits\\(in: \\.horizontal\\)" \
+    "pane title bars must use staged responsive fallback instead of fixed-width accessory columns"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "private enum ShellPaneTitleBarPresentation" \
+    "pane title bars must encode full, compact, and minimal presentation tiers"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "private var titleView" \
+    "pane title bars must keep title text as a persistent title view"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "Text\\(title\\)" \
+    "pane title bars must render the title as text instead of icon-only content"
+
+require_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "minimumTitleWidth" \
+    "pane title bars must preserve a minimum text title width before accessory fallback"
+
+reject_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "terminalChromeSelected\\.fill|terminalChrome\\.fill" \
+    "pane title bars must not reintroduce selected/unselected overlay fills"
+
+reject_pattern \
+    "clients/apple/alan-macos/TerminalPaneView.swift" \
+    "accessoryMaxWidth|maxWidth: accessory\\.maxWidth" \
+    "pane title-bar accessories must not use fixed max-width columns"
+
+require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "onFocusSplitPane: \\{ paneID in" \
     "sidebar split indicators must preserve direct clicked-pane targeting"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -50,6 +50,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesActivityAttentionIsReadTimeOnly()
         verifiesPaneTitleActivityAccessoryLabel()
         verifiesPaneTitleDetailProjectionIncludesContextBranchAndProcess()
+        verifiesPaneTitleDetailProjectionPreservesResponsivePriority()
         verifiesPaneTitleDetailProjectionAvoidsDuplicateAgentAndAlan()
         verifiesActivityNotificationPolicyIsLowNoise()
         verifiesControllerRoutesActivityNotificationsOnce()
@@ -1500,6 +1501,60 @@ private enum ShellRuntimeMetadataTests {
             "pane title details must expose non-redundant worktree, branch, and process"
         )
         expect(details.map(\.title) == ["alan", "main", "fish"], "pane title details must use compact labels")
+    }
+
+    private static func verifiesPaneTitleDetailProjectionPreservesResponsivePriority() {
+        let now = Date(timeIntervalSince1970: 1_779_008_400)
+        let progress = TerminalActivitySnapshot.progressActivity(percent: 42, now: now)
+        let testPane = ShellPane(
+            paneID: "pane_1",
+            tabID: "tab_1",
+            spaceID: "space_1",
+            launchTarget: .shell,
+            cwd: "/Users/morris/Developer/alan",
+            process: ShellProcessBinding(program: "fish", argvPreview: nil),
+            attention: .notable,
+            context: context(
+                workingDirectoryName: "alan",
+                repositoryRoot: "/Users/morris/Developer/alan",
+                gitBranch: "feature/title-bar",
+                processState: "running",
+                rendererHealth: "failed",
+                surfaceReadiness: "renderer_failed",
+                lastCommandExitCode: nil
+            ),
+            viewport: nil,
+            activity: progress,
+            alanBinding: ShellAlanBinding(
+                sessionID: "session_1",
+                runStatus: "running",
+                pendingYield: true,
+                source: "test",
+                lastProjectedAt: nil
+            )
+        )
+
+        let details = shellPaneTitleBarDetailProjection(
+            for: testPane,
+            title: "Editor",
+            now: now
+        )
+
+        expect(
+            details.map(\.id) == ["activity", "status", "worktree", "branch", "process", "alan"],
+            "pane title detail projection must preserve responsive priority order"
+        )
+        expect(
+            details.map(\.title) == [
+                "Progress · 42%",
+                "Renderer failed",
+                "alan",
+                "feature/title-bar",
+                "fish",
+                "Input",
+            ],
+            "pane title detail projection must keep compact labels in priority order"
+        )
     }
 
     private static func verifiesPaneTitleDetailProjectionAvoidsDuplicateAgentAndAlan() {

--- a/openspec/changes/polish-macos-pane-title-bar-readability/.openspec.yaml
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/polish-macos-pane-title-bar-readability/design.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`TerminalPaneView.swift` already renders `ShellPaneTitleBarView` above every
+visible terminal leaf. The current row is fixed height, uses selected and
+unselected terminal-chrome material fills, gives the title an infinite-width
+slot, and gives accessories fixed maximum widths. That made the first
+implementation compact, but it now works against the desired terminal-first
+presentation: the title bar reads as an overlay on top of the pane, selected
+state can wash out the title, and accessory layout is not fit-content.
+
+The title and accessory data already exist. `ShellModel.swift` derives the
+pane title from terminal metadata and projects activity, status, cwd/worktree,
+branch, process, and alan detail into pane-local accessories. This change is
+therefore a presentation and layout refinement, not a metadata or focus-model
+rewrite.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make pane title bars feel like part of the terminal surface instead of a
+  separate chrome strip.
+- Keep title text readable in focused and unfocused panes, especially in light
+  mode.
+- Render title-bar items left to right as fit-content content.
+- Preserve title text in every responsive fallback state; the title may
+  truncate, but it must not become icon-only.
+- Degrade lower-priority accessories predictably when pane width is narrow.
+- Keep terminal input ownership, split geometry, title derivation, and targeted
+  pane close behavior unchanged.
+
+**Non-Goals:**
+
+- Redesign sidebar tab rows, terminal activity semantics, or terminal metadata
+  ingestion.
+- Add a pane toolbar, pane tab strip, breadcrumbs, hover menu, drag-to-reorder
+  behavior, or new pane-management commands.
+- Change how focused pane identity is stored or synchronized.
+- Add a custom general-purpose SwiftUI layout unless the staged fit-content
+  approach proves insufficient during implementation.
+
+## Decisions
+
+1. Title bars use terminal-surface background, not selected chrome material.
+
+   The row should read as the first line of the pane surface. Selected state
+   should not be expressed through a title-bar background wash, because that
+   is the source of the current overlay feel and likely contributes to poor
+   selected-title contrast. Focus remains a pane-level concern expressed by the
+   existing terminal surface, split boundary, or dim treatment.
+
+   Alternative considered: keep a lighter material wash for the selected title
+   bar. That would make focus more local to the title row, but it would keep
+   the title bar visually separate from the terminal.
+
+2. Title and close are persistent; accessories are responsive.
+
+   The title stays as text in every width state and uses middle truncation when
+   needed. The close affordance remains available because it is the pane-scoped
+   action that the title bar owns. Accessories degrade first because they are
+   secondary detail.
+
+   Alternative considered: allow the title to collapse to a terminal or folder
+   icon. That saves space, but it removes the core scanning value of the title
+   bar and makes split panes harder to identify.
+
+3. Use staged `ViewThatFits`-style fallback before a custom layout.
+
+   The first implementation should provide three stable presentations:
+   full accessories with icon and text, compact accessories as icon-only for
+   lower-priority items, and minimal accessories containing only actionable or
+   high-priority state. This keeps implementation understandable while still
+   honoring fit-content layout.
+
+   Alternative considered: write a custom measuring layout that decides item
+   visibility one by one. That can be more precise but adds maintenance cost
+   for a small title-bar row.
+
+4. Accessory priority is semantic and left-to-right.
+
+   The row order is title, activity/status, cwd or worktree, branch, process or
+   alan state, close. Narrow-width fallback should remove or iconize from the
+   lowest-priority end before touching activity/status or title.
+
+   Alternative considered: keep the current accessory projection order and
+   fixed widths. That is lower risk mechanically, but it does not solve the
+   fit-content and narrow-pane behavior.
+
+5. Tests should guard contracts, not screenshots.
+
+   Automated checks should verify the code keeps title text persistent,
+   avoids selected/unselected title-bar fills, uses staged fallback, and does
+   not reintroduce fixed-width accessory slots. Visual review remains required
+   for actual light-mode readability because contrast and composition are
+   perceptual.
+
+## Risks / Trade-offs
+
+- Reduced local focus signal in the title row -> Preserve pane-level focus
+  treatment and verify split panes remain scannable in a running app.
+- Icon-only accessories may become cryptic -> Keep help/accessibility labels
+  on icon-only states and reserve icon-only fallback for secondary detail.
+- `ViewThatFits` fallback may be too coarse for very narrow panes -> Keep the
+  staged approach first; upgrade to a custom layout only if implementation
+  evidence shows unacceptable truncation or hiding behavior.
+- Higher contrast text may feel heavier -> Use role-specific typography and
+  foreground tokens instead of increasing font size or adding a background.
+- Existing contract checks may be too pattern-specific -> Update checks to
+  assert durable behavior while avoiding brittle exact SwiftUI structure where
+  possible.
+
+## Migration Plan
+
+No persisted state, protocol, or runtime migration is required. The change is
+local to macOS shell presentation and verification. Rollback is a UI-only
+revert of the title-bar visual/layout changes while leaving existing title
+metadata and pane close routing intact.
+
+## Open Questions
+
+None. The selected direction is the staged fit-content title bar with persistent
+text title, terminal-surface background, higher foreground contrast, and
+accessory degradation before title degradation.

--- a/openspec/changes/polish-macos-pane-title-bar-readability/proposal.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Pane title bars currently read like a separate overlay above the terminal, and
+their selected state can make the title effectively disappear in normal use.
+This weakens split-pane scanning at exactly the moment the title bar needs to
+identify the focused terminal clearly.
+
+## What Changes
+
+- Make pane title bars visually immersive by matching the terminal surface
+  background instead of adding a selected/unselected chrome wash above it.
+- Increase title and accessory foreground contrast so focused and unfocused
+  panes remain readable in light mode.
+- Keep the pane title as the primary text and never degrade it to an icon-only
+  representation.
+- Lay out title-bar content from left to right as fit-content items:
+  title, activity/status, cwd or worktree, branch, process or alan state, and
+  close.
+- Add deterministic narrow-width fallback: lower-priority accessories degrade
+  from text plus icon to icon-only, then hide before the title text or close
+  affordance disappear.
+- Preserve existing pane-scoped close routing, title metadata projection, split
+  geometry, focus ownership, and terminal input ownership.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Refines the pane title-bar contract for
+  readability, terminal-surface integration, left-to-right fit-content layout,
+  and responsive accessory degradation.
+- `macos-shell-build-test-contract`: Extends pane title-bar verification to
+  guard against unreadable selected titles, overlay-style title-bar chrome, and
+  fixed-width accessory regressions.
+
+## Impact
+
+- Apple client UI: `clients/apple/alan-macos/TerminalPaneView.swift`, especially
+  `ShellPaneTitleBarView` and its accessory views.
+- Apple shell model/projection: `clients/apple/alan-macos/ShellModel.swift`
+  if accessory priority or projection needs to become explicit for layout.
+- Apple shell contract checks and focused tests:
+  `clients/apple/scripts/check-shell-contracts.sh`,
+  `clients/apple/scripts/test-shell-runtime-metadata.swift`, and visual/manual
+  verification notes for light-mode single-pane and split-pane title bars.

--- a/openspec/changes/polish-macos-pane-title-bar-readability/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Pane title bars have focused verification
+The Apple client SHALL include focused automated or documented verification for
+pane title-bar consumption, pane-scoped close routing, terminal input
+ownership, selected-title readability, responsive accessory layout, and
+terminal-surface integration when pane title bars are changed.
+
+#### Scenario: Pane title-bar consumption tested
+- **WHEN** pane title-bar helpers receive existing terminal title, working-directory, cwd, launch-target, and process metadata combinations
+- **THEN** focused tests verify title-bar priority, fallback ordering, long-title handling, and suppression of raw pane IDs or debug terms without retesting terminal title capture itself
+
+#### Scenario: Pane close routing tested
+- **WHEN** a title-bar close action targets a selected pane, an inactive split pane, a single-pane tab with other tabs, or the final remaining pane
+- **THEN** focused tests verify the shell mutation result, selected pane after close, split tree repair, and final-pane protection
+
+#### Scenario: Terminal input preservation reviewed
+- **WHEN** pane title-bar implementation is ready for review
+- **THEN** maintainers can inspect automated shell contract checks or manual notes covering terminal click-to-focus, typing, selection drag, right click, scrolling, and close-button interaction
+
+#### Scenario: Title readability guarded
+- **WHEN** pane title-bar UI polish changes selected or unfocused title styling
+- **THEN** focused checks or documented visual review verify that the focused title remains visible as text against the terminal surface background in light mode
+- **AND** contract checks fail or review blocks the change if selected title-bar styling can hide, wash out, or replace the title text with icon-only content
+
+#### Scenario: Responsive layout guarded
+- **WHEN** pane title-bar layout changes
+- **THEN** focused checks or review verify that title-bar accessories use fit-content layout and staged responsive fallback instead of fixed-width accessory columns
+- **AND** narrow title bars preserve title text and close affordance while lower-priority accessories degrade first
+
+#### Scenario: Terminal-surface integration guarded
+- **WHEN** pane title-bar background or material roles change
+- **THEN** focused checks or documented visual review verify that the title bar matches the terminal surface background and does not reintroduce a selected/unselected overlay band above the pane
+
+#### Scenario: Window chrome and collapsed sidebar guardrails run
+- **WHEN** hidden-titlebar window chrome, titlebar double-click behavior, local app launch behavior, or collapsed-sidebar floating-panel behavior changes
+- **THEN** focused checks verify launch presents one primary window, empty titlebar double-click zoom targets only non-control chrome, system traffic-light buttons keep their normal behavior, and collapsed-sidebar reveal uses narrow hover targets with stable workspace geometry
+
+#### Scenario: Visual evidence captured
+- **WHEN** pane title-bar UI polish is marked complete
+- **THEN** maintainers can inspect a running-app screenshot or manual note showing light-mode single-pane and split-pane tabs with compact pane title bars, readable titles, restrained close buttons, responsive accessory fallback, and no default debug labels

--- a/openspec/changes/polish-macos-pane-title-bar-readability/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal panes expose narrow title bars
+Each visible macOS terminal pane SHALL include a compact title bar at the top of
+the pane that identifies the terminal and provides a pane-scoped close
+affordance while keeping terminal content visually dominant. The title bar SHALL
+read as part of the terminal surface rather than as a separate selected chrome
+overlay.
+
+#### Scenario: Single pane title visible
+- **WHEN** a terminal tab contains one visible pane
+- **THEN** the pane shows a narrow title bar above the terminal canvas with a user-facing terminal title and one slim close button
+- **AND** the title bar uses the same terminal-surface background as the canvas rather than a selected/unselected material wash above it
+
+#### Scenario: Split pane titles visible
+- **WHEN** a terminal tab contains multiple visible panes
+- **THEN** every pane leaf shows its own title bar and close button without adding a pane selector strip, card grid, or debug labels
+- **AND** title-bar backgrounds do not create per-pane cards, opaque overlays, or separate toolbar bands above each terminal pane
+
+#### Scenario: Focused title remains readable
+- **WHEN** a pane becomes the focused terminal pane
+- **THEN** the pane title remains visible as text with sufficient foreground contrast against the terminal surface background
+- **AND** focused state does not hide the title, blend it into the title-bar background, or replace it with an icon-only representation
+
+#### Scenario: Long title fits
+- **WHEN** a pane title is long or changes while the pane is visible
+- **THEN** the title truncates within a stable fixed-height title bar without resizing split dividers, sidebar rows, toolbar content, or sibling panes
+
+#### Scenario: Narrow title bar degrades predictably
+- **WHEN** a pane title bar does not have enough width to show all detail
+- **THEN** lower-priority accessories degrade from text plus icon to icon-only or hidden before the title text or close affordance disappear
+- **AND** the title remains text with truncation rather than degrading to icon-only content
+
+### Requirement: Pane title bars consume terminal metadata
+Pane title bars SHALL consume the current terminal title already projected into
+pane metadata, and SHALL use existing user-facing fallback labels only when the
+terminal title is unavailable. Pane title-bar detail SHALL be presented in
+left-to-right semantic priority order using fit-content item widths where space
+allows.
+
+#### Scenario: Terminal title exists
+- **WHEN** a pane has a non-empty `viewport.title`
+- **THEN** the title bar shows the normalized terminal title rather than raw pane IDs, cwd-first labels, runtime phases, or debug event text
+
+#### Scenario: Terminal title missing
+- **WHEN** a pane has no usable terminal title
+- **THEN** the title bar falls back to cwd leaf, working-directory name, launch target, process name, or `Terminal` using user-facing copy
+
+#### Scenario: Debug terms suppressed
+- **WHEN** terminal metadata contains implementation-oriented summaries such as `title updated`, `window attached`, or raw runtime state
+- **THEN** the title bar does not expose those terms outside explicit developer/debug-only surfaces
+
+#### Scenario: Metadata stays in title chrome
+- **WHEN** terminal status, branch, attention, or alan binding metadata is useful in the default pane UI
+- **THEN** alan presents it as lightweight pane-title-bar accessories rather than as a persistent bottom status strip below the terminal canvas
+
+#### Scenario: Detail order is semantic
+- **WHEN** a pane title bar has title, activity, status, cwd or worktree, branch, process, alan state, and close detail available
+- **THEN** alan orders visible content from left to right as title, activity/status, cwd or worktree, branch, process or alan state, and close
+- **AND** each visible item uses fit-content width rather than reserving a fixed-width column for every accessory
+
+#### Scenario: Detail fallback preserves priority
+- **WHEN** available title-bar width cannot fit all detail labels
+- **THEN** activity and status detail outrank cwd, worktree, branch, process, and alan detail
+- **AND** cwd, worktree, branch, process, and alan detail can collapse to icon-only or hide before the title text collapses

--- a/openspec/changes/polish-macos-pane-title-bar-readability/tasks.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/tasks.md
@@ -1,0 +1,38 @@
+## 1. Current-State Verification
+
+- [x] 1.1 Reproduce or inspect the focused-title readability problem in the current `ShellPaneTitleBarView` styling.
+- [x] 1.2 Confirm the current accessory projection order and identify whether `ShellModel.swift` needs explicit layout priority metadata or whether `TerminalPaneView.swift` can own the presentation priority.
+
+## 2. Title-Bar Visual And Layout Implementation
+
+- [x] 2.1 Update `ShellPaneTitleBarView` so the row uses the terminal surface background rather than selected/unselected terminal chrome material fills.
+- [x] 2.2 Increase title and accessory foreground contrast for focused and unfocused panes while keeping typography compact and terminal-first.
+- [x] 2.3 Replace fixed-width or infinite-width title-bar slots with left-to-right fit-content layout for title, activity/status, cwd/worktree, branch, process/alan, and close.
+- [x] 2.4 Implement staged narrow-width fallback so lower-priority accessories degrade from text plus icon to icon-only or hidden before title text or close disappear.
+- [x] 2.5 Ensure the title always remains text with middle truncation and never becomes icon-only.
+- [x] 2.6 Preserve title-bar click-to-focus, pane-scoped close routing, accessibility labels, and help text.
+- [x] 2.7 Preserve terminal canvas hit-testing, selection, mouse reporting, right click, scrollback, and split geometry below the title bar.
+
+## 3. Contract Checks And Focused Tests
+
+- [x] 3.1 Update focused shell contract checks to guard against selected/unselected title-bar overlay fills, fixed-width accessory regressions, and title icon-only fallback.
+- [x] 3.2 Add or update focused runtime metadata tests for accessory priority, fallback ordering, and title persistence under narrow-layout assumptions.
+- [x] 3.3 Run `clients/apple/scripts/test-shell-runtime-metadata.sh`.
+- [x] 3.4 Run `clients/apple/scripts/test-shell-split-model.sh` if pane close or split targeting code changes. Not applicable: pane close and split targeting code did not change.
+- [x] 3.5 Run `clients/apple/scripts/test-terminal-surface-controller.sh` if title-bar focus or terminal input boundaries change. Not applicable: terminal input boundary code did not change.
+- [x] 3.6 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+
+## 4. Visual Verification
+
+- [ ] 4.1 Inspect or capture a light-mode single-pane view showing the title remains readable when focused.
+- [ ] 4.2 Inspect or capture light-mode split panes showing title bars integrated with the terminal surface rather than rendered as separate overlay bands.
+- [ ] 4.3 Inspect or capture a narrow split pane showing accessory degradation while title text and close remain visible.
+
+## 5. Change Validation And Archive Readiness
+
+- [x] 5.1 Run `git diff --check`.
+- [x] 5.2 Run `openspec validate polish-macos-pane-title-bar-readability --type change --strict --json`.
+- [x] 5.3 Run `openspec validate --all --strict --json`.
+- [x] 5.4 Run the relevant macOS app build command for touched Apple client targets, or document why the local environment cannot complete it.
+- [ ] 5.5 Sync accepted delta requirements into `openspec/specs/` before archive after implementation merges.
+- [x] 5.6 Record implementation verification evidence in the change before archive.

--- a/openspec/changes/polish-macos-pane-title-bar-readability/verification.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/verification.md
@@ -11,3 +11,4 @@
 
 - `/private/tmp` no longer contains top-level `alan*` build directories after cleanup.
 - Visual verification for the light-mode focused title, split-pane integration, and narrow accessory fallback is intentionally pending user relaunch/restart of Alan. Temporary debug launches plus Computer Use are not treated as valid evidence for this UI change.
+- Review follow-up restored the title bar's full-width background and focus hit area while keeping fit-content responsive content inside the row.

--- a/openspec/changes/polish-macos-pane-title-bar-readability/verification.md
+++ b/openspec/changes/polish-macos-pane-title-bar-readability/verification.md
@@ -1,0 +1,13 @@
+## Verification
+
+- `clients/apple/scripts/test-shell-runtime-metadata.sh` passed.
+- `bash clients/apple/scripts/check-shell-contracts.sh` passed.
+- `git diff --check -- clients/apple/alan-macos/TerminalPaneView.swift clients/apple/scripts/check-shell-contracts.sh clients/apple/scripts/test-shell-runtime-metadata.swift openspec/changes/polish-macos-pane-title-bar-readability` passed.
+- `openspec validate polish-macos-pane-title-bar-readability --type change --strict --json` passed.
+- `openspec validate --all --strict --json` passed.
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-pane-title build` passed. The DerivedData path is repo-local and not under `/tmp` or `/private/tmp`.
+
+## Notes
+
+- `/private/tmp` no longer contains top-level `alan*` build directories after cleanup.
+- Visual verification for the light-mode focused title, split-pane integration, and narrow accessory fallback is intentionally pending user relaunch/restart of Alan. Temporary debug launches plus Computer Use are not treated as valid evidence for this UI change.


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for pane title bar readability, terminal-surface integration, and responsive fallback.
- Rework ShellPaneTitleBarView to use the terminal background, higher-contrast title/accessory foregrounds, fit-content layout, and staged ViewThatFits fallback.
- Add contract and runtime metadata coverage for persistent text titles and accessory priority ordering.

## Test Plan
- [x] clients/apple/scripts/test-shell-runtime-metadata.sh
- [x] bash clients/apple/scripts/check-shell-contracts.sh
- [x] git diff --check
- [x] openspec validate polish-macos-pane-title-bar-readability --type change --strict --json
- [x] openspec validate --all --strict --json
- [x] xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-pane-title build

## Notes
- Build output was repo-local under debug/, not /tmp or /private/tmp.
- Visual verification is intentionally left for relaunch/restart because the running Alan app must be restarted before this UI change is visible.