### PR TITLE
Add macOS app auto-update OpenSpec

### DIFF
--- a/openspec/changes/add-macos-app-auto-update/.openspec.yaml
+++ b/openspec/changes/add-macos-app-auto-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/add-macos-app-auto-update/design.md
+++ b/openspec/changes/add-macos-app-auto-update/design.md
@@ -1,0 +1,118 @@
+## Context
+
+Alan 当前已经有 app-first 的 macOS 发布链路：`just release` 构建 Release
+`Alan.app`，嵌入 release CLI/TUI，使用 Developer ID 签名，可选公证并输出
+`alan-<version>-macos.zip`。Homebrew cask 模板已经假定 zip 来自 GitHub
+Releases，并从 app bundle 内链接 `alan` 和 `alan-tui`。
+
+缺口在直接下载安装路径：非 Homebrew 用户拿到 `Alan.app` 后，后续版本只能手动
+检查 GitHub 或重新下载安装。用户已经确定 `alanworks.app` 会作为产品网站域名，
+并希望 Cloudflare 只托管网站和 Sparkle appcast，小文件由 Cloudflare Pages
+负责，zip 继续放 GitHub Releases。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 为直接安装的 `Alan.app` 增加 Sparkle 2 更新检查和安装能力。
+- 使用 `https://alanworks.app/appcast.xml` 作为稳定 `SUFeedURL`。
+- 让 Cloudflare Pages 托管产品网站和 `appcast.xml`，不托管 release zip。
+- 继续使用 GitHub Releases 托管签名、公证后的
+  `alan-<version>-macos.zip` 和 checksum。
+- 明确 Homebrew cask 安装由 Homebrew 更新，不由 Sparkle 改写 bundle。
+- 建立 release/version/appcast 验证，避免 Cargo、Xcode、appcast 和 zip 版本漂移。
+
+**Non-Goals:**
+
+- 设计或实现 `alanworks.app` 的产品网站视觉和内容。
+- 把 release zip 从 GitHub Releases 迁移到 Cloudflare R2。
+- 实现自研 GitHub Release downloader 或自研 app bundle 替换逻辑。
+- 第一版强制静默后台安装；默认保留用户可见的 Sparkle 更新确认流程。
+- 第一版强制 Sparkle signed feed。必须签名的是 update archive；signed feed
+  可以作为后续安全加固。
+- 让 Sparkle 接管 Homebrew cask 安装的更新。
+
+## Decisions
+
+1. **使用 Sparkle 2，而不是自研 GitHub updater。**
+
+   Sparkle 负责 macOS app 更新检查、下载、签名校验、权限处理和原子替换。Alan
+   只负责生成可信 release artifact 和 appcast。自研 updater 会重新实现高风险的
+   bundle 替换、安全校验和权限逻辑，不适合作为第一版。
+
+2. **Cloudflare Pages 只托管网站和 appcast。**
+
+   `https://alanworks.app/` 是产品网站入口，
+   `https://alanworks.app/appcast.xml` 是 Sparkle feed。`appcast.xml` 需要
+   明确 `Content-Type: application/xml; charset=utf-8`，并使用短缓存或
+   `Cache-Control: no-cache, max-age=0, must-revalidate`，避免客户端在发布后
+   长时间读到旧 feed。
+
+3. **GitHub Releases 继续拥有 zip 资产。**
+
+   appcast 的 enclosure URL 指向
+   `https://github.com/realmorrisliu/alan/releases/download/v<version>/alan-<version>-macos.zip`。
+   这保持现有 Homebrew cask 模板、release checksum 和公开发布页面一致。Cloudflare
+   不需要代理或缓存 zip。
+
+4. **直接安装和 Homebrew 安装分流。**
+
+   直接下载或拖拽安装的 `Alan.app` 可以显示 `Check for Updates...` 并使用
+   Sparkle。Homebrew cask 管理的安装必须把 Homebrew 视为权威更新器，避免 Sparkle
+   在 Homebrew 管理的 app bundle 上执行替换。第一版可以通过安装路径、Homebrew
+   管理的 binary links、或其他明确检测信号禁用/改写菜单提示。
+
+5. **版本以发布版本和递增 build number 共同判定。**
+
+   Cargo workspace version、Xcode `MARKETING_VERSION`、zip 文件名、GitHub release
+   tag、appcast `sparkle:shortVersionString` 必须一致。Xcode
+   `CURRENT_PROJECT_VERSION` / appcast `sparkle:version` 必须单调递增，因为 Sparkle
+   用 bundle version 判定更新顺序。release validation 应在发布前阻断漂移。
+
+6. **release 流程先手动闭环，再自动化。**
+
+   第一阶段把本地 `just release`、GitHub release asset 上传、appcast 生成和
+   Cloudflare Pages 部署跑通。真实验收必须从旧版已安装 `Alan.app` 更新到新版。
+   稳定后再把 GitHub Actions、Cloudflare Pages deploy 和 appcast 生成纳入自动化。
+
+## Risks / Trade-offs
+
+- **[Risk] Sparkle 嵌入 framework/helper 后签名顺序不完整。** -> release
+  validation 必须检查 Sparkle 嵌套代码、Alan app、CLI/TUI 都是 Developer ID
+  签名，且最终 app bundle 通过严格 codesign、公证和 stapler 验证。
+- **[Risk] appcast 被 Cloudflare 缓存导致新版不可见。** -> `appcast.xml`
+  使用低缓存头，并在验证中通过 HTTP header 检查确认。
+- **[Risk] Homebrew 安装被 Sparkle 改写，破坏 cask 状态。** -> App 端检测
+  Homebrew 管理路径或链接，禁用 Sparkle 安装路径或给出 Homebrew 更新提示。
+- **[Risk] 版本号漂移导致 Sparkle 不提示更新或错误降级。** -> 发布脚本检查
+  Cargo、Xcode、zip、GitHub tag 和 appcast 版本一致，并检查 build number 单调递增。
+- **[Risk] Sparkle EdDSA private key 泄漏。** -> 私钥不进入 repo；本地或 CI
+  通过安全文件、Keychain 或 secrets 注入，release 日志不得打印私钥内容。
+- **[Risk] 首次发布没有旧版样本，无法证明更新。** -> 在真正公开前保留一个旧版
+  signed/notarized fixture 或通过临时较低 build number 的安装包验证旧版到新版流程。
+
+## Migration Plan
+
+1. 创建 Sparkle EdDSA key，把 public key 写入 app Info.plist 配置，private key
+   存在本地安全位置或未来 CI secret。
+2. 给 Xcode project 增加 Sparkle 2 依赖和 `Check for Updates...` 菜单入口。
+3. 更新 release assembly/signing validation，覆盖 Sparkle 嵌套代码和版本一致性。
+4. 增加 appcast 生成脚本：读取 release zip、GitHub release URL、版本号、长度、
+   EdDSA signature，生成 `appcast.xml`。
+5. 在 `alanworks.app` 的 Cloudflare Pages 项目中发布网站静态文件和 `appcast.xml`，
+   并配置 appcast 的低缓存 header。
+6. 发布一个包含 zip asset 的 GitHub Release，部署 appcast，再用旧版
+   `Alan.app` 验证 Sparkle 能检测、下载、校验并安装新版。
+7. 更新 Homebrew 文档和 cask 维护说明，明确 cask 用户通过 Homebrew 更新。
+
+Rollback：如果 Sparkle 集成出现问题，可以发布一个不启用自动检查的修复版本，或从
+Cloudflare Pages 暂时回滚/移除 `appcast.xml` 中的新 item。已经发布的 GitHub
+Release zip 不应原地替换；需要用更高版本发布修复。
+
+## Open Questions
+
+- Homebrew 安装检测第一版使用哪一个主信号：app 路径、Homebrew binary links，还是
+  release manifest 中的安装来源标记？
+- 第一版是否需要 beta/prerelease channel，还是只支持 stable appcast？
+- GitHub Release asset 上传和 Cloudflare Pages deploy 是否在第一版保留为手动步骤，
+  还是直接接入 GitHub Actions？

--- a/openspec/changes/add-macos-app-auto-update/proposal.md
+++ b/openspec/changes/add-macos-app-auto-update/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Alan 已经有 app-first 的签名、公证、GitHub Release zip 和 Homebrew cask
+包装基础，但直接下载安装的 `Alan.app` 还不能自己发现和安装新版本。现在要把
+自动更新纳入正式 macOS 分发契约，让非 Homebrew 用户可以通过稳定的更新 feed
+跟进公开发布，同时继续保持 GitHub Releases 作为发布产物来源。
+
+## What Changes
+
+- 为直接安装的 `Alan.app` 增加 Sparkle 2 自动更新能力。
+- 将 Sparkle feed 固定到 `https://alanworks.app/appcast.xml`，由
+  Cloudflare Pages 托管网站和 appcast 小文件。
+- 继续让 GitHub Releases 托管签名、公证后的
+  `alan-<version>-macos.zip` 和 checksum，appcast 只引用这些 release
+  asset。
+- 明确 Homebrew cask 安装路径不由 Sparkle 接管；Homebrew 用户继续通过
+  `brew upgrade --cask alan` 更新，避免 cask 状态和 app bundle 内容漂移。
+- 为 release/appcast 生成、版本递增、Sparkle update 签名元数据、公证、
+  feed 缓存和旧版到新版的真实更新流程增加验证要求。
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `alan-app-distribution`: 增加 macOS App 自动更新、Cloudflare 托管
+  appcast、GitHub Release zip 资产、Homebrew 分流和版本递增契约。
+- `macos-shell-build-test-contract`: 增加 Sparkle 集成、appcast 生成、签名
+  公证、缓存头和真实旧版更新到新版的发布验证要求。
+
+## Impact
+
+- `clients/apple/alan-macos.xcodeproj` 需要引入 Sparkle 2 依赖并配置
+  `SUFeedURL` / `SUPublicEDKey` 等 Info.plist 元数据。
+- macOS app 菜单需要提供显式的 `Check for Updates...` 入口，并在
+  Homebrew 管理的安装中避免误导用户使用 Sparkle 更新。
+- `scripts/assemble-release-app.sh` / release validation 需要覆盖 Sparkle
+  framework/helper 的签名、公证和 appcast 签名产物。
+- release 流程需要发布 GitHub Release zip 后生成或刷新
+  `appcast.xml`，并把该文件部署到 `alanworks.app`。
+- Cloudflare Pages 只托管网站和 `appcast.xml`；release zip 仍然属于
+  GitHub Releases。

--- a/openspec/changes/add-macos-app-auto-update/specs/alan-app-distribution/spec.md
+++ b/openspec/changes/add-macos-app-auto-update/specs/alan-app-distribution/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Direct macOS installs receive Sparkle updates
+Alan for macOS SHALL provide Sparkle-based update checking for directly
+installed `Alan.app` bundles that are not managed by Homebrew.
+
+#### Scenario: Direct install checks for updates
+- **WHEN** a user runs a directly installed `Alan.app`
+- **THEN** the app can check the Sparkle feed at `https://alanworks.app/appcast.xml`
+- **AND** the app can present a user-visible update flow for available stable releases
+
+#### Scenario: Update archive is trusted
+- **WHEN** Sparkle downloads an Alan update archive
+- **THEN** the archive is verified with Sparkle EdDSA update-signature metadata from the appcast
+- **AND** the installed app bundle remains Developer ID signed and notarized
+
+### Requirement: alanworks.app owns the Sparkle feed
+Alan SHALL use `https://alanworks.app/appcast.xml` as the stable Sparkle feed
+URL for the default stable macOS update channel.
+
+#### Scenario: Feed URL is configured
+- **WHEN** the release app bundle is built with auto-update support
+- **THEN** its Sparkle feed URL resolves to `https://alanworks.app/appcast.xml`
+- **AND** the app does not depend on a GitHub Pages URL for update discovery
+
+#### Scenario: Appcast is served
+- **WHEN** a client requests `https://alanworks.app/appcast.xml`
+- **THEN** Cloudflare Pages serves the appcast as an XML document
+- **AND** the response uses cache behavior that allows newly published releases to become visible without waiting for a long-lived static cache to expire
+
+### Requirement: GitHub Releases own macOS update archives
+Alan macOS update archives SHALL remain GitHub Release assets while
+`alanworks.app` owns only the website and Sparkle appcast.
+
+#### Scenario: Appcast references release asset
+- **WHEN** an appcast item describes a stable Alan for macOS release
+- **THEN** its enclosure URL points at the matching GitHub Release asset
+- **AND** the asset name follows `alan-<version>-macos.zip`
+- **AND** the corresponding GitHub Release includes checksum metadata for the same archive
+
+#### Scenario: Cloudflare Pages deployment is inspected
+- **WHEN** the Cloudflare Pages site for `alanworks.app` is deployed
+- **THEN** it does not contain the release zip as a Pages static asset
+- **AND** release archive downloads continue to resolve through GitHub Releases
+
+### Requirement: Homebrew-managed installs use Homebrew updates
+Alan for macOS SHALL NOT let Sparkle replace a Homebrew-managed app
+installation.
+
+#### Scenario: Homebrew-managed install is detected
+- **WHEN** Alan detects that the current app installation is managed by the Homebrew cask path or Homebrew-managed command links
+- **THEN** Sparkle installation is disabled or the update UI directs the user to update with Homebrew
+- **AND** Alan does not replace the Homebrew-managed app bundle through Sparkle
+
+#### Scenario: Homebrew documentation is shown
+- **WHEN** install or update documentation describes updating a Homebrew cask install
+- **THEN** it uses `brew upgrade --cask alan` as the update path
+- **AND** it does not tell cask users to rely on Sparkle for app bundle replacement
+
+### Requirement: Release versions are monotonic across appcast and bundle metadata
+Alan release packaging SHALL keep macOS app bundle version metadata,
+GitHub release naming, release archive naming, and Sparkle appcast metadata in
+sync.
+
+#### Scenario: Release version is validated
+- **WHEN** a macOS release is prepared for appcast publication
+- **THEN** Cargo workspace version, Xcode `MARKETING_VERSION`, GitHub release tag, release archive filename, and appcast short version describe the same version
+- **AND** Xcode `CURRENT_PROJECT_VERSION` and appcast version are monotonically greater than the previously published stable release
+
+#### Scenario: Version drift is found
+- **WHEN** release validation detects mismatched version metadata or a non-incremented Sparkle version
+- **THEN** release validation fails before the appcast is deployed
+- **AND** no new appcast item is published for the invalid release

--- a/openspec/changes/add-macos-app-auto-update/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-app-auto-update/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Auto-update packaging has focused validation
+The Apple client build/test contract SHALL provide focused validation for
+Sparkle integration, appcast generation, release archive trust metadata, and
+direct-install update behavior when macOS auto-update support changes.
+
+#### Scenario: Sparkle integration is checked
+- **WHEN** auto-update implementation is ready for review
+- **THEN** focused checks verify the release app includes the Sparkle framework and helper code required for updates
+- **AND** focused checks verify Sparkle public-key and feed URL metadata are present in the release app bundle
+- **AND** focused checks verify Sparkle nested code and the final app bundle are Developer ID signed
+
+#### Scenario: Appcast artifact is checked
+- **WHEN** a release appcast is generated
+- **THEN** focused checks verify `appcast.xml` references the expected GitHub Release zip asset
+- **AND** focused checks verify the appcast includes Sparkle EdDSA signature metadata for the update archive
+- **AND** focused checks verify the appcast version and short version match the release package metadata
+
+#### Scenario: Cloudflare appcast headers are checked
+- **WHEN** `https://alanworks.app/appcast.xml` is deployed for stable updates
+- **THEN** focused checks verify the response is served as XML
+- **AND** focused checks verify cache headers do not create a long-lived stale feed
+
+#### Scenario: Direct app update smoke is checked
+- **WHEN** auto-update support is considered release-ready
+- **THEN** verification installs or launches an older signed and notarized `Alan.app`
+- **AND** verification confirms Sparkle detects the newer appcast item
+- **AND** verification confirms the update downloads, verifies, installs, and relaunches into the newer version
+
+#### Scenario: Homebrew path is checked
+- **WHEN** update behavior is tested for a Homebrew-managed install
+- **THEN** focused checks verify Alan does not let Sparkle replace the Homebrew-managed app bundle
+- **AND** focused checks verify the user-facing update path points to Homebrew instead

--- a/openspec/changes/add-macos-app-auto-update/tasks.md
+++ b/openspec/changes/add-macos-app-auto-update/tasks.md
@@ -1,0 +1,49 @@
+## 1. Sparkle Integration
+
+- [ ] 1.1 Add Sparkle 2 to the macOS Xcode project using the repo's chosen dependency mechanism.
+- [ ] 1.2 Generate a Sparkle EdDSA key pair and store only the public key in tracked app configuration.
+- [ ] 1.3 Configure the release app bundle with `SUFeedURL=https://alanworks.app/appcast.xml`.
+- [ ] 1.4 Configure Sparkle public-key metadata and any required updater bundle metadata in the generated Info.plist surface.
+- [ ] 1.5 Add a focused project/configuration check that fails when the release app is missing Sparkle feed URL or public-key metadata.
+
+## 2. App Update Behavior
+
+- [ ] 2.1 Add a macOS app updater owner that initializes Sparkle for direct app installs.
+- [ ] 2.2 Add a `Check for Updates...` command in the native app menu.
+- [ ] 2.3 Detect Homebrew-managed installs using the selected first-pass signal from the design open question.
+- [ ] 2.4 Disable Sparkle replacement or show a Homebrew update path when the app is Homebrew-managed.
+- [ ] 2.5 Keep the first version user-visible and confirmation-based rather than silent background installation.
+
+## 3. Release And Appcast Pipeline
+
+- [ ] 3.1 Add release validation that checks Cargo workspace version, Xcode `MARKETING_VERSION`, GitHub release tag, zip filename, and appcast short version agree.
+- [ ] 3.2 Add release validation that checks Xcode `CURRENT_PROJECT_VERSION` / appcast version is monotonic against the previous stable release.
+- [ ] 3.3 Add an appcast generation script that reads the notarized zip, GitHub Release asset URL, archive length, version metadata, and Sparkle EdDSA signature.
+- [ ] 3.4 Update release documentation so the zip stays on GitHub Releases while `appcast.xml` is deployed to `alanworks.app`.
+- [ ] 3.5 Add Cloudflare Pages static assets or documented deployment inputs for `appcast.xml` and the website root without including release zip files.
+- [ ] 3.6 Configure or document Cloudflare Pages headers so `/appcast.xml` is served as XML with low-cache behavior.
+
+## 4. Signing And Packaging Validation
+
+- [ ] 4.1 Update release assembly/signing so Sparkle nested framework/helper code is signed correctly with the final app bundle.
+- [ ] 4.2 Extend `scripts/validate-release-app.sh` or adjacent focused checks to verify Sparkle nested code signatures.
+- [ ] 4.3 Add an appcast validation check for GitHub Release enclosure URL, EdDSA signature metadata, archive length, version, and short version.
+- [ ] 4.4 Add a deployed-feed check for `https://alanworks.app/appcast.xml` content type and cache headers.
+- [ ] 4.5 Add a Homebrew-path focused check proving Sparkle does not replace a Homebrew-managed app bundle.
+
+## 5. End-To-End Verification
+
+- [ ] 5.1 Build a signed and notarized release app with Sparkle integration enabled.
+- [ ] 5.2 Publish or stage a GitHub Release zip asset and matching checksum for a testable version.
+- [ ] 5.3 Deploy the matching `appcast.xml` to `alanworks.app`.
+- [ ] 5.4 Verify an older signed and notarized `Alan.app` detects the newer appcast item.
+- [ ] 5.5 Verify the update downloads, verifies, installs, and relaunches into the newer version.
+- [ ] 5.6 Run existing release, Homebrew cask, Apple contract, and brand validation checks.
+
+## 6. Documentation And Change Closure
+
+- [ ] 6.1 Update README and packaging docs to describe direct-app Sparkle updates and Homebrew `brew upgrade --cask alan` updates separately.
+- [ ] 6.2 Document the Sparkle private-key handling rule without committing private material.
+- [ ] 6.3 Add PR notes summarizing Cloudflare Pages, GitHub Releases, Sparkle, and Homebrew ownership boundaries.
+- [ ] 6.4 Run `openspec validate add-macos-app-auto-update --strict`.
+- [ ] 6.5 Before archiving, sync accepted delta specs into `openspec/specs/` and run `openspec validate --all --strict`.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for Sparkle-based Alan.app auto-updates
- define alanworks.app as the Cloudflare Pages-hosted website/appcast owner
- keep macOS zip archives on GitHub Releases and separate Homebrew updates from Sparkle updates

## Validation
- openspec status --change add-macos-app-auto-update
- openspec validate add-macos-app-auto-update --strict