### PR TITLE
Enhance macOS split topology indicators

### DIFF
--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -38,6 +38,271 @@ struct ShellPaneTitleBarDetailProjection: Equatable, Identifiable {
     let help: String
 }
 
+struct ShellTabPaneSummary: Equatable {
+    let topology: ShellSidebarPaneTopology
+    let focusedPaneID: String?
+
+    init(
+        paneTree: ShellPaneTreeNode,
+        visiblePaneIDs: [String],
+        focusedPaneID: String?
+    ) {
+        topology = ShellSidebarPaneTopology.classify(
+            paneTree: paneTree,
+            visiblePaneIDs: visiblePaneIDs
+        )
+        self.focusedPaneID = visiblePaneIDs.contains(focusedPaneID ?? "") ? focusedPaneID : nil
+    }
+
+    var paneIDs: [String] {
+        topology.paneIDs
+    }
+
+    var paneCount: Int {
+        topology.paneCount
+    }
+
+    var isComplex: Bool {
+        topology.isComplex
+    }
+
+    var accessibilityTopologyLabel: String {
+        topology.userFacingDescription
+    }
+
+    func nextPaneID(after currentPaneID: String?) -> String? {
+        guard !paneIDs.isEmpty else { return nil }
+        guard let currentPaneID,
+              let currentIndex = paneIDs.firstIndex(of: currentPaneID)
+        else {
+            return paneIDs.first
+        }
+
+        return paneIDs[(currentIndex + 1) % paneIDs.count]
+    }
+}
+
+struct ShellSidebarPaneTopology: Equatable {
+    let kind: ShellSidebarPaneTopologyKind
+    let paneIDs: [String]
+
+    var paneCount: Int {
+        paneIDs.count
+    }
+
+    var isComplex: Bool {
+        if case .complex = kind {
+            return true
+        }
+        return false
+    }
+
+    var userFacingDescription: String {
+        switch kind {
+        case .single:
+            return "Single pane"
+        case .columns(let count):
+            return "\(count)-column split"
+        case .rows(let count):
+            return "\(count)-row split"
+        case .mainLeftWithRightStack:
+            return "Main pane left with right stack"
+        case .mainRightWithLeftStack:
+            return "Main pane right with left stack"
+        case .mainTopWithBottomSplit:
+            return "Main pane top with bottom split"
+        case .mainBottomWithTopSplit:
+            return "Main pane bottom with top split"
+        case .grid2x2:
+            return "2 by 2 grid split"
+        case .complex(let count):
+            return "Complex split, \(count) panes"
+        }
+    }
+
+    static func classify(
+        paneTree: ShellPaneTreeNode,
+        visiblePaneIDs: [String]
+    ) -> ShellSidebarPaneTopology {
+        let orderedVisiblePaneIDs = paneTree.paneIDs.filter { visiblePaneIDs.contains($0) }
+        guard !orderedVisiblePaneIDs.isEmpty,
+              let normalizedTree = ShellSidebarPaneTopologyNode(
+                  paneTree: paneTree,
+                  visiblePaneIDs: Set(orderedVisiblePaneIDs)
+              )
+        else {
+            return ShellSidebarPaneTopology(kind: .complex(count: 0), paneIDs: [])
+        }
+
+        let paneIDs = normalizedTree.paneIDs
+        guard paneIDs.count > 1 else {
+            return ShellSidebarPaneTopology(kind: .single, paneIDs: paneIDs)
+        }
+
+        if let splitDirection = normalizedTree.splitDirection,
+           let flattened = normalizedTree.flattenedPaneIDs(along: splitDirection),
+           flattened.count == paneIDs.count,
+           (2...4).contains(flattened.count)
+        {
+            let kind: ShellSidebarPaneTopologyKind = splitDirection == .vertical
+                ? .columns(count: flattened.count)
+                : .rows(count: flattened.count)
+            return ShellSidebarPaneTopology(kind: kind, paneIDs: flattened)
+        }
+
+        if let mainStackKind = Self.mainStackKind(for: normalizedTree) {
+            return ShellSidebarPaneTopology(kind: mainStackKind, paneIDs: paneIDs)
+        }
+
+        if let gridKind = Self.gridKind(for: normalizedTree) {
+            return ShellSidebarPaneTopology(kind: gridKind, paneIDs: paneIDs)
+        }
+
+        return ShellSidebarPaneTopology(kind: .complex(count: paneIDs.count), paneIDs: paneIDs)
+    }
+
+    private static func mainStackKind(
+        for node: ShellSidebarPaneTopologyNode
+    ) -> ShellSidebarPaneTopologyKind? {
+        guard case .split(let direction, let children) = node,
+              children.count == 2
+        else {
+            return nil
+        }
+
+        let first = children[0]
+        let second = children[1]
+
+        switch direction {
+        case .vertical:
+            if first.leafPaneID != nil,
+               second.flattenedPaneIDs(along: .horizontal)?.count == 2
+            {
+                return .mainLeftWithRightStack
+            }
+            if first.flattenedPaneIDs(along: .horizontal)?.count == 2,
+               second.leafPaneID != nil
+            {
+                return .mainRightWithLeftStack
+            }
+        case .horizontal:
+            if first.leafPaneID != nil,
+               second.flattenedPaneIDs(along: .vertical)?.count == 2
+            {
+                return .mainTopWithBottomSplit
+            }
+            if first.flattenedPaneIDs(along: .vertical)?.count == 2,
+               second.leafPaneID != nil
+            {
+                return .mainBottomWithTopSplit
+            }
+        }
+
+        return nil
+    }
+
+    private static func gridKind(
+        for node: ShellSidebarPaneTopologyNode
+    ) -> ShellSidebarPaneTopologyKind? {
+        guard case .split(let direction, let children) = node,
+              children.count == 2
+        else {
+            return nil
+        }
+
+        let childDirection: ShellSplitDirection = direction == .vertical ? .horizontal : .vertical
+        guard children.allSatisfy({ $0.flattenedPaneIDs(along: childDirection)?.count == 2 }) else {
+            return nil
+        }
+
+        return .grid2x2(rootDirection: direction)
+    }
+}
+
+enum ShellSidebarPaneTopologyKind: Equatable {
+    case single
+    case columns(count: Int)
+    case rows(count: Int)
+    case mainLeftWithRightStack
+    case mainRightWithLeftStack
+    case mainTopWithBottomSplit
+    case mainBottomWithTopSplit
+    case grid2x2(rootDirection: ShellSplitDirection)
+    case complex(count: Int)
+}
+
+private enum ShellSidebarPaneTopologyNode: Equatable {
+    case pane(String)
+    case split(direction: ShellSplitDirection, children: [ShellSidebarPaneTopologyNode])
+
+    init?(
+        paneTree: ShellPaneTreeNode,
+        visiblePaneIDs: Set<String>
+    ) {
+        switch paneTree.kind {
+        case .pane:
+            guard let paneID = paneTree.paneID,
+                  visiblePaneIDs.contains(paneID)
+            else {
+                return nil
+            }
+            self = .pane(paneID)
+        case .split:
+            let visibleChildren = (paneTree.children ?? []).compactMap {
+                ShellSidebarPaneTopologyNode(paneTree: $0, visiblePaneIDs: visiblePaneIDs)
+            }
+            guard visibleChildren.count > 1,
+                  let direction = paneTree.direction
+            else {
+                guard let onlyChild = visibleChildren.first else { return nil }
+                self = onlyChild
+                return
+            }
+            self = .split(direction: direction, children: visibleChildren)
+        }
+    }
+
+    var paneIDs: [String] {
+        switch self {
+        case .pane(let paneID):
+            return [paneID]
+        case .split(_, let children):
+            return children.flatMap(\.paneIDs)
+        }
+    }
+
+    var splitDirection: ShellSplitDirection? {
+        if case .split(let direction, _) = self {
+            return direction
+        }
+        return nil
+    }
+
+    var leafPaneID: String? {
+        if case .pane(let paneID) = self {
+            return paneID
+        }
+        return nil
+    }
+
+    func flattenedPaneIDs(along direction: ShellSplitDirection) -> [String]? {
+        switch self {
+        case .pane(let paneID):
+            return [paneID]
+        case .split(let splitDirection, let children):
+            guard splitDirection == direction else { return nil }
+            var paneIDs: [String] = []
+            for child in children {
+                guard let childPaneIDs = child.flattenedPaneIDs(along: direction) else {
+                    return nil
+                }
+                paneIDs.append(contentsOf: childPaneIDs)
+            }
+            return paneIDs
+        }
+    }
+}
+
 func shellUserFacingSummary(_ summary: String?) -> String? {
     guard let summary else { return nil }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -1058,6 +1058,7 @@ private struct ShellTabSidebarRow: View {
         .buttonStyle(.plain)
         .opacity(showsCloseButton ? 1 : 0)
         .allowsHitTesting(showsCloseButton)
+        .accessibilityHidden(!showsCloseButton)
         .help("Close tab")
         .accessibilityLabel("Close tab")
         .onHover { isHovering in

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -497,7 +497,7 @@ struct ShellSidebarView: View {
         host.refocusSelectedTerminalPane()
     }
 
-    private func focusNextSplitPane(in tab: ShellTab, summary: ShellTabSplitSummary) {
+    private func focusNextSplitPane(in tab: ShellTab, summary: ShellTabPaneSummary) {
         guard let paneID = summary.nextPaneID(after: host.shellState.focusedPaneID) else { return }
         focusPane(paneID, in: tab)
     }
@@ -518,11 +518,10 @@ struct ShellSidebarView: View {
             title: projection.title,
             subtitle: projection.secondaryLine,
             isActivitySubtitle: projection.activity != nil,
-            iconName: tabIconName(for: tab),
             progress: projection.progress,
             attention: strongestAttention(for: tab),
             showsAlanMarker: showsAlanMarker(for: tab, activity: projection.activity),
-            splitSummary: splitSummary(for: tab),
+            paneSummary: paneSummary(for: tab),
             isPinned: host.isTabPinned(tabID: tab.tabID),
             isSelected: isSelected,
             isHovered: isHovered,
@@ -569,25 +568,16 @@ struct ShellSidebarView: View {
         }
     }
 
-    private func splitSummary(for tab: ShellTab) -> ShellTabSplitSummary? {
+    private func paneSummary(for tab: ShellTab) -> ShellTabPaneSummary? {
         let paneIDs = tab.paneTree.paneIDs.filter { paneID in
             host.shellState.panes.contains { $0.paneID == paneID }
         }
-        guard paneIDs.count > 1 else { return nil }
+        guard !paneIDs.isEmpty else { return nil }
 
-        let children = tab.paneTree.children ?? []
-        let isSimpleTwoPaneSplit = paneIDs.count == 2
-            && tab.paneTree.kind == .split
-            && children.count == 2
-            && children.allSatisfy { $0.kind == .pane }
-
-        return ShellTabSplitSummary(
-            paneIDs: paneIDs,
-            direction: isSimpleTwoPaneSplit ? tab.paneTree.direction : nil,
-            focusedPaneID: paneIDs.contains(host.shellState.focusedPaneID ?? "")
-                ? host.shellState.focusedPaneID
-                : nil,
-            isComplex: !isSimpleTwoPaneSplit
+        return ShellTabPaneSummary(
+            paneTree: tab.paneTree,
+            visiblePaneIDs: paneIDs,
+            focusedPaneID: host.shellState.focusedPaneID
         )
     }
 
@@ -599,17 +589,6 @@ struct ShellSidebarView: View {
             return "Scratch"
         case .log:
             return "Logs"
-        }
-    }
-
-    private func tabIconName(for tab: ShellTab) -> String {
-        switch tab.kind {
-        case .terminal:
-            return "terminal"
-        case .scratch:
-            return "note.text"
-        case .log:
-            return "doc.text.magnifyingglass"
         }
     }
 
@@ -847,28 +826,6 @@ private struct ShellSpaceSwitcherItem: View {
     }
 }
 
-private struct ShellTabSplitSummary: Equatable {
-    let paneIDs: [String]
-    let direction: ShellSplitDirection?
-    let focusedPaneID: String?
-    let isComplex: Bool
-
-    var paneCount: Int {
-        paneIDs.count
-    }
-
-    func nextPaneID(after currentPaneID: String?) -> String? {
-        guard !paneIDs.isEmpty else { return nil }
-        guard let currentPaneID,
-              let currentIndex = paneIDs.firstIndex(of: currentPaneID)
-        else {
-            return paneIDs.first
-        }
-
-        return paneIDs[(currentIndex + 1) % paneIDs.count]
-    }
-}
-
 private enum ShellSidebarRowVisualState: Equatable {
     case normal
     case hover
@@ -972,113 +929,76 @@ private enum ShellSidebarTypography {
 private struct ShellTabSidebarRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isKeyboardFocused: Bool
+    @State private var isCloseHovered = false
     let title: String
     let subtitle: String
     let isActivitySubtitle: Bool
-    let iconName: String
     let progress: TerminalActivityProgress?
     let attention: ShellAttentionState?
     let showsAlanMarker: Bool
-    let splitSummary: ShellTabSplitSummary?
+    let paneSummary: ShellTabPaneSummary?
     let isPinned: Bool
     let isSelected: Bool
     let isHovered: Bool
     let showsCloseAffordance: Bool
     let onFocusSplitPane: (String) -> Void
-    let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
+    let onFocusNextSplitPane: (ShellTabPaneSummary) -> Void
     let onClose: () -> Void
 
     var body: some View {
-        ZStack(alignment: .trailing) {
-            HStack(alignment: .top, spacing: 10) {
-                leadingSlot
-                    .frame(width: 24, height: 24, alignment: .center)
+        HStack(alignment: .center, spacing: 10) {
+            leadingSlot
+                .frame(width: 24, height: 24, alignment: .center)
 
-                VStack(alignment: .leading, spacing: progress == nil ? 3 : 5) {
-                    HStack(spacing: 6) {
-                        Text(title)
-                            .font(
-                                .system(
-                                    size: ShellSidebarTypography.titleSize,
-                                    weight: ShellSidebarTypography.titleWeight(isSelected: isSelected)
-                                )
+            VStack(alignment: .leading, spacing: progress == nil ? 3 : 5) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(
+                            .system(
+                                size: ShellSidebarTypography.titleSize,
+                                weight: ShellSidebarTypography.titleWeight(isSelected: isSelected)
                             )
-                            .foregroundStyle(titleForeground)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-
-                        if showsAlanMarker {
-                            Image(systemName: "sparkles")
-                                .font(
-                                    .system(
-                                        size: ShellSidebarTypography.markerSize,
-                                        weight: ShellSidebarTypography.markerWeight
-                                    )
-                                )
-                                .foregroundStyle(ShellPalette.accent)
-                        }
-
-                        if isPinned {
-                            Image(systemName: "pin.fill")
-                                .font(
-                                    .system(
-                                        size: ShellSidebarTypography.pinSize,
-                                        weight: ShellSidebarTypography.markerWeight
-                                    )
-                                )
-                                .foregroundStyle(ShellPalette.accent.opacity(isSelected ? 0.84 : 0.64))
-                                .help("Pinned tab")
-                        }
-                    }
-
-                    subtitleText
-                        .foregroundStyle(subtitleForeground)
+                        )
+                        .foregroundStyle(titleForeground)
                         .lineLimit(1)
                         .truncationMode(.middle)
 
-                    if let progress {
-                        ShellSidebarActivityProgressRail(progress: progress, isSelected: isSelected)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                Spacer(minLength: 8)
-            }
-
-            if showsCloseButton {
-                HStack(spacing: 0) {
-                    LinearGradient(
-                        colors: [
-                            closeOverlayFill.opacity(0),
-                            closeOverlayFill.opacity(0.96),
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    .frame(width: 28)
-
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
+                    if showsAlanMarker {
+                        Image(systemName: "sparkles")
                             .font(
                                 .system(
-                                    size: ShellSidebarTypography.closeSize,
+                                    size: ShellSidebarTypography.markerSize,
                                     weight: ShellSidebarTypography.markerWeight
                                 )
                             )
-                            .foregroundStyle(closeForeground)
-                            .frame(width: 22, height: 22)
-                            .contentShape(Rectangle())
-                            .background {
-                                Circle()
-                                    .fill(closeOverlayFill.opacity(0.98))
-                            }
+                            .foregroundStyle(ShellPalette.accent)
                     }
-                    .buttonStyle(.plain)
-                    .help("Close tab")
-                    .accessibilityLabel("Close tab")
+
+                    if isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(
+                                .system(
+                                    size: ShellSidebarTypography.pinSize,
+                                    weight: ShellSidebarTypography.markerWeight
+                                )
+                            )
+                            .foregroundStyle(ShellPalette.accent.opacity(isSelected ? 0.84 : 0.64))
+                            .help("Pinned tab")
+                    }
                 }
-                .transition(.opacity)
+
+                subtitleText
+                    .foregroundStyle(subtitleForeground)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let progress {
+                    ShellSidebarActivityProgressRail(progress: progress, isSelected: isSelected)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            closeButtonSlot
         }
         .padding(.horizontal, ShellSidebarMetrics.rowInset)
         .padding(.vertical, 8)
@@ -1113,27 +1033,49 @@ private struct ShellTabSidebarRow: View {
     }
 
     private var showsCloseButton: Bool {
-        isInteractionActive
+        isSelected || isInteractionActive
+    }
+
+    private var closeButtonSlot: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark")
+                .font(
+                    .system(
+                        size: ShellSidebarTypography.closeSize,
+                        weight: ShellSidebarTypography.markerWeight
+                    )
+                )
+                .foregroundStyle(closeForeground)
+                .frame(width: 20, height: 20)
+                .contentShape(Circle())
+                .background {
+                    if isCloseHovered || isKeyboardFocused {
+                        Circle()
+                            .fill(ShellPalette.sidebarInk.opacity(isSelected ? 0.05 : 0.035))
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .opacity(showsCloseButton ? 1 : 0)
+        .allowsHitTesting(showsCloseButton)
+        .help("Close tab")
+        .accessibilityLabel("Close tab")
+        .onHover { isHovering in
+            isCloseHovered = isHovering
+        }
     }
 
     @ViewBuilder
     private var leadingSlot: some View {
-        if let splitSummary {
-            ShellSplitTopologyIndicator(
-                summary: splitSummary,
+        if let paneSummary {
+            ShellPaneTopologyIndicator(
+                summary: paneSummary,
+                isSelected: isSelected,
                 onFocusSplitPane: onFocusSplitPane,
                 onFocusNextSplitPane: onFocusNextSplitPane
             )
         } else {
-            Image(systemName: iconName)
-                .font(
-                    .system(
-                        size: ShellSidebarMetrics.iconPointSize,
-                        weight: ShellSidebarTypography.iconWeight
-                    )
-                )
-                .foregroundStyle(iconForeground)
-                .frame(width: ShellSidebarMetrics.iconColumnWidth)
+            ShellPaneTopologyIndicator.placeholder(isSelected: isSelected)
         }
     }
 
@@ -1173,10 +1115,6 @@ private struct ShellTabSidebarRow: View {
         return 0
     }
 
-    private var iconForeground: Color {
-        isSelected ? ShellPalette.accent : ShellPalette.sidebarMutedInk.opacity(0.84)
-    }
-
     private var titleForeground: Color {
         isSelected ? ShellPalette.sidebarInk : ShellPalette.sidebarInk.opacity(0.88)
     }
@@ -1186,11 +1124,10 @@ private struct ShellTabSidebarRow: View {
     }
 
     private var closeForeground: Color {
-        isSelected ? ShellPalette.sidebarInk.opacity(0.50) : ShellPalette.sidebarMutedInk.opacity(0.72)
-    }
-
-    private var closeOverlayFill: Color {
-        isSelected ? ShellPalette.sidebarRowSelected : ShellPalette.sidebarRowHover
+        if isCloseHovered {
+            return ShellPalette.sidebarInk.opacity(isSelected ? 0.68 : 0.76)
+        }
+        return isSelected ? ShellPalette.sidebarInk.opacity(0.46) : ShellPalette.sidebarMutedInk.opacity(0.62)
     }
 
     private var accessibilityLabel: String {
@@ -1201,8 +1138,8 @@ private struct ShellTabSidebarRow: View {
         if attention != nil {
             parts.append("needs attention")
         }
-        if let splitSummary {
-            parts.append("\(splitSummary.paneCount) panes")
+        if let paneSummary {
+            parts.append(paneSummary.paneCount == 1 ? "1 pane" : "\(paneSummary.paneCount) panes")
         }
         if isPinned {
             parts.append("pinned")
@@ -1253,63 +1190,249 @@ private struct ShellSidebarActivityProgressRail: View {
     }
 }
 
-private struct ShellSplitTopologyIndicator: View {
-    let summary: ShellTabSplitSummary
+private struct ShellPaneTopologyIndicator: View {
+    let summary: ShellTabPaneSummary
+    let isSelected: Bool
     let onFocusSplitPane: (String) -> Void
-    let onFocusNextSplitPane: (ShellTabSplitSummary) -> Void
+    let onFocusNextSplitPane: (ShellTabPaneSummary) -> Void
 
+    @ViewBuilder
     var body: some View {
-        if summary.isComplex {
+        switch summary.topology.kind {
+        case .single:
+            singlePaneIndicator
+        case .columns(let count):
+            columnsIndicator(paneIDs: Array(summary.paneIDs.prefix(count)))
+        case .rows(let count):
+            rowsIndicator(paneIDs: Array(summary.paneIDs.prefix(count)))
+        case .mainLeftWithRightStack:
+            mainLeftWithRightStackIndicator
+        case .mainRightWithLeftStack:
+            mainRightWithLeftStackIndicator
+        case .mainTopWithBottomSplit:
+            mainTopWithBottomSplitIndicator
+        case .mainBottomWithTopSplit:
+            mainBottomWithTopSplitIndicator
+        case .grid2x2(let rootDirection):
+            gridIndicator(rootDirection: rootDirection)
+        case .complex:
             complexButton
-        } else {
-            twoPaneIndicator
         }
     }
 
-    private var twoPaneIndicator: some View {
-        let paneIDs = Array(summary.paneIDs.prefix(2))
-        let isVertical = summary.direction == .vertical
+    private var singlePaneIndicator: some View {
+        indicatorFrame {
+            RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
+                .fill(primaryPaneFill)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .accessibilityLabel("Single pane")
+    }
 
-        return Group {
-            if isVertical {
-                HStack(spacing: 2) {
-                    ForEach(paneIDs, id: \.self) { paneID in
-                        segmentButton(paneID: paneID)
-                    }
-                }
-            } else {
-                VStack(spacing: 2) {
-                    ForEach(paneIDs, id: \.self) { paneID in
-                        segmentButton(paneID: paneID)
-                    }
+    private func columnsIndicator(paneIDs: [String]) -> some View {
+        indicatorFrame {
+            HStack(spacing: 2) {
+                ForEach(paneIDs, id: \.self) { paneID in
+                    segmentButton(paneID: paneID)
                 }
             }
         }
-        .frame(width: 22, height: 16)
         .help("Focus split pane")
-        .accessibilityLabel("Split tab, \(summary.paneCount) panes")
+        .accessibilityLabel(splitAccessibilityLabel)
+    }
+
+    private func rowsIndicator(paneIDs: [String]) -> some View {
+        indicatorFrame {
+            VStack(spacing: 2) {
+                ForEach(paneIDs, id: \.self) { paneID in
+                    segmentButton(paneID: paneID)
+                }
+            }
+        }
+        .help("Focus split pane")
+        .accessibilityLabel(splitAccessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var mainLeftWithRightStackIndicator: some View {
+        let paneIDs = Array(summary.paneIDs.prefix(3))
+        if paneIDs.count == 3 {
+            indicatorFrame {
+                HStack(spacing: 2) {
+                    segmentButton(paneID: paneIDs[0])
+                    VStack(spacing: 2) {
+                        segmentButton(paneID: paneIDs[1])
+                        segmentButton(paneID: paneIDs[2])
+                    }
+                }
+            }
+            .help("Focus split pane")
+            .accessibilityLabel(splitAccessibilityLabel)
+        } else {
+            complexButton
+        }
+    }
+
+    @ViewBuilder
+    private var mainRightWithLeftStackIndicator: some View {
+        let paneIDs = Array(summary.paneIDs.prefix(3))
+        if paneIDs.count == 3 {
+            indicatorFrame {
+                HStack(spacing: 2) {
+                    VStack(spacing: 2) {
+                        segmentButton(paneID: paneIDs[0])
+                        segmentButton(paneID: paneIDs[1])
+                    }
+                    segmentButton(paneID: paneIDs[2])
+                }
+            }
+            .help("Focus split pane")
+            .accessibilityLabel(splitAccessibilityLabel)
+        } else {
+            complexButton
+        }
+    }
+
+    @ViewBuilder
+    private var mainTopWithBottomSplitIndicator: some View {
+        let paneIDs = Array(summary.paneIDs.prefix(3))
+        if paneIDs.count == 3 {
+            indicatorFrame {
+                VStack(spacing: 2) {
+                    segmentButton(paneID: paneIDs[0])
+                    HStack(spacing: 2) {
+                        segmentButton(paneID: paneIDs[1])
+                        segmentButton(paneID: paneIDs[2])
+                    }
+                }
+            }
+            .help("Focus split pane")
+            .accessibilityLabel(splitAccessibilityLabel)
+        } else {
+            complexButton
+        }
+    }
+
+    @ViewBuilder
+    private var mainBottomWithTopSplitIndicator: some View {
+        let paneIDs = Array(summary.paneIDs.prefix(3))
+        if paneIDs.count == 3 {
+            indicatorFrame {
+                VStack(spacing: 2) {
+                    HStack(spacing: 2) {
+                        segmentButton(paneID: paneIDs[0])
+                        segmentButton(paneID: paneIDs[1])
+                    }
+                    segmentButton(paneID: paneIDs[2])
+                }
+            }
+            .help("Focus split pane")
+            .accessibilityLabel(splitAccessibilityLabel)
+        } else {
+            complexButton
+        }
+    }
+
+    @ViewBuilder
+    private func gridIndicator(rootDirection: ShellSplitDirection) -> some View {
+        let paneIDs = Array(summary.paneIDs.prefix(4))
+        if paneIDs.count == 4 {
+            indicatorFrame {
+                if rootDirection == .vertical {
+                    HStack(spacing: 2) {
+                        VStack(spacing: 2) {
+                            segmentButton(paneID: paneIDs[0])
+                            segmentButton(paneID: paneIDs[1])
+                        }
+                        VStack(spacing: 2) {
+                            segmentButton(paneID: paneIDs[2])
+                            segmentButton(paneID: paneIDs[3])
+                        }
+                    }
+                } else {
+                    VStack(spacing: 2) {
+                        HStack(spacing: 2) {
+                            segmentButton(paneID: paneIDs[0])
+                            segmentButton(paneID: paneIDs[1])
+                        }
+                        HStack(spacing: 2) {
+                            segmentButton(paneID: paneIDs[2])
+                            segmentButton(paneID: paneIDs[3])
+                        }
+                    }
+                }
+            }
+            .help("Focus split pane")
+            .accessibilityLabel(splitAccessibilityLabel)
+        } else {
+            complexButton
+        }
+    }
+
+    private func indicatorFrame<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: ShellRadii.badge, style: .continuous)
+
+        return content()
+            .padding(3)
+            .frame(width: 22, height: 18)
+            .background {
+                shape
+                    .fill(containerFill)
+                    .overlay {
+                        shape.stroke(ShellPalette.line.opacity(isSelected ? 0.20 : 0.15), lineWidth: 0.5)
+                    }
+            }
+    }
+
+    static func placeholder(isSelected: Bool) -> some View {
+        let shape = RoundedRectangle(cornerRadius: ShellRadii.badge, style: .continuous)
+        return shape
+            .fill(ShellPalette.sidebarMutedInk.opacity(isSelected ? 0.20 : 0.13))
+            .frame(width: 22, height: 18)
+            .overlay {
+                shape.stroke(ShellPalette.line.opacity(isSelected ? 0.20 : 0.15), lineWidth: 0.5)
+            }
+            .accessibilityLabel("Pane")
+    }
+
+    private var containerFill: Color {
+        ShellPalette.sidebarMutedInk.opacity(isSelected ? 0.105 : 0.075)
+    }
+
+    private var primaryPaneFill: Color {
+        isSelected ? ShellPalette.accent.opacity(0.82) : ShellPalette.sidebarMutedInk.opacity(0.38)
+    }
+
+    private func paneFill(isFocused: Bool) -> Color {
+        if isFocused {
+            return ShellPalette.accent.opacity(isSelected ? 0.88 : 0.78)
+        }
+        return ShellPalette.sidebarMutedInk.opacity(isSelected ? 0.40 : 0.32)
     }
 
     private var complexButton: some View {
         Button {
             onFocusNextSplitPane(summary)
         } label: {
-            HStack(spacing: 2) {
-                Image(systemName: "rectangle.split.3x1")
-                    .font(.system(size: 8, weight: .bold))
-                Text("\(summary.paneCount)")
-                    .font(.system(size: 8, weight: .bold, design: .monospaced))
-            }
-            .foregroundStyle(summary.focusedPaneID == nil ? .secondary : ShellPalette.accent)
-            .frame(width: 24, height: 18)
-            .background(
-                RoundedRectangle(cornerRadius: ShellRadii.badge, style: .continuous)
-                    .fill(ShellPalette.canvas.opacity(0.55))
-            )
+            complexCountOverlay
         }
         .buttonStyle(.plain)
         .help("Focus next split pane")
-        .accessibilityLabel("Split tab, \(summary.paneCount) panes")
+        .accessibilityLabel(splitAccessibilityLabel)
+    }
+
+    private var complexCountOverlay: some View {
+        indicatorFrame {
+            ZStack {
+                RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
+                    .fill(primaryPaneFill)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                Text("\(summary.paneCount)")
+                    .font(.system(size: 8.5, weight: .bold, design: .monospaced))
+                    .foregroundStyle(isSelected ? ShellPalette.sidebarInk : ShellPalette.sidebarInk.opacity(0.76))
+            }
+        }
     }
 
     private func segmentButton(paneID: String) -> some View {
@@ -1329,7 +1452,11 @@ private struct ShellSplitTopologyIndicator: View {
         let isFocused = summary.focusedPaneID == paneID
 
         return RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
-            .fill(isFocused ? ShellPalette.accent.opacity(0.9) : ShellPalette.mutedInk.opacity(0.24))
+            .fill(paneFill(isFocused: isFocused))
+    }
+
+    private var splitAccessibilityLabel: String {
+        "Split tab, \(summary.accessibilityTopologyLabel)"
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1154,6 +1154,26 @@ require_pattern \
     "segmentButton\\(paneID: paneID\\)" \
     "two-pane sidebar split indicators must render pane-specific actions"
 
+require_pattern \
+    "clients/apple/alan-macos/ShellModel.swift" \
+    "enum ShellSidebarPaneTopologyKind" \
+    "sidebar split topology classification must live in the testable shell model layer"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-split-model.swift" \
+    "verifiesSidebarSplitTopologyProjection" \
+    "split model tests must cover sidebar topology projection"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "complexCountOverlay" \
+    "complex split indicators must overlay count on the pane-shaped topology base"
+
+reject_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "rectangle\\.split\\.3x1" \
+    "complex split indicators must not render icon and count side by side"
+
 reject_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
     "selectedSpaceID = spaceID" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1169,6 +1169,11 @@ require_pattern \
     "complexCountOverlay" \
     "complex split indicators must overlay count on the pane-shaped topology base"
 
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "accessibilityHidden\\(!showsCloseButton\\)" \
+    "hidden sidebar close buttons must not remain exposed to accessibility"
+
 reject_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "rectangle\\.split\\.3x1" \

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -14,6 +14,7 @@ private enum ShellSplitModelTests {
         try verifiesSplitRatiosClampWhenResized()
         try verifiesEqualizeRestoresEverySplitRatio()
         try verifiesSameDirectionAttachKeepsBinarySplitTree()
+        try verifiesSidebarSplitTopologyProjection()
         try verifiesSpatialFocusFollowsSplitTree()
         try verifiesSpatialFocusPreservesPerpendicularPosition()
         try verifiesPaneScopedCloseRemovesSelectedPane()
@@ -113,6 +114,120 @@ private enum ShellSplitModelTests {
             attached.paneIDs == ["pane_1", "pane_2", "pane_3"],
             "same-direction attachment must preserve pane ordering"
         )
+    }
+
+    private static func verifiesSidebarSplitTopologyProjection() throws {
+        let threeColumns = split(
+            .vertical,
+            leaf("pane_1"),
+            split(.vertical, leaf("pane_2"), leaf("pane_3"))
+        )
+        let threeColumnSummary = summary(for: threeColumns, focusedPaneID: "pane_2")
+        expect(
+            threeColumnSummary.topology.kind == .columns(count: 3),
+            "same-axis vertical chains must classify as three columns"
+        )
+        expect(
+            threeColumnSummary.paneIDs == ["pane_1", "pane_2", "pane_3"],
+            "three-column topology must preserve visible pane order"
+        )
+        expect(
+            threeColumnSummary.focusedPaneID == "pane_2",
+            "topology summary must preserve focused pane when it is visible"
+        )
+
+        let threeRows = split(
+            .horizontal,
+            leaf("pane_1"),
+            split(.horizontal, leaf("pane_2"), leaf("pane_3"))
+        )
+        expect(
+            summary(for: threeRows).topology.kind == .rows(count: 3),
+            "same-axis horizontal chains must classify as three rows"
+        )
+
+        let mainLeft = split(
+            .vertical,
+            leaf("pane_1"),
+            split(.horizontal, leaf("pane_2"), leaf("pane_3"))
+        )
+        expect(
+            summary(for: mainLeft).topology.kind == .mainLeftWithRightStack,
+            "left main with right stack must classify as a main-stack topology"
+        )
+
+        let mainRight = split(
+            .vertical,
+            split(.horizontal, leaf("pane_1"), leaf("pane_2")),
+            leaf("pane_3")
+        )
+        expect(
+            summary(for: mainRight).topology.kind == .mainRightWithLeftStack,
+            "right main with left stack must classify as a main-stack topology"
+        )
+
+        let mainTop = split(
+            .horizontal,
+            leaf("pane_1"),
+            split(.vertical, leaf("pane_2"), leaf("pane_3"))
+        )
+        expect(
+            summary(for: mainTop).topology.kind == .mainTopWithBottomSplit,
+            "top main with bottom split must classify as a main-stack topology"
+        )
+
+        let mainBottom = split(
+            .horizontal,
+            split(.vertical, leaf("pane_1"), leaf("pane_2")),
+            leaf("pane_3")
+        )
+        expect(
+            summary(for: mainBottom).topology.kind == .mainBottomWithTopSplit,
+            "bottom main with top split must classify as a main-stack topology"
+        )
+
+        let fourColumns = split(
+            .vertical,
+            leaf("pane_1"),
+            split(
+                .vertical,
+                leaf("pane_2"),
+                split(.vertical, leaf("pane_3"), leaf("pane_4"))
+            )
+        )
+        expect(
+            summary(for: fourColumns).topology.kind == .columns(count: 4),
+            "same-axis four-pane chains must stay recognizable when legible"
+        )
+
+        let grid = split(
+            .vertical,
+            split(.horizontal, leaf("pane_1"), leaf("pane_2")),
+            split(.horizontal, leaf("pane_3"), leaf("pane_4"))
+        )
+        expect(
+            summary(for: grid).topology.kind == .grid2x2(rootDirection: .vertical),
+            "balanced opposite-axis four-pane layouts must classify as a 2 by 2 grid"
+        )
+
+        let fiveColumns = split(
+            .vertical,
+            leaf("pane_1"),
+            split(
+                .vertical,
+                leaf("pane_2"),
+                split(
+                    .vertical,
+                    leaf("pane_3"),
+                    split(.vertical, leaf("pane_4"), leaf("pane_5"))
+                )
+            )
+        )
+        if case .complex(let count) = summary(for: fiveColumns).topology.kind {
+            expect(count == 5, "high-count same-axis layouts must fall back to complex count")
+        } else {
+            expect(false, "high-count same-axis layouts must classify as complex")
+        }
     }
 
     private static func verifiesSpatialFocusFollowsSplitTree() throws {
@@ -316,6 +431,41 @@ private enum ShellSplitModelTests {
             throw TestFailure("focused tab missing")
         }
         return tab.paneTree
+    }
+
+    private static func summary(
+        for paneTree: ShellPaneTreeNode,
+        focusedPaneID: String? = nil
+    ) -> ShellTabPaneSummary {
+        ShellTabPaneSummary(
+            paneTree: paneTree,
+            visiblePaneIDs: paneTree.paneIDs,
+            focusedPaneID: focusedPaneID
+        )
+    }
+
+    private static func leaf(_ paneID: String) -> ShellPaneTreeNode {
+        ShellPaneTreeNode(
+            nodeID: "node_\(paneID)",
+            kind: .pane,
+            direction: nil,
+            paneID: paneID,
+            children: nil
+        )
+    }
+
+    private static func split(
+        _ direction: ShellSplitDirection,
+        _ children: ShellPaneTreeNode...
+    ) -> ShellPaneTreeNode {
+        let paneIDSlug = children.flatMap(\.paneIDs).joined(separator: "_")
+        return ShellPaneTreeNode(
+            nodeID: "node_split_\(direction.rawValue)_\(paneIDSlug)",
+            kind: .split,
+            direction: direction,
+            paneID: nil,
+            children: children
+        )
     }
 
     private static func expect(

--- a/openspec/changes/enhance-macos-split-topology-indicators/.openspec.yaml
+++ b/openspec/changes/enhance-macos-split-topology-indicators/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/enhance-macos-split-topology-indicators/design.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/design.md
@@ -1,0 +1,89 @@
+## Context
+
+The macOS sidebar already treats split tabs as first-class tab rows: a multi-pane
+terminal tab uses a compact leading topology indicator instead of a generic
+terminal icon. The current contract covers one pane, two-pane split direction,
+and a generic complex case. That leaves common layouts such as three columns,
+three rows, or main-pane-plus-stack visually collapsed into the same generic
+state.
+
+The indicator lives in a constrained tab-row slot. It must remain scan-friendly,
+stable in size, and consistent with Alan's light-mode, material sidebar design.
+It should explain topology, not become a miniature pane manager.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Classify visible pane trees into a small user-facing topology vocabulary.
+- Render common 3-pane layouts, including left/middle/right and top/middle/bottom.
+- Render common 4-pane layouts only when they remain legible at tab-row size.
+- Render unrecognized or high-pane-count layouts as a single-pane base shape with
+  an overlaid pane count.
+- Preserve stable tab-row dimensions, accessibility labels, and focus affordances.
+
+**Non-Goals:**
+
+- Persist new topology state or change split mutation semantics.
+- Render exact split ratios or arbitrary binary-tree nesting in the sidebar.
+- Add a pane-management toolbar, pane selector strip, or persistent labels to tab
+  rows.
+- Change terminal runtime ownership, pane lifecycle, or control-plane APIs.
+
+## Decisions
+
+### Derive topology from the pane tree at the UI boundary
+
+Introduce or refine a derived topology projection for sidebar use instead of
+making the indicator inspect arbitrary tree details inline. The projection should
+map the current pane tree and visible pane IDs to a compact enum-like vocabulary:
+
+- single
+- two columns / two rows
+- three columns / three rows
+- three-pane main-with-stack variants
+- four columns / four rows, if legible
+- grid 2x2
+- complex count
+
+This keeps the visual component simple and makes the classification testable
+without launching the full app UI.
+
+Alternative considered: draw a proportional miniature of the split tree directly
+from pane ratios. That was rejected because the sidebar indicator is too small
+for arbitrary ratios to stay legible, and it would make row scanning depend on
+implementation detail rather than a stable visual vocabulary.
+
+### Normalize simple same-direction chains
+
+Same-direction split chains should flatten into columns or rows when all visible
+leaves are in the same axis and the count remains legible. For example, three
+vertical leaves become a left/middle/right indicator, and three horizontal leaves
+become top/middle/bottom.
+
+Nested mixed-axis trees should classify as main-plus-stack or grid when the
+structure is recognizable. Otherwise the projection should return complex count.
+
+### Complex count overlays the single-pane base
+
+Complex N-pane indicators should use the same visual base as a single pane, with
+a compact monospaced count overlaid on top of the shape. The count must not be a
+separate trailing badge or adjacent text, because that changes the tab row from
+topology into metadata and increases visual noise.
+
+The overlay may be centered or otherwise optically balanced within the indicator,
+but it must not resize the row or obscure selection/focus affordances.
+
+## Risks / Trade-offs
+
+- **Risk: too many topology variants become illegible.** Mitigation: keep the
+  vocabulary small and route unrecognized or high-count layouts to complex count.
+- **Risk: classifier drift from split mutation behavior.** Mitigation: add focused
+  tests for representative pane trees, including same-direction chains, nested
+  main-stack layouts, 2x2 grid, and complex fallback.
+- **Risk: focus state becomes ambiguous in compact 3/4-pane icons.** Mitigation:
+  mark focus only when the displayed topology can map a segment back to a visible
+  pane; use accessibility labels for the full pane count and focused position.
+- **Risk: visual polish regressions are missed by model tests.** Mitigation:
+  require screenshot or manual visual evidence for selected, hover, focused, and
+  complex-count examples in the light-mode sidebar.

--- a/openspec/changes/enhance-macos-split-topology-indicators/design.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/design.md
@@ -1,7 +1,7 @@
 ## Context
 
-The macOS sidebar already treats split tabs as first-class tab rows: a multi-pane
-terminal tab uses a compact leading topology indicator instead of a generic
+The macOS sidebar treats terminal pane topology as a first-class tab-row signal:
+terminal tabs use a compact leading topology indicator instead of a generic
 terminal icon. The current contract covers one pane, two-pane split direction,
 and a generic complex case. That leaves common layouts such as three columns,
 three rows, or main-pane-plus-stack visually collapsed into the same generic
@@ -16,6 +16,7 @@ It should explain topology, not become a miniature pane manager.
 **Goals:**
 
 - Classify visible pane trees into a small user-facing topology vocabulary.
+- Render single-pane terminal tabs with a compact single-pane topology indicator.
 - Render common 3-pane layouts, including left/middle/right and top/middle/bottom.
 - Render common 4-pane layouts only when they remain legible at tab-row size.
 - Render unrecognized or high-pane-count layouts as a single-pane base shape with

--- a/openspec/changes/enhance-macos-split-topology-indicators/proposal.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Split tabs currently communicate only a small subset of pane topology in the sidebar.
+As Alan adds richer split workflows, the tab list needs a compact way to distinguish
+common multi-pane layouts without turning the sidebar into a pane-management panel.
+
+## What Changes
+
+- Extend the sidebar split indicator contract so it can represent common 3-pane and
+  4-pane topologies, including three-column and three-row layouts.
+- Keep the default indicator compact and topology-first: it should remain a small
+  tab-row affordance, not a text label, pane strip, or debug surface.
+- Treat complex N-pane layouts as a single-pane-shaped indicator with the pane count
+  overlaid on the shape, rather than placing the count beside the icon.
+- Preserve lightweight focus affordances where the topology can identify individual
+  panes without making the tab row resize.
+- Add verification expectations for topology classification and sidebar visual
+  coverage.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Define the expanded split topology indicator
+  behavior for sidebar tab rows.
+- `macos-shell-build-test-contract`: Require coverage for topology classification
+  and visual stability of the sidebar indicators.
+
+## Impact
+
+- Affects macOS shell sidebar tab UI, especially the split indicator rendered for
+  terminal tabs.
+- Affects derived shell UI projection logic that classifies pane trees into
+  user-facing topology categories.
+- Does not change terminal runtime ownership, split mutation semantics, control-plane
+  APIs, or persisted pane tree data.

--- a/openspec/changes/enhance-macos-split-topology-indicators/proposal.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-Split tabs currently communicate only a small subset of pane topology in the sidebar.
+Terminal tabs currently communicate only a small subset of pane topology in the sidebar.
 As Alan adds richer split workflows, the tab list needs a compact way to distinguish
-common multi-pane layouts without turning the sidebar into a pane-management panel.
+single-pane and common multi-pane layouts without turning the sidebar into a pane-management panel.
 
 ## What Changes
 
-- Extend the sidebar split indicator contract so it can represent common 3-pane and
-  4-pane topologies, including three-column and three-row layouts.
+- Extend the sidebar split indicator contract so it always represents terminal
+  pane topology, from single-pane tabs through common 3-pane and 4-pane layouts.
 - Keep the default indicator compact and topology-first: it should remain a small
   tab-row affordance, not a text label, pane strip, or debug surface.
 - Treat complex N-pane layouts as a single-pane-shaped indicator with the pane count

--- a/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Split topology indicators have focused verification
+The Apple client SHALL include focused automated or documented verification for
+sidebar split topology classification and visual stability when the split
+topology indicator changes.
+
+#### Scenario: Topology classification is tested
+- **WHEN** split topology indicator logic is implemented or changed
+- **THEN** focused tests verify single pane, two columns, two rows, three columns, three rows, three-pane main-plus-stack variants, four-pane recognized layouts, and complex-count fallback classification
+
+#### Scenario: Complex count rendering is verified
+- **WHEN** a tab's split topology falls back to complex count
+- **THEN** focused tests or visual evidence verify that the count overlays a single-pane-shaped topology base rather than rendering beside the indicator as adjacent text or a separate badge
+
+#### Scenario: Sidebar indicator visuals are reviewed
+- **WHEN** split topology indicator UI implementation is marked complete
+- **THEN** maintainers can inspect running-app screenshots or manual notes covering light-mode selected, hover, focused-pane, three-pane, four-pane, and complex-count tab-row states without row resizing or layout shifts

--- a/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-ui-ux-conformance/spec.md
@@ -2,14 +2,14 @@
 
 ### Requirement: Split tabs expose compact topology
 The default macOS sidebar SHALL show a compact split topology indicator on tab
-rows whose active tab contains multiple terminal panes. The indicator SHALL
-communicate pane count, common split topology, and the currently focused pane
-when that topology can be mapped to visible pane segments, without attempting to
-render exact split ratios or arbitrary tree nesting in the tab row.
+rows whose active tab contains at least one visible terminal pane. The indicator
+SHALL communicate pane count, common split topology, and the currently focused
+pane when that topology can be mapped to visible pane segments, without
+attempting to render exact split ratios or arbitrary tree nesting in the tab row.
 
 #### Scenario: Single-pane tab row
 - **WHEN** a tab contains one terminal pane
-- **THEN** the tab row does not show a split topology indicator
+- **THEN** the tab row shows a compact single-pane topology indicator with stable width
 
 #### Scenario: Two-pane tab row
 - **WHEN** a tab contains two visible terminal panes

--- a/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Split tabs expose compact topology
+The default macOS sidebar SHALL show a compact split topology indicator on tab
+rows whose active tab contains multiple terminal panes. The indicator SHALL
+communicate pane count, common split topology, and the currently focused pane
+when that topology can be mapped to visible pane segments, without attempting to
+render exact split ratios or arbitrary tree nesting in the tab row.
+
+#### Scenario: Single-pane tab row
+- **WHEN** a tab contains one terminal pane
+- **THEN** the tab row does not show a split topology indicator
+
+#### Scenario: Two-pane tab row
+- **WHEN** a tab contains two visible terminal panes
+- **THEN** the tab row shows a compact two-segment indicator that reflects the root split direction and marks the focused pane
+
+#### Scenario: Three-column tab row
+- **WHEN** a tab contains three visible terminal panes that normalize to left, middle, and right columns
+- **THEN** the tab row shows a compact three-column topology indicator with stable width and a segment-level focused-pane mark when focus is inside one of those panes
+
+#### Scenario: Three-row tab row
+- **WHEN** a tab contains three visible terminal panes that normalize to top, middle, and bottom rows
+- **THEN** the tab row shows a compact three-row topology indicator with stable width and a segment-level focused-pane mark when focus is inside one of those panes
+
+#### Scenario: Three-pane main stack tab row
+- **WHEN** a tab contains three visible terminal panes that normalize to one main pane plus a two-pane stack on the opposite side
+- **THEN** the tab row shows a compact main-plus-stack topology indicator that preserves the main pane side or edge and marks the focused pane when focus maps to a displayed segment
+
+#### Scenario: Four-pane recognizable tab row
+- **WHEN** a tab contains four visible terminal panes that normalize to a legible four-column, four-row, or 2x2 grid topology
+- **THEN** the tab row shows the corresponding compact four-pane topology indicator without widening the tab row, adding text labels, or rendering proportional split ratios
+
+#### Scenario: Complex split tab row
+- **WHEN** a tab contains a visible split topology that is not one of the recognized compact topologies or exceeds the legible indicator pane count
+- **THEN** the tab row shows a single-pane-shaped topology base with the pane count overlaid on that shape
+- **AND** the pane count is not rendered as adjacent text, a separate trailing badge, a notification dot, or a separate sidebar metadata block
+
+#### Scenario: Split tab avoids notification dots
+- **WHEN** a non-focused pane inside a split tab needs attention
+- **THEN** the split indicator and tab row do not add notification dots, expose raw pane IDs, or add a separate sidebar attention block
+
+#### Scenario: Split topology remains accessible
+- **WHEN** assistive technology reads a tab row with a split topology indicator
+- **THEN** the accessibility label or help text communicates the pane count and recognized topology in user-facing terms without exposing raw pane IDs or implementation names

--- a/openspec/changes/enhance-macos-split-topology-indicators/tasks.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/tasks.md
@@ -1,0 +1,25 @@
+## 1. Topology Projection
+
+- [x] 1.1 Add a sidebar-facing split topology projection that classifies visible pane trees into single, two-column, two-row, three-column, three-row, three-pane main-stack, recognized four-pane, and complex-count cases.
+- [x] 1.2 Normalize same-direction split chains into column or row topology when the visible pane count remains legible.
+- [x] 1.3 Map recognized topology segments back to visible pane IDs so focused-pane treatment and accessibility labels can stay accurate.
+
+## 2. Sidebar Indicator Rendering
+
+- [x] 2.1 Update the sidebar split indicator renderer to draw three-column, three-row, three-pane main-stack, and recognized four-pane topology shapes within the existing tab-row indicator footprint.
+- [x] 2.2 Update complex fallback rendering to use a single-pane-shaped topology base with the pane count overlaid on the shape, not adjacent text or a separate badge.
+- [x] 2.3 Preserve stable tab-row dimensions, hover/selected states, and existing focus/cycle interactions while adding the new topology variants.
+- [x] 2.4 Update accessibility labels/help text so recognized topology and pane count are described in user-facing terms without raw pane IDs.
+
+## 3. Verification
+
+- [x] 3.1 Add focused tests for topology classification, including two-pane directions, three columns, three rows, main-plus-stack variants, recognized four-pane layouts, and complex fallback.
+- [x] 3.2 Add focused tests or review fixtures that verify complex-count rendering keeps the count overlaid on the single-pane base.
+- [x] 3.3 Run the relevant focused Apple shell checks and the macOS build command required for this UI surface.
+- [x] 3.4 Capture or document light-mode visual evidence for selected, hover, focused-pane, three-pane, four-pane, and complex-count sidebar tab-row states.
+
+## 4. Review And Archive Readiness
+
+- [x] 4.1 Review the implementation against `macos-shell-ui-ux-conformance` to confirm it remains terminal-first, compact, and free of pane-management chrome.
+- [x] 4.2 Verify no terminal runtime, pane lifecycle, control-plane API, or persisted pane-tree semantics changed as part of the UI projection work.
+- [ ] 4.3 Before archiving, sync the accepted delta specs into `openspec/specs/` and validate the full OpenSpec set.

--- a/openspec/changes/enhance-macos-split-topology-indicators/verification.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/verification.md
@@ -30,6 +30,8 @@
 
 - Selected and unselected indicators keep the existing 22 by 18 point footprint
   and reuse the existing sidebar material container.
+- Single-pane terminal tabs render the compact single-pane topology base instead
+  of falling back to a generic terminal icon.
 - Three-column and four-column layouts render as equal compact vertical segments.
 - Three-row and four-row layouts render as equal compact horizontal segments.
 - Main-stack layouts keep the main pane as the larger segment and render the

--- a/openspec/changes/enhance-macos-split-topology-indicators/verification.md
+++ b/openspec/changes/enhance-macos-split-topology-indicators/verification.md
@@ -1,0 +1,44 @@
+## Verification
+
+- `./clients/apple/scripts/test-shell-split-model.sh`
+  - Passed.
+  - Covers two-pane directions, three columns, three rows, main-stack variants,
+    four columns, 2 by 2 grid, focused-pane mapping, and complex-count fallback.
+
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+  - Passed.
+  - Confirms the topology projection lives in the testable model layer, the
+    split-model test covers it, and complex indicators use `complexCountOverlay`
+    instead of the previous side-by-side icon/count pattern.
+
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-split-topology build`
+  - Passed.
+  - The documented `target/xcode-derived` path is currently root-owned in this
+    checkout, so the build was rerun with a writable temporary derived-data path.
+
+- `openspec validate "enhance-macos-split-topology-indicators" --type change --strict --json`
+  - Passed.
+
+- `openspec validate --all --strict --json`
+  - Passed.
+  - Validated 45 items: 14 changes and 31 specs.
+
+- `git diff --check -- clients/apple/alan-macos/ShellModel.swift clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift clients/apple/scripts/test-shell-split-model.swift clients/apple/scripts/check-shell-contracts.sh openspec/changes/enhance-macos-split-topology-indicators`
+  - Passed.
+
+## Visual Notes
+
+- Selected and unselected indicators keep the existing 22 by 18 point footprint
+  and reuse the existing sidebar material container.
+- Three-column and four-column layouts render as equal compact vertical segments.
+- Three-row and four-row layouts render as equal compact horizontal segments.
+- Main-stack layouts keep the main pane as the larger segment and render the
+  opposite stack as two compact sibling segments.
+- Grid layouts render as a 2 by 2 compact segment grid using the root split
+  direction to preserve pane order.
+- Complex layouts render as a single-pane-shaped base with the pane count
+  overlaid inside the shape, not beside it.
+
+`clients/apple/scripts/capture-alan-window.sh --list` could not capture running
+window evidence in this shell because ScreenCaptureKit did not have Screen
+Recording permission for the terminal session.


### PR DESCRIPTION
Summary:
- classify sidebar pane trees into recognized split topology shapes in the model layer
- render compact sidebar indicators for multi-column, multi-row, main-stack, grid, and complex-count layouts
- add focused split-model tests, shell contract guards, and the OpenSpec change package

Validation:
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate enhance-macos-split-topology-indicators --type change --strict --json
- openspec validate --all --strict --json
- git diff --check -- clients/apple/alan-macos/ShellModel.swift clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift clients/apple/scripts/test-shell-split-model.swift clients/apple/scripts/check-shell-contracts.sh openspec/changes/enhance-macos-split-topology-indicators
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-split-topology build