### PR TITLE
Use generic macOS Xcode destination

### DIFF
--- a/clients/apple/ARCHITECTURE.md
+++ b/clients/apple/ARCHITECTURE.md
@@ -119,10 +119,10 @@ preserving PR slices. The final validation pass before syncing this spec ran:
 - `git diff --check`
 - `openspec validate improve-macos-app-architecture-maintainability --type change --strict --json`
 - `openspec validate --all --strict --json`
-- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath target/xcode-derived build`
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath target/xcode-derived build`
 
 The macOS build succeeded. Local Xcode continued to print the existing
-CoreSimulator version warning while building for `platform=macOS`; simulator
+CoreSimulator version warning while building for `generic/platform=macOS`; simulator
 device support was not required for this validation.
 
 ## Remaining Architecture Debt

--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -189,7 +189,7 @@ The client uses the existing `/api/v1/sessions/*` compatibility layer:
 xcodebuild \
   -project clients/apple/alan-macos.xcodeproj \
   -scheme alan-macos \
-  -destination 'platform=macOS' build
+  -destination 'generic/platform=macOS' build
 
 # Shell control-plane contract smoke
 bash clients/apple/scripts/check-shell-contracts.sh

--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -328,7 +328,7 @@ engineering identity.
 - **WHEN** implementation is ready for review
 - **THEN** the documented Xcode build command uses
   `clients/apple/alan-macos.xcodeproj`, scheme `alan-macos`, configuration
-  `Debug`, destination `platform=macOS`, and the shared derived-data path
+  `Debug`, destination `generic/platform=macOS`, and the shared derived-data path
 - **AND** the build produces `Alan.app`
 
 #### Scenario: Focused scripts are updated

--- a/scripts/assemble-release-app.sh
+++ b/scripts/assemble-release-app.sh
@@ -116,7 +116,7 @@ xcodebuild \
     -project "$REPO_ROOT/clients/apple/alan-macos.xcodeproj" \
     -scheme alan-macos \
     -configuration Release \
-    -destination platform=macOS \
+    -destination generic/platform=macOS \
     -derivedDataPath "$DERIVED_DATA" \
     CODE_SIGNING_ALLOWED=NO \
     build


### PR DESCRIPTION
Summary:
- switch documented macOS xcodebuild commands to generic/platform=macOS
- align release app assembly with the same generic macOS destination
- update the macOS shell build/test OpenSpec contract

Validation:
- bash -n scripts/assemble-release-app.sh
- openspec validate --all --strict --json
- git diff --check -- clients/apple/ARCHITECTURE.md clients/apple/README.md openspec/specs/macos-shell-build-test-contract/spec.md scripts/assemble-release-app.sh