### PR TITLE
docs: propose macOS shell interaction specs

### DIFF
--- a/openspec/changes/add-macos-shell-action-registry/.openspec.yaml
+++ b/openspec/changes/add-macos-shell-action-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/add-macos-shell-action-registry/design.md
+++ b/openspec/changes/add-macos-shell-action-registry/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The macOS shell already has menu commands for common shell operations, sidebar
+context menus for tab pinning, existing SwiftUI keyboard shortcuts, and shell
+controller mutations. Those surfaces are close but not authoritative: an action
+can exist in one entrypoint without the same label, availability, or target
+rules elsewhere.
+
+This change creates the first shell-only registry. It is deliberately narrower
+than a whole-app or cross-client command system.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define stable action IDs for shell operations.
+- Centralize user-facing label, optional default shortcut, target kind,
+  availability check, and execution handler.
+- Support menu bar commands, tab/space context menus, and keyboard shortcuts.
+- Keep targets explicit: current selection/focused pane for keyboard and menu
+  actions, context tab or context space for right-click actions.
+- Let unavailable actions be disabled in menus and context menus.
+- Add validation that prevents duplicate shortcuts and unregistered shell menu
+  actions.
+
+**Non-Goals:**
+
+- No app-wide action registry for console, settings, onboarding, or daemon UI.
+- No daemon/TUI protocol-level action table.
+- No user-customizable shortcuts.
+- No expansion of `Go to or Command...`; this registry can be a future input,
+  but this change does not add typed command behavior or command result
+  filtering.
+
+## Decisions
+
+### 1. Keep the registry shell-only
+
+The first registry should only cover macOS shell actions. It may include Space,
+Tab, Pane, Find, terminal-search, and shell navigation operations, but it should
+not try to model global app commands or daemon protocol actions.
+
+This keeps the registry close to the existing shell controller and avoids
+turning this interaction pass into a broader architecture rewrite.
+
+### 2. Use stable action IDs
+
+Action IDs should be stable strings such as `shell.tab.pin`,
+`shell.tab.move_to_space`, `shell.space.select_next`, or
+`shell.pane.split_right`. Labels can change, but IDs are the durable contract
+used by tests, menus, shortcuts, and future command surfaces.
+
+### 3. Make target resolution explicit
+
+Keyboard shortcuts and menu bar actions target the current selected shell
+context by default: selected Space, selected Tab, and focused pane. Context menu
+actions target the object that opened the menu without first changing
+selection. Actions that require an additional target, such as `Move Tab to
+Space...`, resolve that target through a menu/submenu or picker owned by the
+surface.
+
+### 4. Keep Command UI out of this change
+
+`Go to or Command...` remains a separate surface. This registry should not
+register new tab/space operations into Command UI, add typed command parsing, or
+define Command UI filtering. A future change can connect Command UI once its
+product shape is settled.
+
+### 5. Prefer disabled menu items over hidden menu items
+
+Menus and context menus should keep unavailable actions visible but disabled
+when that preserves discoverability. Keyboard shortcuts for unavailable actions
+should be side-effect free. Tests should cover that availability and handler
+execution are derived from the same registry entry.

--- a/openspec/changes/add-macos-shell-action-registry/proposal.md
+++ b/openspec/changes/add-macos-shell-action-registry/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Alan's macOS shell already exposes related workspace actions through menu items,
+keyboard shortcuts, context menus, command input, and local control paths, but
+the action definitions are not yet a single shell-owned contract. Tab movement,
+pinning, and the next keybinding pass need a stable shell action registry so
+new interaction surfaces do not drift from each other.
+
+## What Changes
+
+- Add a macOS shell-only action registry for Space, Tab, Pane, Find, and shell
+  navigation actions.
+- Give each shell action a stable `action_id`, user-facing title, target model,
+  default shortcut metadata where applicable, availability check, and execution
+  handler.
+- Route menu bar commands, tab/space context menus, and shell keyboard shortcuts
+  through the registry.
+- Keep `Go to or Command...` out of scope for this first registry pass; existing
+  command input behavior remains unchanged.
+- Establish conflict and coverage checks so new shell actions cannot add
+  separate shortcut/menu behavior without a registry entry.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-shell-action-registry`: Owns shell action identity, metadata,
+  availability, targeting, shortcut descriptors, and execution routing for
+  native macOS shell interactions.
+
+### Modified Capabilities
+
+- `macos-shell-workspace-interactions`: Requires menu, context-menu, and
+  keyboard action paths to converge through the shell action registry where
+  they share behavior.
+- `macos-shell-build-test-contract`: Adds focused validation for registry
+  coverage, target resolution, and shortcut conflict detection.
+
+## Impact
+
+- `AlanMacShellCommands.swift`, `ShellSidebarView.swift`, and shell keyboard
+  shortcut views.
+- `ShellHostController`, `ShellLocalCommandExecutor`, and shell mutation
+  helpers that become action handlers or action targets.
+- Focused Swift/script tests that verify action availability, handler routing,
+  menu/context behavior, and shortcut metadata.

--- a/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-action-registry/spec.md
+++ b/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-action-registry/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Shell Actions Have Stable Registry Entries
+The macOS shell SHALL define shared shell operations through a shell-only action
+registry. Each registered action SHALL have a stable action ID, user-facing
+title, target kind, availability check, execution handler, and optional default
+shortcut descriptor.
+
+#### Scenario: Registered action is described
+- **WHEN** a menu, context menu, or keyboard surface asks for a shell action
+- **THEN** the action registry returns the same stable action ID, label,
+  availability, target kind, and shortcut metadata for that action
+
+#### Scenario: Action IDs are stable
+- **WHEN** a shell action label or menu placement changes
+- **THEN** the action keeps its stable `action_id` unless the behavior contract
+  is intentionally replaced
+
+#### Scenario: Action is unavailable
+- **WHEN** a registered action cannot run for the current target
+- **THEN** the registry reports an unavailable state and the execution handler
+  does not mutate shell state
+
+### Requirement: Action Targets Are Explicit
+The macOS shell action registry SHALL distinguish current-selection targets from
+context targets so different entrypoints can share an action without silently
+retargeting user intent.
+
+#### Scenario: Keyboard shortcut targets current selection
+- **WHEN** a keyboard shortcut invokes a Tab or Pane action
+- **THEN** the registry resolves the target from the current selected Tab or
+  focused pane
+
+#### Scenario: Tab context menu targets clicked tab
+- **WHEN** a user opens a context menu for a non-selected Tab
+- **THEN** Tab actions in that menu resolve against the context Tab without
+  first selecting it
+
+#### Scenario: Additional target is required
+- **WHEN** an action such as `Move Tab to Space...` requires a destination Space
+- **THEN** the invoking surface supplies that destination explicitly before the
+  action mutates shell state
+
+### Requirement: Registry Owns Menu Context And Keyboard Routing
+The macOS shell SHALL route shared menu bar, tab/space context menu, and shell
+keyboard shortcut actions through the shell action registry where the surfaces
+perform the same behavior.
+
+#### Scenario: Menu invokes shell action
+- **WHEN** the user chooses a registered shell action from the menu bar
+- **THEN** the menu invokes the registry action rather than a separate
+  view-local mutation path
+
+#### Scenario: Context menu invokes shell action
+- **WHEN** the user chooses a registered Tab or Space action from a context menu
+- **THEN** the context menu invokes the registry action with its context target
+
+#### Scenario: Keyboard invokes shell action
+- **WHEN** the user presses a registered shell shortcut
+- **THEN** the keyboard path invokes the same registry action used by menu and
+  context surfaces
+
+### Requirement: Command UI Is Not Expanded By The First Registry
+The first macOS shell action registry pass SHALL NOT add new `Go to or
+Command...` typed commands, candidate filtering, or target-selection behavior.
+
+#### Scenario: Registry is introduced
+- **WHEN** the action registry is added
+- **THEN** existing Command UI behavior remains unchanged
+- **AND** new Tab or Space organization actions are not exposed through Command
+  UI until a later change explicitly designs that surface

--- a/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Shell Action Registry Is Verified
+The Apple client SHALL include focused verification for macOS shell action
+registry coverage, target resolution, availability, and shortcut conflicts.
+
+#### Scenario: Action IDs are unique
+- **WHEN** shell action registry tests run
+- **THEN** every registered shell action has a unique stable action ID
+
+#### Scenario: Shortcut conflicts are rejected
+- **WHEN** two enabled shell actions in the same keyboard context declare the
+  same default shortcut
+- **THEN** focused verification fails with enough detail to identify both
+  conflicting action IDs
+
+#### Scenario: Context target is preserved
+- **WHEN** a context menu action targets a non-selected Tab
+- **THEN** focused verification proves the action resolves the context target
+  and does not first select the Tab
+
+#### Scenario: Command UI remains unchanged
+- **WHEN** the shell action registry is introduced
+- **THEN** focused checks confirm new Tab and Space organization actions are not
+  added to `Go to or Command...` by this change

--- a/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-macos-shell-action-registry/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Commands use native Mac surfaces
+Workspace actions SHALL be available through native menu/command routing,
+keyboard shortcuts, command input, and any restrained toolbar affordances that
+call the same shell controller mutations where the action is shared. Menu bar,
+context menu, and keyboard shortcut paths SHALL resolve shared shell actions
+through the macOS shell action registry. The default `Command-P` command input
+SHALL accept typed commands without showing persistent candidate action lists;
+this registry change SHALL NOT add new Command UI behaviors.
+
+#### Scenario: Menu command
+- **WHEN** the user selects New Terminal Tab, New alan Tab, Split, Focus Pane,
+  Equalize Splits, Close Pane, or Close Tab from the menu bar
+- **THEN** alan executes the registered shell action used by matching keyboard
+  and context paths where that behavior is shared
+
+#### Scenario: Keyboard command
+- **WHEN** the user invokes a supported command-key shortcut
+- **THEN** the responder chain routes it to alan's shell action registry or
+  terminal surface command handler as appropriate
+
+#### Scenario: Context command
+- **WHEN** the user invokes a supported Tab or Space context menu command
+- **THEN** alan resolves the registry action with the context Tab or Space
+  target rather than first changing shell selection
+
+#### Scenario: Command input opens
+- **WHEN** the user opens `Go to or Command...`
+- **THEN** alan focuses a single command input field instead of presenting
+  default action, routing, or attention candidate lists
+- **AND** this registry change does not add new Tab or Space organization
+  commands to the Command UI
+
+#### Scenario: Command input shortcut toggles
+- **WHEN** the user presses `Command-P` while the command input is focused or
+  visible
+- **THEN** alan dismisses the command input instead of opening a duplicate
+  surface
+
+#### Scenario: Typed command resolves
+- **WHEN** the user submits a typed command that alan can resolve to an existing
+  workspace action or routing target
+- **THEN** alan executes the existing command input behavior and dismisses the
+  command input
+
+#### Scenario: Typed command is unresolved
+- **WHEN** the user submits a typed command that alan cannot resolve
+- **THEN** alan leaves the command input open and communicates the unresolved
+  state without exposing raw pane IDs or debug routing details

--- a/openspec/changes/add-macos-shell-action-registry/tasks.md
+++ b/openspec/changes/add-macos-shell-action-registry/tasks.md
@@ -1,0 +1,52 @@
+## 1. Registry Model
+
+- [ ] 1.1 Define shell action IDs, target kinds, labels, optional default
+  shortcut descriptors, availability results, and execution result types.
+- [ ] 1.2 Add a shell action registry that can resolve actions for menu bar,
+  context-menu, and keyboard surfaces without involving Command UI.
+- [ ] 1.3 Model current-selection targets separately from context-menu targets
+  so right-click actions can operate on a non-selected tab.
+- [ ] 1.4 Add no-op or disabled behavior for unavailable actions with stable
+  diagnostics for focused tests.
+
+## 2. Surface Integration
+
+- [ ] 2.1 Route existing shell menu commands through the registry where they
+  share shell controller behavior.
+- [ ] 2.2 Route tab and space context menu items through registry entries while
+  preserving the right-click context target.
+- [ ] 2.3 Route existing shell keyboard shortcuts through registry entries
+  without changing their default key equivalents.
+- [ ] 2.4 Leave `Go to or Command...` behavior unchanged and avoid adding new
+  tab/space actions to Command UI in this change.
+
+## 3. Action Coverage
+
+- [ ] 3.1 Register existing high-frequency shell actions: new tab, close tab,
+  split pane, close pane, focus pane, equalize splits, Find, and Space
+  navigation.
+- [ ] 3.2 Add placeholder-ready registry entries needed by follow-up tab
+  organization work: pin, unpin, move tab left/right, and move tab to Space.
+- [ ] 3.3 Ensure labels and disabled states use user-facing language and avoid
+  raw pane IDs, tab IDs, or implementation phases.
+
+## 4. Verification
+
+- [ ] 4.1 Add focused tests for action ID uniqueness, target resolution,
+  availability, disabled execution, and handler routing.
+- [ ] 4.2 Add shortcut conflict checks for registered default shortcuts in the
+  same shell context.
+- [ ] 4.3 Add focused menu/context-menu coverage or script checks proving shared
+  actions are no longer duplicated outside the registry.
+- [ ] 4.4 Run relevant Apple shell scripts and the macOS app build command, or
+  document any local blocker.
+- [ ] 4.5 Run `openspec validate add-macos-shell-action-registry --type change --strict --json`.
+- [ ] 4.6 Run `openspec validate --all --strict --json`.
+- [ ] 4.7 Run `git diff --check`.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 Confirm the registry remains shell-only and does not add Command UI,
+  settings, daemon, TUI, or user-custom shortcut scope.
+- [ ] 5.2 Before archive, sync accepted delta requirements into `openspec/specs/`.
+- [ ] 5.3 Archive the OpenSpec change after implementation merges.

--- a/openspec/changes/add-macos-shell-keybinding-system/.openspec.yaml
+++ b/openspec/changes/add-macos-shell-keybinding-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/add-macos-shell-keybinding-system/design.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Keyboard control is central to a terminal-first macOS shell. The current shell
+already has some native shortcuts for actions such as opening Tabs, focusing
+panes, splitting panes, and Find. New Tab and Space organization should not add
+ad hoc shortcut handling in each view. Instead, shortcuts should flow through
+the same action registry used by menus and context menus.
+
+This change deliberately avoids user-custom shortcut editing. The first version
+should provide a stable default surface and a conflict-tested foundation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve existing working shortcuts.
+- Register default shortcuts from shell action descriptors.
+- Provide shortcut coverage for high-frequency Tab, pane, Find, and Space
+  navigation actions.
+- Use current selected Tab and focused pane as the keyboard action target.
+- Display native shortcut hints in menus.
+- Detect duplicate or conflicting default shortcuts in tests.
+- Define input precedence between Find, terminal input, and shell actions.
+
+**Non-Goals:**
+
+- No user-custom shortcut preferences, config file, or import/export format.
+- No Command UI integration.
+- No default shortcut for every action.
+- No hover-targeted shortcut behavior.
+- No default shortcuts for create, rename, or delete Space in the first version.
+
+## Decisions
+
+### 1. Registry descriptors own default shortcuts
+
+Each shortcut-enabled action declares its default shortcut in the shell action
+registry. Menus and direct keyboard dispatch read that same descriptor so labels,
+availability, target semantics, and shortcut hints stay aligned.
+
+### 2. Preserve before filling gaps
+
+Existing macOS shell shortcuts remain the baseline. The new system fills gaps for
+high-frequency operations rather than remapping core habits. If an existing
+shortcut conflicts with a proposed new default, the existing shortcut wins unless
+the implementation plan explicitly accepts a migration.
+
+### 3. First-version coverage is intentionally narrow
+
+Default shortcuts should cover:
+
+- Tab: new, close, next, previous, move left, move right, pin/unpin current Tab.
+- Pane: split, close/focus where already present, equalize where already
+  present or newly standardized.
+- Find: preserve existing Find shortcut and Find-mode behavior.
+- Space: next Space, previous Space, direct numeric Space selection.
+
+Create Space, rename Space, delete Space, and Move Tab to Space remain available
+through menus/actions without default shortcuts in the first version.
+
+### 4. Keyboard target is current selection
+
+Keyboard shortcuts operate on the current selected Space, selected Tab, and
+focused pane. They do not target a hovered row or a Tab that merely owns an open
+context menu.
+
+### 5. Input precedence is explicit
+
+When Find is active, Find-owned shortcuts and text handling take precedence over
+shell actions. Terminal-reserved input remains terminal input. Shell action
+shortcuts are handled only when they match registered actions and the action is
+available for the current shell state.
+
+### 6. Unavailable actions are disabled, not hidden
+
+Shortcut-triggered unavailable actions are no-ops with stable diagnostics where
+appropriate. Menus show disabled actions and their shortcut hints, matching the
+registry availability state.

--- a/openspec/changes/add-macos-shell-keybinding-system/proposal.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Alan's macOS shell has several keyboard shortcuts today, but the shortcut
+surface is distributed across view code and commands. As Tab and Space
+organization grows, shortcuts need one coherent contract: preserve existing Mac
+behavior, expose high-frequency navigation and organization actions, and avoid a
+customization surface until the product direction is clear.
+
+## What Changes
+
+- Add a macOS shell keybinding system backed by the shell action registry.
+- Treat registry action descriptors as the source of truth for default shortcut
+  metadata and menu hints.
+- Preserve existing shortcuts and fill gaps only for high-frequency shell
+  actions.
+- Add default shortcut coverage for Tab navigation, current Tab structural
+  actions, pane focus/split actions, Find, and Space navigation.
+- Keep Space management shortcuts limited to navigation in the first version:
+  next/previous Space and direct Space number selection.
+- Keep create/rename/delete Space as actions and menu items without default
+  shortcuts in the first version.
+- Do not add user-custom shortcut configuration, preference UI, or Command UI
+  integration in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-shell-keybinding-system`: Defines registry-backed default keybindings,
+  fixed first-version coverage, target semantics, conflict detection, and input
+  precedence.
+
+### Modified Capabilities
+
+- `macos-shell-workspace-interactions`: Routes keyboard-driven shell commands
+  through the action registry and defines Space shortcut coverage.
+- `macos-shell-build-test-contract`: Adds validation requirements for shortcut
+  conflicts, preservation of existing shortcuts, target semantics, and input
+  precedence.
+
+## Impact
+
+- Depends on `add-macos-shell-action-registry` for action descriptors,
+  availability, and handler dispatch.
+- Tab pin/move shortcut coverage depends on
+  `improve-macos-tab-organization`.
+- Apple shell commands, menu declarations, focused view shortcut handling, and
+  tests.

--- a/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Keybinding System Is Verified
+The Apple client SHALL include focused verification for default shortcut
+registry descriptors, conflict detection, target semantics, menu hints, and input
+precedence.
+
+#### Scenario: Existing shortcuts are preserved
+- **WHEN** registry-backed keybinding descriptors are introduced
+- **THEN** tests prove existing shell shortcuts keep their previous key
+  equivalents unless a migration is explicitly documented
+
+#### Scenario: Conflicts are detected
+- **WHEN** default shortcut descriptors are validated
+- **THEN** tests fail on duplicate shortcuts in the same dispatch context and
+  include both action IDs in the failure
+
+#### Scenario: Menu hints are verified
+- **WHEN** a menu item is backed by an action with a default shortcut descriptor
+- **THEN** verification proves the native menu hint comes from the registry
+  descriptor
+
+#### Scenario: Keyboard target is verified
+- **WHEN** keyboard dispatch invokes Tab or pane actions
+- **THEN** tests prove the target is the current selected Tab or focused pane
+  rather than a hovered or context-menu row
+
+#### Scenario: Space shortcut scope is verified
+- **WHEN** first-version Space shortcut coverage is tested
+- **THEN** verification covers next Space, previous Space, numeric Space
+  selection, and the absence of default shortcuts for create, rename, and delete
+  Space
+
+#### Scenario: Input precedence is verified
+- **WHEN** Find is active or terminal input owns a key sequence
+- **THEN** tests or script checks prove those handlers take precedence over
+  shell action shortcut dispatch
+
+#### Scenario: No customization surface is verified
+- **WHEN** the first-version keybinding system is reviewed
+- **THEN** tests or code review checklists confirm no shortcut customization UI,
+  config file, manifest field, or Command UI integration was added

--- a/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-keybinding-system/spec.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-keybinding-system/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Default Keybindings Are Registry Backed
+The macOS shell SHALL declare default keybindings on shell action registry
+descriptors, and keyboard dispatch SHALL invoke actions through the same
+registry used by menus and context menus.
+
+#### Scenario: Shortcut invokes registered action
+- **WHEN** the user presses a registered shell shortcut
+- **THEN** alan resolves the matching action descriptor and invokes its handler
+  through the shell action registry
+
+#### Scenario: Menu displays shortcut hint
+- **WHEN** a shell menu item is built from a registry action descriptor that has
+  a default shortcut
+- **THEN** the menu item displays the native shortcut hint from that descriptor
+
+#### Scenario: Shortcut descriptor is missing
+- **WHEN** an action has no default shortcut descriptor
+- **THEN** alan may expose the action in menus or context menus without a
+  keyboard shortcut
+
+### Requirement: First-Version Keybindings Are Fixed Defaults
+The first version of the macOS shell keybinding system SHALL provide fixed
+default shortcuts and SHALL NOT expose user-custom shortcut preferences, config
+files, or import/export behavior.
+
+#### Scenario: User opens settings
+- **WHEN** the first-version keybinding system ships
+- **THEN** alan does not expose a shortcut customization preference screen
+
+#### Scenario: Workspace manifest is saved
+- **WHEN** workspace state is persisted
+- **THEN** alan does not write user-custom shortcut bindings to the workspace
+  manifest
+
+#### Scenario: Connection or agent config loads
+- **WHEN** shell startup loads connection, host, or agent configuration
+- **THEN** alan does not derive user-custom shortcut bindings from those config
+  files
+
+### Requirement: Default Coverage Favors High-Frequency Shell Actions
+The macOS shell SHALL preserve existing shortcuts and add defaults only for
+high-frequency Tab, pane, Find, and Space navigation actions in the first
+version.
+
+#### Scenario: Existing shortcut exists
+- **WHEN** an existing shell shortcut is still valid
+- **THEN** alan preserves its key equivalent and routes it through the registry
+
+#### Scenario: Tab navigation shortcut is pressed
+- **WHEN** the user presses the default shortcut for next or previous Tab
+- **THEN** alan switches Tab inside the current Space
+
+#### Scenario: Tab structural shortcut is pressed
+- **WHEN** the user presses the default shortcut for moving or pinning the
+  current Tab
+- **THEN** alan invokes the registered action against the current selected Tab
+
+#### Scenario: Space navigation shortcut is pressed
+- **WHEN** the user presses the default shortcut for next Space, previous Space,
+  or numeric Space selection
+- **THEN** alan switches the current Space without creating, renaming, or
+  deleting Spaces
+
+#### Scenario: Space management action has no default shortcut
+- **WHEN** the first version exposes create Space, rename Space, or delete Space
+  actions
+- **THEN** alan exposes them without default keyboard shortcuts
+
+### Requirement: Keyboard Shortcuts Target Current Selection
+Keyboard shortcuts SHALL operate on the current selected Space, selected Tab,
+and focused pane. They SHALL NOT target a hovered row or a non-selected context
+menu row.
+
+#### Scenario: Pin shortcut is pressed
+- **WHEN** the user presses the Pin/Unpin Tab shortcut
+- **THEN** alan toggles pin state for the current selected Tab
+
+#### Scenario: Move Tab shortcut is pressed
+- **WHEN** the user presses Move Tab Left or Move Tab Right
+- **THEN** alan reorders the current selected Tab in the current Space
+
+#### Scenario: Pane shortcut is pressed
+- **WHEN** the user presses a pane-focused shell shortcut
+- **THEN** alan applies it to the focused pane inside the current selected Tab
+
+#### Scenario: Context menu remains open
+- **WHEN** a context menu is open on a non-selected Tab and the user invokes a
+  keyboard shortcut outside that menu's direct command handling
+- **THEN** alan targets the current selected Tab, not the context menu Tab
+
+### Requirement: Default Shortcut Conflicts Are Detected
+The macOS shell SHALL detect duplicate default shortcuts in the same dispatch
+context before shipping the keybinding system.
+
+#### Scenario: Duplicate default shortcut exists
+- **WHEN** two enabled shell actions declare the same key equivalent and modifier
+  set in the same dispatch context
+- **THEN** verification fails with both action IDs and the conflicting shortcut
+
+#### Scenario: Same key is valid in separate contexts
+- **WHEN** the same key equivalent is intentionally used in separate contexts
+  with non-overlapping dispatch ownership
+- **THEN** verification records the context boundary and does not fail
+
+### Requirement: Input Precedence Is Explicit
+The macOS shell SHALL define shortcut precedence so Find, terminal input, and
+shell actions do not compete unpredictably.
+
+#### Scenario: Find is active
+- **WHEN** Find is active and the user presses a Find-owned key
+- **THEN** Find handles the key before shell action dispatch
+
+#### Scenario: Terminal owns input
+- **WHEN** the focused terminal view owns a key sequence as terminal input
+- **THEN** alan delivers the sequence to the terminal rather than invoking a
+  shell action
+
+#### Scenario: Shell action shortcut is available
+- **WHEN** Find does not own the key, the terminal does not own the sequence,
+  and a matching available shell action exists
+- **THEN** alan invokes the registered shell action
+
+#### Scenario: Action is unavailable
+- **WHEN** a registered shortcut matches an action that is unavailable in the
+  current shell state
+- **THEN** alan does not mutate shell state and reports a stable unavailable
+  reason for diagnostics where appropriate

--- a/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Keyboard Shell Commands Route Through The Action Registry
+Keyboard-triggered macOS shell commands SHALL resolve and execute through the
+shell action registry so keyboard shortcuts, menus, and context menus share
+action availability and handler semantics.
+
+#### Scenario: Keyboard shortcut invokes Tab action
+- **WHEN** the user presses a Tab-related shell shortcut
+- **THEN** alan resolves the registered Tab action and applies it to the current
+  selected Tab
+
+#### Scenario: Keyboard shortcut invokes Space action
+- **WHEN** the user presses a Space-related shell shortcut
+- **THEN** alan resolves the registered Space action and applies it to the
+  current selected Space context
+
+#### Scenario: Keyboard shortcut invokes pane action
+- **WHEN** the user presses a pane-related shell shortcut
+- **THEN** alan resolves the registered pane action and applies it to the
+  focused pane
+
+### Requirement: First-Version Space Shortcuts Are Navigation Only
+The first version of macOS shell Space shortcuts SHALL cover Space navigation
+only and SHALL NOT provide default shortcuts for Space creation, rename, or
+deletion.
+
+#### Scenario: Next Space shortcut
+- **WHEN** the user presses the default Next Space shortcut
+- **THEN** alan selects the next Space in workspace order
+
+#### Scenario: Previous Space shortcut
+- **WHEN** the user presses the default Previous Space shortcut
+- **THEN** alan selects the previous Space in workspace order
+
+#### Scenario: Numeric Space shortcut
+- **WHEN** the user presses a numeric Space selection shortcut for an existing
+  Space index
+- **THEN** alan selects that Space
+
+#### Scenario: Numeric Space target is missing
+- **WHEN** the user presses a numeric Space selection shortcut for a missing
+  Space index
+- **THEN** alan leaves the current Space selected and reports a stable
+  unavailable reason for diagnostics where appropriate
+
+#### Scenario: Create Space has no default shortcut
+- **WHEN** the first-version Space action registry exposes create Space
+- **THEN** alan exposes the action without a default keyboard shortcut
+
+#### Scenario: Rename or delete Space has no default shortcut
+- **WHEN** the first-version Space action registry exposes rename or delete Space
+- **THEN** alan exposes those actions without default keyboard shortcuts

--- a/openspec/changes/add-macos-shell-keybinding-system/tasks.md
+++ b/openspec/changes/add-macos-shell-keybinding-system/tasks.md
@@ -1,0 +1,55 @@
+## 1. Registry Shortcut Descriptors
+
+- [ ] 1.1 Add default shortcut metadata to shell action descriptors.
+- [ ] 1.2 Move existing shell shortcuts into registry-backed descriptors without
+  changing their key equivalents.
+- [ ] 1.3 Add conflict detection for duplicate default shortcuts within the same
+  dispatch context.
+- [ ] 1.4 Ensure menu shortcut hints are rendered from registry descriptors.
+
+## 2. Keyboard Dispatch
+
+- [ ] 2.1 Route shell keyboard shortcuts through the action registry.
+- [ ] 2.2 Resolve keyboard targets from current selected Space, selected Tab, and
+  focused pane.
+- [ ] 2.3 Apply action availability before invoking handlers.
+- [ ] 2.4 Preserve terminal input behavior for keys that belong to the active
+  terminal view.
+- [ ] 2.5 Preserve Find behavior and Find-owned shortcuts while Find is active.
+
+## 3. Default Coverage
+
+- [ ] 3.1 Preserve existing defaults for new Tab, close Tab, split pane, pane
+  focus, equalize panes, and Find where they already exist.
+- [ ] 3.2 Add or standardize defaults for next/previous Tab and Move Tab
+  Left/Right.
+- [ ] 3.3 Add a default for Pin/Unpin current Tab only after Tab organization
+  exposes the registry-backed action.
+- [ ] 3.4 Add Space navigation defaults for next Space, previous Space, and
+  numeric Space selection.
+- [ ] 3.5 Keep create/rename/delete Space action-only or menu-only with no
+  default shortcut in the first version.
+
+## 4. Verification
+
+- [ ] 4.1 Add tests for default shortcut uniqueness and conflict detection.
+- [ ] 4.2 Add tests that existing shortcuts keep their key equivalents.
+- [ ] 4.3 Add tests for keyboard target semantics on current selected Tab and
+  focused pane.
+- [ ] 4.4 Add tests for disabled/unavailable actions showing in menus but not
+  mutating state when invoked by shortcut.
+- [ ] 4.5 Add tests or script checks for Find-active and terminal-input
+  precedence.
+- [ ] 4.6 Run relevant Apple shell scripts and the macOS app build command, or
+  document any local blocker.
+- [ ] 4.7 Run `openspec validate add-macos-shell-keybinding-system --type change --strict --json`.
+- [ ] 4.8 Run `openspec validate --all --strict --json`.
+- [ ] 4.9 Run `git diff --check`.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 Confirm no user-custom shortcut preference UI, config file, or Command
+  UI integration slipped into scope.
+- [ ] 5.2 Before archive, sync accepted delta requirements into
+  `openspec/specs/`.
+- [ ] 5.3 Archive the OpenSpec change after implementation merges.

--- a/openspec/changes/improve-macos-tab-organization/.openspec.yaml
+++ b/openspec/changes/improve-macos-tab-organization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/improve-macos-tab-organization/design.md
+++ b/openspec/changes/improve-macos-tab-organization/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Alan already treats Spaces as durable containers and Tabs as restorable shell
+work units. Pinned Tabs have explicit restore snapshots, while unpinned Tabs
+have lifecycle semantics. The missing piece is the interaction layer: users need
+to organize Tabs directly in the sidebar without breaking terminal continuity.
+
+The visual direction should reference Arc's sidebar: lightweight top Pinned
+items, a subtle divider or spacing boundary, and regular Tabs below. This
+change does not add folders, nested groups, or a global pinned area.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add per-Space Pinned and Unpinned Tab sections.
+- Support whole-row drag reorder with realtime insertion feedback.
+- Allow drag across sections to pin or unpin.
+- Save the pin snapshot when a Tab is dragged into the Pinned section.
+- Move Tabs between Spaces through explicit menu/context actions.
+- Preserve Tab, pane, split, and terminal runtime identity for every
+  organization mutation.
+- Persist ordering, pin state, Space ownership, and pin snapshots immediately.
+
+**Non-Goals:**
+
+- No global Pinned Tabs.
+- No folders, tab groups, or nested collections.
+- No drag-to-Space-switcher cross-Space movement in the first version.
+- No Command UI integration.
+- No runtime rebuild when moving or reordering Tabs.
+
+## Decisions
+
+### 1. Pinned is per Space
+
+Pinned Tabs belong to their Space. Moving a Pinned Tab to another Space keeps it
+Pinned and inserts it at the end of the target Space's Pinned section. Moving an
+Unpinned Tab inserts it at the end of the target Space's Unpinned section.
+
+This preserves the user's local organization without turning Pinned Tabs into a
+global browser-style shelf.
+
+### 2. Use two lightweight visual sections
+
+The sidebar should not add heavy section headers. Pinned and Unpinned areas are
+separated by spacing and a subtle divider, with Arc-like stable rows and a
+lightweight New Tab affordance. Drag insertion lines and row movement should
+provide feedback during reorder rather than explanatory text.
+
+### 3. Whole-row drag with a threshold
+
+Tab rows are draggable, but short clicks still select the Tab. Drag begins only
+after a movement threshold. Right click, close overlay, and split topology
+indicator interactions remain independent and do not accidentally start a
+reorder.
+
+### 4. Cross-section drag changes pin state
+
+Dragging from Unpinned to Pinned is equivalent to Pin current state and saves
+the current restore snapshot. Dragging from Pinned to Unpinned unpins the Tab.
+Dragging within the same section only changes order.
+
+### 5. Cross-Space movement is explicit
+
+The first version uses `Move Tab to Space...` in menus and Tab context menus.
+If the moved Tab is currently selected, Alan follows it to the target Space and
+keeps it selected. If the moved Tab is not selected, Alan stays on the current
+Space.
+
+### 6. Organization never restarts terminal runtimes
+
+Reorder, pin, unpin, and Move to Space mutate shell organization only. Tab IDs,
+pane IDs, split trees, terminal runtime handles, scrollback, and pending
+delivery state stay attached to the same Tab and panes.

--- a/openspec/changes/improve-macos-tab-organization/proposal.md
+++ b/openspec/changes/improve-macos-tab-organization/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Alan's macOS shell now has persistent Spaces, Tabs, pin snapshots, and stable
+terminal runtimes, but users still cannot organize Tabs with the direct
+manipulation expected from an Arc-like sidebar. Per-Space pinned sections,
+drag-based ordering, and explicit Move to Space actions are needed before the
+shortcut system can expose reliable Tab organization commands.
+
+## What Changes
+
+- Split each Space's Tab list into lightweight Pinned and Unpinned visual
+  sections inspired by Arc's sidebar treatment.
+- Allow whole-row Tab dragging with a movement threshold so short clicks still
+  select the Tab.
+- Support realtime insertion previews while reordering within a section or
+  dragging across Pinned and Unpinned sections.
+- Treat Unpinned-to-Pinned drag as Pin current state and save the pin snapshot.
+- Treat Pinned-to-Unpinned drag as Unpin.
+- Add registry-backed menu and context-menu actions for Pin, Unpin, Move Tab
+  Left/Right, and Move Tab to Space.
+- Keep cross-Space Tab movement in menus/context menus for the first version;
+  dragging a Tab to the Space switcher is out of scope.
+- Preserve Tab, pane, and terminal runtime identity across reorder, pin/unpin,
+  and Move to Space.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-shell-workspace-interactions`: Adds per-Space Pinned/Unpinned Tab
+  sections, drag reorder, drag pin/unpin, and Move Tab to Space semantics.
+- `macos-shell-workspace-persistence`: Persists per-Space Tab order, pin state,
+  pin snapshots, and Space ownership immediately after organization mutations.
+- `macos-shell-ui-ux-conformance`: Adds Arc-like sidebar visual constraints for
+  Pinned/Unpinned Tab sections and drag insertion feedback.
+- `macos-shell-control-plane-reliability`: Adds authoritative mutation results
+  and events for Tab reorder, pin/unpin, and Move Tab to Space.
+- `macos-shell-build-test-contract`: Adds focused validation for drag behavior,
+  target semantics, manifest writes, and runtime identity preservation.
+
+## Impact
+
+- Depends on `add-macos-shell-action-registry` for shared Tab organization
+  actions and target resolution.
+- Apple shell model and manifest mutation helpers for Tab order, pin state, and
+  Space ownership.
+- Sidebar Tab list UI, context menus, and drag/drop state.
+- Shell events, local command execution, and focused Apple tests.

--- a/openspec/changes/improve-macos-tab-organization/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/improve-macos-tab-organization/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Tab Organization Is Verified
+The Apple client SHALL include focused verification for Tab reorder, pin/unpin,
+Move to Space, manifest persistence, context targeting, and runtime identity
+preservation.
+
+#### Scenario: Drag threshold is verified
+- **WHEN** Tab row drag behavior changes
+- **THEN** focused tests or script checks verify short clicks still select Tabs
+  and drag begins only after the movement threshold
+
+#### Scenario: Cross-section drag is verified
+- **WHEN** drag pin/unpin behavior changes
+- **THEN** verification covers Unpinned-to-Pinned snapshot creation,
+  Pinned-to-Unpinned behavior, and realtime insertion preview
+
+#### Scenario: Context target is verified
+- **WHEN** Tab context menu actions change
+- **THEN** verification proves actions target the clicked Tab without selecting
+  it first
+
+#### Scenario: Move to Space focus is verified
+- **WHEN** Move Tab to Space behavior changes
+- **THEN** verification covers current Tab follow behavior and non-current Tab
+  no-follow behavior
+
+#### Scenario: Runtime identity is verified
+- **WHEN** Tab organization mutations are implemented
+- **THEN** verification proves Tab IDs, pane IDs, split trees, runtime handles,
+  and queued delivery state remain stable across reorder, pin/unpin, and Move
+  to Space

--- a/openspec/changes/improve-macos-tab-organization/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/improve-macos-tab-organization/specs/macos-shell-control-plane-reliability/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Tab Organization Mutations Report Authoritative Results
+The macOS shell control plane and local command paths SHALL return results
+derived from authoritative shell state after Tab reorder, pin/unpin, and Move to
+Space mutations are accepted or rejected.
+
+#### Scenario: Reorder succeeds
+- **WHEN** a Tab reorder mutation is accepted
+- **THEN** the result reports `applied: true` with the Tab ID, Space ID, section,
+  and resulting index
+
+#### Scenario: Pin succeeds
+- **WHEN** a Tab pin mutation is accepted
+- **THEN** the result reports `applied: true`, the Tab's pinned state, and the
+  resulting section/index
+
+#### Scenario: Move to Space succeeds
+- **WHEN** a Tab moves to another Space
+- **THEN** the result reports `applied: true`, source Space, target Space,
+  section, resulting index, and resulting focused Space/Tab when focus changes
+
+#### Scenario: Mutation is invalid
+- **WHEN** a Tab organization mutation references a missing Tab, missing Space,
+  invalid section, or invalid index
+- **THEN** the result reports `applied: false` with a stable error code and
+  leaves shell state unchanged
+
+### Requirement: Tab Organization Events Are Observable
+Tab organization mutations SHALL emit shell events with enough detail for
+diagnostics and agents to observe ordering, pin state, Space movement, and focus
+outcomes.
+
+#### Scenario: Tab reordered
+- **WHEN** a Tab order changes
+- **THEN** the shell event stream records the Tab ID, Space ID, previous section
+  and index, and current section and index
+
+#### Scenario: Tab moved to another Space
+- **WHEN** a Tab moves to another Space
+- **THEN** the shell event stream records the previous and current Space,
+  section, index, and focus outcome

--- a/openspec/changes/improve-macos-tab-organization/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/improve-macos-tab-organization/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Tab Organization Follows Lightweight Arc-Like Sections
+The macOS sidebar SHALL present per-Space Pinned and Unpinned Tab sections with
+a restrained Arc-like visual treatment that preserves scan speed and avoids
+heavy group chrome.
+
+#### Scenario: Pinned and Unpinned sections render
+- **WHEN** a Space contains Pinned and Unpinned Tabs
+- **THEN** alan separates the sections with subtle spacing or a divider rather
+  than large boxed panels, cards, or heavy section headers
+
+#### Scenario: Tab rows remain stable
+- **WHEN** the user hovers, selects, drags, pins, unpins, or reorders Tabs
+- **THEN** Tab rows keep stable height and sidebar geometry without resizing
+  terminal content
+
+#### Scenario: New Tab remains lightweight
+- **WHEN** the sidebar shows the New Tab affordance
+- **THEN** it appears as a lightweight list action rather than a large toolbar
+  or dashboard-style primary button
+
+#### Scenario: No folder scope
+- **WHEN** the first Tab organization pass ships
+- **THEN** alan does not introduce tab folders, nested tab groups, or a global
+  pinned shelf
+
+### Requirement: Drag Feedback Is Direct And Minimal
+Tab drag feedback SHALL communicate target section and insertion position
+without explanatory copy or persistent drag chrome.
+
+#### Scenario: Drag insertion preview
+- **WHEN** the user drags a Tab row over a valid insertion point
+- **THEN** alan shows a direct insertion preview in the target section
+
+#### Scenario: Drag crosses section boundary
+- **WHEN** the user drags a Tab row from Pinned to Unpinned or Unpinned to
+  Pinned
+- **THEN** the target section and insertion position are visually clear before
+  drop
+
+#### Scenario: Invalid drag target
+- **WHEN** the user drags over a target that cannot accept the Tab
+- **THEN** alan avoids committing the mutation and preserves current Tab order
+  without showing raw debug identifiers

--- a/openspec/changes/improve-macos-tab-organization/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/improve-macos-tab-organization/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Tabs Are Organized Into Per-Space Pinned And Unpinned Sections
+The macOS shell SHALL organize Tabs inside each Space into a Pinned section and
+an Unpinned section. Pinning is scoped to the owning Space and SHALL NOT create
+a global pinned Tab shelf.
+
+#### Scenario: Space contains pinned and unpinned Tabs
+- **WHEN** a Space has both Pinned and Unpinned Tabs
+- **THEN** alan presents those Tabs as two ordered sections within that Space
+
+#### Scenario: Pinned Tab moves to another Space
+- **WHEN** a Pinned Tab is moved to a different Space
+- **THEN** alan keeps the Tab pinned and inserts it at the end of the target
+  Space's Pinned section
+
+#### Scenario: Unpinned Tab moves to another Space
+- **WHEN** an Unpinned Tab is moved to a different Space
+- **THEN** alan keeps the Tab unpinned and inserts it at the end of the target
+  Space's Unpinned section
+
+### Requirement: Tab Rows Support Direct Reorder And Pin State Changes
+The macOS shell SHALL allow users to drag Tab rows to reorder Tabs within a
+section and to change pin state by dragging across the Pinned and Unpinned
+section boundary.
+
+#### Scenario: Short click selects Tab
+- **WHEN** the user clicks a Tab row without crossing the drag threshold
+- **THEN** alan selects that Tab normally
+
+#### Scenario: Drag reorders inside a section
+- **WHEN** the user drags a Tab row to another position inside the same section
+- **THEN** alan reorders the Tab within that section without changing its pin
+  state
+
+#### Scenario: Drag pins Tab
+- **WHEN** the user drags an Unpinned Tab into the Pinned section and drops it
+- **THEN** alan pins the Tab using its current restorable state and inserts it
+  at the previewed Pinned position
+
+#### Scenario: Drag unpins Tab
+- **WHEN** the user drags a Pinned Tab into the Unpinned section and drops it
+- **THEN** alan unpins the Tab and inserts it at the previewed Unpinned position
+
+#### Scenario: Drag shows insertion preview
+- **WHEN** the user drags a Tab row within or across sections
+- **THEN** alan shows a realtime insertion preview before mutating durable Tab
+  order
+
+### Requirement: Move Tab To Space Is Explicit In The First Version
+The macOS shell SHALL support Move Tab to Space through menu and Tab context
+actions. The first version SHALL NOT require dragging a Tab to the Space
+switcher to move it across Spaces.
+
+#### Scenario: Move selected Tab follows target
+- **WHEN** the user moves the current selected Tab to another Space
+- **THEN** alan selects the target Space and keeps the moved Tab selected
+
+#### Scenario: Move non-selected Tab stays put
+- **WHEN** the user moves a non-selected Tab to another Space through its
+  context menu
+- **THEN** alan keeps the current Space, selected Tab, and focused pane
+  unchanged
+
+#### Scenario: Move target missing
+- **WHEN** the user or a control path requests moving a Tab to a missing Space
+- **THEN** alan rejects the move with a stable reason and leaves Tab order,
+  Space ownership, and focus unchanged
+
+### Requirement: Tab Context Menus Use Context Targets
+Tab context menu actions SHALL target the Tab that opened the menu without first
+changing selected Space, selected Tab, or focused pane.
+
+#### Scenario: Context pin targets clicked Tab
+- **WHEN** the user opens a context menu on a non-selected Tab and chooses Pin
+- **THEN** alan pins the clicked Tab without selecting it first
+
+#### Scenario: Context move targets clicked Tab
+- **WHEN** the user opens a context menu on a non-selected Tab and chooses Move
+  Tab to Space
+- **THEN** alan moves the clicked Tab and keeps the current selection unchanged
+  unless the clicked Tab was already selected

--- a/openspec/changes/improve-macos-tab-organization/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/improve-macos-tab-organization/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Tab Organization Mutations Persist Immediately
+The macOS shell SHALL persist Tab reorder, pin/unpin, and Move to Space
+mutations to the workspace manifest immediately after the mutation is accepted.
+
+#### Scenario: Tab is reordered
+- **WHEN** the user reorders a Tab inside a Space section
+- **THEN** alan writes the new per-Space Tab order to the workspace manifest
+
+#### Scenario: Tab is pinned by drag
+- **WHEN** the user drags an Unpinned Tab into the Pinned section
+- **THEN** alan writes the pinned state and the current pin snapshot to the
+  workspace manifest
+
+#### Scenario: Tab is unpinned by drag
+- **WHEN** the user drags a Pinned Tab into the Unpinned section
+- **THEN** alan writes the unpinned state and updated section order to the
+  workspace manifest
+
+#### Scenario: Tab moves to another Space
+- **WHEN** a Tab is moved to a different Space
+- **THEN** alan writes the source Space order, target Space order, Tab Space
+  ownership, pin state, and selected Space/Tab outcome to the manifest
+
+### Requirement: Organization Preserves Runtime Identity
+The macOS shell SHALL preserve Tab, pane, split tree, and terminal runtime
+identity across reorder, pin/unpin, and Move to Space mutations.
+
+#### Scenario: Tab is reordered
+- **WHEN** a Tab changes order inside its Space
+- **THEN** its Tab ID, pane IDs, split tree, terminal runtime handles, scrollback,
+  metadata, and queued delivery state remain attached to the same Tab
+
+#### Scenario: Tab changes pin state
+- **WHEN** a Tab is pinned or unpinned
+- **THEN** alan changes organization metadata without restarting terminal
+  runtimes or recreating pane identities
+
+#### Scenario: Tab moves across Spaces
+- **WHEN** a Tab moves to another Space
+- **THEN** the moved Tab keeps its Tab ID, pane IDs, split tree, terminal
+  runtime handles, scrollback, metadata, and queued delivery state

--- a/openspec/changes/improve-macos-tab-organization/tasks.md
+++ b/openspec/changes/improve-macos-tab-organization/tasks.md
@@ -1,0 +1,68 @@
+## 1. Model And Manifest
+
+- [ ] 1.1 Extend shell model helpers so each Space exposes stable Pinned and
+  Unpinned Tab ordering.
+- [ ] 1.2 Persist Tab order, pin state, Space ownership, and selected Tab after
+  reorder, pin/unpin, and Move to Space mutations.
+- [ ] 1.3 Save a pin snapshot when an Unpinned Tab is dragged into the Pinned
+  section or otherwise pinned from the organization surface.
+- [ ] 1.4 Preserve existing update-pin behavior for already Pinned Tabs without
+  updating the snapshot on ordinary reorder.
+
+## 2. Registry Actions And Mutations
+
+- [ ] 2.1 Add registry-backed Tab actions for pin, unpin, move left, move right,
+  and Move Tab to Space.
+- [ ] 2.2 Make context-menu Tab actions target the clicked Tab without selecting
+  it first.
+- [ ] 2.3 Implement Move Tab to Space insertion rules: keep pin state and insert
+  at the end of the target Space's corresponding section.
+- [ ] 2.4 Follow the moved Tab only when the moved Tab was the current selected
+  Tab; otherwise keep the current Space selected.
+- [ ] 2.5 Emit shell events for reorder, pin/unpin, and Move Tab to Space.
+
+## 3. Sidebar Drag UI
+
+- [ ] 3.1 Render per-Space Pinned and Unpinned sections with Arc-like lightweight
+  separation and without heavy group headings.
+- [ ] 3.2 Support whole-row drag with a movement threshold so short clicks still
+  select the Tab.
+- [ ] 3.3 Show realtime insertion preview within and across sections.
+- [ ] 3.4 Keep close overlay, right-click menu, and split topology indicator
+  interactions from accidentally starting drag reorder.
+- [ ] 3.5 Keep `New Tab` as a lightweight list action rather than a toolbar-like
+  primary button.
+
+## 4. Runtime Continuity
+
+- [ ] 4.1 Prove reorder, pin/unpin, and Move to Space preserve Tab ID, pane ID,
+  split tree, terminal runtime handle, metadata, scrollback, and queued delivery
+  state.
+- [ ] 4.2 Ensure moving the current Tab follows to the target Space and focuses
+  the same preferred pane.
+- [ ] 4.3 Ensure moving a non-current Tab does not change the current selected
+  Space, selected Tab, or focused pane.
+
+## 5. Verification
+
+- [ ] 5.1 Add focused model tests for same-section reorder, cross-section
+  pin/unpin, snapshot creation, Move to Space, and current/non-current focus
+  behavior.
+- [ ] 5.2 Add focused sidebar tests or script checks for drag threshold,
+  insertion preview, context target, and split indicator/close overlay
+  coexistence.
+- [ ] 5.3 Add manifest persistence tests for immediate order, pin state, snapshot
+  and Space ownership writes.
+- [ ] 5.4 Run relevant Apple shell scripts and the macOS app build command, or
+  document any local blocker.
+- [ ] 5.5 Run `openspec validate improve-macos-tab-organization --type change --strict --json`.
+- [ ] 5.6 Run `openspec validate --all --strict --json`.
+- [ ] 5.7 Run `git diff --check`.
+
+## 6. Archive Readiness
+
+- [ ] 6.1 Confirm the final UI stays Arc-like and does not introduce tab folders,
+  global pinned tabs, heavy section headers, or Command UI scope.
+- [ ] 6.2 Before archive, sync accepted delta requirements into
+  `openspec/specs/`.
+- [ ] 6.3 Archive the OpenSpec change after implementation merges.


### PR DESCRIPTION
## Summary
- Add OpenSpec change for a macOS shell action registry shared by menu, context-menu, and keyboard surfaces, with Command UI explicitly out of scope.
- Add OpenSpec change for Arc-like per-Space Tab organization: pinned/unpinned sections, drag reorder, drag pin/unpin, and Move to Space semantics.
- Add OpenSpec change for registry-backed default keybindings covering high-frequency Tab, pane, Find, and Space navigation actions without user customization in v1.

## Verification
- openspec validate --all --strict --json: 47/47 valid
- rg trailing-whitespace scan over the new change directories: no matches
- rg placeholder scan over the new change directories: no matches
- git diff --cached --check: passed before commit