### PR TITLE
Add macOS shell action registry

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		00000000000000000000003B /* Support/ShellSidebarSpaceContentPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013B /* Support/ShellSidebarSpaceContentPager.swift */; };
 		00000000000000000000003C /* Support/AlanCommandLineToolInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013C /* Support/AlanCommandLineToolInstaller.swift */; };
 		00000000000000000000003D /* Support/ShellSidebarPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013D /* Support/ShellSidebarPresentation.swift */; };
+		00000000000000000000003E /* Models/Shell/ShellActionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */; };
 		00000000000000000000003F /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 00000000000000000000013F /* AppIcon.icon */; };
 /* End PBXBuildFile section */
 
@@ -134,6 +135,7 @@
 		00000000000000000000013B /* Support/ShellSidebarSpaceContentPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceContentPager.swift; sourceTree = "<group>"; };
 		00000000000000000000013C /* Support/AlanCommandLineToolInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/AlanCommandLineToolInstaller.swift; sourceTree = "<group>"; };
 		00000000000000000000013D /* Support/ShellSidebarPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarPresentation.swift; sourceTree = "<group>"; };
+		00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellActionRegistry.swift; sourceTree = "<group>"; };
 		00000000000000000000013F /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -281,6 +283,7 @@
 				000000000000000000000139 /* Models/Shell/ShellWorkspaceManifest.swift */,
 				000000000000000000000123 /* Models/Shell/ShellTreeMutations.swift */,
 				000000000000000000000124 /* Models/Shell/ShellStateMutations.swift */,
+				00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */,
 			);
 			name = Models/Shell;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 				000000000000000000000022 /* Models/Shell/ShellSnapshots.swift in Sources */,
 				000000000000000000000023 /* Models/Shell/ShellTreeMutations.swift in Sources */,
 				000000000000000000000024 /* Models/Shell/ShellStateMutations.swift in Sources */,
+				00000000000000000000003E /* Models/Shell/ShellActionRegistry.swift in Sources */,
 				000000000000000000000025 /* Services/Shell/ShellPaneProjectionService.swift in Sources */,
 				000000000000000000000026 /* Services/Shell/ShellStatePersistenceStore.swift in Sources */,
 				000000000000000000000027 /* Services/Terminal/TerminalHostRuntimeReporter.swift in Sources */,

--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -23,13 +23,13 @@ struct AlanMacShellCommands: Commands {
         }
 
         CommandMenu("Shell") {
-            Button("New Terminal Tab") {
-                host.performShellWorkspaceCommand(.newTerminalTab)
+            Button(host.shellActionTitle(.newTerminalTab)) {
+                host.performShellAction(.newTerminalTab)
             }
             .keyboardShortcut("t", modifiers: .command)
 
-            Button("New alan tab") {
-                host.performShellWorkspaceCommand(.newAlanTab)
+            Button(host.shellActionTitle(.newAlanTab)) {
+                host.performShellAction(.newAlanTab)
             }
             .keyboardShortcut("t", modifiers: [.command, .option])
 
@@ -40,64 +40,74 @@ struct AlanMacShellCommands: Commands {
 
             Divider()
 
-            Button("Split Right") {
-                host.performShellWorkspaceCommand(.splitRight)
+            Button(host.shellActionTitle(.paneSplitRight)) {
+                host.performShellAction(.paneSplitRight)
             }
             .keyboardShortcut("d", modifiers: .command)
+            .disabled(!host.shellActionAvailability(.paneSplitRight).isAvailable)
 
-            Button("Split Down") {
-                host.performShellWorkspaceCommand(.splitDown)
+            Button(host.shellActionTitle(.paneSplitDown)) {
+                host.performShellAction(.paneSplitDown)
             }
             .keyboardShortcut("d", modifiers: [.command, .shift])
+            .disabled(!host.shellActionAvailability(.paneSplitDown).isAvailable)
 
-            Button("Split Left") {
-                host.performShellWorkspaceCommand(.splitLeft)
+            Button(host.shellActionTitle(.paneSplitLeft)) {
+                host.performShellAction(.paneSplitLeft)
             }
             .keyboardShortcut("d", modifiers: [.command, .option])
+            .disabled(!host.shellActionAvailability(.paneSplitLeft).isAvailable)
 
-            Button("Split Up") {
-                host.performShellWorkspaceCommand(.splitUp)
+            Button(host.shellActionTitle(.paneSplitUp)) {
+                host.performShellAction(.paneSplitUp)
             }
             .keyboardShortcut("d", modifiers: [.command, .option, .shift])
+            .disabled(!host.shellActionAvailability(.paneSplitUp).isAvailable)
 
-            Button("Equalize Splits") {
-                host.performShellWorkspaceCommand(.equalizeSplits)
+            Button(host.shellActionTitle(.paneEqualizeSplits)) {
+                host.performShellAction(.paneEqualizeSplits)
             }
             .keyboardShortcut("=", modifiers: [.command, .option])
 
             Divider()
 
-            Button("Focus Pane Left") {
-                host.performShellWorkspaceCommand(.focusLeft)
+            Button(host.shellActionTitle(.paneFocusLeft)) {
+                host.performShellAction(.paneFocusLeft)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.command, .control])
+            .disabled(!host.shellActionAvailability(.paneFocusLeft).isAvailable)
 
-            Button("Focus Pane Right") {
-                host.performShellWorkspaceCommand(.focusRight)
+            Button(host.shellActionTitle(.paneFocusRight)) {
+                host.performShellAction(.paneFocusRight)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.command, .control])
+            .disabled(!host.shellActionAvailability(.paneFocusRight).isAvailable)
 
-            Button("Focus Pane Up") {
-                host.performShellWorkspaceCommand(.focusUp)
+            Button(host.shellActionTitle(.paneFocusUp)) {
+                host.performShellAction(.paneFocusUp)
             }
             .keyboardShortcut(.upArrow, modifiers: [.command, .control])
+            .disabled(!host.shellActionAvailability(.paneFocusUp).isAvailable)
 
-            Button("Focus Pane Down") {
-                host.performShellWorkspaceCommand(.focusDown)
+            Button(host.shellActionTitle(.paneFocusDown)) {
+                host.performShellAction(.paneFocusDown)
             }
             .keyboardShortcut(.downArrow, modifiers: [.command, .control])
+            .disabled(!host.shellActionAvailability(.paneFocusDown).isAvailable)
 
             Divider()
 
-            Button("Close Pane") {
-                host.performShellWorkspaceCommand(.closePane)
+            Button(host.shellActionTitle(.paneClose)) {
+                host.performShellAction(.paneClose)
             }
             .keyboardShortcut("w", modifiers: [.command, .shift])
+            .disabled(!host.shellActionAvailability(.paneClose).isAvailable)
 
-            Button("Close Tab") {
-                host.performShellWorkspaceCommand(.closeTab)
+            Button(host.shellActionTitle(.tabClose)) {
+                host.performShellAction(.tabClose)
             }
             .keyboardShortcut("w", modifiers: .command)
+            .disabled(!host.shellActionAvailability(.tabClose).isAvailable)
         }
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -1,0 +1,540 @@
+import Foundation
+
+enum ShellActionID: String, CaseIterable, Identifiable, Hashable {
+    case newTerminalTab = "shell.tab.new_terminal"
+    case newAlanTab = "shell.tab.new_alan"
+    case tabClose = "shell.tab.close"
+    case tabPin = "shell.tab.pin"
+    case tabUnpin = "shell.tab.unpin"
+    case tabUpdatePin = "shell.tab.update_pin"
+    case tabMoveLeft = "shell.tab.move_left"
+    case tabMoveRight = "shell.tab.move_right"
+    case tabMoveToSpace = "shell.tab.move_to_space"
+    case paneSplitLeft = "shell.pane.split_left"
+    case paneSplitRight = "shell.pane.split_right"
+    case paneSplitUp = "shell.pane.split_up"
+    case paneSplitDown = "shell.pane.split_down"
+    case paneFocusLeft = "shell.pane.focus_left"
+    case paneFocusRight = "shell.pane.focus_right"
+    case paneFocusUp = "shell.pane.focus_up"
+    case paneFocusDown = "shell.pane.focus_down"
+    case paneEqualizeSplits = "shell.pane.equalize_splits"
+    case paneClose = "shell.pane.close"
+    case findOpen = "shell.find.open"
+    case spaceSelectPrevious = "shell.space.select_previous"
+    case spaceSelectNext = "shell.space.select_next"
+    case spaceSelectByIndex = "shell.space.select_by_index"
+    case commandInputOpen = "shell.command_input.open"
+
+    var id: String { rawValue }
+}
+
+enum ShellActionTargetKind: Equatable {
+    case currentSelection
+    case tab
+    case pane
+    case space
+    case destinationSpace
+}
+
+enum ShellActionTarget: Equatable {
+    case currentSelection
+    case contextTab(String)
+    case contextPane(String)
+    case contextSpace(String)
+    case spaceIndex(Int)
+    case tabToSpace(tabID: String, spaceID: String)
+}
+
+enum ShellResolvedActionTarget: Equatable {
+    case selection(spaceID: String?, tabID: String?, paneID: String?)
+    case tab(String)
+    case pane(String)
+    case space(String)
+    case spaceIndex(Int)
+    case tabToSpace(tabID: String, spaceID: String)
+    case unresolved
+}
+
+enum ShellActionSurface: String, Equatable {
+    case menuBar = "menu_bar"
+    case contextMenu = "context_menu"
+    case keyboard
+}
+
+enum ShellActionModifier: String, CaseIterable, Hashable, Comparable {
+    case command
+    case option
+    case shift
+    case control
+
+    static func < (lhs: ShellActionModifier, rhs: ShellActionModifier) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+enum ShellActionShortcutContext: String, Hashable {
+    case shell
+    case terminalFind = "terminal_find"
+}
+
+struct ShellActionShortcut: Hashable {
+    let key: String
+    let modifiers: Set<ShellActionModifier>
+    let context: ShellActionShortcutContext
+}
+
+enum ShellActionAvailability: Equatable {
+    case available
+    case unavailable(reason: String)
+
+    var isAvailable: Bool {
+        self == .available
+    }
+}
+
+enum ShellActionEffect: Equatable {
+    case workspaceCommand(ShellWorkspaceCommand)
+    case openTab(ShellLaunchTarget, spaceID: String?)
+    case closeTab(String?)
+    case closePane(String?)
+    case selectAdjacentSpace(Int)
+    case selectSpaceAt(Int)
+    case pinTab(String?)
+    case unpinTab(String?)
+    case updatePinnedTab(String?)
+    case disabledPlaceholder
+}
+
+enum ShellActionExecutionResult: Equatable {
+    case executed
+    case failed(reason: String)
+    case unavailable(reason: String)
+}
+
+enum ShellActionRegistryError: Error, Equatable {
+    case duplicateActionID(ShellActionID)
+    case duplicateShortcut(ShellActionShortcut, [ShellActionID])
+}
+
+struct ShellResolvedAction {
+    let descriptor: ShellActionDescriptor?
+    let resolvedTarget: ShellResolvedActionTarget
+    let availability: ShellActionAvailability
+}
+
+struct ShellActionDescriptor {
+    let id: ShellActionID
+    let title: String
+    let targetKind: ShellActionTargetKind
+    let defaultShortcut: ShellActionShortcut?
+    let effect: ShellActionEffect
+    private let availabilityEvaluator: (ShellStateSnapshot, ShellActionTarget) -> ShellActionAvailability
+
+    init(
+        id: ShellActionID,
+        title: String,
+        targetKind: ShellActionTargetKind,
+        defaultShortcut: ShellActionShortcut? = nil,
+        effect: ShellActionEffect,
+        availability: @escaping (ShellStateSnapshot, ShellActionTarget) -> ShellActionAvailability = {
+            _, _ in .available
+        }
+    ) {
+        self.id = id
+        self.title = title
+        self.targetKind = targetKind
+        self.defaultShortcut = defaultShortcut
+        self.effect = effect
+        availabilityEvaluator = availability
+    }
+
+    func availability(
+        state: ShellStateSnapshot,
+        target: ShellActionTarget
+    ) -> ShellActionAvailability {
+        availabilityEvaluator(state, target)
+    }
+}
+
+final class ShellActionRegistry {
+    let actions: [ShellActionDescriptor]
+
+    static let standard: ShellActionRegistry = {
+        do {
+            return try ShellActionRegistry(actions: standardActions)
+        } catch {
+            preconditionFailure("Invalid shell action registry: \(error)")
+        }
+    }()
+
+    init(actions: [ShellActionDescriptor]) throws {
+        var actionIDs = Set<ShellActionID>()
+        for action in actions {
+            guard actionIDs.insert(action.id).inserted else {
+                throw ShellActionRegistryError.duplicateActionID(action.id)
+            }
+        }
+
+        let shortcuts = Dictionary(grouping: actions.compactMap { action -> (ShellActionShortcut, ShellActionID)? in
+            guard let shortcut = action.defaultShortcut else { return nil }
+            return (shortcut, action.id)
+        }, by: { $0.0 })
+
+        for (shortcut, entries) in shortcuts where entries.count > 1 {
+            throw ShellActionRegistryError.duplicateShortcut(shortcut, entries.map(\.1))
+        }
+
+        self.actions = actions
+    }
+
+    func action(for id: ShellActionID) -> ShellActionDescriptor? {
+        actions.first { $0.id == id }
+    }
+
+    func resolve(
+        _ id: ShellActionID,
+        target: ShellActionTarget,
+        state: ShellStateSnapshot
+    ) -> ShellResolvedAction {
+        guard let descriptor = action(for: id) else {
+            return ShellResolvedAction(
+                descriptor: nil,
+                resolvedTarget: .unresolved,
+                availability: .unavailable(reason: "Action is not registered")
+            )
+        }
+
+        let resolvedTarget = Self.resolveTarget(
+            descriptor.targetKind,
+            target: target,
+            state: state
+        )
+        let availability = descriptor.availability(state: state, target: target)
+        return ShellResolvedAction(
+            descriptor: descriptor,
+            resolvedTarget: resolvedTarget,
+            availability: availability
+        )
+    }
+
+    func execute(
+        _ id: ShellActionID,
+        target: ShellActionTarget,
+        state: ShellStateSnapshot,
+        handler: (ShellActionEffect) -> Bool
+    ) -> ShellActionExecutionResult {
+        let resolved = resolve(id, target: target, state: state)
+        guard let descriptor = resolved.descriptor else {
+            return .unavailable(reason: "Action is not registered")
+        }
+        guard case .available = resolved.availability else {
+            if case .unavailable(let reason) = resolved.availability {
+                return .unavailable(reason: reason)
+            }
+            return .unavailable(reason: "Action is unavailable")
+        }
+
+        let effect = Self.effect(descriptor.effect, resolvedTarget: resolved.resolvedTarget)
+        guard handler(effect) else {
+            return .failed(reason: "Action handler failed")
+        }
+        return .executed
+    }
+
+    private static func resolveTarget(
+        _ targetKind: ShellActionTargetKind,
+        target: ShellActionTarget,
+        state: ShellStateSnapshot
+    ) -> ShellResolvedActionTarget {
+        switch targetKind {
+        case .currentSelection:
+            return .selection(
+                spaceID: state.focusedSpaceID,
+                tabID: state.focusedTabID,
+                paneID: state.focusedPaneID
+            )
+        case .tab:
+            if case .contextTab(let tabID) = target {
+                return .tab(tabID)
+            }
+            return state.focusedTabID.map(ShellResolvedActionTarget.tab) ?? .unresolved
+        case .pane:
+            if case .contextPane(let paneID) = target {
+                return .pane(paneID)
+            }
+            return state.focusedPaneID.map(ShellResolvedActionTarget.pane) ?? .unresolved
+        case .space:
+            switch target {
+            case .contextSpace(let spaceID):
+                return .space(spaceID)
+            case .spaceIndex(let index):
+                return .spaceIndex(index)
+            default:
+                return state.focusedSpaceID.map(ShellResolvedActionTarget.space) ?? .unresolved
+            }
+        case .destinationSpace:
+            guard case .tabToSpace(let tabID, let spaceID) = target else {
+                return .unresolved
+            }
+            return .tabToSpace(tabID: tabID, spaceID: spaceID)
+        }
+    }
+
+    private static func effect(
+        _ baseEffect: ShellActionEffect,
+        resolvedTarget: ShellResolvedActionTarget
+    ) -> ShellActionEffect {
+        switch baseEffect {
+        case .pinTab:
+            if case .tab(let tabID) = resolvedTarget {
+                return .pinTab(tabID)
+            }
+            return .pinTab(nil)
+        case .unpinTab:
+            if case .tab(let tabID) = resolvedTarget {
+                return .unpinTab(tabID)
+            }
+            return .unpinTab(nil)
+        case .updatePinnedTab:
+            if case .tab(let tabID) = resolvedTarget {
+                return .updatePinnedTab(tabID)
+            }
+            return .updatePinnedTab(nil)
+        case .closeTab:
+            if case .tab(let tabID) = resolvedTarget {
+                return .closeTab(tabID)
+            }
+            return .closeTab(nil)
+        case .closePane:
+            if case .pane(let paneID) = resolvedTarget {
+                return .closePane(paneID)
+            }
+            return .closePane(nil)
+        case .openTab(let launchTarget, _):
+            if case .space(let spaceID) = resolvedTarget {
+                return .openTab(launchTarget, spaceID: spaceID)
+            }
+            return baseEffect
+        case .selectSpaceAt:
+            if case .spaceIndex(let index) = resolvedTarget {
+                return .selectSpaceAt(index)
+            }
+            return baseEffect
+        default:
+            return baseEffect
+        }
+    }
+}
+
+private let standardActions: [ShellActionDescriptor] = [
+    ShellActionDescriptor(
+        id: .newTerminalTab,
+        title: "New Terminal Tab",
+        targetKind: .space,
+        defaultShortcut: ShellActionShortcut(key: "t", modifiers: [.command], context: .shell),
+        effect: .openTab(.shell, spaceID: nil)
+    ),
+    ShellActionDescriptor(
+        id: .newAlanTab,
+        title: "New alan tab",
+        targetKind: .space,
+        defaultShortcut: ShellActionShortcut(key: "t", modifiers: [.command, .option], context: .shell),
+        effect: .openTab(.alan, spaceID: nil)
+    ),
+    ShellActionDescriptor(
+        id: .paneSplitRight,
+        title: "Split Right",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "d", modifiers: [.command], context: .shell),
+        effect: .workspaceCommand(.splitRight),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneSplitDown,
+        title: "Split Down",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "d", modifiers: [.command, .shift], context: .shell),
+        effect: .workspaceCommand(.splitDown),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneSplitLeft,
+        title: "Split Left",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "d", modifiers: [.command, .option], context: .shell),
+        effect: .workspaceCommand(.splitLeft),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneSplitUp,
+        title: "Split Up",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "d", modifiers: [.command, .option, .shift], context: .shell),
+        effect: .workspaceCommand(.splitUp),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneEqualizeSplits,
+        title: "Equalize Splits",
+        targetKind: .currentSelection,
+        defaultShortcut: ShellActionShortcut(key: "=", modifiers: [.command, .option], context: .shell),
+        effect: .workspaceCommand(.equalizeSplits)
+    ),
+    ShellActionDescriptor(
+        id: .paneFocusLeft,
+        title: "Focus Pane Left",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "leftArrow", modifiers: [.command, .control], context: .shell),
+        effect: .workspaceCommand(.focusLeft),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneFocusRight,
+        title: "Focus Pane Right",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "rightArrow", modifiers: [.command, .control], context: .shell),
+        effect: .workspaceCommand(.focusRight),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneFocusUp,
+        title: "Focus Pane Up",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "upArrow", modifiers: [.command, .control], context: .shell),
+        effect: .workspaceCommand(.focusUp),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneFocusDown,
+        title: "Focus Pane Down",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "downArrow", modifiers: [.command, .control], context: .shell),
+        effect: .workspaceCommand(.focusDown),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneClose,
+        title: "Close Pane",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "w", modifiers: [.command, .shift], context: .shell),
+        effect: .closePane(nil),
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .tabClose,
+        title: "Close Tab",
+        targetKind: .tab,
+        defaultShortcut: ShellActionShortcut(key: "w", modifiers: [.command], context: .shell),
+        effect: .closeTab(nil),
+        availability: selectedTabAvailability
+    ),
+    ShellActionDescriptor(
+        id: .findOpen,
+        title: "Find",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "f", modifiers: [.command], context: .shell),
+        effect: .disabledPlaceholder,
+        availability: focusedPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .spaceSelectPrevious,
+        title: "Previous Space",
+        targetKind: .space,
+        defaultShortcut: ShellActionShortcut(key: "leftArrow", modifiers: [.command, .option], context: .shell),
+        effect: .selectAdjacentSpace(-1)
+    ),
+    ShellActionDescriptor(
+        id: .spaceSelectNext,
+        title: "Next Space",
+        targetKind: .space,
+        defaultShortcut: ShellActionShortcut(key: "rightArrow", modifiers: [.command, .option], context: .shell),
+        effect: .selectAdjacentSpace(1)
+    ),
+    ShellActionDescriptor(
+        id: .spaceSelectByIndex,
+        title: "Select Space",
+        targetKind: .space,
+        effect: .selectSpaceAt(0)
+    ),
+    ShellActionDescriptor(
+        id: .tabPin,
+        title: "Pin Tab",
+        targetKind: .tab,
+        effect: .pinTab(nil),
+        availability: selectedTabAvailability
+    ),
+    ShellActionDescriptor(
+        id: .tabUnpin,
+        title: "Unpin Tab",
+        targetKind: .tab,
+        effect: .unpinTab(nil),
+        availability: selectedTabAvailability
+    ),
+    ShellActionDescriptor(
+        id: .tabUpdatePin,
+        title: "Update Pin",
+        targetKind: .tab,
+        effect: .updatePinnedTab(nil),
+        availability: selectedTabAvailability
+    ),
+    ShellActionDescriptor(
+        id: .tabMoveLeft,
+        title: "Move Tab Left",
+        targetKind: .tab,
+        effect: .disabledPlaceholder,
+        availability: disabledPlaceholder("Move Tab Left is not available yet")
+    ),
+    ShellActionDescriptor(
+        id: .tabMoveRight,
+        title: "Move Tab Right",
+        targetKind: .tab,
+        effect: .disabledPlaceholder,
+        availability: disabledPlaceholder("Move Tab Right is not available yet")
+    ),
+    ShellActionDescriptor(
+        id: .tabMoveToSpace,
+        title: "Move Tab to Space...",
+        targetKind: .destinationSpace,
+        effect: .disabledPlaceholder,
+        availability: disabledPlaceholder("Move Tab to Space is not available yet")
+    ),
+]
+
+private func focusedPaneAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    switch target {
+    case .contextPane(let paneID):
+        return state.pane(paneID: paneID) == nil
+            ? .unavailable(reason: "Pane is not available")
+            : .available
+    default:
+        return state.focusedPaneID == nil
+            ? .unavailable(reason: "No focused pane")
+            : .available
+    }
+}
+
+private func selectedTabAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    switch target {
+    case .contextTab(let tabID):
+        return state.tab(tabID: tabID) == nil
+            ? .unavailable(reason: "Tab is not available")
+            : .available
+    default:
+        return state.focusedTabID == nil
+            ? .unavailable(reason: "No selected tab")
+            : .available
+    }
+}
+
+private func disabledPlaceholder(
+    _ reason: String
+) -> (ShellStateSnapshot, ShellActionTarget) -> ShellActionAvailability {
+    { _, _ in .unavailable(reason: reason) }
+}

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -735,7 +735,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .workspaceCommand(let command):
             return performShellWorkspaceCommand(command)
         case .openTab(let launchTarget, let spaceID):
-            return openTab(launchTarget: launchTarget, in: spaceID) != nil
+            switch launchTarget {
+            case .shell:
+                return openTerminalTab(in: spaceID) != nil
+            case .alan:
+                return openAlanTab(in: spaceID) != nil
+            }
         case .closeTab(let tabID):
             guard let tabID else { return closeSelectedTab() }
             return closeTab(tabID: tabID) == .closed

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -705,6 +705,60 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
+    func shellActionTitle(_ id: ShellActionID) -> String {
+        ShellActionRegistry.standard.action(for: id)?.title ?? "Unavailable"
+    }
+
+    func shellActionAvailability(
+        _ id: ShellActionID,
+        target: ShellActionTarget = .currentSelection
+    ) -> ShellActionAvailability {
+        ShellActionRegistry.standard.resolve(id, target: target, state: shellState).availability
+    }
+
+    @discardableResult
+    func performShellAction(
+        _ id: ShellActionID,
+        target: ShellActionTarget = .currentSelection
+    ) -> ShellActionExecutionResult {
+        ShellActionRegistry.standard.execute(
+            id,
+            target: target,
+            state: shellState
+        ) { [weak self] effect in
+            self?.performShellActionEffect(effect) ?? false
+        }
+    }
+
+    private func performShellActionEffect(_ effect: ShellActionEffect) -> Bool {
+        switch effect {
+        case .workspaceCommand(let command):
+            return performShellWorkspaceCommand(command)
+        case .openTab(let launchTarget, let spaceID):
+            return openTab(launchTarget: launchTarget, in: spaceID) != nil
+        case .closeTab(let tabID):
+            guard let tabID else { return closeSelectedTab() }
+            return closeTab(tabID: tabID) == .closed
+        case .closePane(let paneID):
+            guard let paneID else { return closeSelectedPane() }
+            return closePane(paneID: paneID) == .closed
+        case .selectAdjacentSpace(let offset):
+            selectAdjacentSpace(offset: offset)
+            return true
+        case .selectSpaceAt(let index):
+            selectSpace(at: index)
+            return true
+        case .pinTab(let tabID):
+            return pinTab(tabID: tabID)
+        case .unpinTab(let tabID):
+            return unpinTab(tabID: tabID)
+        case .updatePinnedTab(let tabID):
+            return updatePinnedTabSnapshot(tabID: tabID)
+        case .disabledPlaceholder:
+            return false
+        }
+    }
+
     @discardableResult
     func resizeSplit(splitNodeID: String, ratio: Double, persist: Bool = true) -> Bool {
         let result: ShellStateMutationResult

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -170,7 +170,10 @@ struct ShellSidebarView: View {
                             title: "New Tab",
                             systemImage: "plus",
                             action: {
-                                _ = host.openTerminalTab(in: space.spaceID)
+                                host.performShellAction(
+                                    .newTerminalTab,
+                                    target: .contextSpace(space.spaceID)
+                                )
                             }
                         )
                         .help("Create a tab in this space")
@@ -487,8 +490,7 @@ struct ShellSidebarView: View {
     }
 
     private func close(tab: ShellTab) {
-        host.select(tabID: tab.tabID)
-        _ = host.closeSelectedTab()
+        host.performShellAction(.tabClose, target: .contextTab(tab.tabID))
     }
 
     private func focusPane(_ paneID: String, in tab: ShellTab) {
@@ -542,29 +544,34 @@ struct ShellSidebarView: View {
             hoveredTabID = isHovering ? tab.tabID : nil
         }
         .contextMenu {
-            Button("New Tab") {
-                _ = host.openTerminalTab()
+            Button(host.shellActionTitle(.newTerminalTab)) {
+                host.performShellAction(.newTerminalTab)
             }
-            Button("Open in alan") {
-                _ = host.openAlanTab()
+            Button(host.shellActionTitle(.newAlanTab)) {
+                host.performShellAction(.newAlanTab)
             }
             Divider()
             if host.isTabPinned(tabID: tab.tabID) {
-                Button("Update Pin") {
-                    _ = host.updatePinnedTabSnapshot(tabID: tab.tabID)
+                Button(host.shellActionTitle(.tabUpdatePin)) {
+                    host.performShellAction(.tabUpdatePin, target: .contextTab(tab.tabID))
                 }
-                Button("Unpin Tab") {
-                    _ = host.unpinTab(tabID: tab.tabID)
+                .disabled(!host.shellActionAvailability(.tabUpdatePin, target: .contextTab(tab.tabID)).isAvailable)
+
+                Button(host.shellActionTitle(.tabUnpin)) {
+                    host.performShellAction(.tabUnpin, target: .contextTab(tab.tabID))
                 }
+                .disabled(!host.shellActionAvailability(.tabUnpin, target: .contextTab(tab.tabID)).isAvailable)
             } else {
-                Button("Pin Tab") {
-                    _ = host.pinTab(tabID: tab.tabID)
+                Button(host.shellActionTitle(.tabPin)) {
+                    host.performShellAction(.tabPin, target: .contextTab(tab.tabID))
                 }
+                .disabled(!host.shellActionAvailability(.tabPin, target: .contextTab(tab.tabID)).isAvailable)
             }
             Divider()
-            Button("Close Tab", role: .destructive) {
+            Button(host.shellActionTitle(.tabClose), role: .destructive) {
                 close(tab: tab)
             }
+            .disabled(!host.shellActionAvailability(.tabClose, target: .contextTab(tab.tabID)).isAvailable)
         }
     }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -25,18 +25,18 @@ struct ShellSpaceKeyboardShortcuts: View {
     var body: some View {
         VStack(spacing: 0) {
             Button("") {
-                host.selectAdjacentSpace(offset: -1)
+                host.performShellAction(.spaceSelectPrevious)
             }
             .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
 
             Button("") {
-                host.selectAdjacentSpace(offset: 1)
+                host.performShellAction(.spaceSelectNext)
             }
             .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
 
             ForEach(Array(host.spaces.prefix(9).enumerated()), id: \.element.spaceID) { index, _ in
                 Button("") {
-                    host.selectSpace(at: index)
+                    host.performShellAction(.spaceSelectByIndex, target: .spaceIndex(index))
                 }
                 .keyboardShortcut(
                     KeyEquivalent(Character(String(index + 1))),

--- a/clients/apple/scripts/check-shell-action-registry-integration.sh
+++ b/clients/apple/scripts/check-shell-action-registry-integration.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SURFACE_FILES=(
+  "$REPO_ROOT/clients/apple/alan-macos/App/AlanMacShellCommands.swift"
+  "$REPO_ROOT/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift"
+  "$REPO_ROOT/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift"
+)
+
+if rg -n \
+  "performShellWorkspaceCommand|host\\.openTerminalTab|host\\.openAlanTab|host\\.pinTab|host\\.unpinTab|host\\.updatePinnedTabSnapshot|host\\.selectAdjacentSpace|host\\.selectSpace\\(at:" \
+  "${SURFACE_FILES[@]}"; then
+  echo "Shared shell menu/context/keyboard surfaces must route through ShellActionRegistry." >&2
+  exit 1
+fi
+
+COMMAND_UI_FILE="$REPO_ROOT/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift"
+if rg -n "ShellActionRegistry|performShellAction" "$COMMAND_UI_FILE"; then
+  echo "Go to or Command... must stay out of the first shell action registry pass." >&2
+  exit 1
+fi
+
+echo "Shell action registry integration checks passed."

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -585,7 +585,12 @@ require_pattern \
 require_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
     "func performShellWorkspaceCommand\\(_ command: ShellWorkspaceCommand\\)" \
-    "menu, keyboard, and command UI actions must route through one shell command entry point"
+    "command UI and terminal-local workspace actions must keep the shared shell command entry point"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "func performShellAction\\(" \
+    "native menu, context menu, and shell keyboard actions must enter the shell action registry"
 
 require_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
@@ -614,8 +619,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/App/AlanMacShellCommands.swift" \
-    "host\\.performShellWorkspaceCommand\\(\\.closeTab\\)" \
-    "native menu close actions must use the shared shell workspace command vocabulary"
+    "host\\.performShellAction\\(\\.tabClose\\)" \
+    "native menu close actions must use the shell action registry"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift" \

--- a/clients/apple/scripts/test-shell-action-registry.sh
+++ b/clients/apple/scripts/test-shell-action-registry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-action-registry-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-action-registry-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-action-registry.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-action-registry.swift
+++ b/clients/apple/scripts/test-shell-action-registry.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+@main
+struct ShellActionRegistryTestRunner {
+    static func main() throws {
+        try ShellActionRegistryTests.run()
+    }
+}
+
+private enum ShellActionRegistryTests {
+    static func run() throws {
+        try verifiesActionIDsAreUniqueAndStable()
+        try verifiesShortcutConflictsAreRejected()
+        try verifiesContextTabTargetDoesNotSelectTabFirst()
+        try verifiesUnavailableActionDoesNotExecuteHandler()
+        try verifiesCommandInputRemainsOutOfRegistry()
+        print("Shell action registry tests passed.")
+    }
+
+    private static func verifiesActionIDsAreUniqueAndStable() throws {
+        let registry = ShellActionRegistry.standard
+        let ids = registry.actions.map(\.id.rawValue)
+
+        expect(Set(ids).count == ids.count, "shell action ids must be unique")
+        expect(
+            registry.action(for: .tabPin)?.id.rawValue == "shell.tab.pin",
+            "pin-tab action id must stay stable"
+        )
+        expect(
+            registry.action(for: .paneSplitRight)?.title == "Split Right",
+            "registered actions must expose user-facing labels"
+        )
+    }
+
+    private static func verifiesShortcutConflictsAreRejected() throws {
+        let duplicateShortcut = ShellActionShortcut(
+            key: "t",
+            modifiers: [.command],
+            context: .shell
+        )
+        let first = ShellActionDescriptor(
+            id: .newTerminalTab,
+            title: "New Terminal Tab",
+            targetKind: .currentSelection,
+            defaultShortcut: duplicateShortcut,
+            effect: .workspaceCommand(.newTerminalTab)
+        )
+        let second = ShellActionDescriptor(
+            id: .newAlanTab,
+            title: "New alan tab",
+            targetKind: .currentSelection,
+            defaultShortcut: duplicateShortcut,
+            effect: .workspaceCommand(.newAlanTab)
+        )
+
+        do {
+            _ = try ShellActionRegistry(actions: [first, second])
+            expect(false, "duplicate shortcuts in the same context must be rejected")
+        } catch ShellActionRegistryError.duplicateShortcut(let shortcut, let actionIDs) {
+            expect(shortcut == duplicateShortcut, "duplicate shortcut error must include the shortcut")
+            expect(
+                actionIDs == [.newTerminalTab, .newAlanTab],
+                "duplicate shortcut error must name both conflicting actions"
+            )
+        }
+    }
+
+    private static func verifiesContextTabTargetDoesNotSelectTabFirst() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTab(
+            launchTarget: .shell,
+            in: "space_main",
+            title: "Second",
+            workingDirectory: "/tmp"
+        ).state
+        let selectedTabBefore = state.focusedTabID
+        guard let contextTab = state.spaces.first?.tabs.first(where: { $0.tabID != selectedTabBefore }) else {
+            throw TestFailure("expected a second tab")
+        }
+
+        let resolved = ShellActionRegistry.standard.resolve(
+            .tabClose,
+            target: .contextTab(contextTab.tabID),
+            state: state
+        )
+        var handledEffects: [ShellActionEffect] = []
+        let execution = ShellActionRegistry.standard.execute(
+            .tabClose,
+            target: .contextTab(contextTab.tabID),
+            state: state
+        ) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(resolved.resolvedTarget == .tab(contextTab.tabID), "context menu must preserve clicked tab")
+        expect(state.focusedTabID == selectedTabBefore, "resolving context target must not select the tab first")
+        expect(execution == .executed, "context tab close must execute when the tab exists")
+        expect(
+            handledEffects == [.closeTab(contextTab.tabID)],
+            "context tab close must route the clicked tab id to the handler"
+        )
+    }
+
+    private static func verifiesUnavailableActionDoesNotExecuteHandler() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        var handledEffects: [ShellActionEffect] = []
+
+        let result = ShellActionRegistry.standard.execute(
+            .tabMoveToSpace,
+            target: .currentSelection,
+            state: state
+        ) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(
+            result == .unavailable(reason: "Move Tab to Space is not available yet"),
+            "placeholder actions must be disabled"
+        )
+        expect(handledEffects.isEmpty, "unavailable actions must not execute handlers")
+    }
+
+    private static func verifiesCommandInputRemainsOutOfRegistry() throws {
+        let actionIDs = Set(ShellActionRegistry.standard.actions.map(\.id))
+
+        expect(!actionIDs.contains(.commandInputOpen), "Command-P command input must stay out of registry")
+        expect(
+            ShellActionRegistry.standard.action(for: .tabMoveToSpace)?.availability(
+                state: ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp"),
+                target: .currentSelection
+            ) == .unavailable(reason: "Move Tab to Space is not available yet"),
+            "future tab organization actions must be registered as disabled placeholders"
+        )
+    }
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fatalError(message)
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -15,6 +15,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -22,6 +22,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
+        verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
         verifiesOpeningTerminalTabHonorsExplicitCwd()
         verifiesTerminalActivityProjectsByPaneID()
@@ -468,6 +469,19 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.cwd == "/repo/app",
             "new terminal tabs must inherit the focused pane runtime cwd"
+        )
+    }
+
+    private static func verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd() {
+        let controller = makeController()
+        controller.updateTerminalMetadata(metadata(title: "cwd update", cwd: "/repo/app"), for: "pane_1")
+
+        let result = controller.performShellAction(.newTerminalTab)
+
+        expect(result == .executed, "registry new-terminal action must execute")
+        expect(
+            controller.selectedPane?.cwd == "/repo/app",
+            "registry new-terminal action must inherit the focused pane runtime cwd"
         )
     }
 

--- a/openspec/changes/add-macos-shell-action-registry/tasks.md
+++ b/openspec/changes/add-macos-shell-action-registry/tasks.md
@@ -1,52 +1,52 @@
 ## 1. Registry Model
 
-- [ ] 1.1 Define shell action IDs, target kinds, labels, optional default
+- [x] 1.1 Define shell action IDs, target kinds, labels, optional default
   shortcut descriptors, availability results, and execution result types.
-- [ ] 1.2 Add a shell action registry that can resolve actions for menu bar,
+- [x] 1.2 Add a shell action registry that can resolve actions for menu bar,
   context-menu, and keyboard surfaces without involving Command UI.
-- [ ] 1.3 Model current-selection targets separately from context-menu targets
+- [x] 1.3 Model current-selection targets separately from context-menu targets
   so right-click actions can operate on a non-selected tab.
-- [ ] 1.4 Add no-op or disabled behavior for unavailable actions with stable
+- [x] 1.4 Add no-op or disabled behavior for unavailable actions with stable
   diagnostics for focused tests.
 
 ## 2. Surface Integration
 
-- [ ] 2.1 Route existing shell menu commands through the registry where they
+- [x] 2.1 Route existing shell menu commands through the registry where they
   share shell controller behavior.
-- [ ] 2.2 Route tab and space context menu items through registry entries while
+- [x] 2.2 Route tab and space context menu items through registry entries while
   preserving the right-click context target.
-- [ ] 2.3 Route existing shell keyboard shortcuts through registry entries
+- [x] 2.3 Route existing shell keyboard shortcuts through registry entries
   without changing their default key equivalents.
-- [ ] 2.4 Leave `Go to or Command...` behavior unchanged and avoid adding new
+- [x] 2.4 Leave `Go to or Command...` behavior unchanged and avoid adding new
   tab/space actions to Command UI in this change.
 
 ## 3. Action Coverage
 
-- [ ] 3.1 Register existing high-frequency shell actions: new tab, close tab,
+- [x] 3.1 Register existing high-frequency shell actions: new tab, close tab,
   split pane, close pane, focus pane, equalize splits, Find, and Space
   navigation.
-- [ ] 3.2 Add placeholder-ready registry entries needed by follow-up tab
+- [x] 3.2 Add placeholder-ready registry entries needed by follow-up tab
   organization work: pin, unpin, move tab left/right, and move tab to Space.
-- [ ] 3.3 Ensure labels and disabled states use user-facing language and avoid
+- [x] 3.3 Ensure labels and disabled states use user-facing language and avoid
   raw pane IDs, tab IDs, or implementation phases.
 
 ## 4. Verification
 
-- [ ] 4.1 Add focused tests for action ID uniqueness, target resolution,
+- [x] 4.1 Add focused tests for action ID uniqueness, target resolution,
   availability, disabled execution, and handler routing.
-- [ ] 4.2 Add shortcut conflict checks for registered default shortcuts in the
+- [x] 4.2 Add shortcut conflict checks for registered default shortcuts in the
   same shell context.
-- [ ] 4.3 Add focused menu/context-menu coverage or script checks proving shared
+- [x] 4.3 Add focused menu/context-menu coverage or script checks proving shared
   actions are no longer duplicated outside the registry.
-- [ ] 4.4 Run relevant Apple shell scripts and the macOS app build command, or
+- [x] 4.4 Run relevant Apple shell scripts and the macOS app build command, or
   document any local blocker.
-- [ ] 4.5 Run `openspec validate add-macos-shell-action-registry --type change --strict --json`.
-- [ ] 4.6 Run `openspec validate --all --strict --json`.
-- [ ] 4.7 Run `git diff --check`.
+- [x] 4.5 Run `openspec validate add-macos-shell-action-registry --type change --strict --json`.
+- [x] 4.6 Run `openspec validate --all --strict --json`.
+- [x] 4.7 Run `git diff --check`.
 
 ## 5. Archive Readiness
 
-- [ ] 5.1 Confirm the registry remains shell-only and does not add Command UI,
+- [x] 5.1 Confirm the registry remains shell-only and does not add Command UI,
   settings, daemon, TUI, or user-custom shortcut scope.
 - [ ] 5.2 Before archive, sync accepted delta requirements into `openspec/specs/`.
 - [ ] 5.3 Archive the OpenSpec change after implementation merges.


### PR DESCRIPTION
## Summary
- add a shell-only action registry with stable IDs, target resolution, shortcut metadata, availability, and execution effects
- route Shell menu, tab context menu, and Space keyboard shortcuts through the registry while leaving Command UI/Go to behavior outside the registry
- add focused registry/integration checks and update OpenSpec task progress for this change

## Validation
- ./clients/apple/scripts/test-shell-action-registry.sh
- ./clients/apple/scripts/check-shell-action-registry-integration.sh
- ./clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /tmp/alan-action-registry-derived build
- openspec validate add-macos-shell-action-registry --type change --strict --json
- openspec validate --all --strict --json
- git diff --check

## Notes
- OpenSpec archive/spec-sync cleanup tasks remain unchecked until after this PR merges.