### PR TITLE
Improve macOS tab organization

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -103,8 +103,12 @@ extension ShellHostController {
         candidates: [AlanShellRoutingCandidate]? = nil,
         events: [AlanShellEventEnvelope]? = nil,
         spaceID: String? = nil,
+        sourceSpaceID: String? = nil,
+        targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        section: ShellTabOrganizationSection? = nil,
+        index: Int? = nil,
         acceptedBytes: Int? = nil,
         deliveryCode: String? = nil,
         runtimePhase: String? = nil,
@@ -126,8 +130,12 @@ extension ShellHostController {
             events: events,
             focusedPaneID: shellState.focusedPaneID,
             spaceID: spaceID,
+            sourceSpaceID: sourceSpaceID,
+            targetSpaceID: targetSpaceID,
             tabID: tabID,
             paneID: paneID,
+            section: section,
+            index: index,
             acceptedBytes: acceptedBytes,
             deliveryCode: deliveryCode,
             runtimePhase: runtimePhase,
@@ -242,6 +250,154 @@ extension ShellHostController {
                     errorMessage: "alan terminal workspace must keep at least one tab open."
                 )
             }
+
+        case .tabPin:
+            let tabID = command.tabID ?? selectedTabID
+            guard let tabID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "tab_required",
+                    errorMessage: "tab_id is required."
+                )
+            }
+            let sourceLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            guard pinTab(tabID: tabID),
+                  let currentLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: "tab_not_found",
+                    errorMessage: "The requested tab does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: currentLocation.spaceID,
+                sourceSpaceID: sourceLocation?.spaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID,
+                section: currentLocation.section,
+                index: currentLocation.index
+            )
+
+        case .tabUnpin:
+            let tabID = command.tabID ?? selectedTabID
+            guard let tabID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "tab_required",
+                    errorMessage: "tab_id is required."
+                )
+            }
+            let sourceLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            guard unpinTab(tabID: tabID),
+                  let currentLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: "tab_not_found",
+                    errorMessage: "The requested tab does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: currentLocation.spaceID,
+                sourceSpaceID: sourceLocation?.spaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID,
+                section: currentLocation.section,
+                index: currentLocation.index
+            )
+
+        case .tabReorder:
+            guard let tabID = command.tabID,
+                  let section = command.section,
+                  let index = command.index
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: command.tabID,
+                    errorCode: "tab_reorder_target_required",
+                    errorMessage: "tab_id, section, and index are required."
+                )
+            }
+            let sourceLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            guard reorderTab(
+                tabID: tabID,
+                targetSpaceID: command.spaceID,
+                section: section,
+                index: index
+            ),
+            let currentLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: command.spaceID,
+                    tabID: tabID,
+                    section: section,
+                    index: index,
+                    errorCode: "invalid_tab_organization_target",
+                    errorMessage: "The requested tab organization target is not available."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: currentLocation.spaceID,
+                sourceSpaceID: sourceLocation?.spaceID,
+                targetSpaceID: command.spaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID,
+                section: currentLocation.section,
+                index: currentLocation.index
+            )
+
+        case .tabMoveToSpace:
+            guard let tabID = command.tabID,
+                  let targetSpaceID = command.targetSpaceID ?? command.spaceID
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: command.tabID,
+                    errorCode: "tab_move_target_required",
+                    errorMessage: "tab_id and target_space_id are required."
+                )
+            }
+            let sourceLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            guard moveTabToSpace(tabID: tabID, targetSpaceID: targetSpaceID),
+                  let currentLocation = shellState.tabOrganizationLocation(tabID: tabID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    targetSpaceID: targetSpaceID,
+                    tabID: tabID,
+                    errorCode: "invalid_move_target",
+                    errorMessage: "The requested tab could not be moved to the target space."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: currentLocation.spaceID,
+                sourceSpaceID: sourceLocation?.spaceID,
+                targetSpaceID: targetSpaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID,
+                section: currentLocation.section,
+                index: currentLocation.index
+            )
 
         case .paneList:
             return response(

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -115,6 +115,8 @@ enum ShellActionEffect: Equatable {
     case pinTab(String?)
     case unpinTab(String?)
     case updatePinnedTab(String?)
+    case moveTab(String?, offset: Int)
+    case moveTabToSpace(tabID: String?, spaceID: String?)
     case disabledPlaceholder
 }
 
@@ -349,6 +351,16 @@ final class ShellActionRegistry {
                 return .updatePinnedTab(tabID)
             }
             return .updatePinnedTab(nil)
+        case .moveTab(_, let offset):
+            if case .tab(let tabID) = resolvedTarget {
+                return .moveTab(tabID, offset: offset)
+            }
+            return .moveTab(nil, offset: offset)
+        case .moveTabToSpace:
+            if case .tabToSpace(let tabID, let spaceID) = resolvedTarget {
+                return .moveTabToSpace(tabID: tabID, spaceID: spaceID)
+            }
+            return .moveTabToSpace(tabID: nil, spaceID: nil)
         case .closeTab:
             if case .tab(let tabID) = resolvedTarget {
                 return .closeTab(tabID)
@@ -537,21 +549,21 @@ private let standardActions: [ShellActionDescriptor] = [
         title: "Pin Tab",
         targetKind: .tab,
         effect: .pinTab(nil),
-        availability: selectedTabAvailability
+        availability: pinTabAvailability
     ),
     ShellActionDescriptor(
         id: .tabUnpin,
         title: "Unpin Tab",
         targetKind: .tab,
         effect: .unpinTab(nil),
-        availability: selectedTabAvailability
+        availability: unpinTabAvailability
     ),
     ShellActionDescriptor(
         id: .tabUpdatePin,
         title: "Update Pin",
         targetKind: .tab,
         effect: .updatePinnedTab(nil),
-        availability: selectedTabAvailability
+        availability: updatePinnedTabAvailability
     ),
     ShellActionDescriptor(
         id: .tabMoveLeft,
@@ -562,8 +574,8 @@ private let standardActions: [ShellActionDescriptor] = [
             modifiers: [.command, .option, .shift],
             context: .shell
         ),
-        effect: .disabledPlaceholder,
-        availability: disabledPlaceholder("Move Tab Left is not available yet")
+        effect: .moveTab(nil, offset: -1),
+        availability: moveTabAvailability(offset: -1)
     ),
     ShellActionDescriptor(
         id: .tabMoveRight,
@@ -574,15 +586,15 @@ private let standardActions: [ShellActionDescriptor] = [
             modifiers: [.command, .option, .shift],
             context: .shell
         ),
-        effect: .disabledPlaceholder,
-        availability: disabledPlaceholder("Move Tab Right is not available yet")
+        effect: .moveTab(nil, offset: 1),
+        availability: moveTabAvailability(offset: 1)
     ),
     ShellActionDescriptor(
         id: .tabMoveToSpace,
         title: "Move Tab to Space...",
         targetKind: .destinationSpace,
-        effect: .disabledPlaceholder,
-        availability: disabledPlaceholder("Move Tab to Space is not available yet")
+        effect: .moveTabToSpace(tabID: nil, spaceID: nil),
+        availability: moveTabToSpaceAvailability
     ),
 ]
 
@@ -616,6 +628,91 @@ private func selectedTabAvailability(
             ? .unavailable(reason: "No selected tab")
             : .available
     }
+}
+
+private func targetedTab(
+    in state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellTab? {
+    switch target {
+    case .contextTab(let tabID):
+        return state.tab(tabID: tabID)
+    default:
+        return state.focusedTabID.flatMap { state.tab(tabID: $0) }
+    }
+}
+
+private func pinTabAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    guard let tab = targetedTab(in: state, target: target) else {
+        return .unavailable(reason: "Tab is not available")
+    }
+    return tab.isPinned
+        ? .unavailable(reason: "Tab is already pinned")
+        : .available
+}
+
+private func unpinTabAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    guard let tab = targetedTab(in: state, target: target) else {
+        return .unavailable(reason: "Tab is not available")
+    }
+    return tab.isPinned
+        ? .available
+        : .unavailable(reason: "Tab is not pinned")
+}
+
+private func updatePinnedTabAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    guard let tab = targetedTab(in: state, target: target) else {
+        return .unavailable(reason: "Tab is not available")
+    }
+    return tab.isPinned
+        ? .available
+        : .unavailable(reason: "Tab is not pinned")
+}
+
+private func moveTabAvailability(
+    offset: Int
+) -> (ShellStateSnapshot, ShellActionTarget) -> ShellActionAvailability {
+    { state, target in
+        guard let tab = targetedTab(in: state, target: target),
+              let location = state.tabOrganizationLocation(tabID: tab.tabID),
+              let space = state.space(spaceID: location.spaceID)
+        else {
+            return .unavailable(reason: "Tab is not available")
+        }
+
+        let sectionCount = space.tabs(in: location.section).count
+        let nextIndex = location.index + offset
+        return (0..<sectionCount).contains(nextIndex)
+            ? .available
+            : .unavailable(reason: "No adjacent tab in section")
+    }
+}
+
+private func moveTabToSpaceAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    guard case .tabToSpace(let tabID, let spaceID) = target else {
+        return .unavailable(reason: "Move target is required")
+    }
+    guard let location = state.tabOrganizationLocation(tabID: tabID) else {
+        return .unavailable(reason: "Tab is not available")
+    }
+    guard state.space(spaceID: spaceID) != nil else {
+        return .unavailable(reason: "Space is not available")
+    }
+    return location.spaceID == spaceID
+        ? .unavailable(reason: "Tab is already in that space")
+        : .available
 }
 
 private func multipleTabsAvailability(

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -9,6 +9,10 @@ enum AlanShellControlCommandKind: String, Codable {
     case tabList = "tab.list"
     case tabOpen = "tab.open"
     case tabClose = "tab.close"
+    case tabReorder = "tab.reorder"
+    case tabPin = "tab.pin"
+    case tabUnpin = "tab.unpin"
+    case tabMoveToSpace = "tab.move_to_space"
     case paneList = "pane.list"
     case paneSnapshot = "pane.snapshot"
     case paneSplit = "pane.split"
@@ -28,8 +32,11 @@ struct AlanShellControlCommand: Codable {
     let requestID: String
     let command: AlanShellControlCommandKind
     let spaceID: String?
+    let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let section: ShellTabOrganizationSection?
+    let index: Int?
     let direction: ShellSplitDirection?
     let title: String?
     let cwd: String?
@@ -49,8 +56,11 @@ struct AlanShellControlCommand: Codable {
         case requestID = "request_id"
         case command
         case spaceID = "space_id"
+        case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case section
+        case index
         case direction
         case title
         case cwd
@@ -97,14 +107,72 @@ struct AlanShellControlResponse: Codable {
     let events: [AlanShellEventEnvelope]?
     let focusedPaneID: String?
     let spaceID: String?
+    let sourceSpaceID: String?
+    let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let section: ShellTabOrganizationSection?
+    let index: Int?
     let acceptedBytes: Int?
     let deliveryCode: String?
     let runtimePhase: String?
     let latestEventID: String?
     let errorCode: String?
     let errorMessage: String?
+
+    init(
+        requestID: String,
+        contractVersion: String,
+        applied: Bool?,
+        state: ShellStateSnapshot? = nil,
+        spaces: [ShellSpace]? = nil,
+        tabs: [ShellTab]? = nil,
+        panes: [ShellPane]? = nil,
+        pane: ShellPane? = nil,
+        items: [AlanShellAttentionInboxItem]? = nil,
+        candidates: [AlanShellRoutingCandidate]? = nil,
+        events: [AlanShellEventEnvelope]? = nil,
+        focusedPaneID: String? = nil,
+        spaceID: String? = nil,
+        sourceSpaceID: String? = nil,
+        targetSpaceID: String? = nil,
+        tabID: String? = nil,
+        paneID: String? = nil,
+        section: ShellTabOrganizationSection? = nil,
+        index: Int? = nil,
+        acceptedBytes: Int? = nil,
+        deliveryCode: String? = nil,
+        runtimePhase: String? = nil,
+        latestEventID: String? = nil,
+        errorCode: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.requestID = requestID
+        self.contractVersion = contractVersion
+        self.applied = applied
+        self.state = state
+        self.spaces = spaces
+        self.tabs = tabs
+        self.panes = panes
+        self.pane = pane
+        self.items = items
+        self.candidates = candidates
+        self.events = events
+        self.focusedPaneID = focusedPaneID
+        self.spaceID = spaceID
+        self.sourceSpaceID = sourceSpaceID
+        self.targetSpaceID = targetSpaceID
+        self.tabID = tabID
+        self.paneID = paneID
+        self.section = section
+        self.index = index
+        self.acceptedBytes = acceptedBytes
+        self.deliveryCode = deliveryCode
+        self.runtimePhase = runtimePhase
+        self.latestEventID = latestEventID
+        self.errorCode = errorCode
+        self.errorMessage = errorMessage
+    }
 
     private enum CodingKeys: String, CodingKey {
         case requestID = "request_id"
@@ -120,8 +188,12 @@ struct AlanShellControlResponse: Codable {
         case events
         case focusedPaneID = "focused_pane_id"
         case spaceID = "space_id"
+        case sourceSpaceID = "source_space_id"
+        case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case section
+        case index
         case acceptedBytes = "accepted_bytes"
         case deliveryCode = "delivery_code"
         case runtimePhase = "runtime_phase"

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -444,6 +444,7 @@ struct ShellTab: Identifiable, Codable, Equatable {
     let kind: ShellTabKind
     let title: String?
     let paneTree: ShellPaneTreeNode
+    let isPinned: Bool
 
     var id: String { tabID }
 
@@ -452,6 +453,32 @@ struct ShellTab: Identifiable, Codable, Equatable {
         case kind
         case title
         case paneTree = "pane_tree"
+        case isPinned = "is_pinned"
+    }
+
+    init(
+        tabID: String,
+        kind: ShellTabKind,
+        title: String?,
+        paneTree: ShellPaneTreeNode,
+        isPinned: Bool = false
+    ) {
+        self.tabID = tabID
+        self.kind = kind
+        self.title = title
+        self.paneTree = paneTree
+        self.isPinned = isPinned
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            tabID: try container.decode(String.self, forKey: .tabID),
+            kind: try container.decode(ShellTabKind.self, forKey: .kind),
+            title: try container.decodeIfPresent(String.self, forKey: .title),
+            paneTree: try container.decode(ShellPaneTreeNode.self, forKey: .paneTree),
+            isPinned: try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
+        )
     }
 }
 
@@ -508,6 +535,29 @@ extension ShellTab {
     func contains(paneID: String) -> Bool {
         paneTree.contains(paneID: paneID)
     }
+
+    var organizationSection: ShellTabOrganizationSection {
+        isPinned ? .pinned : .unpinned
+    }
+}
+
+extension ShellSpace {
+    var pinnedTabs: [ShellTab] {
+        tabs.filter(\.isPinned)
+    }
+
+    var unpinnedTabs: [ShellTab] {
+        tabs.filter { !$0.isPinned }
+    }
+
+    func tabs(in section: ShellTabOrganizationSection) -> [ShellTab] {
+        switch section {
+        case .pinned:
+            return pinnedTabs
+        case .unpinned:
+            return unpinnedTabs
+        }
+    }
 }
 
 extension ShellStateSnapshot {
@@ -541,5 +591,25 @@ extension ShellStateSnapshot {
             return panes
         }
         return panes.filter { $0.tabID == tabID }
+    }
+
+    func tabOrganizationLocation(tabID: String) -> ShellTabOrganizationLocation? {
+        for space in spaces {
+            if let pinnedIndex = space.pinnedTabs.firstIndex(where: { $0.tabID == tabID }) {
+                return ShellTabOrganizationLocation(
+                    spaceID: space.spaceID,
+                    section: .pinned,
+                    index: pinnedIndex
+                )
+            }
+            if let unpinnedIndex = space.unpinnedTabs.firstIndex(where: { $0.tabID == tabID }) {
+                return ShellTabOrganizationLocation(
+                    spaceID: space.spaceID,
+                    section: .unpinned,
+                    index: unpinnedIndex
+                )
+            }
+        }
+        return nil
     }
 }

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -9,6 +9,7 @@ enum ShellStateMutationError: String, Error {
     case lastTab = "last_tab"
     case lastPane = "last_pane"
     case invalidMoveTarget = "invalid_move_target"
+    case invalidTabOrganizationTarget = "invalid_tab_organization_target"
 }
 
 struct ShellStateMutationResult {
@@ -478,7 +479,8 @@ extension ShellStateSnapshot {
                 splitNodeID: splitNodeID,
                 newLeafNodeID: "node_\(newPaneID)",
                 newPaneID: newPaneID
-            )
+            ),
+            isPinned: tab.isPinned
         )
 
         let nextSpaces = spaces.map { space in
@@ -561,7 +563,8 @@ extension ShellStateSnapshot {
             tabID: tab.tabID,
             kind: tab.kind,
             title: tab.title,
-            paneTree: updatedPaneTree
+            paneTree: updatedPaneTree,
+            isPinned: tab.isPinned
         )
         let nextSpaces = spaces.map { space in
             guard space.spaceID == pane.spaceID else { return space }
@@ -630,7 +633,8 @@ extension ShellStateSnapshot {
             tabID: sourceTab.tabID,
             kind: sourceTab.kind,
             title: sourceTab.title,
-            paneTree: sourcePaneTree
+            paneTree: sourcePaneTree,
+            isPinned: sourceTab.isPinned
         )
         let newTab = ShellTab(
             tabID: newTabID,
@@ -733,7 +737,8 @@ extension ShellStateSnapshot {
                 direction: direction,
                 splitNodeID: newSplitNodeID,
                 newLeafNodeID: newLeafNodeID
-            )
+            ),
+            isPinned: targetTab.isPinned
         )
 
         let updatedSourcePaneTree = sourceTab.paneTree.removingPane(paneID)
@@ -748,7 +753,8 @@ extension ShellStateSnapshot {
                                 tabID: sourceTab.tabID,
                                 kind: sourceTab.kind,
                                 title: sourceTab.title,
-                                paneTree: updatedSourcePaneTree
+                                paneTree: updatedSourcePaneTree,
+                                isPinned: sourceTab.isPinned
                             )
                         )
                     }
@@ -807,6 +813,175 @@ extension ShellStateSnapshot {
         )
     }
 
+    func organizingTab(
+        tabID: String,
+        targetSpaceID requestedTargetSpaceID: String? = nil,
+        section targetSection: ShellTabOrganizationSection,
+        index requestedIndex: Int? = nil
+    ) throws -> ShellStateMutationResult {
+        guard let sourceSpaceIndex = spaces.firstIndex(where: { space in
+            space.tabs.contains(where: { $0.tabID == tabID })
+        }) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+
+        let sourceSpace = spaces[sourceSpaceIndex]
+        guard let sourceTabIndex = sourceSpace.tabs.firstIndex(where: { $0.tabID == tabID }) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+
+        let targetSpaceID = requestedTargetSpaceID ?? sourceSpace.spaceID
+        guard let targetSpaceIndex = spaces.firstIndex(where: { $0.spaceID == targetSpaceID }) else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+
+        let sourceTab = sourceSpace.tabs[sourceTabIndex]
+        let updatedTab = ShellTab(
+            tabID: sourceTab.tabID,
+            kind: sourceTab.kind,
+            title: sourceTab.title,
+            paneTree: sourceTab.paneTree,
+            isPinned: targetSection == .pinned
+        )
+
+        var nextSpaces = spaces
+        nextSpaces[sourceSpaceIndex] = ShellSpace(
+            spaceID: sourceSpace.spaceID,
+            title: sourceSpace.title,
+            attention: sourceSpace.attention,
+            tabs: sourceSpace.tabs.filter { $0.tabID != tabID }
+        )
+
+        let targetSpaceAfterRemoval = nextSpaces[targetSpaceIndex]
+        let targetSectionTabs = targetSpaceAfterRemoval.tabs(in: targetSection)
+        let insertionIndex = requestedIndex ?? targetSectionTabs.count
+        guard (0...targetSectionTabs.count).contains(insertionIndex) else {
+            throw ShellStateMutationError.invalidTabOrganizationTarget
+        }
+
+        let insertionOffset = targetSection == .pinned
+            ? insertionIndex
+            : targetSpaceAfterRemoval.pinnedTabs.count + insertionIndex
+        var targetTabs = targetSpaceAfterRemoval.tabs
+        targetTabs.insert(updatedTab, at: insertionOffset)
+        nextSpaces[targetSpaceIndex] = ShellSpace(
+            spaceID: targetSpaceAfterRemoval.spaceID,
+            title: targetSpaceAfterRemoval.title,
+            attention: targetSpaceAfterRemoval.attention,
+            tabs: targetTabs
+        )
+
+        let nextPanes = panes.map { pane in
+            guard pane.tabID == tabID,
+                  pane.spaceID != targetSpaceID
+            else { return pane }
+
+            return ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: targetSpaceID,
+                launchTarget: pane.launchTarget,
+                cwd: pane.cwd,
+                process: pane.process,
+                attention: pane.attention,
+                context: pane.context,
+                viewport: pane.viewport,
+                activity: pane.activity,
+                alanBinding: pane.alanBinding
+            )
+        }
+
+        let nextFocusedPaneID: String?
+        if focusedTabID == tabID {
+            nextFocusedPaneID = focusedPaneID.flatMap { paneID in
+                nextPanes.contains { $0.paneID == paneID && $0.tabID == tabID } ? paneID : nil
+            } ?? updatedTab.paneTree.paneIDs.first
+        } else {
+            nextFocusedPaneID = focusedPaneID
+        }
+
+        let nextState = replacing(
+            spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
+            panes: nextPanes,
+            focusedPaneID: nextFocusedPaneID
+        )
+
+        return ShellStateMutationResult(
+            state: nextState,
+            spaceID: targetSpaceID,
+            tabID: tabID,
+            paneID: nextState.focusedPaneID
+        )
+    }
+
+    func pinningTab(_ tabID: String) throws -> ShellStateMutationResult {
+        guard let tab = tab(tabID: tabID) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+        guard !tab.isPinned else {
+            return try organizingTab(
+                tabID: tabID,
+                section: .pinned,
+                index: tabOrganizationLocation(tabID: tabID)?.index
+            )
+        }
+        return try organizingTab(tabID: tabID, section: .pinned)
+    }
+
+    func unpinningTab(_ tabID: String) throws -> ShellStateMutationResult {
+        guard let tab = tab(tabID: tabID) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+        guard tab.isPinned else {
+            return try organizingTab(
+                tabID: tabID,
+                section: .unpinned,
+                index: tabOrganizationLocation(tabID: tabID)?.index
+            )
+        }
+        return try organizingTab(tabID: tabID, section: .unpinned)
+    }
+
+    func movingTab(_ tabID: String, sectionOffset: Int) throws -> ShellStateMutationResult {
+        guard sectionOffset != 0 else {
+            throw ShellStateMutationError.invalidTabOrganizationTarget
+        }
+        guard let location = tabOrganizationLocation(tabID: tabID) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+        guard let space = space(spaceID: location.spaceID) else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+        let sectionCount = space.tabs(in: location.section).count
+        let nextIndex = location.index + sectionOffset
+        guard (0..<sectionCount).contains(nextIndex) else {
+            throw ShellStateMutationError.invalidTabOrganizationTarget
+        }
+        return try organizingTab(
+            tabID: tabID,
+            targetSpaceID: location.spaceID,
+            section: location.section,
+            index: nextIndex
+        )
+    }
+
+    func movingTabToSpace(
+        tabID: String,
+        targetSpaceID: String
+    ) throws -> ShellStateMutationResult {
+        guard let tab = tab(tabID: tabID) else {
+            throw ShellStateMutationError.tabNotFound
+        }
+        guard tabOrganizationLocation(tabID: tabID)?.spaceID != targetSpaceID else {
+            throw ShellStateMutationError.invalidMoveTarget
+        }
+        return try organizingTab(
+            tabID: tabID,
+            targetSpaceID: targetSpaceID,
+            section: tab.organizationSection
+        )
+    }
+
     func settingAttention(
         _ attention: ShellAttentionState,
         for paneID: String
@@ -859,7 +1034,8 @@ extension ShellStateSnapshot {
             tabID: targetTab.tabID,
             kind: targetTab.kind,
             title: targetTab.title,
-            paneTree: paneTree
+            paneTree: paneTree,
+            isPinned: targetTab.isPinned
         )
         let nextSpaces = spaces.map { space in
             guard space.spaceID == targetSpace.spaceID else { return space }

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -13,6 +13,23 @@ enum ShellTabKind: String, Codable, CaseIterable {
     case log
 }
 
+enum ShellTabOrganizationSection: String, Codable, CaseIterable {
+    case pinned
+    case unpinned
+}
+
+struct ShellTabOrganizationLocation: Codable, Equatable {
+    let spaceID: String
+    let section: ShellTabOrganizationSection
+    let index: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case spaceID = "space_id"
+        case section
+        case index
+    }
+}
+
 enum ShellPaneTreeKind: String, Codable {
     case split
     case pane

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -259,7 +259,7 @@ struct ShellWorkspaceMaterializer {
         var panes: [ShellPane] = []
 
         for space in spaces {
-            let shellTabs = space.tabs.map { tabRecord -> ShellTab in
+            let shellTabs = organizedTabs(space.tabs).map { tabRecord -> ShellTab in
                 let restoreSnapshot = tabRecord.restoreSnapshot(
                     defaultWorkingDirectory: defaultWorkingDirectory
                 )
@@ -280,7 +280,8 @@ struct ShellWorkspaceMaterializer {
                     tabID: tabRecord.tabID,
                     kind: tabRecord.kind,
                     title: tabRecord.title,
-                    paneTree: restoreSnapshot.paneTree
+                    paneTree: restoreSnapshot.paneTree,
+                    isPinned: tabRecord.isPinned
                 )
             }
 
@@ -345,6 +346,12 @@ struct ShellWorkspaceMaterializer {
             ),
             alanBinding: nil
         )
+    }
+
+    private static func organizedTabs(
+        _ tabs: [ShellWorkspaceTabRecord]
+    ) -> [ShellWorkspaceTabRecord] {
+        tabs.filter(\.isPinned) + tabs.filter { !$0.isPinned }
     }
 
     private static func strongestAttention(

--- a/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
@@ -122,6 +122,12 @@ final class AlanShellEventStore {
             )
         }
 
+        recordTabOrganizationChanges(
+            previousState: previousState,
+            currentState: currentState,
+            commonTabIDs: previousTabs.intersection(currentTabs)
+        )
+
         let allPaneIDs = Set(previousPanesByID.keys).union(currentPanesByID.keys)
         for paneID in allPaneIDs.sorted() {
             let previousPane = previousPanesByID[paneID]
@@ -151,6 +157,50 @@ final class AlanShellEventStore {
                     ]
                 )
             }
+        }
+    }
+
+    private func recordTabOrganizationChanges(
+        previousState: ShellStateSnapshot,
+        currentState: ShellStateSnapshot,
+        commonTabIDs: Set<String>
+    ) {
+        for tabID in commonTabIDs.sorted() {
+            guard let previousLocation = previousState.tabOrganizationLocation(tabID: tabID),
+                  let currentLocation = currentState.tabOrganizationLocation(tabID: tabID),
+                  previousLocation != currentLocation
+            else {
+                continue
+            }
+
+            let eventType: String
+            if previousLocation.spaceID != currentLocation.spaceID {
+                eventType = "tab.moved_to_space"
+            } else if previousLocation.section != currentLocation.section {
+                eventType = "tab.pin_changed"
+            } else {
+                eventType = "tab.reordered"
+            }
+
+            append(
+                type: eventType,
+                spaceID: currentLocation.spaceID,
+                tabID: tabID,
+                paneID: currentState.tab(tabID: tabID)?.paneTree.paneIDs.first,
+                payload: [
+                    "tab_id": .string(tabID),
+                    "previous_space_id": .string(previousLocation.spaceID),
+                    "current_space_id": .string(currentLocation.spaceID),
+                    "previous_section": .string(previousLocation.section.rawValue),
+                    "current_section": .string(currentLocation.section.rawValue),
+                    "previous_index": .number(Double(previousLocation.index)),
+                    "current_index": .number(Double(currentLocation.index)),
+                    "previous_pinned": .bool(previousLocation.section == .pinned),
+                    "current_pinned": .bool(currentLocation.section == .pinned),
+                    "focused_space_id": .string(currentState.focusedSpaceID ?? ""),
+                    "focused_tab_id": .string(currentState.focusedTabID ?? "")
+                ]
+            )
         }
     }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -148,6 +148,183 @@ enum AlanShellLocalCommandExecutor {
                 return nil
             }
 
+        case .tabPin:
+            guard let tabID = command.tabID ?? state.focusedTabID else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "tab_required",
+                        errorMessage: "tab_id is required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            do {
+                let result = try state.pinningTab(tabID)
+                let location = result.state.tabOrganizationLocation(tabID: tabID)
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: result.state,
+                        applied: true,
+                        spaceID: location?.spaceID,
+                        tabID: tabID,
+                        paneID: result.state.focusedPaneID,
+                        section: location?.section,
+                        index: location?.index
+                    ),
+                    updatedState: result.state,
+                    sideEffect: nil
+                )
+            } catch let error as ShellStateMutationError {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(for: error, command: command, state: state),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            } catch {
+                return nil
+            }
+
+        case .tabUnpin:
+            guard let tabID = command.tabID ?? state.focusedTabID else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "tab_required",
+                        errorMessage: "tab_id is required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            do {
+                let result = try state.unpinningTab(tabID)
+                let location = result.state.tabOrganizationLocation(tabID: tabID)
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: result.state,
+                        applied: true,
+                        spaceID: location?.spaceID,
+                        tabID: tabID,
+                        paneID: result.state.focusedPaneID,
+                        section: location?.section,
+                        index: location?.index
+                    ),
+                    updatedState: result.state,
+                    sideEffect: nil
+                )
+            } catch let error as ShellStateMutationError {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(for: error, command: command, state: state),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            } catch {
+                return nil
+            }
+
+        case .tabReorder:
+            guard let tabID = command.tabID,
+                  let section = command.section,
+                  let index = command.index
+            else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        tabID: command.tabID,
+                        errorCode: "tab_reorder_target_required",
+                        errorMessage: "tab_id, section, and index are required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            do {
+                let result = try state.organizingTab(
+                    tabID: tabID,
+                    targetSpaceID: command.spaceID,
+                    section: section,
+                    index: index
+                )
+                let location = result.state.tabOrganizationLocation(tabID: tabID)
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: result.state,
+                        applied: true,
+                        spaceID: location?.spaceID,
+                        tabID: tabID,
+                        paneID: result.state.focusedPaneID,
+                        section: location?.section,
+                        index: location?.index
+                    ),
+                    updatedState: result.state,
+                    sideEffect: nil
+                )
+            } catch let error as ShellStateMutationError {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(for: error, command: command, state: state),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            } catch {
+                return nil
+            }
+
+        case .tabMoveToSpace:
+            guard let tabID = command.tabID,
+                  let targetSpaceID = command.targetSpaceID ?? command.spaceID
+            else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        tabID: command.tabID,
+                        errorCode: "tab_move_target_required",
+                        errorMessage: "tab_id and target_space_id are required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            do {
+                let result = try state.movingTabToSpace(tabID: tabID, targetSpaceID: targetSpaceID)
+                let location = result.state.tabOrganizationLocation(tabID: tabID)
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: result.state,
+                        applied: true,
+                        spaceID: location?.spaceID,
+                        targetSpaceID: targetSpaceID,
+                        tabID: tabID,
+                        paneID: result.state.focusedPaneID,
+                        section: location?.section,
+                        index: location?.index
+                    ),
+                    updatedState: result.state,
+                    sideEffect: nil
+                )
+            } catch let error as ShellStateMutationError {
+                return AlanShellLocalCommandResult(
+                    response: failureResponse(for: error, command: command, state: state),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            } catch {
+                return nil
+            }
+
         case .paneList:
             return AlanShellLocalCommandResult(
                 response: response(
@@ -624,6 +801,16 @@ enum AlanShellLocalCommandExecutor {
                 errorCode: error.rawValue,
                 errorMessage: "The pane cannot be moved onto its current tab."
             )
+        case .invalidTabOrganizationTarget:
+            return response(
+                for: command,
+                state: state,
+                applied: false,
+                spaceID: command.spaceID,
+                tabID: command.tabID,
+                errorCode: error.rawValue,
+                errorMessage: "The requested tab organization target is not available."
+            )
         }
     }
 
@@ -640,8 +827,12 @@ enum AlanShellLocalCommandExecutor {
         candidates: [AlanShellRoutingCandidate]? = nil,
         events: [AlanShellEventEnvelope]? = nil,
         spaceID: String? = nil,
+        sourceSpaceID: String? = nil,
+        targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        section: ShellTabOrganizationSection? = nil,
+        index: Int? = nil,
         acceptedBytes: Int? = nil,
         deliveryCode: String? = nil,
         runtimePhase: String? = nil,
@@ -663,8 +854,12 @@ enum AlanShellLocalCommandExecutor {
             events: events,
             focusedPaneID: state.focusedPaneID,
             spaceID: spaceID,
+            sourceSpaceID: sourceSpaceID,
+            targetSpaceID: targetSpaceID,
             tabID: tabID,
             paneID: paneID,
+            section: section,
+            index: index,
             acceptedBytes: acceptedBytes,
             deliveryCode: deliveryCode,
             runtimePhase: runtimePhase,

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -399,7 +399,8 @@ final class AlanShellSocketServer {
 private extension AlanShellControlCommandKind {
     var requiresHostHandler: Bool {
         switch self {
-        case .spaceCreate, .spaceOpenAlan, .tabOpen, .tabPin, .paneSplit, .agentActivity:
+        case .spaceCreate, .spaceOpenAlan, .tabOpen, .tabPin, .tabReorder, .paneSplit,
+            .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -399,7 +399,7 @@ final class AlanShellSocketServer {
 private extension AlanShellControlCommandKind {
     var requiresHostHandler: Bool {
         switch self {
-        case .spaceCreate, .spaceOpenAlan, .tabOpen, .paneSplit, .agentActivity:
+        case .spaceCreate, .spaceOpenAlan, .tabOpen, .tabPin, .paneSplit, .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -558,7 +558,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func isTabPinned(tabID: String) -> Bool {
-        workspaceManifest?
+        if let tab = shellState.tab(tabID: tabID) {
+            return tab.isPinned
+        }
+        return workspaceManifest?
             .spaces
             .flatMap(\.tabs)
             .first { $0.tabID == tabID }?
@@ -568,24 +571,33 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @discardableResult
     func pinTab(tabID: String? = nil) -> Bool {
         guard let targetTabID = tabID ?? selectedTabID else { return false }
-        return updateWorkspaceManifestTab(tabID: targetTabID) { tab, snapshot in
-            tab.isPinned = true
-            tab.pinSnapshot = snapshot
-            tab.liveSnapshot = snapshot
-        } diagnostic: {
-            "workspace manifest pinned tab: \($0)"
+        if isTabPinned(tabID: targetTabID) {
+            return updatePinnedTabSnapshot(tabID: targetTabID)
         }
+
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.pinningTab(targetTabID)
+        } catch {
+            return false
+        }
+        applyMutationResult(result, pinSnapshotTabIDs: [targetTabID])
+        recordControlPlaneDiagnostic("workspace manifest pinned tab: \(targetTabID)")
+        return true
     }
 
     @discardableResult
     func unpinTab(tabID: String? = nil) -> Bool {
         guard let targetTabID = tabID ?? selectedTabID else { return false }
-        return updateWorkspaceManifestTab(tabID: targetTabID) { tab, _ in
-            tab.isPinned = false
-            tab.pinSnapshot = nil
-        } diagnostic: {
-            "workspace manifest unpinned tab: \($0)"
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.unpinningTab(targetTabID)
+        } catch {
+            return false
         }
+        applyMutationResult(result)
+        recordControlPlaneDiagnostic("workspace manifest unpinned tab: \(targetTabID)")
+        return true
     }
 
     @discardableResult
@@ -598,6 +610,58 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         } diagnostic: {
             "workspace manifest updated pinned tab: \($0)"
         }
+    }
+
+    @discardableResult
+    func reorderTab(
+        tabID: String,
+        targetSpaceID: String? = nil,
+        section: ShellTabOrganizationSection,
+        index: Int
+    ) -> Bool {
+        let wasPinned = isTabPinned(tabID: tabID)
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.organizingTab(
+                tabID: tabID,
+                targetSpaceID: targetSpaceID,
+                section: section,
+                index: index
+            )
+        } catch {
+            return false
+        }
+        let needsPinSnapshot = !wasPinned && section == .pinned
+        applyMutationResult(result, pinSnapshotTabIDs: needsPinSnapshot ? [tabID] : [])
+        return true
+    }
+
+    @discardableResult
+    func moveTab(tabID: String? = nil, offset: Int) -> Bool {
+        guard let targetTabID = tabID ?? selectedTabID else { return false }
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.movingTab(targetTabID, sectionOffset: offset)
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
+    }
+
+    @discardableResult
+    func moveTabToSpace(tabID: String, targetSpaceID: String) -> Bool {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.movingTabToSpace(
+                tabID: tabID,
+                targetSpaceID: targetSpaceID
+            )
+        } catch {
+            return false
+        }
+        applyMutationResult(result)
+        return true
     }
 
     @discardableResult
@@ -790,6 +854,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return unpinTab(tabID: tabID)
         case .updatePinnedTab(let tabID):
             return updatePinnedTabSnapshot(tabID: tabID)
+        case .moveTab(let tabID, let offset):
+            return moveTab(tabID: tabID, offset: offset)
+        case .moveTabToSpace(let tabID, let spaceID):
+            guard let tabID, let spaceID else { return false }
+            return moveTabToSpace(tabID: tabID, targetSpaceID: spaceID)
         case .disabledPlaceholder:
             return false
         }
@@ -1277,7 +1346,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     tabID: tab.tabID,
                     kind: tab.kind,
                     title: nextTitle,
-                    paneTree: tab.paneTree
+                    paneTree: tab.paneTree,
+                    isPinned: tab.isPinned
                 )
             }
 
@@ -1318,9 +1388,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private func applyMutationResult(
         _ result: ShellStateMutationResult,
-        publish: Bool = true
+        publish: Bool = true,
+        pinSnapshotTabIDs: Set<String> = []
     ) {
-        adoptStateFromControlPlane(result.state, publish: publish)
+        adoptStateFromControlPlane(result.state, publish: publish && pinSnapshotTabIDs.isEmpty)
+        if publish && !pinSnapshotTabIDs.isEmpty {
+            publishControlPlaneState(pinSnapshotTabIDs: pinSnapshotTabIDs)
+        }
     }
 
     private func adoptStateFromControlPlane(
@@ -1409,15 +1483,41 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         persistenceStore.save(shellState)
     }
 
-    private func syncWorkspaceManifestFromShellState(now: Date = .now) {
+    private func syncWorkspaceManifestFromShellState(
+        now: Date = .now,
+        pinSnapshotTabIDs: Set<String> = []
+    ) {
         guard let workspaceManifestStore else { return }
 
         let nextManifest = makeWorkspaceManifestFromShellState(now: now)
+        var manifestToSave = nextManifest
+        if !pinSnapshotTabIDs.isEmpty {
+            applyPinSnapshotOverrides(to: &manifestToSave, tabIDs: pinSnapshotTabIDs)
+        }
         do {
-            try workspaceManifestStore.save(nextManifest)
-            workspaceManifest = nextManifest
+            try workspaceManifestStore.save(manifestToSave)
+            workspaceManifest = manifestToSave
         } catch {
             recordControlPlaneDiagnostic("workspace manifest save failed: \(error)")
+        }
+    }
+
+    private func applyPinSnapshotOverrides(
+        to manifest: inout ShellWorkspaceManifest,
+        tabIDs: Set<String>
+    ) {
+        for spaceIndex in manifest.spaces.indices {
+            for tabIndex in manifest.spaces[spaceIndex].tabs.indices {
+                let tabID = manifest.spaces[spaceIndex].tabs[tabIndex].tabID
+                guard tabIDs.contains(tabID),
+                      let tab = shellState.tab(tabID: tabID)
+                else { continue }
+
+                let snapshot = makeRestoreSnapshot(for: tab, panes: shellState.panes(in: tabID))
+                manifest.spaces[spaceIndex].tabs[tabIndex].isPinned = true
+                manifest.spaces[spaceIndex].tabs[tabIndex].pinSnapshot = snapshot
+                manifest.spaces[spaceIndex].tabs[tabIndex].liveSnapshot = snapshot
+            }
         }
     }
 
@@ -1492,8 +1592,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     createdAt: existingTab?.createdAt ?? now,
                     lastActivatedAt: lastActivatedAt,
                     lastActivityAt: lastActivityAt,
-                    isPinned: existingTab?.isPinned ?? false,
-                    pinSnapshot: existingTab?.pinSnapshot,
+                    isPinned: tab.isPinned,
+                    pinSnapshot: tab.isPinned ? existingTab?.pinSnapshot : nil,
                     liveSnapshot: snapshot,
                     activeTask: projectedActiveTask(for: tab, panes: panes)
                 )
@@ -1761,8 +1861,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             ?? .idle
     }
 
-    private func publishControlPlaneState() {
-        syncWorkspaceManifestFromShellState()
+    private func publishControlPlaneState(pinSnapshotTabIDs: Set<String> = []) {
+        syncWorkspaceManifestFromShellState(pinSnapshotTabIDs: pinSnapshotTabIDs)
         persistShellState()
         controlPlane.publish(state: shellState)
     }

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -912,9 +912,11 @@ private struct ShellSidebarTabDropDelegate: DropDelegate {
         preview = nil
         self.activeDrag = nil
 
+        let mutationIndex = mutationIndex(for: insertionTarget, activeDrag: activeDrag)
+
         if activeDrag.sourceSpaceID == insertionTarget.spaceID,
            activeDrag.sourceSection == insertionTarget.section,
-           activeDrag.sourceIndex == insertionTarget.index
+           activeDrag.sourceIndex == mutationIndex
         {
             return true
         }
@@ -923,8 +925,22 @@ private struct ShellSidebarTabDropDelegate: DropDelegate {
             tabID: activeDrag.tabID,
             targetSpaceID: insertionTarget.spaceID,
             section: insertionTarget.section,
-            index: insertionTarget.index
+            index: mutationIndex
         )
+    }
+
+    private func mutationIndex(
+        for insertionTarget: ShellSidebarTabInsertionTarget,
+        activeDrag: ShellSidebarTabDragState
+    ) -> Int {
+        guard activeDrag.sourceSpaceID == insertionTarget.spaceID,
+              activeDrag.sourceSection == insertionTarget.section,
+              insertionTarget.index > activeDrag.sourceIndex
+        else {
+            return insertionTarget.index
+        }
+
+        return insertionTarget.index - 1
     }
 
     private func resolvedTarget(for info: DropInfo) -> ShellSidebarTabInsertionTarget {

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 #if os(macOS)
 struct ShellSidebarView: View {
@@ -16,6 +17,8 @@ struct ShellSidebarView: View {
     @State private var isCommandLauncherHovered = false
     @State private var tabListScrollOffsetY: CGFloat = 0
     @State private var activityFreshnessNow = Date()
+    @State private var activeTabDrag: ShellSidebarTabDragState?
+    @State private var tabInsertionPreview: ShellSidebarTabInsertionTarget?
 
     init(
         host: ShellHostController,
@@ -163,25 +166,20 @@ struct ShellSidebarView: View {
             }
             .frame(height: 0)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 0) {
                 if let space = space(for: spaceID) {
-                    if space.tabs.isEmpty {
-                        ShellCompactEmptyAction(
-                            title: "New Tab",
-                            systemImage: "plus",
-                            action: {
-                                host.performShellAction(
-                                    .newTerminalTab,
-                                    target: .contextSpace(space.spaceID)
-                                )
-                            }
-                        )
-                        .help("Create a tab in this space")
-                    } else {
-                        ForEach(space.tabs) { tab in
-                            tabListRow(for: tab)
+                    tabOrganizationSections(for: space)
+                    ShellCompactEmptyAction(
+                        title: "New Tab",
+                        systemImage: "plus",
+                        action: {
+                            host.performShellAction(
+                                .newTerminalTab,
+                                target: .contextSpace(space.spaceID)
+                            )
                         }
-                    }
+                    )
+                    .help("Create a tab in this space")
                 } else {
                     ShellCompactEmptyAction(
                         title: "New Space",
@@ -202,6 +200,83 @@ struct ShellSidebarView: View {
             guard spaceID == sourceSpaceID else { return }
             tabListScrollOffsetY = offsetY
         }
+    }
+
+    @ViewBuilder
+    private func tabOrganizationSections(for space: ShellSpace) -> some View {
+        let pinnedTabs = space.pinnedTabs
+        let unpinnedTabs = space.unpinnedTabs
+
+        if !pinnedTabs.isEmpty {
+            tabRows(
+                pinnedTabs,
+                in: space,
+                section: .pinned
+            )
+        }
+
+        if !pinnedTabs.isEmpty && !unpinnedTabs.isEmpty {
+            ShellSidebarTabSectionDivider()
+                .padding(.vertical, 4)
+        }
+
+        tabRows(
+            unpinnedTabs,
+            in: space,
+            section: .unpinned
+        )
+    }
+
+    @ViewBuilder
+    private func tabRows(
+        _ tabs: [ShellTab],
+        in space: ShellSpace,
+        section: ShellTabOrganizationSection
+    ) -> some View {
+        ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+            insertionPreviewLine(
+                spaceID: space.spaceID,
+                section: section,
+                index: index
+            )
+            tabListRow(for: tab, in: space, section: section, index: index)
+        }
+
+        insertionPreviewLine(
+            spaceID: space.spaceID,
+            section: section,
+            index: tabs.count
+        )
+        .frame(height: tabs.isEmpty ? 8 : 4)
+        .onDrop(
+            of: [.plainText],
+            delegate: ShellSidebarTabDropDelegate(
+                target: ShellSidebarTabInsertionTarget(
+                    spaceID: space.spaceID,
+                    section: section,
+                    index: tabs.count
+                ),
+                activeDrag: $activeTabDrag,
+                preview: $tabInsertionPreview,
+                host: host
+            )
+        )
+    }
+
+    @ViewBuilder
+    private func insertionPreviewLine(
+        spaceID: String,
+        section: ShellTabOrganizationSection,
+        index: Int
+    ) -> some View {
+        let target = ShellSidebarTabInsertionTarget(
+            spaceID: spaceID,
+            section: section,
+            index: index
+        )
+        ShellSidebarTabInsertionLine(
+            isVisible: tabInsertionPreview == target
+        )
     }
 
     private var spaceDock: some View {
@@ -505,7 +580,12 @@ struct ShellSidebarView: View {
     }
 
     @ViewBuilder
-    private func tabListRow(for tab: ShellTab) -> some View {
+    private func tabListRow(
+        for tab: ShellTab,
+        in space: ShellSpace,
+        section: ShellTabOrganizationSection,
+        index: Int
+    ) -> some View {
         let isSelected = host.selectedTab?.tabID == tab.tabID
         let isHovered = hoveredTabID == tab.tabID
         let projection = shellSidebarTabProjection(
@@ -543,12 +623,38 @@ struct ShellSidebarView: View {
         .onHover { isHovering in
             hoveredTabID = isHovering ? tab.tabID : nil
         }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: ShellSidebarTabDragState.dragThreshold)
+                .onChanged { _ in
+                    beginTabDragIfNeeded(tab: tab, space: space, section: section, index: index)
+                }
+                .onEnded { _ in
+                    scheduleTabDragCleanup()
+                }
+        )
+        .onDrag {
+            beginTabDragIfNeeded(tab: tab, space: space, section: section, index: index)
+            return NSItemProvider(object: tab.tabID as NSString)
+        }
+        .onDrop(
+            of: [.plainText],
+            delegate: ShellSidebarTabDropDelegate(
+                target: ShellSidebarTabInsertionTarget(
+                    spaceID: space.spaceID,
+                    section: section,
+                    index: index
+                ),
+                activeDrag: $activeTabDrag,
+                preview: $tabInsertionPreview,
+                host: host
+            )
+        )
         .contextMenu {
             Button(host.shellActionTitle(.newTerminalTab)) {
-                host.performShellAction(.newTerminalTab)
+                host.performShellAction(.newTerminalTab, target: .contextSpace(space.spaceID))
             }
             Button(host.shellActionTitle(.newAlanTab)) {
-                host.performShellAction(.newAlanTab)
+                host.performShellAction(.newAlanTab, target: .contextSpace(space.spaceID))
             }
             Divider()
             if host.isTabPinned(tabID: tab.tabID) {
@@ -567,11 +673,64 @@ struct ShellSidebarView: View {
                 }
                 .disabled(!host.shellActionAvailability(.tabPin, target: .contextTab(tab.tabID)).isAvailable)
             }
+            if host.spaces.count > 1 {
+                Menu(host.shellActionTitle(.tabMoveToSpace)) {
+                    ForEach(host.spaces.filter { $0.spaceID != space.spaceID }) { targetSpace in
+                        Button(targetSpace.title) {
+                            host.performShellAction(
+                                .tabMoveToSpace,
+                                target: .tabToSpace(
+                                    tabID: tab.tabID,
+                                    spaceID: targetSpace.spaceID
+                                )
+                            )
+                        }
+                        .disabled(
+                            !host.shellActionAvailability(
+                                .tabMoveToSpace,
+                                target: .tabToSpace(
+                                    tabID: tab.tabID,
+                                    spaceID: targetSpace.spaceID
+                                )
+                            ).isAvailable
+                        )
+                    }
+                }
+            }
             Divider()
             Button(host.shellActionTitle(.tabClose), role: .destructive) {
                 close(tab: tab)
             }
             .disabled(!host.shellActionAvailability(.tabClose, target: .contextTab(tab.tabID)).isAvailable)
+        }
+    }
+
+    private func beginTabDragIfNeeded(
+        tab: ShellTab,
+        space: ShellSpace,
+        section: ShellTabOrganizationSection,
+        index: Int
+    ) {
+        let nextDrag = ShellSidebarTabDragState(
+            tabID: tab.tabID,
+            sourceSpaceID: space.spaceID,
+            sourceSection: section,
+            sourceIndex: index
+        )
+        if activeTabDrag != nextDrag {
+            activeTabDrag = nextDrag
+        }
+    }
+
+    private func clearTabDragPreview() {
+        activeTabDrag = nil
+        tabInsertionPreview = nil
+    }
+
+    private func scheduleTabDragCleanup() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            guard tabInsertionPreview == nil else { return }
+            activeTabDrag = nil
         }
     }
 
@@ -704,6 +863,108 @@ private struct ShellSidebarTabListOffsetPreferenceKey: PreferenceKey {
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+private struct ShellSidebarTabDragState: Equatable {
+    static let dragThreshold: CGFloat = 7
+
+    let tabID: String
+    let sourceSpaceID: String
+    let sourceSection: ShellTabOrganizationSection
+    let sourceIndex: Int
+}
+
+private struct ShellSidebarTabInsertionTarget: Equatable {
+    let spaceID: String
+    let section: ShellTabOrganizationSection
+    let index: Int
+}
+
+private struct ShellSidebarTabDropDelegate: DropDelegate {
+    let target: ShellSidebarTabInsertionTarget
+    @Binding var activeDrag: ShellSidebarTabDragState?
+    @Binding var preview: ShellSidebarTabInsertionTarget?
+    let host: ShellHostController
+
+    func dropEntered(info: DropInfo) {
+        preview = resolvedTarget(for: info)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        preview = resolvedTarget(for: info)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        if preview == target {
+            preview = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard let activeDrag else {
+            preview = nil
+            return false
+        }
+
+        let insertionTarget = resolvedTarget(for: info)
+        preview = nil
+        self.activeDrag = nil
+
+        if activeDrag.sourceSpaceID == insertionTarget.spaceID,
+           activeDrag.sourceSection == insertionTarget.section,
+           activeDrag.sourceIndex == insertionTarget.index
+        {
+            return true
+        }
+
+        return host.reorderTab(
+            tabID: activeDrag.tabID,
+            targetSpaceID: insertionTarget.spaceID,
+            section: insertionTarget.section,
+            index: insertionTarget.index
+        )
+    }
+
+    private func resolvedTarget(for info: DropInfo) -> ShellSidebarTabInsertionTarget {
+        let rowMidpoint: CGFloat = 24
+        let sectionCount = host.shellState
+            .space(spaceID: target.spaceID)?
+            .tabs(in: target.section)
+            .count ?? target.index
+        let adjustedIndex = info.location.y > rowMidpoint
+            ? target.index + 1
+            : target.index
+        return ShellSidebarTabInsertionTarget(
+            spaceID: target.spaceID,
+            section: target.section,
+            index: min(max(adjustedIndex, 0), sectionCount)
+        )
+    }
+}
+
+private struct ShellSidebarTabSectionDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(ShellPalette.line.opacity(0.18))
+            .frame(height: 0.5)
+            .padding(.horizontal, ShellSidebarMetrics.rowInset + 4)
+            .allowsHitTesting(false)
+    }
+}
+
+private struct ShellSidebarTabInsertionLine: View {
+    let isVisible: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: ShellRadii.micro, style: .continuous)
+            .fill(ShellPalette.accent.opacity(isVisible ? 0.72 : 0))
+            .frame(height: 2)
+            .padding(.horizontal, ShellSidebarMetrics.rowInset + 2)
+            .padding(.vertical, isVisible ? 3 : 0)
+            .animation(.easeOut(duration: 0.10), value: isVisible)
+            .accessibilityHidden(true)
     }
 }
 

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -216,6 +216,16 @@ require_tab_organization_sidebar_contract() {
         "\\.tabToSpace\\(" \
         "tab context menus must target the clicked tab when moving to another space"
 
+    require_pattern \
+        "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+        "mutationIndex\\(for: insertionTarget, activeDrag: activeDrag\\)" \
+        "same-section downward tab drops must convert preview index to mutation index"
+
+    require_pattern \
+        "clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
+        "\\.tabReorder" \
+        "tab.reorder socket commands must route through the host so pin snapshots persist"
+
     if grep -Eq 'Text\("(Pinned|Unpinned)"\)' "$file"; then
         printf 'error: tab organization sections must avoid heavy visible section headers\n' >&2
         exit 1

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -198,6 +198,30 @@ require_active_complex_split_count_contrast() {
     fi
 }
 
+require_tab_organization_sidebar_contract() {
+    local file="$REPO_ROOT/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift"
+
+    require_pattern \
+        "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+        "ShellSidebarTabDragState\\.dragThreshold" \
+        "tab rows must use an explicit drag threshold so short clicks keep selecting tabs"
+
+    require_pattern \
+        "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+        "ShellSidebarTabInsertionLine" \
+        "tab row drag/drop must expose a direct insertion preview"
+
+    require_pattern \
+        "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+        "\\.tabToSpace\\(" \
+        "tab context menus must target the clicked tab when moving to another space"
+
+    if grep -Eq 'Text\("(Pinned|Unpinned)"\)' "$file"; then
+        printf 'error: tab organization sections must avoid heavy visible section headers\n' >&2
+        exit 1
+    fi
+}
+
 "$SCRIPT_DIR/setup-local-ghosttykit.sh" --check >/dev/null
 "$SCRIPT_DIR/check-architecture-maintainability.sh" >/dev/null
 reject_active_shell_radius_drift
@@ -206,6 +230,7 @@ reject_keydown_programmatic_text_delivery
 require_title_bar_full_width_hit_area
 require_pane_title_bar_trailing_close
 require_active_complex_split_count_contrast
+require_tab_organization_sidebar_contract
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \

--- a/clients/apple/scripts/test-shell-action-registry.swift
+++ b/clients/apple/scripts/test-shell-action-registry.swift
@@ -15,8 +15,9 @@ private enum ShellActionRegistryTests {
         try verifiesShortcutConflictsAreRejected()
         try verifiesDynamicSpaceShortcutConflictsAreRejected()
         try verifiesContextTabTargetDoesNotSelectTabFirst()
-        try verifiesUnavailableActionDoesNotExecuteHandler()
+        try verifiesMoveToSpaceRequiresExplicitTarget()
         try verifiesUnavailableShortcutActionDoesNotExecuteHandler()
+        try verifiesMoveTabShortcutRoutesHandler()
         try verifiesCommandInputRemainsOutOfRegistry()
         print("Shell action registry tests passed.")
     }
@@ -232,7 +233,7 @@ private enum ShellActionRegistryTests {
         )
     }
 
-    private static func verifiesUnavailableActionDoesNotExecuteHandler() throws {
+    private static func verifiesMoveToSpaceRequiresExplicitTarget() throws {
         let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
         var handledEffects: [ShellActionEffect] = []
 
@@ -246,8 +247,8 @@ private enum ShellActionRegistryTests {
         }
 
         expect(
-            result == .unavailable(reason: "Move Tab to Space is not available yet"),
-            "placeholder actions must be disabled"
+            result == .unavailable(reason: "Move target is required"),
+            "move-tab-to-space must require an explicit tab and destination space target"
         )
         expect(handledEffects.isEmpty, "unavailable actions must not execute handlers")
     }
@@ -270,10 +271,36 @@ private enum ShellActionRegistryTests {
         }
 
         expect(
-            result == .unavailable(reason: "Move Tab Left is not available yet"),
-            "disabled move-tab shortcuts must report a stable unavailable reason"
+            result == .unavailable(reason: "No adjacent tab in section"),
+            "move-tab shortcuts must report a stable unavailable reason at section edges"
         )
         expect(handledEffects.isEmpty, "disabled move-tab shortcuts must not mutate state")
+    }
+
+    private static func verifiesMoveTabShortcutRoutesHandler() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTab(
+            launchTarget: .shell,
+            in: "space_main",
+            title: "Second",
+            workingDirectory: "/tmp"
+        ).state
+
+        var handledEffects: [ShellActionEffect] = []
+        let result = ShellActionRegistry.standard.execute(
+            .tabMoveLeft,
+            target: .currentSelection,
+            state: state
+        ) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(result == .executed, "move-tab-left must execute when an adjacent tab exists")
+        expect(
+            handledEffects == [.moveTab(state.focusedTabID, offset: -1)],
+            "move-tab-left must route the selected tab and offset to the handler"
+        )
     }
 
     private static func verifiesCommandInputRemainsOutOfRegistry() throws {
@@ -284,8 +311,8 @@ private enum ShellActionRegistryTests {
             ShellActionRegistry.standard.action(for: .tabMoveToSpace)?.availability(
                 state: ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp"),
                 target: .currentSelection
-            ) == .unavailable(reason: "Move Tab to Space is not available yet"),
-            "future tab organization actions must be registered as disabled placeholders"
+            ) == .unavailable(reason: "Move target is required"),
+            "move-tab-to-space must stay explicit and avoid implicit current-space targets"
         )
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -72,6 +72,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesClosingLastTabLeavesSelectedSpaceEmptyAndPersistsManifest()
         verifiesExplicitSpaceDeletionRemovesManifestSpace()
         verifiesPinSnapshotIsExplicitAndDoesNotTrackTransientChanges()
+        verifiesTabOrganizationPersistsOrderPinAndSpaceOwnership()
         verifiesManifestActiveTaskProjection()
         print("Shell runtime metadata tests passed.")
     }
@@ -2373,6 +2374,60 @@ private enum ShellRuntimeMetadataTests {
         expect(
             updatedTab?.pinSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/moved",
             "update-pin must replace pin cwd snapshot"
+        )
+    }
+
+    private static func verifiesTabOrganizationPersistsOrderPinAndSpaceOwnership() {
+        let windowID = "manifest_tab_org_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-workspace.json")
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/tmp",
+                now: Date(timeIntervalSince1970: 60)
+            )
+        )
+
+        guard let secondTabID = controller.openTerminalTab(title: "Second"),
+              let targetSpaceID = controller.createTerminalSpace(title: "Target")
+        else {
+            fail("tab organization setup must create a second tab and target space")
+        }
+
+        guard let secondPaneID = controller.shellState.panes(in: secondTabID).first?.paneID else {
+            fail("second tab must have a pane")
+        }
+        controller.focus(paneID: secondPaneID)
+        expect(controller.pinTab(tabID: secondTabID), "pinning organization action must be accepted")
+        expect(
+            controller.moveTabToSpace(tabID: secondTabID, targetSpaceID: targetSpaceID),
+            "move-tab-to-space organization action must be accepted"
+        )
+
+        guard let savedManifest = decodeManifest(at: manifestURL),
+              let targetSpace = savedManifest.spaces.first(where: { $0.spaceID == targetSpaceID }),
+              let movedTab = targetSpace.tabs.first(where: { $0.tabID == secondTabID })
+        else {
+            fail("tab organization must persist the moved tab in the target space")
+        }
+
+        expect(movedTab.isPinned, "move-tab-to-space must preserve pin state")
+        expect(movedTab.pinSnapshot != nil, "pinning through organization must persist a pin snapshot")
+        expect(
+            targetSpace.tabs.filter(\.isPinned).map(\.tabID).last == secondTabID,
+            "moved pinned tab must be inserted in the target pinned section"
+        )
+        expect(
+            savedManifest.spaces.first?.tabs.allSatisfy { $0.tabID != secondTabID } == true,
+            "source space order must remove the moved tab"
+        )
+        expect(
+            savedManifest.selectedSpaceID == targetSpaceID && savedManifest.selectedTabID == secondTabID,
+            "moving the selected tab must persist the followed selection"
         )
     }
 

--- a/clients/apple/scripts/test-shell-tab-organization.sh
+++ b/clients/apple/scripts/test-shell-tab-organization.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-tab-organization-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-tab-organization-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-tab-organization.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-tab-organization.swift
+++ b/clients/apple/scripts/test-shell-tab-organization.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+@main
+struct ShellTabOrganizationTestRunner {
+    static func main() throws {
+        try ShellTabOrganizationTests.run()
+    }
+}
+
+private enum ShellTabOrganizationTests {
+    static func run() throws {
+        try verifiesSameSectionReorderPreservesTabAndPaneIdentity()
+        try verifiesCrossSectionPinAndUnpinPreservePaneIdentity()
+        try verifiesMoveCurrentTabToSpaceFollowsSelection()
+        try verifiesMoveNonCurrentTabToSpaceDoesNotFollowSelection()
+        try verifiesMissingMoveTargetIsRejectedWithoutStateChange()
+        print("Shell tab organization tests passed.")
+    }
+
+    private static func verifiesSameSectionReorderPreservesTabAndPaneIdentity() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTerminalTab(in: "space_main", title: "Two", workingDirectory: "/tmp").state
+        state = try state.openingTerminalTab(in: "space_main", title: "Three", workingDirectory: "/tmp").state
+
+        let movedTabID = try requireFocusedTabID(in: state)
+        let movedPaneIDs = try requireTab(movedTabID, in: state).paneTree.paneIDs
+        let reordered = try state.movingTab(movedTabID, sectionOffset: -1).state
+
+        expect(
+            reordered.space(spaceID: "space_main")?.unpinnedTabs.map(\.tabID) == ["tab_main", movedTabID, "tab_2"],
+            "same-section reorder must update only section order"
+        )
+        let reorderedPaneIDs = try requireTab(movedTabID, in: reordered).paneTree.paneIDs
+        expect(
+            reorderedPaneIDs == movedPaneIDs,
+            "same-section reorder must preserve pane identity"
+        )
+        expect(
+            reordered.panes(in: movedTabID).map(\.paneID) == movedPaneIDs,
+            "same-section reorder must keep panes attached to the moved tab"
+        )
+    }
+
+    private static func verifiesCrossSectionPinAndUnpinPreservePaneIdentity() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTerminalTab(in: "space_main", title: "Two", workingDirectory: "/tmp").state
+        let tabID = try requireFocusedTabID(in: state)
+        let paneIDs = try requireTab(tabID, in: state).paneTree.paneIDs
+
+        let pinned = try state.pinningTab(tabID).state
+        expect(
+            pinned.tabOrganizationLocation(tabID: tabID)
+                == ShellTabOrganizationLocation(spaceID: "space_main", section: .pinned, index: 0),
+            "pinning must move the tab into the pinned section"
+        )
+        let pinnedPaneIDs = try requireTab(tabID, in: pinned).paneTree.paneIDs
+        expect(pinnedPaneIDs == paneIDs, "pinning must preserve pane IDs")
+
+        let unpinned = try pinned.unpinningTab(tabID).state
+        expect(
+            unpinned.tabOrganizationLocation(tabID: tabID)?.section == .unpinned,
+            "unpinning must move the tab into the unpinned section"
+        )
+        let unpinnedPaneIDs = try requireTab(tabID, in: unpinned).paneTree.paneIDs
+        expect(unpinnedPaneIDs == paneIDs, "unpinning must preserve pane IDs")
+    }
+
+    private static func verifiesMoveCurrentTabToSpaceFollowsSelection() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTerminalTab(in: "space_main", title: "Two", workingDirectory: "/tmp").state
+        let movedTabID = try requireFocusedTabID(in: state)
+        let focusedPaneID = try requireFocusedPaneID(in: state)
+        state = state.creatingTerminalSpace(title: "Target", workingDirectory: "/tmp").state
+
+        let moved = try state
+            .focusingPane(focusedPaneID).state
+            .movingTabToSpace(tabID: movedTabID, targetSpaceID: "space_2").state
+
+        expect(moved.focusedSpaceID == "space_2", "moving the current tab must follow the target space")
+        expect(moved.focusedTabID == movedTabID, "moving the current tab must keep it selected")
+        expect(moved.focusedPaneID == focusedPaneID, "moving the current tab must keep preferred pane focus")
+        expect(
+            moved.panes(in: movedTabID).allSatisfy { $0.spaceID == "space_2" },
+            "moving a tab to another space must update pane space ownership"
+        )
+    }
+
+    private static func verifiesMoveNonCurrentTabToSpaceDoesNotFollowSelection() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.openingTerminalTab(in: "space_main", title: "Two", workingDirectory: "/tmp").state
+        let nonCurrentTabID = try requireFocusedTabID(in: state)
+        state = state.creatingTerminalSpace(title: "Target", workingDirectory: "/tmp").state
+        state = try state.focusingPane("pane_1").state
+
+        let focusedBefore = (
+            spaceID: state.focusedSpaceID,
+            tabID: state.focusedTabID,
+            paneID: state.focusedPaneID
+        )
+        let moved = try state.movingTabToSpace(tabID: nonCurrentTabID, targetSpaceID: "space_2").state
+
+        expect(moved.focusedSpaceID == focusedBefore.spaceID, "moving a non-current tab must keep current space")
+        expect(moved.focusedTabID == focusedBefore.tabID, "moving a non-current tab must keep current tab")
+        expect(moved.focusedPaneID == focusedBefore.paneID, "moving a non-current tab must keep current pane")
+    }
+
+    private static func verifiesMissingMoveTargetIsRejectedWithoutStateChange() throws {
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        do {
+            _ = try state.movingTabToSpace(tabID: "tab_main", targetSpaceID: "missing_space")
+            fail("missing target space must be rejected")
+        } catch ShellStateMutationError.spaceNotFound {
+            expect(state == ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp"), "failed move must leave state unchanged")
+        }
+    }
+
+    private static func requireFocusedTabID(in state: ShellStateSnapshot) throws -> String {
+        guard let tabID = state.focusedTabID else {
+            throw TestFailure("missing focused tab")
+        }
+        return tabID
+    }
+
+    private static func requireFocusedPaneID(in state: ShellStateSnapshot) throws -> String {
+        guard let paneID = state.focusedPaneID else {
+            throw TestFailure("missing focused pane")
+        }
+        return paneID
+    }
+
+    private static func requireTab(_ tabID: String, in state: ShellStateSnapshot) throws -> ShellTab {
+        guard let tab = state.tab(tabID: tabID) else {
+            throw TestFailure("missing tab \(tabID)")
+        }
+        return tab
+    }
+
+    private static func expect(
+        _ condition: @autoclosure () -> Bool,
+        _ message: String
+    ) {
+        guard condition() else {
+            fail(message)
+        }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fputs("error: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+private struct TestFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/openspec/changes/improve-macos-tab-organization/tasks.md
+++ b/openspec/changes/improve-macos-tab-organization/tasks.md
@@ -1,67 +1,67 @@
 ## 1. Model And Manifest
 
-- [ ] 1.1 Extend shell model helpers so each Space exposes stable Pinned and
+- [x] 1.1 Extend shell model helpers so each Space exposes stable Pinned and
   Unpinned Tab ordering.
-- [ ] 1.2 Persist Tab order, pin state, Space ownership, and selected Tab after
+- [x] 1.2 Persist Tab order, pin state, Space ownership, and selected Tab after
   reorder, pin/unpin, and Move to Space mutations.
-- [ ] 1.3 Save a pin snapshot when an Unpinned Tab is dragged into the Pinned
+- [x] 1.3 Save a pin snapshot when an Unpinned Tab is dragged into the Pinned
   section or otherwise pinned from the organization surface.
-- [ ] 1.4 Preserve existing update-pin behavior for already Pinned Tabs without
+- [x] 1.4 Preserve existing update-pin behavior for already Pinned Tabs without
   updating the snapshot on ordinary reorder.
 
 ## 2. Registry Actions And Mutations
 
-- [ ] 2.1 Add registry-backed Tab actions for pin, unpin, move left, move right,
+- [x] 2.1 Add registry-backed Tab actions for pin, unpin, move left, move right,
   and Move Tab to Space.
-- [ ] 2.2 Make context-menu Tab actions target the clicked Tab without selecting
+- [x] 2.2 Make context-menu Tab actions target the clicked Tab without selecting
   it first.
-- [ ] 2.3 Implement Move Tab to Space insertion rules: keep pin state and insert
+- [x] 2.3 Implement Move Tab to Space insertion rules: keep pin state and insert
   at the end of the target Space's corresponding section.
-- [ ] 2.4 Follow the moved Tab only when the moved Tab was the current selected
+- [x] 2.4 Follow the moved Tab only when the moved Tab was the current selected
   Tab; otherwise keep the current Space selected.
-- [ ] 2.5 Emit shell events for reorder, pin/unpin, and Move Tab to Space.
+- [x] 2.5 Emit shell events for reorder, pin/unpin, and Move Tab to Space.
 
 ## 3. Sidebar Drag UI
 
-- [ ] 3.1 Render per-Space Pinned and Unpinned sections with Arc-like lightweight
+- [x] 3.1 Render per-Space Pinned and Unpinned sections with Arc-like lightweight
   separation and without heavy group headings.
-- [ ] 3.2 Support whole-row drag with a movement threshold so short clicks still
+- [x] 3.2 Support whole-row drag with a movement threshold so short clicks still
   select the Tab.
-- [ ] 3.3 Show realtime insertion preview within and across sections.
-- [ ] 3.4 Keep close overlay, right-click menu, and split topology indicator
+- [x] 3.3 Show realtime insertion preview within and across sections.
+- [x] 3.4 Keep close overlay, right-click menu, and split topology indicator
   interactions from accidentally starting drag reorder.
-- [ ] 3.5 Keep `New Tab` as a lightweight list action rather than a toolbar-like
+- [x] 3.5 Keep `New Tab` as a lightweight list action rather than a toolbar-like
   primary button.
 
 ## 4. Runtime Continuity
 
-- [ ] 4.1 Prove reorder, pin/unpin, and Move to Space preserve Tab ID, pane ID,
+- [x] 4.1 Prove reorder, pin/unpin, and Move to Space preserve Tab ID, pane ID,
   split tree, terminal runtime handle, metadata, scrollback, and queued delivery
   state.
-- [ ] 4.2 Ensure moving the current Tab follows to the target Space and focuses
+- [x] 4.2 Ensure moving the current Tab follows to the target Space and focuses
   the same preferred pane.
-- [ ] 4.3 Ensure moving a non-current Tab does not change the current selected
+- [x] 4.3 Ensure moving a non-current Tab does not change the current selected
   Space, selected Tab, or focused pane.
 
 ## 5. Verification
 
-- [ ] 5.1 Add focused model tests for same-section reorder, cross-section
+- [x] 5.1 Add focused model tests for same-section reorder, cross-section
   pin/unpin, snapshot creation, Move to Space, and current/non-current focus
   behavior.
-- [ ] 5.2 Add focused sidebar tests or script checks for drag threshold,
+- [x] 5.2 Add focused sidebar tests or script checks for drag threshold,
   insertion preview, context target, and split indicator/close overlay
   coexistence.
-- [ ] 5.3 Add manifest persistence tests for immediate order, pin state, snapshot
+- [x] 5.3 Add manifest persistence tests for immediate order, pin state, snapshot
   and Space ownership writes.
-- [ ] 5.4 Run relevant Apple shell scripts and the macOS app build command, or
+- [x] 5.4 Run relevant Apple shell scripts and the macOS app build command, or
   document any local blocker.
-- [ ] 5.5 Run `openspec validate improve-macos-tab-organization --type change --strict --json`.
-- [ ] 5.6 Run `openspec validate --all --strict --json`.
-- [ ] 5.7 Run `git diff --check`.
+- [x] 5.5 Run `openspec validate improve-macos-tab-organization --type change --strict --json`.
+- [x] 5.6 Run `openspec validate --all --strict --json`.
+- [x] 5.7 Run `git diff --check`.
 
 ## 6. Archive Readiness
 
-- [ ] 6.1 Confirm the final UI stays Arc-like and does not introduce tab folders,
+- [x] 6.1 Confirm the final UI stays Arc-like and does not introduce tab folders,
   global pinned tabs, heavy section headers, or Command UI scope.
 - [ ] 6.2 Before archive, sync accepted delta requirements into
   `openspec/specs/`.


### PR DESCRIPTION
## Summary
- Implement OpenSpec change `improve-macos-tab-organization` through implementation task 6.1 (25/27 tasks complete)
- Add pinned/unpinned tab organization, drag reorder, move-to-space, pin persistence, control-plane commands, and shell events
- Add focused tab-organization validation plus sidebar/manifest/runtime contract coverage

## Remaining OpenSpec follow-up
- 6.2 sync accepted delta requirements into `openspec/specs/`
- 6.3 archive the change after this implementation merges

## Validation
- `bash clients/apple/scripts/test-shell-tab-organization.sh`
- `./clients/apple/scripts/test-shell-action-registry.sh`
- `bash clients/apple/scripts/test-shell-workspace-manifest.sh`
- `./clients/apple/scripts/test-shell-runtime-metadata.sh`
- `bash clients/apple/scripts/test-shell-split-model.sh`
- `bash clients/apple/scripts/test-shell-sidebar-presentation.sh`
- `./clients/apple/scripts/check-shell-action-registry-integration.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `openspec validate improve-macos-tab-organization --type change --strict --json`
- `openspec validate --all --strict --json`
- `git diff --check`
- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /tmp/alan-tab-organization-derived build`