### PR TITLE
Add quick terminal routing primitives

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -38,6 +38,11 @@ struct AlanMacShellCommands: Commands {
             }
             .keyboardShortcut("p", modifiers: .command)
 
+            Button(host.shellActionTitle(.quickTerminalToggle)) {
+                host.performShellAction(.quickTerminalToggle)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.quickTerminalToggle))
+
             Divider()
 
             Button(host.shellActionTitle(.paneSplitRight)) {
@@ -201,6 +206,8 @@ extension ShellActionShortcut {
             return .upArrow
         case "downArrow":
             return .downArrow
+        case "space":
+            return .space
         default:
             guard key.count == 1, let character = key.first else { return nil }
             return KeyEquivalent(character)

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -733,6 +733,110 @@ extension ShellHostController {
                 candidates: routingCandidates(preferredPaneID: command.paneID)
             )
 
+        case .quickTerminalToggle:
+            guard let paneID = toggleQuickTerminal() else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "quick_terminal_unavailable",
+                    errorMessage: "The quick terminal could not be toggled."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                paneID: paneID
+            )
+
+        case .quickTerminalShow:
+            guard let paneID = showQuickTerminal() else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "quick_terminal_unavailable",
+                    errorMessage: "The quick terminal could not be shown."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                paneID: paneID
+            )
+
+        case .quickTerminalHide:
+            guard hideQuickTerminal() else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "quick_terminal_not_found",
+                    errorMessage: "The quick terminal does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                paneID: shellState.quickTerminal?.paneID
+            )
+
+        case .quickTerminalFocus:
+            guard let paneID = focusQuickTerminal() else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "quick_terminal_unavailable",
+                    errorMessage: "The quick terminal could not be focused."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                paneID: paneID
+            )
+
+        case .quickTerminalClose:
+            let paneID = shellState.quickTerminal?.paneID
+            guard closeQuickTerminal() else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: "quick_terminal_not_found",
+                    errorMessage: "The quick terminal does not exist."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                paneID: paneID
+            )
+
+        case .quickTerminalPromote:
+            guard let targetSpaceID = command.targetSpaceID ?? command.spaceID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "quick_terminal_destination_required",
+                    errorMessage: "target_space_id is required."
+                )
+            }
+            let paneID = shellState.quickTerminal?.paneID
+            guard promoteQuickTerminal(to: targetSpaceID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    targetSpaceID: targetSpaceID,
+                    paneID: paneID,
+                    errorCode: "quick_terminal_promote_failed",
+                    errorMessage: "The quick terminal could not be moved to the target space."
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                targetSpaceID: targetSpaceID,
+                paneID: paneID
+            )
+
         case .eventsRead:
             return controlPlane.specialCommandResponse(for: command)
                 ?? response(

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -807,7 +807,9 @@ extension ShellHostController {
             return response(
                 requestID: command.requestID,
                 applied: true,
-                paneID: paneID
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: shellState.focusedPaneID
             )
 
         case .quickTerminalPromote:

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 enum ShellActionID: String, CaseIterable, Identifiable, Hashable {
+    case quickTerminalToggle = "shell.quick_terminal.toggle"
+    case quickTerminalShow = "shell.quick_terminal.show"
+    case quickTerminalHide = "shell.quick_terminal.hide"
+    case quickTerminalFocus = "shell.quick_terminal.focus"
+    case quickTerminalClose = "shell.quick_terminal.close"
+    case quickTerminalPromote = "shell.quick_terminal.promote"
     case newTerminalTab = "shell.tab.new_terminal"
     case newAlanTab = "shell.tab.new_alan"
     case tabClose = "shell.tab.close"
@@ -117,6 +123,7 @@ enum ShellActionEffect: Equatable {
     case updatePinnedTab(String?)
     case moveTab(String?, offset: Int)
     case moveTabToSpace(tabID: String?, spaceID: String?)
+    case promoteQuickTerminal(spaceID: String?)
     case disabledPlaceholder
 }
 
@@ -361,6 +368,11 @@ final class ShellActionRegistry {
                 return .moveTabToSpace(tabID: tabID, spaceID: spaceID)
             }
             return .moveTabToSpace(tabID: nil, spaceID: nil)
+        case .promoteQuickTerminal:
+            if case .space(let spaceID) = resolvedTarget {
+                return .promoteQuickTerminal(spaceID: spaceID)
+            }
+            return .promoteQuickTerminal(spaceID: nil)
         case .closeTab:
             if case .tab(let tabID) = resolvedTarget {
                 return .closeTab(tabID)
@@ -396,6 +408,44 @@ final class ShellActionRegistry {
 }
 
 private let standardActions: [ShellActionDescriptor] = [
+    ShellActionDescriptor(
+        id: .quickTerminalToggle,
+        title: "Toggle Quick Terminal",
+        targetKind: .currentSelection,
+        defaultShortcut: ShellActionShortcut(key: "space", modifiers: [.option], context: .shell),
+        effect: .workspaceCommand(.quickTerminalToggle)
+    ),
+    ShellActionDescriptor(
+        id: .quickTerminalShow,
+        title: "Show Quick Terminal",
+        targetKind: .currentSelection,
+        effect: .workspaceCommand(.quickTerminalShow)
+    ),
+    ShellActionDescriptor(
+        id: .quickTerminalHide,
+        title: "Hide Quick Terminal",
+        targetKind: .currentSelection,
+        effect: .workspaceCommand(.quickTerminalHide)
+    ),
+    ShellActionDescriptor(
+        id: .quickTerminalFocus,
+        title: "Focus Quick Terminal",
+        targetKind: .currentSelection,
+        effect: .workspaceCommand(.quickTerminalFocus)
+    ),
+    ShellActionDescriptor(
+        id: .quickTerminalClose,
+        title: "Close Quick Terminal",
+        targetKind: .currentSelection,
+        effect: .workspaceCommand(.quickTerminalClose)
+    ),
+    ShellActionDescriptor(
+        id: .quickTerminalPromote,
+        title: "Open Quick Terminal in Space...",
+        targetKind: .space,
+        effect: .promoteQuickTerminal(spaceID: nil),
+        availability: quickTerminalPromoteAvailability
+    ),
     ShellActionDescriptor(
         id: .newTerminalTab,
         title: "New Terminal Tab",
@@ -749,6 +799,21 @@ private func indexedSpaceAvailability(
     return state.spaces.indices.contains(index)
         ? .available
         : .unavailable(reason: "Space is not available")
+}
+
+private func quickTerminalPromoteAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    guard state.quickTerminal != nil else {
+        return .unavailable(reason: "Quick terminal is not available")
+    }
+    guard case .contextSpace(let spaceID) = target else {
+        return .unavailable(reason: "Quick terminal destination is required")
+    }
+    return state.space(spaceID: spaceID) == nil
+        ? .unavailable(reason: "Space is not available")
+        : .available
 }
 
 private func disabledPlaceholder(

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -26,6 +26,12 @@ enum AlanShellControlCommandKind: String, Codable {
     case attentionSet = "attention.set"
     case routingCandidates = "routing.candidates"
     case eventsRead = "events.read"
+    case quickTerminalToggle = "quick_terminal.toggle"
+    case quickTerminalShow = "quick_terminal.show"
+    case quickTerminalHide = "quick_terminal.hide"
+    case quickTerminalFocus = "quick_terminal.focus"
+    case quickTerminalClose = "quick_terminal.close"
+    case quickTerminalPromote = "quick_terminal.promote"
 }
 
 struct AlanShellControlCommand: Codable {

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -30,6 +30,37 @@ struct ShellAlanBinding: Codable, Equatable {
     }
 }
 
+enum ShellQuickTerminalPresentation: String, Codable, Equatable {
+    case visible
+    case hidden
+}
+
+struct ShellQuickTerminalSlot: Codable, Equatable {
+    static let globalPaneID = "quick_terminal_pane"
+    static let globalTabID = "quick_terminal_tab"
+    static let globalSpaceID = "quick_terminal_space"
+
+    let paneID: String
+    let presentation: ShellQuickTerminalPresentation
+    let lastWorkingDirectory: String?
+
+    init(
+        paneID: String = Self.globalPaneID,
+        presentation: ShellQuickTerminalPresentation,
+        lastWorkingDirectory: String?
+    ) {
+        self.paneID = paneID
+        self.presentation = presentation
+        self.lastWorkingDirectory = lastWorkingDirectory
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case paneID = "pane_id"
+        case presentation
+        case lastWorkingDirectory = "last_working_directory"
+    }
+}
+
 struct ShellPane: Identifiable, Codable, Equatable {
     let paneID: String
     let tabID: String
@@ -83,6 +114,14 @@ struct ShellPane: Identifiable, Codable, Equatable {
         case viewport
         case activity
         case alanBinding = "alan_binding"
+    }
+}
+
+extension ShellPane {
+    var isQuickTerminalPane: Bool {
+        paneID == ShellQuickTerminalSlot.globalPaneID
+            && tabID == ShellQuickTerminalSlot.globalTabID
+            && spaceID == ShellQuickTerminalSlot.globalSpaceID
     }
 }
 
@@ -506,6 +545,7 @@ struct ShellStateSnapshot: Codable, Equatable {
     let focusedPaneID: String?
     let spaces: [ShellSpace]
     let panes: [ShellPane]
+    var quickTerminal: ShellQuickTerminalSlot? = nil
 
     private enum CodingKeys: String, CodingKey {
         case contractVersion = "contract_version"
@@ -515,6 +555,7 @@ struct ShellStateSnapshot: Codable, Equatable {
         case focusedPaneID = "focused_pane_id"
         case spaces
         case panes
+        case quickTerminal = "quick_terminal"
     }
 
     var prettyPrintedJSON: String {

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -315,7 +315,8 @@ extension ShellStateSnapshot {
             focusedTabID: focusedPane?.tabID,
             focusedPaneID: focusedPaneID,
             spaces: rebuildingAttention(in: remainingSpaces, panes: remainingPanes),
-            panes: remainingPanes
+            panes: remainingPanes,
+            quickTerminal: quickTerminal
         )
 
         return ShellStateMutationResult(
@@ -423,6 +424,188 @@ extension ShellStateSnapshot {
             reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
+        )
+    }
+
+    func showingQuickTerminal(
+        workingDirectory: String?,
+        defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
+        now: Date = .now
+    ) -> ShellStateMutationResult {
+        let paneID = quickTerminal?.paneID ?? ShellQuickTerminalSlot.globalPaneID
+        let pane = pane(paneID: paneID)
+        let resolvedWorkingDirectory =
+            pane?.cwd
+            ?? workingDirectory
+            ?? quickTerminal?.lastWorkingDirectory
+            ?? defaultWorkingDirectory
+        let nextPane = pane
+            ?? makeTerminalPane(
+                paneID: paneID,
+                tabID: ShellQuickTerminalSlot.globalTabID,
+                spaceID: ShellQuickTerminalSlot.globalSpaceID,
+                launchTarget: .shell,
+                workingDirectory: resolvedWorkingDirectory,
+                summary: "quick terminal scaffolded",
+                now: now
+            )
+        let nextPanes = pane == nil ? panes + [nextPane] : panes
+        let nextQuickTerminal = ShellQuickTerminalSlot(
+            paneID: paneID,
+            presentation: .visible,
+            lastWorkingDirectory: resolvedWorkingDirectory
+        )
+
+        return ShellStateMutationResult(
+            state: ShellStateSnapshot(
+                contractVersion: contractVersion,
+                windowID: windowID,
+                focusedSpaceID: focusedSpaceID,
+                focusedTabID: focusedTabID,
+                focusedPaneID: focusedPaneID,
+                spaces: spaces,
+                panes: nextPanes,
+                quickTerminal: nextQuickTerminal
+            ),
+            spaceID: focusedSpaceID,
+            tabID: focusedTabID,
+            paneID: paneID
+        )
+    }
+
+    func hidingQuickTerminal() throws -> ShellStateMutationResult {
+        guard let quickTerminal,
+              pane(paneID: quickTerminal.paneID) != nil
+        else {
+            throw ShellStateMutationError.paneNotFound
+        }
+
+        return ShellStateMutationResult(
+            state: ShellStateSnapshot(
+                contractVersion: contractVersion,
+                windowID: windowID,
+                focusedSpaceID: focusedSpaceID,
+                focusedTabID: focusedTabID,
+                focusedPaneID: focusedPaneID,
+                spaces: spaces,
+                panes: panes,
+                quickTerminal: ShellQuickTerminalSlot(
+                    paneID: quickTerminal.paneID,
+                    presentation: .hidden,
+                    lastWorkingDirectory: quickTerminal.lastWorkingDirectory
+                )
+            ),
+            spaceID: focusedSpaceID,
+            tabID: focusedTabID,
+            paneID: quickTerminal.paneID
+        )
+    }
+
+    func closingQuickTerminal() throws -> ShellStateMutationResult {
+        guard let quickTerminal,
+              pane(paneID: quickTerminal.paneID) != nil
+        else {
+            throw ShellStateMutationError.paneNotFound
+        }
+        let nextPanes = panes.filter { $0.paneID != quickTerminal.paneID }
+        let nextFocusedPaneID =
+            focusedPaneID == quickTerminal.paneID
+            ? nextPanes.first(where: { !$0.isQuickTerminalPane })?.paneID
+            : focusedPaneID
+
+        return ShellStateMutationResult(
+            state: ShellStateSnapshot(
+                contractVersion: contractVersion,
+                windowID: windowID,
+                focusedSpaceID: nextFocusedPaneID.flatMap { pane(paneID: $0)?.spaceID } ?? focusedSpaceID,
+                focusedTabID: nextFocusedPaneID.flatMap { pane(paneID: $0)?.tabID } ?? focusedTabID,
+                focusedPaneID: nextFocusedPaneID,
+                spaces: spaces,
+                panes: nextPanes,
+                quickTerminal: nil
+            ),
+            spaceID: focusedSpaceID,
+            tabID: focusedTabID,
+            paneID: nextFocusedPaneID
+        )
+    }
+
+    func promotingQuickTerminal(
+        to targetSpaceID: String,
+        now: Date = .now
+    ) throws -> ShellStateMutationResult {
+        guard let quickTerminal,
+              let quickPane = pane(paneID: quickTerminal.paneID)
+        else {
+            throw ShellStateMutationError.paneNotFound
+        }
+        guard let targetSpace = space(spaceID: targetSpaceID) else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+
+        let newTabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
+        let movedPaneNode = ShellPaneTreeNode(
+            nodeID: "node_\(quickPane.paneID)",
+            kind: .pane,
+            direction: nil,
+            paneID: quickPane.paneID,
+            children: nil
+        )
+        let newTab = ShellTab(
+            tabID: newTabID,
+            kind: .terminal,
+            title: quickPane.viewport?.title ?? "Quick Terminal",
+            paneTree: movedPaneNode
+        )
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == targetSpace.spaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs + [newTab]
+            )
+        }
+
+        let formatter = ISO8601DateFormatter()
+        let nextPanes = panes.map { current in
+            guard current.paneID == quickPane.paneID else { return current }
+            return ShellPane(
+                paneID: current.paneID,
+                tabID: newTabID,
+                spaceID: targetSpace.spaceID,
+                launchTarget: current.launchTarget,
+                cwd: current.cwd,
+                process: current.process,
+                attention: current.attention,
+                context: current.context,
+                viewport: ShellViewportSnapshot(
+                    title: current.viewport?.title,
+                    summary: current.viewport?.summary ?? "quick terminal opened in space",
+                    visibleExcerpt: current.viewport?.visibleExcerpt,
+                    lastActivityAt: formatter.string(from: now)
+                ),
+                activity: current.activity,
+                alanBinding: current.alanBinding
+            )
+        }
+
+        let nextState = ShellStateSnapshot(
+            contractVersion: contractVersion,
+            windowID: windowID,
+            focusedSpaceID: targetSpace.spaceID,
+            focusedTabID: newTabID,
+            focusedPaneID: quickPane.paneID,
+            spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
+            panes: nextPanes,
+            quickTerminal: nil
+        )
+
+        return ShellStateMutationResult(
+            state: nextState,
+            spaceID: targetSpace.spaceID,
+            tabID: newTabID,
+            paneID: quickPane.paneID
         )
     }
 
@@ -1100,7 +1283,8 @@ extension ShellStateSnapshot {
             focusedTabID: focusedTabID,
             focusedPaneID: preferredPaneID,
             spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
-            panes: nextPanes
+            panes: nextPanes,
+            quickTerminal: quickTerminal
         )
 
         return ShellStateMutationResult(
@@ -1131,7 +1315,8 @@ extension ShellStateSnapshot {
             focusedTabID: focusedPane?.tabID ?? spaces.first?.tabs.first?.tabID,
             focusedPaneID: resolvedFocusedPaneID,
             spaces: spaces,
-            panes: panes
+            panes: panes,
+            quickTerminal: quickTerminal
         )
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -113,6 +113,11 @@ enum ShellWorkspaceCommand: String, CaseIterable, Identifiable {
     case equalizeSplits
     case closePane
     case closeTab
+    case quickTerminalToggle
+    case quickTerminalShow
+    case quickTerminalHide
+    case quickTerminalFocus
+    case quickTerminalClose
 
     var id: String { rawValue }
 }

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -715,8 +715,107 @@ enum AlanShellLocalCommandExecutor {
                 sideEffect: nil
             )
 
+        case .quickTerminalToggle:
+            if state.quickTerminal?.presentation == .visible {
+                return quickTerminalResult(
+                    command: command,
+                    state: state,
+                    mutate: { try $0.hidingQuickTerminal() }
+                )
+            }
+            return quickTerminalResult(
+                command: command,
+                state: state,
+                mutate: {
+                    $0.showingQuickTerminal(workingDirectory: command.cwd)
+                }
+            )
+
+        case .quickTerminalShow, .quickTerminalFocus:
+            return quickTerminalResult(
+                command: command,
+                state: state,
+                mutate: {
+                    $0.showingQuickTerminal(workingDirectory: command.cwd)
+                }
+            )
+
+        case .quickTerminalHide:
+            return quickTerminalResult(
+                command: command,
+                state: state,
+                mutate: { try $0.hidingQuickTerminal() }
+            )
+
+        case .quickTerminalClose:
+            return quickTerminalResult(
+                command: command,
+                state: state,
+                mutate: { try $0.closingQuickTerminal() }
+            )
+
+        case .quickTerminalPromote:
+            guard let targetSpaceID = command.targetSpaceID ?? command.spaceID else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "quick_terminal_destination_required",
+                        errorMessage: "target_space_id is required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            return quickTerminalResult(
+                command: command,
+                state: state,
+                mutate: { try $0.promotingQuickTerminal(to: targetSpaceID) }
+            )
+
         case .eventsRead:
             return nil
+        }
+    }
+
+    private static func quickTerminalResult(
+        command: AlanShellControlCommand,
+        state: ShellStateSnapshot,
+        mutate: (ShellStateSnapshot) throws -> ShellStateMutationResult
+    ) -> AlanShellLocalCommandResult {
+        do {
+            let result = try mutate(state)
+            return AlanShellLocalCommandResult(
+                response: response(
+                    for: command,
+                    state: result.state,
+                    applied: true,
+                    spaceID: result.spaceID,
+                    tabID: result.tabID,
+                    paneID: result.paneID
+                ),
+                updatedState: result.state,
+                sideEffect: nil
+            )
+        } catch let error as ShellStateMutationError {
+            return AlanShellLocalCommandResult(
+                response: failureResponse(for: error, command: command, state: state),
+                updatedState: nil,
+                sideEffect: nil
+            )
+        } catch {
+            return AlanShellLocalCommandResult(
+                response: response(
+                    for: command,
+                    state: state,
+                    applied: false,
+                    errorCode: "quick_terminal_unavailable",
+                    errorMessage: "The quick terminal command could not be applied."
+                ),
+                updatedState: nil,
+                sideEffect: nil
+            )
         }
     }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -36,7 +36,8 @@ enum AlanShellPublishedStateMerger {
             focusedTabID: focusedPane?.tabID ?? incoming.focusedTabID ?? authoritative.focusedTabID,
             focusedPaneID: focusedPane?.paneID ?? focusedPaneID,
             spaces: mergedSpaces,
-            panes: mergedPanes
+            panes: mergedPanes,
+            quickTerminal: incoming.quickTerminal
         )
     }
 

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -321,6 +321,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         return panesForSelectedTab.first
     }
 
+    var quickTerminalPane: ShellPane? {
+        shellState.quickTerminal.flatMap { slot in
+            shellState.pane(paneID: slot.paneID)
+        }
+    }
+
+    var quickTerminalPresentation: ShellQuickTerminalPresentation? {
+        shellState.quickTerminal?.presentation
+    }
+
     var focusedPane: ShellPane? {
         guard let focusedPaneID = shellState.focusedPaneID else { return nil }
         return pane(paneID: focusedPaneID)
@@ -400,7 +410,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 focusedTabID: nil,
                 focusedPaneID: nil,
                 spaces: shellState.spaces,
-                panes: shellState.panes
+                panes: shellState.panes,
+                quickTerminal: shellState.quickTerminal
             )
             synchronizeSelection()
             publishControlPlaneState()
@@ -513,6 +524,67 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func refocusSelectedTerminalPane() {
         guard let paneID = selectedPane?.paneID else { return }
         terminalRuntimeRegistry.requestFocus(for: paneID)
+    }
+
+    @discardableResult
+    func toggleQuickTerminal() -> String? {
+        if shellState.quickTerminal?.presentation == .visible {
+            return hideQuickTerminal() ? shellState.quickTerminal?.paneID : nil
+        }
+        return showQuickTerminal()
+    }
+
+    @discardableResult
+    func showQuickTerminal() -> String? {
+        let result = shellState.showingQuickTerminal(
+            workingDirectory: focusedPaneWorkingDirectory()
+        )
+        applyMutationResult(result)
+        terminalRuntimeRegistry.requestFocus(for: result.paneID ?? ShellQuickTerminalSlot.globalPaneID)
+        return result.paneID
+    }
+
+    @discardableResult
+    func hideQuickTerminal() -> Bool {
+        do {
+            let result = try shellState.hidingQuickTerminal()
+            applyMutationResult(result)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    @discardableResult
+    func focusQuickTerminal() -> String? {
+        let paneID = showQuickTerminal()
+        if let paneID {
+            terminalRuntimeRegistry.requestFocus(for: paneID)
+        }
+        return paneID
+    }
+
+    @discardableResult
+    func closeQuickTerminal() -> Bool {
+        do {
+            let result = try shellState.closingQuickTerminal()
+            applyMutationResult(result)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    @discardableResult
+    func promoteQuickTerminal(to targetSpaceID: String) -> Bool {
+        do {
+            let result = try shellState.promotingQuickTerminal(to: targetSpaceID)
+            applyMutationResult(result)
+            terminalRuntimeRegistry.requestFocus(for: result.paneID ?? ShellQuickTerminalSlot.globalPaneID)
+            return true
+        } catch {
+            return false
+        }
     }
 
     func terminalHostDidRequestActivation(paneID: String) {
@@ -790,6 +862,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return closeSelectedPane()
         case .closeTab:
             return closeSelectedTab()
+        case .quickTerminalToggle:
+            return toggleQuickTerminal() != nil
+        case .quickTerminalShow:
+            return showQuickTerminal() != nil
+        case .quickTerminalHide:
+            return hideQuickTerminal()
+        case .quickTerminalFocus:
+            return focusQuickTerminal() != nil
+        case .quickTerminalClose:
+            return closeQuickTerminal()
         }
     }
 
@@ -859,6 +941,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .moveTabToSpace(let tabID, let spaceID):
             guard let tabID, let spaceID else { return false }
             return moveTabToSpace(tabID: tabID, targetSpaceID: spaceID)
+        case .promoteQuickTerminal(let spaceID):
+            guard let spaceID else { return false }
+            return promoteQuickTerminal(to: spaceID)
         case .disabledPlaceholder:
             return false
         }
@@ -1273,7 +1358,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedTabID: shellState.focusedTabID,
             focusedPaneID: shellState.focusedPaneID,
             spaces: updatedSpaces,
-            panes: updatedPanes
+            panes: updatedPanes,
+            quickTerminal: shellState.quickTerminal
         )
         synchronizeSelection()
         routeActivityNotificationIfNeeded(from: existingPane, to: transformedPane)
@@ -1418,7 +1504,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedTabID: focusedPane?.tabID ?? spaces.first?.tabs.first?.tabID,
             focusedPaneID: resolvedFocusedPaneID,
             spaces: spaces,
-            panes: panes
+            panes: panes,
+            quickTerminal: shellState.quickTerminal
         )
         synchronizeSelection()
         publishControlPlaneState()
@@ -1487,7 +1574,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedTabID: state.focusedTabID,
             focusedPaneID: state.focusedPaneID,
             spaces: hydratedSpaces,
-            panes: hydratedPanes
+            panes: hydratedPanes,
+            quickTerminal: state.quickTerminal
         )
         synchronizeSelection()
         if publish {

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -719,6 +719,8 @@ final class AlanTerminalInputRouter {
             return "upArrow"
         case 0x7D:
             return "downArrow"
+        case 0x31:
+            return "space"
         default:
             break
         }

--- a/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
@@ -15,6 +15,11 @@ private enum ShellCommandInputAction: CaseIterable {
     case equalizeSplits
     case closePane
     case closeTab
+    case quickTerminalToggle
+    case quickTerminalShow
+    case quickTerminalHide
+    case quickTerminalFocus
+    case quickTerminalClose
     case jumpToAttention
     case previousPrompt
     case nextPrompt
@@ -49,6 +54,16 @@ private enum ShellCommandInputAction: CaseIterable {
             return ["close pane", "close focused pane"]
         case .closeTab:
             return ["close tab", "close current tab"]
+        case .quickTerminalToggle:
+            return ["quick terminal", "toggle quick terminal"]
+        case .quickTerminalShow:
+            return ["show quick terminal", "open quick terminal"]
+        case .quickTerminalHide:
+            return ["hide quick terminal", "dismiss quick terminal"]
+        case .quickTerminalFocus:
+            return ["focus quick terminal"]
+        case .quickTerminalClose:
+            return ["close quick terminal"]
         case .jumpToAttention:
             return ["jump to attention", "focus attention", "attention"]
         case .previousPrompt:
@@ -229,6 +244,16 @@ struct ShellCommandTabView: View {
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.closePane)
         case .closeTab:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.closeTab)
+        case .quickTerminalToggle:
+            host.performShellWorkspaceCommand(.quickTerminalToggle)
+        case .quickTerminalShow:
+            host.performShellWorkspaceCommand(.quickTerminalShow)
+        case .quickTerminalHide:
+            host.performShellWorkspaceCommand(.quickTerminalHide)
+        case .quickTerminalFocus:
+            host.performShellWorkspaceCommand(.quickTerminalFocus)
+        case .quickTerminalClose:
+            host.performShellWorkspaceCommand(.quickTerminalClose)
         case .jumpToAttention:
             if let firstAttention = host.attentionItems.first {
                 host.focusAttentionItem(firstAttention)

--- a/clients/apple/scripts/test-shell-action-registry.swift
+++ b/clients/apple/scripts/test-shell-action-registry.swift
@@ -19,6 +19,8 @@ private enum ShellActionRegistryTests {
         try verifiesUnavailableShortcutActionDoesNotExecuteHandler()
         try verifiesMoveTabShortcutRoutesHandler()
         try verifiesCommandInputRemainsOutOfRegistry()
+        try verifiesQuickTerminalActionsRouteThroughSharedRegistry()
+        try verifiesQuickTerminalPromoteRequiresExplicitDestination()
         print("Shell action registry tests passed.")
     }
 
@@ -313,6 +315,77 @@ private enum ShellActionRegistryTests {
                 target: .currentSelection
             ) == .unavailable(reason: "Move target is required"),
             "move-tab-to-space must stay explicit and avoid implicit current-space targets"
+        )
+    }
+
+    private static func verifiesQuickTerminalActionsRouteThroughSharedRegistry() throws {
+        let registry = ShellActionRegistry.standard
+        let state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+
+        expect(
+            registry.defaultShortcut(for: .quickTerminalToggle)
+                == ShellActionShortcut(key: "space", modifiers: [.option], context: .shell),
+            "quick terminal toggle must advertise the draft option-space shortcut"
+        )
+        expect(
+            registry.keyboardAction(
+                for: ShellActionShortcut(key: "space", modifiers: [.option], context: .shell)
+            ) == ShellKeyboardAction(id: .quickTerminalToggle, target: .currentSelection),
+            "option-space must resolve to the shared quick-terminal toggle action"
+        )
+
+        let routedEffects: [(ShellActionID, ShellActionEffect)] = [
+            (.quickTerminalToggle, .workspaceCommand(.quickTerminalToggle)),
+            (.quickTerminalShow, .workspaceCommand(.quickTerminalShow)),
+            (.quickTerminalHide, .workspaceCommand(.quickTerminalHide)),
+            (.quickTerminalFocus, .workspaceCommand(.quickTerminalFocus)),
+            (.quickTerminalClose, .workspaceCommand(.quickTerminalClose)),
+        ]
+
+        for (actionID, expectedEffect) in routedEffects {
+            var handledEffects: [ShellActionEffect] = []
+            let result = registry.execute(actionID, target: .currentSelection, state: state) { effect in
+                handledEffects.append(effect)
+                return true
+            }
+
+            expect(result == .executed, "\(actionID.rawValue) must execute through the registry")
+            expect(handledEffects == [expectedEffect], "\(actionID.rawValue) must route the shared command effect")
+        }
+    }
+
+    private static func verifiesQuickTerminalPromoteRequiresExplicitDestination() throws {
+        let registry = ShellActionRegistry.standard
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = state.creatingTerminalSpace(title: "Second", workingDirectory: "/tmp").state
+        state = state.showingQuickTerminal(workingDirectory: "/tmp").state
+
+        var handledEffects: [ShellActionEffect] = []
+        let missingTarget = registry.execute(
+            .quickTerminalPromote,
+            target: .currentSelection,
+            state: state
+        ) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+        let explicitTarget = registry.execute(
+            .quickTerminalPromote,
+            target: .contextSpace("space_2"),
+            state: state
+        ) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(
+            missingTarget == .unavailable(reason: "Quick terminal destination is required"),
+            "quick terminal promotion must require an explicit destination"
+        )
+        expect(explicitTarget == .executed, "quick terminal promotion must execute for an explicit space")
+        expect(
+            handledEffects == [.promoteQuickTerminal(spaceID: "space_2")],
+            "quick terminal promotion must route the selected destination to the handler"
         )
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -605,6 +605,14 @@ private enum ShellRuntimeMetadataTests {
         )
 
         expect(closeResponse.applied == true, "quick terminal close command must use controller routing")
+        expect(
+            closeResponse.paneID == controller.shellState.focusedPaneID,
+            "quick terminal close response must return the resulting focused pane"
+        )
+        expect(
+            closeResponse.paneID != ShellQuickTerminalSlot.globalPaneID,
+            "quick terminal close response must not return the removed quick pane"
+        )
         expect(controller.quickTerminalPane == nil, "close must clear the global quick-terminal slot")
         expect(
             !controller.terminalRuntimeRegistry.registeredPaneIDs.contains("quick_terminal_pane"),

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -25,6 +25,9 @@ private enum ShellRuntimeMetadataTests {
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
         verifiesOpeningTerminalTabHonorsExplicitCwd()
+        verifiesQuickTerminalShowCreatesAndReusesGlobalPane()
+        verifiesQuickTerminalActionsAndControlCommandsShareControllerPath()
+        verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -514,6 +517,129 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.cwd == "/explicit/cwd",
             "explicit new-tab cwd must override focused pane cwd"
+        )
+    }
+
+    private static func verifiesQuickTerminalShowCreatesAndReusesGlobalPane() {
+        let controller = makeController()
+        controller.updateTerminalMetadata(metadata(title: "cwd update", cwd: "/repo/app"), for: "pane_1")
+        let selectedSpaceBefore = controller.selectedSpaceID
+        let selectedTabBefore = controller.selectedTabID
+        let focusedPaneBefore = controller.shellState.focusedPaneID
+
+        let shownPaneID = controller.showQuickTerminal()
+        let hidden = controller.hideQuickTerminal()
+        controller.updateTerminalMetadata(metadata(title: "cwd update", cwd: "/repo/other"), for: "pane_1")
+        let reshownPaneID = controller.showQuickTerminal()
+
+        expect(shownPaneID == "quick_terminal_pane", "quick terminal must use one stable global pane id")
+        expect(hidden == true, "quick terminal hide must apply when the peak is visible")
+        expect(reshownPaneID == shownPaneID, "quick terminal show must reuse the existing global pane")
+        expect(
+            controller.quickTerminalPane?.cwd == "/repo/app",
+            "quick terminal must keep the existing instance cwd across hide/show"
+        )
+        expect(
+            controller.quickTerminalPresentation == .visible,
+            "reshowing quick terminal must make the global slot visible"
+        )
+        expect(
+            controller.shellState.panes.filter(\.isQuickTerminalPane).count == 1,
+            "quick terminal must not create one pane per summon"
+        )
+        expect(controller.selectedSpaceID == selectedSpaceBefore, "show/hide must not move the selected space")
+        expect(controller.selectedTabID == selectedTabBefore, "show/hide must not move the selected tab")
+        expect(
+            controller.shellState.focusedPaneID == focusedPaneBefore,
+            "show/hide must not steal regular pane focus in the shell model"
+        )
+    }
+
+    private static func verifiesQuickTerminalActionsAndControlCommandsShareControllerPath() {
+        let controller = makeController()
+
+        let actionResult = controller.performShellAction(.quickTerminalToggle)
+        let paneIDFromAction = controller.quickTerminalPane?.paneID
+        let hiddenResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "quick-hide-1",
+                  "command": "quick_terminal.hide"
+                }
+                """
+            )
+        )
+
+        expect(actionResult == .executed, "quick terminal action must execute through ShellActionRegistry")
+        expect(paneIDFromAction == "quick_terminal_pane", "quick terminal action must create the global pane")
+        expect(hiddenResponse.applied == true, "quick terminal hide control command must use controller routing")
+        expect(
+            controller.quickTerminalPresentation == .hidden,
+            "quick terminal hide command must preserve the global runtime slot"
+        )
+
+        let focusResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "quick-focus-1",
+                  "command": "quick_terminal.focus"
+                }
+                """
+            )
+        )
+
+        expect(focusResponse.applied == true, "quick terminal focus command must use controller routing")
+        expect(focusResponse.paneID == paneIDFromAction, "focus response must identify the quick pane")
+
+        let closeResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "quick-close-1",
+                  "command": "quick_terminal.close"
+                }
+                """
+            )
+        )
+
+        expect(closeResponse.applied == true, "quick terminal close command must use controller routing")
+        expect(controller.quickTerminalPane == nil, "close must clear the global quick-terminal slot")
+        expect(
+            !controller.terminalRuntimeRegistry.registeredPaneIDs.contains("quick_terminal_pane"),
+            "close must release the quick terminal runtime through regular registry cleanup"
+        )
+    }
+
+    private static func verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace() {
+        let controller = makeController()
+        _ = controller.createTerminalSpace(title: "Second", workingDirectory: "/tmp")
+        let quickPaneID = controller.showQuickTerminal()
+        let response = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "quick-promote-1",
+                  "command": "quick_terminal.promote",
+                  "target_space_id": "space_2"
+                }
+                """
+            )
+        )
+        let promotedPane = controller.pane(paneID: ShellQuickTerminalSlot.globalPaneID)
+        let targetSpace = controller.shellState.space(spaceID: "space_2")
+        let targetTab = targetSpace?.tabs.first { $0.contains(paneID: ShellQuickTerminalSlot.globalPaneID) }
+
+        expect(quickPaneID == ShellQuickTerminalSlot.globalPaneID, "quick setup must create the global pane")
+        expect(response.applied == true, "quick terminal promote command must use controller routing")
+        expect(response.paneID == ShellQuickTerminalSlot.globalPaneID, "promote response must return the moved pane")
+        expect(controller.quickTerminalPane == nil, "promote must clear the quick-terminal slot")
+        expect(promotedPane?.spaceID == "space_2", "promote must move the existing pane into the target space")
+        expect(promotedPane?.tabID == targetTab?.tabID, "promote must attach the existing pane to the new tab")
+        expect(
+            controller.shellState.panes.filter { $0.paneID == ShellQuickTerminalSlot.globalPaneID }.count == 1,
+            "promote must move the pane instead of copying the process"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -393,6 +393,21 @@ private enum TerminalSurfaceControllerTests {
             commandT == .shellAction(.newTerminalTab, .currentSelection),
             "command-t must remain a native workspace shortcut through the shell action registry"
         )
+
+        let optionSpace = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: " ",
+                keyCode: 0x31,
+                modifiers: [.option],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            optionSpace == .shellAction(.quickTerminalToggle, .currentSelection),
+            "option-space must route to the quick terminal toggle through the registry"
+        )
     }
 
     private static func verifiesKeyboardPipelineKeepsPhysicalKeysOnGhosttyKeyPath() {

--- a/openspec/changes/add-quick-terminal-peak/tasks.md
+++ b/openspec/changes/add-quick-terminal-peak/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Model And Command Routing
 
-- [ ] 1.1 Add a single global quick-terminal slot that reuses one terminal
+- [x] 1.1 Add a single global quick-terminal slot that reuses one terminal
   runtime across hide/show and summons it onto the current macOS Space/display.
-- [ ] 1.2 Add shared shell command routing for the configurable global toggle
+- [x] 1.2 Add shared shell command routing for the configurable global toggle
   shortcut, draft default `Option+Space`, plus explicit show, hide, focus,
   close, and promote commands.
-- [ ] 1.3 Ensure keyboard shortcuts, menu commands, command input, and supported
+- [x] 1.3 Ensure keyboard shortcuts, menu commands, command input, and supported
   control commands converge on the same shell controller behavior.
 
 ## 2. Peak Presentation
@@ -21,13 +21,13 @@
 
 ## 3. Runtime Lifecycle And Workspace Promotion
 
-- [ ] 3.1 Preserve quick terminal runtime state across hide/show and tear it down
+- [x] 3.1 Preserve quick terminal runtime state across hide/show and tear it down
   only through explicit close semantics.
-- [ ] 3.2 Apply quick-terminal cwd creation rules: existing instance cwd,
+- [x] 3.2 Apply quick-terminal cwd creation rules: existing instance cwd,
   focused Alan pane cwd, last quick-terminal cwd, then home.
-- [ ] 3.3 Implement `Open in Space` promotion as a move into the selected Alan
+- [x] 3.3 Implement `Open in Space` promotion as a move into the selected Alan
   Space/tab that hides the Peak and clears the global quick slot.
-- [ ] 3.4 Ensure promotion does not copy the terminal process or keep the same
+- [x] 3.4 Ensure promotion does not copy the terminal process or keep the same
   runtime visible in both the Peak and the target tab.
 - [ ] 3.5 Surface hidden quick-terminal user-actionable activity through the
   existing compact activity and notification policy.
@@ -37,12 +37,12 @@
 - [ ] 4.1 Add focus, display/Space placement, hide/show, close, promote, and
   hidden-activity notification tests.
 - [ ] 4.2 Add focused checks for `Esc` terminal routing and focus-loss behavior.
-- [ ] 4.3 Run relevant shell model, window, command-routing, and terminal runtime
+- [x] 4.3 Run relevant shell model, window, command-routing, and terminal runtime
   tests.
-- [ ] 4.4 Run the relevant macOS app build command or document any local blocker.
-- [ ] 4.5 Run `openspec validate add-quick-terminal-peak --type change --strict --json`.
-- [ ] 4.6 Run `openspec validate --all --strict --json`.
-- [ ] 4.7 Run `git diff --check`.
+- [x] 4.4 Run the relevant macOS app build command or document any local blocker.
+- [x] 4.5 Run `openspec validate add-quick-terminal-peak --type change --strict --json`.
+- [x] 4.6 Run `openspec validate --all --strict --json`.
+- [x] 4.7 Run `git diff --check`.
 
 ## 5. Archive Readiness
 


### PR DESCRIPTION
## Summary
- Add a single global quick-terminal slot plus show/hide/focus/close/promote state mutations.
- Route Option+Space, menu commands, command input, local commands, and control-plane commands through the shared shell controller paths.
- Update the OpenSpec task checklist for this model/routing/lifecycle phase.

## Not included in this PR
- Detached native Peak window presentation.
- Esc and focus-loss behavior tests.
- Hidden quick-terminal activity notification policy.

## Verification
- ./clients/apple/scripts/test-shell-action-registry.sh
- ./clients/apple/scripts/test-shell-runtime-metadata.sh
- ./clients/apple/scripts/test-terminal-surface-controller.sh
- ./clients/apple/scripts/check-shell-action-registry-integration.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate add-quick-terminal-peak --type change --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-quick-terminal-peak-derived build