### PR TITLE
Add quick terminal Peak window

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -67,8 +67,7 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
 
         panel.setFrame(placement.frame, display: true)
         panel.collectionBehavior = collectionBehavior(for: placement)
-        NSApp.activate(ignoringOtherApps: true)
-        panel.makeKeyAndOrderFront(nil)
+        orderFrontQuickTerminal(panel)
     }
 
     func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason) {
@@ -80,7 +79,10 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
     }
 
     func focusTerminal(paneID: String) {
-        panel?.makeKeyAndOrderFront(nil)
+        guard let panel else {
+            return
+        }
+        orderFrontQuickTerminal(panel)
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
@@ -99,7 +101,7 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
 
         let panel = NSPanel(
             contentRect: CGRect(x: 0, y: 0, width: 840, height: 360),
-            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -126,6 +128,11 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
         panel.standardWindowButton(.zoomButton)?.isHidden = true
         self.panel = panel
         return panel
+    }
+
+    private func orderFrontQuickTerminal(_ panel: NSPanel) {
+        panel.orderFrontRegardless()
+        panel.makeKey()
     }
 
     private func collectionBehavior(

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -1,21 +1,141 @@
+import Combine
 import Foundation
 import SwiftUI
 
 #if os(macOS)
+import AppKit
+
 @MainActor
 final class AlanMacPrimaryShellOwner: ObservableObject {
     let host: ShellHostController
+    private let quickTerminalPeakWindow: ShellQuickTerminalPeakPanelWindow
+    private let quickTerminalPeakPresenter: ShellQuickTerminalPeakPresenter
+    private var quickTerminalPeakStateSubscription: AnyCancellable?
 
     init(fileManager: FileManager = .default) {
         let windowContext = ShellWindowContext.make(
             fileManager: fileManager,
             windowID: "window_main"
         )
-        host = ShellHostController.live(
+        let resolvedHost = ShellHostController.live(
             fileManager: fileManager,
             windowContext: windowContext,
             startupMode: .workspaceManifest
         )
+        let peakWindow = ShellQuickTerminalPeakPanelWindow()
+        let peakPresenter = ShellQuickTerminalPeakPresenter(
+            host: resolvedHost,
+            window: peakWindow
+        )
+        host = resolvedHost
+        quickTerminalPeakWindow = peakWindow
+        quickTerminalPeakPresenter = peakPresenter
+        quickTerminalPeakStateSubscription = resolvedHost.$shellState.sink { [weak peakPresenter] _ in
+            Task { @MainActor in
+                peakPresenter?.synchronize()
+            }
+        }
+        quickTerminalPeakPresenter.synchronize()
+    }
+
+}
+
+@MainActor
+private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTerminalPeakWindowing, NSWindowDelegate {
+    var onDismissRequest: (() -> Void)?
+    private var panel: NSPanel?
+    private var hostingController: NSHostingController<ShellQuickTerminalPeakView>?
+
+    var isVisible: Bool {
+        panel?.isVisible == true
+    }
+
+    func presentQuickTerminal(
+        host: ShellHostController,
+        pane _: ShellPane,
+        tab _: ShellTab,
+        placement: ShellQuickTerminalPeakPlacement
+    ) {
+        let panel = ensurePanel()
+        if let hostingController {
+            hostingController.rootView = ShellQuickTerminalPeakView(host: host)
+        } else {
+            let hostingController = NSHostingController(rootView: ShellQuickTerminalPeakView(host: host))
+            self.hostingController = hostingController
+            panel.contentViewController = hostingController
+        }
+
+        panel.setFrame(placement.frame, display: true)
+        panel.collectionBehavior = collectionBehavior(for: placement)
+        NSApp.activate(ignoringOtherApps: true)
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason) {
+        panel?.orderOut(nil)
+        if reason == .removed {
+            panel?.contentViewController = nil
+            hostingController = nil
+        }
+    }
+
+    func focusTerminal(paneID: String) {
+        panel?.makeKeyAndOrderFront(nil)
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onDismissRequest?()
+        return false
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        // Intentionally no-op. Focus loss must not hide the quick terminal Peak.
+    }
+
+    private func ensurePanel() -> NSPanel {
+        if let panel {
+            return panel
+        }
+
+        let panel = NSPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 840, height: 360),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Quick Terminal"
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isMovableByWindowBackground = true
+        panel.hidesOnDeactivate = false
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.collectionBehavior = collectionBehavior(
+            for: ShellQuickTerminalPeakPlacement.defaultPlacement(
+                in: ShellQuickTerminalPeakPlacement.activeVisibleFrame()
+            )
+        )
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.animationBehavior = .utilityWindow
+        panel.isReleasedWhenClosed = false
+        panel.minSize = CGSize(width: 520, height: 280)
+        panel.delegate = self
+        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden = true
+        self.panel = panel
+        return panel
+    }
+
+    private func collectionBehavior(
+        for placement: ShellQuickTerminalPeakPlacement
+    ) -> NSWindow.CollectionBehavior {
+        var behavior: NSWindow.CollectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+        if placement.joinsAllSpaces {
+            behavior.insert(.canJoinAllSpaces)
+        }
+        return behavior
     }
 }
 #endif

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -33,6 +33,163 @@ enum ShellPaneLiftResult {
     case lastPane
 }
 
+enum ShellQuickTerminalPeakEscapeBehavior: Equatable {
+    case terminalInput
+}
+
+struct ShellQuickTerminalPeakInteractionPolicy: Equatable {
+    let escapeKeyBehavior: ShellQuickTerminalPeakEscapeBehavior
+    let hidesOnFocusLoss: Bool
+    let usesMainWindowParenting: Bool
+
+    static let terminalFirst = ShellQuickTerminalPeakInteractionPolicy(
+        escapeKeyBehavior: .terminalInput,
+        hidesOnFocusLoss: false,
+        usesMainWindowParenting: false
+    )
+}
+
+struct ShellQuickTerminalPeakPlacement: Equatable {
+    let frame: CGRect
+    let followsActiveSpace: Bool
+    let joinsAllSpaces: Bool
+    let requiresMainWindow: Bool
+
+    static func defaultPlacement(in visibleFrame: CGRect) -> ShellQuickTerminalPeakPlacement {
+        ShellQuickTerminalPeakPlacement(
+            frame: defaultFrame(in: visibleFrame),
+            followsActiveSpace: true,
+            joinsAllSpaces: true,
+            requiresMainWindow: false
+        )
+    }
+
+    static func activeVisibleFrame() -> CGRect {
+        let mouseLocation = NSEvent.mouseLocation
+        let activeScreen = NSScreen.screens.first { screen in
+            screen.frame.contains(mouseLocation)
+        }
+        return activeScreen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? CGRect(x: 0, y: 0, width: 960, height: 600)
+    }
+
+    private static func defaultFrame(in visibleFrame: CGRect) -> CGRect {
+        let horizontalInset = min(max(visibleFrame.width * 0.05, 8), 48)
+        let verticalInset = min(max(visibleFrame.height * 0.06, 8), 52)
+        let availableWidth = max(160, visibleFrame.width - horizontalInset * 2)
+        let availableHeight = max(180, visibleFrame.height - verticalInset * 2)
+        let targetWidth = min(max(visibleFrame.width * 0.68, 720), min(980, availableWidth))
+        let targetHeight = min(max(visibleFrame.height * 0.38, 320), min(520, availableHeight))
+        let rawOriginY = visibleFrame.midY - targetHeight / 2 + visibleFrame.height * 0.08
+        let originX = visibleFrame.midX - targetWidth / 2
+        let originY = min(
+            max(rawOriginY, visibleFrame.minY + verticalInset),
+            visibleFrame.maxY - verticalInset - targetHeight
+        )
+        return CGRect(
+            x: originX,
+            y: originY,
+            width: targetWidth,
+            height: targetHeight
+        ).integral
+    }
+}
+
+enum ShellQuickTerminalPeakDismissalReason: Equatable {
+    case hidden
+    case removed
+}
+
+enum ShellQuickTerminalPeakModel {
+    static func tab(for pane: ShellPane) -> ShellTab {
+        ShellTab(
+            tabID: ShellQuickTerminalSlot.globalTabID,
+            kind: .terminal,
+            title: pane.viewport?.title ?? "Quick Terminal",
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(pane.paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: pane.paneID,
+                children: nil
+            )
+        )
+    }
+}
+
+@MainActor
+protocol ShellQuickTerminalPeakWindowing: AnyObject {
+    var onDismissRequest: (() -> Void)? { get set }
+    var isVisible: Bool { get }
+
+    func presentQuickTerminal(
+        host: ShellHostController,
+        pane: ShellPane,
+        tab: ShellTab,
+        placement: ShellQuickTerminalPeakPlacement
+    )
+    func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason)
+    func focusTerminal(paneID: String)
+}
+
+@MainActor
+final class ShellQuickTerminalPeakPresenter {
+    private let host: ShellHostController
+    private let window: ShellQuickTerminalPeakWindowing
+    private let visibleFrameProvider: () -> CGRect
+    private var lastPresentedPaneID: String?
+
+    init(
+        host: ShellHostController,
+        window: ShellQuickTerminalPeakWindowing,
+        visibleFrameProvider: @escaping () -> CGRect = ShellQuickTerminalPeakPlacement.activeVisibleFrame
+    ) {
+        self.host = host
+        self.window = window
+        self.visibleFrameProvider = visibleFrameProvider
+        self.window.onDismissRequest = { [weak host] in
+            _ = host?.hideQuickTerminal()
+        }
+    }
+
+    func synchronize() {
+        guard let slot = host.shellState.quickTerminal,
+              let pane = host.quickTerminalPane
+        else {
+            if window.isVisible || lastPresentedPaneID != nil {
+                window.dismissQuickTerminalPeak(reason: .removed)
+            }
+            lastPresentedPaneID = nil
+            return
+        }
+
+        switch slot.presentation {
+        case .visible:
+            let tab = ShellQuickTerminalPeakModel.tab(for: pane)
+            let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrameProvider())
+            window.presentQuickTerminal(
+                host: host,
+                pane: pane,
+                tab: tab,
+                placement: placement
+            )
+            window.focusTerminal(paneID: pane.paneID)
+            host.terminalRuntimeRegistry.requestFocus(for: pane.paneID)
+            lastPresentedPaneID = pane.paneID
+        case .hidden:
+            if window.isVisible || lastPresentedPaneID != nil {
+                window.dismissQuickTerminalPeak(reason: .hidden)
+            }
+            lastPresentedPaneID = pane.paneID
+        }
+    }
+
+    func windowDidResignKey() {
+        // Terminal-first policy: focus loss is informational and never hides the Peak.
+    }
+}
+
 @MainActor
 struct ShellWindowContext {
     let windowID: String

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -166,16 +166,19 @@ final class ShellQuickTerminalPeakPresenter {
 
         switch slot.presentation {
         case .visible:
-            let tab = ShellQuickTerminalPeakModel.tab(for: pane)
-            let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrameProvider())
-            window.presentQuickTerminal(
-                host: host,
-                pane: pane,
-                tab: tab,
-                placement: placement
-            )
-            window.focusTerminal(paneID: pane.paneID)
-            host.terminalRuntimeRegistry.requestFocus(for: pane.paneID)
+            let shouldActivate = !window.isVisible || lastPresentedPaneID != pane.paneID
+            if shouldActivate {
+                let tab = ShellQuickTerminalPeakModel.tab(for: pane)
+                let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrameProvider())
+                window.presentQuickTerminal(
+                    host: host,
+                    pane: pane,
+                    tab: tab,
+                    placement: placement
+                )
+                window.focusTerminal(paneID: pane.paneID)
+                host.terminalRuntimeRegistry.requestFocus(for: pane.paneID)
+            }
             lastPresentedPaneID = pane.paneID
         case .hidden:
             if window.isVisible || lastPresentedPaneID != nil {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -7,19 +7,22 @@ struct TerminalPaneView: View {
     let spaceID: String?
     let selectedPaneID: String?
     let terminalSurfaceInsets: EdgeInsets
+    let onClosePane: ((ShellPane) -> Void)?
 
     init(
         host: ShellHostController,
         tab: ShellTab? = nil,
         spaceID: String? = nil,
         selectedPaneID: String? = nil,
-        terminalSurfaceInsets: EdgeInsets
+        terminalSurfaceInsets: EdgeInsets,
+        onClosePane: ((ShellPane) -> Void)? = nil
     ) {
         self.host = host
         self.tab = tab
         self.spaceID = spaceID
         self.selectedPaneID = selectedPaneID
         self.terminalSurfaceInsets = terminalSurfaceInsets
+        self.onClosePane = onClosePane
     }
 
     var body: some View {
@@ -34,7 +37,8 @@ struct TerminalPaneView: View {
                 ShellPaneTreeLayoutView(
                     node: paneTree,
                     host: host,
-                    selectedPaneID: displaySelectedPaneID
+                    selectedPaneID: displaySelectedPaneID,
+                    onClosePane: onClosePane
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             } else {
@@ -352,6 +356,31 @@ struct TerminalPaneView: View {
     }
 }
 
+struct ShellQuickTerminalPeakView: View {
+    @ObservedObject var host: ShellHostController
+
+    var body: some View {
+        ZStack {
+            ShellMaterialBackgroundView(.windowBackdrop)
+                .ignoresSafeArea()
+
+            if let pane = host.quickTerminalPane {
+                TerminalPaneView(
+                    host: host,
+                    tab: ShellQuickTerminalPeakModel.tab(for: pane),
+                    spaceID: ShellQuickTerminalSlot.globalSpaceID,
+                    selectedPaneID: pane.paneID,
+                    terminalSurfaceInsets: EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10),
+                    onClosePane: { _ in
+                        _ = host.closeQuickTerminal()
+                    }
+                )
+            }
+        }
+        .frame(minWidth: 520, minHeight: 280)
+    }
+}
+
 private struct ShellTerminalSurfaceFrame: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
@@ -409,6 +438,7 @@ private struct ShellPaneTreeLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
+    let onClosePane: ((ShellPane) -> Void)?
 
     var body: some View {
         switch node.kind {
@@ -428,7 +458,11 @@ private struct ShellPaneTreeLayoutView: View {
                         host.requestCommandInput()
                     },
                     onClosePane: {
-                        host.closePaneByID(pane.paneID)
+                        if let onClosePane {
+                            onClosePane(pane)
+                        } else {
+                            host.closePaneByID(pane.paneID)
+                        }
                     },
                     onRuntimeUpdate: host.updateTerminalRuntime,
                     onMetadataUpdate: { metadata in
@@ -437,7 +471,12 @@ private struct ShellPaneTreeLayoutView: View {
                 )
             }
         case .split:
-            ShellSplitLayoutView(node: node, host: host, selectedPaneID: selectedPaneID)
+            ShellSplitLayoutView(
+                node: node,
+                host: host,
+                selectedPaneID: selectedPaneID,
+                onClosePane: onClosePane
+            )
         }
     }
 }
@@ -446,6 +485,7 @@ private struct ShellSplitLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
+    let onClosePane: ((ShellPane) -> Void)?
     @State private var dragStartRatio: Double?
     @State private var dragPreviewRatio: Double?
 
@@ -461,7 +501,8 @@ private struct ShellSplitLayoutView: View {
                         ShellPaneTreeLayoutView(
                             node: children[0],
                             host: host,
-                            selectedPaneID: selectedPaneID
+                            selectedPaneID: selectedPaneID,
+                            onClosePane: onClosePane
                         )
                             .frame(width: primaryLength(total: proxy.size.width))
                         ShellSplitDividerView(direction: .vertical)
@@ -469,7 +510,8 @@ private struct ShellSplitLayoutView: View {
                         ShellPaneTreeLayoutView(
                             node: children[1],
                             host: host,
-                            selectedPaneID: selectedPaneID
+                            selectedPaneID: selectedPaneID,
+                            onClosePane: onClosePane
                         )
                             .frame(width: secondaryLength(total: proxy.size.width))
                     }
@@ -478,7 +520,8 @@ private struct ShellSplitLayoutView: View {
                         ShellPaneTreeLayoutView(
                             node: children[0],
                             host: host,
-                            selectedPaneID: selectedPaneID
+                            selectedPaneID: selectedPaneID,
+                            onClosePane: onClosePane
                         )
                             .frame(height: primaryLength(total: proxy.size.height))
                         ShellSplitDividerView(direction: .horizontal)
@@ -486,7 +529,8 @@ private struct ShellSplitLayoutView: View {
                         ShellPaneTreeLayoutView(
                             node: children[1],
                             host: host,
-                            selectedPaneID: selectedPaneID
+                            selectedPaneID: selectedPaneID,
+                            onClosePane: onClosePane
                         )
                             .frame(height: secondaryLength(total: proxy.size.height))
                     }
@@ -512,7 +556,8 @@ private struct ShellSplitLayoutView: View {
             ShellPaneTreeLayoutView(
                 node: child,
                 host: host,
-                selectedPaneID: selectedPaneID
+                selectedPaneID: selectedPaneID,
+                onClosePane: onClosePane
             )
         }
     }

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -98,6 +98,25 @@ reject_keydown_programmatic_text_delivery() {
     fi
 }
 
+require_quick_terminal_peak_nonactivating_panel() {
+    local file="clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift"
+
+    reject_pattern \
+        "$file" \
+        "NSApp\\.activate\\(ignoringOtherApps:" \
+        "quick terminal Peak must not activate the whole app when surfacing its detached panel"
+
+    require_pattern \
+        "$file" \
+        "\\.nonactivatingPanel" \
+        "quick terminal Peak panel must be non-activating so it can surface without raising Alan workspace UI"
+
+    require_pattern \
+        "$file" \
+        "orderFrontRegardless\\(\\)" \
+        "quick terminal Peak panel must order itself forward without depending on app activation"
+}
+
 require_title_bar_full_width_hit_area() {
     local file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
 
@@ -294,6 +313,7 @@ require_semantic_terminal_actions_contract() {
 reject_active_shell_radius_drift
 reject_ghosttykit_umbrella_modulemap
 reject_keydown_programmatic_text_delivery
+require_quick_terminal_peak_nonactivating_panel
 require_title_bar_full_width_hit_area
 require_pane_title_bar_trailing_close
 require_active_complex_split_count_contrast

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -31,6 +31,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace()
         verifiesQuickTerminalPeakPresenterShowsDetachedTerminalWindow()
         verifiesQuickTerminalPeakPresenterPreservesRuntimeOnExplicitHide()
+        verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh()
         verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
         verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal()
         verifiesTerminalActivityProjectsByPaneID()
@@ -715,6 +716,26 @@ private enum ShellRuntimeMetadataTests {
             "explicit close must release the peak presentation"
         )
         expect(controller.quickTerminalPane == nil, "explicit close must remove the quick-terminal slot")
+    }
+
+    private static func verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
+
+        _ = controller.showQuickTerminal()
+        presenter.synchronize()
+        controller.updateTerminalMetadata(metadata(title: "regular pane update", cwd: "/repo/app"), for: "pane_1")
+        presenter.synchronize()
+
+        expect(
+            window.presentedPaneIDs == [ShellQuickTerminalSlot.globalPaneID],
+            "visible state refresh must not bring the Peak window forward again"
+        )
+        expect(
+            window.focusedPaneIDs == [ShellQuickTerminalSlot.globalPaneID],
+            "visible state refresh must not repeatedly focus terminal input"
+        )
     }
 
     private static func verifiesQuickTerminalPeakPlacementFitsActiveDisplay() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Darwin
 import Foundation
 
@@ -28,6 +29,10 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalShowCreatesAndReusesGlobalPane()
         verifiesQuickTerminalActionsAndControlCommandsShareControllerPath()
         verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace()
+        verifiesQuickTerminalPeakPresenterShowsDetachedTerminalWindow()
+        verifiesQuickTerminalPeakPresenterPreservesRuntimeOnExplicitHide()
+        verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
+        verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -649,6 +654,85 @@ private enum ShellRuntimeMetadataTests {
             controller.shellState.panes.filter { $0.paneID == ShellQuickTerminalSlot.globalPaneID }.count == 1,
             "promote must move the pane instead of copying the process"
         )
+    }
+
+    private static func verifiesQuickTerminalPeakPresenterShowsDetachedTerminalWindow() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(
+            host: controller,
+            window: window,
+            visibleFrameProvider: {
+                CGRect(x: 80, y: 120, width: 1_440, height: 900)
+            }
+        )
+        let selectedSpaceBefore = controller.selectedSpaceID
+        let selectedTabBefore = controller.selectedTabID
+
+        let paneID = controller.showQuickTerminal()
+        presenter.synchronize()
+
+        expect(paneID == ShellQuickTerminalSlot.globalPaneID, "peak presenter setup must show the global quick pane")
+        expect(window.presentedPaneIDs == [ShellQuickTerminalSlot.globalPaneID], "peak presenter must present the quick pane")
+        expect(window.lastTabID == ShellQuickTerminalSlot.globalTabID, "peak presenter must wrap the quick pane in the quick tab")
+        expect(window.lastPlacement?.requiresMainWindow == false, "peak window must not depend on the main window")
+        expect(window.lastPlacement?.followsActiveSpace == true, "peak window must follow the active macOS Space")
+        expect(window.lastPlacement?.joinsAllSpaces == true, "peak window must be able to appear across macOS Spaces")
+        expect(window.focusedPaneIDs == [ShellQuickTerminalSlot.globalPaneID], "peak presenter must focus terminal input after show")
+        expect(controller.selectedSpaceID == selectedSpaceBefore, "peak presenter must not move the selected Alan space")
+        expect(controller.selectedTabID == selectedTabBefore, "peak presenter must not move the selected Alan tab")
+    }
+
+    private static func verifiesQuickTerminalPeakPresenterPreservesRuntimeOnExplicitHide() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
+
+        _ = controller.showQuickTerminal()
+        presenter.synchronize()
+        presenter.windowDidResignKey()
+
+        expect(
+            controller.quickTerminalPresentation == .visible,
+            "peak focus loss must not hide the quick terminal"
+        )
+        expect(window.dismissalReasons.isEmpty, "peak focus loss must not dismiss the window")
+
+        expect(controller.hideQuickTerminal(), "explicit quick-terminal hide must apply")
+        presenter.synchronize()
+
+        expect(
+            window.dismissalReasons.last == .hidden,
+            "explicit hide must hide the peak without removing the runtime slot"
+        )
+        expect(controller.quickTerminalPane != nil, "explicit hide must preserve the quick-terminal pane")
+
+        expect(controller.closeQuickTerminal(), "explicit quick-terminal close must apply")
+        presenter.synchronize()
+
+        expect(
+            window.dismissalReasons.last == .removed,
+            "explicit close must release the peak presentation"
+        )
+        expect(controller.quickTerminalPane == nil, "explicit close must remove the quick-terminal slot")
+    }
+
+    private static func verifiesQuickTerminalPeakPlacementFitsActiveDisplay() {
+        let visibleFrame = CGRect(x: 20, y: 40, width: 1_280, height: 760)
+        let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrame)
+
+        expect(visibleFrame.contains(placement.frame), "peak frame must fit inside the active display")
+        expect(placement.frame.width >= 720, "normal displays should get a usable terminal width")
+        expect(placement.frame.height >= 320, "normal displays should get a usable terminal height")
+        expect(placement.requiresMainWindow == false, "peak placement must be detached from the main window")
+    }
+
+    private static func verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal() {
+        let policy = ShellQuickTerminalPeakInteractionPolicy.terminalFirst
+
+        expect(policy.escapeKeyBehavior == .terminalInput, "Esc must remain terminal input by default")
+        expect(policy.hidesOnFocusLoss == false, "focus loss must not auto-hide the peak")
+        expect(policy.usesMainWindowParenting == false, "peak must not be parented to the main window")
     }
 
     private static func verifiesTerminalActivityProjectsByPaneID() {
@@ -2991,6 +3075,38 @@ private enum ShellRuntimeMetadataTests {
 
     private static func activeTask(in url: URL) -> ShellTabActiveTaskState? {
         decodeManifest(at: url)?.spaces.first?.tabs.first?.activeTask
+    }
+
+    @MainActor
+    private final class FakeQuickTerminalPeakWindow: ShellQuickTerminalPeakWindowing {
+        var onDismissRequest: (() -> Void)?
+        private(set) var presentedPaneIDs: [String] = []
+        private(set) var focusedPaneIDs: [String] = []
+        private(set) var dismissalReasons: [ShellQuickTerminalPeakDismissalReason] = []
+        private(set) var lastPlacement: ShellQuickTerminalPeakPlacement?
+        private(set) var lastTabID: String?
+        private(set) var isVisible = false
+
+        func presentQuickTerminal(
+            host: ShellHostController,
+            pane: ShellPane,
+            tab: ShellTab,
+            placement: ShellQuickTerminalPeakPlacement
+        ) {
+            isVisible = true
+            presentedPaneIDs.append(pane.paneID)
+            lastTabID = tab.tabID
+            lastPlacement = placement
+        }
+
+        func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason) {
+            isVisible = false
+            dismissalReasons.append(reason)
+        }
+
+        func focusTerminal(paneID: String) {
+            focusedPaneIDs.append(paneID)
+        }
     }
 
     private static func decodeControlCommand(_ json: String) -> AlanShellControlCommand {

--- a/openspec/changes/add-quick-terminal-peak/tasks.md
+++ b/openspec/changes/add-quick-terminal-peak/tasks.md
@@ -10,14 +10,14 @@
 
 ## 2. Peak Presentation
 
-- [ ] 2.1 Present the quick terminal through a detached native macOS Peak window
+- [x] 2.1 Present the quick terminal through a detached native macOS Peak window
   that does not depend on or raise Alan's main window.
-- [ ] 2.2 Keep the Peak composition terminal-first: restrained native material
+- [x] 2.2 Keep the Peak composition terminal-first: restrained native material
   chrome, no duplicate sidebar, no inspector, no dashboard header, and no
   floating-card layout.
-- [ ] 2.3 Preserve terminal input ownership so `Esc` routes to the terminal
+- [x] 2.3 Preserve terminal input ownership so `Esc` routes to the terminal
   unless an Alan-owned nested quick-terminal menu or picker is open.
-- [ ] 2.4 Avoid focus-loss auto-hide; hide is explicit through toggle or command.
+- [x] 2.4 Avoid focus-loss auto-hide; hide is explicit through toggle or command.
 
 ## 3. Runtime Lifecycle And Workspace Promotion
 
@@ -34,15 +34,16 @@
 
 ## 4. Verification
 
-- [ ] 4.1 Add focus, display/Space placement, hide/show, close, promote, and
-  hidden-activity notification tests.
-- [ ] 4.2 Add focused checks for `Esc` terminal routing and focus-loss behavior.
-- [x] 4.3 Run relevant shell model, window, command-routing, and terminal runtime
+- [x] 4.1 Add focus, display/Space placement, hide/show, close, and promote
   tests.
-- [x] 4.4 Run the relevant macOS app build command or document any local blocker.
-- [x] 4.5 Run `openspec validate add-quick-terminal-peak --type change --strict --json`.
-- [x] 4.6 Run `openspec validate --all --strict --json`.
-- [x] 4.7 Run `git diff --check`.
+- [ ] 4.2 Add hidden-activity notification tests.
+- [x] 4.3 Add focused checks for `Esc` terminal routing and focus-loss behavior.
+- [x] 4.4 Run relevant shell model, window, command-routing, and terminal runtime
+  tests.
+- [x] 4.5 Run the relevant macOS app build command or document any local blocker.
+- [x] 4.6 Run `openspec validate add-quick-terminal-peak --type change --strict --json`.
+- [x] 4.7 Run `openspec validate --all --strict --json`.
+- [x] 4.8 Run `git diff --check`.
 
 ## 5. Archive Readiness
 


### PR DESCRIPTION
## Summary
- present the global quick terminal through a detached native macOS Peak panel wired to the shared shell host
- keep Peak composition terminal-first with shared terminal pane rendering and explicit close semantics
- add presenter policy/placement tests for focus, display/Space behavior, hide/close, Esc routing, and focus-loss handling
- mark the completed OpenSpec Peak presentation tasks while leaving hidden activity and archive work pending

## Verification
- ./clients/apple/scripts/test-shell-runtime-metadata.sh
- ./clients/apple/scripts/test-terminal-surface-controller.sh
- ./clients/apple/scripts/test-shell-window-placement.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-quick-terminal-derived build
- openspec validate add-quick-terminal-peak --type change --strict --json
- openspec validate --all --strict --json
- git diff --check