### PR TITLE
Add macOS split pane zoom

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -74,6 +74,12 @@ struct AlanMacShellCommands: Commands {
             }
             .shellActionKeyboardShortcut(host.shellActionShortcut(.paneEqualizeSplits))
 
+            Button(host.shellActionTitle(.paneZoomToggle)) {
+                host.performShellAction(.paneZoomToggle)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.paneZoomToggle))
+            .disabled(!host.shellActionAvailability(.paneZoomToggle).isAvailable)
+
             Divider()
 
             Button(host.shellActionTitle(.paneFocusLeft)) {
@@ -208,6 +214,8 @@ extension ShellActionShortcut {
             return .downArrow
         case "space":
             return .space
+        case "return":
+            return .return
         default:
             guard key.count == 1, let character = key.first else { return nil }
             return KeyEquivalent(character)

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -27,6 +27,7 @@ enum ShellActionID: String, CaseIterable, Identifiable, Hashable {
     case paneFocusUp = "shell.pane.focus_up"
     case paneFocusDown = "shell.pane.focus_down"
     case paneEqualizeSplits = "shell.pane.equalize_splits"
+    case paneZoomToggle = "shell.pane.zoom_toggle"
     case paneClose = "shell.pane.close"
     case findOpen = "shell.find.open"
     case spaceSelectPrevious = "shell.space.select_previous"
@@ -500,6 +501,14 @@ private let standardActions: [ShellActionDescriptor] = [
         effect: .workspaceCommand(.equalizeSplits)
     ),
     ShellActionDescriptor(
+        id: .paneZoomToggle,
+        title: "Zoom / Unzoom Pane",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell),
+        effect: .workspaceCommand(.togglePaneZoom),
+        availability: splitPaneAvailability
+    ),
+    ShellActionDescriptor(
         id: .paneFocusLeft,
         title: "Focus Pane Left",
         targetKind: .pane,
@@ -662,6 +671,29 @@ private func focusedPaneAvailability(
             ? .unavailable(reason: "No focused pane")
             : .available
     }
+}
+
+private func splitPaneAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    let paneID: String?
+    if case .contextPane(let contextPaneID) = target {
+        paneID = contextPaneID
+    } else {
+        paneID = state.focusedPaneID
+    }
+
+    guard let paneID,
+          let pane = state.pane(paneID: paneID),
+          let tab = state.tab(tabID: pane.tabID)
+    else {
+        return .unavailable(reason: "No focused pane")
+    }
+
+    return tab.paneTree.paneIDs.count > 1
+        ? .available
+        : .unavailable(reason: "Pane zoom requires a split tab")
 }
 
 private func selectedTabAvailability(

--- a/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift
@@ -1,4 +1,15 @@
 extension ShellPaneTreeNode {
+    func leafNode(containingPaneID targetPaneID: String) -> ShellPaneTreeNode? {
+        switch kind {
+        case .pane:
+            return paneID == targetPaneID ? self : nil
+        case .split:
+            return (children ?? []).lazy.compactMap {
+                $0.leafNode(containingPaneID: targetPaneID)
+            }.first
+        }
+    }
+
     func resizingSplit(
         _ targetNodeID: String,
         ratio targetRatio: Double

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -111,6 +111,7 @@ enum ShellWorkspaceCommand: String, CaseIterable, Identifiable {
     case focusUp
     case focusDown
     case equalizeSplits
+    case togglePaneZoom
     case closePane
     case closeTab
     case quickTerminalToggle

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -291,6 +291,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var controlPlaneDiagnostics: [String] = []
     @Published private(set) var commandInputRequestID = 0
     @Published private(set) var activityNotifications: [ShellActivityNotificationRoute] = []
+    @Published private(set) var zoomedPaneIDByTabID: [String: String] = [:]
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
     private let appIsActiveProvider: @MainActor () -> Bool
@@ -469,6 +470,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         selectedTab?.paneTree
     }
 
+    var selectedTabZoomedPaneID: String? {
+        guard let selectedTab else { return nil }
+        return zoomedPaneID(in: selectedTab)
+    }
+
     var panesForSelectedTab: [ShellPane] {
         guard let tabID = selectedTab?.tabID else { return [] }
         return shellState.panes.filter { $0.tabID == tabID }
@@ -558,6 +564,68 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     func runtime(for paneID: String?) -> TerminalHostRuntimeSnapshot {
         terminalRuntimeRegistry.snapshot(for: paneID)
+    }
+
+    func displayPaneTree(for tab: ShellTab?) -> ShellPaneTreeNode? {
+        guard let tab else { return nil }
+        guard let zoomedPaneID = zoomedPaneID(in: tab) else {
+            return tab.paneTree
+        }
+        return tab.paneTree.leafNode(containingPaneID: zoomedPaneID) ?? tab.paneTree
+    }
+
+    func isPaneZoomed(_ paneID: String) -> Bool {
+        guard let pane = pane(paneID: paneID) else { return false }
+        return zoomedPaneIDByTabID[pane.tabID] == paneID
+    }
+
+    func canZoomPane(_ paneID: String) -> Bool {
+        guard let pane = pane(paneID: paneID),
+              let tab = shellState.tab(tabID: pane.tabID)
+        else { return false }
+        return tab.paneTree.paneIDs.count > 1
+    }
+
+    @discardableResult
+    func toggleSelectedPaneZoom() -> Bool {
+        guard let paneID = selectedPane?.paneID else { return false }
+        if isPaneZoomed(paneID) {
+            return unzoomTab(containingPaneID: paneID)
+        }
+        return zoomPane(paneID: paneID)
+    }
+
+    @discardableResult
+    func zoomPane(paneID: String) -> Bool {
+        guard canZoomPane(paneID),
+              let pane = pane(paneID: paneID)
+        else {
+            return false
+        }
+        if shellState.focusedPaneID != paneID {
+            focus(paneID: paneID)
+        }
+        zoomedPaneIDByTabID[pane.tabID] = paneID
+        return true
+    }
+
+    @discardableResult
+    func unzoomSelectedTab() -> Bool {
+        guard let tabID = selectedTab?.tabID else { return false }
+        return unzoomTab(tabID: tabID)
+    }
+
+    @discardableResult
+    private func unzoomTab(containingPaneID paneID: String) -> Bool {
+        guard let pane = pane(paneID: paneID) else { return false }
+        return unzoomTab(tabID: pane.tabID)
+    }
+
+    @discardableResult
+    private func unzoomTab(tabID: String) -> Bool {
+        guard zoomedPaneIDByTabID[tabID] != nil else { return false }
+        zoomedPaneIDByTabID.removeValue(forKey: tabID)
+        return true
     }
 
     func select(spaceID: String) {
@@ -1018,6 +1086,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return focusAdjacentPane(direction: .down)
         case .equalizeSplits:
             return equalizeSelectedTabSplits()
+        case .togglePaneZoom:
+            return toggleSelectedPaneZoom()
         case .closePane:
             return closeSelectedPane()
         case .closeTab:
@@ -1762,6 +1832,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             panes: hydratedPanes,
             quickTerminal: state.quickTerminal
         )
+        reconcilePaneZoomState()
         synchronizeSelection()
         if publish {
             publishControlPlaneState()
@@ -1788,6 +1859,46 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         selectedSpaceID = shellState.focusedSpaceID ?? selectedSpaceID ?? shellState.spaces.first?.spaceID
         selectedTabID = shellState.focusedTabID ?? selectedSpace?.tabs.first?.tabID
         terminalRuntime = runtime(for: selectedPane?.paneID)
+    }
+
+    private func zoomedPaneID(in tab: ShellTab) -> String? {
+        guard let paneID = zoomedPaneIDByTabID[tab.tabID],
+              tab.paneTree.contains(paneID: paneID),
+              shellState.pane(paneID: paneID)?.tabID == tab.tabID,
+              tab.paneTree.paneIDs.count > 1
+        else {
+            return nil
+        }
+        return paneID
+    }
+
+    private func reconcilePaneZoomState() {
+        var nextZoomState: [String: String] = [:]
+        let tabsByID = Dictionary(uniqueKeysWithValues: shellState.spaces.flatMap(\.tabs).map {
+            ($0.tabID, $0)
+        })
+
+        for (tabID, paneID) in zoomedPaneIDByTabID {
+            guard let tab = tabsByID[tabID],
+                  tab.paneTree.paneIDs.count > 1,
+                  tab.paneTree.contains(paneID: paneID),
+                  shellState.pane(paneID: paneID)?.tabID == tabID
+            else {
+                continue
+            }
+            nextZoomState[tabID] = paneID
+        }
+
+        if let focusedPane = focusedPane,
+           nextZoomState[focusedPane.tabID] != nil,
+           tabsByID[focusedPane.tabID]?.paneTree.contains(paneID: focusedPane.paneID) == true
+        {
+            nextZoomState[focusedPane.tabID] = focusedPane.paneID
+        }
+
+        if nextZoomState != zoomedPaneIDByTabID {
+            zoomedPaneIDByTabID = nextZoomState
+        }
     }
 
     private func persistShellState() {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -6,6 +6,7 @@ struct TerminalPaneView: View {
     let tab: ShellTab?
     let spaceID: String?
     let selectedPaneID: String?
+    let zoomedPaneID: String?
     let terminalSurfaceInsets: EdgeInsets
     let onClosePane: ((ShellPane) -> Void)?
 
@@ -14,6 +15,7 @@ struct TerminalPaneView: View {
         tab: ShellTab? = nil,
         spaceID: String? = nil,
         selectedPaneID: String? = nil,
+        zoomedPaneID: String? = nil,
         terminalSurfaceInsets: EdgeInsets,
         onClosePane: ((ShellPane) -> Void)? = nil
     ) {
@@ -21,6 +23,7 @@ struct TerminalPaneView: View {
         self.tab = tab
         self.spaceID = spaceID
         self.selectedPaneID = selectedPaneID
+        self.zoomedPaneID = zoomedPaneID
         self.terminalSurfaceInsets = terminalSurfaceInsets
         self.onClosePane = onClosePane
     }
@@ -33,7 +36,7 @@ struct TerminalPaneView: View {
 
     private var paneCanvas: some View {
         Group {
-            if let paneTree = displayTab?.paneTree {
+            if let paneTree = displayPaneTree {
                 ShellPaneTreeLayoutView(
                     node: paneTree,
                     host: host,
@@ -83,6 +86,16 @@ struct TerminalPaneView: View {
 
     private var displaySelectedPaneID: String? {
         selectedPaneID ?? host.selectedPane?.paneID
+    }
+
+    private var displayPaneTree: ShellPaneTreeNode? {
+        guard let tab = displayTab else { return nil }
+        guard let zoomedPaneID,
+              let zoomedLeaf = tab.paneTree.leafNode(containingPaneID: zoomedPaneID)
+        else {
+            return tab.paneTree
+        }
+        return zoomedLeaf
     }
 
     private var runtimeCard: some View {
@@ -449,6 +462,8 @@ private struct ShellPaneTreeLayoutView: View {
                     pane: pane,
                     bootProfile: host.bootProfile(for: pane),
                     isSelected: selectedPaneID == pane.paneID,
+                    isZoomed: host.isPaneZoomed(pane.paneID),
+                    canZoom: host.canZoomPane(pane.paneID),
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     activationDelegate: host,
                     onShellAction: { actionID, target in
@@ -456,6 +471,13 @@ private struct ShellPaneTreeLayoutView: View {
                     },
                     onCommandInput: {
                         host.requestCommandInput()
+                    },
+                    onToggleZoom: {
+                        if host.isPaneZoomed(pane.paneID) {
+                            _ = host.unzoomSelectedTab()
+                        } else {
+                            _ = host.zoomPane(paneID: pane.paneID)
+                        }
                     },
                     onClosePane: {
                         if let onClosePane {
@@ -648,10 +670,13 @@ private struct ShellTerminalLeafView: View {
     let pane: ShellPane
     let bootProfile: AlanShellBootProfile?
     let isSelected: Bool
+    let isZoomed: Bool
+    let canZoom: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onShellAction: (ShellActionID, ShellActionTarget) -> Void
     let onCommandInput: () -> Void
+    let onToggleZoom: () -> Void
     let onClosePane: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
@@ -662,9 +687,12 @@ private struct ShellTerminalLeafView: View {
                 title: shellPaneTitleBarTitle(for: pane),
                 pane: pane,
                 isSelected: isSelected,
+                isZoomed: isZoomed,
+                canZoom: canZoom,
                 onFocusPane: {
                     activationDelegate?.terminalHostDidRequestActivation(paneID: pane.paneID)
                 },
+                onToggleZoom: onToggleZoom,
                 onClosePane: onClosePane
             )
 
@@ -761,7 +789,10 @@ private struct ShellPaneTitleBarView: View {
     let title: String
     let pane: ShellPane
     let isSelected: Bool
+    let isZoomed: Bool
+    let canZoom: Bool
     let onFocusPane: () -> Void
+    let onToggleZoom: () -> Void
     let onClosePane: () -> Void
     @State private var activityFreshnessNow = Date()
 
@@ -802,6 +833,10 @@ private struct ShellPaneTitleBarView: View {
             }
 
             Spacer(minLength: 0)
+
+            if canZoom {
+                zoomButton
+            }
 
             closeButton
         }
@@ -845,6 +880,28 @@ private struct ShellPaneTitleBarView: View {
         .fixedSize(horizontal: true, vertical: true)
         .help("Close pane")
         .accessibilityLabel("Close pane")
+    }
+
+    private var zoomButton: some View {
+        Button(action: onToggleZoom) {
+            Image(systemName: isZoomed ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.closeSize,
+                        weight: ShellPaneTitleTypography.closeWeight
+                    )
+                )
+                .foregroundStyle(Color.white.opacity(isSelected ? 0.70 : 0.54))
+                .frame(
+                    width: ShellPaneTitleBarMetrics.closeButtonSize,
+                    height: ShellPaneTitleBarMetrics.closeButtonSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: true)
+        .help(isZoomed ? "Unzoom pane" : "Zoom pane")
+        .accessibilityLabel(isZoomed ? "Unzoom pane" : "Zoom pane")
     }
 
     private var activityFreshnessRefreshID: String {

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -721,6 +721,8 @@ final class AlanTerminalInputRouter {
             return "downArrow"
         case 0x31:
             return "space"
+        case 0x24, 0x4C:
+            return "return"
         default:
             break
         }

--- a/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
@@ -13,6 +13,7 @@ private enum ShellCommandInputAction: CaseIterable {
     case focusUp
     case focusDown
     case equalizeSplits
+    case zoomPane
     case closePane
     case closeTab
     case quickTerminalToggle
@@ -50,6 +51,8 @@ private enum ShellCommandInputAction: CaseIterable {
             return ["focus down", "focus pane down", "pane down"]
         case .equalizeSplits:
             return ["equalize splits", "balance splits", "reset splits"]
+        case .zoomPane:
+            return ["zoom pane", "unzoom pane", "toggle pane zoom", "zoom split"]
         case .closePane:
             return ["close pane", "close focused pane"]
         case .closeTab:
@@ -240,6 +243,8 @@ struct ShellCommandTabView: View {
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.focusDown)
         case .equalizeSplits:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.equalizeSplits)
+        case .zoomPane:
+            host.performShellWorkspaceCommand(ShellWorkspaceCommand.togglePaneZoom)
         case .closePane:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.closePane)
         case .closeTab:

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -11,6 +11,7 @@ struct ShellWorkspaceView: View {
             tab: host.selectedTab,
             spaceID: host.selectedSpace?.spaceID,
             selectedPaneID: host.selectedPane?.paneID,
+            zoomedPaneID: host.selectedTabZoomedPaneID,
             terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
                 expandedSidebarProgress: expandedSidebarProgress
             )

--- a/clients/apple/scripts/test-shell-action-registry.swift
+++ b/clients/apple/scripts/test-shell-action-registry.swift
@@ -21,6 +21,7 @@ private enum ShellActionRegistryTests {
         try verifiesCommandInputRemainsOutOfRegistry()
         try verifiesQuickTerminalActionsRouteThroughSharedRegistry()
         try verifiesQuickTerminalPromoteRequiresExplicitDestination()
+        try verifiesPaneZoomRoutesThroughSharedRegistry()
         print("Shell action registry tests passed.")
     }
 
@@ -72,6 +73,7 @@ private enum ShellActionRegistryTests {
                 ShellActionShortcut(key: "d", modifiers: [.command, .option, .shift], context: .shell)
             ),
             (.paneEqualizeSplits, ShellActionShortcut(key: "=", modifiers: [.command, .option], context: .shell)),
+            (.paneZoomToggle, ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell)),
             (
                 .paneFocusRight,
                 ShellActionShortcut(key: "rightArrow", modifiers: [.command, .control], context: .shell)
@@ -130,6 +132,12 @@ private enum ShellActionRegistryTests {
                 for: ShellActionShortcut(key: "2", modifiers: [.command, .option], context: .shell)
             ) == ShellKeyboardAction(id: .spaceSelectByIndex, target: .spaceIndex(1)),
             "command-option-2 must resolve to dynamic second-space selection"
+        )
+        expect(
+            registry.keyboardAction(
+                for: ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell)
+            ) == ShellKeyboardAction(id: .paneZoomToggle, target: .currentSelection),
+            "command-shift-return must resolve to pane zoom toggle"
         )
     }
 
@@ -386,6 +394,31 @@ private enum ShellActionRegistryTests {
         expect(
             handledEffects == [.promoteQuickTerminal(spaceID: "space_2")],
             "quick terminal promotion must route the selected destination to the handler"
+        )
+    }
+
+    private static func verifiesPaneZoomRoutesThroughSharedRegistry() throws {
+        let registry = ShellActionRegistry.standard
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        let unavailable = registry.execute(.paneZoomToggle, target: .currentSelection, state: state) { _ in
+            true
+        }
+        expect(
+            unavailable == .unavailable(reason: "Pane zoom requires a split tab"),
+            "pane zoom must require a split tab"
+        )
+
+        state = try state.splittingPane("pane_1", placement: .right).state
+        var handledEffects: [ShellActionEffect] = []
+        let result = registry.execute(.paneZoomToggle, target: .currentSelection, state: state) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(result == .executed, "pane zoom must execute when a split pane is focused")
+        expect(
+            handledEffects == [.workspaceCommand(.togglePaneZoom)],
+            "pane zoom must route through the shared workspace command path"
         )
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -34,6 +34,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh()
         verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
         verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal()
+        verifiesSplitZoomLeavesCanonicalTreeAndKeepsSiblingRuntimes()
+        verifiesSplitZoomIsTabScopedAndPrunedWhenPaneDisappears()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -755,6 +757,63 @@ private enum ShellRuntimeMetadataTests {
         expect(policy.escapeKeyBehavior == .terminalInput, "Esc must remain terminal input by default")
         expect(policy.hidesOnFocusLoss == false, "focus loss must not auto-hide the peak")
         expect(policy.usesMainWindowParenting == false, "peak must not be parented to the main window")
+    }
+
+    private static func verifiesSplitZoomLeavesCanonicalTreeAndKeepsSiblingRuntimes() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        guard let tab = controller.selectedTab else {
+            fail("test setup must keep a selected tab")
+        }
+        let canonicalTree = tab.paneTree
+        _ = controller.terminalRuntimeRegistry.surfaceHandle(
+            for: controller.pane(paneID: "pane_1"),
+            bootProfile: controller.bootProfile(for: controller.pane(paneID: "pane_1"))
+        )
+        _ = controller.terminalRuntimeRegistry.surfaceHandle(
+            for: controller.pane(paneID: "pane_2"),
+            bootProfile: controller.bootProfile(for: controller.pane(paneID: "pane_2"))
+        )
+
+        expect(controller.zoomPane(paneID: "pane_1"), "zoom must accept a split pane")
+        expect(controller.selectedTabZoomedPaneID == "pane_1", "zoom state must be tab scoped")
+        expect(
+            controller.displayPaneTree(for: controller.selectedTab)?.paneIDs == ["pane_1"],
+            "zoomed display tree must project only the zoomed pane"
+        )
+        expect(
+            controller.selectedTab?.paneTree == canonicalTree,
+            "zoom must leave the canonical split tree unchanged"
+        )
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.isSuperset(of: ["pane_1", "pane_2"]),
+            "zoom must not release sibling terminal runtimes"
+        )
+
+        expect(controller.unzoomSelectedTab(), "unzoom must clear the selected tab zoom state")
+        expect(
+            controller.displayPaneTree(for: controller.selectedTab)?.paneIDs == canonicalTree.paneIDs,
+            "unzoom must restore the displayed split tree"
+        )
+    }
+
+    private static func verifiesSplitZoomIsTabScopedAndPrunedWhenPaneDisappears() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let firstTabID = controller.selectedTabID
+        expect(controller.zoomPane(paneID: "pane_1"), "test setup must zoom the first split tab")
+        let secondTabID = controller.openTerminalTab(in: controller.selectedSpaceID)
+        expect(secondTabID != nil, "test setup must open a second tab")
+
+        expect(controller.selectedTabID == secondTabID, "opening a tab must select it")
+        expect(controller.selectedTabZoomedPaneID == nil, "zoom state must not leak to another tab")
+        if let firstTabID {
+            controller.select(tabID: firstTabID)
+        }
+        expect(controller.selectedTabZoomedPaneID == "pane_1", "zoom state must remain attached to its tab")
+
+        _ = controller.closePane(paneID: "pane_1")
+        expect(controller.selectedTabZoomedPaneID == nil, "closing the zoomed pane must prune zoom state")
     }
 
     private static func verifiesTerminalActivityProjectsByPaneID() {

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -13,6 +13,7 @@ private enum ShellSplitModelTests {
         try verifiesDirectionalSplitsPlaceNewPaneOnRequestedSide()
         try verifiesSplitRatiosClampWhenResized()
         try verifiesEqualizeRestoresEverySplitRatio()
+        try verifiesZoomProjectionUsesLeafWithoutMutatingSplitTree()
         try verifiesSameDirectionAttachKeepsBinarySplitTree()
         try verifiesSidebarSplitTopologyProjection()
         try verifiesSpatialFocusFollowsSplitTree()
@@ -87,6 +88,21 @@ private enum ShellSplitModelTests {
         expect(
             equalizedRatio == 0.5,
             "equalize must restore the tab's root split ratio"
+        )
+    }
+
+    private static func verifiesZoomProjectionUsesLeafWithoutMutatingSplitTree() throws {
+        let base = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        let split = try base.splittingPane("pane_1", placement: .right).state
+        let tree = try requireFocusedTabTree(split)
+        let zoomedLeaf = try require(tree.leafNode(containingPaneID: "pane_2"), "zoom leaf missing")
+
+        expect(zoomedLeaf.kind == .pane, "zoom projection must display a single pane leaf")
+        expect(zoomedLeaf.paneID == "pane_2", "zoom projection must display the requested pane")
+        let treeAfterProjection = try requireFocusedTabTree(split)
+        expect(
+            treeAfterProjection == tree,
+            "zoom projection must not mutate the canonical split tree"
         )
     }
 
@@ -431,6 +447,13 @@ private enum ShellSplitModelTests {
             throw TestFailure("focused tab missing")
         }
         return tab.paneTree
+    }
+
+    private static func require<T>(_ value: T?, _ message: String) throws -> T {
+        guard let value else {
+            throw TestFailure(message)
+        }
+        return value
     }
 
     private static func summary(

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -236,6 +236,21 @@ private enum TerminalSurfaceControllerTests {
             focusRight == .shellAction(.paneFocusRight, .currentSelection),
             "command-control-right must route to registered shell focus right"
         )
+
+        let paneZoom = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: "\r",
+                keyCode: 0x24,
+                modifiers: [.command, .shift],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            paneZoom == .shellAction(.paneZoomToggle, .currentSelection),
+            "command-shift-return must route to registered pane zoom before terminal bindings"
+        )
     }
 
     private static func verifiesRegistryBackedShellShortcuts() {

--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Split Zoom
 
-- [ ] 1.1 Add tab-scoped zoom state that leaves the canonical split tree unchanged.
-- [ ] 1.2 Render zoomed PaneSlots full-area while keeping sibling terminal ContentInstance runtimes registered and restorable.
-- [ ] 1.3 Add menu, keyboard, command UI, and compact visible affordances for zoom and unzoom.
-- [ ] 1.4 Add model/UI tests for zoom, unzoom, disappearing panes, and selected-tab changes.
+- [x] 1.1 Add tab-scoped zoom state that leaves the canonical split tree unchanged.
+- [x] 1.2 Render zoomed PaneSlots full-area while keeping sibling terminal ContentInstance runtimes registered and restorable.
+- [x] 1.3 Add menu, keyboard, command UI, and compact visible affordances for zoom and unzoom.
+- [x] 1.4 Add model/UI tests for zoom, unzoom, disappearing panes, and selected-tab changes.
 
 ## 2. Pane Movement
 


### PR DESCRIPTION
## Summary
- implement the first Split Zoom phase of complete-macos-shell-advanced-splits
- add tab-scoped pane zoom state without mutating the canonical split tree
- render zoomed panes full-area and add menu, keyboard, command input, and pane-title affordances
- add regression coverage for zoom projection, tab scoping, pruning, runtime preservation, and action routing

## Verification
- clients/apple/scripts/test-shell-split-model.sh
- clients/apple/scripts/test-shell-runtime-metadata.sh
- clients/apple/scripts/test-shell-action-registry.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate complete-macos-shell-advanced-splits --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-next-openspec-derived build