### PR TITLE
Add macOS in-tab pane movement

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -82,6 +82,32 @@ struct AlanMacShellCommands: Commands {
 
             Divider()
 
+            Button(host.shellActionTitle(.paneMoveLeft)) {
+                host.performShellAction(.paneMoveLeft)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.paneMoveLeft))
+            .disabled(!host.shellActionAvailability(.paneMoveLeft).isAvailable)
+
+            Button(host.shellActionTitle(.paneMoveRight)) {
+                host.performShellAction(.paneMoveRight)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.paneMoveRight))
+            .disabled(!host.shellActionAvailability(.paneMoveRight).isAvailable)
+
+            Button(host.shellActionTitle(.paneMoveUp)) {
+                host.performShellAction(.paneMoveUp)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.paneMoveUp))
+            .disabled(!host.shellActionAvailability(.paneMoveUp).isAvailable)
+
+            Button(host.shellActionTitle(.paneMoveDown)) {
+                host.performShellAction(.paneMoveDown)
+            }
+            .shellActionKeyboardShortcut(host.shellActionShortcut(.paneMoveDown))
+            .disabled(!host.shellActionAvailability(.paneMoveDown).isAvailable)
+
+            Divider()
+
             Button(host.shellActionTitle(.paneFocusLeft)) {
                 host.performShellAction(.paneFocusLeft)
             }

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -28,6 +28,10 @@ enum ShellActionID: String, CaseIterable, Identifiable, Hashable {
     case paneFocusDown = "shell.pane.focus_down"
     case paneEqualizeSplits = "shell.pane.equalize_splits"
     case paneZoomToggle = "shell.pane.zoom_toggle"
+    case paneMoveLeft = "shell.pane.move_left"
+    case paneMoveRight = "shell.pane.move_right"
+    case paneMoveUp = "shell.pane.move_up"
+    case paneMoveDown = "shell.pane.move_down"
     case paneClose = "shell.pane.close"
     case findOpen = "shell.find.open"
     case spaceSelectPrevious = "shell.space.select_previous"
@@ -124,6 +128,7 @@ enum ShellActionEffect: Equatable {
     case updatePinnedTab(String?)
     case moveTab(String?, offset: Int)
     case moveTabToSpace(tabID: String?, spaceID: String?)
+    case movePaneInTab(String?, placement: ShellPaneSplitDirection)
     case promoteQuickTerminal(spaceID: String?)
     case disabledPlaceholder
 }
@@ -369,6 +374,11 @@ final class ShellActionRegistry {
                 return .moveTabToSpace(tabID: tabID, spaceID: spaceID)
             }
             return .moveTabToSpace(tabID: nil, spaceID: nil)
+        case .movePaneInTab(_, let placement):
+            if case .pane(let paneID) = resolvedTarget {
+                return .movePaneInTab(paneID, placement: placement)
+            }
+            return .movePaneInTab(nil, placement: placement)
         case .promoteQuickTerminal:
             if case .space(let spaceID) = resolvedTarget {
                 return .promoteQuickTerminal(spaceID: spaceID)
@@ -507,6 +517,54 @@ private let standardActions: [ShellActionDescriptor] = [
         defaultShortcut: ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell),
         effect: .workspaceCommand(.togglePaneZoom),
         availability: splitPaneAvailability
+    ),
+    ShellActionDescriptor(
+        id: .paneMoveLeft,
+        title: "Move Pane Left",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(
+            key: "leftArrow",
+            modifiers: [.command, .control, .shift],
+            context: .shell
+        ),
+        effect: .movePaneInTab(nil, placement: .left),
+        availability: paneMovementAvailability(.left)
+    ),
+    ShellActionDescriptor(
+        id: .paneMoveRight,
+        title: "Move Pane Right",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(
+            key: "rightArrow",
+            modifiers: [.command, .control, .shift],
+            context: .shell
+        ),
+        effect: .movePaneInTab(nil, placement: .right),
+        availability: paneMovementAvailability(.right)
+    ),
+    ShellActionDescriptor(
+        id: .paneMoveUp,
+        title: "Move Pane Up",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(
+            key: "upArrow",
+            modifiers: [.command, .control, .shift],
+            context: .shell
+        ),
+        effect: .movePaneInTab(nil, placement: .up),
+        availability: paneMovementAvailability(.up)
+    ),
+    ShellActionDescriptor(
+        id: .paneMoveDown,
+        title: "Move Pane Down",
+        targetKind: .pane,
+        defaultShortcut: ShellActionShortcut(
+            key: "downArrow",
+            modifiers: [.command, .control, .shift],
+            context: .shell
+        ),
+        effect: .movePaneInTab(nil, placement: .down),
+        availability: paneMovementAvailability(.down)
     ),
     ShellActionDescriptor(
         id: .paneFocusLeft,
@@ -694,6 +752,39 @@ private func splitPaneAvailability(
     return tab.paneTree.paneIDs.count > 1
         ? .available
         : .unavailable(reason: "Pane zoom requires a split tab")
+}
+
+private func paneMovementAvailability(
+    _ placement: ShellPaneSplitDirection
+) -> (ShellStateSnapshot, ShellActionTarget) -> ShellActionAvailability {
+    { state, target in
+        let paneID: String?
+        if case .contextPane(let contextPaneID) = target {
+            paneID = contextPaneID
+        } else {
+            paneID = state.focusedPaneID
+        }
+
+        guard let paneID,
+              let pane = state.pane(paneID: paneID),
+              let tab = state.tab(tabID: pane.tabID)
+        else {
+            return .unavailable(reason: "No focused pane")
+        }
+
+        guard tab.paneTree.paneIDs.count > 1 else {
+            return .unavailable(reason: "Pane movement requires a split tab")
+        }
+
+        guard tab.paneTree.adjacentPaneID(
+            from: paneID,
+            direction: placement.spatialFocusDirection
+        ) != nil else {
+            return .unavailable(reason: "No adjacent pane in that direction")
+        }
+
+        return .available
+    }
 }
 
 private func selectedTabAvailability(

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -996,6 +996,78 @@ extension ShellStateSnapshot {
         )
     }
 
+    func movingPaneWithinTab(
+        _ paneID: String,
+        placement: ShellPaneSplitDirection
+    ) throws -> ShellStateMutationResult {
+        guard let pane = pane(paneID: paneID),
+              let tab = tab(tabID: pane.tabID)
+        else {
+            throw ShellStateMutationError.paneNotFound
+        }
+
+        guard tab.paneTree.paneIDs.count > 1 else {
+            throw ShellStateMutationError.invalidMoveTarget
+        }
+
+        guard let targetPaneID = tab.paneTree.adjacentPaneID(
+            from: paneID,
+            direction: placement.spatialFocusDirection
+        ),
+        targetPaneID != paneID
+        else {
+            throw ShellStateMutationError.invalidMoveTarget
+        }
+
+        guard let treeWithoutMovedPane = tab.paneTree.removingPane(paneID),
+              treeWithoutMovedPane.paneIDs.contains(targetPaneID)
+        else {
+            throw ShellStateMutationError.invalidMoveTarget
+        }
+
+        let newSplitNodeID = nextID(
+            prefix: "node",
+            existing: spaces.flatMap { $0.tabs.flatMap { $0.paneTree.nodeIDs } }
+        )
+        let movedLeafNodeID = "node_\(paneID)_moved_in_tab"
+        let movedTree = treeWithoutMovedPane.splittingPane(
+            targetPaneID,
+            placement: placement,
+            splitNodeID: newSplitNodeID,
+            newLeafNodeID: movedLeafNodeID,
+            newPaneID: paneID
+        )
+        let updatedTab = ShellTab(
+            tabID: tab.tabID,
+            kind: tab.kind,
+            title: tab.title,
+            paneTree: movedTree,
+            isPinned: tab.isPinned
+        )
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == pane.spaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs.map { existingTab in
+                    existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
+                }
+            )
+        }
+
+        return ShellStateMutationResult(
+            state: replacing(
+                spaces: rebuildingAttention(in: nextSpaces, panes: panes),
+                panes: panes,
+                focusedPaneID: paneID
+            ),
+            spaceID: pane.spaceID,
+            tabID: pane.tabID,
+            paneID: paneID
+        )
+    }
+
     func organizingTab(
         tabID: String,
         targetSpaceID requestedTargetSpaceID: String? = nil,

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -64,6 +64,19 @@ enum ShellPaneSplitDirection: String, Codable, CaseIterable {
         }
     }
 
+    var spatialFocusDirection: ShellSpatialFocusDirection {
+        switch self {
+        case .left:
+            return .left
+        case .right:
+            return .right
+        case .up:
+            return .up
+        case .down:
+            return .down
+        }
+    }
+
     static func defaultPlacement(for splitDirection: ShellSplitDirection) -> ShellPaneSplitDirection {
         switch splitDirection {
         case .horizontal:
@@ -112,6 +125,10 @@ enum ShellWorkspaceCommand: String, CaseIterable, Identifiable {
     case focusDown
     case equalizeSplits
     case togglePaneZoom
+    case movePaneLeft
+    case movePaneRight
+    case movePaneUp
+    case movePaneDown
     case closePane
     case closeTab
     case quickTerminalToggle

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -33,6 +33,25 @@ enum ShellPaneLiftResult {
     case lastPane
 }
 
+enum ShellPaneMovementInputSource: Equatable {
+    case explicitCommand
+    case titleBarDragAffordance
+    case terminalContentDrag
+}
+
+struct ShellPaneMovementInteractionPolicy: Equatable {
+    static let terminalSelectionFirst = ShellPaneMovementInteractionPolicy()
+
+    func allowsPaneMovement(from source: ShellPaneMovementInputSource) -> Bool {
+        switch source {
+        case .explicitCommand, .titleBarDragAffordance:
+            return true
+        case .terminalContentDrag:
+            return false
+        }
+    }
+}
+
 enum ShellQuickTerminalPeakEscapeBehavior: Equatable {
     case terminalInput
 }
@@ -1088,6 +1107,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return equalizeSelectedTabSplits()
         case .togglePaneZoom:
             return toggleSelectedPaneZoom()
+        case .movePaneLeft:
+            return moveSelectedPaneWithinTab(.left)
+        case .movePaneRight:
+            return moveSelectedPaneWithinTab(.right)
+        case .movePaneUp:
+            return moveSelectedPaneWithinTab(.up)
+        case .movePaneDown:
+            return moveSelectedPaneWithinTab(.down)
         case .closePane:
             return closeSelectedPane()
         case .closeTab:
@@ -1171,6 +1198,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .moveTabToSpace(let tabID, let spaceID):
             guard let tabID, let spaceID else { return false }
             return moveTabToSpace(tabID: tabID, targetSpaceID: spaceID)
+        case .movePaneInTab(let paneID, let placement):
+            guard let paneID else { return false }
+            return movePaneWithinTab(paneID: paneID, placement: placement)
         case .promoteQuickTerminal(let spaceID):
             guard let spaceID else { return false }
             return promoteQuickTerminal(to: spaceID)
@@ -1233,6 +1263,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     ) -> Bool {
         guard let paneID = selectedPane?.paneID else { return false }
         return movePane(paneID: paneID, toTab: tabID, direction: direction)
+    }
+
+    @discardableResult
+    func moveSelectedPaneWithinTab(_ placement: ShellPaneSplitDirection) -> Bool {
+        guard let paneID = selectedPane?.paneID else { return false }
+        return movePaneWithinTab(paneID: paneID, placement: placement)
     }
 
     @discardableResult
@@ -2247,6 +2283,40 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 paneID,
                 toTab: targetTabID,
                 direction: direction
+            )
+            applyMutationResult(result)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func movePaneWithinTab(
+        paneID: String,
+        placement: ShellPaneSplitDirection
+    ) -> Bool {
+        movePaneWithinTab(
+            paneID: paneID,
+            placement: placement,
+            source: .explicitCommand
+        )
+    }
+
+    func movePaneWithinTab(
+        paneID: String,
+        placement: ShellPaneSplitDirection,
+        source: ShellPaneMovementInputSource
+    ) -> Bool {
+        guard ShellPaneMovementInteractionPolicy.terminalSelectionFirst
+            .allowsPaneMovement(from: source)
+        else {
+            return false
+        }
+
+        do {
+            let result = try shellState.movingPaneWithinTab(
+                paneID,
+                placement: placement
             )
             applyMutationResult(result)
             return true

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -464,6 +464,12 @@ private struct ShellPaneTreeLayoutView: View {
                     isSelected: selectedPaneID == pane.paneID,
                     isZoomed: host.isPaneZoomed(pane.paneID),
                     canZoom: host.canZoomPane(pane.paneID),
+                    canMovePane: { placement in
+                        host.shellActionAvailability(
+                            paneMoveActionID(for: placement),
+                            target: .contextPane(pane.paneID)
+                        ).isAvailable
+                    },
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     activationDelegate: host,
                     onShellAction: { actionID, target in
@@ -478,6 +484,12 @@ private struct ShellPaneTreeLayoutView: View {
                         } else {
                             _ = host.zoomPane(paneID: pane.paneID)
                         }
+                    },
+                    onMovePane: { placement in
+                        host.performShellAction(
+                            paneMoveActionID(for: placement),
+                            target: .contextPane(pane.paneID)
+                        )
                     },
                     onClosePane: {
                         if let onClosePane {
@@ -672,11 +684,13 @@ private struct ShellTerminalLeafView: View {
     let isSelected: Bool
     let isZoomed: Bool
     let canZoom: Bool
+    let canMovePane: (ShellPaneSplitDirection) -> Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onShellAction: (ShellActionID, ShellActionTarget) -> Void
     let onCommandInput: () -> Void
     let onToggleZoom: () -> Void
+    let onMovePane: (ShellPaneSplitDirection) -> Void
     let onClosePane: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
@@ -689,10 +703,12 @@ private struct ShellTerminalLeafView: View {
                 isSelected: isSelected,
                 isZoomed: isZoomed,
                 canZoom: canZoom,
+                canMovePane: canMovePane,
                 onFocusPane: {
                     activationDelegate?.terminalHostDidRequestActivation(paneID: pane.paneID)
                 },
                 onToggleZoom: onToggleZoom,
+                onMovePane: onMovePane,
                 onClosePane: onClosePane
             )
 
@@ -748,6 +764,19 @@ private struct ShellTerminalLeafView: View {
     }
 }
 
+private func paneMoveActionID(for placement: ShellPaneSplitDirection) -> ShellActionID {
+    switch placement {
+    case .left:
+        return .paneMoveLeft
+    case .right:
+        return .paneMoveRight
+    case .up:
+        return .paneMoveUp
+    case .down:
+        return .paneMoveDown
+    }
+}
+
 private enum ShellPaneTitleTypography {
     static let titleSize: CGFloat = 11
     static let accessorySize: CGFloat = 10
@@ -791,8 +820,10 @@ private struct ShellPaneTitleBarView: View {
     let isSelected: Bool
     let isZoomed: Bool
     let canZoom: Bool
+    let canMovePane: (ShellPaneSplitDirection) -> Bool
     let onFocusPane: () -> Void
     let onToggleZoom: () -> Void
+    let onMovePane: (ShellPaneSplitDirection) -> Void
     let onClosePane: () -> Void
     @State private var activityFreshnessNow = Date()
 
@@ -809,6 +840,27 @@ private struct ShellPaneTitleBarView: View {
         .background(ShellPalette.terminal)
         .contentShape(Rectangle())
         .onTapGesture(perform: onFocusPane)
+        .contextMenu {
+            Button("Move Pane Left") {
+                onMovePane(.left)
+            }
+            .disabled(!canMovePane(.left))
+
+            Button("Move Pane Right") {
+                onMovePane(.right)
+            }
+            .disabled(!canMovePane(.right))
+
+            Button("Move Pane Up") {
+                onMovePane(.up)
+            }
+            .disabled(!canMovePane(.up))
+
+            Button("Move Pane Down") {
+                onMovePane(.down)
+            }
+            .disabled(!canMovePane(.down))
+        }
         .task(id: activityFreshnessRefreshID) {
             await scheduleActivityFreshnessRefresh()
         }

--- a/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
@@ -14,6 +14,10 @@ private enum ShellCommandInputAction: CaseIterable {
     case focusDown
     case equalizeSplits
     case zoomPane
+    case movePaneLeft
+    case movePaneRight
+    case movePaneUp
+    case movePaneDown
     case closePane
     case closeTab
     case quickTerminalToggle
@@ -53,6 +57,14 @@ private enum ShellCommandInputAction: CaseIterable {
             return ["equalize splits", "balance splits", "reset splits"]
         case .zoomPane:
             return ["zoom pane", "unzoom pane", "toggle pane zoom", "zoom split"]
+        case .movePaneLeft:
+            return ["move pane left", "move split left"]
+        case .movePaneRight:
+            return ["move pane right", "move split right"]
+        case .movePaneUp:
+            return ["move pane up", "move split up"]
+        case .movePaneDown:
+            return ["move pane down", "move split down"]
         case .closePane:
             return ["close pane", "close focused pane"]
         case .closeTab:
@@ -245,6 +257,14 @@ struct ShellCommandTabView: View {
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.equalizeSplits)
         case .zoomPane:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.togglePaneZoom)
+        case .movePaneLeft:
+            host.performShellAction(.paneMoveLeft)
+        case .movePaneRight:
+            host.performShellAction(.paneMoveRight)
+        case .movePaneUp:
+            host.performShellAction(.paneMoveUp)
+        case .movePaneDown:
+            host.performShellAction(.paneMoveDown)
         case .closePane:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.closePane)
         case .closeTab:

--- a/clients/apple/scripts/test-shell-action-registry.swift
+++ b/clients/apple/scripts/test-shell-action-registry.swift
@@ -22,6 +22,7 @@ private enum ShellActionRegistryTests {
         try verifiesQuickTerminalActionsRouteThroughSharedRegistry()
         try verifiesQuickTerminalPromoteRequiresExplicitDestination()
         try verifiesPaneZoomRoutesThroughSharedRegistry()
+        try verifiesPaneMovementRoutesThroughSharedRegistry()
         print("Shell action registry tests passed.")
     }
 
@@ -74,6 +75,38 @@ private enum ShellActionRegistryTests {
             ),
             (.paneEqualizeSplits, ShellActionShortcut(key: "=", modifiers: [.command, .option], context: .shell)),
             (.paneZoomToggle, ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell)),
+            (
+                .paneMoveLeft,
+                ShellActionShortcut(
+                    key: "leftArrow",
+                    modifiers: [.command, .control, .shift],
+                    context: .shell
+                )
+            ),
+            (
+                .paneMoveRight,
+                ShellActionShortcut(
+                    key: "rightArrow",
+                    modifiers: [.command, .control, .shift],
+                    context: .shell
+                )
+            ),
+            (
+                .paneMoveUp,
+                ShellActionShortcut(
+                    key: "upArrow",
+                    modifiers: [.command, .control, .shift],
+                    context: .shell
+                )
+            ),
+            (
+                .paneMoveDown,
+                ShellActionShortcut(
+                    key: "downArrow",
+                    modifiers: [.command, .control, .shift],
+                    context: .shell
+                )
+            ),
             (
                 .paneFocusRight,
                 ShellActionShortcut(key: "rightArrow", modifiers: [.command, .control], context: .shell)
@@ -138,6 +171,16 @@ private enum ShellActionRegistryTests {
                 for: ShellActionShortcut(key: "return", modifiers: [.command, .shift], context: .shell)
             ) == ShellKeyboardAction(id: .paneZoomToggle, target: .currentSelection),
             "command-shift-return must resolve to pane zoom toggle"
+        )
+        expect(
+            registry.keyboardAction(
+                for: ShellActionShortcut(
+                    key: "leftArrow",
+                    modifiers: [.command, .control, .shift],
+                    context: .shell
+                )
+            ) == ShellKeyboardAction(id: .paneMoveLeft, target: .currentSelection),
+            "command-control-shift-left must resolve to pane movement"
         )
     }
 
@@ -419,6 +462,32 @@ private enum ShellActionRegistryTests {
         expect(
             handledEffects == [.workspaceCommand(.togglePaneZoom)],
             "pane zoom must route through the shared workspace command path"
+        )
+    }
+
+    private static func verifiesPaneMovementRoutesThroughSharedRegistry() throws {
+        let registry = ShellActionRegistry.standard
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+
+        let unavailable = registry.execute(.paneMoveRight, target: .currentSelection, state: state) { _ in
+            true
+        }
+        expect(
+            unavailable == .unavailable(reason: "No adjacent pane in that direction"),
+            "pane movement must require an adjacent in-tab destination"
+        )
+
+        var handledEffects: [ShellActionEffect] = []
+        let result = registry.execute(.paneMoveLeft, target: .currentSelection, state: state) { effect in
+            handledEffects.append(effect)
+            return true
+        }
+
+        expect(result == .executed, "pane movement must execute when an adjacent pane exists")
+        expect(
+            handledEffects == [.movePaneInTab("pane_2", placement: .left)],
+            "pane movement must route the selected pane and placement to the shared handler"
         )
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -36,6 +36,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal()
         verifiesSplitZoomLeavesCanonicalTreeAndKeepsSiblingRuntimes()
         verifiesSplitZoomIsTabScopedAndPrunedWhenPaneDisappears()
+        verifiesInTabPaneMovementPreservesRuntimeContinuity()
+        verifiesPaneMovementDragPolicyProtectsTerminalSelection()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -814,6 +816,69 @@ private enum ShellRuntimeMetadataTests {
 
         _ = controller.closePane(paneID: "pane_1")
         expect(controller.selectedTabZoomedPaneID == nil, "closing the zoomed pane must prune zoom state")
+    }
+
+    private static func verifiesInTabPaneMovementPreservesRuntimeContinuity() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let movedPaneBefore = controller.pane(paneID: "pane_2")
+        _ = controller.terminalRuntimeRegistry.surfaceHandle(
+            for: controller.pane(paneID: "pane_1"),
+            bootProfile: controller.bootProfile(for: controller.pane(paneID: "pane_1"))
+        )
+        _ = controller.terminalRuntimeRegistry.surfaceHandle(
+            for: controller.pane(paneID: "pane_2"),
+            bootProfile: controller.bootProfile(for: controller.pane(paneID: "pane_2"))
+        )
+        let registeredBefore = controller.terminalRuntimeRegistry.registeredPaneIDs
+
+        expect(
+            controller.movePaneWithinTab(paneID: "pane_2", placement: .left),
+            "in-tab movement must accept an adjacent destination"
+        )
+        expect(
+            controller.selectedTab?.paneTree.paneIDs == ["pane_2", "pane_1"],
+            "in-tab movement must update PaneSlot placement inside the selected tab"
+        )
+        expect(
+            controller.pane(paneID: "pane_2") == movedPaneBefore,
+            "in-tab movement must preserve mounted terminal content metadata"
+        )
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs == registeredBefore,
+            "in-tab movement must not release or recreate terminal runtimes"
+        )
+    }
+
+    private static func verifiesPaneMovementDragPolicyProtectsTerminalSelection() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let originalTree = controller.selectedTab?.paneTree
+
+        expect(
+            !controller.movePaneWithinTab(
+                paneID: "pane_2",
+                placement: .left,
+                source: .terminalContentDrag
+            ),
+            "terminal content drags must not start pane movement"
+        )
+        expect(
+            controller.selectedTab?.paneTree == originalTree,
+            "rejected terminal-content drag movement must leave layout unchanged"
+        )
+        expect(
+            controller.movePaneWithinTab(
+                paneID: "pane_2",
+                placement: .left,
+                source: .titleBarDragAffordance
+            ),
+            "drag-backed movement must route through the same controller mutation path"
+        )
+        expect(
+            controller.selectedTab?.paneTree.paneIDs == ["pane_2", "pane_1"],
+            "drag-backed movement must preserve the explicit movement result semantics"
+        )
     }
 
     private static func verifiesTerminalActivityProjectsByPaneID() {

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -14,6 +14,8 @@ private enum ShellSplitModelTests {
         try verifiesSplitRatiosClampWhenResized()
         try verifiesEqualizeRestoresEverySplitRatio()
         try verifiesZoomProjectionUsesLeafWithoutMutatingSplitTree()
+        try verifiesInTabPaneMovementPreservesPaneIdentityAndRepairsTree()
+        try verifiesInvalidInTabPaneMovementLeavesStateUnchanged()
         try verifiesSameDirectionAttachKeepsBinarySplitTree()
         try verifiesSidebarSplitTopologyProjection()
         try verifiesSpatialFocusFollowsSplitTree()
@@ -104,6 +106,53 @@ private enum ShellSplitModelTests {
             treeAfterProjection == tree,
             "zoom projection must not mutate the canonical split tree"
         )
+    }
+
+    private static func verifiesInTabPaneMovementPreservesPaneIdentityAndRepairsTree() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+        let movedPaneBefore = try require(state.pane(paneID: "pane_2"), "moved pane missing")
+
+        let result = try state.movingPaneWithinTab("pane_2", placement: .left)
+        let movedTree = try requireFocusedTabTree(result.state)
+
+        expect(
+            movedTree.paneIDs == ["pane_2", "pane_1"],
+            "in-tab movement must repair the tree by placing the moved pane before the target"
+        )
+        expect(
+            result.state.pane(paneID: "pane_2") == movedPaneBefore,
+            "in-tab movement must preserve the moved PaneSlot and mounted content identity"
+        )
+        expect(
+            result.state.focusedPaneID == "pane_2",
+            "in-tab movement must keep focus on the moved pane"
+        )
+        expect(
+            result.state.pane(paneID: "pane_2")?.tabID == "tab_main",
+            "in-tab movement must keep the pane in the same tab"
+        )
+    }
+
+    private static func verifiesInvalidInTabPaneMovementLeavesStateUnchanged() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        state = try state.splittingPane("pane_1", placement: .right).state
+        let original = state
+
+        do {
+            _ = try state.movingPaneWithinTab("pane_1", placement: .left)
+            expect(false, "moving a pane without an adjacent destination must be rejected")
+        } catch ShellStateMutationError.invalidMoveTarget {
+            expect(state == original, "failed movement must leave the original state unchanged")
+        }
+
+        do {
+            _ = try ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+                .movingPaneWithinTab("pane_1", placement: .right)
+            expect(false, "moving a single-pane tab must be rejected")
+        } catch ShellStateMutationError.invalidMoveTarget {
+            // Expected.
+        }
     }
 
     private static func verifiesSameDirectionAttachKeepsBinarySplitTree() throws {

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -237,6 +237,21 @@ private enum TerminalSurfaceControllerTests {
             "command-control-right must route to registered shell focus right"
         )
 
+        let moveLeft = router.routeKeyboard(
+            AlanTerminalKeyInput(
+                characters: nil,
+                keyCode: 0x7B,
+                modifiers: [.command, .control, .shift],
+                phase: .down,
+                isRepeat: false
+            ),
+            hasMarkedText: false
+        )
+        expect(
+            moveLeft == .shellAction(.paneMoveLeft, .currentSelection),
+            "command-control-shift-left must route to registered in-tab pane movement"
+        )
+
         let paneZoom = router.routeKeyboard(
             AlanTerminalKeyInput(
                 characters: "\r",

--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -7,10 +7,10 @@
 
 ## 2. Pane Movement
 
-- [ ] 2.1 Add explicit in-tab pane move operations with stable validation and tree repair.
-- [ ] 2.2 Route pane movement commands through the shared shell controller mutation path.
-- [ ] 2.3 Add drag/drop movement only after proving terminal text selection remains reliable.
-- [ ] 2.4 Add tests for in-tab movement, invalid movement, drag-backed movement routing, and PaneSlot / mounted ContentInstance identity preservation.
+- [x] 2.1 Add explicit in-tab pane move operations with stable validation and tree repair.
+- [x] 2.2 Route pane movement commands through the shared shell controller mutation path.
+- [x] 2.3 Add drag/drop movement only after proving terminal text selection remains reliable.
+- [x] 2.4 Add tests for in-tab movement, invalid movement, drag-backed movement routing, and PaneSlot / mounted ContentInstance identity preservation.
 
 ## 3. Control Plane
 


### PR DESCRIPTION
## Summary
- implement explicit same-tab pane movement with validation and split-tree repair
- route pane movement through shared shell actions, menus, command UI, shortcuts, and titlebar context actions
- preserve terminal selection behavior by keeping movement behind explicit command/titlebar sources
- mark OpenSpec tasks 2.1-2.4 complete for complete-macos-shell-advanced-splits, bringing progress to 8/24

## Verification
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-action-registry.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- git diff --check
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate complete-macos-shell-advanced-splits --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-next-openspec-derived build