### PR TITLE
Add macOS shell control-plane split commands

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -113,6 +113,19 @@ extension ShellHostController {
         deliveryCode: String? = nil,
         runtimePhase: String? = nil,
         latestEventID: String? = nil,
+        splitNodeID: String? = nil,
+        ratio: Double? = nil,
+        changedSplitIDs: [String]? = nil,
+        affectedPaneIDs: [String]? = nil,
+        zoomedPaneID: String? = nil,
+        sourceTabID: String? = nil,
+        targetTabID: String? = nil,
+        previousFocusedPaneID: String? = nil,
+        currentFocusedPaneID: String? = nil,
+        splitDirection: ShellSplitDirection? = nil,
+        spatialDirection: ShellSpatialFocusDirection? = nil,
+        placement: ShellPaneSplitDirection? = nil,
+        mountedContentInstanceID: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) -> AlanShellControlResponse {
@@ -140,6 +153,19 @@ extension ShellHostController {
             deliveryCode: deliveryCode,
             runtimePhase: runtimePhase,
             latestEventID: latestEventID,
+            splitNodeID: splitNodeID,
+            ratio: ratio,
+            changedSplitIDs: changedSplitIDs,
+            affectedPaneIDs: affectedPaneIDs,
+            zoomedPaneID: zoomedPaneID,
+            sourceTabID: sourceTabID,
+            targetTabID: targetTabID,
+            previousFocusedPaneID: previousFocusedPaneID,
+            currentFocusedPaneID: currentFocusedPaneID,
+            splitDirection: splitDirection,
+            spatialDirection: spatialDirection,
+            placement: placement,
+            mountedContentInstanceID: mountedContentInstanceID,
             errorCode: errorCode,
             errorMessage: errorMessage
         )
@@ -553,6 +579,7 @@ extension ShellHostController {
             }
 
             let direction = command.direction ?? .vertical
+            let sourcePane = pane(paneID: paneID)
             guard movePane(paneID: paneID, toTab: targetTabID, direction: direction) else {
                 return response(
                     requestID: command.requestID,
@@ -569,8 +596,15 @@ extension ShellHostController {
                 applied: true,
                 spaceID: shellState.focusedSpaceID,
                 tabID: shellState.focusedTabID,
-                paneID: shellState.focusedPaneID
+                paneID: shellState.focusedPaneID,
+                sourceTabID: sourcePane?.tabID,
+                targetTabID: targetTabID,
+                splitDirection: direction,
+                mountedContentInstanceID: paneID
             )
+
+        case .paneMoveWithinTab:
+            return handlePaneMoveWithinTabCommand(command)
 
         case .paneFocus:
             guard let paneID = command.paneID,
@@ -593,6 +627,21 @@ extension ShellHostController {
                 tabID: shellState.focusedTabID,
                 paneID: paneID
             )
+
+        case .paneSpatialFocus:
+            return handlePaneSpatialFocusCommand(command)
+
+        case .paneResizeSplit:
+            return handlePaneResizeSplitCommand(command)
+
+        case .paneEqualizeSplits:
+            return handlePaneEqualizeSplitsCommand(command)
+
+        case .paneZoom:
+            return handlePaneZoomCommand(command)
+
+        case .paneUnzoom:
+            return handlePaneUnzoomCommand(command)
 
         case .paneSendText:
             guard let paneID = command.paneID,
@@ -847,6 +896,423 @@ extension ShellHostController {
                     errorCode: "events_unavailable",
                     errorMessage: "events.read is handled by the shell control plane."
                 )
+        }
+    }
+
+    private func handlePaneResizeSplitCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        guard let splitNodeID = command.splitNodeID else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "split_node_required",
+                errorMessage: "split_node_id is required."
+            )
+        }
+        guard let ratio = command.ratio else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                splitNodeID: splitNodeID,
+                errorCode: "ratio_required",
+                errorMessage: "ratio is required."
+            )
+        }
+        guard let targetTab = shellState.spaces
+            .flatMap(\.tabs)
+            .first(where: { $0.paneTree.contains(nodeID: splitNodeID) })
+        else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                splitNodeID: splitNodeID,
+                errorCode: "split_not_found",
+                errorMessage: "The requested split does not exist."
+            )
+        }
+
+        do {
+            let result = try shellState.resizingSplit(splitNodeID, ratio: ratio)
+            guard let updatedSplit = result.state.tab(tabID: targetTab.tabID)?
+                .paneTree
+                .node(nodeID: splitNodeID)
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    splitNodeID: splitNodeID,
+                    errorCode: "split_not_found",
+                    errorMessage: "The requested split does not exist."
+                )
+            }
+
+            applyMutationResult(result)
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: result.spaceID,
+                tabID: targetTab.tabID,
+                paneID: result.paneID,
+                latestEventID: controlPlane.latestEventID,
+                splitNodeID: splitNodeID,
+                ratio: updatedSplit.splitRatio,
+                changedSplitIDs: [splitNodeID],
+                affectedPaneIDs: updatedSplit.paneIDs
+            )
+        } catch {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: targetTab.tabID,
+                splitNodeID: splitNodeID,
+                errorCode: "split_not_found",
+                errorMessage: "The requested split does not exist."
+            )
+        }
+    }
+
+    private func handlePaneEqualizeSplitsCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        let tabID = command.tabID ?? selectedTabID
+        guard let tabID else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "tab_required",
+                errorMessage: "tab_id is required."
+            )
+        }
+        guard let tab = shellState.tab(tabID: tabID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: tabID,
+                errorCode: "tab_not_found",
+                errorMessage: "The requested tab does not exist."
+            )
+        }
+        guard !tab.paneTree.splitNodes.isEmpty else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: tabID,
+                errorCode: "no_split_branches",
+                errorMessage: "The requested tab does not have split branches."
+            )
+        }
+
+        do {
+            let result = try shellState.equalizingSplits(in: tabID)
+            guard let updatedTab = result.state.tab(tabID: tabID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: "tab_not_found",
+                    errorMessage: "The requested tab does not exist."
+                )
+            }
+            let changedSplitIDs = updatedTab.paneTree.splitNodeIDsWithChangedRatios(
+                comparedTo: tab.paneTree
+            )
+            guard !changedSplitIDs.isEmpty else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    ratio: 0.5,
+                    changedSplitIDs: [],
+                    affectedPaneIDs: tab.paneTree.paneIDs,
+                    errorCode: "unchanged_state",
+                    errorMessage: "The requested split ratios are already equalized."
+                )
+            }
+
+            applyMutationResult(result)
+            controlPlane.recordSplitEqualized(
+                requestID: command.requestID,
+                spaceID: result.spaceID,
+                tabID: tabID,
+                changedSplitIDs: changedSplitIDs,
+                affectedPaneIDs: updatedTab.paneTree.paneIDs
+            )
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: result.spaceID,
+                tabID: tabID,
+                paneID: result.paneID,
+                latestEventID: controlPlane.latestEventID,
+                ratio: 0.5,
+                changedSplitIDs: changedSplitIDs,
+                affectedPaneIDs: updatedTab.paneTree.paneIDs
+            )
+        } catch {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: tabID,
+                errorCode: "tab_not_found",
+                errorMessage: "The requested tab does not exist."
+            )
+        }
+    }
+
+    private func handlePaneZoomCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        let paneID = command.paneID ?? selectedPane?.paneID
+        guard let paneID else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "pane_required",
+                errorMessage: "pane_id is required."
+            )
+        }
+        guard let targetPane = pane(paneID: paneID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                paneID: paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
+        guard canZoomPane(paneID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: targetPane.tabID,
+                paneID: paneID,
+                errorCode: "split_tab_required",
+                errorMessage: "Pane zoom requires a split tab."
+            )
+        }
+
+        let previousFocusedPaneID = shellState.focusedPaneID
+        guard zoomPane(paneID: paneID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: targetPane.tabID,
+                paneID: paneID,
+                zoomedPaneID: zoomedPaneIDByTabID[targetPane.tabID],
+                previousFocusedPaneID: previousFocusedPaneID,
+                currentFocusedPaneID: shellState.focusedPaneID,
+                mountedContentInstanceID: paneID,
+                errorCode: "unchanged_state",
+                errorMessage: "The requested pane is already zoomed."
+            )
+        }
+
+        return response(
+            requestID: command.requestID,
+            applied: true,
+            spaceID: targetPane.spaceID,
+            tabID: targetPane.tabID,
+            paneID: paneID,
+            latestEventID: controlPlane.latestEventID,
+            zoomedPaneID: paneID,
+            previousFocusedPaneID: previousFocusedPaneID,
+            currentFocusedPaneID: shellState.focusedPaneID,
+            mountedContentInstanceID: paneID
+        )
+    }
+
+    private func handlePaneUnzoomCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        let tabID = command.tabID
+            ?? command.paneID.flatMap { pane(paneID: $0)?.tabID }
+            ?? selectedTabID
+        guard let tabID else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "tab_required",
+                errorMessage: "tab_id is required."
+            )
+        }
+        guard shellState.tab(tabID: tabID) != nil else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: tabID,
+                errorCode: "tab_not_found",
+                errorMessage: "The requested tab does not exist."
+            )
+        }
+
+        let previousFocusedPaneID = shellState.focusedPaneID
+        let previousZoomedPaneID = zoomedPaneIDByTabID[tabID]
+        guard unzoomTab(tabID: tabID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                tabID: tabID,
+                zoomedPaneID: nil,
+                previousFocusedPaneID: previousFocusedPaneID,
+                currentFocusedPaneID: shellState.focusedPaneID,
+                errorCode: "unchanged_state",
+                errorMessage: "The requested tab is not zoomed."
+            )
+        }
+
+        return response(
+            requestID: command.requestID,
+            applied: true,
+            tabID: tabID,
+            paneID: previousZoomedPaneID,
+            latestEventID: controlPlane.latestEventID,
+            zoomedPaneID: nil,
+            previousFocusedPaneID: previousFocusedPaneID,
+            currentFocusedPaneID: shellState.focusedPaneID,
+            mountedContentInstanceID: previousZoomedPaneID
+        )
+    }
+
+    private func handlePaneSpatialFocusCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        guard let direction = command.spatialDirection else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "spatial_direction_required",
+                errorMessage: "spatial_direction is required."
+            )
+        }
+
+        let previousFocusedPaneID = shellState.focusedPaneID
+        let previousPane = previousFocusedPaneID.flatMap { pane(paneID: $0) }
+        do {
+            let result = try shellState.focusingAdjacentPane(direction)
+            applyMutationResult(result)
+            controlPlane.recordSpatialFocus(
+                requestID: command.requestID,
+                spaceID: result.spaceID,
+                tabID: result.tabID,
+                previousPaneID: previousFocusedPaneID,
+                currentPaneID: result.paneID,
+                direction: direction,
+                applied: true
+            )
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: result.spaceID,
+                tabID: result.tabID,
+                paneID: result.paneID,
+                latestEventID: controlPlane.latestEventID,
+                previousFocusedPaneID: previousFocusedPaneID,
+                currentFocusedPaneID: result.paneID,
+                spatialDirection: direction
+            )
+        } catch ShellStateMutationError.spatialFocusTargetNotFound {
+            controlPlane.recordSpatialFocus(
+                requestID: command.requestID,
+                spaceID: previousPane?.spaceID,
+                tabID: previousPane?.tabID,
+                previousPaneID: previousFocusedPaneID,
+                currentPaneID: previousFocusedPaneID,
+                direction: direction,
+                applied: false
+            )
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                spaceID: previousPane?.spaceID,
+                tabID: previousPane?.tabID,
+                paneID: previousFocusedPaneID,
+                latestEventID: controlPlane.latestEventID,
+                previousFocusedPaneID: previousFocusedPaneID,
+                currentFocusedPaneID: previousFocusedPaneID,
+                spatialDirection: direction,
+                errorCode: "spatial_focus_target_not_found",
+                errorMessage: "There is no pane in that direction."
+            )
+        } catch {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                paneID: previousFocusedPaneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The focused pane does not exist."
+            )
+        }
+    }
+
+    private func handlePaneMoveWithinTabCommand(
+        _ command: AlanShellControlCommand
+    ) -> AlanShellControlResponse {
+        guard let paneID = command.paneID else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                errorCode: "pane_required",
+                errorMessage: "pane_id is required."
+            )
+        }
+        guard let placement = command.placement else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                paneID: paneID,
+                errorCode: "placement_required",
+                errorMessage: "placement is required."
+            )
+        }
+        guard let sourcePane = pane(paneID: paneID) else {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                paneID: paneID,
+                placement: placement,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
+
+        do {
+            let result = try shellState.movingPaneWithinTab(paneID, placement: placement)
+            applyMutationResult(result)
+            controlPlane.recordPaneMovedInTab(
+                requestID: command.requestID,
+                spaceID: result.spaceID,
+                tabID: sourcePane.tabID,
+                paneID: paneID,
+                placement: placement,
+                mountedContentInstanceID: paneID
+            )
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: result.spaceID,
+                tabID: sourcePane.tabID,
+                paneID: paneID,
+                latestEventID: controlPlane.latestEventID,
+                sourceTabID: sourcePane.tabID,
+                targetTabID: sourcePane.tabID,
+                placement: placement,
+                mountedContentInstanceID: paneID
+            )
+        } catch {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                spaceID: sourcePane.spaceID,
+                tabID: sourcePane.tabID,
+                paneID: paneID,
+                sourceTabID: sourcePane.tabID,
+                targetTabID: sourcePane.tabID,
+                placement: placement,
+                mountedContentInstanceID: paneID,
+                errorCode: "invalid_move_target",
+                errorMessage: "The requested in-tab pane movement target is not available."
+            )
         }
     }
 

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -1127,8 +1127,18 @@ extension ShellHostController {
     private func handlePaneUnzoomCommand(
         _ command: AlanShellControlCommand
     ) -> AlanShellControlResponse {
+        let requestedPane = command.paneID.flatMap(pane)
+        if command.paneID != nil && requestedPane == nil {
+            return response(
+                requestID: command.requestID,
+                applied: false,
+                paneID: command.paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
         let tabID = command.tabID
-            ?? command.paneID.flatMap { pane(paneID: $0)?.tabID }
+            ?? requestedPane?.tabID
             ?? selectedTabID
         guard let tabID else {
             return response(

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -947,18 +947,19 @@ extension ShellHostController {
                 )
             }
 
+            let affectedPaneIDs = updatedSplit.paneIDs
             applyMutationResult(result)
             return response(
                 requestID: command.requestID,
                 applied: true,
                 spaceID: result.spaceID,
                 tabID: targetTab.tabID,
-                paneID: result.paneID,
+                paneID: affectedPaneIDs.first ?? result.paneID,
                 latestEventID: controlPlane.latestEventID,
                 splitNodeID: splitNodeID,
                 ratio: updatedSplit.splitRatio,
                 changedSplitIDs: [splitNodeID],
-                affectedPaneIDs: updatedSplit.paneIDs
+                affectedPaneIDs: affectedPaneIDs
             )
         } catch {
             return response(
@@ -1030,24 +1031,25 @@ extension ShellHostController {
                 )
             }
 
+            let affectedPaneIDs = updatedTab.paneTree.paneIDs
             applyMutationResult(result)
             controlPlane.recordSplitEqualized(
                 requestID: command.requestID,
                 spaceID: result.spaceID,
                 tabID: tabID,
                 changedSplitIDs: changedSplitIDs,
-                affectedPaneIDs: updatedTab.paneTree.paneIDs
+                affectedPaneIDs: affectedPaneIDs
             )
             return response(
                 requestID: command.requestID,
                 applied: true,
                 spaceID: result.spaceID,
                 tabID: tabID,
-                paneID: result.paneID,
+                paneID: affectedPaneIDs.first ?? result.paneID,
                 latestEventID: controlPlane.latestEventID,
                 ratio: 0.5,
                 changedSplitIDs: changedSplitIDs,
-                affectedPaneIDs: updatedTab.paneTree.paneIDs
+                affectedPaneIDs: affectedPaneIDs
             )
         } catch {
             return response(

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -19,7 +19,13 @@ enum AlanShellControlCommandKind: String, Codable {
     case paneClose = "pane.close"
     case paneLift = "pane.lift"
     case paneMove = "pane.move"
+    case paneMoveWithinTab = "pane.move_within_tab"
     case paneFocus = "pane.focus"
+    case paneSpatialFocus = "pane.spatial_focus"
+    case paneResizeSplit = "pane.resize_split"
+    case paneEqualizeSplits = "pane.equalize_splits"
+    case paneZoom = "pane.zoom"
+    case paneUnzoom = "pane.unzoom"
     case paneSendText = "pane.send_text"
     case agentActivity = "agent.activity"
     case attentionInbox = "attention.inbox"
@@ -41,9 +47,13 @@ struct AlanShellControlCommand: Codable {
     let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let splitNodeID: String?
+    let ratio: Double?
     let section: ShellTabOrganizationSection?
     let index: Int?
     let direction: ShellSplitDirection?
+    let spatialDirection: ShellSpatialFocusDirection?
+    let placement: ShellPaneSplitDirection?
     let title: String?
     let cwd: String?
     let text: String?
@@ -65,9 +75,13 @@ struct AlanShellControlCommand: Codable {
         case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case splitNodeID = "split_node_id"
+        case ratio
         case section
         case index
         case direction
+        case spatialDirection = "spatial_direction"
+        case placement
         case title
         case cwd
         case text
@@ -123,6 +137,19 @@ struct AlanShellControlResponse: Codable {
     let deliveryCode: String?
     let runtimePhase: String?
     let latestEventID: String?
+    let splitNodeID: String?
+    let ratio: Double?
+    let changedSplitIDs: [String]?
+    let affectedPaneIDs: [String]?
+    let zoomedPaneID: String?
+    let sourceTabID: String?
+    let targetTabID: String?
+    let previousFocusedPaneID: String?
+    let currentFocusedPaneID: String?
+    let splitDirection: ShellSplitDirection?
+    let spatialDirection: ShellSpatialFocusDirection?
+    let placement: ShellPaneSplitDirection?
+    let mountedContentInstanceID: String?
     let errorCode: String?
     let errorMessage: String?
 
@@ -150,6 +177,19 @@ struct AlanShellControlResponse: Codable {
         deliveryCode: String? = nil,
         runtimePhase: String? = nil,
         latestEventID: String? = nil,
+        splitNodeID: String? = nil,
+        ratio: Double? = nil,
+        changedSplitIDs: [String]? = nil,
+        affectedPaneIDs: [String]? = nil,
+        zoomedPaneID: String? = nil,
+        sourceTabID: String? = nil,
+        targetTabID: String? = nil,
+        previousFocusedPaneID: String? = nil,
+        currentFocusedPaneID: String? = nil,
+        splitDirection: ShellSplitDirection? = nil,
+        spatialDirection: ShellSpatialFocusDirection? = nil,
+        placement: ShellPaneSplitDirection? = nil,
+        mountedContentInstanceID: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) {
@@ -176,6 +216,19 @@ struct AlanShellControlResponse: Codable {
         self.deliveryCode = deliveryCode
         self.runtimePhase = runtimePhase
         self.latestEventID = latestEventID
+        self.splitNodeID = splitNodeID
+        self.ratio = ratio
+        self.changedSplitIDs = changedSplitIDs
+        self.affectedPaneIDs = affectedPaneIDs
+        self.zoomedPaneID = zoomedPaneID
+        self.sourceTabID = sourceTabID
+        self.targetTabID = targetTabID
+        self.previousFocusedPaneID = previousFocusedPaneID
+        self.currentFocusedPaneID = currentFocusedPaneID
+        self.splitDirection = splitDirection
+        self.spatialDirection = spatialDirection
+        self.placement = placement
+        self.mountedContentInstanceID = mountedContentInstanceID
         self.errorCode = errorCode
         self.errorMessage = errorMessage
     }
@@ -204,6 +257,19 @@ struct AlanShellControlResponse: Codable {
         case deliveryCode = "delivery_code"
         case runtimePhase = "runtime_phase"
         case latestEventID = "latest_event_id"
+        case splitNodeID = "split_node_id"
+        case ratio
+        case changedSplitIDs = "changed_split_ids"
+        case affectedPaneIDs = "affected_pane_ids"
+        case zoomedPaneID = "zoomed_pane_id"
+        case sourceTabID = "source_tab_id"
+        case targetTabID = "target_tab_id"
+        case previousFocusedPaneID = "previous_focused_pane_id"
+        case currentFocusedPaneID = "current_focused_pane_id"
+        case splitDirection = "split_direction"
+        case spatialDirection = "spatial_direction"
+        case placement
+        case mountedContentInstanceID = "mounted_content_instance_id"
         case errorCode = "error_code"
         case errorMessage = "error_message"
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -227,6 +227,33 @@ struct ShellPaneTreeNode: Identifiable, Codable, Equatable {
 }
 
 extension ShellPaneTreeNode {
+    var splitNodes: [ShellPaneTreeNode] {
+        switch kind {
+        case .pane:
+            return []
+        case .split:
+            return [self] + (children ?? []).flatMap(\.splitNodes)
+        }
+    }
+
+    var splitRatiosByNodeID: [String: Double] {
+        Dictionary(uniqueKeysWithValues: splitNodes.map { ($0.nodeID, $0.splitRatio) })
+    }
+
+    func splitNodeIDsWithChangedRatios(comparedTo previous: ShellPaneTreeNode) -> [String] {
+        let previousRatios = previous.splitRatiosByNodeID
+        return splitRatiosByNodeID.keys
+            .filter { nodeID in
+                guard let previousRatio = previousRatios[nodeID],
+                      let currentRatio = splitRatiosByNodeID[nodeID]
+                else {
+                    return false
+                }
+                return previousRatio != currentRatio
+            }
+            .sorted()
+    }
+
     var nodeIDs: [String] {
         [nodeID] + (children ?? []).flatMap(\.nodeIDs)
     }
@@ -252,6 +279,11 @@ extension ShellPaneTreeNode {
     func contains(nodeID targetNodeID: String) -> Bool {
         if nodeID == targetNodeID { return true }
         return (children ?? []).contains { $0.contains(nodeID: targetNodeID) }
+    }
+
+    func node(nodeID targetNodeID: String) -> ShellPaneTreeNode? {
+        if nodeID == targetNodeID { return self }
+        return (children ?? []).lazy.compactMap { $0.node(nodeID: targetNodeID) }.first
     }
 
     func adjacentPaneID(

--- a/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
@@ -74,6 +74,114 @@ final class AlanShellEventStore {
         )
     }
 
+    func recordSplitEqualized(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        changedSplitIDs: [String],
+        affectedPaneIDs: [String]
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "tab_id": .string(tabID),
+            "changed_split_ids": .array(changedSplitIDs.map(AlanShellJSONValue.string)),
+            "affected_pane_ids": .array(affectedPaneIDs.map(AlanShellJSONValue.string)),
+            "ratio": .number(0.5)
+        ]
+        if let requestID {
+            payload["request_id"] = .string(requestID)
+        }
+
+        append(
+            type: "split.equalized",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: affectedPaneIDs.first,
+            payload: payload
+        )
+    }
+
+    func recordZoomStateChanged(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        paneID: String?,
+        zoomedPaneID: String?
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "tab_id": .string(tabID),
+            "zoomed": .bool(zoomedPaneID != nil),
+            "zoomed_pane_id": zoomedPaneID.map(AlanShellJSONValue.string) ?? .null
+        ]
+        if let requestID {
+            payload["request_id"] = .string(requestID)
+        }
+
+        append(
+            type: "pane.zoom_changed",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID ?? zoomedPaneID,
+            payload: payload
+        )
+    }
+
+    func recordSpatialFocus(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String?,
+        previousPaneID: String?,
+        currentPaneID: String?,
+        direction: ShellSpatialFocusDirection,
+        applied: Bool
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "spatial_direction": .string(direction.rawValue),
+            "applied": .bool(applied),
+            "previous_focused_pane_id": previousPaneID.map(AlanShellJSONValue.string) ?? .null,
+            "current_focused_pane_id": currentPaneID.map(AlanShellJSONValue.string) ?? .null
+        ]
+        if let requestID {
+            payload["request_id"] = .string(requestID)
+        }
+
+        append(
+            type: "pane.spatial_focus",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: currentPaneID ?? previousPaneID,
+            payload: payload
+        )
+    }
+
+    func recordPaneMovedInTab(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        paneID: String,
+        placement: ShellPaneSplitDirection,
+        mountedContentInstanceID: String
+    ) {
+        var payload: [String: AlanShellJSONValue] = [
+            "pane_id": .string(paneID),
+            "source_tab_id": .string(tabID),
+            "target_tab_id": .string(tabID),
+            "placement": .string(placement.rawValue),
+            "mounted_content_instance_id": .string(mountedContentInstanceID),
+            "preserved_mounted_content_instance": .bool(true)
+        ]
+        if let requestID {
+            payload["request_id"] = .string(requestID)
+        }
+
+        append(
+            type: "pane.moved_in_tab",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            payload: payload
+        )
+    }
+
     func recordChanges(from previousState: ShellStateSnapshot?, to currentState: ShellStateSnapshot) {
         guard let previousState else { return }
 
@@ -123,6 +231,11 @@ final class AlanShellEventStore {
         }
 
         recordTabOrganizationChanges(
+            previousState: previousState,
+            currentState: currentState,
+            commonTabIDs: previousTabs.intersection(currentTabs)
+        )
+        recordSplitRatioChanges(
             previousState: previousState,
             currentState: currentState,
             commonTabIDs: previousTabs.intersection(currentTabs)
@@ -204,6 +317,46 @@ final class AlanShellEventStore {
         }
     }
 
+    private func recordSplitRatioChanges(
+        previousState: ShellStateSnapshot,
+        currentState: ShellStateSnapshot,
+        commonTabIDs: Set<String>
+    ) {
+        for tabID in commonTabIDs.sorted() {
+            guard let previousTab = previousState.tab(tabID: tabID),
+                  let currentTab = currentState.tab(tabID: tabID)
+            else {
+                continue
+            }
+
+            let previousRatios = previousTab.paneTree.splitRatiosByNodeID
+            let currentRatios = currentTab.paneTree.splitRatiosByNodeID
+            for splitNodeID in Set(previousRatios.keys).intersection(currentRatios.keys).sorted() {
+                guard let previousRatio = previousRatios[splitNodeID],
+                      let currentRatio = currentRatios[splitNodeID],
+                      previousRatio != currentRatio,
+                      let splitNode = currentTab.paneTree.node(nodeID: splitNodeID)
+                else {
+                    continue
+                }
+
+                let affectedPaneIDs = splitNode.paneIDs
+                append(
+                    type: "split.ratio_changed",
+                    spaceID: currentState.panes.first { $0.tabID == tabID }?.spaceID,
+                    tabID: tabID,
+                    paneID: currentState.focusedPaneID,
+                    payload: [
+                        "split_node_id": .string(splitNodeID),
+                        "previous_ratio": .number(previousRatio),
+                        "ratio": .number(currentRatio),
+                        "affected_pane_ids": .array(affectedPaneIDs.map(AlanShellJSONValue.string))
+                    ]
+                )
+            }
+        }
+    }
+
     private func recordExistingPaneChanges(previousPane: ShellPane, currentPane: ShellPane) {
         if previousPane.tabID != currentPane.tabID || previousPane.spaceID != currentPane.spaceID {
             append(
@@ -215,7 +368,9 @@ final class AlanShellEventStore {
                     "previous_space_id": .string(previousPane.spaceID),
                     "current_space_id": .string(currentPane.spaceID),
                     "previous_tab_id": .string(previousPane.tabID),
-                    "current_tab_id": .string(currentPane.tabID)
+                    "current_tab_id": .string(currentPane.tabID),
+                    "mounted_content_instance_id": .string(currentPane.paneID),
+                    "preserved_mounted_content_instance": .bool(true)
                 ]
             )
         }

--- a/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
@@ -345,7 +345,7 @@ final class AlanShellEventStore {
                     type: "split.ratio_changed",
                     spaceID: currentState.panes.first { $0.tabID == tabID }?.spaceID,
                     tabID: tabID,
-                    paneID: currentState.focusedPaneID,
+                    paneID: affectedPaneIDs.first,
                     payload: [
                         "split_node_id": .string(splitNodeID),
                         "previous_ratio": .number(previousRatio),

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -578,6 +578,10 @@ enum AlanShellLocalCommandExecutor {
                 return nil
             }
 
+        case .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit, .paneEqualizeSplits,
+             .paneZoom, .paneUnzoom:
+            return nil
+
         case .paneSendText:
             return nil
 

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -400,7 +400,8 @@ private extension AlanShellControlCommandKind {
     var requiresHostHandler: Bool {
         switch self {
         case .spaceCreate, .spaceOpenAlan, .tabOpen, .tabPin, .tabReorder, .paneSplit,
-            .agentActivity:
+            .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit, .paneEqualizeSplits,
+            .paneZoom, .paneUnzoom, .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -400,8 +400,8 @@ private extension AlanShellControlCommandKind {
     var requiresHostHandler: Bool {
         switch self {
         case .spaceCreate, .spaceOpenAlan, .tabOpen, .tabPin, .tabReorder, .paneSplit,
-            .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit, .paneEqualizeSplits,
-            .paneZoom, .paneUnzoom, .agentActivity:
+            .paneMove, .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit,
+            .paneEqualizeSplits, .paneZoom, .paneUnzoom, .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -141,6 +141,10 @@ final class AlanShellControlPlane {
         socketURL.path
     }
 
+    var latestEventID: String? {
+        eventStore.latestEventID
+    }
+
     func publish(state: ShellStateSnapshot) {
         ensureDirectories()
         let mergeResult = socketServer.mergePublishedState(state)
@@ -214,6 +218,76 @@ final class AlanShellControlPlane {
             tabID: tabID,
             paneID: paneID,
             delivery: delivery
+        )
+    }
+
+    func recordSplitEqualized(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        changedSplitIDs: [String],
+        affectedPaneIDs: [String]
+    ) {
+        eventStore.recordSplitEqualized(
+            requestID: requestID,
+            spaceID: spaceID,
+            tabID: tabID,
+            changedSplitIDs: changedSplitIDs,
+            affectedPaneIDs: affectedPaneIDs
+        )
+    }
+
+    func recordZoomStateChanged(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        paneID: String?,
+        zoomedPaneID: String?
+    ) {
+        eventStore.recordZoomStateChanged(
+            requestID: requestID,
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            zoomedPaneID: zoomedPaneID
+        )
+    }
+
+    func recordSpatialFocus(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String?,
+        previousPaneID: String?,
+        currentPaneID: String?,
+        direction: ShellSpatialFocusDirection,
+        applied: Bool
+    ) {
+        eventStore.recordSpatialFocus(
+            requestID: requestID,
+            spaceID: spaceID,
+            tabID: tabID,
+            previousPaneID: previousPaneID,
+            currentPaneID: currentPaneID,
+            direction: direction,
+            applied: applied
+        )
+    }
+
+    func recordPaneMovedInTab(
+        requestID: String?,
+        spaceID: String?,
+        tabID: String,
+        paneID: String,
+        placement: ShellPaneSplitDirection,
+        mountedContentInstanceID: String
+    ) {
+        eventStore.recordPaneMovedInTab(
+            requestID: requestID,
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneID,
+            placement: placement,
+            mountedContentInstanceID: mountedContentInstanceID
         )
     }
 

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -621,10 +621,20 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         else {
             return false
         }
+        guard zoomedPaneIDByTabID[pane.tabID] != paneID else {
+            return false
+        }
         if shellState.focusedPaneID != paneID {
             focus(paneID: paneID)
         }
         zoomedPaneIDByTabID[pane.tabID] = paneID
+        controlPlane.recordZoomStateChanged(
+            requestID: nil,
+            spaceID: pane.spaceID,
+            tabID: pane.tabID,
+            paneID: paneID,
+            zoomedPaneID: paneID
+        )
         return true
     }
 
@@ -641,9 +651,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
-    private func unzoomTab(tabID: String) -> Bool {
-        guard zoomedPaneIDByTabID[tabID] != nil else { return false }
+    func unzoomTab(tabID: String) -> Bool {
+        guard let zoomedPaneID = zoomedPaneIDByTabID[tabID] else { return false }
+        let pane = pane(paneID: zoomedPaneID)
         zoomedPaneIDByTabID.removeValue(forKey: tabID)
+        controlPlane.recordZoomStateChanged(
+            requestID: nil,
+            spaceID: pane?.spaceID,
+            tabID: tabID,
+            paneID: zoomedPaneID,
+            zoomedPaneID: nil
+        )
         return true
     }
 
@@ -1070,6 +1088,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func focusAdjacentPane(direction: ShellSpatialFocusDirection) -> Bool {
+        let previousPaneID = shellState.focusedPaneID
         let result: ShellStateMutationResult
         do {
             result = try shellState.focusingAdjacentPane(direction)
@@ -1077,6 +1096,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return false
         }
         applyMutationResult(result)
+        controlPlane.recordSpatialFocus(
+            requestID: nil,
+            spaceID: result.spaceID,
+            tabID: result.tabID,
+            previousPaneID: previousPaneID,
+            currentPaneID: result.paneID,
+            direction: direction,
+            applied: true
+        )
         return true
     }
 
@@ -1223,13 +1251,31 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func equalizeSelectedTabSplits() -> Bool {
+        let previousTab = selectedTab
         let result: ShellStateMutationResult
         do {
             result = try shellState.equalizingSplits(in: selectedTabID)
         } catch {
             return false
         }
+        let changedSplitIDs = previousTab
+            .flatMap { previous in
+                result.state.tab(tabID: previous.tabID)?.paneTree
+                    .splitNodeIDsWithChangedRatios(comparedTo: previous.paneTree)
+            } ?? []
         applyMutationResult(result)
+        if let tabID = result.tabID,
+           let previousTab,
+           !changedSplitIDs.isEmpty
+        {
+            controlPlane.recordSplitEqualized(
+                requestID: nil,
+                spaceID: result.spaceID,
+                tabID: tabID,
+                changedSplitIDs: changedSplitIDs,
+                affectedPaneIDs: previousTab.paneTree.paneIDs
+            )
+        }
         return true
     }
 
@@ -1802,7 +1848,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         publishControlPlaneState()
     }
 
-    private func applyMutationResult(
+    func applyMutationResult(
         _ result: ShellStateMutationResult,
         publish: Bool = true,
         pinSnapshotTabIDs: Set<String> = []
@@ -2319,6 +2365,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 placement: placement
             )
             applyMutationResult(result)
+            if let tabID = result.tabID {
+                controlPlane.recordPaneMovedInTab(
+                    requestID: nil,
+                    spaceID: result.spaceID,
+                    tabID: tabID,
+                    paneID: paneID,
+                    placement: placement,
+                    mountedContentInstanceID: paneID
+                )
+            }
             return true
         } catch {
             return false

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -39,6 +39,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesInTabPaneMovementPreservesRuntimeContinuity()
         verifiesPaneMovementDragPolicyProtectsTerminalSelection()
         verifiesAdvancedControlPlaneResizeEqualizeAndEvents()
+        verifiesSplitRatioEventsUseAffectedPaneForBackgroundTabs()
         verifiesAdvancedControlPlaneZoomFocusAndMovementResults()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
@@ -963,6 +964,70 @@ private enum ShellRuntimeMetadataTests {
         expect(
             unchangedResponse.errorCode == "unchanged_state",
             "unchanged equalize must return a stable error code"
+        )
+    }
+
+    private static func verifiesSplitRatioEventsUseAffectedPaneForBackgroundTabs() {
+        let controller = makeController()
+        guard let foregroundTabID = controller.selectedTabID else {
+            fail("bootstrap shell must expose a selected tab")
+        }
+        guard let backgroundTabID = controller.openTerminalTab(workingDirectory: "/background"),
+              let backgroundPaneID = controller.shellState.panes(in: backgroundTabID).first?.paneID
+        else {
+            fail("test setup must create a background tab")
+        }
+        _ = controller.splitPane(paneID: backgroundPaneID, placement: .right)
+        guard let splitNodeID = controller.shellState
+            .tab(tabID: backgroundTabID)?
+            .paneTree
+            .splitNodes
+            .first?
+            .nodeID
+        else {
+            fail("test setup must create a split node in the background tab")
+        }
+
+        controller.select(tabID: foregroundTabID)
+        let foregroundPaneID = controller.shellState.focusedPaneID
+        expect(foregroundPaneID != nil, "foreground tab selection must focus a pane")
+
+        let resizeResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "resize-background-1",
+                  "command": "pane.resize_split",
+                  "split_node_id": "\(splitNodeID)",
+                  "ratio": 0.66
+                }
+                """
+            )
+        )
+
+        expect(resizeResponse.applied == true, "background resize must apply")
+        expect(
+            resizeResponse.affectedPaneIDs?.contains(resizeResponse.paneID ?? "") == true,
+            "resize response pane_id must come from the affected split"
+        )
+        expect(
+            resizeResponse.paneID != foregroundPaneID,
+            "resize response pane_id must not use the unrelated focused pane"
+        )
+        guard let ratioEvent = controlEvents(controller).last(where: {
+            $0.type == "split.ratio_changed"
+                && $0.payload["split_node_id"] == .string(splitNodeID)
+        }) else {
+            fail("background resize must emit a split ratio event")
+        }
+        expect(ratioEvent.tabID == backgroundTabID, "split ratio event must stay tab-scoped")
+        expect(
+            resizeResponse.affectedPaneIDs?.contains(ratioEvent.paneID ?? "") == true,
+            "split ratio event pane_id must come from the affected split"
+        )
+        expect(
+            ratioEvent.paneID != foregroundPaneID,
+            "split ratio event pane_id must not use the unrelated focused pane"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -38,6 +38,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesSplitZoomIsTabScopedAndPrunedWhenPaneDisappears()
         verifiesInTabPaneMovementPreservesRuntimeContinuity()
         verifiesPaneMovementDragPolicyProtectsTerminalSelection()
+        verifiesAdvancedControlPlaneResizeEqualizeAndEvents()
+        verifiesAdvancedControlPlaneZoomFocusAndMovementResults()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -878,6 +880,202 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedTab?.paneTree.paneIDs == ["pane_2", "pane_1"],
             "drag-backed movement must preserve the explicit movement result semantics"
+        )
+    }
+
+    private static func verifiesAdvancedControlPlaneResizeEqualizeAndEvents() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let splitNodeID = controller.selectedTab?.paneTree.splitNodes.first?.nodeID
+        guard let splitNodeID else {
+            fail("test setup must create a split node")
+        }
+
+        let resizeResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "resize-1",
+                  "command": "pane.resize_split",
+                  "split_node_id": "\(splitNodeID)",
+                  "ratio": 0.72
+                }
+                """
+            )
+        )
+
+        expect(resizeResponse.applied == true, "resize_split must report an applied result")
+        expect(resizeResponse.splitNodeID == splitNodeID, "resize response must identify the split node")
+        expect(
+            abs((resizeResponse.ratio ?? 0) - 0.72) < 0.001,
+            "resize response must include the resulting ratio"
+        )
+        expect(
+            resizeResponse.affectedPaneIDs == ["pane_1", "pane_2"],
+            "resize response must include affected pane ids"
+        )
+        expect(
+            controlEvents(controller).contains {
+                $0.type == "split.ratio_changed"
+                    && $0.payload["split_node_id"] == .string(splitNodeID)
+            },
+            "resize command must emit a split ratio event"
+        )
+
+        let equalizeResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "equalize-1",
+                  "command": "pane.equalize_splits",
+                  "tab_id": "\(controller.selectedTabID ?? "")"
+                }
+                """
+            )
+        )
+
+        expect(equalizeResponse.applied == true, "equalize_splits must report an applied result")
+        expect(equalizeResponse.ratio == 0.5, "equalize response must report the reset ratio")
+        expect(
+            equalizeResponse.changedSplitIDs == [splitNodeID],
+            "equalize response must identify changed split ids"
+        )
+        expect(
+            controlEvents(controller).contains {
+                $0.type == "split.equalized"
+                    && $0.payload["changed_split_ids"] == .array([.string(splitNodeID)])
+            },
+            "equalize command must emit an equalization event"
+        )
+
+        let unchangedResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "equalize-unchanged-1",
+                  "command": "pane.equalize_splits",
+                  "tab_id": "\(controller.selectedTabID ?? "")"
+                }
+                """
+            )
+        )
+        expect(unchangedResponse.applied == false, "unchanged equalize must not claim mutation")
+        expect(
+            unchangedResponse.errorCode == "unchanged_state",
+            "unchanged equalize must return a stable error code"
+        )
+    }
+
+    private static func verifiesAdvancedControlPlaneZoomFocusAndMovementResults() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        controller.focus(paneID: "pane_1")
+
+        let zoomResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "zoom-1",
+                  "command": "pane.zoom",
+                  "pane_id": "pane_2"
+                }
+                """
+            )
+        )
+
+        expect(zoomResponse.applied == true, "zoom command must apply to a valid split pane")
+        expect(zoomResponse.zoomedPaneID == "pane_2", "zoom response must include tab zoom state")
+        expect(
+            zoomResponse.previousFocusedPaneID == "pane_1"
+                && zoomResponse.currentFocusedPaneID == "pane_2",
+            "zoom response must report previous/current focus"
+        )
+        expect(
+            controlEvents(controller).contains {
+                $0.type == "pane.zoom_changed"
+                    && $0.payload["zoomed_pane_id"] == .string("pane_2")
+            },
+            "zoom command must emit a zoom state event"
+        )
+
+        let unzoomResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "unzoom-1",
+                  "command": "pane.unzoom",
+                  "tab_id": "\(controller.selectedTabID ?? "")"
+                }
+                """
+            )
+        )
+        expect(unzoomResponse.applied == true, "unzoom command must clear zoom state")
+        expect(unzoomResponse.zoomedPaneID == nil, "unzoom response must report cleared zoom state")
+
+        let spatialResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "spatial-left-1",
+                  "command": "pane.spatial_focus",
+                  "spatial_direction": "left"
+                }
+                """
+            )
+        )
+        expect(spatialResponse.applied == true, "spatial focus left must find the adjacent pane")
+        expect(
+            spatialResponse.previousFocusedPaneID == "pane_2"
+                && spatialResponse.currentFocusedPaneID == "pane_1",
+            "spatial focus response must report previous/current focus"
+        )
+
+        let noTargetResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "spatial-left-2",
+                  "command": "pane.spatial_focus",
+                  "spatial_direction": "left"
+                }
+                """
+            )
+        )
+        expect(noTargetResponse.applied == false, "spatial focus must not apply without a target")
+        expect(
+            noTargetResponse.errorCode == "spatial_focus_target_not_found",
+            "spatial focus must return a stable no-target error"
+        )
+        expect(
+            noTargetResponse.previousFocusedPaneID == "pane_1"
+                && noTargetResponse.currentFocusedPaneID == "pane_1",
+            "no-target spatial focus must preserve focus"
+        )
+
+        let moveResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "move-within-1",
+                  "command": "pane.move_within_tab",
+                  "pane_id": "pane_2",
+                  "placement": "left"
+                }
+                """
+            )
+        )
+        expect(moveResponse.applied == true, "move_within_tab must apply to an adjacent target")
+        expect(moveResponse.sourceTabID == moveResponse.targetTabID, "in-tab move must stay in one tab")
+        expect(
+            moveResponse.mountedContentInstanceID == "pane_2",
+            "movement response must report preserved mounted content identity"
+        )
+        expect(
+            controlEvents(controller).contains {
+                $0.type == "pane.moved_in_tab"
+                    && $0.payload["mounted_content_instance_id"] == .string("pane_2")
+            },
+            "in-tab movement must emit an advanced movement event"
         )
     }
 
@@ -3302,6 +3500,20 @@ private enum ShellRuntimeMetadataTests {
         } catch {
             fail("failed to decode control command fixture: \(error)")
         }
+    }
+
+    private static func controlEvents(_ controller: ShellHostController) -> [AlanShellEventEnvelope] {
+        controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "events-read-\(UUID().uuidString)",
+                  "command": "events.read",
+                  "limit": 200
+                }
+                """
+            )
+        ).events ?? []
     }
 
     private static func expect(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -41,6 +41,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesAdvancedControlPlaneResizeEqualizeAndEvents()
         verifiesSplitRatioEventsUseAffectedPaneForBackgroundTabs()
         verifiesAdvancedControlPlaneZoomFocusAndMovementResults()
+        verifiesAdvancedControlPlaneRejectsUnknownUnzoomPane()
+        verifiesPaneMoveSocketRequestsRequireHostMetadataHandler()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -1142,6 +1144,70 @@ private enum ShellRuntimeMetadataTests {
             },
             "in-tab movement must emit an advanced movement event"
         )
+    }
+
+    private static func verifiesAdvancedControlPlaneRejectsUnknownUnzoomPane() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        _ = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "zoom-before-invalid-unzoom-1",
+                  "command": "pane.zoom",
+                  "pane_id": "pane_2"
+                }
+                """
+            )
+        )
+        expect(controller.selectedTabZoomedPaneID == "pane_2", "test setup must zoom a pane")
+
+        let response = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "invalid-unzoom-pane-1",
+                  "command": "pane.unzoom",
+                  "pane_id": "pane_missing"
+                }
+                """
+            )
+        )
+
+        expect(response.applied == false, "unzoom with an unknown explicit pane must not apply")
+        expect(response.errorCode == "pane_not_found", "unknown unzoom pane must return pane_not_found")
+        expect(response.paneID == "pane_missing", "unknown unzoom pane response must echo pane_id")
+        expect(
+            controller.selectedTabZoomedPaneID == "pane_2",
+            "unknown unzoom pane must not fall back to and mutate the selected tab"
+        )
+    }
+
+    private static func verifiesPaneMoveSocketRequestsRequireHostMetadataHandler() {
+        let controller = makeController()
+        let socketServer = AlanShellSocketServer(
+            socketURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("pane-move-host-\(UUID().uuidString).sock"),
+            commandHandler: { controller.handleControlPlaneCommand($0) },
+            stateAdoptionHandler: { _ in fail("pane.move must not mutate through the local executor") },
+            sideEffectHandler: { _ in fail("pane.move must not use local side effects") }
+        )
+        _ = socketServer.mergePublishedState(controller.shellState)
+
+        let localResponse = socketServer.handleLocally(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "pane-move-host-routing-1",
+                  "command": "pane.move",
+                  "pane_id": "pane_1",
+                  "tab_id": "tab_main"
+                }
+                """
+            )
+        )
+
+        expect(localResponse == nil, "pane.move socket requests must be routed to the host handler")
     }
 
     private static func verifiesTerminalActivityProjectsByPaneID() {

--- a/crates/alan/src/cli/shell.rs
+++ b/crates/alan/src/cli/shell.rs
@@ -32,7 +32,15 @@ struct ShellControlCommand {
     #[serde(skip_serializing_if = "Option::is_none")]
     pane_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    split_node_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ratio: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spatial_direction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    placement: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,6 +72,19 @@ struct ShellControlResponse {
     space_id: Option<String>,
     tab_id: Option<String>,
     pane_id: Option<String>,
+    split_node_id: Option<String>,
+    ratio: Option<f64>,
+    changed_split_ids: Option<Value>,
+    affected_pane_ids: Option<Value>,
+    zoomed_pane_id: Option<String>,
+    source_tab_id: Option<String>,
+    target_tab_id: Option<String>,
+    previous_focused_pane_id: Option<String>,
+    current_focused_pane_id: Option<String>,
+    split_direction: Option<String>,
+    spatial_direction: Option<String>,
+    placement: Option<String>,
+    mounted_content_instance_id: Option<String>,
     accepted_bytes: Option<u64>,
     latest_event_id: Option<String>,
     error_code: Option<String>,
@@ -233,9 +254,75 @@ pub fn run_shell_pane_move(
     print_pretty(&response)
 }
 
+pub fn run_shell_pane_move_within_tab(
+    pane: &str,
+    placement: &str,
+    options: ShellTargetOptions,
+) -> Result<()> {
+    let mut command = build_command("pane.move_within_tab");
+    command.pane_id = Some(pane.to_string());
+    command.placement = Some(placement.to_string());
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
 pub fn run_shell_pane_focus(pane: &str, options: ShellTargetOptions) -> Result<()> {
     let mut command = build_command("pane.focus");
     command.pane_id = Some(pane.to_string());
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
+pub fn run_shell_pane_spatial_focus(direction: &str, options: ShellTargetOptions) -> Result<()> {
+    let mut command = build_command("pane.spatial_focus");
+    command.spatial_direction = Some(direction.to_string());
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
+pub fn run_shell_pane_resize_split(
+    split_node: &str,
+    ratio: f64,
+    options: ShellTargetOptions,
+) -> Result<()> {
+    let mut command = build_command("pane.resize_split");
+    command.split_node_id = Some(split_node.to_string());
+    command.ratio = Some(ratio);
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
+pub fn run_shell_pane_equalize_splits(
+    tab: Option<&str>,
+    options: ShellTargetOptions,
+) -> Result<()> {
+    let mut command = build_command("pane.equalize_splits");
+    command.tab_id = tab.map(str::to_owned);
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
+pub fn run_shell_pane_zoom(pane: &str, options: ShellTargetOptions) -> Result<()> {
+    let mut command = build_command("pane.zoom");
+    command.pane_id = Some(pane.to_string());
+    let response = invoke(&options, command)?;
+    ensure_success(&response)?;
+    print_pretty(&response)
+}
+
+pub fn run_shell_pane_unzoom(
+    pane: Option<&str>,
+    tab: Option<&str>,
+    options: ShellTargetOptions,
+) -> Result<()> {
+    let mut command = build_command("pane.unzoom");
+    command.pane_id = pane.map(str::to_owned);
+    command.tab_id = tab.map(str::to_owned);
     let response = invoke(&options, command)?;
     ensure_success(&response)?;
     print_pretty(&response)
@@ -332,7 +419,11 @@ fn build_command(command: &str) -> ShellControlCommand {
         space_id: None,
         tab_id: None,
         pane_id: None,
+        split_node_id: None,
+        ratio: None,
         direction: None,
+        spatial_direction: None,
+        placement: None,
         title: None,
         cwd: None,
         text: None,
@@ -704,7 +795,11 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: None,
+                split_node_id: None,
+                ratio: None,
                 direction: None,
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,
@@ -767,7 +862,11 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_9".to_string()),
+                split_node_id: None,
+                ratio: None,
                 direction: None,
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,
@@ -830,7 +929,11 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_2".to_string()),
+                split_node_id: None,
+                ratio: None,
                 direction: None,
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,
@@ -891,7 +994,11 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_7".to_string()),
+                split_node_id: None,
+                ratio: None,
                 direction: None,
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,
@@ -936,7 +1043,11 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_2".to_string()),
+                split_node_id: None,
+                ratio: None,
                 direction: None,
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,
@@ -994,7 +1105,11 @@ mod tests {
                 space_id: None,
                 tab_id: Some("tab_9".to_string()),
                 pane_id: Some("pane_2".to_string()),
+                split_node_id: None,
+                ratio: None,
                 direction: Some("vertical".to_string()),
+                spatial_direction: None,
+                placement: None,
                 title: None,
                 cwd: None,
                 text: None,

--- a/crates/alan/src/main.rs
+++ b/crates/alan/src/main.rs
@@ -600,11 +600,68 @@ enum ShellPaneAction {
         #[command(flatten)]
         target: ShellTargetArgs,
     },
+    /// Move a pane inside its current tab
+    MoveWithinTab {
+        /// Pane id to move
+        #[arg(long)]
+        pane: String,
+        /// Placement relative to the adjacent pane
+        #[arg(long, value_parser = ["left", "right", "up", "down"])]
+        placement: String,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
     /// Focus a pane
     Focus {
         /// Pane id to focus
         #[arg(long)]
         pane: String,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+    /// Focus an adjacent pane by spatial direction
+    SpatialFocus {
+        /// Spatial direction to focus
+        #[arg(long, value_parser = ["left", "right", "up", "down"])]
+        direction: String,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+    /// Resize a split node
+    ResizeSplit {
+        /// Split node id to resize
+        #[arg(long)]
+        split_node: String,
+        /// Resulting split ratio
+        #[arg(long)]
+        ratio: f64,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+    /// Equalize split ratios in a tab
+    EqualizeSplits {
+        /// Optional tab id; defaults to the selected tab
+        #[arg(long)]
+        tab: Option<String>,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+    /// Zoom a split pane
+    Zoom {
+        /// Pane id to zoom
+        #[arg(long)]
+        pane: String,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+    /// Unzoom a tab
+    Unzoom {
+        /// Optional pane id whose tab should unzoom
+        #[arg(long)]
+        pane: Option<String>,
+        /// Optional tab id; defaults to the selected tab
+        #[arg(long)]
+        tab: Option<String>,
         #[command(flatten)]
         target: ShellTargetArgs,
     },
@@ -1025,8 +1082,52 @@ async fn main() -> Result<()> {
                         shell_target_options(target),
                     )?;
                 }
+                ShellPaneAction::MoveWithinTab {
+                    pane,
+                    placement,
+                    target,
+                } => {
+                    cli::shell::run_shell_pane_move_within_tab(
+                        &pane,
+                        &placement,
+                        shell_target_options(target),
+                    )?;
+                }
                 ShellPaneAction::Focus { pane, target } => {
                     cli::shell::run_shell_pane_focus(&pane, shell_target_options(target))?;
+                }
+                ShellPaneAction::SpatialFocus { direction, target } => {
+                    cli::shell::run_shell_pane_spatial_focus(
+                        &direction,
+                        shell_target_options(target),
+                    )?;
+                }
+                ShellPaneAction::ResizeSplit {
+                    split_node,
+                    ratio,
+                    target,
+                } => {
+                    cli::shell::run_shell_pane_resize_split(
+                        &split_node,
+                        ratio,
+                        shell_target_options(target),
+                    )?;
+                }
+                ShellPaneAction::EqualizeSplits { tab, target } => {
+                    cli::shell::run_shell_pane_equalize_splits(
+                        tab.as_deref(),
+                        shell_target_options(target),
+                    )?;
+                }
+                ShellPaneAction::Zoom { pane, target } => {
+                    cli::shell::run_shell_pane_zoom(&pane, shell_target_options(target))?;
+                }
+                ShellPaneAction::Unzoom { pane, tab, target } => {
+                    cli::shell::run_shell_pane_unzoom(
+                        pane.as_deref(),
+                        tab.as_deref(),
+                        shell_target_options(target),
+                    )?;
                 }
                 ShellPaneAction::SendText { pane, text, target } => {
                     cli::shell::run_shell_pane_send_text(

--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -14,10 +14,10 @@
 
 ## 3. Control Plane
 
-- [ ] 3.1 Add control-plane commands for resize, equalize, zoom, unzoom, and spatial focus.
-- [ ] 3.2 Return stable result payloads for changed split IDs, ratios, tab zoom state, previous/current focus, and no-target errors.
-- [ ] 3.3 Emit shell events for split ratio changes, equalization, zoom state changes, spatial focus, and advanced movement.
-- [ ] 3.4 Add control-plane tests for success, invalid target, no target, and unchanged-state outcomes.
+- [x] 3.1 Add control-plane commands for resize, equalize, zoom, unzoom, and spatial focus.
+- [x] 3.2 Return stable result payloads for changed split IDs, ratios, tab zoom state, previous/current focus, and no-target errors.
+- [x] 3.3 Emit shell events for split ratio changes, equalization, zoom state changes, spatial focus, and advanced movement.
+- [x] 3.4 Add control-plane tests for success, invalid target, no target, and unchanged-state outcomes.
 
 ## 4. Copy Paste And Search
 


### PR DESCRIPTION
## Summary
- add control-plane commands and CLI entry points for split resize/equalize, pane zoom/unzoom, spatial focus, and same-tab pane movement
- return semantic result fields for split ids, ratios, affected panes, zoom state, previous/current focus, movement source/target, and preserved mounted content identity
- emit shell events for split ratio changes, equalization, zoom state changes, spatial focus, and advanced in-tab movement
- mark OpenSpec tasks 3.1-3.4 complete for complete-macos-shell-advanced-splits, bringing progress to 12/24

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-action-registry.sh
- cargo check -p alan --bin alan
- cargo test -p alan shell::tests --lib
- git diff --check
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate complete-macos-shell-advanced-splits --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-next-openspec-derived build

Note: the first xcodebuild run failed inside the Codex sandbox at Xcode's sandbox-exec script phase; the same command passed after rerunning with the approved Xcode build permission.