### PR TITLE
Route terminal copy paste search commands

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -16,6 +16,32 @@ struct AlanMacShellCommands: Commands {
             .keyboardShortcut("n", modifiers: .command)
         }
 
+        CommandGroup(replacing: .pasteboard) {
+            Button("Cut") {
+                sendResponderAction(#selector(NSText.cut(_:)))
+            }
+            .keyboardShortcut("x", modifiers: .command)
+
+            Button("Copy") {
+                if !host.copyTerminalSelection(source: .menuBar) {
+                    sendResponderAction(#selector(NSText.copy(_:)))
+                }
+            }
+            .keyboardShortcut("c", modifiers: .command)
+
+            Button("Paste") {
+                if !host.pasteIntoTerminalFromPasteboard(source: .menuBar) {
+                    sendResponderAction(#selector(NSText.paste(_:)))
+                }
+            }
+            .keyboardShortcut("v", modifiers: .command)
+
+            Button("Select All") {
+                sendResponderAction(#selector(NSText.selectAll(_:)))
+            }
+            .keyboardShortcut("a", modifiers: .command)
+        }
+
         CommandMenu("Tools") {
             Button("Install Command Line Tools...") {
                 installCommandLineTools()
@@ -37,6 +63,12 @@ struct AlanMacShellCommands: Commands {
                 host.requestCommandInput()
             }
             .keyboardShortcut("p", modifiers: .command)
+
+            Button("Find") {
+                host.openTerminalSearch(source: .menuBar)
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .disabled(!host.canOpenTerminalSearch(source: .menuBar))
 
             Button(host.shellActionTitle(.quickTerminalToggle)) {
                 host.performShellAction(.quickTerminalToggle)
@@ -172,6 +204,10 @@ struct AlanMacShellCommands: Commands {
             .shellActionKeyboardShortcut(host.shellActionShortcut(.tabClose))
             .disabled(!host.shellActionAvailability(.tabClose).isAvailable)
         }
+    }
+
+    private func sendResponderAction(_ selector: Selector) {
+        NSApp.sendAction(selector, to: nil, from: nil)
     }
 
     private func installCommandLineTools() {

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -75,6 +75,106 @@ enum ShellActionSurface: String, Equatable {
     case keyboard
 }
 
+enum ShellTerminalCommand: String, Equatable {
+    case copySelection = "copy_selection"
+    case paste
+    case search
+    case copyLastCommandOutput = "copy_last_command_output"
+    case searchLastCommandOutput = "search_last_command_output"
+}
+
+enum ShellTerminalCommandSource: String, Equatable {
+    case menuBar = "menu_bar"
+    case keyboardShortcut = "keyboard_shortcut"
+    case commandUI = "command_ui"
+    case contextMenu = "context_menu"
+    case terminalHost = "terminal_host"
+}
+
+struct ShellTerminalCommandRuntimeState: Equatable {
+    let paneID: String
+    let hasSelection: Bool
+    let inputReady: Bool
+    let searchAvailable: Bool
+    let hasReliableSemanticCommands: Bool
+}
+
+struct ShellTerminalCommandTarget: Equatable {
+    let paneID: String
+    let tabID: String
+    let spaceID: String
+    let mountedContentID: String
+}
+
+enum ShellTerminalCommandResolution: Equatable {
+    case terminal(ShellTerminalCommandTarget)
+    case shell(reason: String)
+
+    var terminalTarget: ShellTerminalCommandTarget? {
+        guard case .terminal(let target) = self else { return nil }
+        return target
+    }
+}
+
+enum ShellCommandTargetResolver {
+    static func resolveTerminalCommand(
+        _ command: ShellTerminalCommand,
+        source: ShellTerminalCommandSource,
+        target: ShellActionTarget,
+        state: ShellStateSnapshot,
+        commandInputActive: Bool,
+        runtimeState: (String) -> ShellTerminalCommandRuntimeState
+    ) -> ShellTerminalCommandResolution {
+        if commandInputActive,
+           source == .menuBar || source == .keyboardShortcut
+        {
+            return .shell(reason: "shell_text_input_active")
+        }
+
+        let paneID: String?
+        if case .contextPane(let contextPaneID) = target {
+            paneID = contextPaneID
+        } else {
+            paneID = state.focusedPaneID
+        }
+
+        guard let paneID,
+              let pane = state.pane(paneID: paneID)
+        else {
+            return .shell(reason: "terminal_pane_unavailable")
+        }
+
+        let runtime = runtimeState(paneID)
+        switch command {
+        case .copySelection:
+            guard runtime.hasSelection else {
+                return .shell(reason: "terminal_selection_unavailable")
+            }
+        case .paste:
+            guard runtime.inputReady else {
+                return .shell(reason: "terminal_input_unavailable")
+            }
+        case .search:
+            guard runtime.searchAvailable else {
+                return .shell(reason: "terminal_search_unavailable")
+            }
+        case .copyLastCommandOutput, .searchLastCommandOutput:
+            guard runtime.hasReliableSemanticCommands else {
+                return .shell(reason: "terminal_semantic_commands_unavailable")
+            }
+        }
+
+        return .terminal(
+            ShellTerminalCommandTarget(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                mountedContentID: pane.paneID
+            )
+        )
+    }
+}
+
 enum ShellActionModifier: String, CaseIterable, Hashable, Comparable {
     case command
     case option

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -309,6 +309,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var terminalRuntime: TerminalHostRuntimeSnapshot = .placeholder
     @Published private(set) var controlPlaneDiagnostics: [String] = []
     @Published private(set) var commandInputRequestID = 0
+    @Published private(set) var commandInputActive = false
     @Published private(set) var activityNotifications: [ShellActivityNotificationRoute] = []
     @Published private(set) var zoomedPaneIDByTabID: [String: String] = [:]
 
@@ -786,6 +787,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         commandInputRequestID += 1
     }
 
+    func setCommandInputActive(_ active: Bool) {
+        commandInputActive = active
+    }
+
     func refocusSelectedTerminalPane() {
         guard let paneID = selectedPane?.paneID else { return }
         terminalRuntimeRegistry.requestFocus(for: paneID)
@@ -1181,9 +1186,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @discardableResult
     func performShellAction(
         _ id: ShellActionID,
-        target: ShellActionTarget = .currentSelection
+        target: ShellActionTarget = .currentSelection,
+        source: ShellTerminalCommandSource = .keyboardShortcut
     ) -> ShellActionExecutionResult {
-        ShellActionRegistry.standard.execute(
+        if id == .findOpen {
+            return openTerminalSearch(source: source, target: target)
+                ? .executed
+                : .failed(reason: "Terminal search target is unavailable")
+        }
+
+        return ShellActionRegistry.standard.execute(
             id,
             target: target,
             state: shellState
@@ -1343,6 +1355,116 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         lastCopiedAt = .now
     }
 
+    func terminalCommandResolution(
+        for command: ShellTerminalCommand,
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> ShellTerminalCommandResolution {
+        ShellCommandTargetResolver.resolveTerminalCommand(
+            command,
+            source: source,
+            target: target,
+            state: shellState,
+            commandInputActive: commandInputActive
+        ) { [terminalRuntimeRegistry] paneID in
+            terminalRuntimeRegistry.terminalCommandRuntimeState(for: paneID)
+        }
+    }
+
+    func canCopyTerminalSelection(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        terminalCommandResolution(
+            for: .copySelection,
+            source: source,
+            target: target
+        ).terminalTarget != nil
+    }
+
+    func canPasteIntoTerminal(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        terminalCommandResolution(
+            for: .paste,
+            source: source,
+            target: target
+        ).terminalTarget != nil
+    }
+
+    func canOpenTerminalSearch(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        terminalCommandResolution(
+            for: .search,
+            source: source,
+            target: target
+        ).terminalTarget != nil
+    }
+
+    @discardableResult
+    func copyTerminalSelection(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection,
+        writer: AlanTerminalPasteboardWriting? = nil
+    ) -> Bool {
+        guard let terminalTarget = terminalCommandResolution(
+            for: .copySelection,
+            source: source,
+            target: target
+        ).terminalTarget else {
+            return false
+        }
+        if let writer {
+            return terminalRuntimeRegistry.copySelection(for: terminalTarget.paneID, to: writer)
+        }
+        return terminalRuntimeRegistry.copySelection(for: terminalTarget.paneID)
+    }
+
+    @discardableResult
+    func pasteIntoTerminalFromPasteboard(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else {
+            return false
+        }
+        return pasteIntoTerminal(text, source: source, target: target)
+    }
+
+    @discardableResult
+    func pasteIntoTerminal(
+        _ text: String,
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        guard let terminalTarget = terminalCommandResolution(
+            for: .paste,
+            source: source,
+            target: target
+        ).terminalTarget else {
+            return false
+        }
+        return terminalRuntimeRegistry.pasteText(text, to: terminalTarget.paneID).applied
+    }
+
+    @discardableResult
+    func openTerminalSearch(
+        source: ShellTerminalCommandSource = .keyboardShortcut,
+        target: ShellActionTarget = .currentSelection
+    ) -> Bool {
+        guard let terminalTarget = terminalCommandResolution(
+            for: .search,
+            source: source,
+            target: target
+        ).terminalTarget else {
+            return false
+        }
+        return terminalRuntimeRegistry.beginFindInteraction(for: terminalTarget.paneID)
+    }
+
     var focusedPaneHasReliableSemanticCommands: Bool {
         guard let paneID = selectedPane?.paneID,
               paneID == terminalRuntime.paneID
@@ -1365,14 +1487,24 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func copyLastCommandOutput() -> Bool {
-        guard let paneID = selectedPane?.paneID else { return false }
-        return terminalRuntimeRegistry.copyLastCommandOutput(for: paneID)
+        guard let terminalTarget = terminalCommandResolution(
+            for: .copyLastCommandOutput,
+            source: .commandUI
+        ).terminalTarget else {
+            return false
+        }
+        return terminalRuntimeRegistry.copyLastCommandOutput(for: terminalTarget.paneID)
     }
 
     @discardableResult
     func searchLastCommandOutput() -> Bool {
-        guard let paneID = selectedPane?.paneID else { return false }
-        return terminalRuntimeRegistry.beginLastCommandOutputSearch(for: paneID)
+        guard let terminalTarget = terminalCommandResolution(
+            for: .searchLastCommandOutput,
+            source: .commandUI
+        ).terminalTarget else {
+            return false
+        }
+        return terminalRuntimeRegistry.beginLastCommandOutputSearch(for: terminalTarget.paneID)
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -1017,13 +1017,13 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         switch keyboardDecision {
         case .shellAction(let actionID, let target):
             if actionID == .findOpen {
-                _ = beginFindInteraction()
+                _ = routeFindCommandToShellHost(target: target)
             } else {
                 shellActionHandler?(actionID, target)
             }
             return
         case .nativeCommand("find"):
-            _ = beginFindInteraction()
+            _ = routeFindCommandToShellHost()
             return
         case .nativeCommand("quit"):
             NSApp.terminate(nil)
@@ -1205,7 +1205,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     @objc func copy(_ sender: Any?) {
-        _ = surfaceController.copySelection(to: .general)
+        _ = copySelection()
     }
 
     @objc func cut(_ sender: Any?) {
@@ -1214,8 +1214,34 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     @objc func paste(_ sender: Any?) {
         guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else { return }
-        _ = surfaceController.paste(text)
+        _ = pasteText(text)
+    }
+
+    var terminalCommandRuntimeState: ShellTerminalCommandRuntimeState {
+        ShellTerminalCommandRuntimeState(
+            paneID: pane?.paneID ?? "",
+            hasSelection: surfaceController.hasSelection(),
+            inputReady: surfaceController.surfaceStateSnapshot.inputReady,
+            searchAvailable: pane?.paneID != nil,
+            hasReliableSemanticCommands: surfaceController.hasReliableSemanticCommandActions
+        )
+    }
+
+    @discardableResult
+    func copySelection() -> Bool {
+        surfaceController.copySelection(to: .general)
+    }
+
+    @discardableResult
+    func copySelection(to writer: AlanTerminalPasteboardWriting) -> Bool {
+        surfaceController.copySelection(to: writer)
+    }
+
+    @discardableResult
+    func pasteText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        let result = surfaceController.paste(text)
         publishRuntimeSnapshot()
+        return result
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
@@ -1371,7 +1397,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             hasMarkedText: markedText.length > 0
         ) {
         case .nativeCommand("find"):
-            return beginFindInteraction()
+            return routeFindCommandToShellHost()
         case .nativeCommand("quit"):
             return false
         case .nativeCommand, .shellAction, .terminalKey, .interpretTextInput, .drop:
@@ -1387,9 +1413,25 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return false
         }
         if actionID == .findOpen {
-            return beginFindInteraction()
+            return routeFindCommandToShellHost(target: target)
         }
         shellActionHandler?(actionID, target)
+        return true
+    }
+
+    private func routeFindCommandToShellHost(target: ShellActionTarget = .currentSelection) -> Bool {
+        guard let shellActionHandler else {
+            return beginFindInteraction()
+        }
+        let resolvedTarget: ShellActionTarget
+        if case .currentSelection = target,
+           let paneID = pane?.paneID
+        {
+            resolvedTarget = .contextPane(paneID)
+        } else {
+            resolvedTarget = target
+        }
+        shellActionHandler(.findOpen, resolvedTarget)
         return true
     }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -470,10 +470,22 @@ private struct ShellPaneTreeLayoutView: View {
                             target: .contextPane(pane.paneID)
                         ).isAvailable
                     },
+                    canCopyTerminalSelection: host.canCopyTerminalSelection(
+                        source: .contextMenu,
+                        target: .contextPane(pane.paneID)
+                    ),
+                    canPasteIntoTerminal: host.canPasteIntoTerminal(
+                        source: .contextMenu,
+                        target: .contextPane(pane.paneID)
+                    ),
+                    canOpenTerminalSearch: host.canOpenTerminalSearch(
+                        source: .contextMenu,
+                        target: .contextPane(pane.paneID)
+                    ),
                     runtimeRegistry: host.terminalRuntimeRegistry,
                     activationDelegate: host,
                     onShellAction: { actionID, target in
-                        host.performShellAction(actionID, target: target)
+                        host.performShellAction(actionID, target: target, source: .terminalHost)
                     },
                     onCommandInput: {
                         host.requestCommandInput()
@@ -488,6 +500,24 @@ private struct ShellPaneTreeLayoutView: View {
                     onMovePane: { placement in
                         host.performShellAction(
                             paneMoveActionID(for: placement),
+                            target: .contextPane(pane.paneID)
+                        )
+                    },
+                    onCopyTerminalSelection: {
+                        host.copyTerminalSelection(
+                            source: .contextMenu,
+                            target: .contextPane(pane.paneID)
+                        )
+                    },
+                    onPasteIntoTerminal: {
+                        host.pasteIntoTerminalFromPasteboard(
+                            source: .contextMenu,
+                            target: .contextPane(pane.paneID)
+                        )
+                    },
+                    onOpenTerminalSearch: {
+                        host.openTerminalSearch(
+                            source: .contextMenu,
                             target: .contextPane(pane.paneID)
                         )
                     },
@@ -685,12 +715,18 @@ private struct ShellTerminalLeafView: View {
     let isZoomed: Bool
     let canZoom: Bool
     let canMovePane: (ShellPaneSplitDirection) -> Bool
+    let canCopyTerminalSelection: Bool
+    let canPasteIntoTerminal: Bool
+    let canOpenTerminalSearch: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
     let onShellAction: (ShellActionID, ShellActionTarget) -> Void
     let onCommandInput: () -> Void
     let onToggleZoom: () -> Void
     let onMovePane: (ShellPaneSplitDirection) -> Void
+    let onCopyTerminalSelection: () -> Void
+    let onPasteIntoTerminal: () -> Void
+    let onOpenTerminalSearch: () -> Void
     let onClosePane: () -> Void
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
     let onMetadataUpdate: (TerminalPaneMetadataSnapshot) -> Void
@@ -704,11 +740,17 @@ private struct ShellTerminalLeafView: View {
                 isZoomed: isZoomed,
                 canZoom: canZoom,
                 canMovePane: canMovePane,
+                canCopyTerminalSelection: canCopyTerminalSelection,
+                canPasteIntoTerminal: canPasteIntoTerminal,
+                canOpenTerminalSearch: canOpenTerminalSearch,
                 onFocusPane: {
                     activationDelegate?.terminalHostDidRequestActivation(paneID: pane.paneID)
                 },
                 onToggleZoom: onToggleZoom,
                 onMovePane: onMovePane,
+                onCopyTerminalSelection: onCopyTerminalSelection,
+                onPasteIntoTerminal: onPasteIntoTerminal,
+                onOpenTerminalSearch: onOpenTerminalSearch,
                 onClosePane: onClosePane
             )
 
@@ -821,9 +863,15 @@ private struct ShellPaneTitleBarView: View {
     let isZoomed: Bool
     let canZoom: Bool
     let canMovePane: (ShellPaneSplitDirection) -> Bool
+    let canCopyTerminalSelection: Bool
+    let canPasteIntoTerminal: Bool
+    let canOpenTerminalSearch: Bool
     let onFocusPane: () -> Void
     let onToggleZoom: () -> Void
     let onMovePane: (ShellPaneSplitDirection) -> Void
+    let onCopyTerminalSelection: () -> Void
+    let onPasteIntoTerminal: () -> Void
+    let onOpenTerminalSearch: () -> Void
     let onClosePane: () -> Void
     @State private var activityFreshnessNow = Date()
 
@@ -860,6 +908,23 @@ private struct ShellPaneTitleBarView: View {
                 onMovePane(.down)
             }
             .disabled(!canMovePane(.down))
+
+            Divider()
+
+            Button("Copy") {
+                onCopyTerminalSelection()
+            }
+            .disabled(!canCopyTerminalSelection)
+
+            Button("Paste") {
+                onPasteIntoTerminal()
+            }
+            .disabled(!canPasteIntoTerminal)
+
+            Button("Find") {
+                onOpenTerminalSearch()
+            }
+            .disabled(!canOpenTerminalSearch)
         }
         .task(id: activityFreshnessRefreshID) {
             await scheduleActivityFreshnessRefresh()

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -139,6 +139,57 @@ final class TerminalRuntimeRegistry: ObservableObject {
         return runtimeService.sendText(to: paneID, text: text)
     }
 
+    func terminalCommandRuntimeState(for paneID: String) -> ShellTerminalCommandRuntimeState {
+        if let hostView = hostViewsByPaneID[paneID] {
+            return hostView.terminalCommandRuntimeState
+        }
+
+        let surfaceHandle = runtimeService.existingSurfaceHandle(for: paneID)
+        let selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine
+        let searchEngine = surfaceHandle as? AlanTerminalSearchEngine
+        let snapshot = snapshotsByPaneID[paneID]
+        return ShellTerminalCommandRuntimeState(
+            paneID: paneID,
+            hasSelection: selectionEngine?.hasSelection() ?? false,
+            inputReady: surfaceHandle?.isSurfaceReady ?? snapshot?.surfaceState.inputReady ?? false,
+            searchAvailable: searchEngine != nil,
+            hasReliableSemanticCommands: snapshot?.surfaceState.semanticCommands.hasReliableCommandBoundaries ?? false
+        )
+    }
+
+    @discardableResult
+    func copySelection(for paneID: String) -> Bool {
+        if let hostView = hostViewsByPaneID[paneID] {
+            return hostView.copySelection()
+        }
+        return copySelection(
+            for: paneID,
+            to: AlanTerminalSystemPasteboardWriter(pasteboard: .general)
+        )
+    }
+
+    @discardableResult
+    func copySelection(for paneID: String, to writer: AlanTerminalPasteboardWriting) -> Bool {
+        if let hostView = hostViewsByPaneID[paneID] {
+            return hostView.copySelection(to: writer)
+        }
+        guard let selectionEngine = runtimeService.existingSurfaceHandle(for: paneID) as? AlanTerminalSelectionEngine,
+              let selectedText = selectionEngine.readSelectionText(),
+              !selectedText.isEmpty
+        else {
+            return false
+        }
+        return writer.writeString(selectedText)
+    }
+
+    @discardableResult
+    func pasteText(_ text: String, to paneID: String) -> TerminalRuntimeDeliveryResult {
+        if let hostView = hostViewsByPaneID[paneID] {
+            return hostView.pasteText(text)
+        }
+        return sendText(to: paneID, text: text)
+    }
+
     @discardableResult
     func beginFindInteraction(for paneID: String) -> Bool {
         hostViewsByPaneID[paneID]?.beginFindInteraction() ?? false

--- a/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
@@ -26,6 +26,9 @@ private enum ShellCommandInputAction: CaseIterable {
     case quickTerminalFocus
     case quickTerminalClose
     case jumpToAttention
+    case copyTerminalSelection
+    case pasteIntoTerminal
+    case searchTerminal
     case previousPrompt
     case nextPrompt
     case copyLastCommandOutput
@@ -81,6 +84,12 @@ private enum ShellCommandInputAction: CaseIterable {
             return ["close quick terminal"]
         case .jumpToAttention:
             return ["jump to attention", "focus attention", "attention"]
+        case .copyTerminalSelection:
+            return ["copy", "copy selection", "copy terminal selection"]
+        case .pasteIntoTerminal:
+            return ["paste", "paste into terminal"]
+        case .searchTerminal:
+            return ["find", "search", "terminal search", "find in terminal"]
         case .previousPrompt:
             return ["previous prompt", "jump previous prompt", "go previous prompt"]
         case .nextPrompt:
@@ -153,6 +162,9 @@ struct ShellCommandTabView: View {
         }
         .onChange(of: isActive) { _, active in
             updateActiveState(active)
+        }
+        .onDisappear {
+            host.setCommandInputActive(false)
         }
         .onExitCommand {
             dismissAndRestoreFocus()
@@ -283,6 +295,12 @@ struct ShellCommandTabView: View {
             if let firstAttention = host.attentionItems.first {
                 host.focusAttentionItem(firstAttention)
             }
+        case .copyTerminalSelection:
+            host.copyTerminalSelection(source: .commandUI)
+        case .pasteIntoTerminal:
+            host.pasteIntoTerminalFromPasteboard(source: .commandUI)
+        case .searchTerminal:
+            host.openTerminalSearch(source: .commandUI)
         case .previousPrompt:
             host.jumpToPreviousPrompt()
         case .nextPrompt:
@@ -296,6 +314,7 @@ struct ShellCommandTabView: View {
     }
 
     private func updateActiveState(_ active: Bool) {
+        host.setCommandInputActive(active)
         if active {
             query = ""
             unresolvedMessage = nil

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -902,7 +902,7 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "host\\.performShellAction\\(actionID, target: target\\)" \
+    "host\\.performShellAction\\(actionID, target: target, source: \\.terminalHost\\)" \
     "terminal shortcut routing must enter the shared shell action registry handler"
 
 require_pattern \

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -11,6 +11,7 @@ protocol TerminalHostActivationDelegate: AnyObject {
 final class AlanTerminalHostNSView: NSView {
     private(set) var teardownCount = 0
     private(set) var focusCount = 0
+    private weak var surfaceHandle: AlanTerminalSurfaceHandle?
 
     func configure(
         pane: ShellPane?,
@@ -23,14 +24,47 @@ final class AlanTerminalHostNSView: NSView {
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
-    ) {}
+    ) {
+        self.surfaceHandle = surfaceHandle
+    }
 
     func teardownTerminalRuntime() {
         teardownCount += 1
     }
 
+    var terminalCommandRuntimeState: ShellTerminalCommandRuntimeState {
+        let selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine
+        let searchEngine = surfaceHandle as? AlanTerminalSearchEngine
+        return ShellTerminalCommandRuntimeState(
+            paneID: surfaceHandle?.paneID ?? "",
+            hasSelection: selectionEngine?.hasSelection() ?? false,
+            inputReady: surfaceHandle?.isSurfaceReady ?? false,
+            searchAvailable: searchEngine != nil,
+            hasReliableSemanticCommands: false
+        )
+    }
+
+    func copySelection() -> Bool {
+        copySelection(to: AlanTerminalSystemPasteboardWriter(pasteboard: .general))
+    }
+
+    func copySelection(to writer: AlanTerminalPasteboardWriting) -> Bool {
+        guard let selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine,
+              let text = selectionEngine.readSelectionText(),
+              !text.isEmpty
+        else {
+            return false
+        }
+        return writer.writeString(text)
+    }
+
+    func pasteText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        surfaceHandle?.sendControlText(text)
+            ?? .missingTarget(errorMessage: "The stub terminal host has no surface handle.")
+    }
+
     func beginFindInteraction() -> Bool {
-        false
+        (surfaceHandle as? AlanTerminalSearchEngine)?.startSearch() ?? false
     }
 
     func beginLastCommandOutputSearch() -> Bool {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -38,6 +38,10 @@ private enum ShellRuntimeMetadataTests {
         verifiesSplitZoomIsTabScopedAndPrunedWhenPaneDisappears()
         verifiesInTabPaneMovementPreservesRuntimeContinuity()
         verifiesPaneMovementDragPolicyProtectsTerminalSelection()
+        verifiesTerminalCommandResolverProtectsShellTextInput()
+        verifiesCopyPasteRouteToFocusedTerminalRuntime()
+        verifiesContextMenuTerminalCommandsUseContextPane()
+        verifiesTerminalSearchRoutesThroughFocusedHostSurface()
         verifiesAdvancedControlPlaneResizeEqualizeAndEvents()
         verifiesSplitRatioEventsUseAffectedPaneForBackgroundTabs()
         verifiesAdvancedControlPlaneZoomFocusAndMovementResults()
@@ -883,6 +887,127 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedTab?.paneTree.paneIDs == ["pane_2", "pane_1"],
             "drag-backed movement must preserve the explicit movement result semantics"
+        )
+    }
+
+    private static func verifiesTerminalCommandResolverProtectsShellTextInput() {
+        let controller = makeController()
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        handle.selectedText = "terminal selection"
+
+        expect(
+            controller.terminalCommandResolution(for: .copySelection).terminalTarget?.paneID == "pane_1",
+            "keyboard copy must target the focused terminal when it owns a selection"
+        )
+
+        controller.setCommandInputActive(true)
+        expect(
+            controller.terminalCommandResolution(for: .copySelection)
+                == .shell(reason: "shell_text_input_active"),
+            "keyboard copy must not steal text editing while command input is active"
+        )
+        expect(
+            controller.terminalCommandResolution(for: .copySelection, source: .commandUI)
+                .terminalTarget?.paneID == "pane_1",
+            "command UI execution must still route through the shared terminal resolver"
+        )
+    }
+
+    private static func verifiesCopyPasteRouteToFocusedTerminalRuntime() {
+        let controller = makeController()
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        handle.selectedText = "focused terminal selection"
+        let pasteboard = RecordingTerminalPasteboardWriter()
+
+        expect(
+            controller.copyTerminalSelection(source: .menuBar, writer: pasteboard),
+            "menu copy must resolve to the focused terminal selection"
+        )
+        expect(
+            pasteboard.string == "focused terminal selection",
+            "menu copy must write the focused terminal selection"
+        )
+
+        expect(
+            controller.pasteIntoTerminal("pasted payload", source: .menuBar),
+            "menu paste must resolve to the focused terminal input path"
+        )
+        expect(
+            handle.deliveredText.last == "pasted payload",
+            "menu paste must deliver text through the terminal runtime owner"
+        )
+    }
+
+    private static func verifiesContextMenuTerminalCommandsUseContextPane() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let focusedHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let contextHandle = fakeSurfaceHandle(for: "pane_2", controller: controller)
+        focusedHandle.selectedText = "focused selection"
+        contextHandle.selectedText = "context selection"
+        controller.focus(paneID: "pane_1")
+
+        let pasteboard = RecordingTerminalPasteboardWriter()
+        expect(
+            controller.copyTerminalSelection(
+                source: .contextMenu,
+                target: .contextPane("pane_2"),
+                writer: pasteboard
+            ),
+            "context menu copy must use the context pane target"
+        )
+        expect(
+            pasteboard.string == "context selection",
+            "context menu copy must not fall back to the focused pane"
+        )
+
+        expect(
+            controller.pasteIntoTerminal(
+                "context paste",
+                source: .contextMenu,
+                target: .contextPane("pane_2")
+            ),
+            "context menu paste must use the context pane target"
+        )
+        expect(
+            contextHandle.deliveredText.last == "context paste",
+            "context menu paste must reach the context pane runtime"
+        )
+        expect(
+            focusedHandle.deliveredText.isEmpty,
+            "context menu paste must not deliver to the focused pane"
+        )
+    }
+
+    private static func verifiesTerminalSearchRoutesThroughFocusedHostSurface() {
+        let controller = makeController()
+        guard let pane = controller.selectedPane else {
+            fail("test setup must expose a selected pane")
+        }
+        let hostView = controller.terminalRuntimeRegistry.hostView(
+            for: pane,
+            bootProfile: controller.bootProfile(for: pane),
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCommandInput: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { controller.updateTerminalRuntime($0) },
+            onMetadataUpdate: { controller.updateTerminalMetadata($0, for: pane.paneID) }
+        )
+        let handle = fakeSurfaceHandle(for: pane.paneID, controller: controller)
+
+        expect(
+            controller.openTerminalSearch(source: .menuBar),
+            "menu find must resolve to the focused terminal host surface"
+        )
+        expect(
+            handle.searchActions == ["start_search"],
+            "menu find must start search on the focused terminal ContentInstance"
+        )
+        expect(
+            hostView.terminalCommandRuntimeState.searchAvailable,
+            "terminal host path must publish search ownership for the resolver"
         )
     }
 
@@ -3293,6 +3418,30 @@ private enum ShellRuntimeMetadataTests {
             workspaceManifest: workspaceManifest,
             appIsActiveProvider: { appIsActive }
         )
+    }
+
+    private static func fakeSurfaceHandle(
+        for paneID: String,
+        controller: ShellHostController
+    ) -> FakeAlanTerminalSurfaceHandle {
+        guard let pane = controller.pane(paneID: paneID),
+              let handle = controller.terminalRuntimeRegistry.surfaceHandle(
+                for: pane,
+                bootProfile: controller.bootProfile(for: pane)
+              ) as? FakeAlanTerminalSurfaceHandle
+        else {
+            fail("test setup must create a fake terminal surface handle for \(paneID)")
+        }
+        return handle
+    }
+
+    private final class RecordingTerminalPasteboardWriter: AlanTerminalPasteboardWriting {
+        private(set) var string: String?
+
+        func writeString(_ text: String) -> Bool {
+            string = text
+            return true
+        }
     }
 
     private static func manifestURL(_ prefix: String) -> URL {

--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -21,10 +21,10 @@
 
 ## 4. Copy Paste And Search
 
-- [ ] 4.1 Add a shared command target resolver for native menu, keyboard, command UI, context menu, and terminal host paths.
-- [ ] 4.2 Route Copy and Paste to the focused terminal host when terminal selection or input owns the command.
-- [ ] 4.3 Route terminal search to a terminal-content-scoped UI owned by the focused terminal ContentInstance runtime identity.
-- [ ] 4.4 Add tests for command routing precedence and terminal-host ownership.
+- [x] 4.1 Add a shared command target resolver for native menu, keyboard, command UI, context menu, and terminal host paths.
+- [x] 4.2 Route Copy and Paste to the focused terminal host when terminal selection or input owns the command.
+- [x] 4.3 Route terminal search to a terminal-content-scoped UI owned by the focused terminal ContentInstance runtime identity.
+- [x] 4.4 Add tests for command routing precedence and terminal-host ownership.
 
 ## 5. Verification And Archive Readiness
 


### PR DESCRIPTION
## Summary
- add a shared terminal command target resolver for menu, keyboard, command UI, context menu, and terminal host paths
- route Copy, Paste, and Find through the focused/context terminal runtime owner
- add runtime metadata coverage for command precedence and terminal host ownership

## Validation
- clients/apple/scripts/test-shell-runtime-metadata.sh
- clients/apple/scripts/test-terminal-surface-controller.sh
- clients/apple/scripts/test-shell-action-registry.sh
- clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate complete-macos-shell-advanced-splits --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-macos-derived build