### PR TITLE
Complete advanced shell split verification

### DIFF
--- a/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
+++ b/openspec/changes/complete-macos-shell-advanced-splits/tasks.md
@@ -28,11 +28,11 @@
 
 ## 5. Verification And Archive Readiness
 
-- [ ] 5.1 Run `clients/apple/scripts/test-shell-split-model.sh`.
-- [ ] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.3 Run the Apple shell controller/runtime script tests touched by this change.
-- [ ] 5.4 Run `git diff --check`.
-- [ ] 5.5 Run `openspec validate complete-macos-shell-advanced-splits --type change --strict --json`.
-- [ ] 5.6 Run `openspec validate --all --strict --json`.
-- [ ] 5.7 Build the macOS app with the renamed `alan-macos` command.
-- [ ] 5.8 Sync accepted delta requirements into `openspec/specs/` before archive.
+- [x] 5.1 Run `clients/apple/scripts/test-shell-split-model.sh`.
+- [x] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.3 Run the Apple shell controller/runtime script tests touched by this change.
+- [x] 5.4 Run `git diff --check`.
+- [x] 5.5 Run `openspec validate complete-macos-shell-advanced-splits --type change --strict --json`.
+- [x] 5.6 Run `openspec validate --all --strict --json`.
+- [x] 5.7 Build the macOS app with the renamed `alan-macos` command.
+- [x] 5.8 Sync accepted delta requirements into `openspec/specs/` before archive.

--- a/openspec/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/specs/macos-shell-control-plane-reliability/spec.md
@@ -160,6 +160,50 @@ and focus changes.
 - **WHEN** the user or a control client changes focused pane
 - **THEN** the shell event stream records the previous and current focused pane IDs
 
+### Requirement: Advanced split control commands report authoritative results
+The macOS shell control plane SHALL return authoritative results for split
+resize, equalize, zoom, unzoom, and spatial focus commands.
+
+#### Scenario: Resize command succeeds
+- **WHEN** a control client requests a valid split ratio change
+- **THEN** the response reports `applied: true` and includes the resulting ratio and affected split or PaneSlot IDs
+
+#### Scenario: Equalize command succeeds
+- **WHEN** a control client requests equalize for a tab with split branches
+- **THEN** the response reports `applied: true` and identifies the tab whose split ratios were reset
+
+#### Scenario: Zoom command succeeds
+- **WHEN** a control client zooms or unzooms a valid pane
+- **THEN** the response reports `applied: true`, the `pane_slot_id`, and the tab zoom state
+
+#### Scenario: Spatial focus has no target
+- **WHEN** a control client requests spatial focus and no adjacent pane exists
+- **THEN** the response reports `applied: false` with a stable no-target error and preserves existing focus
+
+### Requirement: Advanced movement commands report source and destination
+Pane move commands SHALL report enough source and destination detail for agents
+to observe layout changes without inferring them from raw shell snapshots.
+
+#### Scenario: In-tab move succeeds
+- **WHEN** a control client moves a PaneSlot within a tab
+- **THEN** the response reports the `pane_slot_id`, source tab, destination tab, direction or position, and preserved mounted ContentInstance identity
+
+#### Scenario: Drag-backed move succeeds
+- **WHEN** a drag/drop affordance completes through the control-plane movement path
+- **THEN** the response and event stream use the same result semantics as explicit movement commands
+
+### Requirement: Advanced command outcomes emit shell events
+Advanced workspace mutations SHALL emit shell events for zoom state, split ratio
+changes, equalization, spatial focus, and pane movement.
+
+#### Scenario: Split ratio changes
+- **WHEN** a split ratio changes through UI or control-plane resize
+- **THEN** the shell event stream records the affected split, tab, and resulting ratio
+
+#### Scenario: Zoom state changes
+- **WHEN** a pane is zoomed or unzoomed
+- **THEN** the shell event stream records the tab, pane, and resulting zoom state
+
 ### Requirement: Tab Organization Mutations Report Authoritative Results
 The macOS shell control plane and local command paths SHALL return results
 derived from authoritative shell state after Tab reorder, pin/unpin, and Move to

--- a/openspec/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/specs/macos-shell-terminal-lifecycle/spec.md
@@ -194,6 +194,49 @@ operation explicitly closes the pane or tab.
 - **WHEN** the user moves a pane to another tab within the same window
 - **THEN** the pane keeps its runtime handle, scrollback, title, cwd, and pending delivery state
 
+### Requirement: Zoom preserves sibling runtimes
+The macOS shell host SHALL implement split zoom as view state that does not
+close, recreate, or detach sibling terminal ContentInstance runtimes unnecessarily.
+
+#### Scenario: Zoom hides siblings
+- **WHEN** a PaneSlot with terminal content is zoomed
+- **THEN** sibling terminal ContentInstances remain registered in the terminal runtime service and keep their scrollback, title, cwd, and pending delivery state
+
+#### Scenario: Unzoom reattaches siblings
+- **WHEN** the user exits zoom
+- **THEN** sibling PaneSlots reappear by reattaching terminal views to their existing terminal ContentInstance runtime handles
+
+### Requirement: Pane movement preserves runtime continuity
+In-tab pane movement and drag/drop-backed movement SHALL move PaneSlot placement
+without replacing the mounted ContentInstance identity or any terminal ContentInstance
+runtime identity.
+
+#### Scenario: In-tab movement
+- **WHEN** a PaneSlot moves to another split position in the same tab
+- **THEN** the PaneSlot keeps its mounted ContentInstance
+- **AND** terminal content keeps its runtime handle, scrollback, title, cwd, and pending delivery state
+
+#### Scenario: Drag/drop movement
+- **WHEN** a PaneSlot moves through an enabled drag/drop affordance
+- **THEN** the PaneSlot and mounted ContentInstance keep the same identities as the equivalent explicit move command
+
+### Requirement: Terminal commands target the runtime owner
+Copy, paste, and terminal search SHALL resolve the focused PaneSlot to mounted
+terminal content and deliver to that terminal ContentInstance runtime or host
+surface rather than to transient shell chrome.
+
+#### Scenario: Copy terminal selection
+- **WHEN** Copy is invoked and the focused terminal host owns a selection
+- **THEN** the terminal host handles the copy operation without changing terminal ContentInstance runtime state
+
+#### Scenario: Paste terminal input
+- **WHEN** Paste is invoked for a focused PaneSlot that mounts terminal content
+- **THEN** the paste operation is delivered through that terminal ContentInstance input path
+
+#### Scenario: Search terminal content
+- **WHEN** terminal search is invoked for a focused PaneSlot that mounts terminal content
+- **THEN** search state follows that terminal ContentInstance runtime identity across view reconstruction
+
 ### Requirement: Split close operations define runtime finalization
 The macOS shell host SHALL define explicit terminal runtime finalization
 semantics for close pane, close tab, close window, pane lift, and pane move

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -218,6 +218,18 @@ owning terminal surface search controller.
 - **WHEN** the user presses Escape or clicks the close control
 - **THEN** alan dismisses the Find interaction and returns focus to the owning terminal pane
 
+### Requirement: Copy paste and search surfaces are native and pane scoped
+Copy, paste, and search command UI SHALL feel native, target the focused PaneSlot,
+and avoid displacing the sidebar, toolbar, or split layout.
+
+#### Scenario: Search opens
+- **WHEN** the user invokes terminal search
+- **THEN** the search UI appears as a compact pane-scoped terminal tool
+
+#### Scenario: Copy paste available
+- **WHEN** the focused PaneSlot mounts terminal content that can copy or paste
+- **THEN** native menu and keyboard commands target that terminal content without exposing debug routing details
+
 ### Requirement: Terminal panes have unambiguous hit-testing boundaries
 The macOS shell UI SHALL keep terminal-rendering surfaces from intercepting
 mouse events that must be handled by the terminal host, while preserving
@@ -268,6 +280,30 @@ card grid or debug layout.
 #### Scenario: Inactive split pane
 - **WHEN** a split pane is not the active terminal pane
 - **THEN** alan may apply a preference-backed lightweight dim treatment that preserves terminal readability and pointer input while making the active pane and split boundary easier to scan
+
+### Requirement: Zoom affordances stay compact
+Split zoom UI SHALL make the zoomed state and escape path clear without adding a
+persistent pane-management toolbar.
+
+#### Scenario: Pane zoomed
+- **WHEN** a PaneSlot is zoomed
+- **THEN** the UI provides a compact way to unzoom while keeping the terminal content dominant
+
+#### Scenario: Toolbar remains restrained
+- **WHEN** zoom is available for a split pane
+- **THEN** the default toolbar does not add a dense split-control strip
+
+### Requirement: Movement affordances protect terminal interaction
+Pane movement UI SHALL avoid ambiguous gestures inside terminal content and keep
+terminal text selection reliable.
+
+#### Scenario: Movement command shown
+- **WHEN** the command UI or context menu offers pane movement
+- **THEN** the label describes the destination or action in user-facing terms without raw pane IDs
+
+#### Scenario: Drag affordance visible
+- **WHEN** drag/drop pane movement is enabled
+- **THEN** the movement affordance is visually distinct from terminal text selection regions
 
 ### Requirement: Terminal panes expose narrow title bars
 Each visible macOS terminal pane SHALL include a compact title bar at the top of

--- a/openspec/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/specs/macos-shell-workspace-interactions/spec.md
@@ -71,6 +71,58 @@ delivery state.
 - **WHEN** a pane move would leave a tab without panes
 - **THEN** alan either closes the empty tab through normal tab-close semantics or rejects the move with a stable reason
 
+### Requirement: Split zoom is reversible
+The macOS shell SHALL let users zoom and unzoom the focused PaneSlot without
+mutating the canonical split tree or closing sibling PaneSlots or terminal content.
+
+#### Scenario: Zoom focused pane
+- **WHEN** the user zooms a focused split PaneSlot
+- **THEN** the focused PaneSlot fills the shell content area and sibling PaneSlots remain alive and restorable
+
+#### Scenario: Unzoom focused pane
+- **WHEN** the user exits zoom
+- **THEN** the previous split layout, divider ratios, PaneSlot identities, and mounted ContentInstance identities are restored
+
+### Requirement: In-tab pane movement is explicit and reversible
+The macOS shell SHALL support explicit PaneSlot movement within the same tab while
+preserving PaneSlot identity, mounted ContentInstance identity, and split tree validity.
+
+#### Scenario: Move pane within current tab
+- **WHEN** the user moves a PaneSlot to a valid position in the current tab
+- **THEN** alan updates the split-tree placement and keeps the moved PaneSlot and mounted ContentInstance identities
+
+#### Scenario: Move target invalid
+- **WHEN** the requested in-tab move would create an invalid split tree or move a PaneSlot onto itself
+- **THEN** alan rejects the move with a stable reason and leaves the current layout unchanged
+
+### Requirement: Drag/drop movement has a terminal-selection quality gate
+Pane drag/drop SHALL only be enabled by default after it uses the same controller
+mutation path as explicit moves and preserves terminal text selection behavior.
+
+#### Scenario: Drag starts inside terminal text
+- **WHEN** the user drags inside terminal-rendered text
+- **THEN** alan treats the drag as terminal selection or terminal input rather than pane movement
+
+#### Scenario: Drag uses a movement affordance
+- **WHEN** the user drags a supported PaneSlot movement affordance to another valid target
+- **THEN** alan runs the same move mutation used by explicit move commands
+
+### Requirement: Copy paste and search commands route consistently
+Copy, paste, and terminal search SHALL resolve the same focused terminal target
+across native menus, keyboard shortcuts, command UI, and terminal host surfaces.
+
+#### Scenario: Copy focused terminal selection
+- **WHEN** the user invokes Copy while focused terminal content owns a selection
+- **THEN** the command is delivered to that terminal host rather than to shell debug text
+
+#### Scenario: Paste into focused terminal
+- **WHEN** the user invokes Paste while a PaneSlot that mounts terminal content is focused
+- **THEN** the command is delivered to that terminal ContentInstance host
+
+#### Scenario: Search focused terminal
+- **WHEN** the user invokes terminal search from a native command surface
+- **THEN** the search UI is scoped to the focused terminal ContentInstance
+
 ### Requirement: Commands use native Mac surfaces
 Workspace actions SHALL be available through native menu/command routing,
 keyboard shortcuts, command input, and any restrained toolbar affordances that


### PR DESCRIPTION
## Summary
- mark phase 5 verification/archive-readiness tasks complete for complete-macos-shell-advanced-splits
- sync accepted advanced split/control-plane/runtime/UI requirements into canonical OpenSpec specs

## Validation
- clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- clients/apple/scripts/test-shell-runtime-metadata.sh
- clients/apple/scripts/test-terminal-surface-controller.sh
- clients/apple/scripts/test-shell-action-registry.sh
- git diff --check
- openspec validate complete-macos-shell-advanced-splits --type change --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-advanced-splits build