### PR TITLE
Add shell content container model skeleton

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -149,6 +149,174 @@ extension ShellPane {
     }
 }
 
+enum ShellContentKind: String, Codable, CaseIterable {
+    case terminal
+    case markdown
+    case settings
+}
+
+enum ShellContentCapability: String, Codable, CaseIterable {
+    case terminalInput = "terminal_input"
+    case terminalSearch = "terminal_search"
+    case terminalPaste = "terminal_paste"
+    case terminalRuntimeMetadata = "terminal_runtime_metadata"
+    case markdownReadOnlyViewer = "markdown_read_only_viewer"
+    case settingsSurface = "settings_surface"
+}
+
+enum ShellContentLifecycleState: String, Codable, CaseIterable {
+    case active
+    case closing
+    case closed
+    case failed
+}
+
+struct ShellContentRendererState: Codable, Equatable {
+    let phase: String
+    let detail: String?
+
+    static let placeholder = ShellContentRendererState(phase: "placeholder", detail: nil)
+
+    private enum CodingKeys: String, CodingKey {
+        case phase
+        case detail
+    }
+}
+
+struct ShellTerminalContentPayload: Codable, Equatable {
+    let launchTarget: ShellLaunchTarget
+    let cwd: String?
+    let title: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case launchTarget = "launch_target"
+        case cwd
+        case title
+    }
+}
+
+struct ShellMarkdownContentPayload: Codable, Equatable {
+    let fileURL: String
+    let title: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case fileURL = "file_url"
+        case title
+    }
+}
+
+struct ShellSettingsContentPayload: Codable, Equatable {
+    let surfaceID: String
+    let title: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case surfaceID = "surface_id"
+        case title
+    }
+}
+
+struct ShellContentPayload: Codable, Equatable {
+    let terminal: ShellTerminalContentPayload?
+    let markdown: ShellMarkdownContentPayload?
+    let settings: ShellSettingsContentPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case terminal
+        case markdown
+        case settings
+    }
+
+    static func terminal(_ payload: ShellTerminalContentPayload) -> ShellContentPayload {
+        ShellContentPayload(terminal: payload, markdown: nil, settings: nil)
+    }
+
+    static func markdown(_ payload: ShellMarkdownContentPayload) -> ShellContentPayload {
+        ShellContentPayload(terminal: nil, markdown: payload, settings: nil)
+    }
+
+    static func settings(_ payload: ShellSettingsContentPayload) -> ShellContentPayload {
+        ShellContentPayload(terminal: nil, markdown: nil, settings: payload)
+    }
+}
+
+struct ShellContentInstance: Identifiable, Codable, Equatable {
+    let contentID: String
+    let kind: ShellContentKind
+    let title: String
+    let iconName: String?
+    let capabilities: [ShellContentCapability]
+    let payload: ShellContentPayload
+    let lifecycle: ShellContentLifecycleState
+    let rendererState: ShellContentRendererState
+
+    var id: String { contentID }
+
+    init(
+        contentID: String,
+        kind: ShellContentKind,
+        title: String,
+        iconName: String? = nil,
+        capabilities: [ShellContentCapability]? = nil,
+        payload: ShellContentPayload,
+        lifecycle: ShellContentLifecycleState = .active,
+        rendererState: ShellContentRendererState = .placeholder
+    ) {
+        self.contentID = contentID
+        self.kind = kind
+        self.title = title
+        self.iconName = iconName
+        self.capabilities = capabilities ?? Self.defaultCapabilities(for: kind)
+        self.payload = payload
+        self.lifecycle = lifecycle
+        self.rendererState = rendererState
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case contentID = "content_id"
+        case kind
+        case title
+        case iconName = "icon_name"
+        case capabilities
+        case payload
+        case lifecycle
+        case rendererState = "renderer_state"
+    }
+
+    static func defaultCapabilities(for kind: ShellContentKind) -> [ShellContentCapability] {
+        switch kind {
+        case .terminal:
+            return [
+                .terminalInput,
+                .terminalSearch,
+                .terminalPaste,
+                .terminalRuntimeMetadata,
+            ]
+        case .markdown:
+            return [.markdownReadOnlyViewer]
+        case .settings:
+            return [.settingsSurface]
+        }
+    }
+}
+
+struct ShellPaneSlot: Identifiable, Codable, Equatable {
+    let paneSlotID: String
+    let tabID: String
+    let spaceID: String
+    let contentID: String
+    let attention: ShellAttentionState
+
+    var id: String { paneSlotID }
+
+    private enum CodingKeys: String, CodingKey {
+        case paneSlotID = "pane_slot_id"
+        case tabID = "tab_id"
+        case spaceID = "space_id"
+        case contentID = "content_id"
+        case attention
+    }
+}
+
 struct ShellPaneTreeNode: Identifiable, Codable, Equatable {
     static let minimumSplitRatio = 0.15
     static let maximumSplitRatio = 0.85
@@ -510,6 +678,96 @@ extension ShellPaneTreeNode {
     }
 }
 
+struct ShellPaneSlotTreeNode: Identifiable, Codable, Equatable {
+    let nodeID: String
+    let kind: ShellPaneTreeKind
+    let direction: ShellSplitDirection?
+    let ratio: Double?
+    let paneSlotID: String?
+    let children: [ShellPaneSlotTreeNode]?
+
+    var id: String { nodeID }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeID = "node_id"
+        case kind
+        case direction
+        case ratio
+        case paneSlotID = "pane_slot_id"
+        case children
+    }
+
+    init(
+        nodeID: String,
+        kind: ShellPaneTreeKind,
+        direction: ShellSplitDirection?,
+        ratio: Double? = nil,
+        paneSlotID: String?,
+        children: [ShellPaneSlotTreeNode]?
+    ) {
+        self.nodeID = nodeID
+        self.kind = kind
+        self.direction = direction
+        self.ratio = kind == .split
+            ? ShellPaneTreeNode.clampedSplitRatio(ratio ?? 0.5)
+            : nil
+        self.paneSlotID = paneSlotID
+        self.children = children
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(ShellPaneTreeKind.self, forKey: .kind)
+        let decodedRatio = kind == .split ? try container.decode(Double.self, forKey: .ratio) : nil
+
+        self.init(
+            nodeID: try container.decode(String.self, forKey: .nodeID),
+            kind: kind,
+            direction: try container.decodeIfPresent(ShellSplitDirection.self, forKey: .direction),
+            ratio: decodedRatio,
+            paneSlotID: try container.decodeIfPresent(String.self, forKey: .paneSlotID),
+            children: try container.decodeIfPresent([ShellPaneSlotTreeNode].self, forKey: .children)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(nodeID, forKey: .nodeID)
+        try container.encode(kind, forKey: .kind)
+        try container.encodeIfPresent(direction, forKey: .direction)
+        if kind == .split {
+            try container.encode(ratio ?? 0.5, forKey: .ratio)
+        }
+        try container.encodeIfPresent(paneSlotID, forKey: .paneSlotID)
+        try container.encodeIfPresent(children, forKey: .children)
+    }
+
+    static func migrating(
+        paneTree: ShellPaneTreeNode,
+        paneIDToSlotID: (String) -> String = { $0 }
+    ) -> ShellPaneSlotTreeNode {
+        ShellPaneSlotTreeNode(
+            nodeID: paneTree.nodeID,
+            kind: paneTree.kind,
+            direction: paneTree.direction,
+            ratio: paneTree.ratio,
+            paneSlotID: paneTree.paneID.map(paneIDToSlotID),
+            children: paneTree.children?.map {
+                ShellPaneSlotTreeNode.migrating(paneTree: $0, paneIDToSlotID: paneIDToSlotID)
+            }
+        )
+    }
+
+    var paneSlotIDs: [String] {
+        switch kind {
+        case .pane:
+            return paneSlotID.map { [$0] } ?? []
+        case .split:
+            return (children ?? []).flatMap(\.paneSlotIDs)
+        }
+    }
+}
+
 struct ShellTab: Identifiable, Codable, Equatable {
     let tabID: String
     let kind: ShellTabKind
@@ -553,11 +811,45 @@ struct ShellTab: Identifiable, Codable, Equatable {
     }
 }
 
+struct ShellContentTab: Identifiable, Codable, Equatable {
+    let tabID: String
+    let kind: ShellTabKind
+    let title: String?
+    let paneTree: ShellPaneSlotTreeNode
+    let isPinned: Bool
+
+    var id: String { tabID }
+
+    private enum CodingKeys: String, CodingKey {
+        case tabID = "tab_id"
+        case kind
+        case title
+        case paneTree = "pane_tree"
+        case isPinned = "is_pinned"
+    }
+}
+
 struct ShellSpace: Identifiable, Codable, Equatable {
     let spaceID: String
     let title: String
     let attention: ShellAttentionState
     let tabs: [ShellTab]
+
+    var id: String { spaceID }
+
+    private enum CodingKeys: String, CodingKey {
+        case spaceID = "space_id"
+        case title
+        case attention
+        case tabs
+    }
+}
+
+struct ShellContentSpace: Identifiable, Codable, Equatable {
+    let spaceID: String
+    let title: String
+    let attention: ShellAttentionState
+    let tabs: [ShellContentTab]
 
     var id: String { spaceID }
 
@@ -601,6 +893,30 @@ struct ShellStateSnapshot: Codable, Equatable {
         }
 
         return string
+    }
+}
+
+struct ShellContentStateSnapshot: Codable, Equatable {
+    static let currentContractVersion = "0.2"
+
+    let contractVersion: String
+    let windowID: String
+    let focusedSpaceID: String?
+    let focusedTabID: String?
+    let focusedPaneSlotID: String?
+    let spaces: [ShellContentSpace]
+    let paneSlots: [ShellPaneSlot]
+    let contents: [ShellContentInstance]
+
+    private enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case windowID = "window_id"
+        case focusedSpaceID = "focused_space_id"
+        case focusedTabID = "focused_tab_id"
+        case focusedPaneSlotID = "focused_pane_slot_id"
+        case spaces
+        case paneSlots = "pane_slots"
+        case contents
     }
 }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -190,7 +190,154 @@ struct ShellPaneRestoreRecord: Codable, Equatable, Identifiable {
     }
 }
 
+struct ShellContentWorkspaceManifest: Codable, Equatable {
+    static let currentContentContractVersion = ShellContentStateSnapshot.currentContractVersion
+
+    var schemaVersion: Int
+    var contentContractVersion: String
+    var windowID: String
+    var selectedSpaceID: String?
+    var selectedTabID: String?
+    var spaces: [ShellContentWorkspaceSpaceRecord]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case contentContractVersion = "content_contract_version"
+        case windowID = "window_id"
+        case selectedSpaceID = "selected_space_id"
+        case selectedTabID = "selected_tab_id"
+        case spaces
+    }
+}
+
+struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
+    var spaceID: String
+    var title: String
+    var order: Int
+    var createdAt: Date
+    var updatedAt: Date
+    var tabs: [ShellContentWorkspaceTabRecord]
+
+    var id: String { spaceID }
+
+    private enum CodingKeys: String, CodingKey {
+        case spaceID = "space_id"
+        case title
+        case order
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case tabs
+    }
+}
+
+struct ShellContentWorkspaceTabRecord: Codable, Equatable, Identifiable {
+    var tabID: String
+    var title: String?
+    var kind: ShellTabKind
+    var createdAt: Date
+    var lastActivatedAt: Date
+    var lastActivityAt: Date
+    var isPinned: Bool
+    var pinSnapshot: ShellContentTabRestoreSnapshot?
+    var liveSnapshot: ShellContentTabRestoreSnapshot?
+    var activeTask: ShellTabActiveTaskState
+
+    var id: String { tabID }
+
+    private enum CodingKeys: String, CodingKey {
+        case tabID = "tab_id"
+        case title
+        case kind
+        case createdAt = "created_at"
+        case lastActivatedAt = "last_activated_at"
+        case lastActivityAt = "last_activity_at"
+        case isPinned = "is_pinned"
+        case pinSnapshot = "pin_snapshot"
+        case liveSnapshot = "live_snapshot"
+        case activeTask = "active_task"
+    }
+}
+
+struct ShellContentTabRestoreSnapshot: Codable, Equatable {
+    var paneTree: ShellPaneSlotTreeNode
+    var paneSlots: [ShellPaneSlotRestoreRecord]
+    var contents: [ShellContentRestoreRecord]
+
+    private enum CodingKeys: String, CodingKey {
+        case paneTree = "pane_tree"
+        case paneSlots = "pane_slots"
+        case contents
+    }
+}
+
+struct ShellPaneSlotRestoreRecord: Codable, Equatable, Identifiable {
+    var paneSlotID: String
+    var contentID: String
+
+    var id: String { paneSlotID }
+
+    private enum CodingKeys: String, CodingKey {
+        case paneSlotID = "pane_slot_id"
+        case contentID = "content_id"
+    }
+}
+
+struct ShellContentRestoreRecord: Codable, Equatable, Identifiable {
+    var contentID: String
+    var kind: ShellContentKind
+    var title: String
+    var payload: ShellContentPayload
+
+    var id: String { contentID }
+
+    private enum CodingKeys: String, CodingKey {
+        case contentID = "content_id"
+        case kind
+        case title
+        case payload
+    }
+}
+
 extension ShellWorkspaceManifest {
+    func migratingTerminalRestoreSnapshotsToContentContainers(
+        defaultWorkingDirectory: String
+    ) -> ShellContentWorkspaceManifest {
+        ShellContentWorkspaceManifest(
+            schemaVersion: schemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: windowID,
+            selectedSpaceID: selectedSpaceID,
+            selectedTabID: selectedTabID,
+            spaces: spaces.map { space in
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: space.spaceID,
+                    title: space.title,
+                    order: space.order,
+                    createdAt: space.createdAt,
+                    updatedAt: space.updatedAt,
+                    tabs: space.tabs.map { tab in
+                        ShellContentWorkspaceTabRecord(
+                            tabID: tab.tabID,
+                            title: tab.title,
+                            kind: tab.kind,
+                            createdAt: tab.createdAt,
+                            lastActivatedAt: tab.lastActivatedAt,
+                            lastActivityAt: tab.lastActivityAt,
+                            isPinned: tab.isPinned,
+                            pinSnapshot: tab.pinSnapshot?.migratingTerminalPanesToContentContainers(
+                                defaultWorkingDirectory: defaultWorkingDirectory
+                            ),
+                            liveSnapshot: tab.liveSnapshot?.migratingTerminalPanesToContentContainers(
+                                defaultWorkingDirectory: defaultWorkingDirectory
+                            ),
+                            activeTask: tab.activeTask
+                        )
+                    }
+                )
+            }
+        )
+    }
+
     func pruningExpiredTabs(now: Date, ttl: TimeInterval) -> ShellWorkspaceManifest {
         var pruned = self
         pruned.spaces = spaces.map { space in
@@ -228,6 +375,46 @@ extension ShellWorkspaceManifest {
         if !selectedTabStillExists {
             selectedTabID = selectedSpace.tabs.first?.tabID
         }
+    }
+}
+
+extension ShellTabRestoreSnapshot {
+    func migratingTerminalPanesToContentContainers(
+        defaultWorkingDirectory: String
+    ) -> ShellContentTabRestoreSnapshot {
+        let paneSlots = panes.map { pane in
+            ShellPaneSlotRestoreRecord(
+                paneSlotID: pane.paneID,
+                contentID: Self.contentID(forPaneID: pane.paneID)
+            )
+        }
+        let contents = panes.map { pane in
+            let title = pane.title ?? ShellWorkspaceMaterializer.defaultViewportTitleForMigration(
+                launchTarget: pane.launchTarget
+            )
+            return ShellContentRestoreRecord(
+                contentID: Self.contentID(forPaneID: pane.paneID),
+                kind: .terminal,
+                title: title,
+                payload: .terminal(
+                    ShellTerminalContentPayload(
+                        launchTarget: pane.launchTarget,
+                        cwd: pane.cwd ?? defaultWorkingDirectory,
+                        title: title
+                    )
+                )
+            )
+        }
+
+        return ShellContentTabRestoreSnapshot(
+            paneTree: ShellPaneSlotTreeNode.migrating(paneTree: paneTree),
+            paneSlots: paneSlots,
+            contents: contents
+        )
+    }
+
+    private static func contentID(forPaneID paneID: String) -> String {
+        "content_\(paneID)"
     }
 }
 
@@ -386,5 +573,9 @@ struct ShellWorkspaceMaterializer {
         case .alan:
             return "alan"
         }
+    }
+
+    static func defaultViewportTitleForMigration(launchTarget: ShellLaunchTarget) -> String {
+        defaultViewportTitle(for: launchTarget)
     }
 }

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -299,9 +299,7 @@ struct ShellContentRestoreRecord: Codable, Equatable, Identifiable {
 }
 
 extension ShellWorkspaceManifest {
-    func migratingTerminalRestoreSnapshotsToContentContainers(
-        defaultWorkingDirectory: String
-    ) -> ShellContentWorkspaceManifest {
+    func migratingTerminalRestoreSnapshotsToContentContainers() -> ShellContentWorkspaceManifest {
         ShellContentWorkspaceManifest(
             schemaVersion: schemaVersion,
             contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
@@ -324,12 +322,8 @@ extension ShellWorkspaceManifest {
                             lastActivatedAt: tab.lastActivatedAt,
                             lastActivityAt: tab.lastActivityAt,
                             isPinned: tab.isPinned,
-                            pinSnapshot: tab.pinSnapshot?.migratingTerminalPanesToContentContainers(
-                                defaultWorkingDirectory: defaultWorkingDirectory
-                            ),
-                            liveSnapshot: tab.liveSnapshot?.migratingTerminalPanesToContentContainers(
-                                defaultWorkingDirectory: defaultWorkingDirectory
-                            ),
+                            pinSnapshot: tab.pinSnapshot?.migratingTerminalPanesToContentContainers(),
+                            liveSnapshot: tab.liveSnapshot?.migratingTerminalPanesToContentContainers(),
                             activeTask: tab.activeTask
                         )
                     }
@@ -379,9 +373,7 @@ extension ShellWorkspaceManifest {
 }
 
 extension ShellTabRestoreSnapshot {
-    func migratingTerminalPanesToContentContainers(
-        defaultWorkingDirectory: String
-    ) -> ShellContentTabRestoreSnapshot {
+    func migratingTerminalPanesToContentContainers() -> ShellContentTabRestoreSnapshot {
         let paneSlots = panes.map { pane in
             ShellPaneSlotRestoreRecord(
                 paneSlotID: pane.paneID,
@@ -399,7 +391,7 @@ extension ShellTabRestoreSnapshot {
                 payload: .terminal(
                     ShellTerminalContentPayload(
                         launchTarget: pane.launchTarget,
-                        cwd: pane.cwd ?? defaultWorkingDirectory,
+                        cwd: pane.cwd,
                         title: title
                     )
                 )

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -19,6 +19,7 @@ private enum ShellWorkspaceManifestTests {
         try verifiesPinnedSplitSnapshotRestoresSplitTree()
         try verifiesTerminalOnlySnapshotMigratesToContentContainerShape()
         try verifiesContentContainerMigrationPreservesWorkspaceMetadata()
+        try verifiesContentContainerMigrationPreservesNilRestoreCwd()
         try verifiesUnpinnedTabPruningUsesTtlAndActiveTask()
         try verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty()
         print("Shell workspace manifest tests passed.")
@@ -196,9 +197,7 @@ private enum ShellWorkspaceManifestTests {
         tab.pinSnapshot = makeSplitSnapshot(tabID: tab.tabID)
         let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
 
-        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers(
-            defaultWorkingDirectory: "/fallback"
-        )
+        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers()
         let migratedTab = try requireContentTab("tab_split", in: migrated)
         let snapshot = try requireSnapshot(migratedTab.pinSnapshot)
 
@@ -257,9 +256,7 @@ private enum ShellWorkspaceManifestTests {
         )
         let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
 
-        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers(
-            defaultWorkingDirectory: "/fallback"
-        )
+        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers()
         let migratedSpace = try requireOnlySpace(in: migrated)
         let migratedTab = try requireOnlyContentTab(in: migrated)
 
@@ -281,6 +278,29 @@ private enum ShellWorkspaceManifestTests {
         expect(
             snapshot.contents.first?.payload.terminal?.cwd == "/fallback",
             "migration must preserve terminal restore payload cwd"
+        )
+    }
+
+    private static func verifiesContentContainerMigrationPreservesNilRestoreCwd() throws {
+        var tab = makeTab(
+            tabID: "tab_nil_cwd",
+            title: "Nil Cwd",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/will-be-replaced",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        tab.liveSnapshot = makeSnapshot(tabID: tab.tabID, cwd: nil)
+        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+
+        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers()
+        let snapshot = try requireSnapshot(try requireOnlyContentTab(in: migrated).liveSnapshot)
+
+        expect(
+            snapshot.contents.first?.payload.terminal?.cwd == nil,
+            "migration must preserve nil cwd so restore can resolve the default directory later"
         )
     }
 
@@ -404,7 +424,7 @@ private enum ShellWorkspaceManifestTests {
         )
     }
 
-    private static func makeSnapshot(tabID: String, cwd: String) -> ShellTabRestoreSnapshot {
+    private static func makeSnapshot(tabID: String, cwd: String?) -> ShellTabRestoreSnapshot {
         let paneID = "pane_\(tabID)"
         return ShellTabRestoreSnapshot(
             paneTree: ShellPaneTreeNode(

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -17,6 +17,8 @@ private enum ShellWorkspaceManifestTests {
         try verifiesMaterializerPreservesEmptySelectedSpace()
         try verifiesPinnedSnapshotWinsOverLaterLiveSnapshot()
         try verifiesPinnedSplitSnapshotRestoresSplitTree()
+        try verifiesTerminalOnlySnapshotMigratesToContentContainerShape()
+        try verifiesContentContainerMigrationPreservesWorkspaceMetadata()
         try verifiesUnpinnedTabPruningUsesTtlAndActiveTask()
         try verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty()
         print("Shell workspace manifest tests passed.")
@@ -177,6 +179,108 @@ private enum ShellWorkspaceManifestTests {
         expect(
             state.pane(paneID: "pane_tab_split_right")?.cwd == "/pinned/right",
             "pinned split restore must keep right pane cwd"
+        )
+    }
+
+    private static func verifiesTerminalOnlySnapshotMigratesToContentContainerShape() throws {
+        var tab = makeTab(
+            tabID: "tab_split",
+            title: "Pinned Split",
+            isPinned: true,
+            pinCwd: nil,
+            liveCwd: "/live/single",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        tab.pinSnapshot = makeSplitSnapshot(tabID: tab.tabID)
+        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+
+        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers(
+            defaultWorkingDirectory: "/fallback"
+        )
+        let migratedTab = try requireContentTab("tab_split", in: migrated)
+        let snapshot = try requireSnapshot(migratedTab.pinSnapshot)
+
+        expect(
+            migrated.contentContractVersion == ShellContentStateSnapshot.currentContractVersion,
+            "content manifest migration must use the v0.2 content contract"
+        )
+        expect(
+            snapshot.paneTree.paneSlotIDs == ["pane_tab_split_left", "pane_tab_split_right"],
+            "content migration must preserve terminal pane IDs as PaneSlot IDs"
+        )
+        expect(
+            snapshot.paneSlots.map(\.paneSlotID) == ["pane_tab_split_left", "pane_tab_split_right"],
+            "content migration must create one PaneSlot per terminal restore pane"
+        )
+        expect(
+            snapshot.paneSlots.map(\.contentID) == [
+                "content_pane_tab_split_left",
+                "content_pane_tab_split_right",
+            ],
+            "content migration must assign stable ContentInstance IDs"
+        )
+        expect(
+            snapshot.contents.map(\.kind) == [.terminal, .terminal],
+            "terminal-only restore panes must migrate to terminal ContentInstances"
+        )
+        expect(
+            snapshot.contents.map(\.title) == ["Shell", "Shell"],
+            "terminal ContentInstances must keep user-facing terminal titles"
+        )
+        expect(
+            snapshot.contents.compactMap(\.payload.terminal?.cwd) == [
+                "/pinned/left",
+                "/pinned/right",
+            ],
+            "terminal content payloads must preserve per-pane cwd"
+        )
+        expect(
+            snapshot.contents.allSatisfy { $0.payload.markdown == nil && $0.payload.settings == nil },
+            "terminal migration must not fabricate non-terminal payloads"
+        )
+    }
+
+    private static func verifiesContentContainerMigrationPreservesWorkspaceMetadata() throws {
+        let activatedAt = referenceDate.addingTimeInterval(-120)
+        let activityAt = referenceDate.addingTimeInterval(-30)
+        let tab = makeTab(
+            tabID: "tab_active",
+            title: "Active",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/fallback",
+            lastActivatedAt: activatedAt,
+            lastActivityAt: activityAt,
+            activeTask: .alanPendingYield
+        )
+        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+
+        let migrated = manifest.migratingTerminalRestoreSnapshotsToContentContainers(
+            defaultWorkingDirectory: "/fallback"
+        )
+        let migratedSpace = try requireOnlySpace(in: migrated)
+        let migratedTab = try requireOnlyContentTab(in: migrated)
+
+        expect(migrated.selectedSpaceID == manifest.selectedSpaceID, "migration must preserve selected Space")
+        expect(migrated.selectedTabID == manifest.selectedTabID, "migration must preserve selected Tab")
+        expect(migratedSpace.spaceID == "space_main", "migration must preserve Space identity")
+        expect(migratedSpace.order == 0, "migration must preserve Space ordering")
+        expect(migratedTab.tabID == tab.tabID, "migration must preserve Tab identity")
+        expect(migratedTab.isPinned == tab.isPinned, "migration must preserve pin state")
+        expect(
+            migratedTab.lastActivatedAt == activatedAt && migratedTab.lastActivityAt == activityAt,
+            "migration must preserve TTL anchor timestamps"
+        )
+        expect(
+            migratedTab.activeTask == .alanPendingYield,
+            "migration must preserve active-task metadata"
+        )
+        let snapshot = try requireSnapshot(migratedTab.liveSnapshot)
+        expect(
+            snapshot.contents.first?.payload.terminal?.cwd == "/fallback",
+            "migration must preserve terminal restore payload cwd"
         )
     }
 
@@ -378,6 +482,44 @@ private enum ShellWorkspaceManifestTests {
             throw TestFailure("expected exactly one tab")
         }
         return tab
+    }
+
+    private static func requireOnlySpace(
+        in manifest: ShellContentWorkspaceManifest
+    ) throws -> ShellContentWorkspaceSpaceRecord {
+        guard manifest.spaces.count == 1, let space = manifest.spaces.first else {
+            throw TestFailure("expected exactly one content space")
+        }
+        return space
+    }
+
+    private static func requireOnlyContentTab(
+        in manifest: ShellContentWorkspaceManifest
+    ) throws -> ShellContentWorkspaceTabRecord {
+        let tabs = manifest.spaces.flatMap(\.tabs)
+        guard tabs.count == 1, let tab = tabs.first else {
+            throw TestFailure("expected exactly one content tab")
+        }
+        return tab
+    }
+
+    private static func requireContentTab(
+        _ tabID: String,
+        in manifest: ShellContentWorkspaceManifest
+    ) throws -> ShellContentWorkspaceTabRecord {
+        guard let tab = manifest.spaces.flatMap(\.tabs).first(where: { $0.tabID == tabID }) else {
+            throw TestFailure("missing content tab \(tabID)")
+        }
+        return tab
+    }
+
+    private static func requireSnapshot(
+        _ snapshot: ShellContentTabRestoreSnapshot?
+    ) throws -> ShellContentTabRestoreSnapshot {
+        guard let snapshot else {
+            throw TestFailure("expected content restore snapshot")
+        }
+        return snapshot
     }
 
     private static func requireOnlyPane(in snapshot: ShellTabRestoreSnapshot?) throws -> ShellPaneRestoreRecord {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Model And Migration
 
-- [ ] 1.1 Rebase this change after `persist-macos-shell-workspaces` is archived, and read the accepted `ShellWorkspaceManifest` schema/materializer before implementation.
-- [ ] 1.2 Introduce v0.2 shell state value types: `ShellPaneSlot`, `ShellContentInstance`, content kind, content capabilities, and content payloads for terminal, markdown, and settings surfaces.
+- [x] 1.1 Rebase this change after `persist-macos-shell-workspaces` is archived, and read the accepted `ShellWorkspaceManifest` schema/materializer before implementation.
+- [x] 1.2 Introduce v0.2 shell state value types: `ShellPaneSlot`, `ShellContentInstance`, content kind, content capabilities, and content payloads for terminal, markdown, and settings surfaces.
 - [ ] 1.3 Change pane layout leaves to reference `pane_slot_id` and change shell focus state to use `focused_pane_slot_id`.
 - [ ] 1.4 Replace new-state `panes: [ShellPane]` persistence with `pane_slots` and `contents`; keep v0.1 `ShellPane` decoding only as diagnostics/compatibility input, not as workspace restore authority.
-- [ ] 1.5 Add one-time manifest migration that turns terminal-only workspace restore snapshots into PaneSlot plus terminal ContentInstance restore snapshots while preserving Space/Tab IDs, selection, pin state, TTL anchors, and active-task metadata.
+- [x] 1.5 Add one-time manifest migration that turns terminal-only workspace restore snapshots into PaneSlot plus terminal ContentInstance restore snapshots while preserving Space/Tab IDs, selection, pin state, TTL anchors, and active-task metadata.
 - [ ] 1.6 Update shell state projection helpers so focused space, focused tab, focused PaneSlot, attention, titles, and sidebar rows derive from content-aware descriptors.
 
 ## 2. Terminal Adapter


### PR DESCRIPTION
## Summary
- Add v0.2 shell content value types for PaneSlot, ContentInstance, content kind/capabilities, and terminal/markdown/settings payloads.
- Add content-aware workspace manifest restore descriptors plus terminal-only migration from v0.1 restore snapshots.
- Mark OpenSpec tasks 1.1, 1.2, and 1.5 complete for generalize-macos-shell-content-containers.

## Validation
- bash clients/apple/scripts/test-shell-workspace-manifest.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-action-registry.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-content-container-model build