### PR TITLE
Project shell state into content containers

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -918,6 +918,19 @@ struct ShellContentStateSnapshot: Codable, Equatable {
         case paneSlots = "pane_slots"
         case contents
     }
+
+    var prettyPrintedJSON: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(self),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return "{\n  \"error\": \"failed to encode shell content snapshot\"\n}"
+        }
+
+        return string
+    }
 }
 
 extension ShellTab {
@@ -1000,5 +1013,162 @@ extension ShellStateSnapshot {
             }
         }
         return nil
+    }
+
+    func contentStateProjection() -> ShellContentStateSnapshot {
+        ShellContentStateSnapshot.projecting(self)
+    }
+}
+
+extension ShellContentStateSnapshot {
+    static func projecting(_ shellState: ShellStateSnapshot) -> ShellContentStateSnapshot {
+        let layoutPaneIDs = Set(shellState.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
+        let projectedPanes = shellState.panes.filter { layoutPaneIDs.contains($0.paneID) }
+        let paneSlots = projectedPanes.map(ShellPaneSlot.projectingTerminalPane)
+        let contents = projectedPanes.map(ShellContentInstance.projectingTerminalPane)
+        let validPaneSlotIDs = Set(paneSlots.map(\.paneSlotID))
+        let focusedPaneSlotID =
+            shellState.focusedPaneID.flatMap { validPaneSlotIDs.contains($0) ? $0 : nil }
+            ?? paneSlots.first?.paneSlotID
+        let spaces = shellState.spaces.map { space in
+            ShellContentSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: Self.strongestAttention(
+                    in: paneSlots.filter { $0.spaceID == space.spaceID }
+                ),
+                tabs: space.tabs.map { tab in
+                    ShellContentTab(
+                        tabID: tab.tabID,
+                        kind: tab.kind,
+                        title: tab.title,
+                        paneTree: ShellPaneSlotTreeNode.migrating(paneTree: tab.paneTree),
+                        isPinned: tab.isPinned
+                    )
+                }
+            )
+        }
+
+        return ShellContentStateSnapshot(
+            contractVersion: currentContractVersion,
+            windowID: shellState.windowID,
+            focusedSpaceID: shellState.focusedSpaceID,
+            focusedTabID: shellState.focusedTabID,
+            focusedPaneSlotID: focusedPaneSlotID,
+            spaces: spaces,
+            paneSlots: paneSlots,
+            contents: contents
+        )
+    }
+
+    func space(spaceID: String) -> ShellContentSpace? {
+        spaces.first { $0.spaceID == spaceID }
+    }
+
+    func tab(tabID: String) -> ShellContentTab? {
+        spaces.lazy.flatMap(\.tabs).first { $0.tabID == tabID }
+    }
+
+    func paneSlot(paneSlotID: String) -> ShellPaneSlot? {
+        paneSlots.first { $0.paneSlotID == paneSlotID }
+    }
+
+    func content(contentID: String) -> ShellContentInstance? {
+        contents.first { $0.contentID == contentID }
+    }
+
+    var focusedPaneSlot: ShellPaneSlot? {
+        focusedPaneSlotID.flatMap { paneSlot(paneSlotID: $0) }
+    }
+
+    var focusedContent: ShellContentInstance? {
+        focusedPaneSlot.flatMap { content(contentID: $0.contentID) }
+    }
+
+    func contentMounted(in paneSlotID: String) -> ShellContentInstance? {
+        paneSlot(paneSlotID: paneSlotID).flatMap { content(contentID: $0.contentID) }
+    }
+
+    func userFacingTitle(for tab: ShellContentTab) -> String? {
+        tab.title
+            ?? tab.paneTree.paneSlotIDs.lazy.compactMap { contentMounted(in: $0)?.title }.first
+    }
+
+    private static func strongestAttention(in paneSlots: [ShellPaneSlot]) -> ShellAttentionState {
+        paneSlots
+            .map(\.attention)
+            .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
+            ?? .idle
+    }
+
+    private static func attentionRank(for attention: ShellAttentionState) -> Int {
+        switch attention {
+        case .idle:
+            return 0
+        case .active:
+            return 1
+        case .notable:
+            return 2
+        case .awaitingUser:
+            return 3
+        }
+    }
+}
+
+extension ShellPaneSlot {
+    static func projectingTerminalPane(_ pane: ShellPane) -> ShellPaneSlot {
+        ShellPaneSlot(
+            paneSlotID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID,
+            contentID: ShellContentInstance.terminalContentID(forPaneID: pane.paneID),
+            attention: pane.attention
+        )
+    }
+}
+
+extension ShellContentInstance {
+    static func projectingTerminalPane(_ pane: ShellPane) -> ShellContentInstance {
+        let title = terminalTitle(for: pane)
+        return ShellContentInstance(
+            contentID: terminalContentID(forPaneID: pane.paneID),
+            kind: .terminal,
+            title: title,
+            payload: .terminal(
+                ShellTerminalContentPayload(
+                    launchTarget: pane.resolvedLaunchTarget,
+                    cwd: pane.cwd,
+                    title: title
+                )
+            ),
+            rendererState: terminalRendererState(for: pane)
+        )
+    }
+
+    static func terminalContentID(forPaneID paneID: String) -> String {
+        "content_\(paneID)"
+    }
+
+    private static func terminalTitle(for pane: ShellPane) -> String {
+        if let title = pane.viewport?.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty
+        {
+            return title
+        }
+
+        switch pane.resolvedLaunchTarget {
+        case .shell:
+            return "Shell"
+        case .alan:
+            return "alan"
+        }
+    }
+
+    private static func terminalRendererState(for pane: ShellPane) -> ShellContentRendererState {
+        let phase = pane.context?.rendererPhase
+            ?? pane.context?.rendererHealth
+            ?? "placeholder"
+        let detail = pane.context?.surfaceReadiness ?? pane.viewport?.summary
+        return ShellContentRendererState(phase: phase, detail: detail)
     }
 }

--- a/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
@@ -19,7 +19,7 @@ struct ShellStatePersistenceStore {
         try? fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(shellState) else { return }
+        guard let data = try? encoder.encode(shellState.contentStateProjection()) else { return }
         try? data.write(to: persistenceURL, options: .atomic)
     }
 
@@ -52,7 +52,7 @@ struct ShellStatePersistenceStore {
 
             return urls.compactMap { url -> (Date, ShellWindowContext)? in
                 guard isShellStatePersistenceURL(url),
-                      let state = restoreShellState(fileManager: fileManager, persistenceURL: url)
+                      let windowID = restorePersistedWindowID(fileManager: fileManager, persistenceURL: url)
                 else {
                     return nil
                 }
@@ -60,13 +60,13 @@ struct ShellStatePersistenceStore {
                 let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
                 let modifiedAt = values?.contentModificationDate ?? .distantPast
                 let canonicalURL = defaultPersistenceURL(
-                    windowID: state.windowID,
+                    windowID: windowID,
                     fileManager: fileManager
                 )
                 return (
                     modifiedAt,
                     ShellWindowContext(
-                        windowID: state.windowID,
+                        windowID: windowID,
                         persistenceURL: canonicalURL,
                         terminalRuntimeRegistry: TerminalRuntimeRegistry()
                     )
@@ -106,6 +106,35 @@ struct ShellStatePersistenceStore {
             return nil
         }
         return state
+    }
+
+    private static func restorePersistedWindowID(
+        fileManager: FileManager,
+        persistenceURL: URL
+    ) -> String? {
+        let restoreURL = readablePersistenceURL(fileManager: fileManager, canonicalURL: persistenceURL)
+        guard let restoreURL,
+              let data = try? Data(contentsOf: restoreURL)
+        else {
+            return nil
+        }
+
+        if let contentState = try? JSONDecoder().decode(ShellContentStateSnapshot.self, from: data),
+           contentState.contractVersion == ShellContentStateSnapshot.currentContractVersion,
+           !contentState.windowID.isEmpty,
+           !contentState.spaces.isEmpty
+        {
+            return contentState.windowID
+        }
+
+        if let state = try? JSONDecoder().decode(ShellStateSnapshot.self, from: data),
+           !state.spaces.isEmpty,
+           !state.panes.isEmpty
+        {
+            return state.windowID
+        }
+
+        return nil
     }
 
     private static func persistenceDirectory(fileManager: FileManager) -> URL {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -91,6 +91,9 @@ private enum ShellRuntimeMetadataTests {
         verifiesSpaceSelectionCommitsAuthoritativeFocus()
         verifiesShellActionSpaceSelectionReportsMissingTargets()
         verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout()
+        verifiesContentStateProjectionSeparatesPaneSlotsAndContent()
+        verifiesShellStatePersistenceWritesContentStateShape()
+        verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
         verifiesClosingLastTabLeavesSelectedSpaceEmptyAndPersistsManifest()
         verifiesExplicitSpaceDeletionRemovesManifestSpace()
@@ -3060,6 +3063,128 @@ private enum ShellRuntimeMetadataTests {
             splitTreeAfter == splitTreeBefore,
             "split-tab selection must not rewrite split tree or divider ratios"
         )
+    }
+
+    private static func verifiesContentStateProjectionSeparatesPaneSlotsAndContent() {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+        do {
+            state = try state.splittingPane("pane_1", placement: .right).state
+        } catch {
+            fail("content projection setup must split the bootstrap pane: \(error)")
+        }
+
+        let projection = state.contentStateProjection()
+        let tab = projection.tab(tabID: "tab_main")
+
+        expect(
+            projection.contractVersion == ShellContentStateSnapshot.currentContractVersion,
+            "content projection must publish the v0.2 contract"
+        )
+        expect(
+            projection.focusedPaneSlotID == state.focusedPaneID,
+            "content projection must map focused pane to focused pane slot"
+        )
+        expect(
+            tab?.paneTree.paneSlotIDs == ["pane_1", "pane_2"],
+            "content projection layout leaves must reference pane_slot_id values"
+        )
+        expect(
+            projection.paneSlots.map(\.contentID) == ["content_pane_1", "content_pane_2"],
+            "content projection must bind each PaneSlot to a distinct ContentInstance"
+        )
+        expect(
+            projection.contents.map(\.kind) == [.terminal, .terminal],
+            "terminal-only runtime panes must project as terminal content instances"
+        )
+        expect(
+            tab.flatMap { projection.userFacingTitle(for: $0) } == "Shell",
+            "content-aware title projection must derive sidebar titles from tab/content descriptors"
+        )
+
+        let emptySpaceState = ShellStateSnapshot(
+            contractVersion: "0.1",
+            windowID: "empty_projection",
+            focusedSpaceID: "space_empty",
+            focusedTabID: nil,
+            focusedPaneID: nil,
+            spaces: [
+                ShellSpace(
+                    spaceID: "space_empty",
+                    title: "Empty",
+                    attention: .idle,
+                    tabs: []
+                )
+            ],
+            panes: []
+        )
+        let emptyProjection = emptySpaceState.contentStateProjection()
+        expect(emptyProjection.focusedPaneSlotID == nil, "empty content projection must keep pane-slot focus nil")
+        expect(emptyProjection.paneSlots.isEmpty, "empty content projection must not fabricate PaneSlots")
+        expect(emptyProjection.spaces.first?.spaceID == "space_empty", "empty content projection must keep spaces")
+    }
+
+    private static func verifiesShellStatePersistenceWritesContentStateShape() {
+        let windowID = "content_state_persist_\(UUID().uuidString)"
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let store = ShellStatePersistenceStore(persistenceURL: persistenceURL)
+        var state = ShellStateSnapshot.bootstrapDefault(windowID: windowID, workingDirectory: "/tmp")
+        do {
+            state = try state.splittingPane("pane_1", placement: .right).state
+        } catch {
+            fail("content persistence setup must split the bootstrap pane: \(error)")
+        }
+
+        store.save(state)
+
+        guard let data = try? Data(contentsOf: persistenceURL),
+              let persisted = try? JSONDecoder().decode(ShellContentStateSnapshot.self, from: data),
+              let text = String(data: data, encoding: .utf8)
+        else {
+            fail("shell state persistence must write a decodable content-state snapshot")
+        }
+
+        expect(persisted.windowID == windowID, "content-state persistence must preserve window identity")
+        expect(persisted.paneSlots.count == 2, "content-state persistence must save PaneSlots")
+        expect(persisted.contents.count == 2, "content-state persistence must save ContentInstances")
+        expect(
+            text.contains("\"pane_slots\"") && text.contains("\"contents\""),
+            "content-state persistence must use content-container keys"
+        )
+        expect(!text.contains("\"panes\""), "content-state persistence must not write v0.1 panes")
+        expect(
+            ShellStatePersistenceStore.restoreShellState(
+                fileManager: .default,
+                persistenceURL: persistenceURL
+            ) == nil,
+            "v0.2 content-state snapshots must not be treated as workspace restore authority"
+        )
+    }
+
+    private static func verifiesLegacyShellStateDecodeRemainsCompatibilityOnly() {
+        let windowID = "legacy_state_\(UUID().uuidString)"
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let state = ShellStateSnapshot.bootstrapDefault(windowID: windowID, workingDirectory: "/tmp")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(state) else {
+            fail("legacy shell state setup must encode v0.1 state")
+        }
+
+        do {
+            try data.write(to: persistenceURL, options: .atomic)
+        } catch {
+            fail("legacy shell state setup must write v0.1 state: \(error)")
+        }
+
+        let restored = ShellStatePersistenceStore.restoreShellState(
+            fileManager: .default,
+            persistenceURL: persistenceURL
+        )
+        expect(restored?.windowID == windowID, "legacy v0.1 shell-state decode must remain available")
+        expect(restored?.panes.first?.paneID == "pane_1", "legacy v0.1 shell-state decode must preserve panes")
     }
 
     private static func verifiesWorkspaceManifestStartupRestoresPinnedSnapshot() {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -2,10 +2,10 @@
 
 - [x] 1.1 Rebase this change after `persist-macos-shell-workspaces` is archived, and read the accepted `ShellWorkspaceManifest` schema/materializer before implementation.
 - [x] 1.2 Introduce v0.2 shell state value types: `ShellPaneSlot`, `ShellContentInstance`, content kind, content capabilities, and content payloads for terminal, markdown, and settings surfaces.
-- [ ] 1.3 Change pane layout leaves to reference `pane_slot_id` and change shell focus state to use `focused_pane_slot_id`.
-- [ ] 1.4 Replace new-state `panes: [ShellPane]` persistence with `pane_slots` and `contents`; keep v0.1 `ShellPane` decoding only as diagnostics/compatibility input, not as workspace restore authority.
+- [x] 1.3 Change pane layout leaves to reference `pane_slot_id` and change shell focus state to use `focused_pane_slot_id`.
+- [x] 1.4 Replace new-state `panes: [ShellPane]` persistence with `pane_slots` and `contents`; keep v0.1 `ShellPane` decoding only as diagnostics/compatibility input, not as workspace restore authority.
 - [x] 1.5 Add one-time manifest migration that turns terminal-only workspace restore snapshots into PaneSlot plus terminal ContentInstance restore snapshots while preserving Space/Tab IDs, selection, pin state, TTL anchors, and active-task metadata.
-- [ ] 1.6 Update shell state projection helpers so focused space, focused tab, focused PaneSlot, attention, titles, and sidebar rows derive from content-aware descriptors.
+- [x] 1.6 Update shell state projection helpers so focused space, focused tab, focused PaneSlot, attention, titles, and sidebar rows derive from content-aware descriptors.
 
 ## 2. Terminal Adapter
 


### PR DESCRIPTION
## Summary
- Add v0.2 content-state projection from the current terminal-only shell runtime shape into PaneSlots, ContentInstances, and focused_pane_slot_id.
- Save shell-state persistence as content-container JSON while keeping legacy v0.1 ShellPane decode available only for compatibility input.
- Add focused tests for split projection, empty-space projection, content-state persistence shape, and legacy v0.1 decode.
- Mark OpenSpec tasks 1.3, 1.4, and 1.6 complete for generalize-macos-shell-content-containers.

## Validation
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-shell-workspace-manifest.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-action-registry.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-content-state-projection build