### PR TITLE
Key macOS terminal runtimes by content id

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -123,6 +123,10 @@ extension ShellPane {
             && tabID == ShellQuickTerminalSlot.globalTabID
             && spaceID == ShellQuickTerminalSlot.globalSpaceID
     }
+
+    var terminalContentID: String {
+        ShellContentInstance.terminalContentID(forPaneID: paneID)
+    }
 }
 
 extension ShellPane {

--- a/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
@@ -5,6 +5,7 @@ import AppKit
 
 struct TerminalHostView: NSViewRepresentable {
     let pane: ShellPane?
+    let terminalContentMount: TerminalContentMount?
     let bootProfile: AlanShellBootProfile?
     let isSelected: Bool
     let runtimeRegistry: TerminalRuntimeRegistry
@@ -17,7 +18,8 @@ struct TerminalHostView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> AlanTerminalHostNSView {
         runtimeRegistry.hostView(
-            for: pane,
+            forTerminalContent: terminalContentMount,
+            pane: pane,
             bootProfile: bootProfile,
             isSelected: isSelected,
             activationDelegate: activationDelegate,
@@ -32,9 +34,12 @@ struct TerminalHostView: NSViewRepresentable {
     func updateNSView(_ nsView: AlanTerminalHostNSView, context: Context) {
         nsView.configure(
             pane: pane,
+            terminalContentID: terminalContentMount?.contentID,
             bootProfile: bootProfile,
             isSelected: isSelected,
-            surfaceHandle: runtimeRegistry.surfaceHandle(for: pane, bootProfile: bootProfile),
+            surfaceHandle: terminalContentMount.map {
+                runtimeRegistry.surfaceHandle(forTerminalContent: $0, bootProfile: bootProfile)
+            },
             activationDelegate: activationDelegate,
             onShellAction: onShellAction,
             onCommandInput: onCommandInput,

--- a/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
@@ -32,14 +32,12 @@ struct TerminalHostView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: AlanTerminalHostNSView, context: Context) {
-        nsView.configure(
+        runtimeRegistry.configureHostView(
+            nsView,
+            forTerminalContent: terminalContentMount,
             pane: pane,
-            terminalContentID: terminalContentMount?.contentID,
             bootProfile: bootProfile,
             isSelected: isSelected,
-            surfaceHandle: terminalContentMount.map {
-                runtimeRegistry.surfaceHandle(forTerminalContent: $0, bootProfile: bootProfile)
-            },
             activationDelegate: activationDelegate,
             onShellAction: onShellAction,
             onCommandInput: onCommandInput,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1995,8 +1995,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         _ state: ShellStateSnapshot,
         publish: Bool = true
     ) {
-        let paneIDs = Set(state.panes.map(\.paneID))
-        terminalRuntimeRegistry.releaseRuntimes(excluding: paneIDs)
+        let mountedPaneIDs = Set(state.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
+        let activeMounts = state.panes
+            .filter { mountedPaneIDs.contains($0.paneID) }
+            .map(TerminalContentMount.init(pane:))
+        terminalRuntimeRegistry.releaseRuntimes(excluding: activeMounts)
 
         let hydratedPanes = state.panes.map { pane in
             guard paneProjection.needsBootContextProjection(pane) else { return pane }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1995,11 +1995,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         _ state: ShellStateSnapshot,
         publish: Bool = true
     ) {
-        let mountedPaneIDs = Set(state.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
-        let activeMounts = state.panes
-            .filter { mountedPaneIDs.contains($0.paneID) }
-            .map(TerminalContentMount.init(pane:))
-        terminalRuntimeRegistry.releaseRuntimes(excluding: activeMounts)
+        terminalRuntimeRegistry.releaseRuntimes(excluding: activeTerminalContentMounts(in: state))
 
         let hydratedPanes = state.panes.map { pane in
             guard paneProjection.needsBootContextProjection(pane) else { return pane }
@@ -2054,6 +2050,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         if publish {
             publishControlPlaneState()
         }
+    }
+
+    private func activeTerminalContentMounts(in state: ShellStateSnapshot) -> [TerminalContentMount] {
+        var activePaneIDs = Set(state.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
+        if let quickTerminalPaneID = state.quickTerminal?.paneID {
+            activePaneIDs.insert(quickTerminalPaneID)
+        }
+        return state.panes
+            .filter { activePaneIDs.contains($0.paneID) }
+            .map(TerminalContentMount.init(pane:))
     }
 
     private func recordControlPlaneDiagnostic(_ message: String) {

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -529,6 +529,7 @@ struct AlanShellBootProfile: Equatable {
             "ALAN_SHELL_SPACE_ID": pane.spaceID,
             "ALAN_SHELL_TAB_ID": pane.tabID,
             "ALAN_SHELL_PANE_ID": pane.paneID,
+            "ALAN_SHELL_CONTENT_ID": pane.terminalContentID,
             "ALAN_SHELL_BOOT_MODE": pane.resolvedLaunchTarget.rawValue,
             "ALAN_SHELL_LAUNCH_TARGET": pane.resolvedLaunchTarget.rawValue,
             "ALAN_SHELL_LAUNCH_STRATEGY": command.strategy.rawValue,
@@ -667,6 +668,7 @@ struct TerminalPaneMetadataSnapshot: Equatable {
 
 struct TerminalHostRuntimeSnapshot: Equatable {
     let stage: TerminalHostStage
+    let contentID: String?
     let paneID: String?
     let tabID: String?
     let logicalSize: CGSize
@@ -686,6 +688,7 @@ struct TerminalHostRuntimeSnapshot: Equatable {
 
     static let placeholder = TerminalHostRuntimeSnapshot(
         stage: .scaffold,
+        contentID: nil,
         paneID: nil,
         tabID: nil,
         logicalSize: .zero,

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -19,6 +19,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private let windowObserver = TerminalHostWindowObserver()
 
     private var pane: ShellPane?
+    private var terminalContentID: String?
     private var bootProfile: AlanShellBootProfile?
     private var isSelected = false
     private weak var activationDelegate: TerminalHostActivationDelegate?
@@ -136,6 +137,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
     func configure(
         pane: ShellPane?,
+        terminalContentID: String?,
         bootProfile: AlanShellBootProfile?,
         isSelected: Bool,
         surfaceHandle: AlanTerminalSurfaceHandle?,
@@ -147,9 +149,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) {
         let previousPaneID = self.pane?.paneID
+        let previousContentID = self.terminalContentID
         let wasSelected = self.isSelected
 
         self.pane = pane
+        self.terminalContentID = terminalContentID
         self.bootProfile = bootProfile
         self.isSelected = isSelected
         surfaceController.bind(surfaceHandle: surfaceHandle, paneID: pane?.paneID)
@@ -169,7 +173,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         syncNativeScrollback()
         if terminalHostShouldAutoFocusAfterConfigure(
             isSelected: isSelected,
-            previousPaneID: previousPaneID,
+            previousPaneID: previousContentID == terminalContentID ? previousPaneID : nil,
             paneID: pane?.paneID,
             wasSelected: wasSelected
         ) {
@@ -314,10 +318,10 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             return .accepted(byteCount: 0)
         }
 
-        guard pane?.paneID != nil else {
+        guard terminalContentID != nil else {
             return .rejected(
                 errorCode: "terminal_runtime_unavailable",
-                errorMessage: "No pane is attached to this terminal runtime."
+                errorMessage: "No terminal content is attached to this host."
             )
         }
 
@@ -364,6 +368,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
 
         let snapshot = TerminalHostRuntimeSnapshot(
             stage: stage,
+            contentID: terminalContentID,
             paneID: pane?.paneID,
             tabID: pane?.tabID,
             logicalSize: logicalSize,
@@ -414,8 +419,14 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private func reportCloseRequest(requiresConfirmation: Bool) {
         guard let closeRequestHandler else { return }
         let paneID = pane?.paneID
+        let contentID = terminalContentID
         DispatchQueue.main.async { [weak self] in
-            guard let self, self.pane?.paneID == paneID else { return }
+            guard let self,
+                  self.pane?.paneID == paneID,
+                  self.terminalContentID == contentID
+            else {
+                return
+            }
             closeRequestHandler(requiresConfirmation)
         }
     }

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -757,6 +757,7 @@ private struct ShellTerminalLeafView: View {
             ZStack(alignment: .topTrailing) {
                 TerminalHostView(
                     pane: pane,
+                    terminalContentMount: TerminalContentMount(pane: pane),
                     bootProfile: bootProfile,
                     isSelected: isSelected,
                     runtimeRegistry: runtimeRegistry,

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -63,6 +63,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     private var hostViewsByContentID: [String: AlanTerminalHostNSView] = [:]
     private var snapshotsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
     private var paneSlotIDByContentID: [String: String] = [:]
+    private var contentIDByPaneSlotID: [String: String] = [:]
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
 
@@ -113,7 +114,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     ) -> AlanTerminalHostNSView {
         let hostView: AlanTerminalHostNSView
         if let mount {
-            paneSlotIDByContentID[mount.contentID] = mount.paneSlotID
+            recordMount(contentID: mount.contentID, paneSlotID: mount.paneSlotID)
             if let existing = hostViewsByContentID[mount.contentID] {
                 hostView = existing
             } else {
@@ -167,7 +168,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         forTerminalContent mount: TerminalContentMount,
         bootProfile: AlanShellBootProfile?
     ) -> AlanTerminalSurfaceHandle {
-        paneSlotIDByContentID[mount.contentID] = mount.paneSlotID
+        recordMount(contentID: mount.contentID, paneSlotID: mount.paneSlotID)
         return runtimeService.surfaceHandle(
             forTerminalContentID: mount.contentID,
             mountedAtPaneID: mount.paneSlotID,
@@ -180,7 +181,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             return
         }
         if let paneID = snapshot.paneID {
-            paneSlotIDByContentID[contentID] = paneID
+            recordMount(contentID: contentID, paneSlotID: paneID)
         }
         snapshotsByContentID[contentID] = snapshot
         runtimeService
@@ -190,7 +191,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     func snapshot(for paneID: String?) -> TerminalHostRuntimeSnapshot {
         guard let paneID else { return .placeholder }
-        return snapshot(forTerminalContentID: terminalContentID(forPaneID: paneID))
+        return snapshot(forTerminalContentID: terminalContentID(mountedAtPaneID: paneID))
     }
 
     func snapshot(forTerminalContentID contentID: String?) -> TerminalHostRuntimeSnapshot {
@@ -200,13 +201,13 @@ final class TerminalRuntimeRegistry: ObservableObject {
     }
 
     func releaseRuntimes(excluding activePaneIDs: Set<String>) {
-        let activeContentIDs = Set(activePaneIDs.map(terminalContentID(forPaneID:)))
+        let activeContentIDs = Set(activePaneIDs.map { terminalContentID(mountedAtPaneID: $0) })
         let staleContentIDs = registeredContentIDs.subtracting(activeContentIDs)
         staleContentIDs.forEach { releaseTerminalContent($0) }
     }
 
     func releaseRuntime(for paneID: String) {
-        releaseTerminalContent(terminalContentID(forPaneID: paneID))
+        releaseTerminalContent(terminalContentID(mountedAtPaneID: paneID))
     }
 
     func releaseAllRuntimes() {
@@ -214,7 +215,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     }
 
     func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
-        sendText(toTerminalContentID: terminalContentID(forPaneID: paneID), text: text)
+        sendText(toTerminalContentID: terminalContentID(mountedAtPaneID: paneID), text: text)
     }
 
     func sendText(
@@ -229,7 +230,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     }
 
     func terminalCommandRuntimeState(for paneID: String) -> ShellTerminalCommandRuntimeState {
-        let contentID = terminalContentID(forPaneID: paneID)
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
         if let hostView = hostViewsByContentID[contentID] {
             return hostView.terminalCommandRuntimeState
         }
@@ -249,7 +250,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func copySelection(for paneID: String) -> Bool {
-        let contentID = terminalContentID(forPaneID: paneID)
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
         if let hostView = hostViewsByContentID[contentID] {
             return hostView.copySelection()
         }
@@ -261,7 +262,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func copySelection(for paneID: String, to writer: AlanTerminalPasteboardWriting) -> Bool {
-        let contentID = terminalContentID(forPaneID: paneID)
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
         if let hostView = hostViewsByContentID[contentID] {
             return hostView.copySelection(to: writer)
         }
@@ -277,7 +278,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func pasteText(_ text: String, to paneID: String) -> TerminalRuntimeDeliveryResult {
-        let contentID = terminalContentID(forPaneID: paneID)
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
         if let hostView = hostViewsByContentID[contentID] {
             return hostView.pasteText(text)
         }
@@ -286,12 +287,13 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func beginFindInteraction(for paneID: String) -> Bool {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.beginFindInteraction() ?? false
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
+            .beginFindInteraction() ?? false
     }
 
     @discardableResult
     func beginLastCommandOutputSearch(for paneID: String) -> Bool {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
             .beginLastCommandOutputSearch() ?? false
     }
 
@@ -300,36 +302,37 @@ final class TerminalRuntimeRegistry: ObservableObject {
         for paneID: String,
         direction: AlanTerminalPromptNavigationDirection
     ) -> Bool {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
             .navigateSemanticPrompt(direction) ?? false
     }
 
     @discardableResult
     func copyLastCommandOutput(for paneID: String) -> Bool {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.copyLastCommandOutput() ?? false
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
+            .copyLastCommandOutput() ?? false
     }
 
     @discardableResult
     func updateFindQuery(for paneID: String, query: String) -> Bool {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
             .updateFindQuery(query) ?? false
     }
 
     func selectNextFindMatch(for paneID: String) {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.selectNextFindMatch()
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?.selectNextFindMatch()
     }
 
     func selectPreviousFindMatch(for paneID: String) {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.selectPreviousFindMatch()
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?.selectPreviousFindMatch()
     }
 
     func dismissFindInteraction(for paneID: String, refocusTerminal: Bool = true) {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?
             .dismissFindInteraction(refocusTerminal: refocusTerminal)
     }
 
     func requestFocus(for paneID: String) {
-        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.focusTerminal()
+        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?.focusTerminal()
     }
 
     var registeredContentIDs: Set<String> {
@@ -350,11 +353,35 @@ final class TerminalRuntimeRegistry: ObservableObject {
         }
         runtimeService.finalizeTerminalContent(contentID)
         snapshotsByContentID.removeValue(forKey: contentID)
-        paneSlotIDByContentID.removeValue(forKey: contentID)
+        if let paneSlotID = paneSlotIDByContentID.removeValue(forKey: contentID),
+           contentIDByPaneSlotID[paneSlotID] == contentID
+        {
+            contentIDByPaneSlotID.removeValue(forKey: paneSlotID)
+        }
     }
 
     private func terminalContentID(forPaneID paneID: String) -> String {
         ShellContentInstance.terminalContentID(forPaneID: paneID)
+    }
+
+    private func terminalContentID(mountedAtPaneID paneID: String) -> String {
+        contentIDByPaneSlotID[paneID] ?? terminalContentID(forPaneID: paneID)
+    }
+
+    private func recordMount(contentID: String, paneSlotID: String) {
+        if let previousPaneSlotID = paneSlotIDByContentID[contentID],
+           previousPaneSlotID != paneSlotID,
+           contentIDByPaneSlotID[previousPaneSlotID] == contentID
+        {
+            contentIDByPaneSlotID.removeValue(forKey: previousPaneSlotID)
+        }
+        if let previousContentID = contentIDByPaneSlotID[paneSlotID],
+           previousContentID != contentID
+        {
+            paneSlotIDByContentID.removeValue(forKey: previousContentID)
+        }
+        paneSlotIDByContentID[contentID] = paneSlotID
+        contentIDByPaneSlotID[paneSlotID] = contentID
     }
 
     private func runtimeSnapshot(

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -112,28 +112,48 @@ final class TerminalRuntimeRegistry: ObservableObject {
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
-        let hostView: AlanTerminalHostNSView
-        if let mount {
-            recordMount(contentID: mount.contentID, paneSlotID: mount.paneSlotID)
-            if let existing = hostViewsByContentID[mount.contentID] {
-                hostView = existing
-            } else {
-                let created = AlanTerminalHostNSView()
-                hostViewsByContentID[mount.contentID] = created
-                hostView = created
-            }
-        } else {
-            hostView = AlanTerminalHostNSView()
-        }
+        let hostView = mount.flatMap { hostViewsByContentID[$0.contentID] }
+            ?? AlanTerminalHostNSView()
 
+        configureHostView(
+            hostView,
+            forTerminalContent: mount,
+            pane: pane,
+            bootProfile: bootProfile,
+            isSelected: isSelected,
+            activationDelegate: activationDelegate,
+            onShellAction: onShellAction,
+            onCommandInput: onCommandInput,
+            onCloseRequest: onCloseRequest,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
+        )
+        return hostView
+    }
+
+    func configureHostView(
+        _ hostView: AlanTerminalHostNSView,
+        forTerminalContent mount: TerminalContentMount?,
+        pane: ShellPane?,
+        bootProfile: AlanShellBootProfile?,
+        isSelected: Bool,
+        activationDelegate: TerminalHostActivationDelegate?,
+        onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
+        onCommandInput: (() -> Void)?,
+        onCloseRequest: ((Bool) -> Void)?,
+        onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
+        onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
+    ) {
         let surfaceHandle: AlanTerminalSurfaceHandle?
         if let mount {
+            registerHostView(hostView, contentID: mount.contentID, paneSlotID: mount.paneSlotID)
             surfaceHandle = runtimeService.surfaceHandle(
                 forTerminalContentID: mount.contentID,
                 mountedAtPaneID: mount.paneSlotID,
                 bootProfile: bootProfile
             )
         } else {
+            unregisterHostView(hostView)
             surfaceHandle = nil
         }
 
@@ -150,7 +170,6 @@ final class TerminalRuntimeRegistry: ObservableObject {
             onRuntimeUpdate: onRuntimeUpdate,
             onMetadataUpdate: onMetadataUpdate
         )
-        return hostView
     }
 
     func surfaceHandle(
@@ -366,6 +385,26 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     private func terminalContentID(mountedAtPaneID paneID: String) -> String {
         contentIDByPaneSlotID[paneID] ?? terminalContentID(forPaneID: paneID)
+    }
+
+    private func registerHostView(
+        _ hostView: AlanTerminalHostNSView,
+        contentID: String,
+        paneSlotID: String
+    ) {
+        unregisterHostView(hostView, excludingContentID: contentID)
+        recordMount(contentID: contentID, paneSlotID: paneSlotID)
+        hostViewsByContentID[contentID] = hostView
+    }
+
+    private func unregisterHostView(
+        _ hostView: AlanTerminalHostNSView,
+        excludingContentID retainedContentID: String? = nil
+    ) {
+        let staleContentIDs = hostViewsByContentID.compactMap { contentID, registeredHostView in
+            registeredHostView === hostView && contentID != retainedContentID ? contentID : nil
+        }
+        staleContentIDs.forEach { hostViewsByContentID.removeValue(forKey: $0) }
     }
 
     private func recordMount(contentID: String, paneSlotID: String) {

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -233,7 +233,8 @@ final class TerminalRuntimeRegistry: ObservableObject {
     }
 
     private func releaseRuntimes(excludingTerminalContentIDs activeContentIDs: Set<String>) {
-        let staleContentIDs = registeredContentIDs.subtracting(activeContentIDs)
+        let trackedContentIDs = registeredContentIDs.union(paneSlotIDByContentID.keys)
+        let staleContentIDs = trackedContentIDs.subtracting(activeContentIDs)
         staleContentIDs.forEach { releaseTerminalContent($0) }
     }
 

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -33,12 +33,36 @@ final class MockTerminalRuntimeHandle: TerminalRuntimeHandle {
     }
 }
 
+struct TerminalContentMount: Equatable {
+    let contentID: String
+    let paneSlotID: String
+    let tabID: String
+    let spaceID: String
+
+    init(contentID: String, paneSlotID: String, tabID: String, spaceID: String) {
+        self.contentID = contentID
+        self.paneSlotID = paneSlotID
+        self.tabID = tabID
+        self.spaceID = spaceID
+    }
+
+    init(pane: ShellPane) {
+        self.init(
+            contentID: pane.terminalContentID,
+            paneSlotID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID
+        )
+    }
+}
+
 @MainActor
 final class TerminalRuntimeRegistry: ObservableObject {
     typealias MockDeliveryHandler = (String, String) -> TerminalRuntimeDeliveryResult
 
-    private var hostViewsByPaneID: [String: AlanTerminalHostNSView] = [:]
-    private var snapshotsByPaneID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private var hostViewsByContentID: [String: AlanTerminalHostNSView] = [:]
+    private var snapshotsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
+    private var paneSlotIDByContentID: [String: String] = [:]
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
 
@@ -61,13 +85,40 @@ final class TerminalRuntimeRegistry: ObservableObject {
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
         onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
     ) -> AlanTerminalHostNSView {
+        hostView(
+            forTerminalContent: pane.map(TerminalContentMount.init(pane:)),
+            pane: pane,
+            bootProfile: bootProfile,
+            isSelected: isSelected,
+            activationDelegate: activationDelegate,
+            onShellAction: onShellAction,
+            onCommandInput: onCommandInput,
+            onCloseRequest: onCloseRequest,
+            onRuntimeUpdate: onRuntimeUpdate,
+            onMetadataUpdate: onMetadataUpdate
+        )
+    }
+
+    func hostView(
+        forTerminalContent mount: TerminalContentMount?,
+        pane: ShellPane?,
+        bootProfile: AlanShellBootProfile?,
+        isSelected: Bool,
+        activationDelegate: TerminalHostActivationDelegate?,
+        onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
+        onCommandInput: (() -> Void)?,
+        onCloseRequest: ((Bool) -> Void)?,
+        onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
+        onMetadataUpdate: @escaping (TerminalPaneMetadataSnapshot) -> Void
+    ) -> AlanTerminalHostNSView {
         let hostView: AlanTerminalHostNSView
-        if let paneID = pane?.paneID {
-            if let existing = hostViewsByPaneID[paneID] {
+        if let mount {
+            paneSlotIDByContentID[mount.contentID] = mount.paneSlotID
+            if let existing = hostViewsByContentID[mount.contentID] {
                 hostView = existing
             } else {
                 let created = AlanTerminalHostNSView()
-                hostViewsByPaneID[paneID] = created
+                hostViewsByContentID[mount.contentID] = created
                 hostView = created
             }
         } else {
@@ -75,14 +126,19 @@ final class TerminalRuntimeRegistry: ObservableObject {
         }
 
         let surfaceHandle: AlanTerminalSurfaceHandle?
-        if let paneID = pane?.paneID {
-            surfaceHandle = runtimeService.surfaceHandle(for: paneID, bootProfile: bootProfile)
+        if let mount {
+            surfaceHandle = runtimeService.surfaceHandle(
+                forTerminalContentID: mount.contentID,
+                mountedAtPaneID: mount.paneSlotID,
+                bootProfile: bootProfile
+            )
         } else {
             surfaceHandle = nil
         }
 
         hostView.configure(
             pane: pane,
+            terminalContentID: mount?.contentID,
             bootProfile: bootProfile,
             isSelected: isSelected,
             surfaceHandle: surfaceHandle,
@@ -100,54 +156,88 @@ final class TerminalRuntimeRegistry: ObservableObject {
         for pane: ShellPane?,
         bootProfile: AlanShellBootProfile?
     ) -> AlanTerminalSurfaceHandle? {
-        guard let paneID = pane?.paneID else { return nil }
-        return runtimeService.surfaceHandle(for: paneID, bootProfile: bootProfile)
+        guard let pane else { return nil }
+        return surfaceHandle(
+            forTerminalContent: TerminalContentMount(pane: pane),
+            bootProfile: bootProfile
+        )
+    }
+
+    func surfaceHandle(
+        forTerminalContent mount: TerminalContentMount,
+        bootProfile: AlanShellBootProfile?
+    ) -> AlanTerminalSurfaceHandle {
+        paneSlotIDByContentID[mount.contentID] = mount.paneSlotID
+        return runtimeService.surfaceHandle(
+            forTerminalContentID: mount.contentID,
+            mountedAtPaneID: mount.paneSlotID,
+            bootProfile: bootProfile
+        )
     }
 
     func updateSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {
-        guard let paneID = snapshot.paneID else { return }
-        snapshotsByPaneID[paneID] = snapshot
-        runtimeService.existingSurfaceHandle(for: paneID)?.updateHostRuntimeSnapshot(snapshot)
+        guard let contentID = snapshot.contentID ?? snapshot.paneID.map(terminalContentID(forPaneID:)) else {
+            return
+        }
+        if let paneID = snapshot.paneID {
+            paneSlotIDByContentID[contentID] = paneID
+        }
+        snapshotsByContentID[contentID] = snapshot
+        runtimeService
+            .existingSurfaceHandle(forTerminalContentID: contentID)?
+            .updateHostRuntimeSnapshot(snapshot)
     }
 
     func snapshot(for paneID: String?) -> TerminalHostRuntimeSnapshot {
         guard let paneID else { return .placeholder }
-        return snapshotsByPaneID[paneID] ?? runtimeSnapshot(from: runtimeService.snapshot(for: paneID))
+        return snapshot(forTerminalContentID: terminalContentID(forPaneID: paneID))
+    }
+
+    func snapshot(forTerminalContentID contentID: String?) -> TerminalHostRuntimeSnapshot {
+        guard let contentID else { return .placeholder }
+        return snapshotsByContentID[contentID]
+            ?? runtimeSnapshot(from: runtimeService.snapshot(forTerminalContentID: contentID))
     }
 
     func releaseRuntimes(excluding activePaneIDs: Set<String>) {
-        let stalePaneIDs = Set(hostViewsByPaneID.keys)
-            .union(snapshotsByPaneID.keys)
-            .union(runtimeService.registeredPaneIDs)
-            .subtracting(activePaneIDs)
-        stalePaneIDs.forEach { releaseRuntime($0) }
+        let activeContentIDs = Set(activePaneIDs.map(terminalContentID(forPaneID:)))
+        let staleContentIDs = registeredContentIDs.subtracting(activeContentIDs)
+        staleContentIDs.forEach { releaseTerminalContent($0) }
     }
 
     func releaseRuntime(for paneID: String) {
-        releaseRuntime(paneID)
+        releaseTerminalContent(terminalContentID(forPaneID: paneID))
     }
 
     func releaseAllRuntimes() {
-        registeredPaneIDs.forEach { releaseRuntime($0) }
+        registeredContentIDs.forEach { releaseTerminalContent($0) }
     }
 
     func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
+        sendText(toTerminalContentID: terminalContentID(forPaneID: paneID), text: text)
+    }
+
+    func sendText(
+        toTerminalContentID contentID: String,
+        text: String
+    ) -> TerminalRuntimeDeliveryResult {
         if let mockDeliveryHandler {
-            return mockDeliveryHandler(paneID, text)
+            return mockDeliveryHandler(contentID, text)
         }
 
-        return runtimeService.sendText(to: paneID, text: text)
+        return runtimeService.sendText(toTerminalContentID: contentID, text: text)
     }
 
     func terminalCommandRuntimeState(for paneID: String) -> ShellTerminalCommandRuntimeState {
-        if let hostView = hostViewsByPaneID[paneID] {
+        let contentID = terminalContentID(forPaneID: paneID)
+        if let hostView = hostViewsByContentID[contentID] {
             return hostView.terminalCommandRuntimeState
         }
 
-        let surfaceHandle = runtimeService.existingSurfaceHandle(for: paneID)
+        let surfaceHandle = runtimeService.existingSurfaceHandle(forTerminalContentID: contentID)
         let selectionEngine = surfaceHandle as? AlanTerminalSelectionEngine
         let searchEngine = surfaceHandle as? AlanTerminalSearchEngine
-        let snapshot = snapshotsByPaneID[paneID]
+        let snapshot = snapshotsByContentID[contentID]
         return ShellTerminalCommandRuntimeState(
             paneID: paneID,
             hasSelection: selectionEngine?.hasSelection() ?? false,
@@ -159,7 +249,8 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func copySelection(for paneID: String) -> Bool {
-        if let hostView = hostViewsByPaneID[paneID] {
+        let contentID = terminalContentID(forPaneID: paneID)
+        if let hostView = hostViewsByContentID[contentID] {
             return hostView.copySelection()
         }
         return copySelection(
@@ -170,10 +261,12 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func copySelection(for paneID: String, to writer: AlanTerminalPasteboardWriting) -> Bool {
-        if let hostView = hostViewsByPaneID[paneID] {
+        let contentID = terminalContentID(forPaneID: paneID)
+        if let hostView = hostViewsByContentID[contentID] {
             return hostView.copySelection(to: writer)
         }
-        guard let selectionEngine = runtimeService.existingSurfaceHandle(for: paneID) as? AlanTerminalSelectionEngine,
+        guard let selectionEngine = runtimeService
+            .existingSurfaceHandle(forTerminalContentID: contentID) as? AlanTerminalSelectionEngine,
               let selectedText = selectionEngine.readSelectionText(),
               !selectedText.isEmpty
         else {
@@ -184,7 +277,8 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func pasteText(_ text: String, to paneID: String) -> TerminalRuntimeDeliveryResult {
-        if let hostView = hostViewsByPaneID[paneID] {
+        let contentID = terminalContentID(forPaneID: paneID)
+        if let hostView = hostViewsByContentID[contentID] {
             return hostView.pasteText(text)
         }
         return sendText(to: paneID, text: text)
@@ -192,12 +286,13 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     @discardableResult
     func beginFindInteraction(for paneID: String) -> Bool {
-        hostViewsByPaneID[paneID]?.beginFindInteraction() ?? false
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.beginFindInteraction() ?? false
     }
 
     @discardableResult
     func beginLastCommandOutputSearch(for paneID: String) -> Bool {
-        hostViewsByPaneID[paneID]?.beginLastCommandOutputSearch() ?? false
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+            .beginLastCommandOutputSearch() ?? false
     }
 
     @discardableResult
@@ -205,45 +300,61 @@ final class TerminalRuntimeRegistry: ObservableObject {
         for paneID: String,
         direction: AlanTerminalPromptNavigationDirection
     ) -> Bool {
-        hostViewsByPaneID[paneID]?.navigateSemanticPrompt(direction) ?? false
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+            .navigateSemanticPrompt(direction) ?? false
     }
 
     @discardableResult
     func copyLastCommandOutput(for paneID: String) -> Bool {
-        hostViewsByPaneID[paneID]?.copyLastCommandOutput() ?? false
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.copyLastCommandOutput() ?? false
     }
 
     @discardableResult
     func updateFindQuery(for paneID: String, query: String) -> Bool {
-        hostViewsByPaneID[paneID]?.updateFindQuery(query) ?? false
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+            .updateFindQuery(query) ?? false
     }
 
     func selectNextFindMatch(for paneID: String) {
-        hostViewsByPaneID[paneID]?.selectNextFindMatch()
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.selectNextFindMatch()
     }
 
     func selectPreviousFindMatch(for paneID: String) {
-        hostViewsByPaneID[paneID]?.selectPreviousFindMatch()
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.selectPreviousFindMatch()
     }
 
     func dismissFindInteraction(for paneID: String, refocusTerminal: Bool = true) {
-        hostViewsByPaneID[paneID]?.dismissFindInteraction(refocusTerminal: refocusTerminal)
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?
+            .dismissFindInteraction(refocusTerminal: refocusTerminal)
     }
 
     func requestFocus(for paneID: String) {
-        hostViewsByPaneID[paneID]?.focusTerminal()
+        hostViewsByContentID[terminalContentID(forPaneID: paneID)]?.focusTerminal()
+    }
+
+    var registeredContentIDs: Set<String> {
+        Set(hostViewsByContentID.keys)
+            .union(snapshotsByContentID.keys)
+            .union(runtimeService.registeredContentIDs)
     }
 
     var registeredPaneIDs: Set<String> {
-        Set(hostViewsByPaneID.keys).union(runtimeService.registeredPaneIDs)
+        Set(paneSlotIDByContentID.values)
+            .union(snapshotsByContentID.values.compactMap(\.paneID))
+            .union(runtimeService.registeredPaneIDs)
     }
 
-    private func releaseRuntime(_ paneID: String) {
-        if let hostView = hostViewsByPaneID.removeValue(forKey: paneID) {
+    private func releaseTerminalContent(_ contentID: String) {
+        if let hostView = hostViewsByContentID.removeValue(forKey: contentID) {
             hostView.teardownTerminalRuntime()
         }
-        runtimeService.finalizePane(paneID)
-        snapshotsByPaneID.removeValue(forKey: paneID)
+        runtimeService.finalizeTerminalContent(contentID)
+        snapshotsByContentID.removeValue(forKey: contentID)
+        paneSlotIDByContentID.removeValue(forKey: contentID)
+    }
+
+    private func terminalContentID(forPaneID paneID: String) -> String {
+        ShellContentInstance.terminalContentID(forPaneID: paneID)
     }
 
     private func runtimeSnapshot(
@@ -252,6 +363,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         guard let surfaceSnapshot else { return .placeholder }
         return TerminalHostRuntimeSnapshot(
             stage: .scaffold,
+            contentID: surfaceSnapshot.contentID,
             paneID: surfaceSnapshot.paneID,
             tabID: nil,
             logicalSize: .zero,

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -221,6 +221,18 @@ final class TerminalRuntimeRegistry: ObservableObject {
 
     func releaseRuntimes(excluding activePaneIDs: Set<String>) {
         let activeContentIDs = Set(activePaneIDs.map { terminalContentID(mountedAtPaneID: $0) })
+        releaseRuntimes(excludingTerminalContentIDs: activeContentIDs)
+    }
+
+    func releaseRuntimes(excluding activeMounts: [TerminalContentMount]) {
+        activeMounts.forEach { mount in
+            recordMount(contentID: mount.contentID, paneSlotID: mount.paneSlotID)
+        }
+        let activeContentIDs = Set(activeMounts.map(\.contentID))
+        releaseRuntimes(excludingTerminalContentIDs: activeContentIDs)
+    }
+
+    private func releaseRuntimes(excludingTerminalContentIDs activeContentIDs: Set<String>) {
         let staleContentIDs = registeredContentIDs.subtracting(activeContentIDs)
         staleContentIDs.forEach { releaseTerminalContent($0) }
     }

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -259,6 +259,7 @@ enum AlanTerminalSurfaceTeardownStatus: String, Equatable {
 }
 
 struct AlanTerminalSurfaceSnapshot: Equatable {
+    let contentID: String
     let paneID: String
     let lifecyclePhase: AlanTerminalSurfaceLifecyclePhase
     let renderer: TerminalRendererSnapshot
@@ -272,8 +273,9 @@ struct AlanTerminalSurfaceSnapshot: Equatable {
         renderer.phase.rawValue
     }
 
-    static func pending(paneID: String) -> AlanTerminalSurfaceSnapshot {
+    static func pending(contentID: String, paneID: String) -> AlanTerminalSurfaceSnapshot {
         AlanTerminalSurfaceSnapshot(
+            contentID: contentID,
             paneID: paneID,
             lifecyclePhase: .pending,
             renderer: .placeholder,
@@ -288,11 +290,12 @@ struct AlanTerminalSurfaceSnapshot: Equatable {
 
 @MainActor
 protocol AlanTerminalSurfaceHandle: AnyObject {
+    var contentID: String { get }
     var paneID: String { get }
     var snapshot: AlanTerminalSurfaceSnapshot { get }
     var isSurfaceReady: Bool { get }
 
-    func configure(bootProfile: AlanShellBootProfile?)
+    func configure(mountedAtPaneID paneID: String, bootProfile: AlanShellBootProfile?)
     func attach(
         to canvasView: NSView,
         focused: Bool,
@@ -341,7 +344,8 @@ protocol AlanGhosttyEventSurfaceHandle:
 
 @MainActor
 final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
-    let paneID: String
+    let contentID: String
+    private(set) var paneID: String
 
     private let bootstrap: AlanGhosttyProcessBootstrap
     private var bootProfile: AlanShellBootProfile?
@@ -351,10 +355,11 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
     private let liveHost = AlanGhosttyLiveHost()
 #endif
 
-    init(paneID: String, bootstrap: AlanGhosttyProcessBootstrap) {
+    init(contentID: String, paneID: String, bootstrap: AlanGhosttyProcessBootstrap) {
+        self.contentID = contentID
         self.paneID = paneID
         self.bootstrap = bootstrap
-        self.currentSnapshot = .pending(paneID: paneID)
+        self.currentSnapshot = .pending(contentID: contentID, paneID: paneID)
     }
 
     var snapshot: AlanTerminalSurfaceSnapshot {
@@ -369,7 +374,8 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
 #endif
     }
 
-    func configure(bootProfile: AlanShellBootProfile?) {
+    func configure(mountedAtPaneID paneID: String, bootProfile: AlanShellBootProfile?) {
+        self.paneID = paneID
         self.bootProfile = bootProfile
         guard currentSnapshot.teardownStatus != .completed else { return }
         updateSnapshot(
@@ -581,6 +587,7 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
         attachedViewCount: Int? = nil
     ) {
         currentSnapshot = AlanTerminalSurfaceSnapshot(
+            contentID: contentID,
             paneID: paneID,
             lifecyclePhase: lifecyclePhase ?? currentSnapshot.lifecyclePhase,
             renderer: renderer ?? currentSnapshot.renderer,
@@ -692,31 +699,77 @@ extension AlanGhosttySurfaceHandle: AlanGhosttyEventSurfaceHandle {
 @MainActor
 protocol AlanTerminalRuntimeService: AnyObject {
     var diagnostics: AlanGhosttyBootstrapDiagnostics { get }
+    var registeredContentIDs: Set<String> { get }
     var registeredPaneIDs: Set<String> { get }
 
     @discardableResult
     func ensureReady() -> AlanGhosttyBootstrapDiagnostics
-    func surfaceHandle(for paneID: String, bootProfile: AlanShellBootProfile?) -> AlanTerminalSurfaceHandle
-    func existingSurfaceHandle(for paneID: String) -> AlanTerminalSurfaceHandle?
-    func snapshot(for paneID: String) -> AlanTerminalSurfaceSnapshot?
-    func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult
+    func surfaceHandle(
+        forTerminalContentID contentID: String,
+        mountedAtPaneID paneID: String,
+        bootProfile: AlanShellBootProfile?
+    ) -> AlanTerminalSurfaceHandle
+    func existingSurfaceHandle(forTerminalContentID contentID: String) -> AlanTerminalSurfaceHandle?
+    func snapshot(forTerminalContentID contentID: String) -> AlanTerminalSurfaceSnapshot?
+    func sendText(toTerminalContentID contentID: String, text: String) -> TerminalRuntimeDeliveryResult
     @discardableResult
-    func finalizePane(_ paneID: String) -> AlanTerminalSurfaceTeardownStatus
-    func finalizePanes(excluding activePaneIDs: Set<String>)
+    func finalizeTerminalContent(_ contentID: String) -> AlanTerminalSurfaceTeardownStatus
+    func finalizeTerminalContents(excluding activeContentIDs: Set<String>)
+}
+
+extension AlanTerminalRuntimeService {
+    func surfaceHandle(
+        for paneID: String,
+        bootProfile: AlanShellBootProfile?
+    ) -> AlanTerminalSurfaceHandle {
+        surfaceHandle(
+            forTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
+            mountedAtPaneID: paneID,
+            bootProfile: bootProfile
+        )
+    }
+
+    func existingSurfaceHandle(for paneID: String) -> AlanTerminalSurfaceHandle? {
+        existingSurfaceHandle(
+            forTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID)
+        )
+    }
+
+    func snapshot(for paneID: String) -> AlanTerminalSurfaceSnapshot? {
+        snapshot(forTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID))
+    }
+
+    func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
+        sendText(
+            toTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
+            text: text
+        )
+    }
+
+    @discardableResult
+    func finalizePane(_ paneID: String) -> AlanTerminalSurfaceTeardownStatus {
+        finalizeTerminalContent(ShellContentInstance.terminalContentID(forPaneID: paneID))
+    }
+
+    func finalizePanes(excluding activePaneIDs: Set<String>) {
+        finalizeTerminalContents(
+            excluding: Set(activePaneIDs.map { ShellContentInstance.terminalContentID(forPaneID: $0) })
+        )
+    }
 }
 
 @MainActor
 final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
-    typealias SurfaceFactory = (String, AlanGhosttyProcessBootstrap) -> AlanTerminalSurfaceHandle
+    typealias SurfaceFactory = (String, String, AlanGhosttyProcessBootstrap) -> AlanTerminalSurfaceHandle
 
     private let bootstrap: AlanGhosttyProcessBootstrap
     private let makeSurfaceHandle: SurfaceFactory
-    private var handlesByPaneID: [String: AlanTerminalSurfaceHandle] = [:]
+    private var handlesByContentID: [String: AlanTerminalSurfaceHandle] = [:]
 
     init(surfaceFactory: SurfaceFactory? = nil) {
         self.bootstrap = AlanDefaultGhosttyProcessBootstrap.shared
-        self.makeSurfaceHandle = surfaceFactory ?? { paneID, bootstrap in
-            AlanGhosttySurfaceHandle(paneID: paneID, bootstrap: bootstrap)
+        self.makeSurfaceHandle = surfaceFactory ?? { contentID, paneID, bootstrap in
+            AlanGhosttySurfaceHandle(contentID: contentID, paneID: paneID, bootstrap: bootstrap)
         }
     }
 
@@ -725,8 +778,8 @@ final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
         surfaceFactory: SurfaceFactory? = nil
     ) {
         self.bootstrap = bootstrap
-        self.makeSurfaceHandle = surfaceFactory ?? { paneID, bootstrap in
-            AlanGhosttySurfaceHandle(paneID: paneID, bootstrap: bootstrap)
+        self.makeSurfaceHandle = surfaceFactory ?? { contentID, paneID, bootstrap in
+            AlanGhosttySurfaceHandle(contentID: contentID, paneID: paneID, bootstrap: bootstrap)
         }
     }
 
@@ -734,8 +787,12 @@ final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
         bootstrap.diagnostics
     }
 
+    var registeredContentIDs: Set<String> {
+        Set(handlesByContentID.keys)
+    }
+
     var registeredPaneIDs: Set<String> {
-        Set(handlesByPaneID.keys)
+        Set(handlesByContentID.values.map(\.paneID))
     }
 
     @discardableResult
@@ -744,48 +801,49 @@ final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
     }
 
     func surfaceHandle(
-        for paneID: String,
+        forTerminalContentID contentID: String,
+        mountedAtPaneID paneID: String,
         bootProfile: AlanShellBootProfile?
     ) -> AlanTerminalSurfaceHandle {
         ensureReady()
-        if let handle = handlesByPaneID[paneID] {
-            handle.configure(bootProfile: bootProfile)
+        if let handle = handlesByContentID[contentID] {
+            handle.configure(mountedAtPaneID: paneID, bootProfile: bootProfile)
             return handle
         }
-        let handle = makeSurfaceHandle(paneID, bootstrap)
-        handle.configure(bootProfile: bootProfile)
-        handlesByPaneID[paneID] = handle
+        let handle = makeSurfaceHandle(contentID, paneID, bootstrap)
+        handle.configure(mountedAtPaneID: paneID, bootProfile: bootProfile)
+        handlesByContentID[contentID] = handle
         return handle
     }
 
-    func existingSurfaceHandle(for paneID: String) -> AlanTerminalSurfaceHandle? {
-        handlesByPaneID[paneID]
+    func existingSurfaceHandle(forTerminalContentID contentID: String) -> AlanTerminalSurfaceHandle? {
+        handlesByContentID[contentID]
     }
 
-    func snapshot(for paneID: String) -> AlanTerminalSurfaceSnapshot? {
-        handlesByPaneID[paneID]?.snapshot
+    func snapshot(forTerminalContentID contentID: String) -> AlanTerminalSurfaceSnapshot? {
+        handlesByContentID[contentID]?.snapshot
     }
 
-    func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
-        guard let handle = handlesByPaneID[paneID] else {
+    func sendText(toTerminalContentID contentID: String, text: String) -> TerminalRuntimeDeliveryResult {
+        guard let handle = handlesByContentID[contentID] else {
             return .missingTarget(
-                errorMessage: "The requested pane does not have a service-owned terminal runtime."
+                errorMessage: "The requested terminal content does not have a service-owned runtime."
             )
         }
         return handle.sendControlText(text)
     }
 
     @discardableResult
-    func finalizePane(_ paneID: String) -> AlanTerminalSurfaceTeardownStatus {
-        guard let handle = handlesByPaneID.removeValue(forKey: paneID) else {
+    func finalizeTerminalContent(_ contentID: String) -> AlanTerminalSurfaceTeardownStatus {
+        guard let handle = handlesByContentID.removeValue(forKey: contentID) else {
             return .notStarted
         }
         return handle.teardown()
     }
 
-    func finalizePanes(excluding activePaneIDs: Set<String>) {
-        let stalePaneIDs = Set(handlesByPaneID.keys).subtracting(activePaneIDs)
-        stalePaneIDs.forEach { finalizePane($0) }
+    func finalizeTerminalContents(excluding activeContentIDs: Set<String>) {
+        let staleContentIDs = Set(handlesByContentID.keys).subtracting(activeContentIDs)
+        staleContentIDs.forEach { finalizeTerminalContent($0) }
     }
 }
 
@@ -826,7 +884,8 @@ final class FakeAlanGhosttyProcessBootstrap: AlanGhosttyProcessBootstrap {
 
 @MainActor
 final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
-    let paneID: String
+    let contentID: String
+    private(set) var paneID: String
     private(set) var configureCount = 0
     private(set) var attachCount = 0
     private(set) var detachCount = 0
@@ -845,9 +904,14 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private var closeRequestHandler: ((Bool) -> Void)?
     private var currentSnapshot: AlanTerminalSurfaceSnapshot
 
-    init(paneID: String) {
+    init(contentID: String, paneID: String) {
+        self.contentID = contentID
         self.paneID = paneID
-        self.currentSnapshot = .pending(paneID: paneID)
+        self.currentSnapshot = .pending(contentID: contentID, paneID: paneID)
+    }
+
+    convenience init(paneID: String) {
+        self.init(contentID: ShellContentInstance.terminalContentID(forPaneID: paneID), paneID: paneID)
     }
 
     var snapshot: AlanTerminalSurfaceSnapshot {
@@ -858,7 +922,8 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
         ready && currentSnapshot.teardownStatus != .completed
     }
 
-    func configure(bootProfile: AlanShellBootProfile?) {
+    func configure(mountedAtPaneID paneID: String, bootProfile: AlanShellBootProfile?) {
+        self.paneID = paneID
         configureCount += 1
         updateSnapshot(lifecyclePhase: bootProfile == nil ? .pending : .attachable)
     }
@@ -943,6 +1008,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
         attachedViewCount: Int? = nil
     ) {
         currentSnapshot = AlanTerminalSurfaceSnapshot(
+            contentID: contentID,
             paneID: paneID,
             lifecyclePhase: lifecyclePhase ?? currentSnapshot.lifecyclePhase,
             renderer: currentSnapshot.renderer,
@@ -1034,7 +1100,7 @@ extension FakeAlanTerminalSurfaceHandle: AlanTerminalCommandBufferEngine {
 @MainActor
 final class FakeAlanTerminalRuntimeService: AlanTerminalRuntimeService {
     let bootstrap: FakeAlanGhosttyProcessBootstrap
-    private(set) var handlesByPaneID: [String: FakeAlanTerminalSurfaceHandle] = [:]
+    private(set) var handlesByContentID: [String: FakeAlanTerminalSurfaceHandle] = [:]
 
     init() {
         self.bootstrap = FakeAlanGhosttyProcessBootstrap()
@@ -1048,8 +1114,12 @@ final class FakeAlanTerminalRuntimeService: AlanTerminalRuntimeService {
         bootstrap.diagnostics
     }
 
+    var registeredContentIDs: Set<String> {
+        Set(handlesByContentID.keys)
+    }
+
     var registeredPaneIDs: Set<String> {
-        Set(handlesByPaneID.keys)
+        Set(handlesByContentID.values.map(\.paneID))
     }
 
     @discardableResult
@@ -1058,48 +1128,49 @@ final class FakeAlanTerminalRuntimeService: AlanTerminalRuntimeService {
     }
 
     func surfaceHandle(
-        for paneID: String,
+        forTerminalContentID contentID: String,
+        mountedAtPaneID paneID: String,
         bootProfile: AlanShellBootProfile?
     ) -> AlanTerminalSurfaceHandle {
         ensureReady()
-        if let handle = handlesByPaneID[paneID] {
-            handle.configure(bootProfile: bootProfile)
+        if let handle = handlesByContentID[contentID] {
+            handle.configure(mountedAtPaneID: paneID, bootProfile: bootProfile)
             return handle
         }
-        let handle = FakeAlanTerminalSurfaceHandle(paneID: paneID)
-        handle.configure(bootProfile: bootProfile)
-        handlesByPaneID[paneID] = handle
+        let handle = FakeAlanTerminalSurfaceHandle(contentID: contentID, paneID: paneID)
+        handle.configure(mountedAtPaneID: paneID, bootProfile: bootProfile)
+        handlesByContentID[contentID] = handle
         return handle
     }
 
-    func existingSurfaceHandle(for paneID: String) -> AlanTerminalSurfaceHandle? {
-        handlesByPaneID[paneID]
+    func existingSurfaceHandle(forTerminalContentID contentID: String) -> AlanTerminalSurfaceHandle? {
+        handlesByContentID[contentID]
     }
 
-    func snapshot(for paneID: String) -> AlanTerminalSurfaceSnapshot? {
-        handlesByPaneID[paneID]?.snapshot
+    func snapshot(forTerminalContentID contentID: String) -> AlanTerminalSurfaceSnapshot? {
+        handlesByContentID[contentID]?.snapshot
     }
 
-    func sendText(to paneID: String, text: String) -> TerminalRuntimeDeliveryResult {
-        guard let handle = handlesByPaneID[paneID] else {
+    func sendText(toTerminalContentID contentID: String, text: String) -> TerminalRuntimeDeliveryResult {
+        guard let handle = handlesByContentID[contentID] else {
             return .missingTarget(
-                errorMessage: "The requested pane does not have a fake terminal runtime."
+                errorMessage: "The requested terminal content does not have a fake terminal runtime."
             )
         }
         return handle.sendControlText(text)
     }
 
     @discardableResult
-    func finalizePane(_ paneID: String) -> AlanTerminalSurfaceTeardownStatus {
-        guard let handle = handlesByPaneID.removeValue(forKey: paneID) else {
+    func finalizeTerminalContent(_ contentID: String) -> AlanTerminalSurfaceTeardownStatus {
+        guard let handle = handlesByContentID.removeValue(forKey: contentID) else {
             return .notStarted
         }
         return handle.teardown()
     }
 
-    func finalizePanes(excluding activePaneIDs: Set<String>) {
-        let stalePaneIDs = Set(handlesByPaneID.keys).subtracting(activePaneIDs)
-        stalePaneIDs.forEach { finalizePane($0) }
+    func finalizeTerminalContents(excluding activeContentIDs: Set<String>) {
+        let staleContentIDs = Set(handlesByContentID.keys).subtracting(activeContentIDs)
+        staleContentIDs.forEach { finalizeTerminalContent($0) }
     }
 }
 #endif

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -1156,8 +1156,9 @@ final class AlanTerminalSurfaceController {
         onMetadataChange: @escaping (TerminalPaneMetadataSnapshot) -> Void,
         onCloseRequest: @escaping (Bool) -> Void
     ) {
-        surfaceHandle?.configure(bootProfile: bootProfile)
-        surfaceHandle?.attach(
+        guard let surfaceHandle else { return }
+        surfaceHandle.configure(mountedAtPaneID: surfaceHandle.paneID, bootProfile: bootProfile)
+        surfaceHandle.attach(
             to: canvasView,
             focused: focused,
             onDiagnosticsChange: { [weak self] snapshot in

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -322,8 +322,8 @@ require_semantic_terminal_actions_contract
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
-    "hostViewsByPaneID" \
-    "terminal runtimes must be owned by a pane-keyed registry"
+    "hostViewsByContentID" \
+    "terminal runtimes must be owned by a content-keyed registry"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
@@ -362,18 +362,18 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
-    "runtimeService\\.surfaceHandle\\(for: paneID, bootProfile: bootProfile\\)" \
-    "terminal runtime registry must resolve service-owned handles by pane ID"
+    "forTerminalContentID: mount\\.contentID" \
+    "terminal runtime registry must resolve service-owned handles by content ID"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeService.swift" \
-    "private var handlesByPaneID: \\[String: AlanTerminalSurfaceHandle\\]" \
-    "terminal runtime service must keep runtime identity pane-keyed"
+    "private var handlesByContentID: \\[String: AlanTerminalSurfaceHandle\\]" \
+    "terminal runtime service must keep runtime identity content-keyed"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeService.swift" \
-    "var registeredPaneIDs: Set<String>" \
-    "terminal runtime service must expose pane-keyed registration state"
+    "var registeredContentIDs: Set<String>" \
+    "terminal runtime service must expose content-keyed registration state"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalSurfaceController.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -15,6 +15,7 @@ final class AlanTerminalHostNSView: NSView {
 
     func configure(
         pane: ShellPane?,
+        terminalContentID: String?,
         bootProfile: AlanShellBootProfile?,
         isSelected: Bool,
         surfaceHandle: AlanTerminalSurfaceHandle?,

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -905,6 +905,10 @@ private enum ShellRuntimeMetadataTests {
         let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
 
         _ = controller.showQuickTerminal()
+        let quickHandle = fakeSurfaceHandle(
+            for: ShellQuickTerminalSlot.globalPaneID,
+            controller: controller
+        )
         presenter.synchronize()
         presenter.windowDidResignKey()
 
@@ -922,6 +926,10 @@ private enum ShellRuntimeMetadataTests {
             "explicit hide must hide the peak without removing the runtime slot"
         )
         expect(controller.quickTerminalPane != nil, "explicit hide must preserve the quick-terminal pane")
+        expect(
+            quickHandle.teardownCount == 0,
+            "explicit hide must keep the hidden quick-terminal runtime alive"
+        )
 
         expect(controller.closeQuickTerminal(), "explicit quick-terminal close must apply")
         presenter.synchronize()
@@ -931,6 +939,7 @@ private enum ShellRuntimeMetadataTests {
             "explicit close must release the peak presentation"
         )
         expect(controller.quickTerminalPane == nil, "explicit close must remove the quick-terminal slot")
+        expect(quickHandle.teardownCount == 1, "explicit close must release the quick-terminal runtime")
     }
 
     private static func verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -541,6 +541,22 @@ private enum ShellRuntimeMetadataTests {
             registry.snapshot(forTerminalContentID: contentID).paneID == "pane_right",
             "registry snapshot lookup must be content keyed"
         )
+
+        let delivery = registry.sendText(to: "pane_right", text: "after remount")
+        let handle = second as! FakeAlanTerminalSurfaceHandle
+        expect(delivery.applied, "pane convenience delivery must resolve the mounted content ID")
+        expect(handle.deliveredText == ["after remount"], "delivery must reach the mounted content")
+
+        registry.releaseRuntimes(excluding: ["pane_right"])
+        expect(handle.teardownCount == 0, "active custom content ID must not be released as stale")
+        expect(
+            registry.registeredContentIDs == [contentID],
+            "cleanup must keep the active mounted content registered"
+        )
+
+        registry.releaseRuntime(for: "pane_right")
+        expect(handle.teardownCount == 1, "pane convenience release must finalize the mounted content")
+        expect(registry.registeredContentIDs.isEmpty, "released content must leave the registry")
     }
 
     private static func verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -22,6 +22,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarFallbackOrdering()
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
+        verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -112,6 +113,7 @@ private enum ShellRuntimeMetadataTests {
         controller.updateTerminalRuntime(
             TerminalHostRuntimeSnapshot(
                 stage: .windowAttached,
+                contentID: pane.terminalContentID,
                 paneID: pane.paneID,
                 tabID: pane.tabID,
                 logicalSize: .zero,
@@ -174,6 +176,7 @@ private enum ShellRuntimeMetadataTests {
         controller.updateTerminalRuntime(
             TerminalHostRuntimeSnapshot(
                 stage: .windowAttached,
+                contentID: pane.terminalContentID,
                 paneID: pane.paneID,
                 tabID: pane.tabID,
                 logicalSize: .zero,
@@ -488,6 +491,55 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !registry.registeredPaneIDs.contains("pane_2"),
             "opening a tab must release stale runtime-only panes after adopting the new state"
+        )
+    }
+
+    private static func verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let contentID = "content_terminal_runtime_primary"
+        let firstMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_left",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+        let secondMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_right",
+            tabID: "tab_2",
+            spaceID: "space_main"
+        )
+
+        let first = registry.surfaceHandle(forTerminalContent: firstMount, bootProfile: nil)
+        let second = registry.surfaceHandle(forTerminalContent: secondMount, bootProfile: nil)
+
+        expect(first === second, "registry must reuse runtime handles by terminal content identity")
+        expect(second.contentID == contentID, "registry handle must retain content identity")
+        expect(second.paneID == "pane_right", "registry handle must project the latest PaneSlot mount")
+        expect(registry.registeredContentIDs == [contentID], "registry registration must be content keyed")
+        expect(registry.registeredPaneIDs == ["pane_right"], "registry pane IDs must reflect current mounts")
+
+        registry.updateSnapshot(
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                contentID: contentID,
+                paneID: "pane_right",
+                tabID: "tab_2",
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: nil,
+                displayID: nil,
+                attachedWindowTitle: nil,
+                isFocused: false,
+                renderer: .placeholder,
+                paneMetadata: .placeholder,
+                surfaceState: .placeholder,
+                lastUpdatedAt: Date(timeIntervalSince1970: 10)
+            )
+        )
+        expect(
+            registry.snapshot(forTerminalContentID: contentID).paneID == "pane_right",
+            "registry snapshot lookup must be content keyed"
         )
     }
 
@@ -2829,6 +2881,7 @@ private enum ShellRuntimeMetadataTests {
         controller.updateTerminalRuntime(
             TerminalHostRuntimeSnapshot(
                 stage: .windowAttached,
+                contentID: exitingPane.terminalContentID,
                 paneID: exitingPane.paneID,
                 tabID: exitingPane.tabID,
                 logicalSize: .zero,

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -23,6 +23,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
+        verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -557,6 +558,93 @@ private enum ShellRuntimeMetadataTests {
         registry.releaseRuntime(for: "pane_right")
         expect(handle.teardownCount == 1, "pane convenience release must finalize the mounted content")
         expect(registry.registeredContentIDs.isEmpty, "released content must leave the registry")
+    }
+
+    private static func verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let firstMount = TerminalContentMount(
+            contentID: "content_terminal_first",
+            paneSlotID: "pane_stable",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+        let secondMount = TerminalContentMount(
+            contentID: "content_terminal_second",
+            paneSlotID: "pane_stable",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+
+        let hostView = registry.hostView(
+            forTerminalContent: firstMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCommandInput: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+        let firstHandle = registry.surfaceHandle(
+            forTerminalContent: firstMount,
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+
+        registry.configureHostView(
+            hostView,
+            forTerminalContent: secondMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCommandInput: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+
+        let secondHandle = registry.surfaceHandle(
+            forTerminalContent: secondMount,
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+        expect(
+            registry.beginFindInteraction(for: "pane_stable"),
+            "same-pane content replacement must re-register host actions to the new content"
+        )
+        expect(
+            secondHandle.searchActions == ["start_search"],
+            "host actions must reach the replacement content surface"
+        )
+
+        registry.requestFocus(for: "pane_stable")
+        expect(hostView.focusCount == 1, "focus must route through the re-keyed host view")
+
+        registry.releaseRuntimes(excluding: ["pane_stable"])
+        expect(
+            firstHandle.teardownCount == 1,
+            "cleanup must release stale content after same-pane replacement"
+        )
+        expect(
+            hostView.teardownCount == 0,
+            "stale content cleanup must not teardown the re-keyed active host view"
+        )
+        expect(
+            secondHandle.teardownCount == 0,
+            "active replacement content must remain alive during stale cleanup"
+        )
+
+        registry.releaseRuntime(for: "pane_stable")
+        expect(
+            hostView.teardownCount == 1,
+            "pane release must teardown the active re-keyed host view"
+        )
+        expect(
+            secondHandle.teardownCount == 1,
+            "pane release must finalize the active replacement content"
+        )
     }
 
     private static func verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -23,6 +23,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
+        verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs()
         verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
@@ -558,6 +559,47 @@ private enum ShellRuntimeMetadataTests {
         registry.releaseRuntime(for: "pane_right")
         expect(handle.teardownCount == 1, "pane convenience release must finalize the mounted content")
         expect(registry.registeredContentIDs.isEmpty, "released content must leave the registry")
+    }
+
+    private static func verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let previousMount = TerminalContentMount(
+            contentID: "content_previous_terminal",
+            paneSlotID: "pane_stable",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+        let currentMount = TerminalContentMount(
+            contentID: "content_current_terminal",
+            paneSlotID: "pane_stable",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+
+        let previousHandle = registry.surfaceHandle(
+            forTerminalContent: previousMount,
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+
+        registry.releaseRuntimes(excluding: [currentMount])
+        expect(
+            previousHandle.teardownCount == 1,
+            "cleanup must release stale content before the current host remount is configured"
+        )
+        expect(
+            registry.registeredContentIDs.isEmpty,
+            "current mount registration must not keep the previous content alive"
+        )
+
+        let currentHandle = registry.surfaceHandle(
+            forTerminalContent: currentMount,
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+        registry.releaseRuntimes(excluding: [currentMount])
+        expect(
+            currentHandle.teardownCount == 0,
+            "cleanup must keep the currently mounted content alive"
+        )
     }
 
     private static func verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement() {

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -19,6 +19,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesInstallDiscoveryChangesDoNotRequireSurfaceRecreation()
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
+        verifiesContentScopedHandleSurvivesPaneRemount()
         verifiesDeliveryAndMissingRuntimeResults()
         verifiesDeliveryRejectsExitedRuntime()
         verifiesQueuedAndTimeoutDeliveryStates()
@@ -54,6 +55,10 @@ private enum TerminalRuntimeServiceTests {
         expect(
             profile.environment["COLORTERM"] == "truecolor",
             "boot profile must advertise truecolor terminal support"
+        )
+        expect(
+            profile.environment["ALAN_SHELL_CONTENT_ID"] == pane.terminalContentID,
+            "boot profile must expose terminal content identity to child processes"
         )
     }
 
@@ -144,7 +149,9 @@ private enum TerminalRuntimeServiceTests {
         let bootstrap = FakeAlanGhosttyProcessBootstrap()
         let service = AlanWindowTerminalRuntimeService(
             bootstrap: bootstrap,
-            surfaceFactory: { paneID, _ in FakeAlanTerminalSurfaceHandle(paneID: paneID) }
+            surfaceFactory: { contentID, paneID, _ in
+                FakeAlanTerminalSurfaceHandle(contentID: contentID, paneID: paneID)
+            }
         )
 
         let first = service.surfaceHandle(for: "pane_1", bootProfile: nil)
@@ -154,7 +161,9 @@ private enum TerminalRuntimeServiceTests {
 
         let secondWindow = AlanWindowTerminalRuntimeService(
             bootstrap: bootstrap,
-            surfaceFactory: { paneID, _ in FakeAlanTerminalSurfaceHandle(paneID: paneID) }
+            surfaceFactory: { contentID, paneID, _ in
+                FakeAlanTerminalSurfaceHandle(contentID: contentID, paneID: paneID)
+            }
         )
         secondWindow.ensureReady()
         expect(bootstrap.ensureCallCount == 1, "shared bootstrap must not reinitialize per window")
@@ -174,11 +183,45 @@ private enum TerminalRuntimeServiceTests {
         )
         expect(
             service.snapshot(for: "pane_1")?.paneID == "pane_1",
-            "snapshots must stay pane keyed"
+            "snapshots must remain available through pane convenience lookup"
         )
         expect(
             service.snapshot(for: "pane_2")?.paneID == "pane_2",
-            "snapshots must stay pane keyed"
+            "snapshots must remain available through pane convenience lookup"
+        )
+    }
+
+    private static func verifiesContentScopedHandleSurvivesPaneRemount() {
+        let service = FakeAlanTerminalRuntimeService()
+        let contentID = "content_terminal_primary"
+        let first = service.surfaceHandle(
+            forTerminalContentID: contentID,
+            mountedAtPaneID: "pane_left",
+            bootProfile: nil
+        )
+        let second = service.surfaceHandle(
+            forTerminalContentID: contentID,
+            mountedAtPaneID: "pane_right",
+            bootProfile: nil
+        )
+
+        expect(first === second, "same terminal content must reuse the service-owned handle")
+        expect(second.contentID == contentID, "handle must retain terminal content identity")
+        expect(second.paneID == "pane_right", "handle must update to the latest PaneSlot mount")
+        expect(service.registeredContentIDs == [contentID], "service registration must be content keyed")
+        expect(service.registeredPaneIDs == ["pane_right"], "pane registration must reflect the current mount")
+
+        let accepted = service.sendText(toTerminalContentID: contentID, text: "after move")
+        let handle = second as! FakeAlanTerminalSurfaceHandle
+        expect(accepted.applied, "content-keyed delivery must reach the remounted handle")
+        expect(handle.deliveredText == ["after move"], "delivery must stay bound to content identity")
+        expect(
+            service.snapshot(forTerminalContentID: contentID)?.contentID == contentID,
+            "snapshot lookup must be content keyed"
+        )
+        expect(
+            service.snapshot(forTerminalContentID: contentID)?.paneID == "pane_right",
+            "snapshot must project the latest PaneSlot mount"
         )
     }
 
@@ -305,7 +348,9 @@ private enum TerminalRuntimeServiceTests {
         let bootstrap = FakeAlanGhosttyProcessBootstrap(nextDiagnostics: failedDiagnostics)
         let service = AlanWindowTerminalRuntimeService(
             bootstrap: bootstrap,
-            surfaceFactory: { paneID, _ in FakeAlanTerminalSurfaceHandle(paneID: paneID) }
+            surfaceFactory: { contentID, paneID, _ in
+                FakeAlanTerminalSurfaceHandle(contentID: contentID, paneID: paneID)
+            }
         )
 
         let diagnostics = service.ensureReady()

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -9,8 +9,8 @@
 
 ## 2. Terminal Adapter
 
-- [ ] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
-- [ ] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
+- [x] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
+- [x] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
 - [ ] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
 - [ ] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
 - [ ] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.


### PR DESCRIPTION
## Summary
- move terminal runtime service and registry ownership from pane-keyed maps to terminal content IDs
- add TerminalContentMount adapter so terminal host attachment resolves the current PaneSlot mount
- expose content IDs in terminal runtime snapshots/boot env and add content-keyed continuity tests
- mark OpenSpec tasks 2.1 and 2.2 complete

## Verification
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-workspace-manifest.sh
- bash clients/apple/scripts/test-shell-action-registry.sh
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict --json
- openspec validate --all --strict --json
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-terminal-content-runtime-identity build