### PR TITLE
Move terminal metadata projection into content adapter

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000131 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift */; };
 		000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */; };
 		000000000000000000000033 /* Services/Terminal/TerminalHostViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */; };
+		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -125,6 +126,7 @@
 		000000000000000000000131 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalNativeScrollViewAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostOverlayPresenter.swift; sourceTree = "<group>"; };
 		000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostViewSupport.swift; sourceTree = "<group>"; };
+		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 			children = (
 				000000000000000000000127 /* Services/Terminal/TerminalHostRuntimeReporter.swift */,
 				000000000000000000000128 /* Services/Terminal/TerminalHostWindowObserver.swift */,
+				000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */,
 				000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */,
 				000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */,
 				000000000000000000000131 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift */,
@@ -473,6 +476,7 @@
 				00000000000000000000002E /* Services/Shell/ShellEventStore.swift in Sources */,
 				00000000000000000000002F /* Services/Shell/ShellDiagnostics.swift in Sources */,
 				000000000000000000000030 /* Services/Shell/ShellClipboardWriter.swift in Sources */,
+				000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */,
 				000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */,
 				000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */,
 				000000000000000000000033 /* Services/Terminal/TerminalHostViewSupport.swift in Sources */,

--- a/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+#if os(macOS)
+struct TerminalContentProjection {
+    let pane: ShellPane
+    let processExited: Bool
+    let activity: TerminalActivitySnapshot?
+}
+
+struct TerminalContentProjectionAdapter {
+    private let paneProjection: ShellPaneProjectionService
+
+    init(paneProjection: ShellPaneProjectionService) {
+        self.paneProjection = paneProjection
+    }
+
+    func projectRuntime(
+        _ runtime: TerminalHostRuntimeSnapshot,
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile
+    ) -> TerminalContentProjection {
+        projectTerminalMetadata(
+            runtime.paneMetadata,
+            runtime: runtime,
+            for: pane,
+            bootProfile: bootProfile,
+            workingDirectory: runtime.paneMetadata.workingDirectory ?? pane.cwd
+        )
+    }
+
+    func projectMetadata(
+        _ metadata: TerminalPaneMetadataSnapshot,
+        runtime: TerminalHostRuntimeSnapshot,
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile
+    ) -> TerminalContentProjection {
+        projectTerminalMetadata(
+            metadata,
+            runtime: runtime,
+            for: pane,
+            bootProfile: bootProfile,
+            workingDirectory: metadata.workingDirectory ?? pane.cwd
+        )
+    }
+
+    func projectAlanBinding(
+        _ binding: ShellAlanBinding?,
+        runtime: TerminalHostRuntimeSnapshot,
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile
+    ) -> TerminalContentProjection {
+        let processExited = paneProjection.projectedProcessExited(
+            metadataProcessExited: runtime.paneMetadata.processExited,
+            surfaceState: runtime.surfaceState
+        ) ?? runtime.paneMetadata.processExited
+        let projectedBinding = paneProjection.projectedAlanBinding(
+            for: pane,
+            binding: binding,
+            processExited: processExited
+        )
+        let projectedContext = paneProjection.projectedContext(
+            for: pane,
+            bootProfile: bootProfile,
+            workingDirectory: pane.cwd,
+            processExited: nil,
+            lastCommandExitCode: pane.context?.lastCommandExitCode,
+            lastMetadataAt: nil,
+            activeTaskState: runtime.paneMetadata.activeTaskState,
+            existing: pane.context,
+            runtime: runtime
+        )
+
+        let bindingSummary: String?
+        if let projectedBinding {
+            bindingSummary = projectedBinding.pendingYield
+                ? "alan is waiting for user input"
+                : "alan run status: \(projectedBinding.runStatus)"
+        } else {
+            bindingSummary = nil
+        }
+
+        let viewport = ShellViewportSnapshot(
+            title: pane.viewport?.title,
+            summary: bindingSummary ?? pane.viewport?.summary,
+            visibleExcerpt: pane.viewport?.visibleExcerpt,
+            lastActivityAt: binding?.lastProjectedAt ?? pane.viewport?.lastActivityAt
+        )
+
+        return TerminalContentProjection(
+            pane: ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                launchTarget: pane.launchTarget,
+                cwd: pane.cwd ?? bootProfile.workingDirectory,
+                process: pane.process,
+                attention: projectedBinding?.pendingYield == true ? .awaitingUser : pane.attention,
+                context: projectedContext,
+                viewport: viewport,
+                activity: pane.activity,
+                alanBinding: projectedBinding
+            ),
+            processExited: processExited,
+            activity: pane.activity
+        )
+    }
+
+    func projectBootContext(
+        runtime: TerminalHostRuntimeSnapshot,
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile
+    ) -> TerminalContentProjection {
+        let processExited = paneProjection.projectedProcessExited(
+            metadataProcessExited: nil,
+            surfaceState: runtime.surfaceState
+        ) ?? false
+        let projectedContext = paneProjection.projectedContext(
+            for: pane,
+            bootProfile: bootProfile,
+            workingDirectory: pane.cwd ?? bootProfile.workingDirectory,
+            processExited: nil,
+            lastCommandExitCode: pane.context?.lastCommandExitCode,
+            lastMetadataAt: nil,
+            activeTaskState: runtime.paneMetadata.activeTaskState,
+            existing: pane.context,
+            runtime: runtime
+        )
+        let projectedBinding = paneProjection.projectedAlanBinding(
+            for: pane,
+            binding: pane.alanBinding,
+            processExited: processExited
+        )
+
+        return TerminalContentProjection(
+            pane: ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                launchTarget: pane.launchTarget,
+                cwd: pane.cwd ?? bootProfile.workingDirectory,
+                process: pane.process,
+                attention: pane.attention,
+                context: projectedContext,
+                viewport: pane.viewport,
+                activity: pane.activity,
+                alanBinding: projectedBinding
+            ),
+            processExited: processExited,
+            activity: pane.activity
+        )
+    }
+
+    private func projectTerminalMetadata(
+        _ metadata: TerminalPaneMetadataSnapshot,
+        runtime: TerminalHostRuntimeSnapshot,
+        for pane: ShellPane,
+        bootProfile: AlanShellBootProfile,
+        workingDirectory: String?
+    ) -> TerminalContentProjection {
+        let processExited = paneProjection.projectedProcessExited(
+            metadataProcessExited: metadata.processExited,
+            surfaceState: runtime.surfaceState
+        ) ?? metadata.processExited
+        let projectedBinding = paneProjection.projectedAlanBinding(
+            for: pane,
+            binding: pane.alanBinding,
+            processExited: processExited
+        )
+        let projectedContext = paneProjection.projectedContext(
+            for: pane,
+            bootProfile: bootProfile,
+            workingDirectory: workingDirectory,
+            processExited: metadata.processExited,
+            lastCommandExitCode: metadata.lastCommandExitCode,
+            lastMetadataAt: metadata.lastUpdatedAt,
+            activeTaskState: metadata.activeTaskState,
+            existing: pane.context,
+            runtime: runtime
+        )
+        let viewport = paneProjection.projectedViewport(
+            current: pane,
+            metadata: metadata,
+            runtime: runtime
+        )
+        let projectedActivity = metadata.clearsActivity ? nil : (metadata.activity ?? pane.activity)
+
+        return TerminalContentProjection(
+            pane: ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                launchTarget: pane.launchTarget,
+                cwd: workingDirectory ?? bootProfile.workingDirectory,
+                process: pane.process,
+                attention: paneProjection.projectedAttention(
+                    metadataAttention: metadata.attention,
+                    processExited: processExited,
+                    binding: projectedBinding,
+                    surfaceState: runtime.surfaceState
+                ),
+                context: projectedContext,
+                viewport: viewport,
+                activity: projectedActivity,
+                alanBinding: projectedBinding
+            ),
+            processExited: processExited,
+            activity: projectedActivity
+        )
+    }
+}
+#endif

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -268,6 +268,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private var workspaceManifest: ShellWorkspaceManifest?
     private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     private let paneProjection: ShellPaneProjectionService
+    private let terminalContentProjection: TerminalContentProjectionAdapter
     private let clipboardWriter: ShellClipboardWriter
     lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
@@ -328,7 +329,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
         self.fileManager = fileManager
-        self.paneProjection = ShellPaneProjectionService(fileManager: fileManager)
+        let paneProjection = ShellPaneProjectionService(fileManager: fileManager)
+        self.paneProjection = paneProjection
+        self.terminalContentProjection = TerminalContentProjectionAdapter(
+            paneProjection: paneProjection
+        )
         let resolvedContext = windowContext ?? ShellWindowContext.make(fileManager: fileManager)
         self.windowContext = resolvedContext
         self.persistenceURL = persistenceURL ?? resolvedContext.persistenceURL
@@ -1532,65 +1537,36 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
            let pane = pane(paneID: paneID)
         {
             let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
-            let runtimeProcessExited = paneProjection.projectedProcessExited(
-                metadataProcessExited: runtime.paneMetadata.processExited,
-                surfaceState: runtime.surfaceState
-            ) ?? runtime.paneMetadata.processExited
+            let effectProjection = terminalContentProjection.projectRuntime(
+                runtime,
+                for: pane,
+                bootProfile: bootProfile
+            )
             let activeTaskChanged = recordTerminalActiveTask(
                 runtime.paneMetadata.activeTaskState,
-                processExited: runtimeProcessExited,
+                processExited: effectProjection.processExited,
                 for: paneID
             )
-            let projectedActivity = runtime.paneMetadata.clearsActivity
-                ? nil
-                : (runtime.paneMetadata.activity ?? pane.activity)
-            if runtimeProcessExited {
-                routeActivityNotificationIfNeeded(from: pane, nextActivity: projectedActivity)
+            if effectProjection.processExited {
+                routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
             }
-            if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: runtimeProcessExited) {
+            if closePaneAfterChildExitIfNeeded(
+                paneID: paneID,
+                processExited: effectProjection.processExited
+            ) {
                 return
             }
-            let projectedContext = paneProjection.projectedContext(
-                for: pane,
-                bootProfile: bootProfile,
-                workingDirectory: runtime.paneMetadata.workingDirectory ?? pane.cwd,
-                processExited: runtime.paneMetadata.processExited,
-                lastCommandExitCode: runtime.paneMetadata.lastCommandExitCode,
-                lastMetadataAt: runtime.paneMetadata.lastUpdatedAt,
-                activeTaskState: runtime.paneMetadata.activeTaskState,
-                existing: pane.context,
-                runtime: runtime
-            )
 
             let didPublishPaneUpdate = updatePaneState(paneID: paneID) { current in
-                let projectedBinding = paneProjection.projectedAlanBinding(
+                let currentBootProfile = AlanShellBootProfile.forPane(
+                    current,
+                    shellState: shellState
+                )
+                return terminalContentProjection.projectRuntime(
+                    runtime,
                     for: current,
-                    binding: current.alanBinding,
-                    processExited: runtimeProcessExited
-                )
-                let viewport = paneProjection.projectedViewport(
-                    current: current,
-                    metadata: runtime.paneMetadata,
-                    runtime: runtime
-                )
-                return ShellPane(
-                    paneID: current.paneID,
-                    tabID: current.tabID,
-                    spaceID: current.spaceID,
-                    launchTarget: current.launchTarget,
-                    cwd: current.cwd ?? bootProfile.workingDirectory,
-                    process: current.process,
-                    attention: paneProjection.projectedAttention(
-                        metadataAttention: runtime.paneMetadata.attention,
-                        processExited: runtimeProcessExited,
-                        binding: projectedBinding,
-                        surfaceState: runtime.surfaceState
-                    ),
-                    context: projectedContext,
-                    viewport: viewport,
-                    activity: projectedActivity,
-                    alanBinding: projectedBinding
-                )
+                    bootProfile: currentBootProfile
+                ).pane
             }
             if activeTaskChanged && !didPublishPaneUpdate {
                 syncWorkspaceManifestFromShellState()
@@ -1602,67 +1578,41 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard let pane = pane(paneID: paneID) else { return }
         let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let metadataProcessExited = paneProjection.projectedProcessExited(
-            metadataProcessExited: metadata.processExited,
-            surfaceState: runtime.surfaceState
-        ) ?? metadata.processExited
+        let effectProjection = terminalContentProjection.projectMetadata(
+            metadata,
+            runtime: runtime,
+            for: pane,
+            bootProfile: bootProfile
+        )
         let activeTaskChanged = recordTerminalActiveTask(
             metadata.activeTaskState,
-            processExited: metadataProcessExited,
+            processExited: effectProjection.processExited,
             for: paneID
         )
-        let projectedActivity = metadata.clearsActivity ? nil : (metadata.activity ?? pane.activity)
-        if metadataProcessExited {
-            routeActivityNotificationIfNeeded(from: pane, nextActivity: projectedActivity)
+        if effectProjection.processExited {
+            routeActivityNotificationIfNeeded(from: pane, nextActivity: effectProjection.activity)
         }
-        if closePaneAfterChildExitIfNeeded(paneID: paneID, processExited: metadataProcessExited) {
+        if closePaneAfterChildExitIfNeeded(
+            paneID: paneID,
+            processExited: effectProjection.processExited
+        ) {
             return
         }
-        let projectedContext = paneProjection.projectedContext(
-            for: pane,
-            bootProfile: bootProfile,
-            workingDirectory: metadata.workingDirectory ?? pane.cwd,
-            processExited: metadata.processExited,
-            lastCommandExitCode: metadata.lastCommandExitCode,
-            lastMetadataAt: metadata.lastUpdatedAt,
-            activeTaskState: metadata.activeTaskState,
-            existing: pane.context,
-            runtime: runtime
-        )
 
         let didPublishPaneUpdate = updatePaneState(
             paneID: pane.paneID,
             tabTitleOverride: metadata.title
         ) { current in
-            let projectedBinding = paneProjection.projectedAlanBinding(
+            let currentBootProfile = AlanShellBootProfile.forPane(
+                current,
+                shellState: shellState
+            )
+            return terminalContentProjection.projectMetadata(
+                metadata,
+                runtime: runtime,
                 for: current,
-                binding: current.alanBinding,
-                processExited: metadataProcessExited
-            )
-            let viewport = paneProjection.projectedViewport(
-                current: current,
-                metadata: metadata,
-                runtime: runtime
-            )
-
-            return ShellPane(
-                paneID: current.paneID,
-                tabID: current.tabID,
-                spaceID: current.spaceID,
-                launchTarget: current.launchTarget,
-                cwd: metadata.workingDirectory ?? current.cwd ?? bootProfile.workingDirectory,
-                process: current.process,
-                attention: paneProjection.projectedAttention(
-                    metadataAttention: metadata.attention,
-                    processExited: metadataProcessExited,
-                    binding: projectedBinding,
-                    surfaceState: runtime.surfaceState
-                ),
-                context: projectedContext,
-                viewport: viewport,
-                activity: projectedActivity,
-                alanBinding: projectedBinding
-            )
+                bootProfile: currentBootProfile
+            ).pane
         }
         if activeTaskChanged && !didPublishPaneUpdate {
             syncWorkspaceManifestFromShellState()
@@ -1671,101 +1621,35 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private func applyAlanBinding(_ binding: ShellAlanBinding?, for paneID: String) {
         guard let pane = pane(paneID: paneID) else { return }
-        let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let runtimeProcessExited = paneProjection.projectedProcessExited(
-            metadataProcessExited: runtime.paneMetadata.processExited,
-            surfaceState: runtime.surfaceState
-        ) ?? runtime.paneMetadata.processExited
-        let projectedBinding = paneProjection.projectedAlanBinding(
-            for: pane,
-            binding: binding,
-            processExited: runtimeProcessExited
-        )
-        let projectedContext = paneProjection.projectedContext(
-            for: pane,
-            bootProfile: bootProfile,
-            workingDirectory: pane.cwd,
-            processExited: nil,
-            lastCommandExitCode: pane.context?.lastCommandExitCode,
-            lastMetadataAt: nil,
-            activeTaskState: runtime.paneMetadata.activeTaskState,
-            existing: pane.context,
-            runtime: runtime
-        )
-
         updatePaneState(paneID: paneID) { current in
-            let bindingSummary: String?
-            if let projectedBinding {
-                bindingSummary = projectedBinding.pendingYield
-                    ? "alan is waiting for user input"
-                    : "alan run status: \(projectedBinding.runStatus)"
-            } else {
-                bindingSummary = nil
-            }
-
-            let viewport = ShellViewportSnapshot(
-                title: current.viewport?.title,
-                summary: bindingSummary ?? current.viewport?.summary,
-                visibleExcerpt: current.viewport?.visibleExcerpt,
-                lastActivityAt: binding?.lastProjectedAt ?? current.viewport?.lastActivityAt
+            let currentBootProfile = AlanShellBootProfile.forPane(
+                current,
+                shellState: shellState
             )
-
-            return ShellPane(
-                paneID: current.paneID,
-                tabID: current.tabID,
-                spaceID: current.spaceID,
-                launchTarget: current.launchTarget,
-                cwd: current.cwd ?? bootProfile.workingDirectory,
-                process: current.process,
-                attention: projectedBinding?.pendingYield == true ? .awaitingUser : current.attention,
-                context: projectedContext,
-                viewport: viewport,
-                activity: current.activity,
-                alanBinding: projectedBinding
-            )
+            return terminalContentProjection.projectAlanBinding(
+                binding,
+                runtime: runtime,
+                for: current,
+                bootProfile: currentBootProfile
+            ).pane
         }
     }
 
     private func primeBootContext(for paneID: String) {
         guard let pane = pane(paneID: paneID) else { return }
-        let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
-        let runtimeProcessExited = paneProjection.projectedProcessExited(
-            metadataProcessExited: nil,
-            surfaceState: runtime.surfaceState
-        ) ?? false
-        let projectedContext = paneProjection.projectedContext(
-            for: pane,
-            bootProfile: bootProfile,
-            workingDirectory: pane.cwd ?? bootProfile.workingDirectory,
-            processExited: nil,
-            lastCommandExitCode: pane.context?.lastCommandExitCode,
-            lastMetadataAt: nil,
-            activeTaskState: runtime.paneMetadata.activeTaskState,
-            existing: pane.context,
-            runtime: runtime
-        )
 
         updatePaneState(paneID: paneID) { current in
-            let projectedBinding = paneProjection.projectedAlanBinding(
+            let currentBootProfile = AlanShellBootProfile.forPane(
+                current,
+                shellState: shellState
+            )
+            return terminalContentProjection.projectBootContext(
+                runtime: runtime,
                 for: current,
-                binding: current.alanBinding,
-                processExited: runtimeProcessExited
-            )
-            return ShellPane(
-                paneID: current.paneID,
-                tabID: current.tabID,
-                spaceID: current.spaceID,
-                launchTarget: current.launchTarget,
-                cwd: current.cwd ?? bootProfile.workingDirectory,
-                process: current.process,
-                attention: current.attention,
-                context: projectedContext,
-                viewport: current.viewport,
-                activity: current.activity,
-                alanBinding: projectedBinding
-            )
+                bootProfile: currentBootProfile
+            ).pane
         }
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -30,6 +30,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalSurfaceController.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalRuntimeService.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -16,6 +16,7 @@ struct ShellRuntimeMetadataTestRunner {
 private enum ShellRuntimeMetadataTests {
     static func run() {
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
+        verifiesTerminalContentProjectionAdapterOwnsMetadataProjection()
         verifiesSurfaceExitClosesFinalPaneWithoutRestarting()
         verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth()
         verifiesPaneTitleBarPrefersTerminalTitle()
@@ -167,6 +168,108 @@ private enum ShellRuntimeMetadataTests {
         expect(updated?.viewport?.summary == "Renderer failed", "pane viewport must expose renderer status")
         expect(updated?.attention == .notable, "pane attention must reflect terminal attention")
         expect(controller.shellState.spaces.first?.attention == .notable, "space attention must track pane attention")
+    }
+
+    private static func verifiesTerminalContentProjectionAdapterOwnsMetadataProjection() {
+        let controller = makeController()
+        guard let pane = controller.selectedPane,
+              let bootProfile = controller.bootProfile(for: pane)
+        else {
+            fail("bootstrap shell must expose a selected pane and boot profile")
+        }
+
+        let adapter = TerminalContentProjectionAdapter(
+            paneProjection: ShellPaneProjectionService()
+        )
+        let metadata = TerminalPaneMetadataSnapshot(
+            title: "vim main.rs",
+            workingDirectory: "/tmp/alan",
+            summary: "build running",
+            attention: .active,
+            processExited: false,
+            lastCommandExitCode: 0,
+            lastUpdatedAt: Date(timeIntervalSince1970: 4_000),
+            activeTaskState: .foregroundCommand
+        )
+        let runtime = TerminalHostRuntimeSnapshot(
+            stage: .windowAttached,
+            contentID: pane.terminalContentID,
+            paneID: pane.paneID,
+            tabID: pane.tabID,
+            logicalSize: .zero,
+            backingSize: .zero,
+            displayName: "Studio Display",
+            displayID: "display_1",
+            attachedWindowTitle: "alan",
+            isFocused: false,
+            renderer: TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .surfaceReady,
+                summary: "surface ready",
+                detail: nil,
+                failureReason: nil,
+                recentEvents: []
+            ),
+            paneMetadata: metadata,
+            surfaceState: AlanTerminalSurfaceStateSnapshot(
+                readiness: .ready,
+                terminalMode: .normalBuffer,
+                scrollback: .empty,
+                search: nil,
+                semanticCommands: .placeholder,
+                readonly: false,
+                secureInput: false,
+                inputReady: true,
+                rendererHealth: "ready",
+                childExited: false,
+                lastUpdatedAt: Date(timeIntervalSince1970: 4_001)
+            ),
+            lastUpdatedAt: Date(timeIntervalSince1970: 4_002)
+        )
+
+        let projection = adapter.projectRuntime(runtime, for: pane, bootProfile: bootProfile)
+
+        expect(projection.pane.cwd == "/tmp/alan", "terminal adapter must project runtime cwd")
+        expect(projection.pane.viewport?.title == "vim main.rs", "terminal adapter must project title")
+        expect(projection.pane.viewport?.summary == "build running", "terminal adapter must project summary")
+        expect(
+            projection.pane.context?.processState == "foreground_command",
+            "terminal adapter must project process state"
+        )
+        expect(
+            projection.pane.context?.surfaceReadiness == "ready",
+            "terminal adapter must project surface readiness"
+        )
+        expect(projection.pane.context?.inputReady == true, "terminal adapter must project input readiness")
+        expect(projection.pane.attention == .active, "terminal adapter must project attention")
+
+        let binding = ShellAlanBinding(
+            sessionID: "session_1",
+            runStatus: "waiting",
+            pendingYield: true,
+            source: "test",
+            lastProjectedAt: "2026-05-22T00:00:00Z"
+        )
+        let bindingProjection = adapter.projectAlanBinding(
+            binding,
+            runtime: runtime,
+            for: projection.pane,
+            bootProfile: bootProfile
+        )
+
+        expect(bindingProjection.pane.alanBinding == binding, "terminal adapter must project alan binding")
+        expect(
+            bindingProjection.pane.attention == .awaitingUser,
+            "terminal adapter must project pending-yield attention"
+        )
+        expect(
+            bindingProjection.pane.viewport?.summary == "alan is waiting for user input",
+            "terminal adapter must project alan binding summary"
+        )
+        expect(
+            bindingProjection.pane.viewport?.lastActivityAt == "2026-05-22T00:00:00Z",
+            "terminal adapter must project binding activity time"
+        )
     }
 
     private static func verifiesSurfaceExitClosesFinalPaneWithoutRestarting() {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -11,7 +11,7 @@
 
 - [x] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
 - [x] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
-- [ ] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
+- [x] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
 - [ ] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
 - [ ] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
 - [ ] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.


### PR DESCRIPTION
## Summary
- add TerminalContentProjectionAdapter for runtime metadata, alan binding, and boot-context projection
- route ShellHostController terminal runtime/metadata updates through the adapter
- mark OpenSpec task 2.3 complete with focused adapter coverage

## Validation
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-terminal-metadata-adapter build