### PR TITLE
Route terminal lifecycle cleanup through content adapter

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */; };
 		000000000000000000000033 /* Services/Terminal/TerminalHostViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */; };
 		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
+		000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -127,6 +128,7 @@
 		000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostOverlayPresenter.swift; sourceTree = "<group>"; };
 		000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostViewSupport.swift; sourceTree = "<group>"; };
 		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
+		000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentLifecycleAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 			children = (
 				000000000000000000000127 /* Services/Terminal/TerminalHostRuntimeReporter.swift */,
 				000000000000000000000128 /* Services/Terminal/TerminalHostWindowObserver.swift */,
+				000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */,
 				000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */,
 				000000000000000000000132 /* Services/Terminal/TerminalHostOverlayPresenter.swift */,
 				000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */,
@@ -476,6 +479,7 @@
 				00000000000000000000002E /* Services/Shell/ShellEventStore.swift in Sources */,
 				00000000000000000000002F /* Services/Shell/ShellDiagnostics.swift in Sources */,
 				000000000000000000000030 /* Services/Shell/ShellClipboardWriter.swift in Sources */,
+				000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */,
 				000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */,
 				000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */,
 				000000000000000000000032 /* Services/Terminal/TerminalHostOverlayPresenter.swift in Sources */,

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -38,6 +38,12 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
         quickTerminalPeakPresenter.synchronize()
     }
 
+    deinit {
+        let host = host
+        Task { @MainActor in
+            host.shutdownTerminalRuntimes()
+        }
+    }
 }
 
 @MainActor

--- a/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+struct TerminalContentLifecycleAdapter {
+    func reconcileRuntimes(
+        afterAdopting state: ShellStateSnapshot,
+        registry: TerminalRuntimeRegistry
+    ) {
+        registry.releaseRuntimes(excluding: activeTerminalMounts(in: state))
+    }
+
+    func finalizeAllRuntimes(registry: TerminalRuntimeRegistry) {
+        registry.releaseAllRuntimes()
+    }
+
+    func activeTerminalMounts(in state: ShellStateSnapshot) -> [TerminalContentMount] {
+        let contentState = state.contentStateProjection()
+        var contentsByID: [String: ShellContentInstance] = [:]
+        contentState.contents.forEach { content in
+            contentsByID[content.contentID] = content
+        }
+        let mountedPaneSlotIDs = Set(
+            contentState.spaces
+                .flatMap(\.tabs)
+                .flatMap(\.paneTree.paneSlotIDs)
+        )
+        var mounts = contentState.paneSlots.compactMap { slot -> TerminalContentMount? in
+            guard mountedPaneSlotIDs.contains(slot.paneSlotID),
+                  let content = contentsByID[slot.contentID],
+                  content.kind == .terminal,
+                  content.lifecycle == .active
+            else {
+                return nil
+            }
+
+            return TerminalContentMount(
+                contentID: content.contentID,
+                paneSlotID: slot.paneSlotID,
+                tabID: slot.tabID,
+                spaceID: slot.spaceID
+            )
+        }
+
+        if let quickTerminalPaneID = state.quickTerminal?.paneID,
+           let quickTerminalPane = state.pane(paneID: quickTerminalPaneID)
+        {
+            mounts.append(TerminalContentMount(pane: quickTerminalPane))
+        }
+
+        return mounts
+    }
+}
+#endif

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -269,6 +269,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     private let paneProjection: ShellPaneProjectionService
     private let terminalContentProjection: TerminalContentProjectionAdapter
+    private let terminalContentLifecycle = TerminalContentLifecycleAdapter()
     private let clipboardWriter: ShellClipboardWriter
     lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
         self?.handleControlPlaneCommand(command)
@@ -362,9 +363,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     deinit {
         let terminalRuntimeRegistry = terminalRuntimeRegistry
+        let terminalContentLifecycle = terminalContentLifecycle
         Task { @MainActor in
-            terminalRuntimeRegistry.releaseAllRuntimes()
+            terminalContentLifecycle.finalizeAllRuntimes(registry: terminalRuntimeRegistry)
         }
+    }
+
+    func shutdownTerminalRuntimes() {
+        terminalContentLifecycle.finalizeAllRuntimes(registry: terminalRuntimeRegistry)
     }
 
     static func live(
@@ -1879,7 +1885,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         _ state: ShellStateSnapshot,
         publish: Bool = true
     ) {
-        terminalRuntimeRegistry.releaseRuntimes(excluding: activeTerminalContentMounts(in: state))
+        terminalContentLifecycle.reconcileRuntimes(
+            afterAdopting: state,
+            registry: terminalRuntimeRegistry
+        )
 
         let hydratedPanes = state.panes.map { pane in
             guard paneProjection.needsBootContextProjection(pane) else { return pane }
@@ -1934,16 +1943,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         if publish {
             publishControlPlaneState()
         }
-    }
-
-    private func activeTerminalContentMounts(in state: ShellStateSnapshot) -> [TerminalContentMount] {
-        var activePaneIDs = Set(state.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
-        if let quickTerminalPaneID = state.quickTerminal?.paneID {
-            activePaneIDs.insert(quickTerminalPaneID)
-        }
-        return state.panes
-            .filter { activePaneIDs.contains($0.paneID) }
-            .map(TerminalContentMount.init(pane:))
     }
 
     private func recordControlPlaneDiagnostic(_ message: String) {

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -30,6 +30,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalSurfaceController.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -26,6 +26,11 @@ private enum ShellRuntimeMetadataTests {
         verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
         verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs()
         verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
+        verifiesTerminalLifecycleFinalizesClosedPaneAndPreservesSiblings()
+        verifiesTerminalLifecycleFinalizesAllTabContentsOnce()
+        verifiesTerminalLifecyclePreservesMovedAndLiftedRuntimes()
+        verifiesMovingLastPaneClosesSourceTabWithoutFinalizingMovedRuntime()
+        verifiesTerminalLifecycleShutdownFinalizesAllRuntimes()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -789,6 +794,105 @@ private enum ShellRuntimeMetadataTests {
         expect(
             secondHandle.teardownCount == 1,
             "pane release must finalize the active replacement content"
+        )
+    }
+
+    private static func verifiesTerminalLifecycleFinalizesClosedPaneAndPreservesSiblings() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let leftHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let rightHandle = fakeSurfaceHandle(for: "pane_2", controller: controller)
+
+        _ = controller.closePane(paneID: "pane_2")
+
+        expect(leftHandle.teardownCount == 0, "closing one pane must preserve sibling terminal runtime")
+        expect(rightHandle.teardownCount == 1, "closing one pane must finalize its terminal runtime once")
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs == ["pane_1"],
+            "closed PaneSlot must stop being a terminal runtime target"
+        )
+    }
+
+    private static func verifiesTerminalLifecycleFinalizesAllTabContentsOnce() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let leftHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let rightHandle = fakeSurfaceHandle(for: "pane_2", controller: controller)
+
+        _ = controller.closeTab(tabID: "tab_main")
+        _ = controller.closeTab(tabID: "tab_main")
+
+        expect(leftHandle.teardownCount == 1, "closing a tab must finalize first terminal once")
+        expect(rightHandle.teardownCount == 1, "closing a tab must finalize second terminal once")
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.isEmpty,
+            "closed tab terminal runtimes must leave the registry"
+        )
+    }
+
+    private static func verifiesTerminalLifecyclePreservesMovedAndLiftedRuntimes() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let movedHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let siblingHandle = fakeSurfaceHandle(for: "pane_2", controller: controller)
+        guard let targetTabID = controller.openTerminalTab() else {
+            fail("test setup must create target tab")
+        }
+
+        expect(
+            controller.movePane(paneID: "pane_1", toTab: targetTabID, direction: .horizontal),
+            "pane move must apply"
+        )
+        expect(movedHandle.teardownCount == 0, "moving a pane must preserve moved runtime")
+        expect(siblingHandle.teardownCount == 0, "moving a pane must preserve source sibling runtime")
+
+        switch controller.liftPaneToTab(paneID: "pane_1") {
+        case .lifted:
+            break
+        case .lastPane, .paneNotFound:
+            fail("lift after move must apply while the target tab still has a sibling")
+        }
+        expect(movedHandle.teardownCount == 0, "lifting a pane must preserve moved runtime")
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.contains("pane_1"),
+            "lifted PaneSlot must remain a terminal runtime target"
+        )
+    }
+
+    private static func verifiesMovingLastPaneClosesSourceTabWithoutFinalizingMovedRuntime() {
+        let controller = makeController()
+        let movedHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        guard let targetTabID = controller.openTerminalTab() else {
+            fail("test setup must create target tab")
+        }
+
+        expect(
+            controller.movePane(paneID: "pane_1", toTab: targetTabID, direction: .vertical),
+            "moving the last source pane must apply"
+        )
+
+        expect(controller.shellState.tab(tabID: "tab_main") == nil, "empty source tab must close")
+        expect(movedHandle.teardownCount == 0, "source tab cleanup must not finalize moved runtime")
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.contains("pane_1"),
+            "moved PaneSlot must remain a terminal runtime target"
+        )
+    }
+
+    private static func verifiesTerminalLifecycleShutdownFinalizesAllRuntimes() {
+        let controller = makeController()
+        _ = controller.splitPane(paneID: "pane_1", placement: .right)
+        let leftHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let rightHandle = fakeSurfaceHandle(for: "pane_2", controller: controller)
+
+        controller.shutdownTerminalRuntimes()
+        controller.shutdownTerminalRuntimes()
+
+        expect(leftHandle.teardownCount == 1, "shutdown must finalize first terminal once")
+        expect(rightHandle.teardownCount == 1, "shutdown must finalize second terminal once")
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.isEmpty,
+            "shutdown must clear terminal runtime registry state"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -12,7 +12,7 @@
 - [x] 2.1 Migrate the terminal runtime registry and terminal host attachment boundary from pane-keyed identity to terminal `content_id` identity.
 - [x] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
 - [x] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
-- [ ] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
+- [x] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
 - [ ] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
 - [ ] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
 


### PR DESCRIPTION
## Summary
- add a TerminalContentLifecycleAdapter for active terminal mount reconciliation and full runtime shutdown
- route ShellHostController state adoption and app owner shutdown cleanup through the adapter
- mark OpenSpec task 2.4 complete with focused lifecycle coverage for pane close, tab close, move, lift, source-tab cleanup, and shutdown

## Validation
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict --json
- openspec validate --all --strict --json
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/xcode-derived-terminal-lifecycle-rules build