### PR TITLE
feat(mac): rename terminal text command

### DIFF
--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -157,7 +157,7 @@ for your terminal on first use.
 - External Ghostty artifact cache plus ignored local links and app-bundled
   resources/terminfo
 - Window-scoped file/socket shell control plane with pane lifecycle events,
-  bounded socket requests, diagnostic surfacing, and truthful `pane.send_text`
+  bounded socket requests, diagnostic surfacing, and truthful `terminal.send_text`
   delivery results
 
 ### Mobile (iOS)

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -1,6 +1,31 @@
 import Foundation
 
 #if os(macOS)
+private struct TerminalSendTextTarget {
+    let paneSlot: ShellPaneSlot
+    let content: ShellContentInstance
+}
+
+private extension ShellContentStateSnapshot {
+    func terminalSendTextTarget(paneSlotID: String) -> TerminalSendTextTarget? {
+        guard let paneSlot = paneSlot(paneSlotID: paneSlotID),
+              let content = content(contentID: paneSlot.contentID)
+        else {
+            return nil
+        }
+        return TerminalSendTextTarget(paneSlot: paneSlot, content: content)
+    }
+
+    func terminalSendTextTarget(contentID: String) -> TerminalSendTextTarget? {
+        guard let content = content(contentID: contentID),
+              let paneSlot = paneSlots.first(where: { $0.contentID == contentID })
+        else {
+            return nil
+        }
+        return TerminalSendTextTarget(paneSlot: paneSlot, content: content)
+    }
+}
+
 @MainActor
 extension ShellHostController {
     func attentionInboxRows() -> [AlanShellAttentionInboxItem] {
@@ -107,6 +132,7 @@ extension ShellHostController {
         targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        contentID: String? = nil,
         section: ShellTabOrganizationSection? = nil,
         index: Int? = nil,
         acceptedBytes: Int? = nil,
@@ -147,6 +173,7 @@ extension ShellHostController {
             targetSpaceID: targetSpaceID,
             tabID: tabID,
             paneID: paneID,
+            contentID: contentID,
             section: section,
             index: index,
             acceptedBytes: acceptedBytes,
@@ -643,35 +670,70 @@ extension ShellHostController {
         case .paneUnzoom:
             return handlePaneUnzoomCommand(command)
 
-        case .paneSendText:
-            guard let paneID = command.paneID,
-                  let targetPane = pane(paneID: paneID)
-            else {
+        case .terminalSendText:
+            let contentState = shellState.contentStateProjection()
+            let target: TerminalSendTextTarget?
+            if let contentID = command.contentID {
+                target = contentState.terminalSendTextTarget(contentID: contentID)
+            } else if let paneID = command.paneID {
+                target = contentState.terminalSendTextTarget(paneSlotID: paneID)
+            } else {
+                target = nil
+            }
+
+            guard let target else {
+                let errorCode: String
+                if command.contentID == nil && command.paneID == nil {
+                    errorCode = "terminal_target_required"
+                } else if command.contentID != nil {
+                    errorCode = "content_not_found"
+                } else {
+                    errorCode = "pane_not_found"
+                }
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: command.paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
+                    contentID: command.contentID,
+                    errorCode: errorCode,
+                    errorMessage: "terminal.send_text requires an existing terminal content target."
+                )
+            }
+
+            guard target.content.kind == .terminal else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: target.paneSlot.spaceID,
+                    tabID: target.paneSlot.tabID,
+                    paneID: target.paneSlot.paneSlotID,
+                    contentID: target.content.contentID,
+                    errorCode: "unsupported_content",
+                    errorMessage: "terminal.send_text requires terminal content."
                 )
             }
 
             let text = command.text ?? ""
-            let delivery = terminalRuntimeRegistry.sendText(to: paneID, text: text)
+            let delivery = terminalRuntimeRegistry.sendText(
+                toTerminalContentID: target.content.contentID,
+                text: text
+            )
             controlPlane.recordTextDelivery(
                 requestID: command.requestID,
-                spaceID: targetPane.spaceID,
-                tabID: targetPane.tabID,
-                paneID: paneID,
+                spaceID: target.paneSlot.spaceID,
+                tabID: target.paneSlot.tabID,
+                paneID: target.paneSlot.paneSlotID,
+                contentID: target.content.contentID,
                 delivery: delivery
             )
 
             return response(
                 requestID: command.requestID,
                 applied: delivery.applied,
-                spaceID: targetPane.spaceID,
-                tabID: targetPane.tabID,
-                paneID: paneID,
+                spaceID: target.paneSlot.spaceID,
+                tabID: target.paneSlot.tabID,
+                paneID: target.paneSlot.paneSlotID,
+                contentID: target.content.contentID,
                 acceptedBytes: delivery.acceptedBytes,
                 deliveryCode: delivery.code.rawValue,
                 runtimePhase: delivery.runtimePhase,

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -26,7 +26,7 @@ enum AlanShellControlCommandKind: String, Codable {
     case paneEqualizeSplits = "pane.equalize_splits"
     case paneZoom = "pane.zoom"
     case paneUnzoom = "pane.unzoom"
-    case paneSendText = "pane.send_text"
+    case terminalSendText = "terminal.send_text"
     case agentActivity = "agent.activity"
     case attentionInbox = "attention.inbox"
     case attentionSet = "attention.set"
@@ -47,6 +47,7 @@ struct AlanShellControlCommand: Codable {
     let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let contentID: String?
     let splitNodeID: String?
     let ratio: Double?
     let section: ShellTabOrganizationSection?
@@ -75,6 +76,7 @@ struct AlanShellControlCommand: Codable {
         case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case contentID = "content_id"
         case splitNodeID = "split_node_id"
         case ratio
         case section
@@ -131,6 +133,7 @@ struct AlanShellControlResponse: Codable {
     let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let contentID: String?
     let section: ShellTabOrganizationSection?
     let index: Int?
     let acceptedBytes: Int?
@@ -171,6 +174,7 @@ struct AlanShellControlResponse: Codable {
         targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        contentID: String? = nil,
         section: ShellTabOrganizationSection? = nil,
         index: Int? = nil,
         acceptedBytes: Int? = nil,
@@ -210,6 +214,7 @@ struct AlanShellControlResponse: Codable {
         self.targetSpaceID = targetSpaceID
         self.tabID = tabID
         self.paneID = paneID
+        self.contentID = contentID
         self.section = section
         self.index = index
         self.acceptedBytes = acceptedBytes
@@ -251,6 +256,7 @@ struct AlanShellControlResponse: Codable {
         case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case contentID = "content_id"
         case section
         case index
         case acceptedBytes = "accepted_bytes"

--- a/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
@@ -48,10 +48,12 @@ final class AlanShellEventStore {
         spaceID: String?,
         tabID: String?,
         paneID: String,
+        contentID: String,
         delivery: TerminalRuntimeDeliveryResult
     ) {
         var payload: [String: AlanShellJSONValue] = [
             "request_id": .string(requestID),
+            "content_id": .string(contentID),
             "delivery_code": .string(delivery.code.rawValue),
             "accepted_bytes": .number(Double(delivery.acceptedBytes))
         ]
@@ -66,7 +68,7 @@ final class AlanShellEventStore {
         }
 
         append(
-            type: "pane.text_delivery",
+            type: "terminal.text_delivery",
             spaceID: spaceID,
             tabID: tabID,
             paneID: paneID,

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -582,7 +582,7 @@ enum AlanShellLocalCommandExecutor {
              .paneZoom, .paneUnzoom:
             return nil
 
-        case .paneSendText:
+        case .terminalSendText:
             return nil
 
         case .agentActivity:

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -210,6 +210,7 @@ final class AlanShellControlPlane {
         spaceID: String?,
         tabID: String?,
         paneID: String,
+        contentID: String,
         delivery: TerminalRuntimeDeliveryResult
     ) {
         eventStore.recordTextDelivery(
@@ -217,6 +218,7 @@ final class AlanShellControlPlane {
             spaceID: spaceID,
             tabID: tabID,
             paneID: paneID,
+            contentID: contentID,
             delivery: delivery
         )
     }

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -553,7 +553,7 @@ require_pattern \
 require_pattern \
     "clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
     "deliveryCode: String?" \
-    "pane.send_text responses must expose service delivery state"
+    "terminal.send_text responses must expose service delivery state"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
@@ -568,7 +568,7 @@ reject_pattern \
 require_pattern \
     "clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift" \
     "runtimePhase: delivery.runtimePhase" \
-    "pane.send_text responses must expose the service runtime phase"
+    "terminal.send_text responses must expose the service runtime phase"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
@@ -577,13 +577,13 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/TerminalRuntimeRegistry.swift" \
-    "func sendText\\(to paneID: String, text: String\\)" \
+    "toTerminalContentID contentID: String" \
     "terminal text delivery must go through the runtime registry"
 
 require_pattern \
     "clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift" \
-    "terminalRuntimeRegistry\\.sendText\\(to: paneID, text: text\\)" \
-    "pane.send_text must use the registry delivery result"
+    "toTerminalContentID: target\\.content\\.contentID" \
+    "terminal.send_text must use the registry delivery result"
 
 require_pattern \
     "clients/apple/alan-macos/GhosttyLiveHost.swift" \

--- a/crates/alan/src/cli/shell.rs
+++ b/crates/alan/src/cli/shell.rs
@@ -32,6 +32,8 @@ struct ShellControlCommand {
     #[serde(skip_serializing_if = "Option::is_none")]
     pane_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    content_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     split_node_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ratio: Option<f64>,
@@ -72,6 +74,7 @@ struct ShellControlResponse {
     space_id: Option<String>,
     tab_id: Option<String>,
     pane_id: Option<String>,
+    content_id: Option<String>,
     split_node_id: Option<String>,
     ratio: Option<f64>,
     changed_split_ids: Option<Value>,
@@ -328,13 +331,23 @@ pub fn run_shell_pane_unzoom(
     print_pretty(&response)
 }
 
-pub fn run_shell_pane_send_text(pane: &str, text: &str, options: ShellTargetOptions) -> Result<()> {
-    let mut command = build_command("pane.send_text");
-    command.pane_id = Some(pane.to_string());
+pub fn run_shell_terminal_send_text(
+    pane: Option<&str>,
+    content: Option<&str>,
+    text: &str,
+    options: ShellTargetOptions,
+) -> Result<()> {
+    let mut command = build_command("terminal.send_text");
+    command.pane_id = pane.map(str::to_owned);
+    command.content_id = content.map(str::to_owned);
     command.text = Some(text.to_string());
     let response = invoke(&options, command)?;
     ensure_success(&response)?;
     print_pretty(&response)
+}
+
+pub fn run_shell_pane_send_text(pane: &str, text: &str, options: ShellTargetOptions) -> Result<()> {
+    run_shell_terminal_send_text(Some(pane), None, text, options)
 }
 
 pub fn run_shell_attention_inbox(options: ShellTargetOptions) -> Result<()> {
@@ -419,6 +432,7 @@ fn build_command(command: &str) -> ShellControlCommand {
         space_id: None,
         tab_id: None,
         pane_id: None,
+        content_id: None,
         split_node_id: None,
         ratio: None,
         direction: None,
@@ -795,6 +809,7 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: None,
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: None,
@@ -862,6 +877,7 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_9".to_string()),
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: None,
@@ -929,6 +945,7 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_2".to_string()),
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: None,
@@ -994,6 +1011,7 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_7".to_string()),
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: None,
@@ -1043,6 +1061,7 @@ mod tests {
                 space_id: None,
                 tab_id: None,
                 pane_id: Some("pane_2".to_string()),
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: None,
@@ -1105,6 +1124,7 @@ mod tests {
                 space_id: None,
                 tab_id: Some("tab_9".to_string()),
                 pane_id: Some("pane_2".to_string()),
+                content_id: None,
                 split_node_id: None,
                 ratio: None,
                 direction: Some("vertical".to_string()),

--- a/crates/alan/src/main.rs
+++ b/crates/alan/src/main.rs
@@ -447,6 +447,11 @@ enum ShellAction {
         #[command(subcommand)]
         action: ShellPaneAction,
     },
+    /// Operate on terminal content
+    Terminal {
+        #[command(subcommand)]
+        action: ShellTerminalAction,
+    },
     /// Attention inbox and overrides
     Attention {
         #[command(subcommand)]
@@ -665,11 +670,30 @@ enum ShellPaneAction {
         #[command(flatten)]
         target: ShellTargetArgs,
     },
-    /// Send text to a pane
+    /// Deprecated alias for `terminal send-text --pane`
+    #[command(hide = true)]
     SendText {
         /// Pane id to target
         #[arg(long)]
         pane: String,
+        /// Text to send
+        #[arg(long)]
+        text: String,
+        #[command(flatten)]
+        target: ShellTargetArgs,
+    },
+}
+
+#[derive(Subcommand)]
+enum ShellTerminalAction {
+    /// Send text to terminal content
+    SendText {
+        /// PaneSlot id to resolve to terminal content
+        #[arg(long, conflicts_with = "content")]
+        pane: Option<String>,
+        /// Terminal content id to target directly
+        #[arg(long, conflicts_with = "pane")]
+        content: Option<String>,
         /// Text to send
         #[arg(long)]
         text: String,
@@ -1132,6 +1156,24 @@ async fn main() -> Result<()> {
                 ShellPaneAction::SendText { pane, text, target } => {
                     cli::shell::run_shell_pane_send_text(
                         &pane,
+                        &text,
+                        shell_target_options(target),
+                    )?;
+                }
+            },
+            ShellAction::Terminal { action } => match action {
+                ShellTerminalAction::SendText {
+                    pane,
+                    content,
+                    text,
+                    target,
+                } => {
+                    if pane.is_none() && content.is_none() {
+                        anyhow::bail!("terminal send-text requires --pane or --content");
+                    }
+                    cli::shell::run_shell_terminal_send_text(
+                        pane.as_deref(),
+                        content.as_deref(),
                         &text,
                         shell_target_options(target),
                     )?;

--- a/crates/runtime/skills/alan-shell-control/SKILL.md
+++ b/crates/runtime/skills/alan-shell-control/SKILL.md
@@ -51,7 +51,7 @@ alan shell pane list
 alan shell pane snapshot --pane <id>
 alan shell pane focus --pane <id>
 alan shell pane split --pane <id> --direction <horizontal|vertical>
-alan shell pane send-text --pane <id> --text "..."
+alan shell terminal send-text --pane <id> --text "..."
 alan shell space create --cwd <path>
 alan shell space open-alan --cwd <path>
 alan shell attention inbox

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -13,7 +13,7 @@
 - [x] 2.2 Wrap terminal rendering and runtime attachment behind a terminal ContentInstance adapter that resolves the current PaneSlot mount point.
 - [x] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
 - [x] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
-- [ ] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
+- [x] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
 - [ ] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
 
 ## 3. Non-Terminal Content Surfaces


### PR DESCRIPTION
## Summary
- replace the shell control-plane raw text delivery command with terminal.send_text
- keep PaneSlot targeting as a convenience path and add direct content_id targeting
- return content_id in delivery responses/events and update shell docs/skill guidance
- mark OpenSpec task 2.5 complete for generalize-macos-shell-content-containers

## Validation
- cargo check --target-dir /private/tmp/alan-cargo-check -p alan
- cargo test --target-dir /private/tmp/alan-cargo-check -p alan cli::shell
- bash clients/apple/scripts/check-shell-contracts.sh
- ./clients/apple/scripts/test-terminal-runtime-service.sh
- ./clients/apple/scripts/test-shell-runtime-metadata.sh
- openspec validate generalize-macos-shell-content-containers --strict
- git diff --check