### PR TITLE
test(mac): cover content-keyed terminal runtime regressions

### DIFF
--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -24,6 +24,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesPaneTitleBarSuppressesInternalTitles()
         verifiesOpeningTabSkipsStaleRuntimePaneIDs()
         verifiesRuntimeRegistryKeepsContentIdentityAcrossPaneMounts()
+        verifiesRuntimeRegistryPreservesInteractiveBehaviorAcrossPaneRemount()
         verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs()
         verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
         verifiesTerminalLifecycleFinalizesClosedPaneAndPreservesSiblings()
@@ -667,6 +668,116 @@ private enum ShellRuntimeMetadataTests {
         registry.releaseRuntime(for: "pane_right")
         expect(handle.teardownCount == 1, "pane convenience release must finalize the mounted content")
         expect(registry.registeredContentIDs.isEmpty, "released content must leave the registry")
+    }
+
+    private static func verifiesRuntimeRegistryPreservesInteractiveBehaviorAcrossPaneRemount() {
+        let runtimeService = FakeAlanTerminalRuntimeService()
+        let registry = TerminalRuntimeRegistry(runtimeService: runtimeService)
+        let contentID = "content_terminal_interactive"
+        let firstMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_left",
+            tabID: "tab_1",
+            spaceID: "space_main"
+        )
+        let secondMount = TerminalContentMount(
+            contentID: contentID,
+            paneSlotID: "pane_right",
+            tabID: "tab_2",
+            spaceID: "space_main"
+        )
+        let firstHostView = registry.hostView(
+            forTerminalContent: firstMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCommandInput: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+        let handle = registry.surfaceHandle(
+            forTerminalContent: firstMount,
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+
+        let replacementHostView = AlanTerminalHostNSView()
+        registry.configureHostView(
+            replacementHostView,
+            forTerminalContent: secondMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCommandInput: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+        let remountedHandle = registry.surfaceHandle(
+            forTerminalContent: secondMount,
+            bootProfile: nil
+        )
+
+        expect(remountedHandle === handle, "reattachment must keep the content-keyed runtime handle")
+        expect(firstHostView.teardownCount == 0, "view reattachment must not teardown the runtime")
+        expect(handle.paneID == "pane_right", "remounted handle must project the latest PaneSlot")
+        expect(
+            registry.terminalCommandRuntimeState(for: "pane_right").inputReady,
+            "terminal input readiness must follow the remounted terminal content"
+        )
+        expect(
+            !registry.terminalCommandRuntimeState(for: "pane_left").inputReady,
+            "stale PaneSlot must not remain an input target after remount"
+        )
+
+        handle.selectedText = "remounted selection"
+        let pasteboard = RecordingTerminalPasteboardWriter()
+        expect(
+            registry.copySelection(for: "pane_right", to: pasteboard),
+            "copy must resolve through the remounted terminal content"
+        )
+        expect(
+            pasteboard.string == "remounted selection",
+            "copy must read selection from the content-keyed runtime"
+        )
+
+        expect(
+            registry.beginFindInteraction(for: "pane_right"),
+            "search must resolve through the remounted terminal host"
+        )
+        expect(
+            handle.searchActions == ["start_search"],
+            "search must reach the remounted content runtime"
+        )
+
+        let paste = registry.pasteText("paste after remount", to: "pane_right")
+        expect(paste.applied, "paste must deliver through the remounted terminal content")
+        expect(
+            handle.deliveredText.last == "paste after remount",
+            "paste must reach the content-keyed runtime"
+        )
+
+        let queuedText = "queued after remount"
+        handle.deliveryResult = .queued(
+            byteCount: queuedText.lengthOfBytes(using: .utf8),
+            runtimePhase: "attachable"
+        )
+        let queued = registry.sendText(to: "pane_right", text: queuedText)
+        expect(queued.code == .queued, "terminal text delivery must preserve queued state")
+        expect(
+            runtimeService.snapshot(forTerminalContentID: contentID)?.lastDelivery == queued,
+            "pending delivery diagnostics must stay on the remounted content"
+        )
+
+        let staleDelivery = registry.sendText(to: "pane_left", text: "stale target")
+        expect(
+            staleDelivery.code == .missingTarget,
+            "stale PaneSlot delivery must not fall through to the remounted runtime"
+        )
     }
 
     private static func verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs() {

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -20,6 +20,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
         verifiesContentScopedHandleSurvivesPaneRemount()
+        verifiesContentScopedDeliveryPreservesPendingDiagnostics()
         verifiesDeliveryAndMissingRuntimeResults()
         verifiesDeliveryRejectsExitedRuntime()
         verifiesQueuedAndTimeoutDeliveryStates()
@@ -223,6 +224,56 @@ private enum TerminalRuntimeServiceTests {
             service.snapshot(forTerminalContentID: contentID)?.paneID == "pane_right",
             "snapshot must project the latest PaneSlot mount"
         )
+    }
+
+    private static func verifiesContentScopedDeliveryPreservesPendingDiagnostics() {
+        let service = FakeAlanTerminalRuntimeService()
+        let contentID = "content_terminal_delivery"
+        let handle = service.surfaceHandle(
+            forTerminalContentID: contentID,
+            mountedAtPaneID: "pane_left",
+            bootProfile: nil
+        ) as! FakeAlanTerminalSurfaceHandle
+
+        let accepted = service.sendText(toTerminalContentID: contentID, text: "hello")
+        expect(accepted.applied, "content-keyed delivery must report accepted delivery")
+        expect(accepted.acceptedBytes == 5, "content-keyed delivery must report accepted bytes")
+        expect(handle.deliveredText == ["hello"], "content-keyed delivery must reach the surface")
+        expect(
+            service.snapshot(forTerminalContentID: contentID)?.lastDelivery == accepted,
+            "content-keyed delivery diagnostics must stay on the terminal content snapshot"
+        )
+
+        _ = service.surfaceHandle(
+            forTerminalContentID: contentID,
+            mountedAtPaneID: "pane_right",
+            bootProfile: nil
+        )
+        let queuedText = "queued input"
+        handle.deliveryResult = .queued(
+            byteCount: queuedText.lengthOfBytes(using: .utf8),
+            runtimePhase: "attachable"
+        )
+
+        let queued = service.sendText(toTerminalContentID: contentID, text: queuedText)
+        expect(queued.code == .queued, "queued delivery must stay content keyed after remount")
+        expect(
+            queued.acceptedBytes == queuedText.lengthOfBytes(using: .utf8),
+            "queued delivery must preserve queued byte count"
+        )
+        expect(queued.runtimePhase == "attachable", "queued delivery must preserve runtime phase")
+        expect(
+            service.snapshot(forTerminalContentID: contentID)?.paneID == "pane_right",
+            "queued diagnostics must project the latest PaneSlot mount"
+        )
+        expect(
+            service.snapshot(forTerminalContentID: contentID)?.lastDelivery == queued,
+            "pending delivery state must remain observable by content ID"
+        )
+
+        let missing = service.sendText(toTerminalContentID: "content_missing", text: "hello")
+        expect(missing.code == .missingTarget, "missing content must report runtime-missing")
+        expect(missing.applied == false, "missing content delivery must not report applied")
     }
 
     private static func verifiesDeliveryAndMissingRuntimeResults() {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -14,7 +14,7 @@
 - [x] 2.3 Move terminal metadata projection for cwd, title, process status, alan binding, surface readiness, and attention into the terminal content adapter boundary.
 - [x] 2.4 Ensure close PaneSlot, close tab, lifecycle retirement, PaneSlot move, PaneSlot lift, content replacement, and app shutdown finalize or preserve terminal runtimes according to content lifecycle specs.
 - [x] 2.5 Replace `pane.send_text` surfaces with `terminal.send_text` while keeping PaneSlot as an optional convenience target that resolves to terminal ContentInstance before runtime delivery.
-- [ ] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
+- [x] 2.6 Preserve existing terminal input, search, paste, terminal text delivery, reattachment, and pending delivery behavior through focused content-keyed runtime tests.
 
 ## 3. Non-Terminal Content Surfaces
 


### PR DESCRIPTION
## Summary
- add content-keyed runtime-service coverage for accepted, queued, missing, and remounted terminal delivery diagnostics
- add terminal registry coverage proving input readiness, copy/search/paste, send_text queueing, reattachment, and stale PaneSlot rejection follow terminal content identity
- mark OpenSpec task 2.6 complete

## Validation
- ./clients/apple/scripts/test-terminal-runtime-service.sh
- ./clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- git diff --check