### PR TITLE
feat(mac): route shell content renderers

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		000000000000000000000033 /* Services/Terminal/TerminalHostViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */; };
 		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
 		000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */; };
+		000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -129,6 +130,7 @@
 		000000000000000000000133 /* Services/Terminal/TerminalHostViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalHostViewSupport.swift; sourceTree = "<group>"; };
 		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentLifecycleAdapter.swift; sourceTree = "<group>"; };
+		000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellContentRenderingRegistry.swift; sourceTree = "<group>"; };
 		000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 			children = (
 				000000000000000000000125 /* Services/Shell/ShellPaneProjectionService.swift */,
 				000000000000000000000130 /* Services/Shell/ShellClipboardWriter.swift */,
+				000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */,
 				00000000000000000000012D /* Services/Shell/ShellControlFilePoller.swift */,
 				00000000000000000000012F /* Services/Shell/ShellDiagnostics.swift */,
 				00000000000000000000012E /* Services/Shell/ShellEventStore.swift */,
@@ -479,6 +482,7 @@
 				00000000000000000000002E /* Services/Shell/ShellEventStore.swift in Sources */,
 				00000000000000000000002F /* Services/Shell/ShellDiagnostics.swift in Sources */,
 				000000000000000000000030 /* Services/Shell/ShellClipboardWriter.swift in Sources */,
+				000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */,
 				000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */,
 				000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */,
 				000000000000000000000031 /* Services/Terminal/TerminalNativeScrollViewAdapter.swift in Sources */,

--- a/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+#if os(macOS)
+enum ShellContentRenderKind: String, Codable, CaseIterable, Equatable {
+    case terminal
+    case markdown
+    case settings
+    case unavailable
+}
+
+struct ShellContentRenderDescriptor: Equatable {
+    let renderKind: ShellContentRenderKind
+    let contentID: String?
+    let contentKind: ShellContentKind?
+    let title: String
+    let iconName: String
+    let capabilities: [ShellContentCapability]
+    let rendererPhase: String
+    let detail: String?
+
+    var isTerminalSurface: Bool {
+        renderKind == .terminal
+    }
+}
+
+enum ShellContentRenderingRegistry {
+    static func descriptor(for content: ShellContentInstance?) -> ShellContentRenderDescriptor {
+        guard let content else {
+            return ShellContentRenderDescriptor(
+                renderKind: .unavailable,
+                contentID: nil,
+                contentKind: nil,
+                title: "Unavailable",
+                iconName: "exclamationmark.triangle",
+                capabilities: [],
+                rendererPhase: "missing_content",
+                detail: "No content is mounted in this pane."
+            )
+        }
+
+        return ShellContentRenderDescriptor(
+            renderKind: renderKind(for: content.kind),
+            contentID: content.contentID,
+            contentKind: content.kind,
+            title: content.title,
+            iconName: iconName(for: content),
+            capabilities: content.capabilities,
+            rendererPhase: content.rendererState.phase,
+            detail: content.rendererState.detail
+        )
+    }
+
+    private static func renderKind(for contentKind: ShellContentKind) -> ShellContentRenderKind {
+        switch contentKind {
+        case .terminal:
+            return .terminal
+        case .markdown:
+            return .markdown
+        case .settings:
+            return .settings
+        }
+    }
+
+    private static func iconName(for content: ShellContentInstance) -> String {
+        if let iconName = content.iconName,
+           !iconName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return iconName
+        }
+
+        switch content.kind {
+        case .terminal:
+            return "terminal"
+        case .markdown:
+            return "doc.text"
+        case .settings:
+            return "gearshape"
+        }
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
@@ -24,6 +24,17 @@ struct ShellContentRenderDescriptor: Equatable {
 }
 
 enum ShellContentRenderingRegistry {
+    static func descriptor(
+        forPaneSlotID paneSlotID: String,
+        in contentState: ShellContentStateSnapshot,
+        fallbackPane: ShellPane? = nil
+    ) -> ShellContentRenderDescriptor {
+        let content =
+            contentState.contentMounted(in: paneSlotID)
+            ?? fallbackPane.map(ShellContentInstance.projectingTerminalPane)
+        return descriptor(for: content)
+    }
+
     static func descriptor(for content: ShellContentInstance?) -> ShellContentRenderDescriptor {
         guard let content else {
             return ShellContentRenderDescriptor(

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -456,83 +456,8 @@ private struct ShellPaneTreeLayoutView: View {
     var body: some View {
         switch node.kind {
         case .pane:
-            if let paneID = node.paneID,
-               let pane = host.shellState.panes.first(where: { $0.paneID == paneID }) {
-                ShellTerminalLeafView(
-                    pane: pane,
-                    bootProfile: host.bootProfile(for: pane),
-                    isSelected: selectedPaneID == pane.paneID,
-                    isZoomed: host.isPaneZoomed(pane.paneID),
-                    canZoom: host.canZoomPane(pane.paneID),
-                    canMovePane: { placement in
-                        host.shellActionAvailability(
-                            paneMoveActionID(for: placement),
-                            target: .contextPane(pane.paneID)
-                        ).isAvailable
-                    },
-                    canCopyTerminalSelection: host.canCopyTerminalSelection(
-                        source: .contextMenu,
-                        target: .contextPane(pane.paneID)
-                    ),
-                    canPasteIntoTerminal: host.canPasteIntoTerminal(
-                        source: .contextMenu,
-                        target: .contextPane(pane.paneID)
-                    ),
-                    canOpenTerminalSearch: host.canOpenTerminalSearch(
-                        source: .contextMenu,
-                        target: .contextPane(pane.paneID)
-                    ),
-                    runtimeRegistry: host.terminalRuntimeRegistry,
-                    activationDelegate: host,
-                    onShellAction: { actionID, target in
-                        host.performShellAction(actionID, target: target, source: .terminalHost)
-                    },
-                    onCommandInput: {
-                        host.requestCommandInput()
-                    },
-                    onToggleZoom: {
-                        if host.isPaneZoomed(pane.paneID) {
-                            _ = host.unzoomSelectedTab()
-                        } else {
-                            _ = host.zoomPane(paneID: pane.paneID)
-                        }
-                    },
-                    onMovePane: { placement in
-                        host.performShellAction(
-                            paneMoveActionID(for: placement),
-                            target: .contextPane(pane.paneID)
-                        )
-                    },
-                    onCopyTerminalSelection: {
-                        host.copyTerminalSelection(
-                            source: .contextMenu,
-                            target: .contextPane(pane.paneID)
-                        )
-                    },
-                    onPasteIntoTerminal: {
-                        host.pasteIntoTerminalFromPasteboard(
-                            source: .contextMenu,
-                            target: .contextPane(pane.paneID)
-                        )
-                    },
-                    onOpenTerminalSearch: {
-                        host.openTerminalSearch(
-                            source: .contextMenu,
-                            target: .contextPane(pane.paneID)
-                        )
-                    },
-                    onClosePane: {
-                        if let onClosePane {
-                            onClosePane(pane)
-                        } else {
-                            host.closePaneByID(pane.paneID)
-                        }
-                    },
-                    onRuntimeUpdate: host.updateTerminalRuntime,
-                    onMetadataUpdate: { metadata in
-                        host.updateTerminalMetadata(metadata, for: pane.paneID)
-                    }
-                )
+            if let paneID = node.paneID {
+                contentLeaf(for: paneID)
             }
         case .split:
             ShellSplitLayoutView(
@@ -542,6 +467,140 @@ private struct ShellPaneTreeLayoutView: View {
                 onClosePane: onClosePane
             )
         }
+    }
+
+    @ViewBuilder
+    private func contentLeaf(for paneSlotID: String) -> some View {
+        let contentState = host.shellState.contentStateProjection()
+        let content = contentState.contentMounted(in: paneSlotID)
+        let descriptor = ShellContentRenderingRegistry.descriptor(for: content)
+
+        switch descriptor.renderKind {
+        case .terminal:
+            if let pane = host.shellState.panes.first(where: { $0.paneID == paneSlotID }) {
+                terminalLeaf(for: pane)
+            } else {
+                boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID)
+            }
+        case .markdown, .settings, .unavailable:
+            boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID)
+        }
+    }
+
+    private func terminalLeaf(for pane: ShellPane) -> some View {
+        ShellTerminalLeafView(
+            pane: pane,
+            bootProfile: host.bootProfile(for: pane),
+            isSelected: selectedPaneID == pane.paneID,
+            isZoomed: host.isPaneZoomed(pane.paneID),
+            canZoom: host.canZoomPane(pane.paneID),
+            canMovePane: { placement in
+                host.shellActionAvailability(
+                    paneMoveActionID(for: placement),
+                    target: .contextPane(pane.paneID)
+                ).isAvailable
+            },
+            canCopyTerminalSelection: host.canCopyTerminalSelection(
+                source: .contextMenu,
+                target: .contextPane(pane.paneID)
+            ),
+            canPasteIntoTerminal: host.canPasteIntoTerminal(
+                source: .contextMenu,
+                target: .contextPane(pane.paneID)
+            ),
+            canOpenTerminalSearch: host.canOpenTerminalSearch(
+                source: .contextMenu,
+                target: .contextPane(pane.paneID)
+            ),
+            runtimeRegistry: host.terminalRuntimeRegistry,
+            activationDelegate: host,
+            onShellAction: { actionID, target in
+                host.performShellAction(actionID, target: target, source: .terminalHost)
+            },
+            onCommandInput: {
+                host.requestCommandInput()
+            },
+            onToggleZoom: {
+                if host.isPaneZoomed(pane.paneID) {
+                    _ = host.unzoomSelectedTab()
+                } else {
+                    _ = host.zoomPane(paneID: pane.paneID)
+                }
+            },
+            onMovePane: { placement in
+                host.performShellAction(
+                    paneMoveActionID(for: placement),
+                    target: .contextPane(pane.paneID)
+                )
+            },
+            onCopyTerminalSelection: {
+                host.copyTerminalSelection(
+                    source: .contextMenu,
+                    target: .contextPane(pane.paneID)
+                )
+            },
+            onPasteIntoTerminal: {
+                host.pasteIntoTerminalFromPasteboard(
+                    source: .contextMenu,
+                    target: .contextPane(pane.paneID)
+                )
+            },
+            onOpenTerminalSearch: {
+                host.openTerminalSearch(
+                    source: .contextMenu,
+                    target: .contextPane(pane.paneID)
+                )
+            },
+            onClosePane: {
+                if let onClosePane {
+                    onClosePane(pane)
+                } else {
+                    host.closePaneByID(pane.paneID)
+                }
+            },
+            onRuntimeUpdate: host.updateTerminalRuntime,
+            onMetadataUpdate: { metadata in
+                host.updateTerminalMetadata(metadata, for: pane.paneID)
+            }
+        )
+    }
+
+    private func boundedContentLeaf(
+        descriptor: ShellContentRenderDescriptor,
+        paneSlotID: String
+    ) -> some View {
+        ShellBoundedContentLeafView(
+            descriptor: descriptor,
+            paneSlotID: paneSlotID,
+            isSelected: selectedPaneID == paneSlotID,
+            isZoomed: host.isPaneZoomed(paneSlotID),
+            canZoom: host.canZoomPane(paneSlotID),
+            canMovePane: { placement in
+                host.shellActionAvailability(
+                    paneMoveActionID(for: placement),
+                    target: .contextPane(paneSlotID)
+                ).isAvailable
+            },
+            onFocusPane: {
+                host.focus(paneID: paneSlotID)
+            },
+            onToggleZoom: {
+                if host.isPaneZoomed(paneSlotID) {
+                    _ = host.unzoomSelectedTab()
+                } else {
+                    _ = host.zoomPane(paneID: paneSlotID)
+                }
+            },
+            onMovePane: { placement in
+                host.performShellAction(
+                    paneMoveActionID(for: placement),
+                    target: .contextPane(paneSlotID)
+                )
+            },
+            onClosePane: {
+                host.closePaneByID(paneSlotID)
+            }
+        )
     }
 }
 
@@ -855,6 +914,187 @@ private enum ShellPaneTitleBarPresentation {
 private enum ShellPaneTitleBarAccessoryMode: Equatable {
     case textAndIcon
     case iconOnly
+}
+
+private struct ShellBoundedContentLeafView: View {
+    let descriptor: ShellContentRenderDescriptor
+    let paneSlotID: String
+    let isSelected: Bool
+    let isZoomed: Bool
+    let canZoom: Bool
+    let canMovePane: (ShellPaneSplitDirection) -> Bool
+    let onFocusPane: () -> Void
+    let onToggleZoom: () -> Void
+    let onMovePane: (ShellPaneSplitDirection) -> Void
+    let onClosePane: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ShellContentPaneTitleBarView(
+                descriptor: descriptor,
+                isSelected: isSelected,
+                isZoomed: isZoomed,
+                canZoom: canZoom,
+                canMovePane: canMovePane,
+                onFocusPane: onFocusPane,
+                onToggleZoom: onToggleZoom,
+                onMovePane: onMovePane,
+                onClosePane: onClosePane
+            )
+
+            ZStack {
+                ShellPalette.workspace
+
+                VStack(spacing: 10) {
+                    Image(systemName: descriptor.iconName)
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(ShellPalette.mutedInk)
+                        .frame(width: 32, height: 32)
+
+                    Text(descriptor.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(ShellPalette.ink)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 260)
+
+                    Text(contentKindLabel)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(ShellPalette.mutedInk)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onFocusPane)
+            }
+        }
+    }
+
+    private var contentKindLabel: String {
+        switch descriptor.renderKind {
+        case .terminal:
+            return "Terminal"
+        case .markdown:
+            return "Document"
+        case .settings:
+            return "Settings"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+}
+
+private struct ShellContentPaneTitleBarView: View {
+    let descriptor: ShellContentRenderDescriptor
+    let isSelected: Bool
+    let isZoomed: Bool
+    let canZoom: Bool
+    let canMovePane: (ShellPaneSplitDirection) -> Bool
+    let onFocusPane: () -> Void
+    let onToggleZoom: () -> Void
+    let onMovePane: (ShellPaneSplitDirection) -> Void
+    let onClosePane: () -> Void
+
+    var body: some View {
+        HStack(spacing: ShellPaneTitleBarMetrics.itemSpacing) {
+            Image(systemName: descriptor.iconName)
+                .font(.system(size: ShellPaneTitleTypography.accessorySize, weight: .medium))
+                .foregroundStyle(ShellPalette.mutedInk)
+                .frame(width: 14, height: 14)
+
+            Text(descriptor.title)
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.titleSize,
+                        weight: ShellPaneTitleTypography.titleWeight(isSelected: isSelected)
+                    )
+                )
+                .foregroundStyle(ShellPalette.ink.opacity(isSelected ? 0.96 : 0.72))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .layoutPriority(2)
+
+            Spacer(minLength: 0)
+
+            if canZoom {
+                zoomButton
+            }
+
+            closeButton
+        }
+        .padding(.leading, ShellPaneTitleBarMetrics.horizontalLeadingPadding)
+        .padding(.trailing, ShellPaneTitleBarMetrics.horizontalTrailingPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: ShellPaneTitleBarMetrics.height)
+        .background(ShellPalette.workspace)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onFocusPane)
+        .contextMenu {
+            Button("Move Pane Left") {
+                onMovePane(.left)
+            }
+            .disabled(!canMovePane(.left))
+
+            Button("Move Pane Right") {
+                onMovePane(.right)
+            }
+            .disabled(!canMovePane(.right))
+
+            Button("Move Pane Up") {
+                onMovePane(.up)
+            }
+            .disabled(!canMovePane(.up))
+
+            Button("Move Pane Down") {
+                onMovePane(.down)
+            }
+            .disabled(!canMovePane(.down))
+        }
+    }
+
+    private var closeButton: some View {
+        Button(action: onClosePane) {
+            Image(systemName: "xmark")
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.closeSize,
+                        weight: ShellPaneTitleTypography.closeWeight
+                    )
+                )
+                .foregroundStyle(ShellPalette.mutedInk.opacity(isSelected ? 0.78 : 0.58))
+                .frame(
+                    width: ShellPaneTitleBarMetrics.closeButtonSize,
+                    height: ShellPaneTitleBarMetrics.closeButtonSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: true)
+        .help("Close pane")
+        .accessibilityLabel("Close pane")
+    }
+
+    private var zoomButton: some View {
+        Button(action: onToggleZoom) {
+            Image(systemName: isZoomed ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+                .font(
+                    .system(
+                        size: ShellPaneTitleTypography.closeSize,
+                        weight: ShellPaneTitleTypography.closeWeight
+                    )
+                )
+                .foregroundStyle(ShellPalette.mutedInk.opacity(isSelected ? 0.82 : 0.62))
+                .frame(
+                    width: ShellPaneTitleBarMetrics.closeButtonSize,
+                    height: ShellPaneTitleBarMetrics.closeButtonSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: true)
+        .help(isZoomed ? "Unzoom pane" : "Zoom pane")
+        .accessibilityLabel(isZoomed ? "Unzoom pane" : "Zoom pane")
+    }
 }
 
 private struct ShellPaneTitleBarView: View {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -472,18 +472,22 @@ private struct ShellPaneTreeLayoutView: View {
     @ViewBuilder
     private func contentLeaf(for paneSlotID: String) -> some View {
         let contentState = host.shellState.contentStateProjection()
-        let content = contentState.contentMounted(in: paneSlotID)
-        let descriptor = ShellContentRenderingRegistry.descriptor(for: content)
+        let pane = host.shellState.pane(paneID: paneSlotID)
+        let descriptor = ShellContentRenderingRegistry.descriptor(
+            forPaneSlotID: paneSlotID,
+            in: contentState,
+            fallbackPane: pane
+        )
 
         switch descriptor.renderKind {
         case .terminal:
-            if let pane = host.shellState.panes.first(where: { $0.paneID == paneSlotID }) {
+            if let pane {
                 terminalLeaf(for: pane)
             } else {
-                boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID)
+                boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID, backingPane: nil)
             }
         case .markdown, .settings, .unavailable:
-            boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID)
+            boundedContentLeaf(descriptor: descriptor, paneSlotID: paneSlotID, backingPane: pane)
         }
     }
 
@@ -567,7 +571,8 @@ private struct ShellPaneTreeLayoutView: View {
 
     private func boundedContentLeaf(
         descriptor: ShellContentRenderDescriptor,
-        paneSlotID: String
+        paneSlotID: String,
+        backingPane: ShellPane?
     ) -> some View {
         ShellBoundedContentLeafView(
             descriptor: descriptor,
@@ -598,7 +603,13 @@ private struct ShellPaneTreeLayoutView: View {
                 )
             },
             onClosePane: {
-                host.closePaneByID(paneSlotID)
+                if let backingPane,
+                   let onClosePane
+                {
+                    onClosePane(backingPane)
+                } else {
+                    host.closePaneByID(paneSlotID)
+                }
             }
         )
     }

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -20,6 +20,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellClipboardWriter.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -3716,6 +3716,32 @@ private enum ShellRuntimeMetadataTests {
             missingDescriptor.contentID == nil,
             "missing content fallback must not invent a content identity"
         )
+
+        let quickTerminalState = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp")
+            .showingQuickTerminal(workingDirectory: "/tmp")
+            .state
+        let quickTerminalProjection = quickTerminalState.contentStateProjection()
+        let quickTerminalPane = quickTerminalState.pane(paneID: ShellQuickTerminalSlot.globalPaneID)
+        expect(
+            quickTerminalProjection.contentMounted(in: ShellQuickTerminalSlot.globalPaneID) == nil,
+            "quick terminal peak panes must stay outside workspace content projection"
+        )
+        let quickTerminalDescriptor = ShellContentRenderingRegistry.descriptor(
+            forPaneSlotID: ShellQuickTerminalSlot.globalPaneID,
+            in: quickTerminalProjection,
+            fallbackPane: quickTerminalPane
+        )
+        expect(
+            quickTerminalDescriptor.renderKind == .terminal,
+            "quick terminal fallback pane must still route to the terminal renderer"
+        )
+        let expectedQuickTerminalContentID = ShellContentInstance.terminalContentID(
+            forPaneID: ShellQuickTerminalSlot.globalPaneID
+        )
+        expect(
+            quickTerminalDescriptor.contentID == expectedQuickTerminalContentID,
+            "quick terminal fallback must retain the terminal content identity"
+        )
     }
 
     private static func verifiesShellStatePersistenceWritesContentStateShape() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -102,6 +102,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesShellActionSpaceSelectionReportsMissingTargets()
         verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout()
         verifiesContentStateProjectionSeparatesPaneSlotsAndContent()
+        verifiesContentRenderingRegistryRoutesSupportedKinds()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
@@ -3647,6 +3648,74 @@ private enum ShellRuntimeMetadataTests {
         expect(emptyProjection.focusedPaneSlotID == nil, "empty content projection must keep pane-slot focus nil")
         expect(emptyProjection.paneSlots.isEmpty, "empty content projection must not fabricate PaneSlots")
         expect(emptyProjection.spaces.first?.spaceID == "space_empty", "empty content projection must keep spaces")
+    }
+
+    private static func verifiesContentRenderingRegistryRoutesSupportedKinds() {
+        let terminal = ShellContentInstance(
+            contentID: "content_terminal",
+            kind: .terminal,
+            title: "Shell",
+            payload: .terminal(
+                ShellTerminalContentPayload(
+                    launchTarget: .shell,
+                    cwd: "/tmp",
+                    title: "Shell"
+                )
+            )
+        )
+        let markdown = ShellContentInstance(
+            contentID: "content_markdown",
+            kind: .markdown,
+            title: "README.md",
+            payload: .markdown(
+                ShellMarkdownContentPayload(
+                    fileURL: "file:///tmp/README.md",
+                    title: "README.md"
+                )
+            )
+        )
+        let settings = ShellContentInstance(
+            contentID: "content_settings",
+            kind: .settings,
+            title: "Settings",
+            payload: .settings(
+                ShellSettingsContentPayload(
+                    surfaceID: "settings_main",
+                    title: "Settings"
+                )
+            )
+        )
+
+        let terminalDescriptor = ShellContentRenderingRegistry.descriptor(for: terminal)
+        expect(terminalDescriptor.renderKind == .terminal, "terminal content must route to terminal renderer")
+        expect(terminalDescriptor.isTerminalSurface, "terminal descriptor must expose terminal ownership")
+        expect(
+            terminalDescriptor.capabilities.contains(.terminalInput),
+            "terminal descriptor must retain terminal input capability"
+        )
+
+        let markdownDescriptor = ShellContentRenderingRegistry.descriptor(for: markdown)
+        expect(markdownDescriptor.renderKind == .markdown, "markdown content must route to markdown renderer")
+        expect(markdownDescriptor.iconName == "doc.text", "markdown descriptor must get a bounded viewer icon")
+        expect(
+            !markdownDescriptor.capabilities.contains(.terminalInput),
+            "markdown descriptor must not expose terminal input capability"
+        )
+
+        let settingsDescriptor = ShellContentRenderingRegistry.descriptor(for: settings)
+        expect(settingsDescriptor.renderKind == .settings, "settings content must route to settings renderer")
+        expect(settingsDescriptor.iconName == "gearshape", "settings descriptor must get a settings icon")
+        expect(
+            settingsDescriptor.capabilities == [.settingsSurface],
+            "settings descriptor must retain settings capabilities"
+        )
+
+        let missingDescriptor = ShellContentRenderingRegistry.descriptor(for: nil)
+        expect(missingDescriptor.renderKind == .unavailable, "missing content must route to bounded fallback")
+        expect(
+            missingDescriptor.contentID == nil,
+            "missing content fallback must not invent a content identity"
+        )
     }
 
     private static func verifiesShellStatePersistenceWritesContentStateShape() {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -18,7 +18,7 @@
 
 ## 3. Non-Terminal Content Surfaces
 
-- [ ] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
+- [x] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
 - [ ] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
 - [ ] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
 - [ ] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.


### PR DESCRIPTION
## Summary
- add a content rendering registry for terminal, markdown, settings, and bounded unavailable shell content descriptors
- route shell pane leaves through content descriptors before rendering terminal or bounded non-terminal host surfaces
- add registry coverage and mark OpenSpec task 3.1 complete

## Validation
- git diff --check
- ./clients/apple/scripts/test-shell-runtime-metadata.sh
- ./clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/DerivedData/ContentRenderingRegistry CODE_SIGNING_ALLOWED=NO build

Note: the first sandboxed xcodebuild attempt failed at Xcode's run-script sandbox with `sandbox-exec: sandbox_apply: Operation not permitted`; rerunning the same command outside the Codex sandbox passed.