### PR TITLE
feat(mac): open markdown content tabs

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 #if os(macOS)
 import AppKit
+import UniformTypeIdentifiers
 
 struct AlanMacShellCommands: Commands {
     @ObservedObject var host: ShellHostController
@@ -58,6 +59,10 @@ struct AlanMacShellCommands: Commands {
                 host.performShellAction(.newAlanTab)
             }
             .shellActionKeyboardShortcut(host.shellActionShortcut(.newAlanTab))
+
+            Button("Open Markdown...") {
+                openMarkdownFile()
+            }
 
             Button("Ask alan...") {
                 host.requestCommandInput()
@@ -208,6 +213,24 @@ struct AlanMacShellCommands: Commands {
 
     private func sendResponderAction(_ selector: Selector) {
         NSApp.sendAction(selector, to: nil, from: nil)
+    }
+
+    private func openMarkdownFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = markdownContentTypes
+
+        guard panel.runModal() == .OK,
+              let fileURL = panel.url
+        else { return }
+
+        _ = host.openMarkdownTab(fileURL: fileURL)
+    }
+
+    private var markdownContentTypes: [UTType] {
+        ["md", "markdown", "mdown"].compactMap { UTType(filenameExtension: $0) }
     }
 
     private func installCommandLineTools() {

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -770,6 +770,17 @@ struct ShellPaneSlotTreeNode: Identifiable, Codable, Equatable {
             return (children ?? []).flatMap(\.paneSlotIDs)
         }
     }
+
+    func restoringPaneTree() -> ShellPaneTreeNode {
+        ShellPaneTreeNode(
+            nodeID: nodeID,
+            kind: kind,
+            direction: direction,
+            ratio: ratio,
+            paneID: paneSlotID,
+            children: children?.map { $0.restoringPaneTree() }
+        )
+    }
 }
 
 struct ShellTab: Identifiable, Codable, Equatable {
@@ -873,6 +884,8 @@ struct ShellStateSnapshot: Codable, Equatable {
     let focusedPaneID: String?
     let spaces: [ShellSpace]
     let panes: [ShellPane]
+    var paneSlots: [ShellPaneSlot]? = nil
+    var contents: [ShellContentInstance]? = nil
     var quickTerminal: ShellQuickTerminalSlot? = nil
 
     private enum CodingKeys: String, CodingKey {
@@ -883,6 +896,8 @@ struct ShellStateSnapshot: Codable, Equatable {
         case focusedPaneID = "focused_pane_id"
         case spaces
         case panes
+        case paneSlots = "pane_slots"
+        case contents
         case quickTerminal = "quick_terminal"
     }
 
@@ -1028,8 +1043,33 @@ extension ShellContentStateSnapshot {
     static func projecting(_ shellState: ShellStateSnapshot) -> ShellContentStateSnapshot {
         let layoutPaneIDs = Set(shellState.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
         let projectedPanes = shellState.panes.filter { layoutPaneIDs.contains($0.paneID) }
-        let paneSlots = projectedPanes.map(ShellPaneSlot.projectingTerminalPane)
-        let contents = projectedPanes.map(ShellContentInstance.projectingTerminalPane)
+        let explicitPaneSlots = (shellState.paneSlots ?? []).filter {
+            layoutPaneIDs.contains($0.paneSlotID)
+        }
+        let explicitPaneSlotIDs = Set(explicitPaneSlots.map(\.paneSlotID))
+        let explicitContentIDs = Set(explicitPaneSlots.map(\.contentID))
+        let explicitPaneSlotsByContentID = explicitPaneSlots.reduce(into: [String: ShellPaneSlot]()) {
+            slotsByContentID, slot in
+            slotsByContentID[slot.contentID] = slot
+        }
+        let projectedPanesByID = projectedPanes.reduce(into: [String: ShellPane]()) { panesByID, pane in
+            panesByID[pane.paneID] = pane
+        }
+        let explicitContents = (shellState.contents ?? []).filter {
+            explicitContentIDs.contains($0.contentID)
+        }.map { content in
+            guard content.kind == .terminal,
+                  let paneSlot = explicitPaneSlotsByContentID[content.contentID],
+                  let pane = projectedPanesByID[paneSlot.paneSlotID]
+            else {
+                return content
+            }
+
+            return ShellContentInstance.projectingTerminalPane(pane, contentID: content.contentID)
+        }
+        let terminalPanes = projectedPanes.filter { !explicitPaneSlotIDs.contains($0.paneID) }
+        let paneSlots = explicitPaneSlots + terminalPanes.map(ShellPaneSlot.projectingTerminalPane)
+        let contents = explicitContents + terminalPanes.map(ShellContentInstance.projectingTerminalPane)
         let validPaneSlotIDs = Set(paneSlots.map(\.paneSlotID))
         let focusedPaneSlotID =
             shellState.focusedPaneID.flatMap { validPaneSlotIDs.contains($0) ? $0 : nil }
@@ -1093,9 +1133,105 @@ extension ShellContentStateSnapshot {
         paneSlot(paneSlotID: paneSlotID).flatMap { content(contentID: $0.contentID) }
     }
 
+    func primaryContent(in tabID: String) -> ShellContentInstance? {
+        guard let tab = tab(tabID: tabID) else { return nil }
+        return tab.paneTree.paneSlotIDs.lazy.compactMap { contentMounted(in: $0) }.first
+    }
+
     func userFacingTitle(for tab: ShellContentTab) -> String? {
         tab.title
             ?? tab.paneTree.paneSlotIDs.lazy.compactMap { contentMounted(in: $0)?.title }.first
+    }
+
+    func materializingShellState() -> ShellStateSnapshot? {
+        guard contractVersion == Self.currentContractVersion else { return nil }
+
+        let paneSlotsByID = paneSlots.reduce(into: [String: ShellPaneSlot]()) { slotsByID, slot in
+            slotsByID[slot.paneSlotID] = slot
+        }
+        let contentsByID = contents.reduce(into: [String: ShellContentInstance]()) { contentsByID, content in
+            contentsByID[content.contentID] = content
+        }
+        var materializedPanes: [ShellPane] = []
+        var materializedPaneSlots: [ShellPaneSlot] = []
+        var materializedContents: [ShellContentInstance] = []
+
+        let materializedSpaces = spaces.map { space -> ShellSpace in
+            let tabs = space.tabs.compactMap { tab -> ShellTab? in
+                let paneSlotIDs = tab.paneTree.paneSlotIDs
+                guard !paneSlotIDs.isEmpty else { return nil }
+
+                var tabPaneSlots: [ShellPaneSlot] = []
+                var tabContents: [ShellContentInstance] = []
+                for paneSlotID in paneSlotIDs {
+                    guard let paneSlot = paneSlotsByID[paneSlotID],
+                          let content = contentsByID[paneSlot.contentID]
+                    else {
+                        return nil
+                    }
+                    tabPaneSlots.append(paneSlot)
+                    tabContents.append(content)
+                }
+
+                materializedPanes.append(
+                    contentsOf: zip(tabPaneSlots, tabContents).map {
+                        ShellPane.restoringContent($1, mountedIn: $0)
+                    }
+                )
+                materializedPaneSlots.append(contentsOf: tabPaneSlots)
+                materializedContents.append(contentsOf: tabContents)
+
+                return ShellTab(
+                    tabID: tab.tabID,
+                    kind: tab.kind,
+                    title: tab.title,
+                    paneTree: tab.paneTree.restoringPaneTree(),
+                    isPinned: tab.isPinned
+                )
+            }
+
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: Self.strongestAttention(
+                    in: materializedPaneSlots.filter { $0.spaceID == space.spaceID }
+                ),
+                tabs: tabs
+            )
+        }
+
+        guard !materializedPanes.isEmpty else { return nil }
+
+        let focusableSpaces = materializedSpaces.filter { !$0.tabs.isEmpty }
+        let validSpaceIDs = Set(focusableSpaces.map(\.spaceID))
+        let resolvedFocusedSpaceID = focusedSpaceID.flatMap {
+            validSpaceIDs.contains($0) ? $0 : nil
+        } ?? focusableSpaces.first?.spaceID
+        let focusedSpace = resolvedFocusedSpaceID.flatMap { spaceID in
+            materializedSpaces.first { $0.spaceID == spaceID }
+        }
+        let resolvedFocusedTabID = focusedTabID.flatMap { tabID in
+            focusedSpace?.tabs.contains { $0.tabID == tabID } == true ? tabID : nil
+        } ?? focusedSpace?.tabs.first?.tabID
+        let focusedTab = resolvedFocusedTabID.flatMap { tabID in
+            focusedSpace?.tabs.first { $0.tabID == tabID }
+        }
+        let validPaneSlotIDs = Set(materializedPaneSlots.map(\.paneSlotID))
+        let resolvedFocusedPaneID = focusedPaneSlotID.flatMap {
+            validPaneSlotIDs.contains($0) ? $0 : nil
+        } ?? focusedTab?.paneTree.paneIDs.first ?? materializedPanes.first?.paneID
+
+        return ShellStateSnapshot(
+            contractVersion: Self.currentContractVersion,
+            windowID: windowID,
+            focusedSpaceID: resolvedFocusedSpaceID,
+            focusedTabID: resolvedFocusedTabID,
+            focusedPaneID: resolvedFocusedPaneID,
+            spaces: materializedSpaces,
+            panes: materializedPanes,
+            paneSlots: materializedPaneSlots,
+            contents: materializedContents
+        )
     }
 
     private static func strongestAttention(in paneSlots: [ShellPaneSlot]) -> ShellAttentionState {
@@ -1119,6 +1255,43 @@ extension ShellContentStateSnapshot {
     }
 }
 
+private extension ShellPane {
+    static func restoringContent(
+        _ content: ShellContentInstance,
+        mountedIn paneSlot: ShellPaneSlot
+    ) -> ShellPane {
+        let terminalPayload = content.payload.terminal
+        return ShellPane(
+            paneID: paneSlot.paneSlotID,
+            tabID: paneSlot.tabID,
+            spaceID: paneSlot.spaceID,
+            launchTarget: terminalPayload?.launchTarget,
+            cwd: terminalPayload?.cwd,
+            process: nil,
+            attention: paneSlot.attention,
+            context: nil,
+            viewport: ShellViewportSnapshot(
+                title: content.title,
+                summary: restoredSummary(for: content.kind),
+                visibleExcerpt: nil,
+                lastActivityAt: nil
+            ),
+            alanBinding: nil
+        )
+    }
+
+    static func restoredSummary(for kind: ShellContentKind) -> String? {
+        switch kind {
+        case .terminal:
+            return nil
+        case .markdown:
+            return "markdown viewer ready"
+        case .settings:
+            return "settings surface ready"
+        }
+    }
+}
+
 extension ShellPaneSlot {
     static func projectingTerminalPane(_ pane: ShellPane) -> ShellPaneSlot {
         ShellPaneSlot(
@@ -1133,9 +1306,13 @@ extension ShellPaneSlot {
 
 extension ShellContentInstance {
     static func projectingTerminalPane(_ pane: ShellPane) -> ShellContentInstance {
+        projectingTerminalPane(pane, contentID: terminalContentID(forPaneID: pane.paneID))
+    }
+
+    static func projectingTerminalPane(_ pane: ShellPane, contentID: String) -> ShellContentInstance {
         let title = terminalTitle(for: pane)
         return ShellContentInstance(
-            contentID: terminalContentID(forPaneID: pane.paneID),
+            contentID: contentID,
             kind: .terminal,
             title: title,
             payload: .terminal(
@@ -1151,6 +1328,10 @@ extension ShellContentInstance {
 
     static func terminalContentID(forPaneID paneID: String) -> String {
         "content_\(paneID)"
+    }
+
+    static func markdownContentID(forPaneSlotID paneSlotID: String) -> String {
+        "content_markdown_\(paneSlotID)"
     }
 
     private static func terminalTitle(for pane: ShellPane) -> String {

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -308,6 +308,7 @@ extension ShellStateSnapshot {
         let focusedPane = focusedPaneID.flatMap { paneID in
             remainingPanes.first { $0.paneID == paneID }
         }
+        let retained = retainedContentRecords(in: remainingSpaces)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -316,6 +317,8 @@ extension ShellStateSnapshot {
             focusedPaneID: focusedPaneID,
             spaces: rebuildingAttention(in: remainingSpaces, panes: remainingPanes),
             panes: remainingPanes,
+            paneSlots: retained.paneSlots,
+            contents: retained.contents,
             quickTerminal: quickTerminal
         )
 
@@ -427,6 +430,97 @@ extension ShellStateSnapshot {
         )
     }
 
+    func openingMarkdownTab(
+        fileURL: URL,
+        in requestedSpaceID: String?,
+        title: String?,
+        reservedPaneIDs: Set<String> = [],
+        now: Date = .now
+    ) throws -> ShellStateMutationResult {
+        let targetSpaceID = requestedSpaceID ?? focusedSpaceID ?? spaces.first?.spaceID
+        guard let targetSpaceID,
+              space(spaceID: targetSpaceID) != nil
+        else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+
+        let tabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
+        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
+        let contentID = ShellContentInstance.markdownContentID(forPaneSlotID: paneID)
+        let resolvedURL = fileURL.isFileURL ? fileURL.standardizedFileURL : fileURL
+        let resolvedTitle = Self.markdownTitle(for: resolvedURL, explicitTitle: title)
+        let pane = makeContentPlaceholderPane(
+            paneID: paneID,
+            tabID: tabID,
+            spaceID: targetSpaceID,
+            title: resolvedTitle,
+            summary: "markdown viewer ready",
+            now: now
+        )
+        let tab = ShellTab(
+            tabID: tabID,
+            kind: .terminal,
+            title: resolvedTitle,
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            )
+        )
+        let paneSlot = ShellPaneSlot(
+            paneSlotID: paneID,
+            tabID: tabID,
+            spaceID: targetSpaceID,
+            contentID: contentID,
+            attention: .active
+        )
+        let content = ShellContentInstance(
+            contentID: contentID,
+            kind: .markdown,
+            title: resolvedTitle,
+            payload: .markdown(
+                ShellMarkdownContentPayload(
+                    fileURL: resolvedURL.absoluteString,
+                    title: resolvedTitle
+                )
+            ),
+            rendererState: ShellContentRendererState(phase: "ready", detail: resolvedURL.path)
+        )
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == targetSpaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs + [tab]
+            )
+        }
+        let nextPanes = panes + [pane]
+        let retained = retainedContentRecords(in: nextSpaces)
+        let nextPaneSlots = (retained.paneSlots ?? []) + [paneSlot]
+        let nextContents = (retained.contents ?? []) + [content]
+
+        return ShellStateMutationResult(
+            state: ShellStateSnapshot(
+                contractVersion: ShellContentStateSnapshot.currentContractVersion,
+                windowID: windowID,
+                focusedSpaceID: targetSpaceID,
+                focusedTabID: tabID,
+                focusedPaneID: paneID,
+                spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
+                panes: nextPanes,
+                paneSlots: nextPaneSlots,
+                contents: nextContents,
+                quickTerminal: quickTerminal
+            ),
+            spaceID: targetSpaceID,
+            tabID: tabID,
+            paneID: paneID
+        )
+    }
+
     func showingQuickTerminal(
         workingDirectory: String?,
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
@@ -455,6 +549,7 @@ extension ShellStateSnapshot {
             presentation: .visible,
             lastWorkingDirectory: resolvedWorkingDirectory
         )
+        let retained = retainedContentRecords(in: spaces)
 
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
@@ -465,6 +560,8 @@ extension ShellStateSnapshot {
                 focusedPaneID: focusedPaneID,
                 spaces: spaces,
                 panes: nextPanes,
+                paneSlots: retained.paneSlots,
+                contents: retained.contents,
                 quickTerminal: nextQuickTerminal
             ),
             spaceID: focusedSpaceID,
@@ -480,6 +577,7 @@ extension ShellStateSnapshot {
             throw ShellStateMutationError.paneNotFound
         }
 
+        let retained = retainedContentRecords(in: spaces)
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
                 contractVersion: contractVersion,
@@ -489,6 +587,8 @@ extension ShellStateSnapshot {
                 focusedPaneID: focusedPaneID,
                 spaces: spaces,
                 panes: panes,
+                paneSlots: retained.paneSlots,
+                contents: retained.contents,
                 quickTerminal: ShellQuickTerminalSlot(
                     paneID: quickTerminal.paneID,
                     presentation: .hidden,
@@ -512,6 +612,7 @@ extension ShellStateSnapshot {
             focusedPaneID == quickTerminal.paneID
             ? nextPanes.first(where: { !$0.isQuickTerminalPane })?.paneID
             : focusedPaneID
+        let retained = retainedContentRecords(in: spaces)
 
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
@@ -522,6 +623,8 @@ extension ShellStateSnapshot {
                 focusedPaneID: nextFocusedPaneID,
                 spaces: spaces,
                 panes: nextPanes,
+                paneSlots: retained.paneSlots,
+                contents: retained.contents,
                 quickTerminal: nil
             ),
             spaceID: focusedSpaceID,
@@ -590,6 +693,7 @@ extension ShellStateSnapshot {
             )
         }
 
+        let retained = retainedContentRecords(in: nextSpaces)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -598,6 +702,8 @@ extension ShellStateSnapshot {
             focusedPaneID: quickPane.paneID,
             spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
             panes: nextPanes,
+            paneSlots: retained.paneSlots,
+            contents: retained.contents,
             quickTerminal: nil
         )
 
@@ -1348,6 +1454,7 @@ extension ShellStateSnapshot {
         }
         let focusedSpaceID = focusedPane?.spaceID ?? targetSpaceAfterClose?.spaceID ?? nextSpaces.first?.spaceID
         let focusedTabID = focusedPane?.tabID
+        let retained = retainedContentRecords(in: nextSpaces)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -1356,6 +1463,8 @@ extension ShellStateSnapshot {
             focusedPaneID: preferredPaneID,
             spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
             panes: nextPanes,
+            paneSlots: retained.paneSlots,
+            contents: retained.contents,
             quickTerminal: quickTerminal
         )
 
@@ -1379,6 +1488,7 @@ extension ShellStateSnapshot {
         let focusedPane = resolvedFocusedPaneID.flatMap { candidate in
             panes.first(where: { $0.paneID == candidate })
         }
+        let retained = retainedContentRecords(in: spaces)
 
         return ShellStateSnapshot(
             contractVersion: contractVersion,
@@ -1388,7 +1498,24 @@ extension ShellStateSnapshot {
             focusedPaneID: resolvedFocusedPaneID,
             spaces: spaces,
             panes: panes,
+            paneSlots: retained.paneSlots,
+            contents: retained.contents,
             quickTerminal: quickTerminal
+        )
+    }
+
+    private func retainedContentRecords(in spaces: [ShellSpace]) -> (
+        paneSlots: [ShellPaneSlot]?,
+        contents: [ShellContentInstance]?
+    ) {
+        let activePaneSlotIDs = Set(spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
+        let retainedPaneSlots = (paneSlots ?? []).filter { activePaneSlotIDs.contains($0.paneSlotID) }
+        let retainedContentIDs = Set(retainedPaneSlots.map(\.contentID))
+        let retainedContents = (contents ?? []).filter { retainedContentIDs.contains($0.contentID) }
+
+        return (
+            paneSlots: retainedPaneSlots.isEmpty ? nil : retainedPaneSlots,
+            contents: retainedContents.isEmpty ? nil : retainedContents
         )
     }
 
@@ -1466,6 +1593,34 @@ extension ShellStateSnapshot {
         )
     }
 
+    private func makeContentPlaceholderPane(
+        paneID: String,
+        tabID: String,
+        spaceID: String,
+        title: String,
+        summary: String,
+        now: Date
+    ) -> ShellPane {
+        let formatter = ISO8601DateFormatter()
+        return ShellPane(
+            paneID: paneID,
+            tabID: tabID,
+            spaceID: spaceID,
+            launchTarget: nil,
+            cwd: nil,
+            process: nil,
+            attention: .active,
+            context: nil,
+            viewport: ShellViewportSnapshot(
+                title: title,
+                summary: summary,
+                visibleExcerpt: nil,
+                lastActivityAt: formatter.string(from: now)
+            ),
+            alanBinding: nil
+        )
+    }
+
     private static func defaultProcessBinding(for launchTarget: ShellLaunchTarget) -> ShellProcessBinding {
         switch launchTarget {
         case .shell:
@@ -1488,6 +1643,17 @@ extension ShellStateSnapshot {
         case .alan:
             return "alan"
         }
+    }
+
+    private static func markdownTitle(for fileURL: URL, explicitTitle: String?) -> String {
+        if let title = explicitTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty
+        {
+            return title
+        }
+
+        let lastPathComponent = fileURL.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+        return lastPathComponent.isEmpty ? "Markdown" : lastPathComponent
     }
 
     private static func defaultShellPath(

--- a/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellContentRenderingRegistry.swift
@@ -15,6 +15,7 @@ struct ShellContentRenderDescriptor: Equatable {
     let title: String
     let iconName: String
     let capabilities: [ShellContentCapability]
+    let payload: ShellContentPayload?
     let rendererPhase: String
     let detail: String?
 
@@ -44,6 +45,7 @@ enum ShellContentRenderingRegistry {
                 title: "Unavailable",
                 iconName: "exclamationmark.triangle",
                 capabilities: [],
+                payload: nil,
                 rendererPhase: "missing_content",
                 detail: "No content is mounted in this pane."
             )
@@ -56,6 +58,7 @@ enum ShellContentRenderingRegistry {
             title: content.title,
             iconName: iconName(for: content),
             capabilities: content.capabilities,
+            payload: content.payload,
             rendererPhase: content.rendererState.phase,
             detail: content.rendererState.detail
         )

--- a/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
@@ -98,8 +98,20 @@ struct ShellStatePersistenceStore {
     ) -> ShellStateSnapshot? {
         let restoreURL = readablePersistenceURL(fileManager: fileManager, canonicalURL: persistenceURL)
         guard let restoreURL,
-              let data = try? Data(contentsOf: restoreURL),
-              let state = try? JSONDecoder().decode(ShellStateSnapshot.self, from: data),
+              let data = try? Data(contentsOf: restoreURL)
+        else {
+            return nil
+        }
+
+        if let contentState = try? JSONDecoder().decode(ShellContentStateSnapshot.self, from: data),
+           let state = contentState.materializingShellState(),
+           !state.spaces.isEmpty,
+           !state.panes.isEmpty
+        {
+            return state
+        }
+
+        guard let state = try? JSONDecoder().decode(ShellStateSnapshot.self, from: data),
               !state.spaces.isEmpty,
               !state.panes.isEmpty
         else {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -688,6 +688,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 focusedPaneID: nil,
                 spaces: shellState.spaces,
                 panes: shellState.panes,
+                paneSlots: shellState.paneSlots,
+                contents: shellState.contents,
                 quickTerminal: shellState.quickTerminal
             )
             synchronizeSelection()
@@ -1068,6 +1070,27 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             title: title,
             workingDirectory: workingDirectory
         )
+    }
+
+    @discardableResult
+    func openMarkdownTab(
+        fileURL: URL,
+        in spaceID: String? = nil,
+        title: String? = nil
+    ) -> String? {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.openingMarkdownTab(
+                fileURL: fileURL,
+                in: spaceID,
+                title: title,
+                reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
+            )
+        } catch {
+            return nil
+        }
+        applyMutationResult(result)
+        return result.tabID
     }
 
     @discardableResult
@@ -1693,6 +1716,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedPaneID: shellState.focusedPaneID,
             spaces: updatedSpaces,
             panes: updatedPanes,
+            paneSlots: shellState.paneSlots,
+            contents: shellState.contents,
             quickTerminal: shellState.quickTerminal
         )
         synchronizeSelection()
@@ -1864,6 +1889,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedPaneID: resolvedFocusedPaneID,
             spaces: spaces,
             panes: panes,
+            paneSlots: shellState.paneSlots,
+            contents: shellState.contents,
             quickTerminal: shellState.quickTerminal
         )
         synchronizeSelection()
@@ -1890,7 +1917,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             registry: terminalRuntimeRegistry
         )
 
+        let contentState = state.contentStateProjection()
         let hydratedPanes = state.panes.map { pane in
+            guard contentState.contentMounted(in: pane.paneID)?.kind == .terminal else {
+                return pane
+            }
             guard paneProjection.needsBootContextProjection(pane) else { return pane }
             let bootProfile = AlanShellBootProfile.forPane(pane, shellState: state)
             let projectedContext = paneProjection.projectedContext(
@@ -1936,6 +1967,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             focusedPaneID: state.focusedPaneID,
             spaces: hydratedSpaces,
             panes: hydratedPanes,
+            paneSlots: state.paneSlots,
+            contents: state.contents,
             quickTerminal: state.quickTerminal
         )
         reconcilePaneZoomState()

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 #if os(macOS)
@@ -953,31 +954,42 @@ private struct ShellBoundedContentLeafView: View {
                 onClosePane: onClosePane
             )
 
-            ZStack {
-                ShellPalette.workspace
-
-                VStack(spacing: 10) {
-                    Image(systemName: descriptor.iconName)
-                        .font(.system(size: 22, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                        .frame(width: 32, height: 32)
-
-                    Text(descriptor.title)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(ShellPalette.ink)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: 260)
-
-                    Text(contentKindLabel)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .contentShape(Rectangle())
-                .onTapGesture(perform: onFocusPane)
+            switch descriptor.renderKind {
+            case .markdown:
+                ShellMarkdownContentView(descriptor: descriptor)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: onFocusPane)
+            case .terminal, .settings, .unavailable:
+                boundedPlaceholder
             }
+        }
+    }
+
+    private var boundedPlaceholder: some View {
+        ZStack {
+            ShellPalette.workspace
+
+            VStack(spacing: 10) {
+                Image(systemName: descriptor.iconName)
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                    .frame(width: 32, height: 32)
+
+                Text(descriptor.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(ShellPalette.ink)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 260)
+
+                Text(contentKindLabel)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(ShellPalette.mutedInk)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: onFocusPane)
         }
     }
 
@@ -992,6 +1004,65 @@ private struct ShellBoundedContentLeafView: View {
         case .unavailable:
             return "Unavailable"
         }
+    }
+}
+
+private struct ShellMarkdownContentView: View {
+    let descriptor: ShellContentRenderDescriptor
+    @State private var renderedContent = AttributedString("")
+    @State private var loadError: String?
+
+    var body: some View {
+        ZStack {
+            ShellPalette.workspace
+
+            ScrollView {
+                if let loadError {
+                    VStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 20, weight: .medium))
+                            .foregroundStyle(ShellPalette.mutedInk)
+                        Text(loadError)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(ShellPalette.ink)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 180)
+                    .padding(24)
+                } else {
+                    Text(renderedContent)
+                        .font(.system(size: 13))
+                        .foregroundStyle(ShellPalette.ink)
+                        .lineSpacing(3)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 20)
+                }
+            }
+        }
+        .onAppear(perform: loadMarkdown)
+    }
+
+    private func loadMarkdown() {
+        guard let fileURL else {
+            renderedContent = AttributedString("")
+            loadError = "Unable to open this document."
+            return
+        }
+
+        do {
+            let markdown = try String(contentsOf: fileURL, encoding: .utf8)
+            renderedContent = (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+            loadError = nil
+        } catch {
+            renderedContent = AttributedString("")
+            loadError = "Unable to read this document."
+        }
+    }
+
+    private var fileURL: URL? {
+        guard let fileURLString = descriptor.payload?.markdown?.fileURL else { return nil }
+        return URL(string: fileURLString) ?? URL(fileURLWithPath: fileURLString)
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1011,13 +1011,19 @@ private struct ShellMarkdownContentView: View {
     let descriptor: ShellContentRenderDescriptor
     @State private var renderedContent = AttributedString("")
     @State private var loadError: String?
+    @State private var isLoading = false
 
     var body: some View {
         ZStack {
             ShellPalette.workspace
 
             ScrollView {
-                if let loadError {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(maxWidth: .infinity, minHeight: 180)
+                        .padding(24)
+                } else if let loadError {
                     VStack(spacing: 8) {
                         Image(systemName: "exclamationmark.triangle")
                             .font(.system(size: 20, weight: .medium))
@@ -1040,30 +1046,79 @@ private struct ShellMarkdownContentView: View {
                 }
             }
         }
-        .onAppear(perform: loadMarkdown)
+        .task(id: markdownSource) {
+            await loadMarkdown()
+        }
     }
 
-    private func loadMarkdown() {
+    @MainActor
+    private func loadMarkdown() async {
         guard let fileURL else {
             renderedContent = AttributedString("")
             loadError = "Unable to open this document."
+            isLoading = false
             return
         }
 
-        do {
-            let markdown = try String(contentsOf: fileURL, encoding: .utf8)
-            renderedContent = (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+        isLoading = true
+        loadError = nil
+        renderedContent = AttributedString("")
+
+        let result = await Task.detached(priority: .userInitiated) {
+            ShellMarkdownContentLoader.load(fileURL: fileURL)
+        }.value
+        guard !Task.isCancelled else { return }
+
+        isLoading = false
+        switch result {
+        case .success(let content):
+            renderedContent = content
             loadError = nil
-        } catch {
+        case .failure:
             renderedContent = AttributedString("")
             loadError = "Unable to read this document."
         }
     }
 
-    private var fileURL: URL? {
-        guard let fileURLString = descriptor.payload?.markdown?.fileURL else { return nil }
-        return URL(string: fileURLString) ?? URL(fileURLWithPath: fileURLString)
+    private var markdownSource: String {
+        descriptor.payload?.markdown?.fileURL ?? ""
     }
+
+    private var fileURL: URL? {
+        ShellMarkdownContentLoader.fileURL(from: descriptor.payload?.markdown?.fileURL)
+    }
+}
+
+private enum ShellMarkdownContentLoader {
+    static func fileURL(from rawValue: String?) -> URL? {
+        guard let rawValue else { return nil }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        if let url = URL(string: value),
+           url.scheme != nil
+        {
+            return url.isFileURL ? url.standardizedFileURL : url
+        }
+
+        return URL(fileURLWithPath: NSString(string: value).expandingTildeInPath)
+            .standardizedFileURL
+    }
+
+    static func load(fileURL: URL) -> ShellMarkdownContentLoadResult {
+        do {
+            let markdown = try String(contentsOf: fileURL, encoding: .utf8)
+            let content = (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+            return .success(content)
+        } catch {
+            return .failure
+        }
+    }
+}
+
+private enum ShellMarkdownContentLoadResult {
+    case success(AttributedString)
+    case failure
 }
 
 private struct ShellContentPaneTitleBarView: View {

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -759,6 +759,12 @@ struct ShellSidebarView: View {
     }
 
     private func tabTitle(for tab: ShellTab) -> String {
+        if let content = host.shellState.contentStateProjection().primaryContent(in: tab.tabID),
+           content.kind != .terminal
+        {
+            return content.title
+        }
+
         let panes = host.shellState.panes.filter { $0.tabID == tab.tabID }
         let primaryPane = panes.first
         return shellDisplayTitle(
@@ -772,6 +778,12 @@ struct ShellSidebarView: View {
     }
 
     private func tabSubtitle(for tab: ShellTab) -> String {
+        if let content = host.shellState.contentStateProjection().primaryContent(in: tab.tabID),
+           content.kind == .markdown
+        {
+            return "Document"
+        }
+
         let panes = host.shellState.panes.filter { $0.tabID == tab.tabID }
         let primaryPane = panes.first
         let title = tabTitle(for: tab)

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -103,6 +103,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout()
         verifiesContentStateProjectionSeparatesPaneSlotsAndContent()
         verifiesContentRenderingRegistryRoutesSupportedKinds()
+        verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
@@ -3744,6 +3745,78 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Alan-\(UUID().uuidString).md")
+        let markdown = "# Notes\n\nRead-only content."
+        do {
+            try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            fail("markdown open setup must create a file: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let controller = makeController()
+        guard let tabID = controller.openMarkdownTab(fileURL: fileURL) else {
+            fail("opening markdown must create a shell tab")
+        }
+
+        let projection = controller.shellState.contentStateProjection()
+        guard let content = projection.focusedContent else {
+            fail("markdown tab must focus a content descriptor")
+        }
+        let descriptor = ShellContentRenderingRegistry.descriptor(for: content)
+        let expectedURL = fileURL.standardizedFileURL.absoluteString
+
+        expect(controller.shellState.focusedTabID == tabID, "markdown open must focus the new tab")
+        expect(content.kind == .markdown, "markdown open must create markdown content")
+        expect(content.title == fileURL.lastPathComponent, "markdown title must come from file name")
+        expect(
+            content.payload.markdown?.fileURL == expectedURL,
+            "markdown descriptor must persist the backing file URL"
+        )
+        expect(
+            content.capabilities == [.markdownReadOnlyViewer],
+            "markdown descriptor must expose only read-only viewer capability"
+        )
+        expect(
+            !content.capabilities.contains(.terminalInput),
+            "markdown descriptor must not expose terminal input"
+        )
+        expect(descriptor.renderKind == .markdown, "markdown descriptor must route to markdown renderer")
+        expect(
+            descriptor.payload?.markdown?.fileURL == expectedURL,
+            "render descriptor must carry the markdown file payload"
+        )
+        expect(
+            controller.selectedPane?.launchTarget == nil && controller.selectedPane?.process == nil,
+            "markdown pane must not describe a terminal process"
+        )
+        expect(
+            controller.selectedPane.map {
+                !controller.terminalRuntimeRegistry.registeredPaneIDs.contains($0.paneID)
+            } == true,
+            "markdown open must not create a terminal runtime"
+        )
+
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("markdown-content-\(UUID().uuidString).json")
+        let store = ShellStatePersistenceStore(persistenceURL: persistenceURL)
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+        store.save(controller.shellState)
+
+        let restored = ShellStatePersistenceStore.restoreShellState(
+            fileManager: .default,
+            persistenceURL: persistenceURL
+        )
+        let restoredContent = restored?.contentStateProjection().focusedContent
+        expect(restoredContent?.kind == .markdown, "persisted markdown state must restore markdown kind")
+        expect(
+            restoredContent?.payload.markdown?.fileURL == expectedURL,
+            "persisted markdown state must restore markdown file URL"
+        )
+    }
+
     private static func verifiesShellStatePersistenceWritesContentStateShape() {
         let windowID = "content_state_persist_\(UUID().uuidString)"
         let persistenceURL = FileManager.default.temporaryDirectory
@@ -3773,12 +3846,61 @@ private enum ShellRuntimeMetadataTests {
             "content-state persistence must use content-container keys"
         )
         expect(!text.contains("\"panes\""), "content-state persistence must not write v0.1 panes")
+        let restored = ShellStatePersistenceStore.restoreShellState(
+            fileManager: .default,
+            persistenceURL: persistenceURL
+        )
+        guard let restored else {
+            fail("content-state restore must materialize shell state")
+        }
+        expect(restored.contractVersion == "0.2", "content-state restore must materialize v0.2 shell state")
+        expect(restored.paneSlots?.count == 2, "content-state restore must preserve PaneSlots")
+        expect(restored.contents?.count == 2, "content-state restore must preserve ContentInstances")
         expect(
-            ShellStatePersistenceStore.restoreShellState(
-                fileManager: .default,
-                persistenceURL: persistenceURL
-            ) == nil,
-            "v0.2 content-state snapshots must not be treated as workspace restore authority"
+            restored.contentStateProjection().contents.map(\.kind) == [.terminal, .terminal],
+            "content-state restore must preserve terminal content descriptors"
+        )
+
+        let refreshedPanes = restored.panes.map { pane -> ShellPane in
+            guard pane.paneID == "pane_1" else { return pane }
+            return ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                launchTarget: pane.launchTarget,
+                cwd: "/tmp/refreshed",
+                process: pane.process,
+                attention: pane.attention,
+                context: pane.context,
+                viewport: ShellViewportSnapshot(
+                    title: "vim README.md",
+                    summary: pane.viewport?.summary,
+                    visibleExcerpt: nil,
+                    lastActivityAt: pane.viewport?.lastActivityAt
+                ),
+                activity: pane.activity,
+                alanBinding: pane.alanBinding
+            )
+        }
+        let refreshed = ShellStateSnapshot(
+            contractVersion: restored.contractVersion,
+            windowID: restored.windowID,
+            focusedSpaceID: restored.focusedSpaceID,
+            focusedTabID: restored.focusedTabID,
+            focusedPaneID: restored.focusedPaneID,
+            spaces: restored.spaces,
+            panes: refreshedPanes,
+            paneSlots: restored.paneSlots,
+            contents: restored.contents
+        )
+        let refreshedContent = refreshed.contentStateProjection().contentMounted(in: "pane_1")
+        expect(
+            refreshedContent?.title == "vim README.md",
+            "explicit terminal descriptors must refresh from current pane metadata"
+        )
+        expect(
+            refreshedContent?.payload.terminal?.cwd == "/tmp/refreshed",
+            "explicit terminal descriptors must refresh cwd from current pane metadata"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -19,7 +19,7 @@
 ## 3. Non-Terminal Content Surfaces
 
 - [x] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
-- [ ] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
+- [x] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
 - [ ] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
 - [ ] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.
 


### PR DESCRIPTION
## Summary
- add Open Markdown menu flow and host mutation for read-only markdown content tabs
- persist markdown file descriptors through v0.2 content-state save/restore and keep terminal descriptors refreshed from runtime pane metadata
- render markdown files inside the bounded shell content area and update sidebar labels
- mark OpenSpec task 3.2 complete

## Validation
- git diff --check
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/DerivedData/MarkdownContentViewer CODE_SIGNING_ALLOWED=NO build