### PR TITLE
Add macOS Matter controller spike spec

### DIFF
--- a/openspec/changes/spike-macos-matter-controller/.openspec.yaml
+++ b/openspec/changes/spike-macos-matter-controller/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/spike-macos-matter-controller/design.md
+++ b/openspec/changes/spike-macos-matter-controller/design.md
@@ -1,0 +1,133 @@
+## Context
+
+alan currently treats tools as side-effect boundaries and keeps platform-specific
+client code out of `alan-runtime`. Smart-home control raises the stakes because
+it affects physical devices. The first step should therefore prove the platform
+controller path with a low-risk device before defining product-level `home.*`
+tools or broader governance policy.
+
+Apple exposes a public `Matter.framework` on macOS with `MTRDeviceController`.
+That makes a macOS-only spike possible without bridging Apple Home, Home
+Assistant, or a cloud smart-home service. The spike target is a directly
+Matter-capable light that can enter normal Matter pairing or multi-admin pairing
+mode and join Alan's own Matter fabric.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prove Alan for macOS can act as a local Matter controller through Apple's
+  public `Matter.framework`.
+- Commission one directly Matter-capable light from a setup payload.
+- Persist enough controller/fabric state to reuse the commissioned node after
+  app restart.
+- Read and write low-risk On/Off state and record an auditable action result.
+- Keep Matter framework integration in the Apple client/service layer, behind a
+  local service boundary that can later back typed `home.*` tools.
+
+**Non-Goals:**
+
+- Do not control Apple Home, read HomeKit rooms/scenes/automations, or depend on
+  a Mac Catalyst HomeKit helper.
+- Do not bridge Home Assistant, Aqara cloud, Aqara app APIs, or Apple Home APIs.
+- Do not support HomeKit-only devices, bridges, bridged endpoints, locks,
+  garage doors, cameras, security systems, appliances, or high-power devices.
+- Do not expose raw Matter endpoint/cluster/command control to the LLM.
+- Do not productize `home.*` tools, device naming, user-facing UI, or full
+  physical-device governance in this spike.
+
+## Decisions
+
+1. **Use Apple `Matter.framework` for the macOS spike.**
+
+   The spike should use the platform framework that is already present in the
+   macOS SDK instead of starting with upstream `connectedhomeip`, `matter.js`, or
+   a Rust implementation. This keeps the first verification close to the Alan
+   for macOS product surface and avoids introducing a sidecar runtime before the
+   core controller feasibility is known.
+
+   Alternative considered: use upstream `connectedhomeip` directly. That is the
+   most portable Matter implementation, but it adds C++ build, storage, and
+   packaging complexity before we know whether the Apple platform path is enough.
+
+2. **Keep Matter code out of `alan-runtime`.**
+
+   Matter controller setup, fabric storage, setup payload parsing, and device
+   command execution are Apple-platform concerns. The spike should place them in
+   a macOS Matter controller service under the Apple client boundary. The future
+   runtime-facing surface is a typed local RPC/tool provider, not direct linkage
+   from Rust runtime core to `Matter.framework`.
+
+   Alternative considered: add built-in Rust tools that call Apple APIs. That
+   would pollute generic runtime/tool code with macOS-only dependencies and make
+   Linux support harder.
+
+3. **Target one directly Matter-capable light.**
+
+   A light is low risk and maps cleanly to Matter On/Off behavior. Using a direct
+   Matter light also avoids bridge endpoint mapping, vendor-specific device
+   exposure, and Aqara gateway firmware variability during the first spike.
+
+   Alternative considered: commission an Aqara Matter bridge and control a
+   bridged light endpoint. That is valuable later but adds bridge-node topology
+   and supported-device-type uncertainty to the first proof.
+
+4. **Treat setup payload entry as an operator/debug surface.**
+
+   The spike can accept a setup payload from a local debug command or narrow
+   developer UI. It does not need final onboarding UX. The payload source may be
+   the physical light's setup code or a multi-admin pairing code from an existing
+   ecosystem, but Alan must treat the resulting commissioned node as part of
+   Alan's own fabric.
+
+   Alternative considered: design full pairing UI now. That would prematurely
+   couple the spike to product UX before controller feasibility and persistence
+   are proven.
+
+5. **Record physical action evidence even in the spike.**
+
+   Every write action should produce a structured result that includes target,
+   requested action, execution status, timestamp, and error details when
+   available. This is not the final governance/audit contract, but it ensures the
+   later `home.*` tools can build on an evidence-producing service.
+
+   Alternative considered: rely on logs only. Logs are useful for debugging but
+   not enough for future agent-visible tool results or owner decisions.
+
+## Risks / Trade-offs
+
+- **Matter commissioning can fail due to network, Thread border router, setup
+  code, or device state issues.** -> Keep the target to one direct Matter light
+  and require manual verification notes with exact failure modes.
+- **Apple framework storage behavior may require additional delegate work.** ->
+  Make controller/fabric persistence an explicit spike requirement and test app
+  restart before declaring success.
+- **Physical writes can surprise users even when low risk.** -> Limit writes to
+  On/Off on a light and record each action result.
+- **A successful direct-light spike may not prove bridge support.** -> Treat
+  bridge and bridged endpoint support as a follow-up product/spike scope.
+- **Temporary debug entry points can become accidental product API.** -> Mark
+  any setup payload entry or debug command as spike-only unless the later
+  `add-home-control-tools` change adopts it.
+
+## Migration Plan
+
+1. Add a macOS Matter controller service prototype behind an internal boundary.
+2. Add setup payload intake for a direct Matter light through a spike/debug path.
+3. Create or load the Matter controller and commission the light into Alan's
+   fabric.
+4. Persist controller/fabric state and verify restart reuse.
+5. Add read/list/set OnOff operations and structured result records.
+6. Add fake-service tests for the service boundary and manual verification notes
+   for the real light path.
+7. After the spike, decide whether to proceed to `add-home-control-tools`.
+
+## Open Questions
+
+- Which local storage backend should the product path use for Matter controller
+  credentials: framework-managed storage, Application Support with restricted
+  permissions, Keychain-backed material, or a combination?
+- Should the first productized service be in-process in Alan.app or split into a
+  signed XPC helper?
+- Which additional low-risk clusters, if any, should enter the next product
+  change after On/Off succeeds?

--- a/openspec/changes/spike-macos-matter-controller/proposal.md
+++ b/openspec/changes/spike-macos-matter-controller/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+alan needs evidence before productizing physical-device control. The first
+question is whether Alan for macOS can safely act as a local Matter controller
+using Apple's public `Matter.framework`, commission a low-risk Matter light, and
+perform basic state read/write operations without coupling the generic runtime
+to Apple-specific APIs.
+
+## What Changes
+
+- Add a macOS-only Matter controller spike that uses Apple `Matter.framework`
+  from the Apple client/service layer.
+- Prove Alan can create or load a local Matter controller, commission a directly
+  paired Matter light from a setup payload, persist controller/fabric state, list
+  the commissioned node, read On/Off state, and set On/Off state.
+- Keep Matter APIs out of `alan-runtime`; the runtime-facing boundary remains a
+  future typed `home.*` tool/RPC surface.
+- Capture physical-device action evidence and safety constraints for the later
+  `add-home-control-tools` product change.
+- Exclude Apple Home control, HomeKit-only devices, Home Assistant bridges,
+  Aqara bridge endpoints, raw LLM-visible Matter cluster control, and high-risk
+  device categories from this spike.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-matter-controller-spike`: Defines the macOS-only Matter controller
+  spike contract, including setup-payload commissioning, controller state
+  persistence, low-risk light control, RPC boundary expectations, and manual
+  verification evidence.
+
+### Modified Capabilities
+
+- None. The spike records constraints for future governance/tooling work but
+  does not yet change stable `home.*` tools, policy semantics, or daemon APIs.
+
+## Impact
+
+- Affected Apple client areas: new macOS Matter controller service prototype,
+  controller state storage, Matter setup-payload handling, commissioned device
+  registry projection, and low-risk light command execution.
+- Affected runtime/daemon areas: no runtime-core coupling in this spike; any
+  temporary invocation path must stay behind a local service/RPC boundary that
+  can later become the typed `home.*` tool provider.
+- Affected dependencies: Apple public `Matter.framework` on macOS.
+- Affected verification: focused unit/fake-service tests where possible plus
+  manual verification against a real directly Matter-capable light.

--- a/openspec/changes/spike-macos-matter-controller/specs/macos-matter-controller-spike/spec.md
+++ b/openspec/changes/spike-macos-matter-controller/specs/macos-matter-controller-spike/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: macOS Matter controller spike is platform-scoped
+Alan for macOS SHALL isolate Apple `Matter.framework` integration inside the
+Apple client/service layer and MUST NOT require `alan-runtime` to link against
+or model Apple Matter types.
+
+#### Scenario: Runtime invokes future home capability
+- **WHEN** Matter controller behavior is exposed beyond the Apple service layer
+- **THEN** the boundary is expressed as typed local service/RPC behavior suitable
+  for future `home.*` tools
+- **AND** `alan-runtime` remains platform-agnostic
+
+#### Scenario: Linux or non-Apple runtime builds are evaluated
+- **WHEN** non-macOS runtime crates are built or tested
+- **THEN** they do not require Apple `Matter.framework`, `MTRDeviceController`,
+  or Apple Matter storage types
+
+### Requirement: Spike commissions one direct Matter light
+The macOS Matter controller spike SHALL support commissioning one directly
+Matter-capable light into Alan's own Matter fabric from a setup payload.
+
+#### Scenario: Setup payload is provided
+- **WHEN** the operator provides a valid setup payload for a direct Matter light
+  in pairing or multi-admin pairing mode
+- **THEN** Alan creates or loads a local Matter controller
+- **AND** Alan attempts to commission the light into Alan's own fabric
+- **AND** the result records success or the concrete commissioning failure
+
+#### Scenario: Payload targets unsupported scope
+- **WHEN** the setup payload is for a HomeKit-only device, bridge-only topology,
+  bridged endpoint, or unsupported high-risk device type
+- **THEN** the spike does not claim support for that target
+- **AND** the result reports an unsupported target or verification blocker
+
+### Requirement: Controller state survives app restart
+The macOS Matter controller spike SHALL persist the controller state needed to
+reuse a commissioned direct Matter light after Alan for macOS restarts.
+
+#### Scenario: App restarts after commissioning
+- **WHEN** the light was successfully commissioned and Alan for macOS restarts
+- **THEN** Alan reloads the local Matter controller state
+- **AND** the commissioned light remains listable without repeating
+  commissioning
+
+#### Scenario: Persisted state is unavailable
+- **WHEN** controller or fabric state cannot be loaded
+- **THEN** Alan reports the controller as unavailable or uninitialized
+- **AND** Alan does not pretend that previously commissioned devices are ready
+
+### Requirement: Spike lists and reads the commissioned light
+The macOS Matter controller spike SHALL list the commissioned direct Matter light
+and read its On/Off state through the macOS Matter controller service.
+
+#### Scenario: Commissioned light is reachable
+- **WHEN** the commissioned light is online and reachable on the local Matter
+  fabric
+- **THEN** Alan lists the light as a commissioned node
+- **AND** Alan can read its On/Off state with a structured result
+
+#### Scenario: Commissioned light is unreachable
+- **WHEN** the commissioned light is offline or unreachable
+- **THEN** Alan returns a structured unavailable result
+- **AND** Alan does not report stale state as confirmed current state
+
+### Requirement: Spike performs low-risk light OnOff writes
+The macOS Matter controller spike SHALL support setting the commissioned direct
+Matter light On or Off and SHALL record a structured physical-action result.
+
+#### Scenario: Turn light on
+- **WHEN** the operator requests turning the commissioned light on through the
+  spike path
+- **THEN** Alan sends the On command through the macOS Matter controller service
+- **AND** Alan records target, requested action, status, timestamp, and any error
+  detail in the action result
+
+#### Scenario: Turn light off
+- **WHEN** the operator requests turning the commissioned light off through the
+  spike path
+- **THEN** Alan sends the Off command through the macOS Matter controller service
+- **AND** Alan records target, requested action, status, timestamp, and any error
+  detail in the action result
+
+### Requirement: Spike excludes product home-control tooling
+The macOS Matter controller spike SHALL NOT define final `home.*` tool schemas,
+general physical-device governance policy, or LLM-visible raw Matter
+endpoint/cluster command access.
+
+#### Scenario: Agent-facing control is requested during the spike
+- **WHEN** a design or implementation path would expose raw Matter cluster
+  commands or broad physical-device writes to the LLM
+- **THEN** that behavior is deferred to the later home-control product change
+- **AND** the spike remains limited to service feasibility and low-risk light
+  verification
+
+#### Scenario: Product scope is evaluated after spike success
+- **WHEN** the direct Matter light spike passes commissioning, persistence,
+  list, read, and OnOff write verification
+- **THEN** productized `home.*` tools, device registry naming, governance risk
+  levels, and skill instructions are handled by a separate OpenSpec change

--- a/openspec/changes/spike-macos-matter-controller/tasks.md
+++ b/openspec/changes/spike-macos-matter-controller/tasks.md
@@ -1,0 +1,42 @@
+## 1. Spike Boundaries And Project Setup
+
+- [ ] 1.1 Confirm the macOS deployment target and Apple `Matter.framework` availability for the Alan for macOS target.
+- [ ] 1.2 Add a macOS-only Matter controller service boundary under the Apple client without importing Matter types into `alan-runtime`.
+- [ ] 1.3 Define a narrow spike/debug invocation path for setup payload intake, device list/read, and OnOff commands.
+- [ ] 1.4 Add compile-time gates so non-macOS runtime crates and non-Apple builds do not require Apple Matter APIs.
+
+## 2. Controller State And Commissioning
+
+- [ ] 2.1 Create or load a local `MTRDeviceController` through Apple `Matter.framework`.
+- [ ] 2.2 Implement spike storage for controller/fabric state with restricted local access and clear failure reporting.
+- [ ] 2.3 Accept a setup payload for one directly Matter-capable light in pairing or multi-admin pairing mode.
+- [ ] 2.4 Commission the light into Alan's own Matter fabric and record structured success or failure details.
+- [ ] 2.5 Verify app restart reloads controller state and can address the commissioned light without repeating commissioning.
+
+## 3. Light Registry And Low-Risk Operations
+
+- [ ] 3.1 Project the commissioned light into a minimal local device registry with stable node identity and human-readable debug metadata.
+- [ ] 3.2 Implement list commissioned devices for the spike path.
+- [ ] 3.3 Implement read OnOff state with a structured current-state or unavailable result.
+- [ ] 3.4 Implement set OnOff state for the commissioned light only.
+- [ ] 3.5 Record each physical write with target, requested action, status, timestamp, and error details when available.
+
+## 4. Safety Constraints
+
+- [ ] 4.1 Reject unsupported target categories such as HomeKit-only devices, bridges, bridged endpoints, locks, cameras, security systems, appliances, and high-power devices.
+- [ ] 4.2 Keep raw Matter endpoint, cluster, and command invocation out of LLM-visible surfaces.
+- [ ] 4.3 Document that final `home.*` tools, device naming, governance risk levels, and skill instructions belong to the follow-up product change.
+
+## 5. Verification
+
+- [ ] 5.1 Add fake-service or adapter tests for setup payload validation, state-load failure, list/read/write result shaping, and unsupported target rejection where practical.
+- [ ] 5.2 Run focused Apple build checks covering the Matter-gated code path.
+- [ ] 5.3 Manually commission a real directly Matter-capable light and capture verification evidence for commissioning, restart persistence, list, read OnOff, set On, and set Off.
+- [ ] 5.4 Run `openspec validate spike-macos-matter-controller --strict`.
+- [ ] 5.5 Run `openspec validate --all --strict`.
+
+## 6. Archive Readiness
+
+- [ ] 6.1 Summarize spike findings, including framework limitations, storage decision gaps, and real-device failure modes.
+- [ ] 6.2 Decide whether the follow-up product change should proceed as `add-home-control-tools`.
+- [ ] 6.3 After implementation merges, sync accepted requirements into `openspec/specs/` before archiving.


### PR DESCRIPTION
## Summary
- Adds the `spike-macos-matter-controller` OpenSpec change.
- Scopes the first Matter work to a macOS-only Apple `Matter.framework` spike for one directly Matter-capable light.
- Defers productized `home.*` tools, broader governance, Apple Home, bridges, and high-risk devices to follow-up work.

## Test Plan
- `openspec validate spike-macos-matter-controller --strict`
- `openspec validate --all --strict`
- `git diff --check origin/main...HEAD`