### PR TITLE
Open settings as shell content

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacShellCommands.swift
+++ b/clients/apple/alan-macos/App/AlanMacShellCommands.swift
@@ -49,6 +49,13 @@ struct AlanMacShellCommands: Commands {
             }
         }
 
+        CommandGroup(replacing: .appSettings) {
+            Button("Settings...") {
+                openSettingsTab()
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+
         CommandMenu("Shell") {
             Button(host.shellActionTitle(.newTerminalTab)) {
                 host.performShellAction(.newTerminalTab)
@@ -62,6 +69,10 @@ struct AlanMacShellCommands: Commands {
 
             Button("Open Markdown...") {
                 openMarkdownFile()
+            }
+
+            Button("Open Settings") {
+                openSettingsTab()
             }
 
             Button("Ask alan...") {
@@ -227,6 +238,12 @@ struct AlanMacShellCommands: Commands {
         else { return }
 
         _ = host.openMarkdownTab(fileURL: fileURL)
+    }
+
+    private func openSettingsTab() {
+        openWindow(id: "main")
+        _ = host.openSettingsTab()
+        AlanMacPrimaryWindowPresenter.focusExistingWindowSoon()
     }
 
     private var markdownContentTypes: [UTType] {

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -1334,6 +1334,9 @@ extension ShellContentInstance {
         "content_markdown_\(paneSlotID)"
     }
 
+    static let settingsSurfaceID = "settings_main"
+    static let settingsContentID = "content_settings_main"
+
     private static func terminalTitle(for pane: ShellPane) -> String {
         if let title = pane.viewport?.title?.trimmingCharacters(in: .whitespacesAndNewlines),
            !title.isEmpty

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -521,6 +521,111 @@ extension ShellStateSnapshot {
         )
     }
 
+    func openingSettingsTab(
+        in requestedSpaceID: String?,
+        title: String?,
+        reservedPaneIDs: Set<String> = [],
+        now: Date = .now
+    ) throws -> ShellStateMutationResult {
+        let resolvedTitle = Self.settingsTitle(explicitTitle: title)
+        let contentState = contentStateProjection()
+        if let existingPaneID = contentState.paneSlots.first(where: { paneSlot in
+            guard let content = contentState.content(contentID: paneSlot.contentID) else {
+                return false
+            }
+            return content.kind == .settings
+                && content.contentID == ShellContentInstance.settingsContentID
+                && content.payload.settings?.surfaceID == ShellContentInstance.settingsSurfaceID
+        })?.paneSlotID,
+           pane(paneID: existingPaneID) != nil
+        {
+            return try focusingPane(existingPaneID)
+        }
+
+        let targetSpaceID = requestedSpaceID ?? focusedSpaceID ?? spaces.first?.spaceID
+        guard let targetSpaceID,
+              space(spaceID: targetSpaceID) != nil
+        else {
+            throw ShellStateMutationError.spaceNotFound
+        }
+
+        let tabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
+        let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
+        let pane = makeContentPlaceholderPane(
+            paneID: paneID,
+            tabID: tabID,
+            spaceID: targetSpaceID,
+            title: resolvedTitle,
+            summary: "settings surface ready",
+            now: now
+        )
+        let tab = ShellTab(
+            tabID: tabID,
+            kind: .terminal,
+            title: resolvedTitle,
+            paneTree: ShellPaneTreeNode(
+                nodeID: "node_\(paneID)",
+                kind: .pane,
+                direction: nil,
+                paneID: paneID,
+                children: nil
+            )
+        )
+        let paneSlot = ShellPaneSlot(
+            paneSlotID: paneID,
+            tabID: tabID,
+            spaceID: targetSpaceID,
+            contentID: ShellContentInstance.settingsContentID,
+            attention: .active
+        )
+        let content = ShellContentInstance(
+            contentID: ShellContentInstance.settingsContentID,
+            kind: .settings,
+            title: resolvedTitle,
+            payload: .settings(
+                ShellSettingsContentPayload(
+                    surfaceID: ShellContentInstance.settingsSurfaceID,
+                    title: resolvedTitle
+                )
+            ),
+            rendererState: ShellContentRendererState(
+                phase: "ready",
+                detail: ShellContentInstance.settingsSurfaceID
+            )
+        )
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == targetSpaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs + [tab]
+            )
+        }
+        let nextPanes = panes + [pane]
+        let retained = retainedContentRecords(in: nextSpaces)
+        let nextPaneSlots = (retained.paneSlots ?? []) + [paneSlot]
+        let nextContents = (retained.contents ?? []) + [content]
+
+        return ShellStateMutationResult(
+            state: ShellStateSnapshot(
+                contractVersion: ShellContentStateSnapshot.currentContractVersion,
+                windowID: windowID,
+                focusedSpaceID: targetSpaceID,
+                focusedTabID: tabID,
+                focusedPaneID: paneID,
+                spaces: rebuildingAttention(in: nextSpaces, panes: nextPanes),
+                panes: nextPanes,
+                paneSlots: nextPaneSlots,
+                contents: nextContents,
+                quickTerminal: quickTerminal
+            ),
+            spaceID: targetSpaceID,
+            tabID: tabID,
+            paneID: paneID
+        )
+    }
+
     func showingQuickTerminal(
         workingDirectory: String?,
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
@@ -1654,6 +1759,16 @@ extension ShellStateSnapshot {
 
         let lastPathComponent = fileURL.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
         return lastPathComponent.isEmpty ? "Markdown" : lastPathComponent
+    }
+
+    private static func settingsTitle(explicitTitle: String?) -> String {
+        if let title = explicitTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !title.isEmpty
+        {
+            return title
+        }
+
+        return "Settings"
     }
 
     private static func defaultShellPath(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -757,7 +757,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private func focus(paneID: String, requestTerminalFocus: Bool) {
         guard let result = try? shellState.focusingPane(paneID) else { return }
         applyMutationResult(result)
-        if requestTerminalFocus {
+        if requestTerminalFocus && canRequestTerminalFocus(for: paneID) {
             terminalRuntimeRegistry.requestFocus(for: paneID)
         }
     }
@@ -806,7 +806,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     func refocusSelectedTerminalPane() {
         guard let paneID = selectedPane?.paneID else { return }
+        guard canRequestTerminalFocus(for: paneID) else { return }
         terminalRuntimeRegistry.requestFocus(for: paneID)
+    }
+
+    private func canRequestTerminalFocus(for paneID: String) -> Bool {
+        if shellState.contentStateProjection().contentMounted(in: paneID)?.kind == .terminal {
+            return true
+        }
+
+        return pane(paneID: paneID)?.isQuickTerminalPane == true
     }
 
     @discardableResult
@@ -1082,6 +1091,25 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         do {
             result = try shellState.openingMarkdownTab(
                 fileURL: fileURL,
+                in: spaceID,
+                title: title,
+                reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
+            )
+        } catch {
+            return nil
+        }
+        applyMutationResult(result)
+        return result.tabID
+    }
+
+    @discardableResult
+    func openSettingsTab(
+        in spaceID: String? = nil,
+        title: String? = nil
+    ) -> String? {
+        let result: ShellStateMutationResult
+        do {
+            result = try shellState.openingSettingsTab(
                 in: spaceID,
                 title: title,
                 reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -959,7 +959,11 @@ private struct ShellBoundedContentLeafView: View {
                 ShellMarkdownContentView(descriptor: descriptor)
                     .contentShape(Rectangle())
                     .onTapGesture(perform: onFocusPane)
-            case .terminal, .settings, .unavailable:
+            case .settings:
+                ShellSettingsContentView(descriptor: descriptor)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: onFocusPane)
+            case .terminal, .unavailable:
                 boundedPlaceholder
             }
         }
@@ -1119,6 +1123,132 @@ private enum ShellMarkdownContentLoader {
 private enum ShellMarkdownContentLoadResult {
     case success(AttributedString)
     case failure
+}
+
+private struct ShellSettingsContentView: View {
+    let descriptor: ShellContentRenderDescriptor
+
+    @AppStorage("alanShellAppearanceMode") private var appearanceMode = ShellAppearanceMode.system
+    @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
+    @AppStorage("alanShellDimsInactiveSplitPanes") private var dimsInactiveSplitPanes = true
+
+    var body: some View {
+        ZStack {
+            ShellPalette.workspace
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+
+                    VStack(spacing: 0) {
+                        ShellSettingsRow(
+                            systemName: "circle.lefthalf.filled",
+                            title: "Appearance"
+                        ) {
+                            Picker("Appearance", selection: $appearanceMode) {
+                                ForEach(ShellAppearanceMode.allCases) { mode in
+                                    Text(mode.label).tag(mode)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.segmented)
+                            .frame(maxWidth: 240)
+                        }
+
+                        ShellSettingsDivider()
+
+                        ShellSettingsRow(
+                            systemName: "sidebar.left",
+                            title: "Sidebar"
+                        ) {
+                            Toggle("Show", isOn: sidebarVisible)
+                                .toggleStyle(.switch)
+                        }
+
+                        ShellSettingsDivider()
+
+                        ShellSettingsRow(
+                            systemName: "rectangle.split.2x1",
+                            title: "Inactive split dimming"
+                        ) {
+                            Toggle("Enabled", isOn: $dimsInactiveSplitPanes)
+                                .toggleStyle(.switch)
+                        }
+                    }
+                    .background {
+                        RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                            .fill(ShellPalette.panel.opacity(0.72))
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                            .stroke(ShellPalette.line.opacity(0.26), lineWidth: 0.8)
+                    }
+                }
+                .frame(maxWidth: 680, alignment: .leading)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 24)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: descriptor.iconName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(ShellPalette.mutedInk)
+                .frame(width: 22, height: 22)
+
+            Text(descriptor.title)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(ShellPalette.ink)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    private var sidebarVisible: Binding<Bool> {
+        Binding(
+            get: { !isSidebarCollapsed },
+            set: { isSidebarCollapsed = !$0 }
+        )
+    }
+}
+
+private struct ShellSettingsRow<Accessory: View>: View {
+    let systemName: String
+    let title: String
+    @ViewBuilder let accessory: () -> Accessory
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: systemName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(ShellPalette.mutedInk)
+                .frame(width: 18, height: 18)
+
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(ShellPalette.ink)
+                .lineLimit(1)
+
+            Spacer(minLength: 16)
+
+            accessory()
+                .font(.system(size: 12, weight: .medium))
+        }
+        .padding(.horizontal, 14)
+        .frame(minHeight: 48)
+    }
+}
+
+private struct ShellSettingsDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(ShellPalette.line.opacity(0.22))
+            .frame(height: 0.8)
+            .padding(.leading, 44)
+    }
 }
 
 private struct ShellContentPaneTitleBarView: View {

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -778,10 +778,13 @@ struct ShellSidebarView: View {
     }
 
     private func tabSubtitle(for tab: ShellTab) -> String {
-        if let content = host.shellState.contentStateProjection().primaryContent(in: tab.tabID),
-           content.kind == .markdown
-        {
-            return "Document"
+        if let content = host.shellState.contentStateProjection().primaryContent(in: tab.tabID) {
+            if content.kind == .settings {
+                return "Settings"
+            }
+            if content.kind == .markdown {
+                return "Document"
+            }
         }
 
         let panes = host.shellState.panes.filter { $0.tabID == tab.tabID }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -104,6 +104,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesContentStateProjectionSeparatesPaneSlotsAndContent()
         verifiesContentRenderingRegistryRoutesSupportedKinds()
         verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor()
+        verifiesOpeningSettingsTabCreatesSingletonShellContent()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
@@ -3814,6 +3815,84 @@ private enum ShellRuntimeMetadataTests {
         expect(
             restoredContent?.payload.markdown?.fileURL == expectedURL,
             "persisted markdown state must restore markdown file URL"
+        )
+    }
+
+    private static func verifiesOpeningSettingsTabCreatesSingletonShellContent() {
+        let controller = makeController()
+        let initialTabCount = controller.shellState.spaces.flatMap(\.tabs).count
+        guard let firstTabID = controller.openSettingsTab() else {
+            fail("opening settings must create a shell tab")
+        }
+
+        let firstProjection = controller.shellState.contentStateProjection()
+        guard let content = firstProjection.focusedContent else {
+            fail("settings tab must focus a content descriptor")
+        }
+        let descriptor = ShellContentRenderingRegistry.descriptor(for: content)
+        let selectedPaneID = controller.selectedPane?.paneID
+
+        expect(controller.shellState.focusedTabID == firstTabID, "settings open must focus the settings tab")
+        expect(content.contentID == ShellContentInstance.settingsContentID, "settings content must use the canonical content ID")
+        expect(content.kind == .settings, "settings open must create settings content")
+        expect(content.title == "Settings", "settings descriptor must expose a user-facing title")
+        expect(
+            content.payload.settings?.surfaceID == ShellContentInstance.settingsSurfaceID,
+            "settings descriptor must persist the canonical settings surface"
+        )
+        expect(
+            content.capabilities == [.settingsSurface],
+            "settings descriptor must expose only settings surface capability"
+        )
+        expect(
+            !content.capabilities.contains(.terminalInput),
+            "settings descriptor must not expose terminal input"
+        )
+        expect(descriptor.renderKind == .settings, "settings descriptor must route to settings renderer")
+        expect(
+            controller.selectedPane?.launchTarget == nil && controller.selectedPane?.process == nil,
+            "settings pane must not describe a terminal process"
+        )
+        expect(
+            selectedPaneID.map {
+                !controller.terminalRuntimeRegistry.registeredPaneIDs.contains($0)
+            } == true,
+            "settings open must not create a terminal runtime"
+        )
+
+        guard let secondTabID = controller.openSettingsTab() else {
+            fail("reopening settings must focus the existing settings tab")
+        }
+        let secondProjection = controller.shellState.contentStateProjection()
+        let settingsContents = secondProjection.contents.filter { $0.kind == .settings }
+        let settingsSlots = secondProjection.paneSlots.filter { paneSlot in
+            secondProjection.content(contentID: paneSlot.contentID)?.kind == .settings
+        }
+
+        expect(secondTabID == firstTabID, "reopening settings must return the existing tab")
+        expect(controller.shellState.focusedTabID == firstTabID, "reopening settings must keep focus on the settings tab")
+        expect(
+            controller.shellState.spaces.flatMap(\.tabs).count == initialTabCount + 1,
+            "reopening settings must not create duplicate tabs"
+        )
+        expect(settingsContents.count == 1, "settings content must remain singleton")
+        expect(settingsSlots.count == 1, "settings PaneSlot must remain singleton")
+
+        let persistenceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("settings-content-\(UUID().uuidString).json")
+        let store = ShellStatePersistenceStore(persistenceURL: persistenceURL)
+        defer { try? FileManager.default.removeItem(at: persistenceURL) }
+        store.save(controller.shellState)
+
+        let restored = ShellStatePersistenceStore.restoreShellState(
+            fileManager: .default,
+            persistenceURL: persistenceURL
+        )
+        let restoredContent = restored?.contentStateProjection().focusedContent
+        expect(restoredContent?.kind == .settings, "persisted settings state must restore settings kind")
+        expect(
+            restoredContent?.payload.settings?.surfaceID == ShellContentInstance.settingsSurfaceID,
+            "persisted settings state must restore settings surface identity"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -20,7 +20,7 @@
 
 - [x] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
 - [x] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
-- [ ] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
+- [x] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
 - [ ] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.
 
 ## 4. Workspace Mutations And Control Plane
@@ -38,7 +38,7 @@
 - [ ] 5.1 Update `ShellWorkspaceView` / pane layout leaf rendering so mixed content panes share split geometry and focus treatment.
 - [ ] 5.2 Update sidebar tab rows, toolbar titles, pane title bars, and command input labels to use user-facing content titles and type hints.
 - [ ] 5.3 Keep terminal-only status, search, and input affordances visible only on terminal content panes.
-- [ ] 5.4 Make settings content a singleton tab target in v1 so repeated Open Settings focuses the existing ContentInstance.
+- [x] 5.4 Make settings content a singleton tab target in v1 so repeated Open Settings focuses the existing ContentInstance.
 - [ ] 5.5 Capture running-app visual evidence for light-mode mixed content tabs and split panes.
 
 ## 6. Verification And Archive Readiness


### PR DESCRIPTION
## Summary
- route macOS Settings into a singleton shell content tab
- render the settings surface inside the existing shell pane chrome
- cover the settings descriptor, singleton behavior, persistence, and no-terminal-runtime contract

## Validation
- git diff --check
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/DerivedData/SettingsContentTab CODE_SIGNING_ALLOWED=NO build

OpenSpec: generalize-macos-shell-content-containers tasks 3.3 and 5.4