### PR TITLE
Add macOS dev channel install spec

### DIFF
--- a/openspec/changes/add-macos-dev-channel-install/.openspec.yaml
+++ b/openspec/changes/add-macos-dev-channel-install/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/add-macos-dev-channel-install/design.md
+++ b/openspec/changes/add-macos-dev-channel-install/design.md
@@ -1,0 +1,159 @@
+## Context
+
+Alan 当前的 macOS 本地安装链路是单通道的：
+
+- `just install` 调用 `scripts/install.sh`，安装
+  `$HOME/Applications/Alan.app`，并把 `alan` / `alan-tui` 链到嵌入式
+  `Contents/Resources/bin`。
+- Xcode project 默认生成 `Alan.app`，display name 为 `Alan`，bundle id 为
+  `app.alanworks.macos`。
+- runtime path resolver 默认把用户数据放在 `~/.alan`，并把全局 public skills
+  放在 `~/.agents/skills`。
+- daemon host config、connection profiles、credentials、managed auth、registry、
+  sessions 和 models 都是这个单一身份的一部分。
+- macOS shell-control socket 当前使用临时目录下的 `alan-shell-control`，没有
+  channel 维度。
+
+这些默认值适合正式 Alan，但不适合本机开发。开发者需要一个可并行运行的
+`Alan Dev`，它可以测试未发布代码、破坏自己的配置和登录状态，但不能影响正式
+Alan 的日常工作环境。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 定义 `stable` 和 `dev` 两个 install channel，并让第一版 dev channel 可在本机与
+  stable channel 并行运行。
+- 保持 stable channel 现有用户可见契约不变。
+- 让 dev channel 拥有独立 app bundle、bundle id、CLI/TUI command names、alan
+  home、daemon endpoint、host config、credentials、managed auth、skills source、
+  singleton 和 shell-control namespace。
+- 让同一个 source workspace 可以同时被 stable 和 dev 使用，但 generated runtime
+  state 必须按 channel 隔离。
+- 提供本地安装和卸载工作流，避免手动 env 切换成为主要使用方式。
+- 把第一版限制为本地开发通道，便于后续实现和验证。
+
+**Non-Goals:**
+
+- 不发布公开 `Alan Dev` 下载包、Homebrew cask、Sparkle appcast 或 auto-update
+  channel。
+- 不自动迁移、复制或同步 stable channel 的 connections、credentials、managed auth、
+  agents、models、skills、sessions 或 memory。
+- 不改变 stable channel 的 `Alan.app`、`alan`、`alan-tui`、`~/.alan`、
+  Homebrew cask 或 direct install contract。
+- 不把 workspace-authored `.alan/agents/` 或 `.agents/skills/` 改成 dev-only；这些
+  仍然是 workspace 内容，由 source control/工作区语义决定是否共享。
+- 不把 dev channel 作为 production beta/nightly 发行体系。
+
+## Decisions
+
+1. **使用显式 install channel，而不是 env-only dev mode。**
+
+   Channel 是安装和运行身份，不只是 `ALAN_HOME=...`。`alan-dev`、`Alan Dev.app`
+   和 `alan-dev-tui` 必须在进入 config/path/daemon 解析前选择 `dev` channel。
+   环境变量可以作为调试覆盖，但不能是第一版的主入口。这样可以避免用户在正式
+   `alan` 命令里忘记设置 env 后误写 `~/.alan`。
+
+2. **用一个 channel descriptor 驱动所有 machine identity。**
+
+   实现应集中定义至少这些字段：
+
+   | Field | stable | dev |
+   | --- | --- | --- |
+   | channel id | `stable` | `dev` |
+   | app bundle | `Alan.app` | `Alan Dev.app` |
+   | display name | `Alan` | `Alan Dev` |
+   | bundle id | `app.alanworks.macos` | `app.alanworks.macos.dev` |
+   | CLI | `alan` | `alan-dev` |
+   | TUI | `alan-tui` | `alan-dev-tui` |
+   | alan home | `~/.alan` | `~/.alan-dev` |
+   | global public skills | `~/.agents/skills` | `~/.agents-dev/skills` |
+   | daemon bind default | `0.0.0.0:8090` | `127.0.0.1:8091` |
+   | daemon URL default | `http://127.0.0.1:8090` | `http://127.0.0.1:8091` |
+   | shell control namespace | `alan-shell-control` | `alan-dev-shell-control` |
+
+   Scripts, app metadata generation, CLI daemon defaults, TUI config resolution,
+   shell-control paths, logging/capture helpers and tests should consume this descriptor or a generated
+   projection of it. Scattering literals would recreate the same single-channel problem.
+
+3. **Keep stable behavior untouched and make dev additive.**
+
+   `just install` and `just uninstall` remain stable-only. Dev gets separate recipes such as
+   `just install-dev` and `just uninstall-dev`. Dev uninstall removes `Alan Dev.app` and
+   `alan-dev` / `alan-dev-tui` links when owned by that install, but it does not delete
+   `~/.alan-dev` unless a future explicit data-removal command is added.
+
+4. **Dev app is local-only but still release-shaped.**
+
+   Dev install should exercise the same broad packaging shape as stable: app bundle with embedded
+   CLI/TUI, signing, manifest checks, ownership-safe symlink behavior and no force-kill/relaunch.
+   It may skip notarization because it is not a public artifact. Reusing the release-shaped path
+   prevents dev-only launch assumptions from hiding bugs that would appear in stable packaging.
+
+5. **Runtime data isolation is channel-scoped by default.**
+
+   The active channel controls alan home resolution before any runtime, daemon, CLI, TUI or app
+   config is read. Dev channel reads and writes `~/.alan-dev/host.toml`,
+   `~/.alan-dev/connections.toml`, `~/.alan-dev/credentials/`,
+   `~/.alan-dev/agents/`, `~/.alan-dev/models.toml`, session/history stores,
+   registry, managed auth, memory and caches. It MUST NOT silently fall back to
+   stable channel state when dev state is missing.
+
+6. **Workspace authored content can be shared; generated runtime state cannot.**
+
+   Source-controlled workspace definitions such as `<workspace>/.alan/agents/` and
+   `<workspace>/.agents/skills/` remain workspace content. Generated workspace state must carry a
+   channel dimension, for example under `<workspace>/.alan/runtime/<channel>/...`, or another
+   clearly channel-scoped generated path. Dev channel must not write into legacy stable generated
+   paths such as `<workspace>/.alan/sessions/` or `<workspace>/.alan/memory/`.
+
+7. **Connection and auth import is explicit.**
+
+   First run of `Alan Dev` should behave like a fresh install. If users want to reuse a stable
+   profile or login for testing, that must be a deliberate import/copy command or manual action.
+   Dev startup must not read stable managed auth as fallback, because auth-state bugs are exactly
+   the kind of breakage this channel is meant to contain.
+
+## Risks / Trade-offs
+
+- **[Risk] Literal drift across scripts, Xcode, Swift, Rust and TUI.** -> Centralize channel
+  metadata and add focused guardrails that scan for unallowlisted stable-only literals in dev-aware
+  code paths.
+- **[Risk] Two daemons accidentally bind the same endpoint.** -> Give dev a distinct default bind
+  address and client URL; validation should launch or inspect both channel configs together.
+- **[Risk] Dev reads stable auth because a path resolver falls back on missing files.** -> Treat
+  missing dev config as configuration-required or onboarding-required, not as permission to read
+  stable state.
+- **[Risk] Workspace `.alan` state becomes confusing.** -> Keep authored workspace definitions in
+  their existing locations, but put generated runtime state under an explicit channel namespace and
+  update ignore/docs accordingly.
+- **[Risk] Brand guardrails reject `Alan Dev`.** -> Add an allowlisted local-channel exception while
+  keeping public product branding as `Alan`.
+- **[Risk] Dev channel packaging becomes a parallel release system.** -> Keep dev non-public in V1:
+  no cask, no Sparkle feed, no public zip, no notarized release requirement.
+
+## Migration Plan
+
+1. Introduce a channel descriptor and teach local install scripts to assemble/install stable and dev
+   without changing stable behavior.
+2. Add dev app metadata generation or build-setting overrides for `Alan Dev.app` and
+   `app.alanworks.macos.dev`.
+3. Add `alan-dev` and `alan-dev-tui` entrypoints that select dev channel before reading config.
+4. Thread channel-aware path resolution through runtime, daemon, CLI/TUI, managed auth and skill
+   discovery.
+5. Add channel-specific shell-control, singleton, support path, logging and capture-helper defaults.
+6. Add focused checks that verify stable and dev install outputs, data paths and daemon/control
+   endpoints are distinct.
+7. Manually verify stable Alan keeps running while `Alan Dev` starts, opens a workspace, creates a
+   session and logs into or configures its own provider profile.
+
+Rollback is straightforward because dev is additive: remove `Alan Dev.app`, `alan-dev` and
+`alan-dev-tui`, and leave `~/.alan-dev` intact for inspection. Stable `Alan.app`, `alan`,
+`alan-tui` and `~/.alan` are not modified by dev uninstall.
+
+## Open Questions
+
+- Should a later change add an explicit `alan-dev import stable-profile <id>` helper, or keep
+  profile reuse entirely manual?
+- Should dev channel ever offer an opt-in read-only view of `~/.agents/skills` for convenience?
+  This design chooses isolation first for V1.

--- a/openspec/changes/add-macos-dev-channel-install/proposal.md
+++ b/openspec/changes/add-macos-dev-channel-install/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+Alan 现在只有一个本地安装通道：开发中的 `Alan.app`、`alan` CLI、daemon 配置和
+`~/.alan` 数据都服务同一个日常工作环境。开发者在本机测试 macOS app、runtime、
+connection 或 shell-control 改动时，一旦改坏安装产物或数据路径，就可能影响正在使用的
+正式 Alan。
+
+## What Changes
+
+- 增加本地-only 的 `dev` install channel，用于安装和运行 `Alan Dev.app`。
+- 保持正式通道现状：`Alan.app`、`app.alanworks.macos`、`alan`、`alan-tui`、
+  `~/.alan`。
+- 为 dev 通道定义独立身份和入口：`Alan Dev.app`、
+  `app.alanworks.macos.dev`、`alan-dev`、`alan-dev-tui`、`~/.alan-dev`。
+- 允许正式 Alan 和 Alan Dev 同时运行，并隔离 bundle singleton、shell-control
+  socket、daemon endpoint、host config、connection profiles、credentials、managed
+  auth、session/memory/cache 和 generated workspace runtime state。
+- 增加 `just install-dev` / `just uninstall-dev` 之类的本地工作流，且不得覆盖正式
+  app、CLI/TUI links 或 `~/.alan` 数据。
+- 明确第一版不做公开 dev release、Homebrew dev cask、Sparkle dev feed、自动迁移或
+  自动复制正式配置；配置导入必须是显式用户动作。
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `alan-app-distribution`: 增加 stable/dev install channel、dev app/CLI/TUI
+  命名、本地安装/卸载和非公开分发边界。
+- `macos-app-instance-lifecycle`: 增加 channel-scoped bundle identity、
+  singleton、logging/support identity 和 shell-control namespace 隔离。
+- `agent-root-layout`: 将全局 agent root 从固定 `~/.alan` 扩展为当前 install
+  channel 的 alan home；stable 仍使用 `~/.alan`，dev 使用 `~/.alan-dev`。
+- `workspace-runtime-state-hygiene`: 增加 channel-scoped generated workspace
+  runtime state，防止 dev 版写入正式版会读取的 generated state。
+- `provider-connection-contract`: 增加 channel-scoped connection metadata、
+  credential store 和 managed auth state，防止 dev 版复用或覆盖正式登录状态。
+- `skill-system-contract`: 增加 channel-scoped global public skill source 约束，
+  避免 dev 通道安装/修改的全局 skill 影响正式通道。
+- `remote-control-contract`: 增加 channel-scoped local daemon defaults，确保
+  dev daemon/client 不默认连接或绑定到正式通道。
+- `product-brand-identity`: 允许 `Alan Dev` 作为本地开发通道的限定显示名和
+  machine identifier，同时保持公开产品品牌为 `Alan`。
+- `macos-shell-build-test-contract`: 增加 dev channel 安装、并行运行、路径隔离和
+  guardrail 验证要求。
+
+## Impact
+
+- macOS Xcode build settings / packaging scripts need channel-aware product name,
+  bundle identifier, display name, signing, package manifest, and app install
+  target handling.
+- CLI/TUI embedding and link installers need channel-aware tool names and
+  ownership checks.
+- Runtime path resolution needs a host/install-channel input so stable uses
+  `~/.alan` while dev uses `~/.alan-dev`, including host config, registry,
+  connections, credentials, models, agents, sessions, and managed auth.
+- Daemon/client startup needs per-channel defaults so `alan` talks to the stable
+  daemon and `alan-dev` talks to the dev daemon without relying on manual env
+  switching.
+- macOS shell control-plane paths, singleton locks, log subsystems, support
+  paths, capture helpers, tests, and brand guardrails need channel-aware
+  allowlists.

--- a/openspec/changes/add-macos-dev-channel-install/specs/agent-root-layout/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/agent-root-layout/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Global agent roots are channel-scoped
+Alan SHALL resolve global agent roots from the active install channel's alan
+home. Existing `~/.alan/...` global agent-root paths remain the stable-channel
+paths; the dev channel SHALL use equivalent paths under `~/.alan-dev/...`.
+
+#### Scenario: Stable default agent root is resolved
+- **WHEN** stable-channel `alan` resolves the default global agent root
+- **THEN** the root is `~/.alan/agents/default/`
+- **AND** existing stable root overlay behavior remains unchanged
+
+#### Scenario: Dev default agent root is resolved
+- **WHEN** dev-channel `alan-dev` resolves the default global agent root
+- **THEN** the root is `~/.alan-dev/agents/default/`
+- **AND** it does not read `~/.alan/agents/default/` as a fallback
+
+#### Scenario: Dev named agent root is resolved
+- **WHEN** dev-channel `alan-dev` resolves `agent_name = "reviewer"`
+- **THEN** the dev global named root is `~/.alan-dev/agents/reviewer/`
+- **AND** stable `~/.alan/agents/reviewer/` is not part of the dev global overlay chain
+
+### Requirement: Agent-root writes use the active channel
+Setup, connection pinning, workspace setup, and agent-root mutation flows SHALL
+write global agent-root files under the active channel's alan home.
+
+#### Scenario: Stable setup writes global config
+- **WHEN** stable-channel setup creates a global default `agent.toml`
+- **THEN** it writes `~/.alan/agents/default/agent.toml`
+- **AND** it does not create dev-channel global config files
+
+#### Scenario: Dev setup writes global config
+- **WHEN** dev-channel setup creates a global default `agent.toml`
+- **THEN** it writes `~/.alan-dev/agents/default/agent.toml`
+- **AND** it does not create or mutate `~/.alan/agents/default/agent.toml`
+
+#### Scenario: Workspace agent root remains workspace-scoped
+- **WHEN** either channel resolves authored workspace agent roots
+- **THEN** the workspace default root remains `<workspace>/.alan/agents/default/`
+- **AND** the workspace named root remains `<workspace>/.alan/agents/<name>/`
+- **AND** channel isolation applies to global roots and generated runtime state, not to authored workspace roots

--- a/openspec/changes/add-macos-dev-channel-install/specs/alan-app-distribution/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/alan-app-distribution/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: macOS install channels are explicit
+Alan SHALL define separate `stable` and `dev` macOS install channels. The
+stable channel SHALL preserve the existing public Alan distribution identity,
+while the dev channel SHALL be a local-only development install identity.
+
+#### Scenario: Stable channel identity is inspected
+- **WHEN** the stable macOS install channel is assembled or installed
+- **THEN** the app bundle is `Alan.app`
+- **AND** the bundle identifier is `app.alanworks.macos`
+- **AND** the embedded command-line tools are exposed as `alan` and `alan-tui`
+- **AND** the channel uses `~/.alan` as its default alan home
+
+#### Scenario: Dev channel identity is inspected
+- **WHEN** the dev macOS install channel is assembled or installed
+- **THEN** the app bundle is `Alan Dev.app`
+- **AND** the bundle identifier is `app.alanworks.macos.dev`
+- **AND** the embedded command-line tools are exposed as `alan-dev` and `alan-dev-tui`
+- **AND** the channel uses `~/.alan-dev` as its default alan home
+
+### Requirement: Dev install does not overwrite stable install
+The dev install workflow SHALL install and uninstall the dev channel without
+modifying the stable app bundle, stable command-line links, or stable alan home.
+
+#### Scenario: Dev local install runs
+- **WHEN** a developer runs the dev local install workflow
+- **THEN** the workflow installs `Alan Dev.app` into the configured user-level app directory
+- **AND** the workflow installs or refreshes only `alan-dev` and `alan-dev-tui` links
+- **AND** it does not replace `Alan.app`
+- **AND** it does not replace `alan` or `alan-tui`
+- **AND** it does not write generated data under `~/.alan`
+
+#### Scenario: Dev local uninstall runs
+- **WHEN** a developer runs the dev local uninstall workflow
+- **THEN** the workflow removes `Alan Dev.app` when it is owned by the dev install
+- **AND** it removes `alan-dev` and `alan-dev-tui` links when they point at the dev app bundle
+- **AND** it leaves `Alan.app`, `alan`, `alan-tui`, and `~/.alan` untouched
+- **AND** it leaves `~/.alan-dev` intact unless a future explicit data-removal command is added
+
+### Requirement: Dev channel remains local-only in V1
+The first dev channel implementation SHALL NOT create a public distribution
+channel for Alan Dev.
+
+#### Scenario: Public release packaging runs
+- **WHEN** a public macOS release package is produced for direct download, Sparkle, or Homebrew
+- **THEN** the package contains the stable `Alan.app` distribution artifacts
+- **AND** it does not publish `Alan Dev.app`
+- **AND** it does not publish a Homebrew cask, Sparkle feed item, or public release archive for the dev channel
+
+#### Scenario: Dev install is documented
+- **WHEN** developer documentation or just recipes describe the dev channel
+- **THEN** they describe it as a local testing install
+- **AND** they do not present it as a beta, nightly, or user-facing release channel

--- a/openspec/changes/add-macos-dev-channel-install/specs/macos-app-instance-lifecycle/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/macos-app-instance-lifecycle/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: macOS app singleton is channel-scoped
+The macOS app singleton, support identity, and shell-control namespace SHALL be
+scoped by install channel so stable Alan and Alan Dev can run at the same time.
+
+#### Scenario: Stable and dev apps launch together
+- **WHEN** `Alan.app` is already running and the user launches `Alan Dev.app`
+- **THEN** the dev app acquires a dev-channel singleton lock
+- **AND** it does not activate or terminate the stable app instance
+- **AND** it creates only dev-channel shell windows, support paths, runtime registries, and shell-control sockets
+
+#### Scenario: Duplicate dev app launches
+- **WHEN** a dev-channel app instance is already running and the user launches `Alan Dev.app` again
+- **THEN** the existing dev app instance is activated
+- **AND** no second dev app process remains running
+- **AND** the stable app singleton state is not consulted as the owner for this decision
+
+#### Scenario: Duplicate stable app launches while dev is running
+- **WHEN** `Alan Dev.app` is running and the user launches `Alan.app` again
+- **THEN** the existing stable app instance is activated if stable is already running
+- **AND** the dev app instance is not treated as the stable singleton owner
+
+### Requirement: Channel identity is visible in local diagnostics
+Local diagnostics, logs, capture helpers, and shell-control paths SHALL expose
+enough channel identity to distinguish stable Alan from Alan Dev.
+
+#### Scenario: Logs are inspected
+- **WHEN** maintainers inspect unified logs for both running apps
+- **THEN** stable logs use the stable subsystem identity
+- **AND** dev logs use a dev-channel subsystem identity such as `app.alanworks.macos.dev`
+- **AND** filtering for one channel does not require excluding events from the other channel by process name alone
+
+#### Scenario: Shell-control paths are inspected
+- **WHEN** shell-control sockets or binding files are created
+- **THEN** stable paths use the stable shell-control namespace
+- **AND** dev paths use a distinct dev shell-control namespace
+- **AND** both namespaces can exist simultaneously under the system temporary directory without one app reading or overwriting the other's control files
+
+#### Scenario: Capture helper targets an app
+- **WHEN** a capture or debugging helper targets an Alan channel
+- **THEN** it can target the stable bundle identifier or the dev bundle identifier explicitly
+- **AND** the default stable capture behavior remains compatible with `app.alanworks.macos`

--- a/openspec/changes/add-macos-dev-channel-install/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Dev channel packaging has focused validation
+The Apple client build/test contract SHALL include focused checks for dev
+channel app metadata, embedded tools, signing, install targets, and ownership
+guards when dev channel packaging changes.
+
+#### Scenario: Dev app layout is checked
+- **WHEN** dev channel packaging implementation is ready for review
+- **THEN** focused checks verify `Alan Dev.app` is built
+- **AND** focused checks verify the bundle identifier is `app.alanworks.macos.dev`
+- **AND** focused checks verify embedded `Contents/Resources/bin/alan-dev` and `Contents/Resources/bin/alan-dev-tui` exist and are executable
+- **AND** focused checks verify stable `Alan.app` packaging remains unchanged
+
+#### Scenario: Dev install ownership is checked
+- **WHEN** dev channel local install checks run
+- **THEN** they verify the install creates or refreshes `Alan Dev.app`, `alan-dev`, and `alan-dev-tui`
+- **AND** they verify the install does not overwrite `Alan.app`, `alan`, or `alan-tui`
+- **AND** they verify dev uninstall does not remove stable app or stable command-line links
+
+#### Scenario: Dev signing is checked
+- **WHEN** dev channel local install produces an app bundle
+- **THEN** focused checks verify the app and embedded tools are signed according to the local install signing policy
+- **AND** checks report whether notarization was skipped because the dev channel is local-only
+
+### Requirement: Channel isolation has focused verification
+Changes to install-channel resolution SHALL include focused validation that
+stable and dev channels resolve distinct runtime state, daemon, singleton, and
+shell-control boundaries.
+
+#### Scenario: Runtime paths are checked
+- **WHEN** channel-aware path resolution changes
+- **THEN** focused tests verify stable channel paths resolve under `~/.alan`
+- **AND** focused tests verify dev channel paths resolve under `~/.alan-dev`
+- **AND** tests cover host config, connections, credentials, agents, models, sessions, managed auth, registry, and global public skill sources
+
+#### Scenario: Daemon endpoints are checked
+- **WHEN** channel-aware daemon/client defaults change
+- **THEN** focused tests verify stable and dev channels use distinct default daemon endpoints
+- **AND** a missing dev config does not cause dev clients to connect to the stable daemon implicitly
+
+#### Scenario: Shell-control namespaces are checked
+- **WHEN** channel-aware shell-control paths change
+- **THEN** focused tests verify stable and dev shell-control socket paths differ
+- **AND** tests verify commands for one channel do not read binding files from the other channel
+
+#### Scenario: Side-by-side smoke is checked
+- **WHEN** dev channel support is considered ready for local use
+- **THEN** maintainers can run an automated or documented manual smoke that keeps stable Alan installed while installing and launching Alan Dev
+- **AND** the smoke verifies both apps can be identified independently by bundle id
+- **AND** the smoke verifies dev session/config/auth state is written only to dev-channel paths

--- a/openspec/changes/add-macos-dev-channel-install/specs/product-brand-identity/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/product-brand-identity/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Alan Dev is an allowlisted local development channel name
+The product SHALL keep `Alan` as the public product brand while allowing
+`Alan Dev` only as the user-visible name for the local dev install channel.
+
+#### Scenario: Dev app metadata is generated
+- **WHEN** the local dev macOS app bundle is built
+- **THEN** `CFBundleDisplayName` and the generated app product name may use `Alan Dev`
+- **AND** the bundle identifier may use `app.alanworks.macos.dev`
+- **AND** these identifiers are treated as dev-channel identities rather than public rebrands
+
+#### Scenario: Stable app metadata is generated
+- **WHEN** the stable macOS app bundle is built
+- **THEN** `CFBundleDisplayName` and product name remain `Alan`
+- **AND** the bundle identifier remains `app.alanworks.macos`
+- **AND** stable build metadata does not include `Alan Dev` or dev-channel bundle identifiers
+
+#### Scenario: Brand validation runs
+- **WHEN** brand validation scans active source, scripts, docs, project metadata, and active OpenSpec changes
+- **THEN** it allows `Alan Dev`, `alan-dev`, `alan-dev-tui`, `~/.alan-dev`, `~/.agents-dev/skills`, and `app.alanworks.macos.dev` only in dev-channel contexts
+- **AND** it continues to reject obsolete product names and unallowlisted lowercase user-visible app branding

--- a/openspec/changes/add-macos-dev-channel-install/specs/provider-connection-contract/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/provider-connection-contract/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Connection and credential stores are channel-scoped
+Alan SHALL store connection metadata, credential references, secret-bearing
+credentials, managed auth state, default profile state, and provider model
+overlays under the active install channel's alan home.
+
+#### Scenario: Stable connection store is used
+- **WHEN** stable-channel `alan` or `Alan.app` reads connection metadata
+- **THEN** it uses `~/.alan/connections.toml`
+- **AND** it uses stable-channel credential and managed-auth stores under `~/.alan`
+
+#### Scenario: Dev connection store is used
+- **WHEN** dev-channel `alan-dev` or `Alan Dev.app` reads connection metadata
+- **THEN** it uses `~/.alan-dev/connections.toml`
+- **AND** it uses dev-channel credential and managed-auth stores under `~/.alan-dev`
+- **AND** it does not read `~/.alan/connections.toml`, stable credentials, or stable managed auth as fallback
+
+#### Scenario: Dev channel has no configured profile
+- **WHEN** a dev-channel session starts without a resolvable dev connection profile
+- **THEN** Alan reports a configuration-required or onboarding-required condition
+- **AND** it does not silently reuse the stable default profile
+
+### Requirement: Cross-channel connection reuse is explicit
+Alan SHALL require an explicit user action before copying or importing stable
+connection profile metadata or auth material into the dev channel.
+
+#### Scenario: User requests profile import
+- **WHEN** a future import command copies a stable profile into the dev channel
+- **THEN** the command identifies the source channel and target channel explicitly
+- **AND** it writes new dev-channel metadata and credential references under `~/.alan-dev`
+- **AND** it does not make the dev profile a live reference to stable credential storage
+
+#### Scenario: Managed auth is reused
+- **WHEN** a future command or UI flow allows managed-auth reuse across channels
+- **THEN** the user must approve that operation explicitly
+- **AND** the resulting dev-channel auth state is stored under the dev-channel managed auth store
+- **AND** routine dev startup still does not read stable managed auth as implicit fallback

--- a/openspec/changes/add-macos-dev-channel-install/specs/remote-control-contract/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/remote-control-contract/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Local daemon defaults are channel-scoped
+Direct-mode local daemon and client defaults SHALL be scoped by active install
+channel so stable Alan and Alan Dev do not bind or connect to each other's
+default daemon endpoint.
+
+#### Scenario: Stable daemon defaults are resolved
+- **WHEN** stable-channel daemon or client configuration is resolved without explicit overrides
+- **THEN** the host config path is `~/.alan/host.toml`
+- **AND** the stable default bind address remains `0.0.0.0:8090`
+- **AND** the stable default daemon URL remains `http://127.0.0.1:8090`
+
+#### Scenario: Dev daemon defaults are resolved
+- **WHEN** dev-channel daemon or client configuration is resolved without explicit overrides
+- **THEN** the host config path is `~/.alan-dev/host.toml`
+- **AND** the dev default bind address is `127.0.0.1:8091`
+- **AND** the dev default daemon URL is `http://127.0.0.1:8091`
+- **AND** missing dev host config does not cause the dev client to connect to the stable daemon URL
+
+#### Scenario: Channel endpoint override is used
+- **WHEN** an operator explicitly supplies a daemon bind address or daemon URL override for a process
+- **THEN** the override applies only to that launched process and active channel
+- **AND** it does not mutate the other channel's host config
+- **AND** documentation identifies overrides as advanced/debug controls rather than the primary dev-channel selection mechanism

--- a/openspec/changes/add-macos-dev-channel-install/specs/skill-system-contract/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/skill-system-contract/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Global public skill sources are channel-scoped
+Alan SHALL resolve and mutate global public skill install sources according to
+the active install channel. The stable channel SHALL keep `~/.agents/skills/`;
+the dev channel SHALL use a separate global public skill source.
+
+#### Scenario: Stable global public skills are discovered
+- **WHEN** stable-channel Alan discovers global public skill packages
+- **THEN** it discovers packages under `~/.agents/skills/`
+- **AND** existing stable public skill compatibility remains unchanged
+
+#### Scenario: Dev global public skills are discovered
+- **WHEN** dev-channel Alan discovers global public skill packages
+- **THEN** it discovers packages under `~/.agents-dev/skills/`
+- **AND** it does not discover `~/.agents/skills/` as an implicit fallback
+
+#### Scenario: Dev installs a global skill
+- **WHEN** a dev-channel command installs or updates a global public skill package
+- **THEN** it writes under `~/.agents-dev/skills/`
+- **AND** it does not create, modify, or remove packages under `~/.agents/skills/`
+
+### Requirement: Workspace skill sources remain workspace-authored
+Install-channel isolation SHALL NOT change the portable workspace public skill
+source path.
+
+#### Scenario: Workspace public skills are discovered
+- **WHEN** either channel discovers portable public skill packages in a workspace
+- **THEN** `<workspace>/.agents/skills/` remains the workspace public skill source
+- **AND** packages discovered there are treated as workspace-authored content rather than channel-private global data
+
+#### Scenario: Workspace skill writes generated output
+- **WHEN** a workspace skill run writes generated runtime output, evaluation cache, or logs through Alan-managed paths
+- **THEN** those generated outputs are channel-scoped
+- **AND** the source skill package under `<workspace>/.agents/skills/` remains unchanged unless the user explicitly edits or installs into that workspace source

--- a/openspec/changes/add-macos-dev-channel-install/specs/workspace-runtime-state-hygiene/spec.md
+++ b/openspec/changes/add-macos-dev-channel-install/specs/workspace-runtime-state-hygiene/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Generated workspace runtime state is channel-scoped
+Generated workspace runtime state SHALL include an install-channel namespace so
+stable Alan and Alan Dev do not read or overwrite each other's workspace-local
+sessions, memory, caches, shell restore state, or runtime metadata.
+
+#### Scenario: Dev channel writes workspace runtime state
+- **WHEN** Alan Dev creates generated runtime state for a workspace
+- **THEN** the state is written under a dev-channel generated path such as `<workspace>/.alan/runtime/dev/`
+- **AND** it is not written to legacy stable generated paths such as `<workspace>/.alan/sessions/` or `<workspace>/.alan/memory/`
+
+#### Scenario: Stable channel reads legacy state
+- **WHEN** stable Alan reads existing legacy generated workspace state
+- **THEN** it may continue to read stable-compatible legacy paths for compatibility
+- **AND** it does not treat dev-channel generated state as stable runtime state
+
+#### Scenario: Both channels use the same workspace
+- **WHEN** stable Alan and Alan Dev both open the same source workspace
+- **THEN** each channel can maintain its own generated runtime state
+- **AND** session, memory, cache, shell restore, and runtime metadata written by one channel are not consumed as authoritative state by the other channel
+
+### Requirement: Authored workspace content remains shared by workspace semantics
+Channel isolation SHALL NOT make authored workspace agent definitions or
+workspace public skills private to one install channel.
+
+#### Scenario: Authored workspace agent root exists
+- **WHEN** either channel resolves `<workspace>/.alan/agents/default/`
+- **THEN** the authored workspace root remains available according to normal agent-root overlay rules
+- **AND** the channel does not create a duplicate authored workspace root under a channel-specific source-controlled path
+
+#### Scenario: Workspace public skill package exists
+- **WHEN** either channel discovers `<workspace>/.agents/skills/<skill>/SKILL.md`
+- **THEN** the skill package remains workspace-authored content
+- **AND** generated evaluation output, caches, or runtime state for that skill remain channel-scoped when written by Alan
+
+### Requirement: Ignore rules cover channel-scoped generated state
+Repository hygiene rules SHALL ignore channel-scoped generated workspace runtime
+state while continuing to allow authored workspace definitions to be tracked.
+
+#### Scenario: Channel generated state exists
+- **WHEN** a workspace contains generated state under a channel-scoped runtime path
+- **THEN** normal repository status does not show that generated state as untracked source changes
+- **AND** authored `.alan/agents/` and `.agents/skills/` paths remain trackable when intentionally committed

--- a/openspec/changes/add-macos-dev-channel-install/tasks.md
+++ b/openspec/changes/add-macos-dev-channel-install/tasks.md
@@ -1,0 +1,45 @@
+## 1. Channel Model And Path Resolution
+
+- [ ] 1.1 Add a typed install-channel descriptor for `stable` and `dev` identities, including app name, bundle id, CLI/TUI names, alan home, global skill source, daemon defaults, and shell-control namespace.
+- [ ] 1.2 Thread channel selection into CLI, daemon, TUI, and macOS app startup before any config, auth, daemon, or runtime path is resolved.
+- [ ] 1.3 Update runtime alan-home path resolution so stable uses `~/.alan` and dev uses `~/.alan-dev` for host config, registry, agents, models, connections, credentials, sessions, memory, managed auth, and caches.
+- [ ] 1.4 Update agent-root layout resolution and writes so global roots are channel-scoped while workspace roots remain unchanged.
+- [ ] 1.5 Update global public skill discovery and install/update flows so stable uses `~/.agents/skills` and dev uses `~/.agents-dev/skills`.
+
+## 2. macOS Packaging And Install Scripts
+
+- [ ] 2.1 Make app assembly channel-aware without changing stable `Alan.app` output.
+- [ ] 2.2 Add dev app metadata/build overrides for `Alan Dev.app` and `app.alanworks.macos.dev`.
+- [ ] 2.3 Embed channel-appropriate CLI/TUI binaries as `alan`/`alan-tui` for stable and `alan-dev`/`alan-dev-tui` for dev.
+- [ ] 2.4 Add `just install-dev` and dev install script behavior that installs `Alan Dev.app` plus `alan-dev`/`alan-dev-tui` without touching stable artifacts.
+- [ ] 2.5 Add `just uninstall-dev` and dev uninstall behavior that removes only dev-owned app and command links while preserving `~/.alan-dev` data.
+- [ ] 2.6 Keep public release, Homebrew cask, and Sparkle publication paths stable-only.
+
+## 3. Daemon, TUI, And App Runtime Isolation
+
+- [ ] 3.1 Add distinct dev daemon/client defaults so `alan-dev` and `alan-dev-tui` do not connect to the stable daemon implicitly.
+- [ ] 3.2 Ensure missing dev connection/auth config produces onboarding or configuration-required state instead of falling back to stable credentials.
+- [ ] 3.3 Scope macOS singleton locks, support paths, log subsystems, capture-helper defaults, and diagnostics by channel.
+- [ ] 3.4 Scope shell-control socket and binding paths by channel so stable and dev commands cannot read each other's control files.
+- [ ] 3.5 Verify stable and dev apps can run side by side without activating, terminating, or hijacking each other's singleton state.
+
+## 4. Workspace Generated State
+
+- [ ] 4.1 Add a channel namespace for generated workspace runtime state such as sessions, memory, cache, shell restore, and runtime metadata.
+- [ ] 4.2 Preserve stable compatibility with existing legacy generated state while ensuring dev never writes to stable legacy generated paths.
+- [ ] 4.3 Update repository ignore rules and docs so channel-scoped generated state is ignored and authored `.alan/agents/` / `.agents/skills/` content remains trackable.
+
+## 5. Verification And Guardrails
+
+- [ ] 5.1 Add focused tests for channel descriptor values and channel-aware path resolution.
+- [ ] 5.2 Add packaging/install contract checks for `Alan Dev.app`, `alan-dev`, `alan-dev-tui`, and stable artifact preservation.
+- [ ] 5.3 Add guardrails or allowlists for dev-channel brand strings without weakening stable brand validation.
+- [ ] 5.4 Add tests for channel-scoped connection stores, managed auth stores, global public skills, daemon defaults, and shell-control paths.
+- [ ] 5.5 Run a documented side-by-side smoke with stable Alan installed while Alan Dev launches and writes only dev-channel state.
+- [ ] 5.6 Run `openspec validate add-macos-dev-channel-install --strict` and `openspec validate --all --strict`.
+
+## 6. Review And Archive Readiness
+
+- [ ] 6.1 Keep implementation commits scoped to this change and avoid mixing with unrelated macOS shell work.
+- [ ] 6.2 Before PR review, confirm public stable install, Homebrew, and Sparkle contracts remain unchanged.
+- [ ] 6.3 After merge, archive the change and verify the delta specs are folded into long-lived `openspec/specs/` owners.


### PR DESCRIPTION
## Summary
- Add OpenSpec change for a local-only macOS dev install channel.
- Define Alan Dev app/CLI/TUI identity, data isolation, daemon defaults, shell-control isolation, and validation tasks.
- Keep public stable release, Homebrew, and Sparkle paths stable-only.

## Test Plan
- openspec validate add-macos-dev-channel-install --strict
- openspec validate --all --strict