### PR TITLE
Document deferred browser shell content

### DIFF
--- a/openspec/changes/generalize-macos-shell-content-containers/design.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/design.md
@@ -90,6 +90,10 @@ embedded browser 或未来 agent-native 工具面板时，会产生三个问题�
    v1 需要能表达并打开 markdown viewer 和 alan settings。markdown 先做 read-only viewer；
    settings 先承载 alan app 设置。Browser 不进入 v1 implementation，也不要求 browser
    ContentInstance descriptor；完整 webview 安全策略和 browser content kind 后续单独 change 细化。
+   当前模型名称必须保持通用：`ShellContentKind` 表达可扩展 content kind，`ShellContentPayload`
+   承载 kind-specific restore/render 数据，`ShellContentCapability` 表达 command surface。
+   因此后续 browser change 只需要新增 browser kind/payload/capability/renderer，而不应把
+   `PaneSlot`、`ContentInstance` 或 v0.2 container contract 重命名为 markdown/settings 专用模型。
 
    Alternative considered: v1 加入 browser host boundary。它能提前验证外部资源和嵌入式 host
    边界，但会把 scope 拉到 webview、安全策略、profile/cookie、下载和导航权限，不适合与模型拆分同批完成。
@@ -128,7 +132,7 @@ embedded browser 或未来 agent-native 工具面板时，会产生三个问题�
 - **Risk: control plane 命令语义膨胀。** -> 将命令分为 pane mutation、content creation、
   content-specific runtime command 三类，并为不支持的 content 返回稳定 unsupported code。
 - **Risk: browser scope 过大。** -> browser 不进入 v1；只保留模型扩展性，browser content kind
-  和 webview 策略后续单独设计。
+  和 webview 策略后续单独设计；当前只要求 v0.2 命名和 payload/capability 边界保持可扩展。
 - **Risk: settings 变成 dashboard。** -> UI spec 明确 settings 是 tab content，继承 shell
   chrome，只显示设置本身，不引入营销式页面布局。
 

--- a/openspec/changes/generalize-macos-shell-content-containers/proposal.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/proposal.md
@@ -27,6 +27,9 @@ workspace restore authority 先由 `ShellWorkspaceManifest` 接管；随后本 c
   runtime owner，PaneSlot 只是当前承载位置。
 - 为首批非 terminal content 定义 v1 范围：markdown viewer 和 alan settings；browser 作为
   后续 change 单独设计。
+- v0.2 采用 `ContentInstance`、content kind、capability 和 payload 这组通用命名；
+  v1 不新增 browser kind，但后续 browser change 可以在同一模型中添加 browser
+  descriptor、capability、payload 和 renderer，而不需要重命名 PaneSlot / ContentInstance。
 - 区分通用 pane/control-plane 命令和 content-specific 命令：split、focus、move、close 是
   PaneSlot 命令；terminal input 使用 terminal-specific command，并先解析到 `terminal`
   ContentInstance。

--- a/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-content-containers/spec.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/specs/macos-shell-content-containers/spec.md
@@ -111,3 +111,8 @@ surface；超出边界的编辑器、browser content、浏览器权限和扩展�
 - **WHEN** 用户打开 alan app 设置
 - **THEN** alan 将设置页作为 shell tab content 呈现
 - **AND** 设置页继承 shell sidebar、toolbar 和 tab selection 模型
+
+#### Scenario: Browser content is deferred but not blocked
+- **WHEN** 维护者检查 v0.2 content-container 模型
+- **THEN** v1 SHALL NOT 要求 browser ContentInstance kind、browser renderer、WKWebView host、browser profile/cookie policy、download manager 或 browser permission model
+- **AND** 模型 SHALL 保持通用 `ContentInstance`、content kind、payload、capability、renderer、lifecycle 和 PaneSlot 命名，使后续 browser change 可以新增 browser-specific descriptors，而不需要重命名 container contract

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -21,7 +21,7 @@
 - [x] 3.1 Add a content rendering registry or equivalent switch that routes terminal, markdown, and settings descriptors to bounded SwiftUI/AppKit host views.
 - [x] 3.2 Implement read-only markdown content opening with file-backed title, descriptor persistence, and viewer rendering.
 - [x] 3.3 Implement alan settings as shell tab content using the shared shell chrome rather than a separate page/window model.
-- [ ] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.
+- [x] 3.4 Document browser content as a deferred follow-up area and ensure v0.2 model naming does not block adding a browser ContentInstance kind later.
 
 ## 4. Workspace Mutations And Control Plane
 


### PR DESCRIPTION
## Summary
- document browser content as a deferred follow-up for content containers
- clarify that v0.2 keeps generic ContentInstance/payload/capability naming for future browser descriptors
- mark OpenSpec task 3.4 complete

## Validation
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict