### PR TITLE
Handle mixed content PaneSlot mutations

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -1049,17 +1049,30 @@ extension ShellContentStateSnapshot {
     static func projecting(_ shellState: ShellStateSnapshot) -> ShellContentStateSnapshot {
         let layoutPaneIDs = Set(shellState.spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
         let projectedPanes = shellState.panes.filter { layoutPaneIDs.contains($0.paneID) }
-        let explicitPaneSlots = (shellState.paneSlots ?? []).filter {
-            layoutPaneIDs.contains($0.paneSlotID)
+        let paneSlotLocations = paneSlotLocations(in: shellState.spaces)
+        let projectedPanesByID = projectedPanes.reduce(into: [String: ShellPane]()) { panesByID, pane in
+            panesByID[pane.paneID] = pane
+        }
+        let explicitPaneSlots = (shellState.paneSlots ?? []).compactMap { paneSlot -> ShellPaneSlot? in
+            guard layoutPaneIDs.contains(paneSlot.paneSlotID),
+                  let location = paneSlotLocations[paneSlot.paneSlotID]
+            else {
+                return nil
+            }
+
+            return ShellPaneSlot(
+                paneSlotID: paneSlot.paneSlotID,
+                tabID: location.tabID,
+                spaceID: location.spaceID,
+                contentID: paneSlot.contentID,
+                attention: projectedPanesByID[paneSlot.paneSlotID]?.attention ?? paneSlot.attention
+            )
         }
         let explicitPaneSlotIDs = Set(explicitPaneSlots.map(\.paneSlotID))
         let explicitContentIDs = Set(explicitPaneSlots.map(\.contentID))
         let explicitPaneSlotsByContentID = explicitPaneSlots.reduce(into: [String: ShellPaneSlot]()) {
             slotsByContentID, slot in
             slotsByContentID[slot.contentID] = slot
-        }
-        let projectedPanesByID = projectedPanes.reduce(into: [String: ShellPane]()) { panesByID, pane in
-            panesByID[pane.paneID] = pane
         }
         let explicitContents = (shellState.contents ?? []).filter {
             explicitContentIDs.contains($0.contentID)
@@ -1245,6 +1258,18 @@ extension ShellContentStateSnapshot {
             .map(\.attention)
             .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
             ?? .idle
+    }
+
+    private static func paneSlotLocations(
+        in spaces: [ShellSpace]
+    ) -> [String: (spaceID: String, tabID: String)] {
+        spaces.reduce(into: [String: (spaceID: String, tabID: String)]()) { locationsByID, space in
+            for tab in space.tabs {
+                for paneSlotID in tab.paneTree.paneIDs {
+                    locationsByID[paneSlotID] = (spaceID: space.spaceID, tabID: tab.tabID)
+                }
+            }
+        }
     }
 
     private static func attentionRank(for attention: ShellAttentionState) -> Int {

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -315,7 +315,7 @@ extension ShellStateSnapshot {
         let focusedPane = focusedPaneID.flatMap { paneID in
             remainingPanes.first { $0.paneID == paneID }
         }
-        let retained = retainedContentRecords(in: remainingSpaces)
+        let retained = retainedContentRecords(in: remainingSpaces, panes: remainingPanes)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -526,7 +526,7 @@ extension ShellStateSnapshot {
             presentation: .visible,
             lastWorkingDirectory: resolvedWorkingDirectory
         )
-        let retained = retainedContentRecords(in: spaces)
+        let retained = retainedContentRecords(in: spaces, panes: nextPanes)
 
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
@@ -554,7 +554,7 @@ extension ShellStateSnapshot {
             throw ShellStateMutationError.paneNotFound
         }
 
-        let retained = retainedContentRecords(in: spaces)
+        let retained = retainedContentRecords(in: spaces, panes: panes)
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
                 contractVersion: contractVersion,
@@ -589,7 +589,7 @@ extension ShellStateSnapshot {
             focusedPaneID == quickTerminal.paneID
             ? nextPanes.first(where: { !$0.isQuickTerminalPane })?.paneID
             : focusedPaneID
-        let retained = retainedContentRecords(in: spaces)
+        let retained = retainedContentRecords(in: spaces, panes: nextPanes)
 
         return ShellStateMutationResult(
             state: ShellStateSnapshot(
@@ -670,7 +670,7 @@ extension ShellStateSnapshot {
             )
         }
 
-        let retained = retainedContentRecords(in: nextSpaces)
+        let retained = retainedContentRecords(in: nextSpaces, panes: nextPanes)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -1449,7 +1449,7 @@ extension ShellStateSnapshot {
         }
         let focusedSpaceID = focusedPane?.spaceID ?? targetSpaceAfterClose?.spaceID ?? nextSpaces.first?.spaceID
         let focusedTabID = focusedPane?.tabID
-        let retained = retainedContentRecords(in: nextSpaces)
+        let retained = retainedContentRecords(in: nextSpaces, panes: nextPanes)
         let nextState = ShellStateSnapshot(
             contractVersion: contractVersion,
             windowID: windowID,
@@ -1485,7 +1485,7 @@ extension ShellStateSnapshot {
         let focusedPane = resolvedFocusedPaneID.flatMap { candidate in
             panes.first(where: { $0.paneID == candidate })
         }
-        let retained = retainedContentRecords(in: spaces)
+        let retained = retainedContentRecords(in: spaces, panes: panes)
         let nextPaneSlots = (retained.paneSlots ?? []) + additionalPaneSlots
         let nextContents = (retained.contents ?? []) + additionalContents
         let nextContractVersion =
@@ -1507,12 +1507,27 @@ extension ShellStateSnapshot {
         )
     }
 
-    private func retainedContentRecords(in spaces: [ShellSpace]) -> (
+    private func retainedContentRecords(
+        in spaces: [ShellSpace],
+        panes sourcePanes: [ShellPane]
+    ) -> (
         paneSlots: [ShellPaneSlot]?,
         contents: [ShellContentInstance]?
     ) {
-        let activePaneSlotIDs = Set(spaces.flatMap(\.tabs).flatMap(\.paneTree.paneIDs))
-        let retainedPaneSlots = (paneSlots ?? []).filter { activePaneSlotIDs.contains($0.paneSlotID) }
+        let paneSlotLocations = paneSlotLocations(in: spaces)
+        let panesByID = sourcePanes.reduce(into: [String: ShellPane]()) { panesByID, pane in
+            panesByID[pane.paneID] = pane
+        }
+        let retainedPaneSlots = (paneSlots ?? []).compactMap { paneSlot -> ShellPaneSlot? in
+            guard let location = paneSlotLocations[paneSlot.paneSlotID] else { return nil }
+            return ShellPaneSlot(
+                paneSlotID: paneSlot.paneSlotID,
+                tabID: location.tabID,
+                spaceID: location.spaceID,
+                contentID: paneSlot.contentID,
+                attention: panesByID[paneSlot.paneSlotID]?.attention ?? paneSlot.attention
+            )
+        }
         let retainedContentIDs = Set(retainedPaneSlots.map(\.contentID))
         let retainedContents = (contents ?? []).filter { retainedContentIDs.contains($0.contentID) }
 
@@ -1520,6 +1535,16 @@ extension ShellStateSnapshot {
             paneSlots: retainedPaneSlots.isEmpty ? nil : retainedPaneSlots,
             contents: retainedContents.isEmpty ? nil : retainedContents
         )
+    }
+
+    private func paneSlotLocations(in spaces: [ShellSpace]) -> [String: (spaceID: String, tabID: String)] {
+        spaces.reduce(into: [String: (spaceID: String, tabID: String)]()) { locationsByID, space in
+            for tab in space.tabs {
+                for paneSlotID in tab.paneTree.paneIDs {
+                    locationsByID[paneSlotID] = (spaceID: space.spaceID, tabID: tab.tabID)
+                }
+            }
+        }
     }
 
     private func rebuildingAttention(in spaces: [ShellSpace], panes: [ShellPane]) -> [ShellSpace] {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -107,6 +107,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor()
         verifiesOpeningSettingsTabCreatesSingletonShellContent()
         verifiesSplitPaneAcceptsMarkdownContentIntent()
+        verifiesMixedContentPaneSlotMutationsStayContentAgnostic()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
@@ -3965,6 +3966,195 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.launchTarget == nil && controller.selectedPane?.process == nil,
             "markdown split intent must not create a terminal process for the new PaneSlot"
+        )
+    }
+
+    private static func verifiesMixedContentPaneSlotMutationsStayContentAgnostic() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Mixed-\(UUID().uuidString).md")
+        do {
+            try "## Mixed notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            fail("mixed content setup must create a markdown file: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let controller = makeController()
+        let terminalHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let terminalContentID = controller.shellState
+            .contentStateProjection()
+            .contentMounted(in: "pane_1")?
+            .contentID
+        guard let markdownPaneID = controller.splitPane(
+            paneID: "pane_1",
+            placement: .right,
+            contentIntent: .markdown(fileURL: fileURL, title: nil)
+        ) else {
+            fail("mixed content setup must create a markdown split")
+        }
+        guard let settingsPaneID = controller.splitPane(
+            paneID: markdownPaneID,
+            placement: .down,
+            contentIntent: .settings(title: nil)
+        ) else {
+            fail("mixed content setup must create a settings split")
+        }
+        guard let mixedTabID = controller.shellState.pane(paneID: "pane_1")?.tabID else {
+            fail("mixed content setup must keep the source tab")
+        }
+
+        var projection = controller.shellState.contentStateProjection()
+        let markdownContentID = projection.contentMounted(in: markdownPaneID)?.contentID
+        let settingsContentID = projection.contentMounted(in: settingsPaneID)?.contentID
+        expect(
+            projection.tab(tabID: mixedTabID)?.paneTree.paneSlotIDs == [
+                "pane_1",
+                markdownPaneID,
+                settingsPaneID,
+            ],
+            "mixed split setup must keep terminal, markdown, and settings PaneSlots in one tree"
+        )
+        expect(
+            projection.contentMounted(in: markdownPaneID)?.kind == .markdown,
+            "mixed split setup must mount markdown content"
+        )
+        expect(
+            projection.contentMounted(in: settingsPaneID)?.kind == .settings,
+            "mixed split setup must mount settings content"
+        )
+        expect(
+            terminalContentID == projection.contentMounted(in: "pane_1")?.contentID,
+            "mixed split setup must preserve terminal content identity"
+        )
+        expect(
+            !controller.terminalRuntimeRegistry.registeredPaneIDs.contains(markdownPaneID),
+            "markdown PaneSlot must not allocate a terminal runtime"
+        )
+        expect(
+            !controller.terminalRuntimeRegistry.registeredPaneIDs.contains(settingsPaneID),
+            "settings PaneSlot must not allocate a terminal runtime"
+        )
+
+        controller.focus(paneID: settingsPaneID)
+        projection = controller.shellState.contentStateProjection()
+        expect(
+            projection.focusedContent?.kind == .settings,
+            "PaneSlot focus must move from terminal to settings content"
+        )
+        expect(
+            terminalHandle.teardownCount == 0,
+            "focusing non-terminal content must not finalize the terminal runtime"
+        )
+
+        guard let splitNodeID = controller.shellState
+            .tab(tabID: mixedTabID)?
+            .paneTree
+            .splitNodes
+            .first?
+            .nodeID
+        else {
+            fail("mixed split setup must expose a resizable split node")
+        }
+        expect(controller.resizeSplit(splitNodeID: splitNodeID, ratio: 0.7), "mixed split resize must apply")
+        expect(controller.equalizeSelectedTabSplits(), "mixed split equalize must apply")
+        expect(
+            terminalHandle.teardownCount == 0,
+            "resize and equalize must preserve terminal runtime identity"
+        )
+
+        guard let targetTabID = controller.openTerminalTab(in: controller.selectedSpaceID) else {
+            fail("mixed content move setup must create a target tab")
+        }
+        expect(
+            controller.movePane(paneID: markdownPaneID, toTab: targetTabID, direction: .horizontal),
+            "cross-tab move must accept a markdown PaneSlot"
+        )
+        projection = controller.shellState.contentStateProjection()
+        expect(
+            projection.paneSlot(paneSlotID: markdownPaneID)?.tabID == targetTabID,
+            "moved markdown PaneSlot must adopt the target tab membership"
+        )
+        expect(
+            controller.shellState.paneSlots?.first { $0.paneSlotID == markdownPaneID }?.tabID == targetTabID,
+            "cross-tab move must persist markdown PaneSlot target tab membership"
+        )
+        expect(
+            projection.paneSlot(paneSlotID: markdownPaneID)?.spaceID == controller.shellState.focusedSpaceID,
+            "moved markdown PaneSlot must adopt the target space membership"
+        )
+        expect(
+            projection.contentMounted(in: markdownPaneID)?.contentID == markdownContentID,
+            "cross-tab move must preserve markdown ContentInstance identity"
+        )
+        expect(
+            projection.tab(tabID: mixedTabID)?.paneTree.paneSlotIDs.contains(markdownPaneID) == false,
+            "source split tree must drop the moved markdown PaneSlot"
+        )
+        expect(
+            projection.tab(tabID: targetTabID)?.paneTree.paneSlotIDs.contains(markdownPaneID) == true,
+            "target split tree must include the moved markdown PaneSlot"
+        )
+        expect(
+            terminalHandle.teardownCount == 0,
+            "moving non-terminal content must preserve sibling terminal runtime"
+        )
+
+        expect(
+            controller.closePane(paneID: markdownPaneID) == .closed,
+            "closing moved markdown PaneSlot must apply"
+        )
+        projection = controller.shellState.contentStateProjection()
+        expect(
+            projection.paneSlot(paneSlotID: markdownPaneID) == nil,
+            "closing markdown PaneSlot must remove the PaneSlot descriptor"
+        )
+        expect(
+            markdownContentID.flatMap { projection.content(contentID: $0) } == nil,
+            "closing markdown PaneSlot must remove the mounted ContentInstance"
+        )
+        expect(
+            terminalHandle.teardownCount == 0,
+            "closing markdown PaneSlot must not call terminal finalizer"
+        )
+
+        expect(
+            controller.liftPaneToTab(paneID: settingsPaneID) == .lifted,
+            "PaneSlot lift must accept settings content"
+        )
+        projection = controller.shellState.contentStateProjection()
+        guard let liftedSettingsSlot = projection.paneSlot(paneSlotID: settingsPaneID) else {
+            fail("lifted settings PaneSlot must remain in content state")
+        }
+        expect(
+            liftedSettingsSlot.tabID != mixedTabID,
+            "lifted settings PaneSlot must adopt the new tab membership"
+        )
+        expect(
+            controller.shellState.paneSlots?.first { $0.paneSlotID == settingsPaneID }?.tabID
+                == liftedSettingsSlot.tabID,
+            "PaneSlot lift must persist settings target tab membership"
+        )
+        expect(
+            projection.contentMounted(in: settingsPaneID)?.contentID == settingsContentID,
+            "PaneSlot lift must preserve settings ContentInstance identity"
+        )
+        expect(
+            controller.terminalRuntimeRegistry.registeredPaneIDs.contains(settingsPaneID) == false,
+            "lifted settings PaneSlot must not allocate a terminal runtime"
+        )
+
+        expect(
+            controller.closeTab(tabID: liftedSettingsSlot.tabID) == .closed,
+            "closing settings tab must apply"
+        )
+        projection = controller.shellState.contentStateProjection()
+        expect(
+            settingsContentID.flatMap { projection.content(contentID: $0) } == nil,
+            "closing settings tab must remove the settings ContentInstance"
+        )
+        expect(
+            terminalHandle.teardownCount == 0,
+            "closing settings tab must not finalize unrelated terminal runtime"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -26,7 +26,7 @@
 ## 4. Workspace Mutations And Control Plane
 
 - [x] 4.1 Update tab and split creation paths to accept content intent while keeping New Terminal Tab as the default behavior.
-- [ ] 4.2 Update split, focus, resize, equalize, PaneSlot lift, PaneSlot move, close PaneSlot, and close tab mutations to operate on content-agnostic PaneSlots.
+- [x] 4.2 Update split, focus, resize, equalize, PaneSlot lift, PaneSlot move, close PaneSlot, and close tab mutations to operate on content-agnostic PaneSlots.
 - [ ] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
 - [ ] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
 - [ ] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.


### PR DESCRIPTION
## Summary
- derive retained explicit PaneSlot tab/space membership from the authoritative split layout tree during mutations
- normalize content-state projection the same way so stale explicit PaneSlot records cannot leak old container membership
- add a mixed terminal/markdown/settings mutation regression and mark OpenSpec task 4.2 complete

## Verification
- git diff --check
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination platform=macOS -derivedDataPath debug/DerivedData/PaneSlotAgnosticMutations CODE_SIGNING_ALLOWED=NO build