### PR TITLE
Expose content containers in shell control plane

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -123,6 +123,8 @@ extension ShellHostController {
         spaces: [ShellSpace]? = nil,
         tabs: [ShellTab]? = nil,
         panes: [ShellPane]? = nil,
+        paneSlots: [ShellPaneSlot]? = nil,
+        contents: [ShellContentInstance]? = nil,
         pane: ShellPane? = nil,
         items: [AlanShellAttentionInboxItem]? = nil,
         candidates: [AlanShellRoutingCandidate]? = nil,
@@ -132,7 +134,11 @@ extension ShellHostController {
         targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        paneSlotID: String? = nil,
         contentID: String? = nil,
+        contentKind: ShellContentKind? = nil,
+        contentTitle: String? = nil,
+        contentCapabilities: [ShellContentCapability]? = nil,
         section: ShellTabOrganizationSection? = nil,
         index: Int? = nil,
         acceptedBytes: Int? = nil,
@@ -148,6 +154,8 @@ extension ShellHostController {
         targetTabID: String? = nil,
         previousFocusedPaneID: String? = nil,
         currentFocusedPaneID: String? = nil,
+        previousFocusedPaneSlotID: String? = nil,
+        currentFocusedPaneSlotID: String? = nil,
         splitDirection: ShellSplitDirection? = nil,
         spatialDirection: ShellSpatialFocusDirection? = nil,
         placement: ShellPaneSplitDirection? = nil,
@@ -155,25 +163,37 @@ extension ShellHostController {
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) -> AlanShellControlResponse {
-        AlanShellControlResponse(
+        let contentState = shellState.contentStateProjection()
+        let contentProjection = contentState.controlPlaneContentProjection(
+            paneSlotID: paneSlotID ?? paneID,
+            contentID: contentID
+        )
+        return AlanShellControlResponse(
             requestID: requestID,
-            contractVersion: shellState.contractVersion,
+            contractVersion: contentState.contractVersion,
             applied: applied,
             state: state,
             spaces: spaces,
             tabs: tabs,
             panes: panes,
+            paneSlots: paneSlots,
+            contents: contents,
             pane: pane,
             items: items,
             candidates: candidates,
             events: events,
             focusedPaneID: shellState.focusedPaneID,
+            focusedPaneSlotID: contentState.focusedPaneSlotID,
             spaceID: spaceID,
             sourceSpaceID: sourceSpaceID,
             targetSpaceID: targetSpaceID,
             tabID: tabID,
             paneID: paneID,
-            contentID: contentID,
+            paneSlotID: paneSlotID ?? contentProjection.paneSlotID,
+            contentID: contentID ?? contentProjection.contentID,
+            contentKind: contentKind ?? contentProjection.kind,
+            contentTitle: contentTitle ?? contentProjection.title,
+            contentCapabilities: contentCapabilities ?? contentProjection.capabilities,
             section: section,
             index: index,
             acceptedBytes: acceptedBytes,
@@ -189,10 +209,12 @@ extension ShellHostController {
             targetTabID: targetTabID,
             previousFocusedPaneID: previousFocusedPaneID,
             currentFocusedPaneID: currentFocusedPaneID,
+            previousFocusedPaneSlotID: previousFocusedPaneSlotID ?? previousFocusedPaneID,
+            currentFocusedPaneSlotID: currentFocusedPaneSlotID ?? currentFocusedPaneID,
             splitDirection: splitDirection,
             spatialDirection: spatialDirection,
             placement: placement,
-            mountedContentInstanceID: mountedContentInstanceID,
+            mountedContentInstanceID: contentProjection.contentID ?? mountedContentInstanceID,
             errorCode: errorCode,
             errorMessage: errorMessage
         )
@@ -201,10 +223,14 @@ extension ShellHostController {
     func handleControlPlaneCommand(_ command: AlanShellControlCommand) -> AlanShellControlResponse {
         switch command.command {
         case .state:
+            let contentState = shellState.contentStateProjection()
             return response(
                 requestID: command.requestID,
                 applied: true,
-                state: shellState
+                state: shellState,
+                paneSlots: contentState.paneSlots,
+                contents: contentState.contents,
+                paneSlotID: contentState.focusedPaneSlotID
             )
 
         case .spaceList:
@@ -453,10 +479,13 @@ extension ShellHostController {
             )
 
         case .paneList:
+            let contentState = shellState.contentStateProjection()
             return response(
                 requestID: command.requestID,
                 applied: true,
                 panes: paneList(tabID: command.tabID),
+                paneSlots: contentState.controlPlanePaneSlots(in: command.tabID),
+                contents: contentState.controlPlaneContents(in: command.tabID),
                 tabID: command.tabID
             )
 
@@ -479,7 +508,8 @@ extension ShellHostController {
                 pane: pane,
                 spaceID: pane.spaceID,
                 tabID: pane.tabID,
-                paneID: pane.paneID
+                paneID: pane.paneID,
+                paneSlotID: pane.paneID
             )
 
         case .paneSplit:
@@ -512,9 +542,11 @@ extension ShellHostController {
             return response(
                 requestID: command.requestID,
                 applied: true,
+                state: shellState,
                 spaceID: shellState.focusedSpaceID,
                 tabID: shellState.focusedTabID,
-                paneID: newPaneID
+                paneID: newPaneID,
+                paneSlotID: newPaneID
             )
 
         case .paneClose:
@@ -707,6 +739,7 @@ extension ShellHostController {
                     spaceID: target.paneSlot.spaceID,
                     tabID: target.paneSlot.tabID,
                     paneID: target.paneSlot.paneSlotID,
+                    paneSlotID: target.paneSlot.paneSlotID,
                     contentID: target.content.contentID,
                     errorCode: "unsupported_content",
                     errorMessage: "terminal.send_text requires terminal content."
@@ -733,6 +766,7 @@ extension ShellHostController {
                 spaceID: target.paneSlot.spaceID,
                 tabID: target.paneSlot.tabID,
                 paneID: target.paneSlot.paneSlotID,
+                paneSlotID: target.paneSlot.paneSlotID,
                 contentID: target.content.contentID,
                 acceptedBytes: delivery.acceptedBytes,
                 deliveryCode: delivery.code.rawValue,

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -115,6 +115,65 @@ extension AlanShellControlCommand {
     }
 }
 
+struct AlanShellControlContentProjection {
+    let paneSlotID: String?
+    let contentID: String?
+    let kind: ShellContentKind?
+    let title: String?
+    let capabilities: [ShellContentCapability]?
+}
+
+extension ShellContentStateSnapshot {
+    func controlPlanePaneSlots(in tabID: String?) -> [ShellPaneSlot] {
+        guard let tabID else { return paneSlots }
+        return paneSlots.filter { $0.tabID == tabID }
+    }
+
+    func controlPlaneContents(in tabID: String?) -> [ShellContentInstance] {
+        let mountedContentIDs = Set(controlPlanePaneSlots(in: tabID).map(\.contentID))
+        return contents.filter { mountedContentIDs.contains($0.contentID) }
+    }
+
+    func controlPlaneContentProjection(
+        paneSlotID: String?,
+        contentID: String?
+    ) -> AlanShellControlContentProjection {
+        if let contentID,
+           let content = content(contentID: contentID)
+        {
+            let paneSlot = paneSlots.first { $0.contentID == contentID }
+            return AlanShellControlContentProjection(
+                paneSlotID: paneSlot?.paneSlotID,
+                contentID: content.contentID,
+                kind: content.kind,
+                title: content.title,
+                capabilities: content.capabilities
+            )
+        }
+
+        if let paneSlotID,
+           let paneSlot = paneSlot(paneSlotID: paneSlotID),
+           let content = content(contentID: paneSlot.contentID)
+        {
+            return AlanShellControlContentProjection(
+                paneSlotID: paneSlot.paneSlotID,
+                contentID: content.contentID,
+                kind: content.kind,
+                title: content.title,
+                capabilities: content.capabilities
+            )
+        }
+
+        return AlanShellControlContentProjection(
+            paneSlotID: paneSlotID,
+            contentID: contentID,
+            kind: nil,
+            title: nil,
+            capabilities: nil
+        )
+    }
+}
+
 struct AlanShellControlResponse: Codable {
     let requestID: String
     let contractVersion: String
@@ -123,17 +182,24 @@ struct AlanShellControlResponse: Codable {
     let spaces: [ShellSpace]?
     let tabs: [ShellTab]?
     let panes: [ShellPane]?
+    let paneSlots: [ShellPaneSlot]?
+    let contents: [ShellContentInstance]?
     let pane: ShellPane?
     let items: [AlanShellAttentionInboxItem]?
     let candidates: [AlanShellRoutingCandidate]?
     let events: [AlanShellEventEnvelope]?
     let focusedPaneID: String?
+    let focusedPaneSlotID: String?
     let spaceID: String?
     let sourceSpaceID: String?
     let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let paneSlotID: String?
     let contentID: String?
+    let contentKind: ShellContentKind?
+    let contentTitle: String?
+    let contentCapabilities: [ShellContentCapability]?
     let section: ShellTabOrganizationSection?
     let index: Int?
     let acceptedBytes: Int?
@@ -149,6 +215,8 @@ struct AlanShellControlResponse: Codable {
     let targetTabID: String?
     let previousFocusedPaneID: String?
     let currentFocusedPaneID: String?
+    let previousFocusedPaneSlotID: String?
+    let currentFocusedPaneSlotID: String?
     let splitDirection: ShellSplitDirection?
     let spatialDirection: ShellSpatialFocusDirection?
     let placement: ShellPaneSplitDirection?
@@ -164,17 +232,24 @@ struct AlanShellControlResponse: Codable {
         spaces: [ShellSpace]? = nil,
         tabs: [ShellTab]? = nil,
         panes: [ShellPane]? = nil,
+        paneSlots: [ShellPaneSlot]? = nil,
+        contents: [ShellContentInstance]? = nil,
         pane: ShellPane? = nil,
         items: [AlanShellAttentionInboxItem]? = nil,
         candidates: [AlanShellRoutingCandidate]? = nil,
         events: [AlanShellEventEnvelope]? = nil,
         focusedPaneID: String? = nil,
+        focusedPaneSlotID: String? = nil,
         spaceID: String? = nil,
         sourceSpaceID: String? = nil,
         targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        paneSlotID: String? = nil,
         contentID: String? = nil,
+        contentKind: ShellContentKind? = nil,
+        contentTitle: String? = nil,
+        contentCapabilities: [ShellContentCapability]? = nil,
         section: ShellTabOrganizationSection? = nil,
         index: Int? = nil,
         acceptedBytes: Int? = nil,
@@ -190,6 +265,8 @@ struct AlanShellControlResponse: Codable {
         targetTabID: String? = nil,
         previousFocusedPaneID: String? = nil,
         currentFocusedPaneID: String? = nil,
+        previousFocusedPaneSlotID: String? = nil,
+        currentFocusedPaneSlotID: String? = nil,
         splitDirection: ShellSplitDirection? = nil,
         spatialDirection: ShellSpatialFocusDirection? = nil,
         placement: ShellPaneSplitDirection? = nil,
@@ -204,17 +281,24 @@ struct AlanShellControlResponse: Codable {
         self.spaces = spaces
         self.tabs = tabs
         self.panes = panes
+        self.paneSlots = paneSlots
+        self.contents = contents
         self.pane = pane
         self.items = items
         self.candidates = candidates
         self.events = events
         self.focusedPaneID = focusedPaneID
+        self.focusedPaneSlotID = focusedPaneSlotID
         self.spaceID = spaceID
         self.sourceSpaceID = sourceSpaceID
         self.targetSpaceID = targetSpaceID
         self.tabID = tabID
         self.paneID = paneID
+        self.paneSlotID = paneSlotID
         self.contentID = contentID
+        self.contentKind = contentKind
+        self.contentTitle = contentTitle
+        self.contentCapabilities = contentCapabilities
         self.section = section
         self.index = index
         self.acceptedBytes = acceptedBytes
@@ -230,6 +314,8 @@ struct AlanShellControlResponse: Codable {
         self.targetTabID = targetTabID
         self.previousFocusedPaneID = previousFocusedPaneID
         self.currentFocusedPaneID = currentFocusedPaneID
+        self.previousFocusedPaneSlotID = previousFocusedPaneSlotID
+        self.currentFocusedPaneSlotID = currentFocusedPaneSlotID
         self.splitDirection = splitDirection
         self.spatialDirection = spatialDirection
         self.placement = placement
@@ -246,17 +332,24 @@ struct AlanShellControlResponse: Codable {
         case spaces
         case tabs
         case panes
+        case paneSlots = "pane_slots"
+        case contents
         case pane
         case items
         case candidates
         case events
         case focusedPaneID = "focused_pane_id"
+        case focusedPaneSlotID = "focused_pane_slot_id"
         case spaceID = "space_id"
         case sourceSpaceID = "source_space_id"
         case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case paneSlotID = "pane_slot_id"
         case contentID = "content_id"
+        case contentKind = "content_kind"
+        case contentTitle = "content_title"
+        case contentCapabilities = "content_capabilities"
         case section
         case index
         case acceptedBytes = "accepted_bytes"
@@ -272,6 +365,8 @@ struct AlanShellControlResponse: Codable {
         case targetTabID = "target_tab_id"
         case previousFocusedPaneID = "previous_focused_pane_id"
         case currentFocusedPaneID = "current_focused_pane_id"
+        case previousFocusedPaneSlotID = "previous_focused_pane_slot_id"
+        case currentFocusedPaneSlotID = "current_focused_pane_slot_id"
         case splitDirection = "split_direction"
         case spatialDirection = "spatial_direction"
         case placement

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -138,9 +138,17 @@ extension ShellContentStateSnapshot {
         paneSlotID: String?,
         contentID: String?
     ) -> AlanShellControlContentProjection {
-        if let contentID,
-           let content = content(contentID: contentID)
-        {
+        if let contentID {
+            guard let content = content(contentID: contentID) else {
+                return AlanShellControlContentProjection(
+                    paneSlotID: nil,
+                    contentID: contentID,
+                    kind: nil,
+                    title: nil,
+                    capabilities: nil
+                )
+            }
+
             let paneSlot = paneSlots.first { $0.contentID == contentID }
             return AlanShellControlContentProjection(
                 paneSlotID: paneSlot?.paneSlotID,

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -18,15 +18,19 @@ enum AlanShellLocalCommandExecutor {
     ) -> AlanShellLocalCommandResult? {
         switch command.command {
         case .state:
+            let contentState = state.contentStateProjection()
             return AlanShellLocalCommandResult(
                 response: response(
                     for: command,
                     state: state,
                     applied: true,
                     snapshot: state,
+                    paneSlots: contentState.paneSlots,
+                    contents: contentState.contents,
                     spaceID: state.focusedSpaceID,
                     tabID: state.focusedTabID,
-                    paneID: state.focusedPaneID
+                    paneID: state.focusedPaneID,
+                    paneSlotID: contentState.focusedPaneSlotID
                 ),
                 updatedState: nil,
                 sideEffect: nil
@@ -326,12 +330,15 @@ enum AlanShellLocalCommandExecutor {
             }
 
         case .paneList:
+            let contentState = state.contentStateProjection()
             return AlanShellLocalCommandResult(
                 response: response(
                     for: command,
                     state: state,
                     applied: true,
                     panes: state.panes(in: command.tabID),
+                    paneSlots: contentState.controlPlanePaneSlots(in: command.tabID),
+                    contents: contentState.controlPlaneContents(in: command.tabID),
                     tabID: command.tabID ?? state.focusedTabID
                 ),
                 updatedState: nil,
@@ -360,7 +367,8 @@ enum AlanShellLocalCommandExecutor {
                     pane: pane,
                     spaceID: pane.spaceID,
                     tabID: pane.tabID,
-                    paneID: pane.paneID
+                    paneID: pane.paneID,
+                    paneSlotID: pane.paneID
                 ),
                 updatedState: nil,
                 sideEffect: nil
@@ -401,9 +409,11 @@ enum AlanShellLocalCommandExecutor {
                         for: command,
                         state: result.state,
                         applied: true,
+                        snapshot: result.state,
                         spaceID: result.spaceID,
                         tabID: result.tabID,
-                        paneID: result.paneID
+                        paneID: result.paneID,
+                        paneSlotID: result.paneID
                     ),
                     updatedState: result.state,
                     sideEffect: nil
@@ -925,6 +935,8 @@ enum AlanShellLocalCommandExecutor {
         spaces: [ShellSpace]? = nil,
         tabs: [ShellTab]? = nil,
         panes: [ShellPane]? = nil,
+        paneSlots: [ShellPaneSlot]? = nil,
+        contents: [ShellContentInstance]? = nil,
         pane: ShellPane? = nil,
         items: [AlanShellAttentionInboxItem]? = nil,
         candidates: [AlanShellRoutingCandidate]? = nil,
@@ -934,6 +946,11 @@ enum AlanShellLocalCommandExecutor {
         targetSpaceID: String? = nil,
         tabID: String? = nil,
         paneID: String? = nil,
+        paneSlotID: String? = nil,
+        contentID: String? = nil,
+        contentKind: ShellContentKind? = nil,
+        contentTitle: String? = nil,
+        contentCapabilities: [ShellContentCapability]? = nil,
         section: ShellTabOrganizationSection? = nil,
         index: Int? = nil,
         acceptedBytes: Int? = nil,
@@ -943,24 +960,37 @@ enum AlanShellLocalCommandExecutor {
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) -> AlanShellControlResponse {
-        AlanShellControlResponse(
+        let contentState = state.contentStateProjection()
+        let contentProjection = contentState.controlPlaneContentProjection(
+            paneSlotID: paneSlotID ?? paneID,
+            contentID: contentID
+        )
+        return AlanShellControlResponse(
             requestID: command.requestID,
-            contractVersion: state.contractVersion,
+            contractVersion: contentState.contractVersion,
             applied: applied,
             state: snapshot,
             spaces: spaces,
             tabs: tabs,
             panes: panes,
+            paneSlots: paneSlots,
+            contents: contents,
             pane: pane,
             items: items,
             candidates: candidates,
             events: events,
             focusedPaneID: state.focusedPaneID,
+            focusedPaneSlotID: contentState.focusedPaneSlotID,
             spaceID: spaceID,
             sourceSpaceID: sourceSpaceID,
             targetSpaceID: targetSpaceID,
             tabID: tabID,
             paneID: paneID,
+            paneSlotID: paneSlotID ?? contentProjection.paneSlotID,
+            contentID: contentID ?? contentProjection.contentID,
+            contentKind: contentKind ?? contentProjection.kind,
+            contentTitle: contentTitle ?? contentProjection.title,
+            contentCapabilities: contentCapabilities ?? contentProjection.capabilities,
             section: section,
             index: index,
             acceptedBytes: acceptedBytes,

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -224,7 +224,7 @@ final class AlanShellSocketServer {
             debugLog("socket response timeout fd=\(fileDescriptor)")
             let timeoutResponse = AlanShellControlResponse(
                 requestID: command.requestID,
-                contractVersion: "0.1",
+                contractVersion: ShellContentStateSnapshot.currentContractVersion,
                 applied: false,
                 state: nil,
                 spaces: nil,
@@ -256,7 +256,7 @@ final class AlanShellSocketServer {
             response
             ?? AlanShellControlResponse(
                 requestID: command.requestID,
-                contractVersion: "0.1",
+                contractVersion: ShellContentStateSnapshot.currentContractVersion,
                 applied: false,
                 state: nil,
                 spaces: nil,

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -174,7 +174,7 @@ final class AlanShellControlPlane {
         let rows = eventStore.read(afterEventID: command.afterEventID, limit: command.limit)
         return AlanShellControlResponse(
             requestID: command.requestID,
-            contractVersion: "0.1",
+            contractVersion: ShellContentStateSnapshot.currentContractVersion,
             applied: true,
             state: nil,
             spaces: nil,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -275,7 +275,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
                 requestID: command.requestID,
-                contractVersion: "0.1",
+                contractVersion: ShellContentStateSnapshot.currentContractVersion,
                 applied: false,
                 state: nil,
                 spaces: nil,

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -556,6 +556,16 @@ require_pattern \
     "terminal.send_text responses must expose service delivery state"
 
 require_pattern \
+    "clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
+    "paneSlots: \\[ShellPaneSlot\\]?" \
+    "shell control-plane responses must expose PaneSlot descriptors"
+
+require_pattern \
+    "clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
+    "contentCapabilities: \\[ShellContentCapability\\]?" \
+    "shell control-plane responses must expose content capabilities"
+
+require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
     "enum AlanShellLocalCommandExecutor" \
     "shell local command execution must live outside the socket server boundary"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -107,6 +107,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor()
         verifiesOpeningSettingsTabCreatesSingletonShellContent()
         verifiesSplitPaneAcceptsMarkdownContentIntent()
+        verifiesControlPlaneResponsesExposeContentContainers()
         verifiesMixedContentPaneSlotMutationsStayContentAgnostic()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
@@ -1793,7 +1794,8 @@ private enum ShellRuntimeMetadataTests {
         expect(moveResponse.applied == true, "move_within_tab must apply to an adjacent target")
         expect(moveResponse.sourceTabID == moveResponse.targetTabID, "in-tab move must stay in one tab")
         expect(
-            moveResponse.mountedContentInstanceID == "pane_2",
+            moveResponse.mountedContentInstanceID
+                == ShellContentInstance.terminalContentID(forPaneID: "pane_2"),
             "movement response must report preserved mounted content identity"
         )
         expect(
@@ -3966,6 +3968,146 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.launchTarget == nil && controller.selectedPane?.process == nil,
             "markdown split intent must not create a terminal process for the new PaneSlot"
+        )
+    }
+
+    private static func verifiesControlPlaneResponsesExposeContentContainers() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ControlPlane-\(UUID().uuidString).md")
+        do {
+            try "## Control plane notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            fail("control-plane content setup must create a markdown file: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let controller = makeController()
+        guard let markdownPaneID = controller.splitPane(
+            paneID: "pane_1",
+            placement: .right,
+            contentIntent: .markdown(fileURL: fileURL, title: "Notes")
+        ) else {
+            fail("control-plane setup must create markdown content")
+        }
+        guard let settingsPaneID = controller.splitPane(
+            paneID: markdownPaneID,
+            placement: .down,
+            contentIntent: .settings(title: "Settings")
+        ) else {
+            fail("control-plane setup must create settings content")
+        }
+        controller.focus(paneID: settingsPaneID)
+
+        let stateResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-state-1",
+                  "command": "state"
+                }
+                """
+            )
+        )
+        let statePaneSlotIDs = Set(stateResponse.paneSlots?.map(\.paneSlotID) ?? [])
+        let stateContentKinds = Set(stateResponse.contents?.map(\.kind) ?? [])
+        expect(
+            stateResponse.contractVersion == ShellContentStateSnapshot.currentContractVersion,
+            "control-plane state response must advertise the content-state contract"
+        )
+        expect(
+            statePaneSlotIDs.isSuperset(of: Set(["pane_1", markdownPaneID, settingsPaneID])),
+            "control-plane state response must expose PaneSlot descriptors"
+        )
+        expect(
+            stateContentKinds == [.terminal, .markdown, .settings],
+            "control-plane state response must expose mounted ContentInstances"
+        )
+        expect(
+            stateResponse.focusedPaneSlotID == settingsPaneID
+                && stateResponse.paneSlotID == settingsPaneID,
+            "control-plane state response must report focused PaneSlot identity"
+        )
+        expect(
+            stateResponse.contentKind == .settings
+                && stateResponse.contentCapabilities == [.settingsSurface],
+            "control-plane state response must expose focused content capabilities"
+        )
+
+        let snapshotResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-snapshot-1",
+                  "command": "pane.snapshot",
+                  "pane_id": "\(markdownPaneID)"
+                }
+                """
+            )
+        )
+        expect(
+            snapshotResponse.paneSlotID == markdownPaneID
+                && snapshotResponse.contentKind == .markdown
+                && snapshotResponse.contentTitle == "Notes",
+            "pane.snapshot response must project the PaneSlot's mounted content"
+        )
+        expect(
+            snapshotResponse.contentCapabilities == [.markdownReadOnlyViewer],
+            "pane.snapshot response must expose content capabilities"
+        )
+
+        let listResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-list-1",
+                  "command": "pane.list",
+                  "tab_id": "\(controller.selectedTabID ?? "")"
+                }
+                """
+            )
+        )
+        expect(
+            listResponse.paneSlots?.count == 3 && listResponse.contents?.count == 3,
+            "pane.list response must include tab-scoped content containers"
+        )
+
+        let splitResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-split-1",
+                  "command": "pane.split",
+                  "pane_id": "pane_1",
+                  "direction": "horizontal"
+                }
+                """
+            )
+        )
+        expect(splitResponse.applied == true, "pane.split content response setup must apply")
+        expect(
+            splitResponse.state != nil
+                && splitResponse.paneSlotID == splitResponse.paneID
+                && splitResponse.contentKind == .terminal,
+            "pane.split response must include resulting state and mounted content identity"
+        )
+        expect(
+            splitResponse.contentCapabilities?.contains(.terminalInput) == true,
+            "pane.split response must expose terminal content capabilities"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(stateResponse),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            fail("control-plane content response must encode to JSON")
+        }
+        expect(
+            json.contains("\"pane_slots\"")
+                && json.contains("\"contents\"")
+                && json.contains("\"pane_slot_id\"")
+                && json.contains("\"content_capabilities\""),
+            "control-plane content response JSON must use stable content-container keys"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -4095,6 +4095,36 @@ private enum ShellRuntimeMetadataTests {
             "pane.split response must expose terminal content capabilities"
         )
 
+        let invalidContentResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-invalid-1",
+                  "command": "terminal.send_text",
+                  "pane_id": "pane_1",
+                  "content_id": "content_missing",
+                  "text": "echo ignored"
+                }
+                """
+            )
+        )
+        expect(
+            invalidContentResponse.applied == false
+                && invalidContentResponse.errorCode == "content_not_found",
+            "terminal.send_text must reject an explicit unknown content_id"
+        )
+        expect(
+            invalidContentResponse.paneID == "pane_1"
+                && invalidContentResponse.contentID == "content_missing",
+            "unknown content_id response must preserve the requested ids"
+        )
+        expect(
+            invalidContentResponse.paneSlotID == nil
+                && invalidContentResponse.contentKind == nil
+                && invalidContentResponse.contentCapabilities == nil,
+            "unknown content_id response must not fall back to pane-slot content metadata"
+        )
+
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         guard let data = try? encoder.encode(stateResponse),

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -27,7 +27,7 @@
 
 - [x] 4.1 Update tab and split creation paths to accept content intent while keeping New Terminal Tab as the default behavior.
 - [x] 4.2 Update split, focus, resize, equalize, PaneSlot lift, PaneSlot move, close PaneSlot, and close tab mutations to operate on content-agnostic PaneSlots.
-- [ ] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
+- [x] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
 - [ ] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
 - [ ] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
 - [ ] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.


### PR DESCRIPTION
## Summary
- add content-container fields to shell control-plane responses (pane_slots, contents, pane_slot_id, content_id, content kind/title/capabilities)
- project focused/target content metadata through host and local command response paths
- add control-plane coverage for state/list/snapshot/split content-container responses and mark OpenSpec task 4.3 complete

## Verification
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict