### PR TITLE
Accept PaneSlot terminal send targets

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -704,18 +704,19 @@ extension ShellHostController {
 
         case .terminalSendText:
             let contentState = shellState.contentStateProjection()
+            let requestedPaneSlotID = command.paneSlotID ?? command.paneID
             let target: TerminalSendTextTarget?
             if let contentID = command.contentID {
                 target = contentState.terminalSendTextTarget(contentID: contentID)
-            } else if let paneID = command.paneID {
-                target = contentState.terminalSendTextTarget(paneSlotID: paneID)
+            } else if let requestedPaneSlotID {
+                target = contentState.terminalSendTextTarget(paneSlotID: requestedPaneSlotID)
             } else {
                 target = nil
             }
 
             guard let target else {
                 let errorCode: String
-                if command.contentID == nil && command.paneID == nil {
+                if command.contentID == nil && requestedPaneSlotID == nil {
                     errorCode = "terminal_target_required"
                 } else if command.contentID != nil {
                     errorCode = "content_not_found"
@@ -726,6 +727,7 @@ extension ShellHostController {
                     requestID: command.requestID,
                     applied: false,
                     paneID: command.paneID,
+                    paneSlotID: command.paneSlotID,
                     contentID: command.contentID,
                     errorCode: errorCode,
                     errorMessage: "terminal.send_text requires an existing terminal content target."

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -47,6 +47,7 @@ struct AlanShellControlCommand: Codable {
     let targetSpaceID: String?
     let tabID: String?
     let paneID: String?
+    let paneSlotID: String?
     let contentID: String?
     let splitNodeID: String?
     let ratio: Double?
@@ -76,6 +77,7 @@ struct AlanShellControlCommand: Codable {
         case targetSpaceID = "target_space_id"
         case tabID = "tab_id"
         case paneID = "pane_id"
+        case paneSlotID = "pane_slot_id"
         case contentID = "content_id"
         case splitNodeID = "split_node_id"
         case ratio

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -557,6 +557,11 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
+    "case paneSlotID = \"pane_slot_id\"" \
+    "terminal.send_text commands must accept PaneSlot convenience targets"
+
+require_pattern \
+    "clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
     "paneSlots: \\[ShellPaneSlot\\]?" \
     "shell control-plane responses must expose PaneSlot descriptors"
 
@@ -594,6 +599,11 @@ require_pattern \
     "clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift" \
     "toTerminalContentID: target\\.content\\.contentID" \
     "terminal.send_text must use the registry delivery result"
+
+require_pattern \
+    "clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift" \
+    "command\\.paneSlotID \\?\\? command\\.paneID" \
+    "terminal.send_text must resolve PaneSlot targets before terminal delivery"
 
 require_pattern \
     "clients/apple/alan-macos/GhosttyLiveHost.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -4095,6 +4095,119 @@ private enum ShellRuntimeMetadataTests {
             "pane.split response must expose terminal content capabilities"
         )
 
+        let terminalHandle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        guard let terminalContentID = controller.shellState
+            .contentStateProjection()
+            .contentMounted(in: "pane_1")?
+            .contentID
+        else {
+            fail("control-plane send-text setup must expose terminal content identity")
+        }
+
+        let paneSlotText = "echo slot"
+        let paneSlotSendResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "terminal-slot-send-1",
+                  "command": "terminal.send_text",
+                  "pane_slot_id": "pane_1",
+                  "text": "\(paneSlotText)"
+                }
+                """
+            )
+        )
+        expect(
+            paneSlotSendResponse.applied == true
+                && paneSlotSendResponse.paneSlotID == "pane_1"
+                && paneSlotSendResponse.contentID == terminalContentID
+                && paneSlotSendResponse.contentKind == .terminal
+                && paneSlotSendResponse.acceptedBytes == paneSlotText.lengthOfBytes(using: .utf8)
+                && paneSlotSendResponse.deliveryCode == TerminalRuntimeDeliveryCode.accepted.rawValue,
+            "terminal.send_text must resolve pane_slot_id to terminal content before delivery"
+        )
+        expect(
+            terminalHandle.deliveredText == [paneSlotText],
+            "pane_slot_id delivery must reach the terminal runtime"
+        )
+
+        let contentText = "echo content"
+        let contentSendResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "terminal-content-send-1",
+                  "command": "terminal.send_text",
+                  "content_id": "\(terminalContentID)",
+                  "text": "\(contentText)"
+                }
+                """
+            )
+        )
+        expect(
+            contentSendResponse.applied == true
+                && contentSendResponse.paneSlotID == "pane_1"
+                && contentSendResponse.contentID == terminalContentID
+                && contentSendResponse.acceptedBytes == contentText.lengthOfBytes(using: .utf8),
+            "terminal.send_text must deliver explicit terminal content_id targets"
+        )
+        expect(
+            terminalHandle.deliveredText == [paneSlotText, contentText],
+            "content_id delivery must use the terminal content runtime"
+        )
+
+        let deliveredBeforeRejections = terminalHandle.deliveredText
+        let nonTerminalResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "terminal-markdown-send-1",
+                  "command": "terminal.send_text",
+                  "pane_slot_id": "\(markdownPaneID)",
+                  "text": "ignored"
+                }
+                """
+            )
+        )
+        expect(
+            nonTerminalResponse.applied == false
+                && nonTerminalResponse.errorCode == "unsupported_content"
+                && nonTerminalResponse.paneSlotID == markdownPaneID
+                && nonTerminalResponse.contentKind == .markdown
+                && nonTerminalResponse.acceptedBytes == nil
+                && nonTerminalResponse.deliveryCode == nil,
+            "terminal.send_text must reject non-terminal PaneSlot targets"
+        )
+        expect(
+            terminalHandle.deliveredText == deliveredBeforeRejections,
+            "non-terminal terminal.send_text rejection must not deliver runtime text"
+        )
+
+        let missingPaneSlotResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "terminal-missing-slot-1",
+                  "command": "terminal.send_text",
+                  "pane_slot_id": "pane_missing",
+                  "text": "ignored"
+                }
+                """
+            )
+        )
+        expect(
+            missingPaneSlotResponse.applied == false
+                && missingPaneSlotResponse.errorCode == "pane_not_found"
+                && missingPaneSlotResponse.paneSlotID == "pane_missing"
+                && missingPaneSlotResponse.contentID == nil
+                && missingPaneSlotResponse.contentKind == nil,
+            "terminal.send_text must preserve missing pane_slot_id diagnostics"
+        )
+        expect(
+            terminalHandle.deliveredText == deliveredBeforeRejections,
+            "missing pane_slot_id rejection must not deliver runtime text"
+        )
+
         let invalidContentResponse = controller.handleControlPlaneCommand(
             decodeControlCommand(
                 """

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -28,8 +28,8 @@
 - [x] 4.1 Update tab and split creation paths to accept content intent while keeping New Terminal Tab as the default behavior.
 - [x] 4.2 Update split, focus, resize, equalize, PaneSlot lift, PaneSlot move, close PaneSlot, and close tab mutations to operate on content-agnostic PaneSlots.
 - [x] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
-- [ ] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
-- [ ] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
+- [x] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
+- [x] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
 - [ ] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.
 - [ ] 4.7 Ensure workspace manifest updates for pin/live snapshots write content-aware restore payloads and do not dual-write terminal-only snapshots.
 
@@ -46,7 +46,7 @@
 - [ ] 6.1 Add focused shell model tests for v0.1-to-v0.2 migration, mixed content split mutation, and content-aware focus behavior.
 - [ ] 6.2 Add terminal runtime tests proving runtime continuity is keyed by `content_id` across PaneSlot move, tab move, view reattachment, and new-runtime creation after manifest restore.
 - [ ] 6.3 Add fake runtime service tests for `terminal.send_text`, `content_id` delivery, missing runtime errors, and queued delivery diagnostics.
-- [ ] 6.4 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
+- [x] 6.4 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
 - [ ] 6.5 Add workspace manifest migration and lifecycle tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, inactive unpinned Tab retirement finalization, and the rule that `shell-state-window_main.json` is not restore authority.
 - [ ] 6.6 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
 - [ ] 6.7 Run the macOS app build or document any local dependency blocker with the exact failing command.


### PR DESCRIPTION
## Summary
- add pane_slot_id to the shell control-plane command DTO and resolve terminal.send_text by content_id, pane_slot_id, then legacy pane_id
- reject non-terminal terminal.send_text targets with unsupported_content before runtime delivery
- mark OpenSpec tasks 4.4, 4.5, and 6.4 complete

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate generalize-macos-shell-content-containers --strict
- git diff --check