### PR TITLE
Emit content container shell events

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -735,6 +735,18 @@ extension ShellHostController {
             }
 
             guard target.content.kind == .terminal else {
+                let errorCode = "unsupported_content"
+                let errorMessage = "terminal.send_text requires terminal content."
+                controlPlane.recordContentCommandRejected(
+                    requestID: command.requestID,
+                    command: command.command,
+                    spaceID: target.paneSlot.spaceID,
+                    tabID: target.paneSlot.tabID,
+                    paneSlotID: target.paneSlot.paneSlotID,
+                    content: target.content,
+                    errorCode: errorCode,
+                    errorMessage: errorMessage
+                )
                 return response(
                     requestID: command.requestID,
                     applied: false,
@@ -743,8 +755,8 @@ extension ShellHostController {
                     paneID: target.paneSlot.paneSlotID,
                     paneSlotID: target.paneSlot.paneSlotID,
                     contentID: target.content.contentID,
-                    errorCode: "unsupported_content",
-                    errorMessage: "terminal.send_text requires terminal content."
+                    errorCode: errorCode,
+                    errorMessage: errorMessage
                 )
             }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift
@@ -76,6 +76,34 @@ final class AlanShellEventStore {
         )
     }
 
+    func recordContentCommandRejected(
+        requestID: String,
+        command: String,
+        spaceID: String?,
+        tabID: String?,
+        paneSlotID: String,
+        content: ShellContentInstance,
+        errorCode: String,
+        errorMessage: String
+    ) {
+        append(
+            type: "content.command_rejected",
+            spaceID: spaceID,
+            tabID: tabID,
+            paneID: paneSlotID,
+            payload: [
+                "request_id": .string(requestID),
+                "command": .string(command),
+                "pane_slot_id": .string(paneSlotID),
+                "content_id": .string(content.contentID),
+                "content_kind": .string(content.kind.rawValue),
+                "content_title": .string(content.title),
+                "error_code": .string(errorCode),
+                "error_message": .string(errorMessage)
+            ]
+        )
+    }
+
     func recordSplitEqualized(
         requestID: String?,
         spaceID: String?,
@@ -198,7 +226,9 @@ final class AlanShellEventStore {
                 paneID: currentState.focusedPaneID,
                 payload: [
                     "previous_pane_id": .string(previousState.focusedPaneID ?? ""),
-                    "current_pane_id": .string(currentState.focusedPaneID ?? "")
+                    "current_pane_id": .string(currentState.focusedPaneID ?? ""),
+                    "previous_pane_slot_id": .string(previousState.focusedPaneID ?? ""),
+                    "current_pane_slot_id": .string(currentState.focusedPaneID ?? "")
                 ]
             )
         }
@@ -242,6 +272,10 @@ final class AlanShellEventStore {
             currentState: currentState,
             commonTabIDs: previousTabs.intersection(currentTabs)
         )
+        recordContentContainerChanges(
+            previousState: previousState,
+            currentState: currentState
+        )
 
         let allPaneIDs = Set(previousPanesByID.keys).union(currentPanesByID.keys)
         for paneID in allPaneIDs.sorted() {
@@ -273,6 +307,144 @@ final class AlanShellEventStore {
                 )
             }
         }
+    }
+
+    private func recordContentContainerChanges(
+        previousState: ShellStateSnapshot,
+        currentState: ShellStateSnapshot
+    ) {
+        let previousContentState = previousState.contentStateProjection()
+        let currentContentState = currentState.contentStateProjection()
+        let previousPaneSlotsByID = Dictionary(
+            uniqueKeysWithValues: previousContentState.paneSlots.map { ($0.paneSlotID, $0) }
+        )
+        let currentPaneSlotsByID = Dictionary(
+            uniqueKeysWithValues: currentContentState.paneSlots.map { ($0.paneSlotID, $0) }
+        )
+        let previousContentsByID = Dictionary(
+            uniqueKeysWithValues: previousContentState.contents.map { ($0.contentID, $0) }
+        )
+        let currentContentsByID = Dictionary(
+            uniqueKeysWithValues: currentContentState.contents.map { ($0.contentID, $0) }
+        )
+        let previousPaneSlotIDs = Set(previousPaneSlotsByID.keys)
+        let currentPaneSlotIDs = Set(currentPaneSlotsByID.keys)
+        let previousContentIDs = Set(previousContentsByID.keys)
+        let currentContentIDs = Set(currentContentsByID.keys)
+
+        for paneSlotID in currentPaneSlotIDs.subtracting(previousPaneSlotIDs).sorted() {
+            guard let paneSlot = currentPaneSlotsByID[paneSlotID],
+                  let content = currentContentsByID[paneSlot.contentID]
+            else {
+                continue
+            }
+            append(
+                type: "pane_slot.created",
+                spaceID: paneSlot.spaceID,
+                tabID: paneSlot.tabID,
+                paneID: paneSlot.paneSlotID,
+                payload: paneSlotPayload(paneSlot, content: content)
+            )
+        }
+
+        for paneSlotID in previousPaneSlotIDs.subtracting(currentPaneSlotIDs).sorted() {
+            guard let paneSlot = previousPaneSlotsByID[paneSlotID],
+                  let content = previousContentsByID[paneSlot.contentID]
+            else {
+                continue
+            }
+            append(
+                type: "pane_slot.closed",
+                spaceID: paneSlot.spaceID,
+                tabID: paneSlot.tabID,
+                paneID: paneSlot.paneSlotID,
+                payload: paneSlotPayload(paneSlot, content: content)
+            )
+        }
+
+        for paneSlotID in previousPaneSlotIDs.intersection(currentPaneSlotIDs).sorted() {
+            guard let previousPaneSlot = previousPaneSlotsByID[paneSlotID],
+                  let currentPaneSlot = currentPaneSlotsByID[paneSlotID],
+                  previousPaneSlot.contentID != currentPaneSlot.contentID,
+                  let previousContent = previousContentsByID[previousPaneSlot.contentID],
+                  let currentContent = currentContentsByID[currentPaneSlot.contentID]
+            else {
+                continue
+            }
+            append(
+                type: "content.replaced",
+                spaceID: currentPaneSlot.spaceID,
+                tabID: currentPaneSlot.tabID,
+                paneID: currentPaneSlot.paneSlotID,
+                payload: [
+                    "pane_slot_id": .string(currentPaneSlot.paneSlotID),
+                    "previous_content_id": .string(previousContent.contentID),
+                    "previous_content_kind": .string(previousContent.kind.rawValue),
+                    "current_content_id": .string(currentContent.contentID),
+                    "current_content_kind": .string(currentContent.kind.rawValue),
+                    "current_content_title": .string(currentContent.title)
+                ]
+            )
+        }
+
+        for contentID in currentContentIDs.subtracting(previousContentIDs).sorted() {
+            guard let content = currentContentsByID[contentID] else { continue }
+            let paneSlot = currentContentState.paneSlots.first { $0.contentID == contentID }
+            append(
+                type: "content.created",
+                spaceID: paneSlot?.spaceID,
+                tabID: paneSlot?.tabID,
+                paneID: paneSlot?.paneSlotID,
+                payload: contentPayload(content, paneSlot: paneSlot)
+            )
+        }
+
+        for contentID in previousContentIDs.subtracting(currentContentIDs).sorted() {
+            guard let content = previousContentsByID[contentID] else { continue }
+            let paneSlot = previousContentState.paneSlots.first { $0.contentID == contentID }
+            append(
+                type: "content.closed",
+                spaceID: paneSlot?.spaceID,
+                tabID: paneSlot?.tabID,
+                paneID: paneSlot?.paneSlotID,
+                payload: contentPayload(content, paneSlot: paneSlot)
+            )
+        }
+    }
+
+    private func paneSlotPayload(
+        _ paneSlot: ShellPaneSlot,
+        content: ShellContentInstance
+    ) -> [String: AlanShellJSONValue] {
+        var payload = contentPayload(content, paneSlot: paneSlot)
+        payload["pane_slot_id"] = .string(paneSlot.paneSlotID)
+        payload["tab_id"] = .string(paneSlot.tabID)
+        payload["space_id"] = .string(paneSlot.spaceID)
+        payload["attention"] = .string(paneSlot.attention.rawValue)
+        return payload
+    }
+
+    private func contentPayload(
+        _ content: ShellContentInstance,
+        paneSlot: ShellPaneSlot?
+    ) -> [String: AlanShellJSONValue] {
+        var payload: [String: AlanShellJSONValue] = [
+            "content_id": .string(content.contentID),
+            "content_kind": .string(content.kind.rawValue),
+            "content_title": .string(content.title),
+            "content_lifecycle": .string(content.lifecycle.rawValue),
+            "content_capabilities": .array(content.capabilities.map { .string($0.rawValue) }),
+            "renderer_phase": .string(content.rendererState.phase)
+        ]
+        if let detail = content.rendererState.detail {
+            payload["renderer_detail"] = .string(detail)
+        }
+        if let paneSlot {
+            payload["pane_slot_id"] = .string(paneSlot.paneSlotID)
+            payload["tab_id"] = .string(paneSlot.tabID)
+            payload["space_id"] = .string(paneSlot.spaceID)
+        }
+        return payload
     }
 
     private func recordTabOrganizationChanges(

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -37,6 +37,8 @@ enum AlanShellPublishedStateMerger {
             focusedPaneID: focusedPane?.paneID ?? focusedPaneID,
             spaces: mergedSpaces,
             panes: mergedPanes,
+            paneSlots: incoming.paneSlots,
+            contents: incoming.contents,
             quickTerminal: incoming.quickTerminal
         )
     }

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -223,6 +223,28 @@ final class AlanShellControlPlane {
         )
     }
 
+    func recordContentCommandRejected(
+        requestID: String,
+        command: AlanShellControlCommandKind,
+        spaceID: String?,
+        tabID: String?,
+        paneSlotID: String,
+        content: ShellContentInstance,
+        errorCode: String,
+        errorMessage: String
+    ) {
+        eventStore.recordContentCommandRejected(
+            requestID: requestID,
+            command: command.rawValue,
+            spaceID: spaceID,
+            tabID: tabID,
+            paneSlotID: paneSlotID,
+            content: content,
+            errorCode: errorCode,
+            errorMessage: errorMessage
+        )
+    }
+
     func recordSplitEqualized(
         requestID: String?,
         spaceID: String?,

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -571,6 +571,16 @@ require_pattern \
     "shell control-plane responses must expose content capabilities"
 
 require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
+    "pane_slot.created" \
+    "shell events must expose PaneSlot lifecycle creation"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
+    "content.command_rejected" \
+    "shell events must expose rejected content-specific commands"
+
+require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
     "enum AlanShellLocalCommandExecutor" \
     "shell local command execution must live outside the socket server boundary"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -71,6 +71,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesAgentActivityControlCommandProjectsOntoPane()
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
+        verifiesPublishedStateMergePreservesContentContainers()
         verifiesPaneRebuildMutationsPreserveActivity()
         verifiesTabSidebarActivityProjectionUsesHighestPriorityPane()
         verifiesTabSidebarProjectionFallsBackToRepositoryBranch()
@@ -108,6 +109,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesOpeningSettingsTabCreatesSingletonShellContent()
         verifiesSplitPaneAcceptsMarkdownContentIntent()
         verifiesControlPlaneResponsesExposeContentContainers()
+        verifiesContentContainerEventsCaptureLifecycleAndRejections()
         verifiesMixedContentPaneSlotMutationsStayContentAgnostic()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
@@ -2314,6 +2316,47 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesPublishedStateMergePreservesContentContainers() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PublishedStateMerge-\(UUID().uuidString).md")
+        do {
+            try "## Merge notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            fail("published state merge setup must create markdown file: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let baseline = makeController().shellState
+        let splitResult: ShellStateMutationResult
+        do {
+            splitResult = try baseline.splittingPane(
+                "pane_1",
+                placement: .right,
+                contentIntent: .markdown(fileURL: fileURL, title: "Merge Notes")
+            )
+        } catch {
+            fail("published state merge setup must create markdown split: \(error)")
+        }
+        guard let paneSlotID = splitResult.paneID else {
+            fail("published state merge setup must return new PaneSlot id")
+        }
+
+        let merged = AlanShellPublishedStateMerger.merge(
+            authoritative: baseline,
+            incoming: splitResult.state
+        )
+        let mergedContentState = merged.contentStateProjection()
+
+        expect(
+            merged.paneSlots != nil && merged.contents != nil,
+            "published state merge must retain explicit content container records"
+        )
+        expect(
+            mergedContentState.contentMounted(in: paneSlotID)?.kind == .markdown,
+            "published state merge must not project markdown content back into terminal content"
+        )
+    }
+
     private static func verifiesPaneRebuildMutationsPreserveActivity() {
         let controller = makeController()
         let progress = progressActivity(
@@ -4251,6 +4294,164 @@ private enum ShellRuntimeMetadataTests {
                 && json.contains("\"pane_slot_id\"")
                 && json.contains("\"content_capabilities\""),
             "control-plane content response JSON must use stable content-container keys"
+        )
+    }
+
+    private static func verifiesContentContainerEventsCaptureLifecycleAndRejections() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Events-\(UUID().uuidString).md")
+        do {
+            try "## Event notes\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            fail("content event setup must create a markdown file: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let controller = makeController()
+        controller.controlPlane.publish(state: controller.shellState)
+        guard let markdownPaneID = controller.splitPane(
+            paneID: "pane_1",
+            placement: .right,
+            contentIntent: .markdown(fileURL: fileURL, title: "Event Notes")
+        ) else {
+            fail("content event setup must create markdown content")
+        }
+        guard let markdownContent = controller.shellState
+            .contentStateProjection()
+            .contentMounted(in: markdownPaneID)
+        else {
+            fail("content event setup must expose markdown content")
+        }
+
+        let splitEvents = controlEvents(controller)
+        expect(
+            splitEvents.contains {
+                $0.type == "pane_slot.created"
+                    && $0.payload["pane_slot_id"] == .string(markdownPaneID)
+                    && $0.payload["content_id"] == .string(markdownContent.contentID)
+                    && $0.payload["content_kind"] == .string(ShellContentKind.markdown.rawValue)
+            },
+            "markdown split must emit PaneSlot creation event with mounted content"
+        )
+        expect(
+            splitEvents.contains {
+                $0.type == "content.created"
+                    && $0.payload["pane_slot_id"] == .string(markdownPaneID)
+                    && $0.payload["content_id"] == .string(markdownContent.contentID)
+                    && $0.payload["content_kind"] == .string(ShellContentKind.markdown.rawValue)
+            },
+            "markdown split must emit content creation event"
+        )
+
+        let rejectionResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "content-event-reject-1",
+                  "command": "terminal.send_text",
+                  "pane_slot_id": "\(markdownPaneID)",
+                  "text": "ignored"
+                }
+                """
+            )
+        )
+        expect(
+            rejectionResponse.applied == false
+                && rejectionResponse.errorCode == "unsupported_content",
+            "content event setup must reject terminal command for markdown content"
+        )
+        expect(
+            controlEvents(controller).contains {
+                $0.type == "content.command_rejected"
+                    && $0.payload["request_id"] == .string("content-event-reject-1")
+                    && $0.payload["command"] == .string("terminal.send_text")
+                    && $0.payload["pane_slot_id"] == .string(markdownPaneID)
+                    && $0.payload["content_id"] == .string(markdownContent.contentID)
+                    && $0.payload["content_kind"] == .string(ShellContentKind.markdown.rawValue)
+                    && $0.payload["error_code"] == .string("unsupported_content")
+            },
+            "unsupported content command must emit a rejected command event"
+        )
+
+        expect(
+            controller.closePane(paneID: markdownPaneID) == .closed,
+            "content event setup must close markdown PaneSlot"
+        )
+        let closeEvents = controlEvents(controller)
+        expect(
+            closeEvents.contains {
+                $0.type == "pane_slot.closed"
+                    && $0.payload["pane_slot_id"] == .string(markdownPaneID)
+                    && $0.payload["content_id"] == .string(markdownContent.contentID)
+            },
+            "closing markdown content must emit PaneSlot closure event"
+        )
+        expect(
+            closeEvents.contains {
+                $0.type == "content.closed"
+                    && $0.payload["pane_slot_id"] == .string(markdownPaneID)
+                    && $0.payload["content_id"] == .string(markdownContent.contentID)
+                    && $0.payload["content_kind"] == .string(ShellContentKind.markdown.rawValue)
+            },
+            "closing markdown content must emit content closure event"
+        )
+
+        let replacementController = makeController()
+        replacementController.controlPlane.publish(state: replacementController.shellState)
+        let baselineContentState = replacementController.shellState.contentStateProjection()
+        guard let originalSlot = baselineContentState.paneSlot(paneSlotID: "pane_1"),
+              let originalContent = baselineContentState.content(contentID: originalSlot.contentID)
+        else {
+            fail("replacement event setup must expose original terminal content")
+        }
+        let replacementContent = ShellContentInstance(
+            contentID: "content_replacement_markdown",
+            kind: .markdown,
+            title: "Replacement.md",
+            payload: .markdown(
+                ShellMarkdownContentPayload(
+                    fileURL: fileURL.standardizedFileURL.absoluteString,
+                    title: "Replacement.md"
+                )
+            ),
+            rendererState: ShellContentRendererState(phase: "ready", detail: fileURL.path)
+        )
+        let replacementSlot = ShellPaneSlot(
+            paneSlotID: originalSlot.paneSlotID,
+            tabID: originalSlot.tabID,
+            spaceID: originalSlot.spaceID,
+            contentID: replacementContent.contentID,
+            attention: originalSlot.attention
+        )
+        let replacementContentState = ShellContentStateSnapshot(
+            contractVersion: baselineContentState.contractVersion,
+            windowID: baselineContentState.windowID,
+            focusedSpaceID: baselineContentState.focusedSpaceID,
+            focusedTabID: baselineContentState.focusedTabID,
+            focusedPaneSlotID: baselineContentState.focusedPaneSlotID,
+            spaces: baselineContentState.spaces,
+            paneSlots: baselineContentState.paneSlots.map { paneSlot in
+                paneSlot.paneSlotID == originalSlot.paneSlotID ? replacementSlot : paneSlot
+            },
+            contents: baselineContentState.contents.filter {
+                $0.contentID != originalContent.contentID
+            } + [replacementContent]
+        )
+        guard let replacementState = replacementContentState.materializingShellState() else {
+            fail("replacement content state must materialize shell state")
+        }
+        replacementController.controlPlane.publish(state: replacementState)
+
+        expect(
+            controlEvents(replacementController).contains {
+                $0.type == "content.replaced"
+                    && $0.payload["pane_slot_id"] == .string(originalSlot.paneSlotID)
+                    && $0.payload["previous_content_id"] == .string(originalContent.contentID)
+                    && $0.payload["previous_content_kind"] == .string(ShellContentKind.terminal.rawValue)
+                    && $0.payload["current_content_id"] == .string(replacementContent.contentID)
+                    && $0.payload["current_content_kind"] == .string(ShellContentKind.markdown.rawValue)
+            },
+            "same PaneSlot content replacement must emit replacement event"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -30,7 +30,7 @@
 - [x] 4.3 Extend shell control-plane DTOs and responses to expose `pane_slots`, `contents`, `pane_slot_id`, `content_id`, content capabilities, and content-aware mutation results.
 - [x] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
 - [x] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
-- [ ] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.
+- [x] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.
 - [ ] 4.7 Ensure workspace manifest updates for pin/live snapshots write content-aware restore payloads and do not dual-write terminal-only snapshots.
 
 ## 5. UI Integration


### PR DESCRIPTION
## Summary
- emit PaneSlot/content lifecycle and replacement events from shell state diffs
- emit content.command_rejected when terminal.send_text targets non-terminal content
- preserve explicit content containers through published state merging
- mark OpenSpec task 4.6 complete

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict