### PR TITLE
Write content-aware workspace manifests

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -1226,10 +1226,10 @@ extension ShellContentStateSnapshot {
             return nil
         }
 
+        let existingSpaceIDs = Set(materializedSpaces.map(\.spaceID))
         let focusableSpaces = materializedSpaces.filter { !$0.tabs.isEmpty }
-        let validSpaceIDs = Set(focusableSpaces.map(\.spaceID))
         let resolvedFocusedSpaceID = focusedSpaceID.flatMap {
-            validSpaceIDs.contains($0) ? $0 : nil
+            existingSpaceIDs.contains($0) ? $0 : nil
         } ?? focusableSpaces.first?.spaceID ?? materializedSpaces.first?.spaceID
         let focusedSpace = resolvedFocusedSpaceID.flatMap { spaceID in
             materializedSpaces.first { $0.spaceID == spaceID }
@@ -1240,10 +1240,10 @@ extension ShellContentStateSnapshot {
         let focusedTab = resolvedFocusedTabID.flatMap { tabID in
             focusedSpace?.tabs.first { $0.tabID == tabID }
         }
-        let validPaneSlotIDs = Set(materializedPaneSlots.map(\.paneSlotID))
+        let focusedTabPaneIDs = Set(focusedTab?.paneTree.paneIDs ?? [])
         let resolvedFocusedPaneID = focusedPaneSlotID.flatMap {
-            validPaneSlotIDs.contains($0) ? $0 : nil
-        } ?? focusedTab?.paneTree.paneIDs.first ?? materializedPanes.first?.paneID
+            focusedTabPaneIDs.contains($0) ? $0 : nil
+        } ?? focusedTab?.paneTree.paneIDs.first
 
         return ShellStateSnapshot(
             contractVersion: Self.currentContractVersion,

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -1165,6 +1165,9 @@ extension ShellContentStateSnapshot {
     func materializingShellState() -> ShellStateSnapshot? {
         guard contractVersion == Self.currentContractVersion else { return nil }
 
+        let sourceTabCount = spaces.reduce(0) { count, space in
+            count + space.tabs.count
+        }
         let paneSlotsByID = paneSlots.reduce(into: [String: ShellPaneSlot]()) { slotsByID, slot in
             slotsByID[slot.paneSlotID] = slot
         }
@@ -1219,13 +1222,15 @@ extension ShellContentStateSnapshot {
             )
         }
 
-        guard !materializedPanes.isEmpty else { return nil }
+        if sourceTabCount > 0 && materializedPanes.isEmpty {
+            return nil
+        }
 
         let focusableSpaces = materializedSpaces.filter { !$0.tabs.isEmpty }
         let validSpaceIDs = Set(focusableSpaces.map(\.spaceID))
         let resolvedFocusedSpaceID = focusedSpaceID.flatMap {
             validSpaceIDs.contains($0) ? $0 : nil
-        } ?? focusableSpaces.first?.spaceID
+        } ?? focusableSpaces.first?.spaceID ?? materializedSpaces.first?.spaceID
         let focusedSpace = resolvedFocusedSpaceID.flatMap { spaceID in
             materializedSpaces.first { $0.spaceID == spaceID }
         }

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -625,11 +625,9 @@ struct ShellWorkspaceMaterializer {
                 paneSlots.append(contentsOf: snapshotPaneSlots)
                 contents.append(
                     contentsOf: restoreSnapshot.contents.map { content in
-                        ShellContentInstance(
-                            contentID: content.contentID,
-                            kind: content.kind,
-                            title: content.title,
-                            payload: content.payload
+                        restoredContentInstance(
+                            content,
+                            defaultWorkingDirectory: defaultWorkingDirectory
                         )
                     }
                 )
@@ -673,6 +671,33 @@ struct ShellWorkspaceMaterializer {
         )
 
         return contentState.materializingShellState()
+    }
+
+    private static func restoredContentInstance(
+        _ record: ShellContentRestoreRecord,
+        defaultWorkingDirectory: String
+    ) -> ShellContentInstance {
+        let payload: ShellContentPayload
+        if record.kind == .terminal,
+           let terminalPayload = record.payload.terminal
+        {
+            payload = .terminal(
+                ShellTerminalContentPayload(
+                    launchTarget: terminalPayload.launchTarget,
+                    cwd: terminalPayload.cwd ?? defaultWorkingDirectory,
+                    title: terminalPayload.title
+                )
+            )
+        } else {
+            payload = record.payload
+        }
+
+        return ShellContentInstance(
+            contentID: record.contentID,
+            kind: record.kind,
+            title: record.title,
+            payload: payload
+        )
     }
 
     static func materialize(

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -210,6 +210,60 @@ struct ShellContentWorkspaceManifest: Codable, Equatable {
     }
 }
 
+extension ShellContentWorkspaceManifest {
+    static func defaultManifest(
+        windowID: String,
+        defaultWorkingDirectory: String,
+        now: Date
+    ) -> ShellContentWorkspaceManifest {
+        ShellWorkspaceManifest.defaultManifest(
+            windowID: windowID,
+            defaultWorkingDirectory: defaultWorkingDirectory,
+            now: now
+        )
+        .migratingTerminalRestoreSnapshotsToContentContainers()
+    }
+
+    func pruningExpiredTabs(now: Date, ttl: TimeInterval) -> ShellContentWorkspaceManifest {
+        var pruned = self
+        pruned.spaces = spaces.map { space in
+            var space = space
+            space.tabs = space.tabs.filter { $0.shouldRetain(now: now, ttl: ttl) }
+            space.updatedAt = now
+            return space
+        }
+        pruned.repairSelection()
+        return pruned
+    }
+
+    mutating func repairSelection() {
+        guard !spaces.isEmpty else {
+            selectedSpaceID = nil
+            selectedTabID = nil
+            return
+        }
+
+        if selectedSpaceID == nil || !spaces.contains(where: { $0.spaceID == selectedSpaceID }) {
+            selectedSpaceID = spaces.first?.spaceID
+        }
+
+        guard let selectedSpaceID,
+              let selectedSpace = spaces.first(where: { $0.spaceID == selectedSpaceID })
+        else {
+            selectedTabID = nil
+            return
+        }
+
+        let selectedTabStillExists = selectedTabID.map { selectedTabID in
+            selectedSpace.tabs.contains { $0.tabID == selectedTabID }
+        } ?? false
+
+        if !selectedTabStillExists {
+            selectedTabID = selectedSpace.tabs.first?.tabID
+        }
+    }
+}
+
 struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
     var spaceID: String
     var title: String
@@ -256,6 +310,63 @@ struct ShellContentWorkspaceTabRecord: Codable, Equatable, Identifiable {
         case liveSnapshot = "live_snapshot"
         case activeTask = "active_task"
     }
+
+    func restoreSnapshot(defaultWorkingDirectory: String) -> ShellContentTabRestoreSnapshot {
+        if isPinned, let pinSnapshot {
+            return pinSnapshot
+        }
+
+        if let liveSnapshot {
+            return liveSnapshot
+        }
+
+        let paneSlotID = "pane_\(tabID)"
+        let contentID = ShellContentInstance.terminalContentID(forPaneID: paneSlotID)
+        let title = title ?? ShellWorkspaceMaterializer.defaultViewportTitleForMigration(
+            launchTarget: .shell
+        )
+        return ShellContentTabRestoreSnapshot(
+            paneTree: ShellPaneSlotTreeNode(
+                nodeID: "node_\(paneSlotID)",
+                kind: .pane,
+                direction: nil,
+                paneSlotID: paneSlotID,
+                children: nil
+            ),
+            paneSlots: [
+                ShellPaneSlotRestoreRecord(
+                    paneSlotID: paneSlotID,
+                    contentID: contentID
+                )
+            ],
+            contents: [
+                ShellContentRestoreRecord(
+                    contentID: contentID,
+                    kind: .terminal,
+                    title: title,
+                    payload: .terminal(
+                        ShellTerminalContentPayload(
+                            launchTarget: .shell,
+                            cwd: defaultWorkingDirectory,
+                            title: title
+                        )
+                    )
+                )
+            ]
+        )
+    }
+
+    func shouldRetain(now: Date, ttl: TimeInterval) -> Bool {
+        if isPinned {
+            return true
+        }
+
+        if activeTask.protectsFromPruning {
+            return true
+        }
+
+        return now.timeIntervalSince(max(lastActivatedAt, lastActivityAt)) <= ttl
+    }
 }
 
 struct ShellContentTabRestoreSnapshot: Codable, Equatable {
@@ -295,6 +406,38 @@ struct ShellContentRestoreRecord: Codable, Equatable, Identifiable {
         case kind
         case title
         case payload
+    }
+}
+
+extension ShellContentTabRestoreSnapshot {
+    static func projecting(
+        tab: ShellTab,
+        contentState: ShellContentStateSnapshot
+    ) -> ShellContentTabRestoreSnapshot {
+        let paneSlotIDs = tab.paneTree.paneIDs
+        let paneSlots = paneSlotIDs.compactMap { paneSlotID in
+            contentState.paneSlot(paneSlotID: paneSlotID)
+        }
+        let mountedContentIDs = Set(paneSlots.map(\.contentID))
+        let contents = contentState.contents.filter { mountedContentIDs.contains($0.contentID) }
+
+        return ShellContentTabRestoreSnapshot(
+            paneTree: ShellPaneSlotTreeNode.migrating(paneTree: tab.paneTree),
+            paneSlots: paneSlots.map { paneSlot in
+                ShellPaneSlotRestoreRecord(
+                    paneSlotID: paneSlot.paneSlotID,
+                    contentID: paneSlot.contentID
+                )
+            },
+            contents: contents.map { content in
+                ShellContentRestoreRecord(
+                    contentID: content.contentID,
+                    kind: content.kind,
+                    title: content.title,
+                    payload: content.payload
+                )
+            }
+        )
     }
 }
 
@@ -411,6 +554,127 @@ extension ShellTabRestoreSnapshot {
 }
 
 struct ShellWorkspaceMaterializer {
+    static func materialize(
+        manifest: ShellContentWorkspaceManifest,
+        defaultWorkingDirectory: String,
+        now: Date
+    ) -> ShellStateSnapshot {
+        var repairedManifest = manifest
+        repairedManifest.repairSelection()
+
+        let sourceManifest = repairedManifest.spaces.isEmpty
+            ? ShellContentWorkspaceManifest.defaultManifest(
+                windowID: manifest.windowID,
+                defaultWorkingDirectory: defaultWorkingDirectory,
+                now: now
+            )
+            : repairedManifest
+
+        if let state = materializeContentManifest(
+            sourceManifest,
+            defaultWorkingDirectory: defaultWorkingDirectory
+        ) {
+            return state
+        }
+
+        let fallbackManifest = ShellContentWorkspaceManifest.defaultManifest(
+            windowID: manifest.windowID,
+            defaultWorkingDirectory: defaultWorkingDirectory,
+            now: now
+        )
+        return materializeContentManifest(
+            fallbackManifest,
+            defaultWorkingDirectory: defaultWorkingDirectory
+        ) ?? ShellStateSnapshot.bootstrapDefault(
+            windowID: manifest.windowID,
+            workingDirectory: defaultWorkingDirectory
+        )
+    }
+
+    private static func materializeContentManifest(
+        _ sourceManifest: ShellContentWorkspaceManifest,
+        defaultWorkingDirectory: String
+    ) -> ShellStateSnapshot? {
+        let spaces = sourceManifest.spaces.sorted { lhs, rhs in
+            if lhs.order == rhs.order {
+                return lhs.spaceID < rhs.spaceID
+            }
+            return lhs.order < rhs.order
+        }
+
+        var paneSlots: [ShellPaneSlot] = []
+        var contents: [ShellContentInstance] = []
+        let contentSpaces = spaces.map { space -> ShellContentSpace in
+            let contentTabs = organizedTabs(space.tabs).compactMap { tabRecord -> ShellContentTab? in
+                let restoreSnapshot = tabRecord.restoreSnapshot(
+                    defaultWorkingDirectory: defaultWorkingDirectory
+                )
+                let validContentIDs = Set(restoreSnapshot.contents.map(\.contentID))
+                let snapshotPaneSlots = restoreSnapshot.paneSlots.compactMap { paneSlot -> ShellPaneSlot? in
+                    guard validContentIDs.contains(paneSlot.contentID) else { return nil }
+                    return ShellPaneSlot(
+                        paneSlotID: paneSlot.paneSlotID,
+                        tabID: tabRecord.tabID,
+                        spaceID: space.spaceID,
+                        contentID: paneSlot.contentID,
+                        attention: tabRecord.tabID == sourceManifest.selectedTabID ? .active : .idle
+                    )
+                }
+                guard !snapshotPaneSlots.isEmpty else { return nil }
+
+                paneSlots.append(contentsOf: snapshotPaneSlots)
+                contents.append(
+                    contentsOf: restoreSnapshot.contents.map { content in
+                        ShellContentInstance(
+                            contentID: content.contentID,
+                            kind: content.kind,
+                            title: content.title,
+                            payload: content.payload
+                        )
+                    }
+                )
+
+                return ShellContentTab(
+                    tabID: tabRecord.tabID,
+                    kind: tabRecord.kind,
+                    title: tabRecord.title,
+                    paneTree: restoreSnapshot.paneTree,
+                    isPinned: tabRecord.isPinned
+                )
+            }
+
+            return ShellContentSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: strongestAttention(
+                    in: paneSlots.filter { $0.spaceID == space.spaceID }
+                ),
+                tabs: contentTabs
+            )
+        }
+
+        let contentState = ShellContentStateSnapshot(
+            contractVersion: ShellContentStateSnapshot.currentContractVersion,
+            windowID: sourceManifest.windowID,
+            focusedSpaceID: sourceManifest.selectedSpaceID,
+            focusedTabID: sourceManifest.selectedTabID,
+            focusedPaneSlotID: sourceManifest.selectedTabID
+                .flatMap { selectedTabID in
+                    contentSpaces
+                        .flatMap(\.tabs)
+                        .first { $0.tabID == selectedTabID }?
+                        .paneTree
+                        .paneSlotIDs
+                        .first
+                },
+            spaces: contentSpaces,
+            paneSlots: paneSlots,
+            contents: contents
+        )
+
+        return contentState.materializingShellState()
+    }
+
     static func materialize(
         manifest: ShellWorkspaceManifest,
         defaultWorkingDirectory: String,
@@ -533,6 +797,12 @@ struct ShellWorkspaceMaterializer {
         tabs.filter(\.isPinned) + tabs.filter { !$0.isPinned }
     }
 
+    private static func organizedTabs(
+        _ tabs: [ShellContentWorkspaceTabRecord]
+    ) -> [ShellContentWorkspaceTabRecord] {
+        tabs.filter(\.isPinned) + tabs.filter { !$0.isPinned }
+    }
+
     private static func strongestAttention(
         for tabs: [ShellTab],
         panes: [ShellPane]
@@ -556,6 +826,13 @@ struct ShellWorkspaceMaterializer {
         case .awaitingUser:
             return 3
         }
+    }
+
+    private static func strongestAttention(in paneSlots: [ShellPaneSlot]) -> ShellAttentionState {
+        paneSlots
+            .map(\.attention)
+            .max { attentionRank(for: $0) < attentionRank(for: $1) }
+            ?? .idle
     }
 
     private static func defaultViewportTitle(for launchTarget: ShellLaunchTarget) -> String {

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -1,12 +1,13 @@
 import Foundation
 
 struct ShellWorkspaceManifestLoadResult: Equatable {
-    var manifest: ShellWorkspaceManifest
+    var manifest: ShellContentWorkspaceManifest
     var recovery: ShellWorkspaceManifestRecovery
 }
 
 enum ShellWorkspaceManifestRecovery: Equatable {
     case loadedExisting
+    case migratedLegacyTerminalManifest
     case createdDefault
     case quarantinedCorruptFile(URL)
 }
@@ -39,7 +40,7 @@ struct ShellWorkspaceManifestStore {
         now: Date
     ) throws -> ShellWorkspaceManifestLoadResult {
         if !fileManager.fileExists(atPath: manifestURL.path) {
-            let manifest = ShellWorkspaceManifest.defaultManifest(
+            let manifest = ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: defaultWorkingDirectory,
                 now: now
@@ -50,16 +51,35 @@ struct ShellWorkspaceManifestStore {
 
         do {
             let data = try Data(contentsOf: manifestURL)
-            let manifest = try Self.decoder.decode(ShellWorkspaceManifest.self, from: data)
-            guard manifest.schemaVersion == ShellWorkspaceManifest.currentSchemaVersion else {
+            if let manifest = try? Self.decoder.decode(ShellContentWorkspaceManifest.self, from: data) {
+                guard manifest.schemaVersion == ShellWorkspaceManifest.currentSchemaVersion,
+                      manifest.contentContractVersion == ShellContentWorkspaceManifest.currentContentContractVersion
+                else {
+                    throw DecodingError.dataCorrupted(
+                        DecodingError.Context(
+                            codingPath: [],
+                            debugDescription: "Unsupported shell workspace manifest schema"
+                        )
+                    )
+                }
+                return ShellWorkspaceManifestLoadResult(manifest: manifest, recovery: .loadedExisting)
+            }
+
+            let legacyManifest = try Self.decoder.decode(ShellWorkspaceManifest.self, from: data)
+            guard legacyManifest.schemaVersion == ShellWorkspaceManifest.currentSchemaVersion else {
                 throw DecodingError.dataCorrupted(
                     DecodingError.Context(
                         codingPath: [],
-                        debugDescription: "Unsupported shell workspace manifest schema"
+                        debugDescription: "Unsupported legacy shell workspace manifest schema"
                     )
                 )
             }
-            return ShellWorkspaceManifestLoadResult(manifest: manifest, recovery: .loadedExisting)
+            let migratedManifest = legacyManifest.migratingTerminalRestoreSnapshotsToContentContainers()
+            try save(migratedManifest)
+            return ShellWorkspaceManifestLoadResult(
+                manifest: migratedManifest,
+                recovery: .migratedLegacyTerminalManifest
+            )
         } catch {
             let corruptURL = quarantineURL(now: now)
             if fileManager.fileExists(atPath: corruptURL.path) {
@@ -67,7 +87,7 @@ struct ShellWorkspaceManifestStore {
             }
             try fileManager.moveItem(at: manifestURL, to: corruptURL)
 
-            let manifest = ShellWorkspaceManifest.defaultManifest(
+            let manifest = ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: defaultWorkingDirectory,
                 now: now
@@ -80,7 +100,17 @@ struct ShellWorkspaceManifestStore {
         }
     }
 
-    func save(_ manifest: ShellWorkspaceManifest) throws {
+    func save(_ manifest: ShellContentWorkspaceManifest) throws {
+        let directoryURL = manifestURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        let data = try Self.encoder.encode(manifest)
+        try data.write(to: manifestURL, options: .atomic)
+    }
+
+    func saveLegacyTerminalManifest(_ manifest: ShellWorkspaceManifest) throws {
         let directoryURL = manifestURL.deletingLastPathComponent()
         try fileManager.createDirectory(
             at: directoryURL,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -265,7 +265,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let persistenceURL: URL
     private let persistenceStore: ShellStatePersistenceStore
     private let workspaceManifestStore: ShellWorkspaceManifestStore?
-    private var workspaceManifest: ShellWorkspaceManifest?
+    private var workspaceManifest: ShellContentWorkspaceManifest?
     private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     private let paneProjection: ShellPaneProjectionService
     private let terminalContentProjection: TerminalContentProjectionAdapter
@@ -326,7 +326,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         persistenceURL: URL? = nil,
         terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil,
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
-        workspaceManifest: ShellWorkspaceManifest? = nil,
+        workspaceManifest: ShellContentWorkspaceManifest? = nil,
         appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
         self.fileManager = fileManager
@@ -395,7 +395,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
         let manifestStore: ShellWorkspaceManifestStore?
-        let manifest: ShellWorkspaceManifest?
+        let manifest: ShellContentWorkspaceManifest?
         let manifestRecovery: ShellWorkspaceManifestRecovery?
         let retiredTabCount: Int
         switch startupMode {
@@ -433,7 +433,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 now: now
             )
             let loadedManifest = loadResult?.manifest
-                ?? ShellWorkspaceManifest.defaultManifest(
+                ?? ShellContentWorkspaceManifest.defaultManifest(
                     windowID: resolvedWindowContext.windowID,
                     defaultWorkingDirectory: workingDirectory,
                     now: now
@@ -2118,7 +2118,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func applyPinSnapshotOverrides(
-        to manifest: inout ShellWorkspaceManifest,
+        to manifest: inout ShellContentWorkspaceManifest,
         tabIDs: Set<String>
     ) {
         for spaceIndex in manifest.spaces.indices {
@@ -2128,7 +2128,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                       let tab = shellState.tab(tabID: tabID)
                 else { continue }
 
-                let snapshot = makeRestoreSnapshot(for: tab, panes: shellState.panes(in: tabID))
+                let snapshot = makeRestoreSnapshot(for: tab)
                 manifest.spaces[spaceIndex].tabs[tabIndex].isPinned = true
                 manifest.spaces[spaceIndex].tabs[tabIndex].pinSnapshot = snapshot
                 manifest.spaces[spaceIndex].tabs[tabIndex].liveSnapshot = snapshot
@@ -2138,7 +2138,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private func updateWorkspaceManifestTab(
         tabID: String,
-        mutate: (inout ShellWorkspaceTabRecord, ShellTabRestoreSnapshot) -> Void,
+        mutate: (inout ShellContentWorkspaceTabRecord, ShellContentTabRestoreSnapshot) -> Void,
         diagnostic: (String) -> String
     ) -> Bool {
         guard let tab = shellState.tab(tabID: tabID),
@@ -2147,8 +2147,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return false
         }
 
-        let panes = shellState.panes(in: tabID)
-        let snapshot = makeRestoreSnapshot(for: tab, panes: panes)
+        let snapshot = makeRestoreSnapshot(for: tab)
         var manifest = makeWorkspaceManifestFromShellState(now: .now)
         var didUpdate = false
 
@@ -2175,7 +2174,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func makeWorkspaceManifestFromShellState(now: Date) -> ShellWorkspaceManifest {
+    private func makeWorkspaceManifestFromShellState(now: Date) -> ShellContentWorkspaceManifest {
         let existingSpaces = Dictionary(
             uniqueKeysWithValues: (workspaceManifest?.spaces ?? []).map { ($0.spaceID, $0) }
         )
@@ -2184,13 +2183,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 .flatMap(\.tabs)
                 .map { ($0.tabID, $0) }
         )
+        let contentState = shellState.contentStateProjection()
 
-        let spaces = shellState.spaces.enumerated().map { index, space -> ShellWorkspaceSpaceRecord in
+        let spaces = shellState.spaces.enumerated().map { index, space -> ShellContentWorkspaceSpaceRecord in
             let existingSpace = existingSpaces[space.spaceID]
-            let tabRecords = space.tabs.map { tab -> ShellWorkspaceTabRecord in
+            let tabRecords = space.tabs.map { tab -> ShellContentWorkspaceTabRecord in
                 let existingTab = existingTabs[tab.tabID]
                 let panes = shellState.panes(in: tab.tabID)
-                let snapshot = makeRestoreSnapshot(for: tab, panes: panes)
+                let snapshot = makeRestoreSnapshot(for: tab, contentState: contentState)
                 let paneActivityAt = panes.compactMap { paneActivityDate($0) }.max()
                 let lastActivatedAt = tab.tabID == shellState.focusedTabID
                     ? now
@@ -2200,7 +2200,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     paneActivityAt ?? existingTab?.lastActivityAt ?? now
                 )
 
-                return ShellWorkspaceTabRecord(
+                return ShellContentWorkspaceTabRecord(
                     tabID: tab.tabID,
                     title: tab.title,
                     kind: tab.kind,
@@ -2214,7 +2214,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 )
             }
 
-            return ShellWorkspaceSpaceRecord(
+            return ShellContentWorkspaceSpaceRecord(
                 spaceID: space.spaceID,
                 title: space.title,
                 order: existingSpace?.order ?? index,
@@ -2224,8 +2224,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             )
         }
 
-        var manifest = ShellWorkspaceManifest(
+        var manifest = ShellContentWorkspaceManifest(
             schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
             windowID: shellState.windowID,
             selectedSpaceID: shellState.focusedSpaceID ?? selectedSpaceID,
             selectedTabID: shellState.focusedTabID,
@@ -2236,20 +2237,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func makeRestoreSnapshot(
+        for tab: ShellTab
+    ) -> ShellContentTabRestoreSnapshot {
+        makeRestoreSnapshot(for: tab, contentState: shellState.contentStateProjection())
+    }
+
+    private func makeRestoreSnapshot(
         for tab: ShellTab,
-        panes: [ShellPane]
-    ) -> ShellTabRestoreSnapshot {
-        let paneByID = Dictionary(uniqueKeysWithValues: panes.map { ($0.paneID, $0) })
-        let restorePanes = tab.paneTree.paneIDs.compactMap { paneID -> ShellPaneRestoreRecord? in
-            guard let pane = paneByID[paneID] else { return nil }
-            return ShellPaneRestoreRecord(
-                paneID: pane.paneID,
-                launchTarget: pane.resolvedLaunchTarget,
-                cwd: pane.cwd,
-                title: pane.viewport?.title ?? tab.title
-            )
-        }
-        return ShellTabRestoreSnapshot(paneTree: tab.paneTree, panes: restorePanes)
+        contentState: ShellContentStateSnapshot
+    ) -> ShellContentTabRestoreSnapshot {
+        ShellContentTabRestoreSnapshot.projecting(tab: tab, contentState: contentState)
     }
 
     private func paneActivityDate(_ pane: ShellPane) -> Date? {
@@ -2354,6 +2351,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         switch recovery {
         case .loadedExisting:
             return
+        case .migratedLegacyTerminalManifest:
+            recordControlPlaneDiagnostic("workspace manifest migrated terminal snapshots to content containers")
         case .createdDefault:
             recordControlPlaneDiagnostic("workspace manifest created default")
         case .quarantinedCorruptFile(let url):

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -516,6 +516,21 @@ require_pattern \
     "workspace restore authority must use the ShellWorkspaceManifest store filename"
 
 require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
+    "ShellContentWorkspaceManifest\\.self" \
+    "workspace manifest restore must prefer content-container manifests"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "makeWorkspaceManifestFromShellState\\(now: Date\\) -> ShellContentWorkspaceManifest" \
+    "workspace manifest writes must produce content-container manifests"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-runtime-metadata.swift" \
+    "persisted content manifest must not dual-write terminal-only panes" \
+    "workspace manifest tests must reject terminal-only snapshot dual-write"
+
+require_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
     "case \\.workspaceManifest:" \
     "shell host startup must have a workspace-manifest restore path"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -4794,7 +4794,7 @@ private enum ShellRuntimeMetadataTests {
         )
 
         do {
-            try store.save(manifest)
+            try store.saveLegacyTerminalManifest(manifest)
         } catch {
             fail("failed to write test manifest: \(error)")
         }
@@ -4816,6 +4816,19 @@ private enum ShellRuntimeMetadataTests {
             controller.shellState.focusedTabID == "tab_main",
             "workspace manifest startup must preserve selected tab"
         )
+        guard let migratedManifest = decodeManifest(at: manifestURL),
+              let migratedTab = migratedManifest.spaces.flatMap(\.tabs).first
+        else {
+            fail("workspace manifest startup must migrate legacy terminal manifest")
+        }
+        expect(
+            migratedTab.pinSnapshot?.paneSlots.first?.paneSlotID == "pane_1",
+            "legacy terminal manifest migration must preserve PaneSlot identity"
+        )
+        expect(
+            migratedTab.pinSnapshot?.contents.first?.payload.terminal?.cwd == "/pinned",
+            "legacy terminal manifest migration must preserve terminal restore payload"
+        )
     }
 
     private static func verifiesClosingLastTabLeavesSelectedSpaceEmptyAndPersistsManifest() {
@@ -4826,7 +4839,7 @@ private enum ShellRuntimeMetadataTests {
         let controller = makeController(
             windowID: windowID,
             workspaceManifestStore: store,
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 30)
@@ -4862,7 +4875,7 @@ private enum ShellRuntimeMetadataTests {
         let controller = makeController(
             windowID: windowID,
             workspaceManifestStore: store,
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 40)
@@ -4891,7 +4904,7 @@ private enum ShellRuntimeMetadataTests {
         let controller = makeController(
             windowID: windowID,
             workspaceManifestStore: store,
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 50)
@@ -4911,24 +4924,28 @@ private enum ShellRuntimeMetadataTests {
             fail("pin-tab must persist manifest tab")
         }
 
-        expect(tab.isPinned, "pin-tab must mark the tab as pinned")
-        expect(tab.pinSnapshot?.paneTree.paneIDs.count == 2, "pin snapshot must preserve split layout at pin time")
-        expect(tab.liveSnapshot?.paneTree.paneIDs.count == 3, "live snapshot must track later transient split changes")
         expect(
-            tab.pinSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/pinned",
+            rawManifestText(at: manifestURL)?.contains("\"panes\"") == false,
+            "persisted content manifest must not dual-write terminal-only panes"
+        )
+        expect(tab.isPinned, "pin-tab must mark the tab as pinned")
+        expect(tab.pinSnapshot?.paneTree.paneSlotIDs.count == 2, "pin snapshot must preserve split layout at pin time")
+        expect(tab.liveSnapshot?.paneTree.paneSlotIDs.count == 3, "live snapshot must track later transient split changes")
+        expect(
+            terminalPayload(in: tab.pinSnapshot, paneSlotID: "pane_1")?.cwd == "/pinned",
             "pin snapshot must keep cwd from pin time"
         )
         expect(
-            tab.liveSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/moved",
+            terminalPayload(in: tab.liveSnapshot, paneSlotID: "pane_1")?.cwd == "/moved",
             "live snapshot must track later cwd changes without mutating pin snapshot"
         )
 
         expect(controller.updatePinnedTabSnapshot(tabID: "tab_main"), "update-pin must be accepted")
         let updatedManifest = decodeManifest(at: manifestURL)
         let updatedTab = updatedManifest?.spaces.flatMap(\.tabs).first { $0.tabID == "tab_main" }
-        expect(updatedTab?.pinSnapshot?.paneTree.paneIDs.count == 3, "update-pin must replace pin split snapshot")
+        expect(updatedTab?.pinSnapshot?.paneTree.paneSlotIDs.count == 3, "update-pin must replace pin split snapshot")
         expect(
-            updatedTab?.pinSnapshot?.panes.first(where: { $0.paneID == "pane_1" })?.cwd == "/moved",
+            terminalPayload(in: updatedTab?.pinSnapshot, paneSlotID: "pane_1")?.cwd == "/moved",
             "update-pin must replace pin cwd snapshot"
         )
     }
@@ -4941,7 +4958,7 @@ private enum ShellRuntimeMetadataTests {
         let controller = makeController(
             windowID: windowID,
             workspaceManifestStore: store,
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: windowID,
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 60)
@@ -4992,7 +5009,7 @@ private enum ShellRuntimeMetadataTests {
         let foregroundController = makeController(
             windowID: "active_foreground_\(UUID().uuidString)",
             workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: foregroundURL),
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: "window_main",
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 60)
@@ -5012,7 +5029,7 @@ private enum ShellRuntimeMetadataTests {
         let idleController = makeController(
             windowID: "active_idle_\(UUID().uuidString)",
             workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: idleURL),
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: "window_main",
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 61)
@@ -5032,7 +5049,7 @@ private enum ShellRuntimeMetadataTests {
         let exitedController = makeController(
             windowID: "active_exited_\(UUID().uuidString)",
             workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: exitedURL),
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: "window_main",
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 62)
@@ -5055,7 +5072,7 @@ private enum ShellRuntimeMetadataTests {
         let activeOnlyController = makeController(
             windowID: "active_only_\(UUID().uuidString)",
             workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: activeOnlyURL),
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: "window_main",
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 64)
@@ -5080,7 +5097,7 @@ private enum ShellRuntimeMetadataTests {
             windowID: alanPendingWindowID,
             shellState: stateWithAlanBinding(windowID: alanPendingWindowID, pendingYield: true),
             workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: alanPendingURL),
-            workspaceManifest: ShellWorkspaceManifest.defaultManifest(
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
                 windowID: alanPendingWindowID,
                 defaultWorkingDirectory: "/tmp",
                 now: Date(timeIntervalSince1970: 63)
@@ -5094,7 +5111,7 @@ private enum ShellRuntimeMetadataTests {
         windowID: String = "metadata_test_\(UUID().uuidString)",
         shellState: ShellStateSnapshot? = nil,
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
-        workspaceManifest: ShellWorkspaceManifest? = nil,
+        workspaceManifest: ShellContentWorkspaceManifest? = nil,
         appIsActive: Bool = true
     ) -> ShellHostController {
         let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
@@ -5168,11 +5185,28 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
-    private static func decodeManifest(at url: URL) -> ShellWorkspaceManifest? {
+    private static func decodeManifest(at url: URL) -> ShellContentWorkspaceManifest? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try? decoder.decode(ShellWorkspaceManifest.self, from: data)
+        return try? decoder.decode(ShellContentWorkspaceManifest.self, from: data)
+    }
+
+    private static func rawManifestText(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func terminalPayload(
+        in snapshot: ShellContentTabRestoreSnapshot?,
+        paneSlotID: String
+    ) -> ShellTerminalContentPayload? {
+        guard let snapshot,
+              let paneSlot = snapshot.paneSlots.first(where: { $0.paneSlotID == paneSlotID })
+        else {
+            return nil
+        }
+        return snapshot.contents.first { $0.contentID == paneSlot.contentID }?.payload.terminal
     }
 
     private static func pane(

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -307,6 +307,17 @@ private enum ShellWorkspaceManifestTests {
             snapshot.contents.first?.payload.terminal?.cwd == nil,
             "migration must preserve nil cwd so restore can resolve the default directory later"
         )
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: migrated,
+            defaultWorkingDirectory: "/default/project",
+            now: referenceDate
+        )
+        let pane = try requirePane("pane_tab_nil_cwd", in: state)
+        expect(
+            pane.cwd == "/default/project",
+            "content manifest restore must resolve nil terminal cwd to the workspace default directory"
+        )
     }
 
     private static func verifiesUnpinnedTabPruningUsesTtlAndActiveTask() throws {

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -47,10 +47,10 @@ private enum ShellWorkspaceManifestTests {
         expect(result.recovery == .createdDefault, "missing manifest must report default creation")
         expect(fileManager.fileExists(atPath: manifestURL.path), "missing manifest must write a new manifest")
 
-        let tab = try requireOnlyTab(in: result.manifest)
-        let pane = try requireOnlyPane(in: tab.liveSnapshot)
+        let tab = try requireOnlyContentTab(in: result.manifest)
+        let content = try requireOnlyTerminalContent(in: tab.liveSnapshot)
         expect(
-            pane.cwd == "/fresh/project",
+            content.payload.terminal?.cwd == "/fresh/project",
             "default manifest must use the requested working directory"
         )
 
@@ -58,6 +58,10 @@ private enum ShellWorkspaceManifestTests {
         expect(
             !persistedManifestText.contains("/legacy/project"),
             "workspace manifest startup must not migrate legacy ShellStateSnapshot data"
+        )
+        expect(
+            !persistedManifestText.contains("\"panes\""),
+            "default workspace manifest must not dual-write terminal-only panes"
         )
     }
 
@@ -88,19 +92,20 @@ private enum ShellWorkspaceManifestTests {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         _ = try decoder.decode(
-            ShellWorkspaceManifest.self,
+            ShellContentWorkspaceManifest.self,
             from: Data(contentsOf: manifestURL)
         )
     }
 
     private static func verifiesMaterializerPreservesEmptySelectedSpace() throws {
-        let manifest = ShellWorkspaceManifest(
+        let manifest = ShellContentWorkspaceManifest(
             schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
             windowID: "window_main",
             selectedSpaceID: "space_empty",
             selectedTabID: nil,
             spaces: [
-                ShellWorkspaceSpaceRecord(
+                ShellContentWorkspaceSpaceRecord(
                     spaceID: "space_empty",
                     title: "Empty",
                     order: 0,
@@ -125,7 +130,7 @@ private enum ShellWorkspaceManifestTests {
     }
 
     private static func verifiesPinnedSnapshotWinsOverLaterLiveSnapshot() throws {
-        let tab = makeTab(
+        let tab = makeContentTab(
             tabID: "tab_pinned",
             title: "Pinned",
             isPinned: true,
@@ -135,7 +140,7 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: referenceDate,
             activeTask: .inactive
         )
-        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+        let manifest = makeContentManifest(selectedTabID: tab.tabID, tabs: [tab])
 
         let state = ShellWorkspaceMaterializer.materialize(
             manifest: manifest,
@@ -151,7 +156,7 @@ private enum ShellWorkspaceManifestTests {
     }
 
     private static func verifiesPinnedSplitSnapshotRestoresSplitTree() throws {
-        var tab = makeTab(
+        var tab = makeContentTab(
             tabID: "tab_split",
             title: "Pinned Split",
             isPinned: true,
@@ -161,8 +166,8 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: referenceDate,
             activeTask: .inactive
         )
-        tab.pinSnapshot = makeSplitSnapshot(tabID: tab.tabID)
-        let manifest = makeManifest(selectedTabID: tab.tabID, tabs: [tab])
+        tab.pinSnapshot = makeContentSplitSnapshot(tabID: tab.tabID)
+        let manifest = makeContentManifest(selectedTabID: tab.tabID, tabs: [tab])
 
         let state = ShellWorkspaceMaterializer.materialize(
             manifest: manifest,
@@ -307,7 +312,7 @@ private enum ShellWorkspaceManifestTests {
     private static func verifiesUnpinnedTabPruningUsesTtlAndActiveTask() throws {
         let expiredAt = referenceDate.addingTimeInterval(-(twelveHours + 60))
         let recentAt = referenceDate.addingTimeInterval(-60)
-        let expiredInactive = makeTab(
+        let expiredInactive = makeContentTab(
             tabID: "tab_expired",
             title: "Expired",
             isPinned: false,
@@ -317,7 +322,7 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: expiredAt,
             activeTask: .inactive
         )
-        let expiredActive = makeTab(
+        let expiredActive = makeContentTab(
             tabID: "tab_active",
             title: "Active",
             isPinned: false,
@@ -327,7 +332,7 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: expiredAt,
             activeTask: .foregroundCommand
         )
-        let recentInactive = makeTab(
+        let recentInactive = makeContentTab(
             tabID: "tab_recent",
             title: "Recent",
             isPinned: false,
@@ -337,22 +342,22 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: recentAt,
             activeTask: .inactive
         )
-        let manifest = makeManifest(
+        let manifest = makeContentManifest(
             selectedTabID: expiredInactive.tabID,
             tabs: [expiredInactive, expiredActive, recentInactive]
         )
 
         let pruned = manifest.pruningExpiredTabs(now: referenceDate, ttl: twelveHours)
 
-        expect(findTab("tab_expired", in: pruned) == nil, "expired inactive unpinned tab must be pruned")
-        expect(findTab("tab_active", in: pruned) != nil, "active unpinned tab must survive TTL pruning")
-        expect(findTab("tab_recent", in: pruned) != nil, "recent unpinned tab must survive TTL pruning")
+        expect(findContentTab("tab_expired", in: pruned) == nil, "expired inactive unpinned tab must be pruned")
+        expect(findContentTab("tab_active", in: pruned) != nil, "active unpinned tab must survive TTL pruning")
+        expect(findContentTab("tab_recent", in: pruned) != nil, "recent unpinned tab must survive TTL pruning")
         expect(pruned.selectedTabID == "tab_active", "selected pruned tab must repair to first retained tab")
     }
 
     private static func verifiesSelectedTabPruningCanLeaveSelectedSpaceEmpty() throws {
         let expiredAt = referenceDate.addingTimeInterval(-(twelveHours + 60))
-        let expiredInactive = makeTab(
+        let expiredInactive = makeContentTab(
             tabID: "tab_expired",
             title: "Expired",
             isPinned: false,
@@ -362,7 +367,7 @@ private enum ShellWorkspaceManifestTests {
             lastActivityAt: expiredAt,
             activeTask: .inactive
         )
-        let manifest = makeManifest(selectedTabID: expiredInactive.tabID, tabs: [expiredInactive])
+        let manifest = makeContentManifest(selectedTabID: expiredInactive.tabID, tabs: [expiredInactive])
 
         let pruned = manifest.pruningExpiredTabs(now: referenceDate, ttl: twelveHours)
         let state = ShellWorkspaceMaterializer.materialize(
@@ -400,6 +405,29 @@ private enum ShellWorkspaceManifestTests {
         )
     }
 
+    private static func makeContentManifest(
+        selectedTabID: String?,
+        tabs: [ShellContentWorkspaceTabRecord]
+    ) -> ShellContentWorkspaceManifest {
+        ShellContentWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_main",
+            selectedTabID: selectedTabID,
+            spaces: [
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Main",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    tabs: tabs
+                )
+            ]
+        )
+    }
+
     private static func makeTab(
         tabID: String,
         title: String,
@@ -424,6 +452,30 @@ private enum ShellWorkspaceManifestTests {
         )
     }
 
+    private static func makeContentTab(
+        tabID: String,
+        title: String,
+        isPinned: Bool,
+        pinCwd: String?,
+        liveCwd: String?,
+        lastActivatedAt: Date,
+        lastActivityAt: Date,
+        activeTask: ShellTabActiveTaskState
+    ) -> ShellContentWorkspaceTabRecord {
+        ShellContentWorkspaceTabRecord(
+            tabID: tabID,
+            title: title,
+            kind: .terminal,
+            createdAt: referenceDate,
+            lastActivatedAt: lastActivatedAt,
+            lastActivityAt: lastActivityAt,
+            isPinned: isPinned,
+            pinSnapshot: pinCwd.map { makeContentSnapshot(tabID: tabID, cwd: $0) },
+            liveSnapshot: liveCwd.map { makeContentSnapshot(tabID: tabID, cwd: $0) },
+            activeTask: activeTask
+        )
+    }
+
     private static func makeSnapshot(tabID: String, cwd: String?) -> ShellTabRestoreSnapshot {
         let paneID = "pane_\(tabID)"
         return ShellTabRestoreSnapshot(
@@ -440,6 +492,43 @@ private enum ShellWorkspaceManifestTests {
                     launchTarget: .shell,
                     cwd: cwd,
                     title: nil
+                )
+            ]
+        )
+    }
+
+    private static func makeContentSnapshot(
+        tabID: String,
+        cwd: String?
+    ) -> ShellContentTabRestoreSnapshot {
+        let paneSlotID = "pane_\(tabID)"
+        let contentID = "content_\(paneSlotID)"
+        return ShellContentTabRestoreSnapshot(
+            paneTree: ShellPaneSlotTreeNode(
+                nodeID: "node_\(paneSlotID)",
+                kind: .pane,
+                direction: nil,
+                paneSlotID: paneSlotID,
+                children: nil
+            ),
+            paneSlots: [
+                ShellPaneSlotRestoreRecord(
+                    paneSlotID: paneSlotID,
+                    contentID: contentID
+                )
+            ],
+            contents: [
+                ShellContentRestoreRecord(
+                    contentID: contentID,
+                    kind: .terminal,
+                    title: "Shell",
+                    payload: .terminal(
+                        ShellTerminalContentPayload(
+                            launchTarget: .shell,
+                            cwd: cwd,
+                            title: "Shell"
+                        )
+                    )
                 )
             ]
         )
@@ -489,19 +578,15 @@ private enum ShellWorkspaceManifestTests {
         )
     }
 
-    private static func findTab(
-        _ tabID: String,
-        in manifest: ShellWorkspaceManifest
-    ) -> ShellWorkspaceTabRecord? {
-        manifest.spaces.flatMap(\.tabs).first { $0.tabID == tabID }
+    private static func makeContentSplitSnapshot(tabID: String) -> ShellContentTabRestoreSnapshot {
+        makeSplitSnapshot(tabID: tabID).migratingTerminalPanesToContentContainers()
     }
 
-    private static func requireOnlyTab(in manifest: ShellWorkspaceManifest) throws -> ShellWorkspaceTabRecord {
-        let tabs = manifest.spaces.flatMap(\.tabs)
-        guard tabs.count == 1, let tab = tabs.first else {
-            throw TestFailure("expected exactly one tab")
-        }
-        return tab
+    private static func findContentTab(
+        _ tabID: String,
+        in manifest: ShellContentWorkspaceManifest
+    ) -> ShellContentWorkspaceTabRecord? {
+        manifest.spaces.flatMap(\.tabs).first { $0.tabID == tabID }
     }
 
     private static func requireOnlySpace(
@@ -542,11 +627,18 @@ private enum ShellWorkspaceManifestTests {
         return snapshot
     }
 
-    private static func requireOnlyPane(in snapshot: ShellTabRestoreSnapshot?) throws -> ShellPaneRestoreRecord {
-        guard let snapshot, snapshot.panes.count == 1, let pane = snapshot.panes.first else {
-            throw TestFailure("expected exactly one restore pane")
+    private static func requireOnlyTerminalContent(
+        in snapshot: ShellContentTabRestoreSnapshot?
+    ) throws -> ShellContentRestoreRecord {
+        let snapshot = try requireSnapshot(snapshot)
+        guard snapshot.contents.count == 1,
+              let content = snapshot.contents.first,
+              content.kind == .terminal,
+              content.payload.terminal != nil
+        else {
+            throw TestFailure("expected exactly one terminal content restore record")
         }
-        return pane
+        return content
     }
 
     private static func requirePane(_ paneID: String, in state: ShellStateSnapshot) throws -> ShellPane {

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -15,6 +15,7 @@ private enum ShellWorkspaceManifestTests {
         try verifiesMissingManifestCreatesDefaultWithoutMigratingShellState()
         try verifiesCorruptManifestIsQuarantined()
         try verifiesMaterializerPreservesEmptySelectedSpace()
+        try verifiesMaterializerPreservesEmptySelectedSpaceWithOtherTabs()
         try verifiesPinnedSnapshotWinsOverLaterLiveSnapshot()
         try verifiesPinnedSplitSnapshotRestoresSplitTree()
         try verifiesTerminalOnlySnapshotMigratesToContentContainerShape()
@@ -127,6 +128,56 @@ private enum ShellWorkspaceManifestTests {
         expect(state.focusedTabID == nil, "selected empty space must not fabricate a tab selection")
         expect(state.focusedPaneID == nil, "selected empty space must not fabricate a pane selection")
         expect(state.panes.isEmpty, "selected empty space must not fabricate panes")
+    }
+
+    private static func verifiesMaterializerPreservesEmptySelectedSpaceWithOtherTabs() throws {
+        let otherTab = makeContentTab(
+            tabID: "tab_other",
+            title: "Other",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/other/project",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        let manifest = ShellContentWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_empty",
+            selectedTabID: nil,
+            spaces: [
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_empty",
+                    title: "Empty",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    tabs: []
+                ),
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_other",
+                    title: "Other",
+                    order: 1,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    tabs: [otherTab]
+                ),
+            ]
+        )
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: manifest,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(state.spaces.count == 2, "materializer must preserve empty and populated spaces")
+        expect(state.focusedSpaceID == "space_empty", "selected empty space must remain focused")
+        expect(state.focusedTabID == nil, "selected empty space must not focus another space's tab")
+        expect(state.focusedPaneID == nil, "selected empty space must not focus another space's pane")
+        expect(state.pane(paneID: "pane_tab_other") != nil, "other space panes must still materialize")
     }
 
     private static func verifiesPinnedSnapshotWinsOverLaterLiveSnapshot() throws {

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -31,7 +31,7 @@
 - [x] 4.4 Replace terminal text delivery with a terminal-specific command such as `terminal.send_text` that resolves PaneSlot targets to terminal ContentInstances before delivery.
 - [x] 4.5 Reject terminal-specific commands against non-terminal ContentInstances with stable unsupported-content errors and observable diagnostics.
 - [x] 4.6 Emit shell events for PaneSlot creation, PaneSlot closure, content creation, content closure, content replacement, and content-specific command rejection.
-- [ ] 4.7 Ensure workspace manifest updates for pin/live snapshots write content-aware restore payloads and do not dual-write terminal-only snapshots.
+- [x] 4.7 Ensure workspace manifest updates for pin/live snapshots write content-aware restore payloads and do not dual-write terminal-only snapshots.
 
 ## 5. UI Integration
 


### PR DESCRIPTION
## Summary
- switch workspace manifest load/save to content-container manifests
- migrate legacy terminal-only manifest snapshots on read and rewrite them as content manifests
- write pin/live snapshots with PaneSlot/ContentInstance restore payloads only
- mark OpenSpec task 4.7 complete

## Verification
- bash clients/apple/scripts/test-shell-workspace-manifest.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict