### PR TITLE
Make macOS shell UI content-aware

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -143,6 +143,12 @@ enum ShellCommandTargetResolver {
         else {
             return .shell(reason: "terminal_pane_unavailable")
         }
+        let contentState = state.contentStateProjection()
+        guard let mountedContent = contentState.contentMounted(in: paneID),
+              mountedContent.kind == .terminal
+        else {
+            return .shell(reason: "terminal_content_unavailable")
+        }
 
         let runtime = runtimeState(paneID)
         switch command {
@@ -169,7 +175,7 @@ enum ShellCommandTargetResolver {
                 paneID: pane.paneID,
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
-                mountedContentID: pane.paneID
+                mountedContentID: mountedContent.contentID
             )
         )
     }
@@ -736,7 +742,7 @@ private let standardActions: [ShellActionDescriptor] = [
         targetKind: .pane,
         defaultShortcut: ShellActionShortcut(key: "f", modifiers: [.command], context: .shell),
         effect: .disabledPlaceholder,
-        availability: focusedPaneAvailability
+        availability: terminalContentAvailability
     ),
     ShellActionDescriptor(
         id: .spaceSelectPrevious,
@@ -829,6 +835,29 @@ private func focusedPaneAvailability(
             ? .unavailable(reason: "No focused pane")
             : .available
     }
+}
+
+private func terminalContentAvailability(
+    state: ShellStateSnapshot,
+    target: ShellActionTarget
+) -> ShellActionAvailability {
+    let paneID: String?
+    if case .contextPane(let contextPaneID) = target {
+        paneID = contextPaneID
+    } else {
+        paneID = state.focusedPaneID
+    }
+
+    guard let paneID else {
+        return .unavailable(reason: "No focused pane")
+    }
+    guard state.pane(paneID: paneID) != nil else {
+        return .unavailable(reason: "Pane is not available")
+    }
+    guard state.contentStateProjection().contentMounted(in: paneID)?.kind == .terminal else {
+        return .unavailable(reason: "Focused content is not a terminal")
+    }
+    return .available
 }
 
 private func splitPaneAvailability(

--- a/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift
@@ -143,9 +143,10 @@ enum ShellCommandTargetResolver {
         else {
             return .shell(reason: "terminal_pane_unavailable")
         }
-        let contentState = state.contentStateProjection()
-        guard let mountedContent = contentState.contentMounted(in: paneID),
-              mountedContent.kind == .terminal
+        guard let mountedContentID = terminalContentIDIfAvailable(
+            for: pane,
+            in: state
+        )
         else {
             return .shell(reason: "terminal_content_unavailable")
         }
@@ -175,7 +176,7 @@ enum ShellCommandTargetResolver {
                 paneID: pane.paneID,
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
-                mountedContentID: mountedContent.contentID
+                mountedContentID: mountedContentID
             )
         )
     }
@@ -851,13 +852,30 @@ private func terminalContentAvailability(
     guard let paneID else {
         return .unavailable(reason: "No focused pane")
     }
-    guard state.pane(paneID: paneID) != nil else {
+    guard let pane = state.pane(paneID: paneID) else {
         return .unavailable(reason: "Pane is not available")
     }
-    guard state.contentStateProjection().contentMounted(in: paneID)?.kind == .terminal else {
+    guard terminalContentIDIfAvailable(for: pane, in: state) != nil else {
         return .unavailable(reason: "Focused content is not a terminal")
     }
     return .available
+}
+
+private func terminalContentIDIfAvailable(
+    for pane: ShellPane,
+    in state: ShellStateSnapshot
+) -> String? {
+    if let mountedContent = state.contentStateProjection().contentMounted(in: pane.paneID) {
+        return mountedContent.kind == .terminal ? mountedContent.contentID : nil
+    }
+
+    if pane.isQuickTerminalPane,
+       state.quickTerminal?.paneID == pane.paneID
+    {
+        return pane.terminalContentID
+    }
+
+    return nil
 }
 
 private func splitPaneAvailability(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -541,6 +541,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         runtime(for: selectedPane?.paneID)
     }
 
+    var focusedContentSupportsTerminalCommands: Bool {
+        let content = shellState.contentStateProjection().focusedContent
+        return content?.kind == .terminal
+            && content?.capabilities.contains(.terminalInput) == true
+    }
+
     var attentionItems: [ShellAttentionItem] {
         let now = Date()
         return shellState.panes
@@ -606,14 +612,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func isPaneZoomed(_ paneID: String) -> Bool {
-        guard let pane = pane(paneID: paneID) else { return false }
-        return zoomedPaneIDByTabID[pane.tabID] == paneID
+        guard let tab = tab(containingPaneID: paneID) else { return false }
+        return zoomedPaneIDByTabID[tab.tabID] == paneID
     }
 
     func canZoomPane(_ paneID: String) -> Bool {
-        guard let pane = pane(paneID: paneID),
-              let tab = shellState.tab(tabID: pane.tabID)
-        else { return false }
+        guard let tab = tab(containingPaneID: paneID) else { return false }
         return tab.paneTree.paneIDs.count > 1
     }
 
@@ -629,21 +633,21 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @discardableResult
     func zoomPane(paneID: String) -> Bool {
         guard canZoomPane(paneID),
-              let pane = pane(paneID: paneID)
+              let tab = tab(containingPaneID: paneID)
         else {
             return false
         }
-        guard zoomedPaneIDByTabID[pane.tabID] != paneID else {
+        guard zoomedPaneIDByTabID[tab.tabID] != paneID else {
             return false
         }
         if shellState.focusedPaneID != paneID {
             focus(paneID: paneID)
         }
-        zoomedPaneIDByTabID[pane.tabID] = paneID
+        zoomedPaneIDByTabID[tab.tabID] = paneID
         controlPlane.recordZoomStateChanged(
             requestID: nil,
-            spaceID: pane.spaceID,
-            tabID: pane.tabID,
+            spaceID: shellState.contentStateProjection().paneSlot(paneSlotID: paneID)?.spaceID,
+            tabID: tab.tabID,
             paneID: paneID,
             zoomedPaneID: paneID
         )
@@ -791,9 +795,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         {
             return focusedPaneID
         }
+        let contentState = shellState.contentStateProjection()
         return tab.paneTree.paneIDs.first { paneID in
-            pane(paneID: paneID)?.tabID == tab.tabID
-        }
+            contentState.paneSlot(paneSlotID: paneID)?.tabID == tab.tabID
+        } ?? tab.paneTree.paneIDs.first
     }
 
     func requestCommandInput() {
@@ -1554,6 +1559,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     var focusedPaneHasReliableSemanticCommands: Bool {
+        guard focusedContentSupportsTerminalCommands else { return false }
         guard let paneID = selectedPane?.paneID,
               paneID == terminalRuntime.paneID
         else {
@@ -2057,12 +2063,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private func zoomedPaneID(in tab: ShellTab) -> String? {
         guard let paneID = zoomedPaneIDByTabID[tab.tabID],
               tab.paneTree.contains(paneID: paneID),
-              shellState.pane(paneID: paneID)?.tabID == tab.tabID,
               tab.paneTree.paneIDs.count > 1
         else {
             return nil
         }
         return paneID
+    }
+
+    private func tab(containingPaneID paneID: String) -> ShellTab? {
+        shellState.spaces
+            .flatMap(\.tabs)
+            .first { $0.contains(paneID: paneID) }
     }
 
     private func reconcilePaneZoomState() {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -542,9 +542,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     var focusedContentSupportsTerminalCommands: Bool {
-        let content = shellState.contentStateProjection().focusedContent
-        return content?.kind == .terminal
-            && content?.capabilities.contains(.terminalInput) == true
+        guard let focusedPaneID = shellState.focusedPaneID,
+              let pane = pane(paneID: focusedPaneID)
+        else {
+            return false
+        }
+        return paneSupportsTerminalCommands(pane, in: shellState.contentStateProjection())
     }
 
     var attentionItems: [ShellAttentionItem] {
@@ -816,11 +819,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func canRequestTerminalFocus(for paneID: String) -> Bool {
-        if shellState.contentStateProjection().contentMounted(in: paneID)?.kind == .terminal {
-            return true
-        }
-
-        return pane(paneID: paneID)?.isQuickTerminalPane == true
+        guard let pane = pane(paneID: paneID) else { return false }
+        return paneHasTerminalContent(pane, in: shellState.contentStateProjection())
     }
 
     @discardableResult
@@ -1979,7 +1979,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
         let contentState = state.contentStateProjection()
         let hydratedPanes = state.panes.map { pane in
-            guard contentState.contentMounted(in: pane.paneID)?.kind == .terminal else {
+            guard paneHasTerminalContent(pane, in: contentState, state: state) else {
                 return pane
             }
             guard paneProjection.needsBootContextProjection(pane) else { return pane }
@@ -2068,6 +2068,40 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return nil
         }
         return paneID
+    }
+
+    private func paneSupportsTerminalCommands(
+        _ pane: ShellPane,
+        in contentState: ShellContentStateSnapshot,
+        state: ShellStateSnapshot? = nil
+    ) -> Bool {
+        if let content = contentState.contentMounted(in: pane.paneID) {
+            return content.kind == .terminal
+                && content.capabilities.contains(.terminalInput)
+        }
+
+        return paneIsQuickTerminalContent(pane, state: state)
+    }
+
+    private func paneHasTerminalContent(
+        _ pane: ShellPane,
+        in contentState: ShellContentStateSnapshot,
+        state: ShellStateSnapshot? = nil
+    ) -> Bool {
+        if let content = contentState.contentMounted(in: pane.paneID) {
+            return content.kind == .terminal
+        }
+
+        return paneIsQuickTerminalContent(pane, state: state)
+    }
+
+    private func paneIsQuickTerminalContent(
+        _ pane: ShellPane,
+        state: ShellStateSnapshot? = nil
+    ) -> Bool {
+        let snapshot = state ?? shellState
+        return pane.isQuickTerminalPane
+            && snapshot.quickTerminal?.paneID == pane.paneID
     }
 
     private func tab(containingPaneID paneID: String) -> ShellTab? {

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -482,6 +482,17 @@ func shellPaneTitleBarTitle(for pane: ShellPane) -> String {
     return "Terminal"
 }
 
+func shellContentTypeHint(for kind: ShellContentKind) -> String {
+    switch kind {
+    case .terminal:
+        return "Terminal"
+    case .markdown:
+        return "Document"
+    case .settings:
+        return "Settings"
+    }
+}
+
 func shellPaneActivityAccessoryLabel(for pane: ShellPane, now: Date? = nil) -> String? {
     guard let activity = pane.activity else { return nil }
     if let now, !activity.isFresh(at: now) {
@@ -824,16 +835,23 @@ private func shellIsCodingAgentActivity(_ activity: TerminalActivitySnapshot) ->
 func shellSidebarTabProjection(
     for tab: ShellTab,
     panes allPanes: [ShellPane],
+    contentState: ShellContentStateSnapshot? = nil,
     focusedPaneID: String?,
     focusedTabID: String?,
     now: Date? = nil
 ) -> ShellSidebarTabProjection {
     let panes = shellOrderedPanes(for: tab, panes: allPanes)
     let primaryPane = shellPrimaryPane(in: panes, focusedPaneID: focusedPaneID)
-    let title = shellSidebarTabTitle(for: tab, primaryPane: primaryPane)
+    let primaryContent = shellPrimaryContent(in: tab, contentState: contentState, focusedPaneID: focusedPaneID)
+    let title = shellSidebarTabTitle(for: tab, primaryPane: primaryPane, primaryContent: primaryContent)
     let isOwningTabFocused = focusedTabID == tab.tabID
 
     let activityCandidates = panes.enumerated().compactMap { index, pane -> TerminalActivitySnapshot? in
+        if let contentState,
+           contentState.contentMounted(in: pane.paneID)?.kind != .terminal
+        {
+            return nil
+        }
         guard let activity = pane.activity,
               activity.isSidebarWorthy(at: now, owningTabFocused: isOwningTabFocused)
         else { return nil }
@@ -859,7 +877,8 @@ func shellSidebarTabProjection(
         )
     }
 
-    let fallback = primaryPane.flatMap { shellTerminalStatusSummary(for: $0, now: now) }
+    let fallback = shellSidebarContentLine(for: primaryContent)
+        ?? primaryPane.flatMap { shellTerminalStatusSummary(for: $0, now: now) }
         ?? primaryPane.flatMap { shellSidebarContextLine(for: $0, title: title) }
         ?? shellFallbackTitle(for: tab.kind)
     return ShellSidebarTabProjection(
@@ -889,8 +908,36 @@ private func shellPrimaryPane(in panes: [ShellPane], focusedPaneID: String?) -> 
     return panes.first
 }
 
-private func shellSidebarTabTitle(for tab: ShellTab, primaryPane: ShellPane?) -> String {
-    shellDisplayTitle(
+private func shellPrimaryContent(
+    in tab: ShellTab,
+    contentState: ShellContentStateSnapshot?,
+    focusedPaneID: String?
+) -> ShellContentInstance? {
+    guard let contentState else { return nil }
+    if let focusedPaneID,
+       tab.contains(paneID: focusedPaneID),
+       let focusedContent = contentState.contentMounted(in: focusedPaneID)
+    {
+        return focusedContent
+    }
+
+    return tab.paneTree.paneIDs.lazy.compactMap {
+        contentState.contentMounted(in: $0)
+    }.first
+}
+
+private func shellSidebarTabTitle(
+    for tab: ShellTab,
+    primaryPane: ShellPane?,
+    primaryContent: ShellContentInstance?
+) -> String {
+    if let primaryContent,
+       primaryContent.kind != .terminal
+    {
+        return primaryContent.title
+    }
+
+    return shellDisplayTitle(
         rawTitle: tab.title ?? primaryPane?.viewport?.title,
         workingDirectoryName: primaryPane?.context?.workingDirectoryName,
         cwd: primaryPane?.cwd,
@@ -898,6 +945,16 @@ private func shellSidebarTabTitle(for tab: ShellTab, primaryPane: ShellPane?) ->
         launchTarget: primaryPane?.resolvedLaunchTarget ?? .shell,
         fallback: shellFallbackTitle(for: tab.kind)
     )
+}
+
+private func shellSidebarContentLine(for content: ShellContentInstance?) -> String? {
+    guard let content,
+          content.kind != .terminal
+    else {
+        return nil
+    }
+
+    return shellContentTypeHint(for: content.kind)
 }
 
 private func shellSidebarContextLine(for pane: ShellPane, title: String) -> String? {

--- a/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellCommandTabView.swift
@@ -110,14 +110,26 @@ private enum ShellCommandInputAction: CaseIterable {
         }
     }
 
+    var requiresTerminalContent: Bool {
+        switch self {
+        case .copyTerminalSelection, .pasteIntoTerminal, .searchTerminal,
+             .previousPrompt, .nextPrompt, .copyLastCommandOutput, .searchLastCommandOutput:
+            return true
+        default:
+            return false
+        }
+    }
+
     static func resolve(
         _ rawValue: String,
+        terminalCommandsAvailable: Bool = false,
         semanticCommandsAvailable: Bool = false
     ) -> ShellCommandInputAction? {
         let normalized = normalizedCommand(rawValue)
         guard !normalized.isEmpty else { return nil }
         return allCases.first {
-            (!$0.requiresSemanticCommandBoundaries || semanticCommandsAvailable)
+            (!$0.requiresTerminalContent || terminalCommandsAvailable)
+                && (!$0.requiresSemanticCommandBoundaries || semanticCommandsAvailable)
                 && $0.aliases.contains(normalized)
         }
     }
@@ -193,7 +205,7 @@ struct ShellCommandTabView: View {
             TextField(
                 "",
                 text: $query,
-                prompt: Text("Ask alan...")
+                prompt: Text(commandPrompt)
                     .foregroundStyle(.secondary)
             )
             .textFieldStyle(.plain)
@@ -230,6 +242,7 @@ struct ShellCommandTabView: View {
     private func submit() {
         guard let action = ShellCommandInputAction.resolve(
             query,
+            terminalCommandsAvailable: host.focusedContentSupportsTerminalCommands,
             semanticCommandsAvailable: host.focusedPaneHasReliableSemanticCommands
         ) else {
             unresolvedMessage = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -270,13 +283,13 @@ struct ShellCommandTabView: View {
         case .zoomPane:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.togglePaneZoom)
         case .movePaneLeft:
-            host.performShellAction(.paneMoveLeft)
+            host.moveSelectedPaneWithinTab(.left)
         case .movePaneRight:
-            host.performShellAction(.paneMoveRight)
+            host.moveSelectedPaneWithinTab(.right)
         case .movePaneUp:
-            host.performShellAction(.paneMoveUp)
+            host.moveSelectedPaneWithinTab(.up)
         case .movePaneDown:
-            host.performShellAction(.paneMoveDown)
+            host.moveSelectedPaneWithinTab(.down)
         case .closePane:
             host.performShellWorkspaceCommand(ShellWorkspaceCommand.closePane)
         case .closeTab:
@@ -339,6 +352,14 @@ struct ShellCommandTabView: View {
 
     private var commandInputAnimation: Animation? {
         reduceMotion ? nil : .easeOut(duration: 0.14)
+    }
+
+    private var commandPrompt: String {
+        let contentState = host.shellState.contentStateProjection()
+        guard let content = contentState.focusedContent else {
+            return "Command..."
+        }
+        return "Command for \(content.title) · \(shellContentTypeHint(for: content.kind))"
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -588,9 +588,11 @@ struct ShellSidebarView: View {
     ) -> some View {
         let isSelected = host.selectedTab?.tabID == tab.tabID
         let isHovered = hoveredTabID == tab.tabID
+        let contentState = host.shellState.contentStateProjection()
         let projection = shellSidebarTabProjection(
             for: tab,
             panes: host.shellState.panes,
+            contentState: contentState,
             focusedPaneID: host.shellState.focusedPaneID,
             focusedTabID: host.selectedTab?.tabID,
             now: activityFreshnessNow
@@ -735,8 +737,9 @@ struct ShellSidebarView: View {
     }
 
     private func paneSummary(for tab: ShellTab) -> ShellTabPaneSummary? {
+        let contentState = host.shellState.contentStateProjection()
         let paneIDs = tab.paneTree.paneIDs.filter { paneID in
-            host.shellState.panes.contains { $0.paneID == paneID }
+            contentState.paneSlot(paneSlotID: paneID)?.tabID == tab.tabID
         }
         guard !paneIDs.isEmpty else { return nil }
 
@@ -849,6 +852,11 @@ struct ShellSidebarView: View {
             return "square.stack.3d.up"
         }
 
+        let contentState = host.shellState.contentStateProjection()
+        if let content = space.tabs.lazy.compactMap({ contentState.primaryContent(in: $0.tabID) }).first {
+            return contentIconName(for: content)
+        }
+
         return "terminal"
     }
 
@@ -856,6 +864,23 @@ struct ShellSidebarView: View {
         guard activity?.source.kind != .alan else { return false }
         return host.shellState.panes.contains { pane in
             pane.tabID == tab.tabID && pane.resolvedLaunchTarget == .alan
+        }
+    }
+
+    private func contentIconName(for content: ShellContentInstance) -> String {
+        if let iconName = content.iconName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !iconName.isEmpty
+        {
+            return iconName
+        }
+
+        switch content.kind {
+        case .terminal:
+            return "terminal"
+        case .markdown:
+            return "doc.text"
+        case .settings:
+            return "gearshape"
         }
     }
 
@@ -1074,7 +1099,29 @@ private struct ShellSidebarSpaceHeader: View {
             return "square.stack.3d.up"
         }
 
+        let contentState = host.shellState.contentStateProjection()
+        if let content = space.tabs.lazy.compactMap({ contentState.primaryContent(in: $0.tabID) }).first {
+            return contentIconName(for: content)
+        }
+
         return "terminal"
+    }
+
+    private func contentIconName(for content: ShellContentInstance) -> String {
+        if let iconName = content.iconName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !iconName.isEmpty
+        {
+            return iconName
+        }
+
+        switch content.kind {
+        case .terminal:
+            return "terminal"
+        case .markdown:
+            return "doc.text"
+        case .settings:
+            return "gearshape"
+        }
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -6,11 +6,12 @@ struct ShellWorkspaceView: View {
     let expandedSidebarProgress: CGFloat
 
     var body: some View {
+        let contentState = host.shellState.contentStateProjection()
         TerminalPaneView(
             host: host,
             tab: host.selectedTab,
             spaceID: host.selectedSpace?.spaceID,
-            selectedPaneID: host.selectedPane?.paneID,
+            selectedPaneID: contentState.focusedPaneSlotID,
             zoomedPaneID: host.selectedTabZoomedPaneID,
             terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
                 expandedSidebarProgress: expandedSidebarProgress

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1132,8 +1132,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "selectedPaneID: host\\.selectedPane\\?\\.paneID" \
-    "workspace view must render committed host pane selection"
+    "selectedPaneID: contentState\\.focusedPaneSlotID" \
+    "workspace view must render committed content PaneSlot selection"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -49,6 +49,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesInTabPaneMovementPreservesRuntimeContinuity()
         verifiesPaneMovementDragPolicyProtectsTerminalSelection()
         verifiesTerminalCommandResolverProtectsShellTextInput()
+        verifiesTerminalCommandResolverRejectsNonTerminalContent()
         verifiesCopyPasteRouteToFocusedTerminalRuntime()
         verifiesContextMenuTerminalCommandsUseContextPane()
         verifiesTerminalSearchRoutesThroughFocusedHostSurface()
@@ -104,6 +105,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesSplitTabSelectionUsesStablePaneWithoutChangingLayout()
         verifiesContentStateProjectionSeparatesPaneSlotsAndContent()
         verifiesContentRenderingRegistryRoutesSupportedKinds()
+        verifiesContentAwareSidebarProjectionUsesNonTerminalLabels()
         verifiesOpeningContentTabDefaultsToTerminalIntent()
         verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor()
         verifiesOpeningSettingsTabCreatesSingletonShellContent()
@@ -1447,6 +1449,33 @@ private enum ShellRuntimeMetadataTests {
             controller.terminalCommandResolution(for: .copySelection, source: .commandUI)
                 .terminalTarget?.paneID == "pane_1",
             "command UI execution must still route through the shared terminal resolver"
+        )
+    }
+
+    private static func verifiesTerminalCommandResolverRejectsNonTerminalContent() {
+        let controller = makeController()
+        guard let markdownPaneID = controller.splitPane(
+            paneID: "pane_1",
+            placement: .right,
+            contentIntent: .markdown(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("notes.md"),
+                title: "Notes"
+            )
+        ) else {
+            fail("test setup must create a markdown PaneSlot")
+        }
+        controller.focus(paneID: markdownPaneID)
+
+        expect(
+            controller.terminalCommandResolution(for: .paste, source: .commandUI)
+                == .shell(reason: "terminal_content_unavailable"),
+            "terminal commands must reject a focused non-terminal ContentInstance before runtime lookup"
+        )
+        expect(
+            controller.shellActionAvailability(.findOpen)
+                == .unavailable(reason: "Focused content is not a terminal"),
+            "find action availability must be terminal-content scoped"
         )
     }
 
@@ -3792,6 +3821,58 @@ private enum ShellRuntimeMetadataTests {
             quickTerminalDescriptor.contentID == expectedQuickTerminalContentID,
             "quick terminal fallback must retain the terminal content identity"
         )
+    }
+
+    private static func verifiesContentAwareSidebarProjectionUsesNonTerminalLabels() {
+        let controller = makeController()
+        guard let markdownPaneID = controller.splitPane(
+            paneID: "pane_1",
+            placement: .right,
+            contentIntent: .markdown(
+                fileURL: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("sidebar-notes.md"),
+                title: "Research Notes"
+            )
+        ) else {
+            fail("sidebar projection setup must create a markdown split")
+        }
+
+        guard let tab = controller.shellState.tab(tabID: "tab_main") else {
+            fail("sidebar projection setup must keep the mixed tab")
+        }
+        let projection = shellSidebarTabProjection(
+            for: tab,
+            panes: controller.shellState.panes,
+            contentState: controller.shellState.contentStateProjection(),
+            focusedPaneID: markdownPaneID,
+            focusedTabID: tab.tabID
+        )
+        expect(
+            projection.title == "Research Notes",
+            "focused markdown content must provide the sidebar row primary label"
+        )
+        expect(
+            projection.secondaryLine == "Document",
+            "focused markdown content must provide a user-facing type hint"
+        )
+        expect(
+            !projection.title.contains("pane_") && !projection.secondaryLine.contains("content_"),
+            "content-aware sidebar labels must not expose implementation identifiers"
+        )
+
+        _ = controller.openSettingsTab()
+        guard let settingsTab = controller.selectedTab else {
+            fail("settings open must focus a settings tab")
+        }
+        let settingsProjection = shellSidebarTabProjection(
+            for: settingsTab,
+            panes: controller.shellState.panes,
+            contentState: controller.shellState.contentStateProjection(),
+            focusedPaneID: controller.shellState.focusedPaneID,
+            focusedTabID: settingsTab.tabID
+        )
+        expect(settingsProjection.title == "Settings", "settings content must label the sidebar row")
+        expect(settingsProjection.secondaryLine == "Settings", "settings content must expose a type hint")
     }
 
     private static func verifiesOpeningMarkdownTabCreatesReadOnlyContentDescriptor() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -38,6 +38,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesOpeningTerminalTabHonorsExplicitCwd()
         verifiesQuickTerminalShowCreatesAndReusesGlobalPane()
         verifiesQuickTerminalActionsAndControlCommandsShareControllerPath()
+        verifiesQuickTerminalTerminalCommandsStayRoutable()
         verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace()
         verifiesQuickTerminalPeakPresenterShowsDetachedTerminalWindow()
         verifiesQuickTerminalPeakPresenterPreservesRuntimeOnExplicitHide()
@@ -1167,6 +1168,45 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !controller.terminalRuntimeRegistry.registeredPaneIDs.contains("quick_terminal_pane"),
             "close must release the quick terminal runtime through regular registry cleanup"
+        )
+    }
+
+    private static func verifiesQuickTerminalTerminalCommandsStayRoutable() {
+        let controller = makeController()
+        guard let quickPaneID = controller.showQuickTerminal() else {
+            fail("quick terminal setup must create the global pane")
+        }
+        let handle = fakeSurfaceHandle(for: quickPaneID, controller: controller)
+        handle.selectedText = "quick terminal selection"
+
+        let contextTarget = ShellTerminalCommandTarget(
+            paneID: quickPaneID,
+            tabID: ShellQuickTerminalSlot.globalTabID,
+            spaceID: ShellQuickTerminalSlot.globalSpaceID,
+            mountedContentID: ShellContentInstance.terminalContentID(forPaneID: quickPaneID)
+        )
+        expect(
+            controller.terminalCommandResolution(
+                for: .copySelection,
+                source: .contextMenu,
+                target: .contextPane(quickPaneID)
+            ) == .terminal(contextTarget),
+            "context-menu terminal commands must remain routable to the quick terminal pane"
+        )
+        expect(
+            controller.shellActionAvailability(.findOpen, target: .contextPane(quickPaneID)) == .available,
+            "terminal action availability must treat the quick terminal as terminal content"
+        )
+
+        controller.focus(paneID: quickPaneID)
+        expect(
+            controller.focusedContentSupportsTerminalCommands,
+            "command palette terminal gating must use the actual focused quick terminal pane"
+        )
+        expect(
+            controller.terminalCommandResolution(for: .copySelection, source: .commandUI)
+                == .terminal(contextTarget),
+            "focused quick terminal commands must not fall back to unrelated projected content"
         )
     }
 

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -35,9 +35,9 @@
 
 ## 5. UI Integration
 
-- [ ] 5.1 Update `ShellWorkspaceView` / pane layout leaf rendering so mixed content panes share split geometry and focus treatment.
-- [ ] 5.2 Update sidebar tab rows, toolbar titles, pane title bars, and command input labels to use user-facing content titles and type hints.
-- [ ] 5.3 Keep terminal-only status, search, and input affordances visible only on terminal content panes.
+- [x] 5.1 Update `ShellWorkspaceView` / pane layout leaf rendering so mixed content panes share split geometry and focus treatment.
+- [x] 5.2 Update sidebar tab rows, toolbar titles, pane title bars, and command input labels to use user-facing content titles and type hints.
+- [x] 5.3 Keep terminal-only status, search, and input affordances visible only on terminal content panes.
 - [x] 5.4 Make settings content a singleton tab target in v1 so repeated Open Settings focuses the existing ContentInstance.
 - [ ] 5.5 Capture running-app visual evidence for light-mode mixed content tabs and split panes.
 
@@ -48,8 +48,8 @@
 - [ ] 6.3 Add fake runtime service tests for `terminal.send_text`, `content_id` delivery, missing runtime errors, and queued delivery diagnostics.
 - [x] 6.4 Add control-plane tests for `pane_slots` / `contents` query, content-aware split creation, `terminal.send_text` success, and non-terminal terminal-command rejection.
 - [ ] 6.5 Add workspace manifest migration and lifecycle tests for terminal-only pin snapshots, terminal-only live snapshots, mixed content pin/live snapshots, inactive unpinned Tab retirement finalization, and the rule that `shell-state-window_main.json` is not restore authority.
-- [ ] 6.6 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
-- [ ] 6.7 Run the macOS app build or document any local dependency blocker with the exact failing command.
-- [ ] 6.8 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.
-- [ ] 6.9 Run `openspec validate --all --strict` after `persist-macos-shell-workspaces` is archived or while both active changes validate together.
+- [x] 6.6 Run the focused Apple shell contract scripts affected by model, control-plane, workspace manifest, and terminal-runtime changes.
+- [x] 6.7 Run the macOS app build or document any local dependency blocker with the exact failing command.
+- [x] 6.8 Validate `generalize-macos-shell-content-containers` with `openspec validate generalize-macos-shell-content-containers --strict`.
+- [x] 6.9 Run `openspec validate --all --strict` after `persist-macos-shell-workspaces` is archived or while both active changes validate together.
 - [ ] 6.10 After implementation is merged, sync accepted requirements into `openspec/specs/` and confirm the change is archive-ready.


### PR DESCRIPTION
## Summary
- Route shell workspace selection, sidebar rows, and command palette labels through content-aware PaneSlot projections.
- Gate terminal-only commands and affordances when the focused content is markdown/settings.
- Add focused Swift shell tests and update OpenSpec task status for this UI integration slice.

## Validation
- env TMPDIR=/Users/morris/Developer/alan/debug/tmp clients/apple/scripts/test-shell-runtime-metadata.sh
- env TMPDIR=/Users/morris/Developer/alan/debug/tmp clients/apple/scripts/test-shell-action-registry.sh
- env TMPDIR=/Users/morris/Developer/alan/debug/tmp clients/apple/scripts/test-shell-split-model.sh
- clients/apple/scripts/check-shell-action-registry-integration.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath debug/DerivedData CODE_SIGNING_ALLOWED=NO build
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict

## Notes
- Running-app visual evidence remains unchecked in OpenSpec because it still needs a fresh installed app relaunch before claiming visual verification.