### PR TITLE
Add macOS dev channel install basics

### DIFF
--- a/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
+++ b/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
@@ -1,6 +1,66 @@
 import Foundation
 
 #if os(macOS)
+enum AlanInstallChannel: Equatable {
+    case stable
+    case dev
+
+    static func current(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> AlanInstallChannel {
+        if let channel = fromBundleIdentifier(bundleIdentifier) {
+            return channel
+        }
+        if environment["ALAN_INSTALL_CHANNEL"] == "dev" {
+            return .dev
+        }
+        return .stable
+    }
+
+    static func fromBundleIdentifier(_ bundleIdentifier: String?) -> AlanInstallChannel? {
+        switch bundleIdentifier {
+        case "app.alanworks.macos":
+            return .stable
+        case "app.alanworks.macos.dev":
+            return .dev
+        default:
+            return nil
+        }
+    }
+
+    var cliToolName: String {
+        switch self {
+        case .stable:
+            return "alan"
+        case .dev:
+            return "alan-dev"
+        }
+    }
+
+    var tuiToolName: String {
+        switch self {
+        case .stable:
+            return "alan-tui"
+        case .dev:
+            return "alan-dev-tui"
+        }
+    }
+
+    var toolNames: [String] {
+        [cliToolName, tuiToolName]
+    }
+
+    var ownedAppBundleNames: [String] {
+        switch self {
+        case .stable:
+            return ["Alan.app", "alan.app"]
+        case .dev:
+            return ["Alan Dev.app"]
+        }
+    }
+}
+
 struct AlanCommandLineToolInstallRecord: Equatable {
     enum Status: Equatable {
         case installed
@@ -15,7 +75,7 @@ struct AlanCommandLineToolInstallRecord: Equatable {
 
 enum AlanCommandLineToolInstaller {
     static let defaultInstallDirectory = URL(fileURLWithPath: "/usr/local/bin", isDirectory: true)
-    static let toolNames = ["alan", "alan-tui"]
+    static let toolNames = AlanInstallChannel.stable.toolNames
 
     static func embeddedBinDirectory(resourceURL: URL? = Bundle.main.resourceURL) -> URL? {
         resourceURL?.appendingPathComponent("bin", isDirectory: true)
@@ -25,13 +85,18 @@ enum AlanCommandLineToolInstaller {
         targetDirectory: URL = defaultInstallDirectory,
         resourceURL: URL? = Bundle.main.resourceURL,
         fileManager: FileManager = .default,
-        homebrewPrefixes: [String]? = nil
+        homebrewPrefixes: [String]? = nil,
+        channel: AlanInstallChannel = .current()
     ) throws -> [AlanCommandLineToolInstallRecord] {
         guard let embeddedBinDirectory = embeddedBinDirectory(resourceURL: resourceURL) else {
             throw CocoaError(.fileNoSuchFile)
         }
+        let toolNames = channel.toolNames
 
-        if targetDirectory.standardizedFileURL.path.contains("/.alan/bin") {
+        let standardizedTargetPath = targetDirectory.standardizedFileURL.path
+        if standardizedTargetPath.contains("/.alan/bin")
+            || standardizedTargetPath.contains("/.alan-dev/bin")
+        {
             throw CocoaError(.fileWriteInvalidFileName)
         }
         if isHomebrewPrefixTarget(
@@ -44,7 +109,8 @@ enum AlanCommandLineToolInstaller {
 
         let existingHomebrewLinks = homebrewManagedCommandLinks(
             fileManager: fileManager,
-            homebrewPrefixes: homebrewPrefixes
+            homebrewPrefixes: homebrewPrefixes,
+            channel: channel
         )
         if !existingHomebrewLinks.isEmpty {
             return toolNames.map { tool in
@@ -74,7 +140,7 @@ enum AlanCommandLineToolInstaller {
             }
 
             if fileManager.fileExists(atPath: target.path) || isSymbolicLink(target, fileManager: fileManager) {
-                guard isAlanOwnedLink(target, tool: tool, fileManager: fileManager) else {
+                guard isAlanOwnedLink(target, tool: tool, channel: channel, fileManager: fileManager) else {
                     return AlanCommandLineToolInstallRecord(
                         tool: tool,
                         sourcePath: source.path,
@@ -111,6 +177,7 @@ enum AlanCommandLineToolInstaller {
     private static func isAlanOwnedLink(
         _ url: URL,
         tool: String,
+        channel: AlanInstallChannel,
         fileManager: FileManager
     ) -> Bool {
         guard isSymbolicLink(url, fileManager: fileManager),
@@ -119,8 +186,9 @@ enum AlanCommandLineToolInstaller {
             return false
         }
 
-        return destination.hasSuffix("/Alan.app/Contents/Resources/bin/\(tool)")
-            || destination.hasSuffix("/alan.app/Contents/Resources/bin/\(tool)")
+        return channel.ownedAppBundleNames.contains { bundleName in
+            destination.hasSuffix("/\(bundleName)/Contents/Resources/bin/\(tool)")
+        }
     }
 
     private static func isHomebrewPrefixTarget(
@@ -144,7 +212,8 @@ enum AlanCommandLineToolInstaller {
 
     private static func homebrewManagedCommandLinks(
         fileManager: FileManager,
-        homebrewPrefixes: [String]? = nil
+        homebrewPrefixes: [String]? = nil,
+        channel: AlanInstallChannel
     ) -> [String: String] {
         let prefixes = resolvedHomebrewPrefixes(
             fileManager: fileManager,
@@ -155,9 +224,9 @@ enum AlanCommandLineToolInstaller {
         for prefix in prefixes {
             let binDirectory = URL(fileURLWithPath: prefix, isDirectory: true)
                 .appendingPathComponent("bin", isDirectory: true)
-            for tool in toolNames {
+            for tool in channel.toolNames {
                 let link = binDirectory.appendingPathComponent(tool)
-                if isAlanOwnedLink(link, tool: tool, fileManager: fileManager) {
+                if isAlanOwnedLink(link, tool: tool, channel: channel, fileManager: fileManager) {
                     links[tool] = link.path
                 }
             }

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -164,6 +164,8 @@ struct AlanCommandResolution: Equatable {
         environment: [String: String]
     ) -> AlanCommandResolution {
         let repoRoot = inferredAlanRepoRoot()
+        let channel = AlanInstallChannel.current(environment: environment)
+        let cliName = channel.cliToolName
 
         let envOverride = normalizedExecutablePath(
             environment["ALAN_SHELL_ALAN_PATH"],
@@ -175,9 +177,13 @@ struct AlanCommandResolution: Equatable {
         let repoRelease = repoRoot.flatMap {
             normalizedExecutablePath("\($0)/target/release/alan", fileManager: fileManager)
         }
-        let bundled = bundledAlanExecutablePath(environment: environment, fileManager: fileManager)
+        let bundled = bundledAlanExecutablePath(
+            channel: channel,
+            environment: environment,
+            fileManager: fileManager
+        )
         let pathBinary = searchPath(
-            executable: "alan",
+            executable: cliName,
             environment: environment,
             fileManager: fileManager
         )
@@ -205,7 +211,7 @@ struct AlanCommandResolution: Equatable {
             ),
             AlanCommandCandidate(
                 label: "PATH lookup",
-                path: pathBinary ?? "alan",
+                path: pathBinary ?? cliName,
                 isPresent: pathBinary != nil
             ),
         ]
@@ -216,6 +222,28 @@ struct AlanCommandResolution: Equatable {
                 executablePath: envOverride,
                 summary: "Launching alan from ALAN_SHELL_ALAN_PATH",
                 detail: envOverride,
+                repoRoot: repoRoot,
+                candidates: candidates
+            )
+        }
+
+        if channel == .dev, let bundled {
+            return directBinary(
+                strategy: .bundledResourceBinary,
+                executablePath: bundled.path,
+                summary: "Launching \(cliName) from the app bundle",
+                detail: bundled.path,
+                repoRoot: repoRoot,
+                candidates: candidates
+            )
+        }
+
+        if channel == .dev, let pathBinary {
+            return directBinary(
+                strategy: .pathBinary,
+                executablePath: pathBinary,
+                summary: "Launching \(cliName) from the current PATH",
+                detail: pathBinary,
                 repoRoot: repoRoot,
                 candidates: candidates
             )
@@ -247,7 +275,7 @@ struct AlanCommandResolution: Equatable {
             return directBinary(
                 strategy: .bundledResourceBinary,
                 executablePath: bundled.path,
-                summary: "Launching alan from the app bundle",
+                summary: "Launching \(cliName) from the app bundle",
                 detail: bundled.path,
                 repoRoot: repoRoot,
                 candidates: candidates
@@ -258,7 +286,7 @@ struct AlanCommandResolution: Equatable {
             return directBinary(
                 strategy: .pathBinary,
                 executablePath: pathBinary,
-                summary: "Launching alan from the current PATH",
+                summary: "Launching \(cliName) from the current PATH",
                 detail: pathBinary,
                 repoRoot: repoRoot,
                 candidates: candidates
@@ -269,17 +297,18 @@ struct AlanCommandResolution: Equatable {
             strategy: .shellLookup,
             executablePath: nil,
             launchPath: "/bin/zsh",
-            arguments: ["-lc", "alan chat"],
-            bootCommand: "alan chat",
-            surfaceCommand: "alan chat",
-            summary: "No direct alan binary found; falling back to shell PATH lookup",
-            detail: "Make sure `alan` is in PATH or set ALAN_SHELL_ALAN_PATH.",
+            arguments: ["-lc", "\(cliName) chat"],
+            bootCommand: "\(cliName) chat",
+            surfaceCommand: "\(cliName) chat",
+            summary: "No direct \(cliName) binary found; falling back to shell PATH lookup",
+            detail: "Make sure `\(cliName)` is in PATH or set ALAN_SHELL_ALAN_PATH.",
             repoRoot: repoRoot,
             candidates: candidates
         )
     }
 
     private static func bundledAlanExecutablePath(
+        channel: AlanInstallChannel,
         environment: [String: String],
         fileManager: FileManager
     ) -> URL? {
@@ -288,7 +317,7 @@ struct AlanCommandResolution: Equatable {
         } ?? Bundle.main.resourceURL
         guard let candidate = resourceRoot?
             .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("alan")
+            .appendingPathComponent(channel.cliToolName)
         else {
             return nil
         }

--- a/clients/apple/scripts/check-brand-identity.sh
+++ b/clients/apple/scripts/check-brand-identity.sh
@@ -49,7 +49,16 @@ is_allowed_occurrence() {
         *"scripts/install.sh:"*"LEGACY_APP_TARGET"*|*"scripts/install.sh:"*"/alan.app/Contents/Resources/bin/"*)
             return 0
             ;;
+        *"scripts/install-channel.sh:"*"ALAN_LEGACY_APP_BUNDLE_NAME=\"alan.app\""*)
+            return 0
+            ;;
+        *"scripts/test-install-channel-descriptor.sh:"*"ALAN_LEGACY_APP_BUNDLE_NAME"*'"alan.app"'*)
+            return 0
+            ;;
         *"scripts/uninstall.sh:"*"LEGACY_APP_TARGET"*|*"scripts/uninstall.sh:"*"/alan.app/Contents/Resources/bin/"*)
+            return 0
+            ;;
+        *"AlanCommandLineToolInstaller.swift:"*"\"alan.app\""*)
             return 0
             ;;
         *"scripts/test-app-bundle-paths.sh:"*"alan.app"*)
@@ -61,7 +70,7 @@ is_allowed_occurrence() {
         *"clients/apple/scripts/test-command-line-tool-installer.swift:"*"/Applications/alan.app"*)
             return 0
             ;;
-        *"clients/apple/scripts/check-brand-identity.sh:"*"PATTERN="*)
+        *"clients/apple/scripts/check-brand-identity.sh:"*)
             return 0
             ;;
         *"github.com/realmorrisliu/Alan"*|*"git@github.com:realmorrisliu/Alan.git"*)

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1871,6 +1871,11 @@ require_pattern \
     "Homebrew cask validation must check embedded CLI/TUI binary links"
 
 require_pattern \
+    "scripts/install-channel.sh" \
+    "Alan Dev\\.app" \
+    "dev channel install contract checks must cover the dev app bundle"
+
+require_pattern \
     "clients/apple/README.md" \
     "stable .*window_main.* identity" \
     "Apple client docs must describe the singleton primary shell identity"

--- a/clients/apple/scripts/test-command-line-tool-installer.swift
+++ b/clients/apple/scripts/test-command-line-tool-installer.swift
@@ -26,21 +26,46 @@ private func temporaryDirectory(_ name: String) throws -> URL {
     return directory
 }
 
-private func makeResourceRoot() throws -> URL {
-    let appRoot = try temporaryDirectory("Alan.app")
+private func makeResourceRoot(channel: AlanInstallChannel = .stable) throws -> URL {
+    let appRoot = try temporaryDirectory(channel.ownedAppBundleNames[0])
     let root = appRoot
         .appendingPathComponent("Contents", isDirectory: true)
         .appendingPathComponent("Resources", isDirectory: true)
     let bin = root.appendingPathComponent("bin", isDirectory: true)
     try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
 
-    for tool in AlanCommandLineToolInstaller.toolNames {
+    for tool in channel.toolNames {
         let url = bin.appendingPathComponent(tool)
         try "#!/bin/sh\nexit 0\n".write(to: url, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
     }
 
     return root
+}
+
+private func testDevChannelInstallsDevToolNames() throws {
+    let resourceRoot = try makeResourceRoot(channel: .dev)
+    let targetDirectory = try temporaryDirectory("dev-target")
+
+    let records = try AlanCommandLineToolInstaller.install(
+        targetDirectory: targetDirectory,
+        resourceURL: resourceRoot,
+        channel: .dev
+    )
+
+    try require(records.map(\.tool) == ["alan-dev", "alan-dev-tui"], "dev installer must report dev tools")
+    for tool in AlanInstallChannel.dev.toolNames {
+        let target = targetDirectory.appendingPathComponent(tool)
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: target.path)
+        try require(
+            destination.hasSuffix("/bin/\(tool)"),
+            "dev installer must link \(tool) to the embedded resource"
+        )
+    }
+    try require(
+        !FileManager.default.fileExists(atPath: targetDirectory.appendingPathComponent("alan").path),
+        "dev installer must not create stable alan link"
+    )
 }
 
 private func testInstallsSymlinks() throws {
@@ -185,14 +210,51 @@ private func testRejectsAlanHomeBinTarget() throws {
     }
 }
 
+private func testRejectsDevAlanHomeBinTarget() throws {
+    let resourceRoot = try makeResourceRoot(channel: .dev)
+    let targetDirectory = try temporaryDirectory("dev-home")
+        .appendingPathComponent(".alan-dev", isDirectory: true)
+        .appendingPathComponent("bin", isDirectory: true)
+
+    do {
+        _ = try AlanCommandLineToolInstaller.install(
+            targetDirectory: targetDirectory,
+            resourceURL: resourceRoot,
+            channel: .dev
+        )
+        throw TestFailure.message("dev installer must reject ~/.alan-dev/bin-style targets")
+    } catch let error as CocoaError where error.code == .fileWriteInvalidFileName {
+        _ = error
+        return
+    }
+}
+
+private func testChannelResolvesFromBundleIdentifier() throws {
+    try require(
+        AlanInstallChannel.fromBundleIdentifier("app.alanworks.macos") == .stable,
+        "stable bundle id must resolve to stable channel"
+    )
+    try require(
+        AlanInstallChannel.fromBundleIdentifier("app.alanworks.macos.dev") == .dev,
+        "dev bundle id must resolve to dev channel"
+    )
+    try require(
+        AlanInstallChannel.fromBundleIdentifier("example.invalid") == nil,
+        "unknown bundle id must not resolve to an install channel"
+    )
+}
+
 @main
 private enum TestRunner {
     static func main() throws {
         try testInstallsSymlinks()
+        try testDevChannelInstallsDevToolNames()
         try testSkipsNonAlanFiles()
         try testRejectsHomebrewPrefixTarget()
         try testSkipsWhenHomebrewAlreadyManagesLinks()
         try testReplacesLegacyLowercaseAppLinks()
         try testRejectsAlanHomeBinTarget()
+        try testRejectsDevAlanHomeBinTarget()
+        try testChannelResolvesFromBundleIdentifier()
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -30,6 +30,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -24,6 +24,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalSurfaceController.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -17,6 +17,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesGhosttyTerminfoEnvironmentProjection()
         verifiesRuntimeCwdDoesNotRequireSurfaceRecreation()
         verifiesInstallDiscoveryChangesDoNotRequireSurfaceRecreation()
+        verifiesDevChannelUsesBundledDevBinary()
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
         verifiesContentScopedHandleSurvivesPaneRemount()
@@ -143,6 +144,42 @@ private enum TerminalRuntimeServiceTests {
         expect(
             !alanDuringInstall.requiresSurfaceRecreation(comparedTo: alanFromBundle),
             "install-time alan binary discovery changes must not recreate a running surface"
+        )
+    }
+
+    private static func verifiesDevChannelUsesBundledDevBinary() {
+        let resourceRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-dev-resource-\(UUID().uuidString)", isDirectory: true)
+        let bin = resourceRoot.appendingPathComponent("bin", isDirectory: true)
+        let alanDev = bin.appendingPathComponent("alan-dev", isDirectory: false)
+
+        try! FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        try! "#!/bin/sh\nexit 0\n".write(to: alanDev, atomically: true, encoding: .utf8)
+        try! FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: alanDev.path)
+        defer {
+            try? FileManager.default.removeItem(at: resourceRoot)
+        }
+
+        let resolution = AlanCommandResolution.resolve(
+            for: .alan,
+            environment: [
+                "ALAN_INSTALL_CHANNEL": "dev",
+                "ALAN_APP_RESOURCE_DIR": resourceRoot.path,
+                "PATH": "",
+            ]
+        )
+
+        expect(
+            resolution.strategy == .bundledResourceBinary,
+            "dev channel must prefer the bundled alan-dev binary"
+        )
+        expect(
+            resolution.executablePath == alanDev.path,
+            "dev channel must resolve the bundled alan-dev path"
+        )
+        expect(
+            resolution.bootCommand.contains("alan-dev") && resolution.arguments == ["chat"],
+            "dev channel boot command must use alan-dev"
         )
     }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -24,6 +24,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalNativeScrollViewAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalRuntimeService.swift" \

--- a/crates/alan/src/install_channel.rs
+++ b/crates/alan/src/install_channel.rs
@@ -1,0 +1,136 @@
+//! Install-channel identity descriptors for host-facing packaging surfaces.
+
+/// Stable and local development install identities.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InstallChannel {
+    /// Public stable Alan install.
+    Stable,
+    /// Local-only Alan Dev install.
+    Dev,
+}
+
+/// Host-facing install-channel values that must remain stable across packaging,
+/// launcher, and runtime path-resolution code.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InstallChannelDescriptor {
+    /// Channel id used by scripts and future runtime selection.
+    pub id: &'static str,
+    /// App bundle directory name.
+    pub app_bundle_name: &'static str,
+    /// Human-readable app name.
+    pub display_name: &'static str,
+    /// macOS bundle identifier.
+    pub bundle_identifier: &'static str,
+    /// CLI executable/link name.
+    pub cli_name: &'static str,
+    /// TUI executable/link name.
+    pub tui_name: &'static str,
+    /// Channel root under the user's home directory.
+    pub alan_home: &'static str,
+    /// Global public skill install root.
+    pub global_skills_dir: &'static str,
+    /// Default daemon bind address.
+    pub daemon_bind: &'static str,
+    /// Default daemon client URL.
+    pub daemon_url: &'static str,
+    /// Shell-control namespace.
+    pub shell_control_namespace: &'static str,
+}
+
+impl InstallChannel {
+    /// Resolve an install channel from its script-facing id.
+    pub fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "stable" => Some(Self::Stable),
+            "dev" => Some(Self::Dev),
+            _ => None,
+        }
+    }
+
+    /// Return the descriptor for this install channel.
+    pub const fn descriptor(self) -> InstallChannelDescriptor {
+        match self {
+            Self::Stable => InstallChannelDescriptor {
+                id: "stable",
+                app_bundle_name: "Alan.app",
+                display_name: "Alan",
+                bundle_identifier: "app.alanworks.macos",
+                cli_name: "alan",
+                tui_name: "alan-tui",
+                alan_home: "~/.alan",
+                global_skills_dir: "~/.agents/skills",
+                daemon_bind: "0.0.0.0:8090",
+                daemon_url: "http://127.0.0.1:8090",
+                shell_control_namespace: "alan-shell-control",
+            },
+            Self::Dev => InstallChannelDescriptor {
+                id: "dev",
+                app_bundle_name: "Alan Dev.app",
+                display_name: "Alan Dev",
+                bundle_identifier: "app.alanworks.macos.dev",
+                cli_name: "alan-dev",
+                tui_name: "alan-dev-tui",
+                alan_home: "~/.alan-dev",
+                global_skills_dir: "~/.agents-dev/skills",
+                daemon_bind: "127.0.0.1:8091",
+                daemon_url: "http://127.0.0.1:8091",
+                shell_control_namespace: "alan-dev-shell-control",
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InstallChannel, InstallChannelDescriptor};
+
+    #[test]
+    fn stable_descriptor_preserves_public_identity() {
+        assert_eq!(
+            InstallChannel::Stable.descriptor(),
+            InstallChannelDescriptor {
+                id: "stable",
+                app_bundle_name: "Alan.app",
+                display_name: "Alan",
+                bundle_identifier: "app.alanworks.macos",
+                cli_name: "alan",
+                tui_name: "alan-tui",
+                alan_home: "~/.alan",
+                global_skills_dir: "~/.agents/skills",
+                daemon_bind: "0.0.0.0:8090",
+                daemon_url: "http://127.0.0.1:8090",
+                shell_control_namespace: "alan-shell-control",
+            }
+        );
+    }
+
+    #[test]
+    fn dev_descriptor_uses_isolated_local_identity() {
+        assert_eq!(
+            InstallChannel::Dev.descriptor(),
+            InstallChannelDescriptor {
+                id: "dev",
+                app_bundle_name: "Alan Dev.app",
+                display_name: "Alan Dev",
+                bundle_identifier: "app.alanworks.macos.dev",
+                cli_name: "alan-dev",
+                tui_name: "alan-dev-tui",
+                alan_home: "~/.alan-dev",
+                global_skills_dir: "~/.agents-dev/skills",
+                daemon_bind: "127.0.0.1:8091",
+                daemon_url: "http://127.0.0.1:8091",
+                shell_control_namespace: "alan-dev-shell-control",
+            }
+        );
+    }
+
+    #[test]
+    fn ids_resolve_to_known_channels_only() {
+        assert_eq!(
+            InstallChannel::from_id("stable"),
+            Some(InstallChannel::Stable)
+        );
+        assert_eq!(InstallChannel::from_id("dev"), Some(InstallChannel::Dev));
+        assert_eq!(InstallChannel::from_id("nightly"), None);
+    }
+}

--- a/crates/alan/src/lib.rs
+++ b/crates/alan/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod cli;
 pub mod daemon;
 pub mod host_config;
+pub mod install_channel;
 pub mod registry;
 mod skill_catalog;
 

--- a/justfile
+++ b/justfile
@@ -54,7 +54,11 @@ build:
 
 # Install release Alan.app plus CLI/TUI locally
 install:
-    ./scripts/install.sh
+    ALAN_INSTALL_CHANNEL=stable ./scripts/install.sh
+
+# Install local-only Alan Dev.app plus alan-dev/alan-dev-tui
+install-dev:
+    ./scripts/install-dev.sh
 
 # Check release signing and notarization configuration without building
 release-check:
@@ -62,11 +66,15 @@ release-check:
 
 # Build, sign, notarize, staple, and archive the public macOS release app
 release:
-    ALAN_NOTARIZE=1 ALAN_CREATE_RELEASE_ARCHIVE=1 ./scripts/assemble-release-app.sh
+    ALAN_INSTALL_CHANNEL=stable ALAN_NOTARIZE=1 ALAN_CREATE_RELEASE_ARCHIVE=1 ./scripts/assemble-release-app.sh
 
 # Uninstall alan app and user-level CLI/TUI without removing ~/.alan data
 uninstall:
-    ./scripts/uninstall.sh
+    ALAN_INSTALL_CHANNEL=stable ./scripts/uninstall.sh
+
+# Uninstall Alan Dev.app and dev command links without removing ~/.alan-dev data
+uninstall-dev:
+    ./scripts/uninstall-dev.sh
 
 # Clean artifacts
 clean:

--- a/openspec/changes/add-macos-dev-channel-install/tasks.md
+++ b/openspec/changes/add-macos-dev-channel-install/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Channel Model And Path Resolution
 
-- [ ] 1.1 Add a typed install-channel descriptor for `stable` and `dev` identities, including app name, bundle id, CLI/TUI names, alan home, global skill source, daemon defaults, and shell-control namespace.
+- [x] 1.1 Add a typed install-channel descriptor for `stable` and `dev` identities, including app name, bundle id, CLI/TUI names, alan home, global skill source, daemon defaults, and shell-control namespace.
 - [ ] 1.2 Thread channel selection into CLI, daemon, TUI, and macOS app startup before any config, auth, daemon, or runtime path is resolved.
 - [ ] 1.3 Update runtime alan-home path resolution so stable uses `~/.alan` and dev uses `~/.alan-dev` for host config, registry, agents, models, connections, credentials, sessions, memory, managed auth, and caches.
 - [ ] 1.4 Update agent-root layout resolution and writes so global roots are channel-scoped while workspace roots remain unchanged.
@@ -8,12 +8,12 @@
 
 ## 2. macOS Packaging And Install Scripts
 
-- [ ] 2.1 Make app assembly channel-aware without changing stable `Alan.app` output.
-- [ ] 2.2 Add dev app metadata/build overrides for `Alan Dev.app` and `app.alanworks.macos.dev`.
-- [ ] 2.3 Embed channel-appropriate CLI/TUI binaries as `alan`/`alan-tui` for stable and `alan-dev`/`alan-dev-tui` for dev.
-- [ ] 2.4 Add `just install-dev` and dev install script behavior that installs `Alan Dev.app` plus `alan-dev`/`alan-dev-tui` without touching stable artifacts.
-- [ ] 2.5 Add `just uninstall-dev` and dev uninstall behavior that removes only dev-owned app and command links while preserving `~/.alan-dev` data.
-- [ ] 2.6 Keep public release, Homebrew cask, and Sparkle publication paths stable-only.
+- [x] 2.1 Make app assembly channel-aware without changing stable `Alan.app` output.
+- [x] 2.2 Add dev app metadata/build overrides for `Alan Dev.app` and `app.alanworks.macos.dev`.
+- [x] 2.3 Embed channel-appropriate CLI/TUI binaries as `alan`/`alan-tui` for stable and `alan-dev`/`alan-dev-tui` for dev.
+- [x] 2.4 Add `just install-dev` and dev install script behavior that installs `Alan Dev.app` plus `alan-dev`/`alan-dev-tui` without touching stable artifacts.
+- [x] 2.5 Add `just uninstall-dev` and dev uninstall behavior that removes only dev-owned app and command links while preserving `~/.alan-dev` data.
+- [x] 2.6 Keep public release, Homebrew cask, and Sparkle publication paths stable-only.
 
 ## 3. Daemon, TUI, And App Runtime Isolation
 
@@ -31,15 +31,15 @@
 
 ## 5. Verification And Guardrails
 
-- [ ] 5.1 Add focused tests for channel descriptor values and channel-aware path resolution.
-- [ ] 5.2 Add packaging/install contract checks for `Alan Dev.app`, `alan-dev`, `alan-dev-tui`, and stable artifact preservation.
-- [ ] 5.3 Add guardrails or allowlists for dev-channel brand strings without weakening stable brand validation.
+- [x] 5.1 Add focused tests for channel descriptor values and channel-aware path resolution.
+- [x] 5.2 Add packaging/install contract checks for `Alan Dev.app`, `alan-dev`, `alan-dev-tui`, and stable artifact preservation.
+- [x] 5.3 Add guardrails or allowlists for dev-channel brand strings without weakening stable brand validation.
 - [ ] 5.4 Add tests for channel-scoped connection stores, managed auth stores, global public skills, daemon defaults, and shell-control paths.
 - [ ] 5.5 Run a documented side-by-side smoke with stable Alan installed while Alan Dev launches and writes only dev-channel state.
-- [ ] 5.6 Run `openspec validate add-macos-dev-channel-install --strict` and `openspec validate --all --strict`.
+- [x] 5.6 Run `openspec validate add-macos-dev-channel-install --strict` and `openspec validate --all --strict`.
 
 ## 6. Review And Archive Readiness
 
-- [ ] 6.1 Keep implementation commits scoped to this change and avoid mixing with unrelated macOS shell work.
-- [ ] 6.2 Before PR review, confirm public stable install, Homebrew, and Sparkle contracts remain unchanged.
+- [x] 6.1 Keep implementation commits scoped to this change and avoid mixing with unrelated macOS shell work.
+- [x] 6.2 Before PR review, confirm public stable install, Homebrew, and Sparkle contracts remain unchanged.
 - [ ] 6.3 After merge, archive the change and verify the delta specs are folded into long-lived `openspec/specs/` owners.

--- a/scripts/assemble-release-app.sh
+++ b/scripts/assemble-release-app.sh
@@ -6,11 +6,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=scripts/release-env.sh
 source "$SCRIPT_DIR/release-env.sh"
+# shellcheck source=scripts/install-channel.sh
+source "$SCRIPT_DIR/install-channel.sh"
+
+alan_install_channel_load "${ALAN_INSTALL_CHANNEL:-stable}"
 
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$REPO_ROOT/target/xcode-derived}"
 ARTIFACT_DIR="${ALAN_RELEASE_ARTIFACT_DIR:-$REPO_ROOT/target/release-artifacts}"
 STAGING_DIR="$ARTIFACT_DIR/staging"
-APP_BUNDLE="$DERIVED_DATA/Build/Products/Release/Alan.app"
+APP_BUNDLE="$DERIVED_DATA/Build/Products/Release/$ALAN_APP_BUNDLE_NAME"
 EMBEDDED_BIN_DIR="$APP_BUNDLE/Contents/Resources/bin"
 MANIFEST_PATH="$APP_BUNDLE/Contents/Resources/alan-package-manifest.json"
 TUI_ENTITLEMENTS="$REPO_ROOT/scripts/entitlements/alan-tui.entitlements"
@@ -26,6 +30,10 @@ if ! git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- 2>/dev/null ||
     DIRTY="true"
 fi
 
+if alan_install_channel_is_dev && [[ -z "$SIGNING_IDENTITY" ]]; then
+    SIGNING_IDENTITY="-"
+fi
+
 fail() {
     printf 'error: %s\n' "$*" >&2
     exit 1
@@ -38,6 +46,10 @@ require_command() {
 }
 
 require_signing_identity() {
+    if [[ "$SIGNING_IDENTITY" == "-" ]]; then
+        return
+    fi
+
     if [[ -z "$SIGNING_IDENTITY" ]]; then
         fail "Developer ID signing identity is required. Set ALAN_DEVELOPER_ID_APPLICATION='Developer ID Application: ...', ALAN_SIGNING_IDENTITY, or ALAN_RELEASE_ENV_FILE."
     fi
@@ -69,17 +81,26 @@ sha256() {
 
 sign_path() {
     local path="$1"
-    codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" "$path"
+    local args=(--force --options runtime --sign "$SIGNING_IDENTITY")
+    if [[ "$SIGNING_IDENTITY" != "-" ]]; then
+        args+=(--timestamp)
+    fi
+    codesign "${args[@]}" "$path"
 }
 
 sign_path_with_entitlements() {
     local path="$1"
     local entitlements="$2"
-    codesign --force --timestamp --options runtime \
-        --entitlements "$entitlements" \
-        --sign "$SIGNING_IDENTITY" \
-        "$path"
+    local args=(--force --options runtime --entitlements "$entitlements" --sign "$SIGNING_IDENTITY")
+    if [[ "$SIGNING_IDENTITY" != "-" ]]; then
+        args+=(--timestamp)
+    fi
+    codesign "${args[@]}" "$path"
 }
+
+if ! alan_install_channel_is_stable && [[ "$NOTARIZE" == "1" || "$CREATE_ARCHIVE" == "1" ]]; then
+    fail "Dev channel builds are local-only and cannot create public release archives or notarization submissions."
+fi
 
 require_command cargo
 require_command bun
@@ -87,37 +108,42 @@ require_command xcodebuild
 require_command codesign
 require_command ditto
 require_command shasum
-require_command security
+if [[ "$SIGNING_IDENTITY" != "-" ]]; then
+    require_command security
+fi
 require_signing_identity
 
 [[ -f "$TUI_ENTITLEMENTS" ]] || fail "alan-tui entitlements file not found: $TUI_ENTITLEMENTS"
 
 mkdir -p "$STAGING_DIR" "$ARTIFACT_DIR"
 
-printf 'Building release alan CLI...\n'
+printf 'Building release alan CLI for %s channel...\n' "$ALAN_CHANNEL_ID"
 cargo build --release -p alan
 
-printf 'Building standalone alan-tui...\n'
+printf 'Building standalone %s...\n' "$ALAN_TUI_NAME"
 (
     cd "$REPO_ROOT/clients/tui"
     bun install --frozen-lockfile 2>/dev/null || bun install
     bun run build:js
-    ALAN_TUI_BINARY_OUTFILE="$STAGING_DIR/alan-tui" bun run build:standalone
+    ALAN_TUI_BINARY_OUTFILE="$STAGING_DIR/$ALAN_TUI_NAME" bun run build:standalone
 )
-chmod +x "$STAGING_DIR/alan-tui"
+chmod +x "$STAGING_DIR/$ALAN_TUI_NAME"
 
 if [[ -e "$APP_BUNDLE" ]]; then
-    printf 'Removing stale Release Alan.app build product...\n'
+    printf 'Removing stale Release %s build product...\n' "$ALAN_APP_BUNDLE_NAME"
     rm -rf "$APP_BUNDLE"
 fi
 
-printf 'Building Release Alan.app...\n'
+printf 'Building Release %s...\n' "$ALAN_APP_BUNDLE_NAME"
 xcodebuild \
     -project "$REPO_ROOT/clients/apple/alan-macos.xcodeproj" \
     -scheme alan-macos \
     -configuration Release \
     -destination generic/platform=macOS \
     -derivedDataPath "$DERIVED_DATA" \
+    PRODUCT_BUNDLE_IDENTIFIER="$ALAN_BUNDLE_ID" \
+    PRODUCT_NAME="$ALAN_DISPLAY_NAME" \
+    INFOPLIST_KEY_CFBundleDisplayName="$ALAN_DISPLAY_NAME" \
     CODE_SIGNING_ALLOWED=NO \
     build
 
@@ -125,36 +151,38 @@ if [[ ! -d "$APP_BUNDLE" ]]; then
     fail "Release build did not produce $APP_BUNDLE"
 fi
 
-printf 'Embedding CLI and TUI into Alan.app...\n'
+printf 'Embedding CLI and TUI into %s...\n' "$ALAN_APP_BUNDLE_NAME"
 mkdir -p "$EMBEDDED_BIN_DIR"
-cp "$REPO_ROOT/target/release/alan" "$EMBEDDED_BIN_DIR/alan"
-cp "$STAGING_DIR/alan-tui" "$EMBEDDED_BIN_DIR/alan-tui"
-chmod +x "$EMBEDDED_BIN_DIR/alan" "$EMBEDDED_BIN_DIR/alan-tui"
+cp "$REPO_ROOT/target/release/alan" "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME"
+cp "$STAGING_DIR/$ALAN_TUI_NAME" "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME"
+chmod +x "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME" "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME"
 
 ASSEMBLED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 printf 'Signing embedded binaries...\n'
-sign_path "$EMBEDDED_BIN_DIR/alan"
-sign_path_with_entitlements "$EMBEDDED_BIN_DIR/alan-tui" "$TUI_ENTITLEMENTS"
+sign_path "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME"
+sign_path_with_entitlements "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME" "$TUI_ENTITLEMENTS"
 
 printf 'Recording signed embedded binary checksums...\n'
-ALAN_SHA="$(sha256 "$EMBEDDED_BIN_DIR/alan")"
-TUI_SHA="$(sha256 "$EMBEDDED_BIN_DIR/alan-tui")"
+ALAN_SHA="$(sha256 "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME")"
+TUI_SHA="$(sha256 "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME")"
 
 cat >"$MANIFEST_PATH" <<EOF
 {
   "schema_version": 1,
-  "package": "Alan.app",
+  "install_channel": "$(json_escape "$ALAN_CHANNEL_ID")",
+  "package": "$(json_escape "$ALAN_APP_BUNDLE_NAME")",
+  "bundle_identifier": "$(json_escape "$ALAN_BUNDLE_ID")",
   "version": "$(json_escape "$VERSION")",
   "git_revision": "$(json_escape "$REVISION")",
   "git_dirty": $DIRTY,
   "assembled_at_utc": "$(json_escape "$ASSEMBLED_AT")",
   "embedded_binaries": {
-    "alan": {
-      "path": "Contents/Resources/bin/alan",
+    "$(json_escape "$ALAN_CLI_NAME")": {
+      "path": "Contents/Resources/bin/$(json_escape "$ALAN_CLI_NAME")",
       "sha256": "$(json_escape "$ALAN_SHA")"
     },
-    "alan-tui": {
-      "path": "Contents/Resources/bin/alan-tui",
+    "$(json_escape "$ALAN_TUI_NAME")": {
+      "path": "Contents/Resources/bin/$(json_escape "$ALAN_TUI_NAME")",
       "sha256": "$(json_escape "$TUI_SHA")"
     }
   }
@@ -162,7 +190,7 @@ cat >"$MANIFEST_PATH" <<EOF
 EOF
 
 printf 'Signing app bundle...\n'
-codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE"
+sign_path "$APP_BUNDLE"
 codesign --verify --strict --verbose=2 "$APP_BUNDLE"
 
 ZIP_PATH=""

--- a/scripts/check-dev-channel-install-contract.sh
+++ b/scripts/check-dev-channel-install-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local message="$3"
+
+    if ! rg -n --pcre2 "$pattern" "$REPO_ROOT/$file" >/dev/null; then
+        fail "$message"
+    fi
+}
+
+reject_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local message="$3"
+
+    if rg -n --pcre2 "$pattern" "$REPO_ROOT/$file" >/dev/null; then
+        fail "$message"
+    fi
+}
+
+"$SCRIPT_DIR/test-install-channel-descriptor.sh" >/dev/null
+
+require_pattern "justfile" "^install-dev:" "justfile must expose install-dev"
+require_pattern "justfile" "^uninstall-dev:" "justfile must expose uninstall-dev"
+require_pattern "scripts/assemble-release-app.sh" "ALAN_APP_BUNDLE_NAME" "assembly must use channel app bundle name"
+require_pattern "scripts/assemble-release-app.sh" 'PRODUCT_BUNDLE_IDENTIFIER="\$ALAN_BUNDLE_ID"' "assembly must override channel bundle id"
+require_pattern "scripts/assemble-release-app.sh" 'INFOPLIST_KEY_CFBundleDisplayName="\$ALAN_DISPLAY_NAME"' "assembly must override channel display name"
+require_pattern "scripts/assemble-release-app.sh" 'ALAN_TUI_BINARY_OUTFILE="\$STAGING_DIR/\$ALAN_TUI_NAME"' "assembly must build channel-named TUI"
+require_pattern "scripts/assemble-release-app.sh" "Dev channel builds are local-only" "assembly must block dev public release artifacts"
+require_pattern "scripts/install.sh" "ALAN_CLI_NAME" "install script must link channel CLI name"
+require_pattern "scripts/install.sh" "ALAN_TUI_NAME" "install script must link channel TUI name"
+require_pattern "scripts/uninstall.sh" "ALAN_CLI_NAME" "uninstall script must remove channel CLI name"
+require_pattern "scripts/uninstall.sh" "ALAN_TUI_NAME" "uninstall script must remove channel TUI name"
+require_pattern "packaging/homebrew/Casks/alan.rb.template" "app \"Alan\\.app\"" "Homebrew cask must remain stable-only"
+require_pattern "packaging/homebrew/Casks/alan.rb.template" "target: \"alan\"" "Homebrew cask must keep stable CLI target"
+reject_pattern "packaging/homebrew/Casks/alan.rb.template" "Alan Dev|alan-dev" "Homebrew cask must not publish dev artifacts"
+
+printf 'Dev channel install contract checks passed.\n'

--- a/scripts/install-channel.sh
+++ b/scripts/install-channel.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+alan_install_channel_load() {
+    local channel="${1:-stable}"
+
+    case "$channel" in
+        stable)
+            ALAN_CHANNEL_ID="stable"
+            ALAN_APP_BUNDLE_NAME="Alan.app"
+            ALAN_DISPLAY_NAME="Alan"
+            ALAN_BUNDLE_ID="app.alanworks.macos"
+            ALAN_CLI_NAME="alan"
+            ALAN_TUI_NAME="alan-tui"
+            ALAN_HOME_DISPLAY="~/.alan"
+            ALAN_GLOBAL_SKILLS_DIR_DISPLAY="~/.agents/skills"
+            ALAN_DAEMON_BIND="0.0.0.0:8090"
+            ALAN_DAEMON_URL="http://127.0.0.1:8090"
+            ALAN_SHELL_CONTROL_NAMESPACE="alan-shell-control"
+            ALAN_LEGACY_APP_BUNDLE_NAME="alan.app"
+            ;;
+        dev)
+            ALAN_CHANNEL_ID="dev"
+            ALAN_APP_BUNDLE_NAME="Alan Dev.app"
+            ALAN_DISPLAY_NAME="Alan Dev"
+            ALAN_BUNDLE_ID="app.alanworks.macos.dev"
+            ALAN_CLI_NAME="alan-dev"
+            ALAN_TUI_NAME="alan-dev-tui"
+            ALAN_HOME_DISPLAY="~/.alan-dev"
+            ALAN_GLOBAL_SKILLS_DIR_DISPLAY="~/.agents-dev/skills"
+            ALAN_DAEMON_BIND="127.0.0.1:8091"
+            ALAN_DAEMON_URL="http://127.0.0.1:8091"
+            ALAN_SHELL_CONTROL_NAMESPACE="alan-dev-shell-control"
+            ALAN_LEGACY_APP_BUNDLE_NAME=""
+            ;;
+        *)
+            printf 'error: unknown alan install channel: %s\n' "$channel" >&2
+            return 1
+            ;;
+    esac
+
+    export ALAN_CHANNEL_ID
+    export ALAN_APP_BUNDLE_NAME
+    export ALAN_DISPLAY_NAME
+    export ALAN_BUNDLE_ID
+    export ALAN_CLI_NAME
+    export ALAN_TUI_NAME
+    export ALAN_HOME_DISPLAY
+    export ALAN_GLOBAL_SKILLS_DIR_DISPLAY
+    export ALAN_DAEMON_BIND
+    export ALAN_DAEMON_URL
+    export ALAN_SHELL_CONTROL_NAMESPACE
+    export ALAN_LEGACY_APP_BUNDLE_NAME
+}
+
+alan_install_channel_is_stable() {
+    [[ "${ALAN_CHANNEL_ID:-}" == "stable" ]]
+}
+
+alan_install_channel_is_dev() {
+    [[ "${ALAN_CHANNEL_ID:-}" == "dev" ]]
+}

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export ALAN_INSTALL_CHANNEL="dev"
+export ALAN_NOTARIZE="0"
+export ALAN_CREATE_RELEASE_ARCHIVE="0"
+
+exec "$SCRIPT_DIR/install.sh" "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,20 +6,35 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=scripts/release-env.sh
 source "$SCRIPT_DIR/release-env.sh"
+# shellcheck source=scripts/install-channel.sh
+source "$SCRIPT_DIR/install-channel.sh"
 # shellcheck source=scripts/app-bundle-paths.sh
 source "$SCRIPT_DIR/app-bundle-paths.sh"
 
+alan_install_channel_load "${ALAN_INSTALL_CHANNEL:-stable}"
+
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$PROJECT_ROOT/target/xcode-derived}"
-APP_SOURCE="$DERIVED_DATA/Build/Products/Release/Alan.app"
+APP_SOURCE="$DERIVED_DATA/Build/Products/Release/$ALAN_APP_BUNDLE_NAME"
 APP_INSTALL_DIR="${ALAN_APP_INSTALL_DIR:-$HOME/Applications}"
-APP_TARGET="$APP_INSTALL_DIR/Alan.app"
-LEGACY_APP_TARGET="$APP_INSTALL_DIR/alan.app"
+APP_TARGET="$APP_INSTALL_DIR/$ALAN_APP_BUNDLE_NAME"
+LEGACY_APP_TARGET=""
+if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+    LEGACY_APP_TARGET="$APP_INSTALL_DIR/$ALAN_LEGACY_APP_BUNDLE_NAME"
+fi
 CLI_INSTALL_DIR="${ALAN_CLI_INSTALL_DIR:-/usr/local/bin}"
 APP_WAS_RUNNING=0
 
 is_app_running() {
-    pgrep -f "/Alan\\.app/Contents/MacOS/Alan" >/dev/null 2>&1 ||
-        pgrep -f "/alan\\.app/Contents/MacOS/alan" >/dev/null 2>&1
+    local app_pattern="${ALAN_APP_BUNDLE_NAME//./\\.}"
+
+    pgrep -f "/$app_pattern/Contents/MacOS/" >/dev/null 2>&1 && return 0
+
+    if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+        local legacy_pattern="${ALAN_LEGACY_APP_BUNDLE_NAME//./\\.}"
+        pgrep -f "/$legacy_pattern/Contents/MacOS/" >/dev/null 2>&1 && return 0
+    fi
+
+    return 1
 }
 
 is_alan_owned_link() {
@@ -32,13 +47,22 @@ is_alan_owned_link() {
 
     target="$(readlink "$path")"
     case "$target" in
-        *"/Alan.app/Contents/Resources/bin/"*|*"/alan.app/Contents/Resources/bin/"*)
+        *"/$ALAN_APP_BUNDLE_NAME/Contents/Resources/bin/"*)
             return 0
             ;;
         *)
-            return 1
             ;;
     esac
+
+    if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+        case "$target" in
+            *"/$ALAN_LEGACY_APP_BUNDLE_NAME/Contents/Resources/bin/"*)
+                return 0
+                ;;
+        esac
+    fi
+
+    return 1
 }
 
 is_homebrew_prefix_target() {
@@ -85,18 +109,26 @@ has_homebrew_managed_tool_links() {
     [[ -d /usr/local/Homebrew ]] && prefixes+=("/usr/local")
 
     for prefix in "${prefixes[@]}"; do
-        for tool in alan alan-tui; do
+        for tool in "$ALAN_CLI_NAME" "$ALAN_TUI_NAME"; do
             link="$prefix/bin/$tool"
             if [[ ! -L "$link" ]]; then
                 continue
             fi
             target="$(readlink "$link")"
             case "$target" in
-                *"/Alan.app/Contents/Resources/bin/$tool"|*"/alan.app/Contents/Resources/bin/$tool")
+                *"/$ALAN_APP_BUNDLE_NAME/Contents/Resources/bin/$tool")
                     printf '%s\n' "$link"
                     return 0
                     ;;
             esac
+            if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+                case "$target" in
+                    *"/$ALAN_LEGACY_APP_BUNDLE_NAME/Contents/Resources/bin/$tool")
+                        printf '%s\n' "$link"
+                        return 0
+                        ;;
+                esac
+            fi
         done
     done
 
@@ -139,11 +171,11 @@ if [[ ! -d "$APP_SOURCE" ]]; then
     exit 1
 fi
 
-printf 'Installing Alan.app to %s...\n' "$APP_TARGET"
+printf 'Installing %s to %s...\n' "$ALAN_APP_BUNDLE_NAME" "$APP_TARGET"
 mkdir -p "$APP_INSTALL_DIR"
 rm -rf "$APP_TARGET"
 ditto "$APP_SOURCE" "$APP_TARGET"
-if alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
+if [[ -n "$LEGACY_APP_TARGET" ]] && alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
     printf 'Removing legacy lowercase app bundle at %s...\n' "$LEGACY_APP_TARGET"
     rm -rf "$LEGACY_APP_TARGET"
 fi
@@ -155,21 +187,21 @@ if is_homebrew_prefix_target "$CLI_INSTALL_DIR"; then
     exit 1
 fi
 if homebrew_link="$(has_homebrew_managed_tool_links)"; then
-    printf 'error: Homebrew already manages alan command-line links at %s\n' "$homebrew_link" >&2
-    printf '       use the Homebrew cask to update alan, or remove the Homebrew links before creating direct-install symlinks.\n' >&2
+    printf 'error: Homebrew already manages %s command-line links at %s\n' "$ALAN_DISPLAY_NAME" "$homebrew_link" >&2
+    printf '       use the Homebrew cask to update stable Alan, or remove the Homebrew links before creating direct-install symlinks.\n' >&2
     exit 1
 fi
 mkdir -p "$CLI_INSTALL_DIR"
-link_tool "alan"
-link_tool "alan-tui"
+link_tool "$ALAN_CLI_NAME"
+link_tool "$ALAN_TUI_NAME"
 
-printf '\nAlan installed:\n'
+printf '\n%s installed:\n' "$ALAN_DISPLAY_NAME"
 printf '  app: %s\n' "$APP_TARGET"
-printf '  cli: %s/alan -> %s/Contents/Resources/bin/alan\n' "$CLI_INSTALL_DIR" "$APP_TARGET"
-printf '  tui: %s/alan-tui -> %s/Contents/Resources/bin/alan-tui\n' "$CLI_INSTALL_DIR" "$APP_TARGET"
+printf '  cli: %s/%s -> %s/Contents/Resources/bin/%s\n' "$CLI_INSTALL_DIR" "$ALAN_CLI_NAME" "$APP_TARGET" "$ALAN_CLI_NAME"
+printf '  tui: %s/%s -> %s/Contents/Resources/bin/%s\n' "$CLI_INSTALL_DIR" "$ALAN_TUI_NAME" "$APP_TARGET" "$ALAN_TUI_NAME"
 
 if [[ "$APP_WAS_RUNNING" -eq 1 ]]; then
-    printf '\nAlan.app was running during install. It was not stopped or relaunched; restart it manually to use the newly installed app.\n'
+    printf '\n%s was running during install. It was not stopped or relaunched; restart it manually to use the newly installed app.\n' "$ALAN_APP_BUNDLE_NAME"
 fi
 
 printf '\nEnsure %s is on PATH if you want shell access.\n' "$CLI_INSTALL_DIR"

--- a/scripts/release-env.sh
+++ b/scripts/release-env.sh
@@ -14,6 +14,7 @@ alan_release_env_allowed_key() {
         APPLE_APP_SPECIFIC_PASSWORD | \
         ALAN_NOTARIZE | \
         ALAN_CREATE_RELEASE_ARCHIVE | \
+        ALAN_INSTALL_CHANNEL | \
         ALAN_XCODE_DERIVED_DATA | \
         ALAN_RELEASE_ARTIFACT_DIR | \
         ALAN_APP_INSTALL_DIR | \

--- a/scripts/test-install-channel-descriptor.sh
+++ b/scripts/test-install-channel-descriptor.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/install-channel.sh
+source "$SCRIPT_DIR/install-channel.sh"
+# shellcheck source=scripts/release-env.sh
+source "$SCRIPT_DIR/release-env.sh"
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_equal() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+
+    [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
+}
+
+alan_install_channel_load stable
+require_equal "$ALAN_APP_BUNDLE_NAME" "Alan.app" "stable app bundle"
+require_equal "$ALAN_DISPLAY_NAME" "Alan" "stable display name"
+require_equal "$ALAN_BUNDLE_ID" "app.alanworks.macos" "stable bundle id"
+require_equal "$ALAN_CLI_NAME" "alan" "stable CLI"
+require_equal "$ALAN_TUI_NAME" "alan-tui" "stable TUI"
+require_equal "$ALAN_HOME_DISPLAY" "~/.alan" "stable alan home"
+require_equal "$ALAN_GLOBAL_SKILLS_DIR_DISPLAY" "~/.agents/skills" "stable global skills"
+require_equal "$ALAN_DAEMON_BIND" "0.0.0.0:8090" "stable daemon bind"
+require_equal "$ALAN_DAEMON_URL" "http://127.0.0.1:8090" "stable daemon URL"
+require_equal "$ALAN_SHELL_CONTROL_NAMESPACE" "alan-shell-control" "stable shell namespace"
+require_equal "$ALAN_LEGACY_APP_BUNDLE_NAME" "alan.app" "stable legacy app bundle"
+
+alan_install_channel_load dev
+require_equal "$ALAN_APP_BUNDLE_NAME" "Alan Dev.app" "dev app bundle"
+require_equal "$ALAN_DISPLAY_NAME" "Alan Dev" "dev display name"
+require_equal "$ALAN_BUNDLE_ID" "app.alanworks.macos.dev" "dev bundle id"
+require_equal "$ALAN_CLI_NAME" "alan-dev" "dev CLI"
+require_equal "$ALAN_TUI_NAME" "alan-dev-tui" "dev TUI"
+require_equal "$ALAN_HOME_DISPLAY" "~/.alan-dev" "dev alan home"
+require_equal "$ALAN_GLOBAL_SKILLS_DIR_DISPLAY" "~/.agents-dev/skills" "dev global skills"
+require_equal "$ALAN_DAEMON_BIND" "127.0.0.1:8091" "dev daemon bind"
+require_equal "$ALAN_DAEMON_URL" "http://127.0.0.1:8091" "dev daemon URL"
+require_equal "$ALAN_SHELL_CONTROL_NAMESPACE" "alan-dev-shell-control" "dev shell namespace"
+require_equal "$ALAN_LEGACY_APP_BUNDLE_NAME" "" "dev legacy app bundle"
+
+if alan_install_channel_load nightly 2>/dev/null; then
+    fail "unknown install channels must fail"
+fi
+
+if ! alan_release_env_allowed_key ALAN_INSTALL_CHANNEL; then
+    fail "release env allowlist must include ALAN_INSTALL_CHANNEL"
+fi
+
+printf 'Install channel descriptor checks passed.\n'

--- a/scripts/uninstall-dev.sh
+++ b/scripts/uninstall-dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export ALAN_INSTALL_CHANNEL="dev"
+
+exec "$SCRIPT_DIR/uninstall.sh" "$@"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,12 +2,19 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/install-channel.sh
+source "$SCRIPT_DIR/install-channel.sh"
 # shellcheck source=scripts/app-bundle-paths.sh
 source "$SCRIPT_DIR/app-bundle-paths.sh"
 
+alan_install_channel_load "${ALAN_INSTALL_CHANNEL:-stable}"
+
 APP_INSTALL_DIR="${ALAN_APP_INSTALL_DIR:-$HOME/Applications}"
-APP_TARGET="$APP_INSTALL_DIR/Alan.app"
-LEGACY_APP_TARGET="$APP_INSTALL_DIR/alan.app"
+APP_TARGET="$APP_INSTALL_DIR/$ALAN_APP_BUNDLE_NAME"
+LEGACY_APP_TARGET=""
+if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+    LEGACY_APP_TARGET="$APP_INSTALL_DIR/$ALAN_LEGACY_APP_BUNDLE_NAME"
+fi
 CLI_INSTALL_DIR="${ALAN_CLI_INSTALL_DIR:-/usr/local/bin}"
 
 remove_alan_link() {
@@ -21,18 +28,26 @@ remove_alan_link() {
 
     target="$(readlink "$path")"
     case "$target" in
-        *"/Alan.app/Contents/Resources/bin/$tool"|*"/alan.app/Contents/Resources/bin/$tool")
+        *"/$ALAN_APP_BUNDLE_NAME/Contents/Resources/bin/$tool")
             rm -f "$path"
             ;;
     esac
+
+    if [[ -n "$ALAN_LEGACY_APP_BUNDLE_NAME" ]]; then
+        case "$target" in
+            *"/$ALAN_LEGACY_APP_BUNDLE_NAME/Contents/Resources/bin/$tool")
+                rm -f "$path"
+                ;;
+        esac
+    fi
 }
 
-remove_alan_link "alan"
-remove_alan_link "alan-tui"
+remove_alan_link "$ALAN_CLI_NAME"
+remove_alan_link "$ALAN_TUI_NAME"
 rm -rf "$APP_TARGET"
-if alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
+if [[ -n "$LEGACY_APP_TARGET" ]] && alan_is_distinct_existing_path "$LEGACY_APP_TARGET" "$APP_TARGET"; then
     rm -rf "$LEGACY_APP_TARGET"
 fi
 
-printf 'Alan app and PATH symlinks were removed when owned by this install.\n'
-printf 'User data under ~/.alan was left intact.\n'
+printf '%s app and PATH symlinks were removed when owned by this install.\n' "$ALAN_DISPLAY_NAME"
+printf 'User data under %s was left intact.\n' "$ALAN_HOME_DISPLAY"

--- a/scripts/validate-release-app.sh
+++ b/scripts/validate-release-app.sh
@@ -3,11 +3,24 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/install-channel.sh
+source "$SCRIPT_DIR/install-channel.sh"
+
+VALIDATE_CHANNEL="${ALAN_VALIDATE_CHANNEL:-${ALAN_INSTALL_CHANNEL:-stable}}"
+if [[ -z "${ALAN_VALIDATE_CHANNEL:-}" && -n "${1:-}" ]]; then
+    case "$1" in
+        *"/Alan Dev.app"|*"Alan Dev.app")
+            VALIDATE_CHANNEL="dev"
+            ;;
+    esac
+fi
+alan_install_channel_load "$VALIDATE_CHANNEL"
+
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$REPO_ROOT/target/xcode-derived}"
-APP_BUNDLE="${1:-$DERIVED_DATA/Build/Products/Release/Alan.app}"
+APP_BUNDLE="${1:-$DERIVED_DATA/Build/Products/Release/$ALAN_APP_BUNDLE_NAME}"
 MANIFEST="$APP_BUNDLE/Contents/Resources/alan-package-manifest.json"
-ALAN_BIN="$APP_BUNDLE/Contents/Resources/bin/alan"
-TUI_BIN="$APP_BUNDLE/Contents/Resources/bin/alan-tui"
+ALAN_BIN="$APP_BUNDLE/Contents/Resources/bin/$ALAN_CLI_NAME"
+TUI_BIN="$APP_BUNDLE/Contents/Resources/bin/$ALAN_TUI_NAME"
 
 fail() {
     printf 'error: %s\n' "$*" >&2
@@ -86,17 +99,21 @@ require_manifest_checksum() {
 }
 
 [[ -d "$APP_BUNDLE" ]] || fail "app bundle not found: $APP_BUNDLE"
-require_executable "$APP_BUNDLE/Contents/MacOS/Alan"
+require_executable "$APP_BUNDLE/Contents/MacOS/$ALAN_DISPLAY_NAME"
 require_executable "$ALAN_BIN"
 require_executable "$TUI_BIN"
 [[ -f "$MANIFEST" ]] || fail "package manifest not found: $MANIFEST"
 
-grep -q '"package": "Alan.app"' "$MANIFEST" ||
-    fail "manifest does not record Alan.app package name"
-grep -q '"path": "Contents/Resources/bin/alan"' "$MANIFEST" ||
-    fail "manifest does not record embedded alan path"
-grep -q '"path": "Contents/Resources/bin/alan-tui"' "$MANIFEST" ||
-    fail "manifest does not record embedded alan-tui path"
+grep -q "\"install_channel\": \"$ALAN_CHANNEL_ID\"" "$MANIFEST" ||
+    fail "manifest does not record $ALAN_CHANNEL_ID install channel"
+grep -q "\"package\": \"$ALAN_APP_BUNDLE_NAME\"" "$MANIFEST" ||
+    fail "manifest does not record $ALAN_APP_BUNDLE_NAME package name"
+grep -q "\"bundle_identifier\": \"$ALAN_BUNDLE_ID\"" "$MANIFEST" ||
+    fail "manifest does not record $ALAN_BUNDLE_ID bundle id"
+grep -q "\"path\": \"Contents/Resources/bin/$ALAN_CLI_NAME\"" "$MANIFEST" ||
+    fail "manifest does not record embedded $ALAN_CLI_NAME path"
+grep -q "\"path\": \"Contents/Resources/bin/$ALAN_TUI_NAME\"" "$MANIFEST" ||
+    fail "manifest does not record embedded $ALAN_TUI_NAME path"
 
 manifest_version="$(manifest_value "version")"
 repo_version="$(awk -F '"' '/^version = / { print $2; exit }' "$REPO_ROOT/Cargo.toml")"
@@ -104,8 +121,8 @@ repo_version="$(awk -F '"' '/^version = / { print $2; exit }' "$REPO_ROOT/Cargo.
 if [[ "$manifest_version" != "$repo_version" ]]; then
     fail "manifest version $manifest_version does not match Cargo.toml version $repo_version"
 fi
-require_manifest_checksum "alan" "$ALAN_BIN"
-require_manifest_checksum "alan-tui" "$TUI_BIN"
+require_manifest_checksum "$ALAN_CLI_NAME" "$ALAN_BIN"
+require_manifest_checksum "$ALAN_TUI_NAME" "$TUI_BIN"
 
 require_developer_id_signature "$ALAN_BIN"
 require_developer_id_signature "$TUI_BIN"


### PR DESCRIPTION
## Summary
- add stable/dev install-channel descriptors for Rust and packaging scripts
- make macOS assembly/install/uninstall channel-aware with `install-dev` / `uninstall-dev`
- teach macOS command-line installer and terminal launch resolution to use `alan-dev` / `alan-dev-tui` for dev bundles
- add guardrails for dev-channel install contracts and update OpenSpec task status

## Verification
- `CARGO_TARGET_DIR=debug/cargo-target cargo test -p alan install_channel`
- `./clients/apple/scripts/test-command-line-tool-installer.sh`
- `./clients/apple/scripts/test-terminal-runtime-service.sh`
- `./clients/apple/scripts/test-shell-runtime-metadata.sh`
- `./clients/apple/scripts/test-terminal-surface-controller.sh`
- `./scripts/test-install-channel-descriptor.sh`
- `./scripts/check-dev-channel-install-contract.sh`
- `./clients/apple/scripts/check-brand-identity.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `./scripts/validate-homebrew-cask.sh`
- `openspec validate add-macos-dev-channel-install --strict`
- `openspec validate --all --strict`

Note: direct `xcodebuild ... build` reached the dev `Alan Dev.app` settings but is blocked in this sandbox by CoreSimulator/actool. `xcodebuild ... -showBuildSettings` confirmed `FULL_PRODUCT_NAME = Alan Dev.app`, `PRODUCT_BUNDLE_IDENTIFIER = app.alanworks.macos.dev`, and `INFOPLIST_KEY_CFBundleDisplayName = Alan Dev`.