### PR TITLE
Isolate macOS dev app control paths

### DIFF
--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -131,6 +131,7 @@ For screenshot-driven UI iteration on the native macOS app, use:
 ```bash
 zsh ./clients/apple/scripts/capture-alan-window.sh --list
 zsh ./clients/apple/scripts/capture-alan-window.sh --output .artifacts/alan-window.png
+zsh ./clients/apple/scripts/capture-alan-window.sh --channel dev --output .artifacts/alan-dev-window.png
 ```
 
 You can also target a specific running process:

--- a/clients/apple/alan-macos/AlanAppSingletonGuard.swift
+++ b/clients/apple/alan-macos/AlanAppSingletonGuard.swift
@@ -42,6 +42,7 @@ final class AlanAppSingletonGuard {
 
         let lockDirectory = try singletonLockDirectory(
             applicationSupportDirectory: applicationSupportDirectory,
+            channel: AlanInstallChannel.current(bundleIdentifier: bundleIdentifier),
             fileManager: fileManager
         )
         let lockURL = lockDirectory.appendingPathComponent(
@@ -96,6 +97,7 @@ final class AlanAppSingletonGuard {
 
     private static func singletonLockDirectory(
         applicationSupportDirectory: URL?,
+        channel: AlanInstallChannel,
         fileManager: FileManager
     ) throws -> URL {
         let appSupportURL =
@@ -103,7 +105,7 @@ final class AlanAppSingletonGuard {
             ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
         let lockDirectory = appSupportURL
-            .appendingPathComponent("alan-macos", isDirectory: true)
+            .appendingPathComponent(channel.applicationSupportDirectoryName, isDirectory: true)
             .appendingPathComponent("SingletonLocks", isDirectory: true)
         try fileManager.createDirectory(at: lockDirectory, withIntermediateDirectories: true)
         return lockDirectory

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -14,7 +14,7 @@ final class AlanGhosttyLiveHost: NSObject {
     var onScrollbackUpdate: ((AlanTerminalScrollbackMetrics) -> Void)?
 
     private let logger = Logger(
-        subsystem: "app.alanworks.macos",
+        subsystem: AlanInstallChannel.current().logSubsystem,
         category: "GhosttyLiveHost"
     )
 

--- a/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift
@@ -5,6 +5,7 @@ import Foundation
 final class AlanShellControlFilePoller {
     private let windowID: String
     private let fileManager: FileManager
+    private let channel: AlanInstallChannel
     private let commandsURL: URL
     private let resultsURL: URL
     private let encoder: JSONEncoder
@@ -19,6 +20,7 @@ final class AlanShellControlFilePoller {
     init(
         windowID: String,
         fileManager: FileManager,
+        channel: AlanInstallChannel = .current(),
         commandsURL: URL,
         resultsURL: URL,
         encoder: JSONEncoder,
@@ -29,6 +31,7 @@ final class AlanShellControlFilePoller {
     ) {
         self.windowID = windowID
         self.fileManager = fileManager
+        self.channel = channel
         self.commandsURL = commandsURL
         self.resultsURL = resultsURL
         self.encoder = encoder
@@ -149,7 +152,8 @@ final class AlanShellControlFilePoller {
             let bindingURL = alanShellBindingFileURL(
                 windowID: windowID,
                 paneID: paneID,
-                fileManager: fileManager
+                fileManager: fileManager,
+                channel: channel
             )
 
             guard fileManager.fileExists(atPath: bindingURL.path) else {

--- a/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift
@@ -23,23 +23,28 @@ struct ShellStatePersistenceStore {
         try? data.write(to: persistenceURL, options: .atomic)
     }
 
-    static func defaultPersistenceURL(windowID: String, fileManager: FileManager) -> URL {
+    static func defaultPersistenceURL(
+        windowID: String,
+        fileManager: FileManager,
+        channel: AlanInstallChannel = .current()
+    ) -> URL {
         let sanitizedWindowID = windowID
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: ":", with: "_")
-        return persistenceDirectory(fileManager: fileManager)
+        return persistenceDirectory(fileManager: fileManager, channel: channel)
             .appendingPathComponent("\(persistenceFilePrefix)\(sanitizedWindowID)\(persistenceFileExtension)")
     }
 
     @MainActor
     static func restoredWindowContext(
         fileManager: FileManager,
-        restorePrevious: Bool
+        restorePrevious: Bool,
+        channel: AlanInstallChannel = .current()
     ) -> ShellWindowContext? {
         guard restorePrevious else { return nil }
 
-        let directories = [persistenceDirectory(fileManager: fileManager)]
-            + legacyPersistenceDirectories(fileManager: fileManager)
+        let directories = [persistenceDirectory(fileManager: fileManager, channel: channel)]
+            + legacyPersistenceDirectories(fileManager: fileManager, channel: channel)
 
         let candidates = directories.flatMap { directory -> [(Date, ShellWindowContext)] in
             guard let urls = try? fileManager.contentsOfDirectory(
@@ -52,7 +57,11 @@ struct ShellStatePersistenceStore {
 
             return urls.compactMap { url -> (Date, ShellWindowContext)? in
                 guard isShellStatePersistenceURL(url),
-                      let windowID = restorePersistedWindowID(fileManager: fileManager, persistenceURL: url)
+                      let windowID = restorePersistedWindowID(
+                        fileManager: fileManager,
+                        persistenceURL: url,
+                        channel: channel
+                      )
                 else {
                     return nil
                 }
@@ -61,13 +70,15 @@ struct ShellStatePersistenceStore {
                 let modifiedAt = values?.contentModificationDate ?? .distantPast
                 let canonicalURL = defaultPersistenceURL(
                     windowID: windowID,
-                    fileManager: fileManager
+                    fileManager: fileManager,
+                    channel: channel
                 )
                 return (
                     modifiedAt,
                     ShellWindowContext(
                         windowID: windowID,
                         persistenceURL: canonicalURL,
+                        installChannel: channel,
                         terminalRuntimeRegistry: TerminalRuntimeRegistry()
                     )
                 )
@@ -80,23 +91,30 @@ struct ShellStatePersistenceStore {
     @MainActor
     static func defaultWindowContext(
         fileManager: FileManager,
-        restorePrevious: Bool
+        restorePrevious: Bool,
+        channel: AlanInstallChannel = .current()
     ) -> ShellWindowContext {
         if restorePrevious {
             return ShellWindowContext.make(
                 fileManager: fileManager,
-                windowID: defaultRestorationWindowID
+                windowID: defaultRestorationWindowID,
+                installChannel: channel
             )
         }
 
-        return ShellWindowContext.make(fileManager: fileManager)
+        return ShellWindowContext.make(fileManager: fileManager, installChannel: channel)
     }
 
     static func restoreShellState(
         fileManager: FileManager,
-        persistenceURL: URL
+        persistenceURL: URL,
+        channel: AlanInstallChannel = .current()
     ) -> ShellStateSnapshot? {
-        let restoreURL = readablePersistenceURL(fileManager: fileManager, canonicalURL: persistenceURL)
+        let restoreURL = readablePersistenceURL(
+            fileManager: fileManager,
+            canonicalURL: persistenceURL,
+            channel: channel
+        )
         guard let restoreURL,
               let data = try? Data(contentsOf: restoreURL)
         else {
@@ -122,9 +140,14 @@ struct ShellStatePersistenceStore {
 
     private static func restorePersistedWindowID(
         fileManager: FileManager,
-        persistenceURL: URL
+        persistenceURL: URL,
+        channel: AlanInstallChannel
     ) -> String? {
-        let restoreURL = readablePersistenceURL(fileManager: fileManager, canonicalURL: persistenceURL)
+        let restoreURL = readablePersistenceURL(
+            fileManager: fileManager,
+            canonicalURL: persistenceURL,
+            channel: channel
+        )
         guard let restoreURL,
               let data = try? Data(contentsOf: restoreURL)
         else {
@@ -149,14 +172,27 @@ struct ShellStatePersistenceStore {
         return nil
     }
 
-    private static func persistenceDirectory(fileManager: FileManager) -> URL {
+    private static func persistenceDirectory(
+        fileManager: FileManager,
+        channel: AlanInstallChannel
+    ) -> URL {
         let appSupportURL =
             fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
-        return appSupportURL.appendingPathComponent("alan-macos", isDirectory: true)
+        return appSupportURL.appendingPathComponent(
+            channel.applicationSupportDirectoryName,
+            isDirectory: true
+        )
     }
 
-    private static func legacyPersistenceDirectories(fileManager: FileManager) -> [URL] {
+    private static func legacyPersistenceDirectories(
+        fileManager: FileManager,
+        channel: AlanInstallChannel
+    ) -> [URL] {
+        guard channel == .stable else {
+            return []
+        }
+
         let appSupportURL =
             fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
@@ -167,13 +203,14 @@ struct ShellStatePersistenceStore {
 
     private static func readablePersistenceURL(
         fileManager: FileManager,
-        canonicalURL: URL
+        canonicalURL: URL,
+        channel: AlanInstallChannel
     ) -> URL? {
         if fileManager.fileExists(atPath: canonicalURL.path) {
             return canonicalURL
         }
 
-        return legacyPersistenceDirectories(fileManager: fileManager)
+        return legacyPersistenceDirectories(fileManager: fileManager, channel: channel)
             .map { $0.appendingPathComponent(canonicalURL.lastPathComponent) }
             .first { fileManager.fileExists(atPath: $0.path) }
     }

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -26,11 +26,16 @@ struct ShellWorkspaceManifestStore {
 
     init(
         fileManager: FileManager = .default,
-        windowID: String
+        windowID: String,
+        channel: AlanInstallChannel = .current()
     ) {
         self.init(
             fileManager: fileManager,
-            manifestURL: Self.defaultManifestURL(windowID: windowID, fileManager: fileManager)
+            manifestURL: Self.defaultManifestURL(
+                windowID: windowID,
+                fileManager: fileManager,
+                channel: channel
+            )
         )
     }
 
@@ -122,14 +127,15 @@ struct ShellWorkspaceManifestStore {
 
     static func defaultManifestURL(
         windowID: String,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        channel: AlanInstallChannel = .current()
     ) -> URL {
         let applicationSupportURL = fileManager.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         ).first ?? fileManager.temporaryDirectory
         return applicationSupportURL
-            .appendingPathComponent("alan-macos", isDirectory: true)
+            .appendingPathComponent(channel.applicationSupportDirectoryName, isDirectory: true)
             .appendingPathComponent("shell-workspace-\(sanitizedWindowID(windowID)).json")
     }
 

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -3,27 +3,30 @@ import Foundation
 #if os(macOS)
 func alanShellControlPlaneRootURL(
     windowID: String,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    channel: AlanInstallChannel = .current()
 ) -> URL {
     fileManager.temporaryDirectory
-        .appendingPathComponent("alan-shell-control", isDirectory: true)
+        .appendingPathComponent(channel.shellControlNamespace, isDirectory: true)
         .appendingPathComponent(windowID, isDirectory: true)
 }
 
 func alanShellControlPlaneSocketURL(
     windowID: String,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    channel: AlanInstallChannel = .current()
 ) -> URL {
-    alanShellControlPlaneRootURL(windowID: windowID, fileManager: fileManager)
+    alanShellControlPlaneRootURL(windowID: windowID, fileManager: fileManager, channel: channel)
         .appendingPathComponent("shell.sock")
 }
 
 func alanShellPaneSupportDirectoryURL(
     windowID: String,
     paneID: String,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    channel: AlanInstallChannel = .current()
 ) -> URL {
-    alanShellControlPlaneRootURL(windowID: windowID, fileManager: fileManager)
+    alanShellControlPlaneRootURL(windowID: windowID, fileManager: fileManager, channel: channel)
         .appendingPathComponent("panes", isDirectory: true)
         .appendingPathComponent(paneID, isDirectory: true)
 }
@@ -31,9 +34,15 @@ func alanShellPaneSupportDirectoryURL(
 func alanShellBindingFileURL(
     windowID: String,
     paneID: String,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    channel: AlanInstallChannel = .current()
 ) -> URL {
-    alanShellPaneSupportDirectoryURL(windowID: windowID, paneID: paneID, fileManager: fileManager)
+    alanShellPaneSupportDirectoryURL(
+        windowID: windowID,
+        paneID: paneID,
+        fileManager: fileManager,
+        channel: channel
+    )
         .appendingPathComponent("alan-binding.json")
 }
 
@@ -60,6 +69,7 @@ final class AlanShellControlPlane {
     init(
         windowID: String,
         fileManager: FileManager = .default,
+        channel: AlanInstallChannel = .current(),
         commandHandler: @escaping (AlanShellControlCommand) -> AlanShellControlResponse,
         stateAdoptionHandler: @escaping @MainActor (ShellStateSnapshot) -> Void,
         bindingProjectionHandler: @escaping @MainActor (String, ShellAlanBinding?) -> Void,
@@ -70,8 +80,16 @@ final class AlanShellControlPlane {
         self.encoder = JSONEncoder()
         self.encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         self.decoder = JSONDecoder()
-        self.rootURL = alanShellControlPlaneRootURL(windowID: windowID, fileManager: fileManager)
-        self.socketURL = alanShellControlPlaneSocketURL(windowID: windowID, fileManager: fileManager)
+        self.rootURL = alanShellControlPlaneRootURL(
+            windowID: windowID,
+            fileManager: fileManager,
+            channel: channel
+        )
+        self.socketURL = alanShellControlPlaneSocketURL(
+            windowID: windowID,
+            fileManager: fileManager,
+            channel: channel
+        )
         self.panesURL = rootURL.appendingPathComponent("panes", isDirectory: true)
         self.commandsURL = rootURL.appendingPathComponent("commands", isDirectory: true)
         self.resultsURL = rootURL.appendingPathComponent("results", isDirectory: true)
@@ -100,6 +118,7 @@ final class AlanShellControlPlane {
         self.filePoller = AlanShellControlFilePoller(
             windowID: windowID,
             fileManager: fileManager,
+            channel: channel,
             commandsURL: commandsURL,
             resultsURL: resultsURL,
             encoder: encoder,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -216,14 +216,15 @@ final class ShellQuickTerminalPeakPresenter {
 struct ShellWindowContext {
     let windowID: String
     let persistenceURL: URL
+    let installChannel: AlanInstallChannel
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
 
     var controlRootURL: URL {
-        alanShellControlPlaneRootURL(windowID: windowID)
+        alanShellControlPlaneRootURL(windowID: windowID, channel: installChannel)
     }
 
     var socketURL: URL {
-        alanShellControlPlaneSocketURL(windowID: windowID)
+        alanShellControlPlaneSocketURL(windowID: windowID, channel: installChannel)
     }
 
     var stateURL: URL {
@@ -237,14 +238,17 @@ struct ShellWindowContext {
     static func make(
         fileManager: FileManager = .default,
         windowID: String = "window_\(UUID().uuidString.lowercased())",
+        installChannel: AlanInstallChannel = .current(),
         terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil
     ) -> ShellWindowContext {
         ShellWindowContext(
             windowID: windowID,
             persistenceURL: ShellStatePersistenceStore.defaultPersistenceURL(
                 windowID: windowID,
-                fileManager: fileManager
+                fileManager: fileManager,
+                channel: installChannel
             ),
+            installChannel: installChannel,
             terminalRuntimeRegistry: terminalRuntimeRegistry ?? TerminalRuntimeRegistry()
         )
     }
@@ -271,7 +275,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let terminalContentProjection: TerminalContentProjectionAdapter
     private let terminalContentLifecycle = TerminalContentLifecycleAdapter()
     private let clipboardWriter: ShellClipboardWriter
-    lazy var controlPlane = AlanShellControlPlane(windowID: windowContext.windowID) { [weak self] command in
+    lazy var controlPlane = AlanShellControlPlane(
+        windowID: windowContext.windowID,
+        channel: windowContext.installChannel
+    ) { [weak self] command in
         self?.handleControlPlaneCommand(command)
             ?? AlanShellControlResponse(
                 requestID: command.requestID,
@@ -381,16 +388,19 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         defaultWorkingDirectory: String? = nil,
         now: Date = .now
     ) -> ShellHostController {
-        let usesStableWindowContext = startupMode == .restorePrevious || startupMode == .workspaceManifest
+        let installChannel = AlanInstallChannel.current()
+        let usesRestorableWindowContext = startupMode == .restorePrevious || startupMode == .workspaceManifest
         let resolvedWindowContext =
             windowContext
             ?? ShellStatePersistenceStore.restoredWindowContext(
                 fileManager: fileManager,
-                restorePrevious: startupMode == .restorePrevious
+                restorePrevious: startupMode == .restorePrevious,
+                channel: installChannel
             )
             ?? ShellStatePersistenceStore.defaultWindowContext(
                 fileManager: fileManager,
-                restorePrevious: usesStableWindowContext
+                restorePrevious: usesRestorableWindowContext,
+                channel: installChannel
             )
         let persistenceURL = resolvedWindowContext.persistenceURL
         let shellState: ShellStateSnapshot
@@ -409,7 +419,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             shellState =
                 ShellStatePersistenceStore.restoreShellState(
                     fileManager: fileManager,
-                    persistenceURL: persistenceURL
+                    persistenceURL: persistenceURL,
+                    channel: resolvedWindowContext.installChannel
                 )
                 ?? .bootstrapDefault(windowID: resolvedWindowContext.windowID)
             manifestStore = nil
@@ -424,7 +435,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 manifestURL: workspaceManifestURL
                     ?? ShellWorkspaceManifestStore.defaultManifestURL(
                         windowID: resolvedWindowContext.windowID,
-                        fileManager: fileManager
+                        fileManager: fileManager,
+                        channel: resolvedWindowContext.installChannel
                     )
             )
             let loadResult = try? store.loadOrCreateDefault(

--- a/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
+++ b/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift
@@ -56,6 +56,37 @@ enum AlanInstallChannel: Equatable {
         }
     }
 
+    var bundleIdentifier: String {
+        switch self {
+        case .stable:
+            return "app.alanworks.macos"
+        case .dev:
+            return "app.alanworks.macos.dev"
+        }
+    }
+
+    var applicationSupportDirectoryName: String {
+        switch self {
+        case .stable:
+            return "alan-macos"
+        case .dev:
+            return "alan-macos-dev"
+        }
+    }
+
+    var shellControlNamespace: String {
+        switch self {
+        case .stable:
+            return "alan-shell-control"
+        case .dev:
+            return "alan-dev-shell-control"
+        }
+    }
+
+    var logSubsystem: String {
+        bundleIdentifier
+    }
+
     var toolNames: [String] {
         [cliToolName, tuiToolName]
     }

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -549,9 +549,19 @@ struct AlanShellBootProfile: Equatable {
         let ghostty = GhosttyIntegrationStatus.discover()
         let command = AlanCommandResolution.resolve(for: pane.resolvedLaunchTarget)
         let installChannel = AlanInstallChannel.current()
-        let controlPlaneRoot = alanShellControlPlaneRootURL(windowID: shellState.windowID)
-        let controlPlaneSocket = alanShellControlPlaneSocketURL(windowID: shellState.windowID)
-        let bindingFile = alanShellBindingFileURL(windowID: shellState.windowID, paneID: pane.paneID)
+        let controlPlaneRoot = alanShellControlPlaneRootURL(
+            windowID: shellState.windowID,
+            channel: installChannel
+        )
+        let controlPlaneSocket = alanShellControlPlaneSocketURL(
+            windowID: shellState.windowID,
+            channel: installChannel
+        )
+        let bindingFile = alanShellBindingFileURL(
+            windowID: shellState.windowID,
+            paneID: pane.paneID,
+            channel: installChannel
+        )
 
         var environment: [String: String] = [
             "ALAN_INSTALL_CHANNEL": installChannel.installChannelID,

--- a/clients/apple/scripts/capture-alan-window.swift
+++ b/clients/apple/scripts/capture-alan-window.swift
@@ -10,6 +10,20 @@ struct CaptureOptions {
     var listOnly = false
 }
 
+enum CaptureChannel: String {
+    case stable
+    case dev
+
+    var bundleID: String {
+        switch self {
+        case .stable:
+            return "app.alanworks.macos"
+        case .dev:
+            return "app.alanworks.macos.dev"
+        }
+    }
+}
+
 enum CaptureAlanWindow {
     static func run(options: CaptureOptions) async throws {
         await MainActor.run {
@@ -158,6 +172,17 @@ enum CaptureAlanWindow {
             let argument = arguments[index]
 
             switch argument {
+            case "--channel":
+                index += 1
+                let rawValue = try value(after: argument, at: index, in: arguments)
+                guard let channel = CaptureChannel(rawValue: rawValue) else {
+                    throw NSError(
+                        domain: "AlanCapture",
+                        code: 8,
+                        userInfo: [NSLocalizedDescriptionKey: "Invalid channel: \(rawValue)"]
+                    )
+                }
+                options.bundleID = channel.bundleID
             case "--bundle-id":
                 index += 1
                 options.bundleID = try value(after: argument, at: index, in: arguments)
@@ -223,6 +248,7 @@ enum CaptureAlanWindow {
 
             Options:
               --output <path>            Write PNG screenshot to this path.
+              --channel <stable|dev>     Match Alan or Alan Dev by bundle id. Default: stable
               --bundle-id <bundle_id>    Bundle identifier to match. Default: app.alanworks.macos
               --pid <pid>                Match a specific process ID instead of bundle id.
               --title-contains <text>    Match only windows whose title contains this text.

--- a/clients/apple/scripts/test-app-singleton-guard.sh
+++ b/clients/apple/scripts/test-app-singleton-guard.sh
@@ -10,6 +10,7 @@ TEST_BINARY="${BUILD_DIR}/app-singleton-guard-tests"
 mkdir -p "$MODULE_CACHE_DIR"
 
 CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/AlanAppSingletonGuard.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-app-singleton-guard.swift" \
     -o "$TEST_BINARY"

--- a/clients/apple/scripts/test-app-singleton-guard.swift
+++ b/clients/apple/scripts/test-app-singleton-guard.swift
@@ -89,10 +89,45 @@ private func testDroppedOwnerReleasesLock() throws {
     reacquired.release()
 }
 
+private func testStableAndDevLocksUseChannelSupportDirectories() throws {
+    let supportDirectory = try temporarySupportDirectory("channel-locks")
+
+    let stable = try acquiredGuard(
+        supportDirectory: supportDirectory,
+        bundleIdentifier: AlanInstallChannel.stable.bundleIdentifier
+    )
+    defer { stable.release() }
+
+    let dev = try acquiredGuard(
+        supportDirectory: supportDirectory,
+        bundleIdentifier: AlanInstallChannel.dev.bundleIdentifier
+    )
+    defer { dev.release() }
+
+    try require(stable.lockURL != dev.lockURL, "stable and dev singleton locks must differ")
+    try require(
+        stable.lockURL.path.contains("/alan-macos/SingletonLocks/"),
+        "stable singleton lock must stay under the stable support directory"
+    )
+    try require(
+        dev.lockURL.path.contains("/alan-macos-dev/SingletonLocks/"),
+        "dev singleton lock must use the dev support directory"
+    )
+    try require(
+        stable.lockURL.lastPathComponent == "app.alanworks.macos.lock",
+        "stable singleton lock must be keyed by stable bundle id"
+    )
+    try require(
+        dev.lockURL.lastPathComponent == "app.alanworks.macos.dev.lock",
+        "dev singleton lock must be keyed by dev bundle id"
+    )
+}
+
 @main
 private enum TestRunner {
     static func main() throws {
         try testRejectsSecondOwnerUntilRelease()
         try testDroppedOwnerReleasesLock()
+        try testStableAndDevLocksUseChannelSupportDirectories()
     }
 }

--- a/clients/apple/scripts/test-command-line-tool-installer.swift
+++ b/clients/apple/scripts/test-command-line-tool-installer.swift
@@ -244,6 +244,37 @@ private func testChannelResolvesFromBundleIdentifier() throws {
     )
 }
 
+private func testChannelDescriptorsExposeRuntimeIsolationIdentity() throws {
+    try require(
+        AlanInstallChannel.stable.bundleIdentifier == "app.alanworks.macos",
+        "stable bundle identifier must preserve public app identity"
+    )
+    try require(
+        AlanInstallChannel.dev.bundleIdentifier == "app.alanworks.macos.dev",
+        "dev bundle identifier must expose local dev app identity"
+    )
+    try require(
+        AlanInstallChannel.stable.applicationSupportDirectoryName == "alan-macos",
+        "stable support directory must remain compatible"
+    )
+    try require(
+        AlanInstallChannel.dev.applicationSupportDirectoryName == "alan-macos-dev",
+        "dev support directory must be channel-scoped"
+    )
+    try require(
+        AlanInstallChannel.stable.shellControlNamespace == "alan-shell-control",
+        "stable shell-control namespace must remain compatible"
+    )
+    try require(
+        AlanInstallChannel.dev.shellControlNamespace == "alan-dev-shell-control",
+        "dev shell-control namespace must be channel-scoped"
+    )
+    try require(
+        AlanInstallChannel.dev.logSubsystem == "app.alanworks.macos.dev",
+        "dev log subsystem must be channel-scoped"
+    )
+}
+
 @main
 private enum TestRunner {
     static func main() throws {
@@ -256,5 +287,6 @@ private enum TestRunner {
         try testRejectsAlanHomeBinTarget()
         try testRejectsDevAlanHomeBinTarget()
         try testChannelResolvesFromBundleIdentifier()
+        try testChannelDescriptorsExposeRuntimeIsolationIdentity()
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -114,6 +114,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesControlPlaneResponsesExposeContentContainers()
         verifiesContentContainerEventsCaptureLifecycleAndRejections()
         verifiesMixedContentPaneSlotMutationsStayContentAgnostic()
+        verifiesChannelScopedSupportStatePaths()
         verifiesShellStatePersistenceWritesContentStateShape()
         verifiesLegacyShellStateDecodeRemainsCompatibilityOnly()
         verifiesWorkspaceManifestStartupRestoresPinnedSnapshot()
@@ -4762,6 +4763,49 @@ private enum ShellRuntimeMetadataTests {
         expect(
             terminalHandle.teardownCount == 0,
             "closing settings tab must not finalize unrelated terminal runtime"
+        )
+    }
+
+    private static func verifiesChannelScopedSupportStatePaths() {
+        let fileManager = FileManager.default
+        let stableState = ShellStatePersistenceStore.defaultPersistenceURL(
+            windowID: "window_main",
+            fileManager: fileManager,
+            channel: .stable
+        )
+        let devState = ShellStatePersistenceStore.defaultPersistenceURL(
+            windowID: "window_main",
+            fileManager: fileManager,
+            channel: .dev
+        )
+        let stableManifest = ShellWorkspaceManifestStore.defaultManifestURL(
+            windowID: "window_main",
+            fileManager: fileManager,
+            channel: .stable
+        )
+        let devManifest = ShellWorkspaceManifestStore.defaultManifestURL(
+            windowID: "window_main",
+            fileManager: fileManager,
+            channel: .dev
+        )
+
+        expect(stableState != devState, "stable and dev shell state paths must differ")
+        expect(stableManifest != devManifest, "stable and dev shell manifest paths must differ")
+        expect(
+            stableState.path.contains("/alan-macos/"),
+            "stable shell state path must remain under alan-macos"
+        )
+        expect(
+            devState.path.contains("/alan-macos-dev/"),
+            "dev shell state path must be under alan-macos-dev"
+        )
+        expect(
+            stableManifest.path.contains("/alan-macos/"),
+            "stable shell manifest path must remain under alan-macos"
+        )
+        expect(
+            devManifest.path.contains("/alan-macos-dev/"),
+            "dev shell manifest path must be under alan-macos-dev"
         )
     }
 

--- a/clients/apple/scripts/test-shell-workspace-manifest.sh
+++ b/clients/apple/scripts/test-shell-workspace-manifest.sh
@@ -15,6 +15,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-workspace-manifest.swift" \
     -o "$TEST_BINARY"

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -19,6 +19,8 @@ private enum TerminalRuntimeServiceTests {
         verifiesInstallDiscoveryChangesDoNotRequireSurfaceRecreation()
         verifiesDevChannelUsesBundledDevBinary()
         verifiesDevChannelPropagatesInstallChannelEnvironment()
+        verifiesChannelScopedShellControlPaths()
+        verifiesDevBootProfileUsesDevShellControlNamespace()
         verifiesBootstrapReuseAndPaneHandleIdentity()
         verifiesPaneScopedHandleIsolation()
         verifiesContentScopedHandleSurvivesPaneRemount()
@@ -197,6 +199,71 @@ private enum TerminalRuntimeServiceTests {
         expect(
             profile.environment["ALAN_INSTALL_CHANNEL"] == "dev",
             "dev boot profile must propagate ALAN_INSTALL_CHANNEL to child processes"
+        )
+    }
+
+    private static func verifiesChannelScopedShellControlPaths() {
+        let stableRoot = alanShellControlPlaneRootURL(
+            windowID: "window_main",
+            channel: .stable
+        )
+        let devRoot = alanShellControlPlaneRootURL(
+            windowID: "window_main",
+            channel: .dev
+        )
+        let stableSocket = alanShellControlPlaneSocketURL(
+            windowID: "window_main",
+            channel: .stable
+        )
+        let devSocket = alanShellControlPlaneSocketURL(
+            windowID: "window_main",
+            channel: .dev
+        )
+        let stableBinding = alanShellBindingFileURL(
+            windowID: "window_main",
+            paneID: "pane_1",
+            channel: .stable
+        )
+        let devBinding = alanShellBindingFileURL(
+            windowID: "window_main",
+            paneID: "pane_1",
+            channel: .dev
+        )
+
+        expect(stableRoot != devRoot, "stable and dev shell-control roots must differ")
+        expect(stableSocket != devSocket, "stable and dev shell-control sockets must differ")
+        expect(stableBinding != devBinding, "stable and dev binding files must differ")
+        expect(
+            stableRoot.path.contains("/alan-shell-control/"),
+            "stable shell-control root must use the stable namespace"
+        )
+        expect(
+            devRoot.path.contains("/alan-dev-shell-control/"),
+            "dev shell-control root must use the dev namespace"
+        )
+    }
+
+    private static func verifiesDevBootProfileUsesDevShellControlNamespace() {
+        setenv("ALAN_INSTALL_CHANNEL", "dev", 1)
+        defer {
+            unsetenv("ALAN_INSTALL_CHANNEL")
+        }
+
+        let state = ShellStateSnapshot.bootstrapDefault()
+        let pane = state.panes[0]
+        let profile = AlanShellBootProfile.forPane(pane, shellState: state)
+
+        expect(
+            profile.environment["ALAN_SHELL_CONTROL_DIR"]?.contains("/alan-dev-shell-control/") == true,
+            "dev boot profile must expose the dev shell-control directory"
+        )
+        expect(
+            profile.environment["ALAN_SHELL_SOCKET"]?.contains("/alan-dev-shell-control/") == true,
+            "dev boot profile must expose the dev shell-control socket"
+        )
+        expect(
+            profile.environment["ALAN_SHELL_BINDING_FILE"]?.contains("/alan-dev-shell-control/") == true,
+            "dev boot profile must expose the dev binding file"
         )
     }
 

--- a/crates/alan/src/cli/shell.rs
+++ b/crates/alan/src/cli/shell.rs
@@ -1,3 +1,4 @@
+use alan_runtime::InstallChannel;
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -471,11 +472,21 @@ fn invoke(
 }
 
 fn resolve_target(options: &ShellTargetOptions) -> Result<ShellTarget> {
+    resolve_target_for_channel(options, InstallChannel::detect_current())
+}
+
+fn resolve_target_for_channel(
+    options: &ShellTargetOptions,
+    channel: InstallChannel,
+) -> Result<ShellTarget> {
     let explicit_socket = options.socket.clone();
     let explicit_control_dir = options.control_dir.clone();
     let env_socket = std::env::var_os("ALAN_SHELL_SOCKET").map(PathBuf::from);
     let env_control_dir = std::env::var_os("ALAN_SHELL_CONTROL_DIR").map(PathBuf::from);
-    let window_root = options.window.as_deref().map(control_dir_for_window);
+    let window_root = options
+        .window
+        .as_deref()
+        .map(|window| control_dir_for_window_for_channel(window, channel));
 
     let control_dir = explicit_control_dir
         .clone()
@@ -520,8 +531,10 @@ fn resolve_target(options: &ShellTargetOptions) -> Result<ShellTarget> {
     })
 }
 
-fn control_dir_for_window(window: &str) -> PathBuf {
-    std::env::temp_dir().join("alan-shell-control").join(window)
+fn control_dir_for_window_for_channel(window: &str, channel: InstallChannel) -> PathBuf {
+    std::env::temp_dir()
+        .join(channel.descriptor().shell_control_namespace)
+        .join(window)
 }
 
 fn invoke_via_socket(
@@ -772,6 +785,41 @@ mod tests {
         let target = resolve_target(&options).unwrap();
         assert!(target.socket_path.ends_with("window_test/shell.sock"));
         assert!(target.control_dir.ends_with("window_test"));
+    }
+
+    #[test]
+    fn resolve_target_derives_window_control_dir_from_channel_namespace() {
+        let options = ShellTargetOptions {
+            socket: None,
+            control_dir: None,
+            window: Some("window_test".to_string()),
+            timeout_ms: 500,
+        };
+
+        let stable = resolve_target_for_channel(&options, InstallChannel::Stable).unwrap();
+        let dev = resolve_target_for_channel(&options, InstallChannel::Dev).unwrap();
+
+        assert_ne!(stable.control_dir, dev.control_dir);
+        assert!(
+            stable
+                .control_dir
+                .components()
+                .any(|component| component.as_os_str().to_string_lossy() == "alan-shell-control")
+        );
+        assert!(
+            dev.control_dir.components().any(
+                |component| component.as_os_str().to_string_lossy() == "alan-dev-shell-control"
+            )
+        );
+        assert!(
+            stable
+                .socket_path
+                .ends_with("alan-shell-control/window_test/shell.sock")
+        );
+        assert!(
+            dev.socket_path
+                .ends_with("alan-dev-shell-control/window_test/shell.sock")
+        );
     }
 
     #[test]

--- a/openspec/changes/add-macos-dev-channel-install/tasks.md
+++ b/openspec/changes/add-macos-dev-channel-install/tasks.md
@@ -19,8 +19,8 @@
 
 - [x] 3.1 Add distinct dev daemon/client defaults so `alan-dev` and `alan-dev-tui` do not connect to the stable daemon implicitly.
 - [x] 3.2 Ensure missing dev connection/auth config produces onboarding or configuration-required state instead of falling back to stable credentials.
-- [ ] 3.3 Scope macOS singleton locks, support paths, log subsystems, capture-helper defaults, and diagnostics by channel.
-- [ ] 3.4 Scope shell-control socket and binding paths by channel so stable and dev commands cannot read each other's control files.
+- [x] 3.3 Scope macOS singleton locks, support paths, log subsystems, capture-helper defaults, and diagnostics by channel.
+- [x] 3.4 Scope shell-control socket and binding paths by channel so stable and dev commands cannot read each other's control files.
 - [ ] 3.5 Verify stable and dev apps can run side by side without activating, terminating, or hijacking each other's singleton state.
 
 ## 4. Workspace Generated State
@@ -34,7 +34,7 @@
 - [x] 5.1 Add focused tests for channel descriptor values and channel-aware path resolution.
 - [x] 5.2 Add packaging/install contract checks for `Alan Dev.app`, `alan-dev`, `alan-dev-tui`, and stable artifact preservation.
 - [x] 5.3 Add guardrails or allowlists for dev-channel brand strings without weakening stable brand validation.
-- [ ] 5.4 Add tests for channel-scoped connection stores, managed auth stores, global public skills, daemon defaults, and shell-control paths.
+- [x] 5.4 Add tests for channel-scoped connection stores, managed auth stores, global public skills, daemon defaults, and shell-control paths.
 - [ ] 5.5 Run a documented side-by-side smoke with stable Alan installed while Alan Dev launches and writes only dev-channel state.
 - [x] 5.6 Run `openspec validate add-macos-dev-channel-install --strict` and `openspec validate --all --strict`.
 


### PR DESCRIPTION
## Summary
- scope macOS singleton/support paths, shell-control temp namespaces, binding files, and Ghostty log subsystem by install channel
- add capture helper --channel stable|dev targeting while preserving stable default
- add focused Swift/Rust tests for dev shell-control paths and channel support identity, and mark OpenSpec 3.3/3.4/5.4 complete

## Validation
- cargo fmt --all
- cargo test -p alan --target-dir /private/tmp/alan-target shell::tests
- cargo check -p alan --target-dir /private/tmp/alan-target
- clients/apple/scripts/test-app-singleton-guard.sh
- clients/apple/scripts/test-command-line-tool-installer.sh
- clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-shell-workspace-manifest.sh
- clients/apple/scripts/test-shell-runtime-metadata.sh
- clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- clients/apple/scripts/check-brand-identity.sh
- env CLANG_MODULE_CACHE_PATH=/private/tmp/alan-capture-module-cache clients/apple/scripts/capture-alan-window.sh --help
- git diff --check
- openspec validate add-macos-dev-channel-install --strict
- openspec validate --all --strict

Note: I also tried an Xcode Debug build with /private/tmp DerivedData. It progressed into the target but the sandboxed environment failed in actool/CoreSimulator/AppIcon handling, so I did not count it as a passing validation.