### PR TITLE
Add macOS dev channel side-by-side smoke

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ guarantees today.
 - [Testing Strategy](./testing_strategy.md)
 - [Live Provider Harness](./live_provider_harness.md)
 - [Live Runtime Smoke](./live_runtime_smoke.md)
+- [macOS Dev Channel Side-by-Side Smoke](./macos_dev_channel_side_by_side_smoke.md)
 
 Important current-vs-target pairs:
 

--- a/docs/macos_dev_channel_side_by_side_smoke.md
+++ b/docs/macos_dev_channel_side_by_side_smoke.md
@@ -1,0 +1,85 @@
+# macOS Dev Channel Side-by-Side Smoke
+
+> Status: current validation guide for the local-only Alan Dev install channel.
+
+## Purpose
+
+This smoke verifies the local dev install channel after `Alan Dev.app` is
+installed on a machine that also has stable `Alan.app` installed.
+
+It covers the OpenSpec side-by-side boundary:
+
+1. stable and dev apps are identifiable by distinct bundle identifiers;
+2. launching Alan Dev does not terminate or replace the stable Alan process;
+3. repeated Alan Dev launches reuse the dev singleton instead of creating a
+   second dev process;
+4. dev shell-control state uses the `alan-dev-shell-control` namespace;
+5. `alan-dev init` writes workspace runtime state under `.alan/runtime/dev/`
+   and does not create legacy stable `.alan/sessions` or `.alan/memory` paths.
+
+## Prerequisites
+
+Install stable Alan through the normal stable path. Then install Alan Dev:
+
+```bash
+just install-dev
+```
+
+If local release signing configuration points at an unavailable Developer ID
+identity, use ad-hoc signing for the local-only dev channel:
+
+```bash
+ALAN_DEVELOPER_ID_APPLICATION= \
+ALAN_SIGNING_IDENTITY=- \
+just install-dev
+```
+
+If the default cargo target directory is not writable on a local machine, keep
+the build output under an ignored repo-local directory:
+
+```bash
+ALAN_DEVELOPER_ID_APPLICATION= \
+ALAN_SIGNING_IDENTITY=- \
+ALAN_CARGO_TARGET_DIR="$PWD/debug/dev-channel-smoke/cargo-target" \
+ALAN_XCODE_DERIVED_DATA="$PWD/debug/dev-channel-smoke/xcode-derived" \
+ALAN_RELEASE_ARTIFACT_DIR="$PWD/debug/dev-channel-smoke/release-artifacts" \
+ALAN_CLI_INSTALL_DIR="$HOME/.local/bin" \
+just install-dev
+```
+
+## Run
+
+```bash
+just dev-channel-smoke
+```
+
+The script uses LaunchServices and System Events, so run it in an interactive
+macOS user session. In sandboxed automation, allow the command to run outside
+the sandbox.
+
+## Latest Local Evidence
+
+Last run: 2026-05-23.
+
+Observed result:
+
+```text
+Dev channel side-by-side smoke passed.
+  stable pid(s): 60215
+  dev pid(s): 49390
+  frontmost before dev launch: com.apple.finder
+  frontmost after dev launch: app.alanworks.macos.dev
+  dev shell-control: .../T/alan-dev-shell-control
+  dev workspace state: .../alan-dev-channel-smoke-workspace.../.alan/runtime/dev
+```
+
+Additional install evidence from the same run:
+
+- stable remained installed as `$HOME/Applications/Alan.app`;
+- stable command links remained `/usr/local/bin/alan` and
+  `/usr/local/bin/alan-tui`;
+- dev installed as `$HOME/Applications/Alan Dev.app`;
+- dev command links were installed as `$HOME/.local/bin/alan-dev` and
+  `$HOME/.local/bin/alan-dev-tui`;
+- `Alan Dev.app` reported bundle id `app.alanworks.macos.dev` and display name
+  `Alan Dev`.

--- a/docs/macos_dev_channel_side_by_side_smoke.md
+++ b/docs/macos_dev_channel_side_by_side_smoke.md
@@ -11,11 +11,15 @@ It covers the OpenSpec side-by-side boundary:
 
 1. stable and dev apps are identifiable by distinct bundle identifiers;
 2. launching Alan Dev does not terminate or replace the stable Alan process;
-3. repeated Alan Dev launches reuse the dev singleton instead of creating a
-   second dev process;
-4. dev shell-control state uses the `alan-dev-shell-control` namespace;
-5. `alan-dev init` writes workspace runtime state under `.alan/runtime/dev/`
-   and does not create legacy stable `.alan/sessions` or `.alan/memory` paths.
+3. repeated Alan Dev launches activate and reuse the dev singleton instead of
+   creating a second dev process;
+4. repeated stable Alan launches activate and reuse the stable singleton while
+   Alan Dev is running;
+5. dev shell-control state is created for the current run in the
+   `alan-dev-shell-control` namespace;
+6. `alan-dev init` writes the current smoke workspace to the dev registry and
+   writes workspace runtime state under `.alan/runtime/dev/` without creating
+   legacy stable `.alan/sessions` or `.alan/memory` paths.
 
 ## Prerequisites
 
@@ -57,21 +61,33 @@ The script uses LaunchServices and System Events, so run it in an interactive
 macOS user session. In sandboxed automation, allow the command to run outside
 the sandbox.
 
+Quit any already-running `Alan Dev.app` before running the smoke. The script
+starts Alan Dev from a clean dev-app state so shell-control namespace checks
+prove the current launch created the dev namespace rather than reusing stale
+temporary files from an earlier run. Stable `Alan.app` may already be running;
+if not, the smoke starts it.
+
 ## Latest Local Evidence
 
-Last run: 2026-05-23.
+Last run: 2026-05-24.
 
 Observed result:
 
 ```text
 Dev channel side-by-side smoke passed.
   stable pid(s): 60215
-  dev pid(s): 57051
-  dev pid(s) after duplicate launch: 57051
+  dev pid(s): 10528
+  dev pid(s) after duplicate launch: 10528
+  stable pid(s) after duplicate launch: 60215
   frontmost before dev launch: com.apple.finder
   frontmost after dev launch: com.apple.finder
-  dev shell-control: .../T/alan-dev-shell-control
-  dev workspace state: .../alan-dev-channel-smoke-workspace.../.alan/runtime/dev
+  frontmost before duplicate dev launch: com.apple.finder
+  frontmost after duplicate dev launch: app.alanworks.macos.dev
+  frontmost before duplicate stable launch: com.apple.finder
+  frontmost after duplicate stable launch: app.alanworks.macos
+  dev shell-control: /var/folders/3v/mr9cv4y12l30h9y_mtc2txx80000gn/T/alan-dev-shell-control
+  dev registry: /Users/morris/.alan-dev/registry.json
+  dev workspace state: /var/folders/3v/mr9cv4y12l30h9y_mtc2txx80000gn/T/alan-dev-channel-smoke-workspace.V6XdvX/.alan/runtime/dev
 ```
 
 Additional install evidence from the same run:

--- a/docs/macos_dev_channel_side_by_side_smoke.md
+++ b/docs/macos_dev_channel_side_by_side_smoke.md
@@ -12,9 +12,9 @@ It covers the OpenSpec side-by-side boundary:
 1. stable and dev apps are identifiable by distinct bundle identifiers;
 2. launching Alan Dev does not terminate or replace the stable Alan process;
 3. repeated Alan Dev launches activate and reuse the dev singleton instead of
-   creating a second dev process;
+   creating or retaining a second dev process;
 4. repeated stable Alan launches activate and reuse the stable singleton while
-   Alan Dev is running;
+   Alan Dev is running without creating or retaining a second stable process;
 5. dev shell-control state is created for the current run in the
    `alan-dev-shell-control` namespace;
 6. `alan-dev init` writes the current smoke workspace to the dev registry and
@@ -76,8 +76,8 @@ Observed result:
 ```text
 Dev channel side-by-side smoke passed.
   stable pid(s): 60215
-  dev pid(s): 10528
-  dev pid(s) after duplicate launch: 10528
+  dev pid(s): 12095
+  dev pid(s) after duplicate launch: 12095
   stable pid(s) after duplicate launch: 60215
   frontmost before dev launch: com.apple.finder
   frontmost after dev launch: com.apple.finder
@@ -87,7 +87,7 @@ Dev channel side-by-side smoke passed.
   frontmost after duplicate stable launch: app.alanworks.macos
   dev shell-control: /var/folders/3v/mr9cv4y12l30h9y_mtc2txx80000gn/T/alan-dev-shell-control
   dev registry: /Users/morris/.alan-dev/registry.json
-  dev workspace state: /var/folders/3v/mr9cv4y12l30h9y_mtc2txx80000gn/T/alan-dev-channel-smoke-workspace.V6XdvX/.alan/runtime/dev
+  dev workspace state: /var/folders/3v/mr9cv4y12l30h9y_mtc2txx80000gn/T/alan-dev-channel-smoke-workspace.6zBX7X/.alan/runtime/dev
 ```
 
 Additional install evidence from the same run:

--- a/docs/macos_dev_channel_side_by_side_smoke.md
+++ b/docs/macos_dev_channel_side_by_side_smoke.md
@@ -66,9 +66,10 @@ Observed result:
 ```text
 Dev channel side-by-side smoke passed.
   stable pid(s): 60215
-  dev pid(s): 49390
+  dev pid(s): 57051
+  dev pid(s) after duplicate launch: 57051
   frontmost before dev launch: com.apple.finder
-  frontmost after dev launch: app.alanworks.macos.dev
+  frontmost after dev launch: com.apple.finder
   dev shell-control: .../T/alan-dev-shell-control
   dev workspace state: .../alan-dev-channel-smoke-workspace.../.alan/runtime/dev
 ```

--- a/justfile
+++ b/justfile
@@ -60,6 +60,10 @@ install:
 install-dev:
     ./scripts/install-dev.sh
 
+# Run local side-by-side smoke for stable Alan and Alan Dev
+dev-channel-smoke:
+    ./scripts/smoke-dev-channel-side-by-side.sh
+
 # Check release signing and notarization configuration without building
 release-check:
     ALAN_NOTARIZE=1 ./scripts/release-check.sh

--- a/openspec/changes/add-macos-dev-channel-install/tasks.md
+++ b/openspec/changes/add-macos-dev-channel-install/tasks.md
@@ -21,7 +21,7 @@
 - [x] 3.2 Ensure missing dev connection/auth config produces onboarding or configuration-required state instead of falling back to stable credentials.
 - [x] 3.3 Scope macOS singleton locks, support paths, log subsystems, capture-helper defaults, and diagnostics by channel.
 - [x] 3.4 Scope shell-control socket and binding paths by channel so stable and dev commands cannot read each other's control files.
-- [ ] 3.5 Verify stable and dev apps can run side by side without activating, terminating, or hijacking each other's singleton state.
+- [x] 3.5 Verify stable and dev apps can run side by side without activating, terminating, or hijacking each other's singleton state.
 
 ## 4. Workspace Generated State
 
@@ -35,7 +35,7 @@
 - [x] 5.2 Add packaging/install contract checks for `Alan Dev.app`, `alan-dev`, `alan-dev-tui`, and stable artifact preservation.
 - [x] 5.3 Add guardrails or allowlists for dev-channel brand strings without weakening stable brand validation.
 - [x] 5.4 Add tests for channel-scoped connection stores, managed auth stores, global public skills, daemon defaults, and shell-control paths.
-- [ ] 5.5 Run a documented side-by-side smoke with stable Alan installed while Alan Dev launches and writes only dev-channel state.
+- [x] 5.5 Run a documented side-by-side smoke with stable Alan installed while Alan Dev launches and writes only dev-channel state.
 - [x] 5.6 Run `openspec validate add-macos-dev-channel-install --strict` and `openspec validate --all --strict`.
 
 ## 6. Review And Archive Readiness

--- a/scripts/assemble-release-app.sh
+++ b/scripts/assemble-release-app.sh
@@ -12,6 +12,7 @@ source "$SCRIPT_DIR/install-channel.sh"
 alan_install_channel_load "${ALAN_INSTALL_CHANNEL:-stable}"
 
 DERIVED_DATA="${ALAN_XCODE_DERIVED_DATA:-$REPO_ROOT/target/xcode-derived}"
+CARGO_TARGET_DIR="${ALAN_CARGO_TARGET_DIR:-${CARGO_TARGET_DIR:-$REPO_ROOT/target}}"
 ARTIFACT_DIR="${ALAN_RELEASE_ARTIFACT_DIR:-$REPO_ROOT/target/release-artifacts}"
 STAGING_DIR="$ARTIFACT_DIR/staging"
 APP_BUNDLE="$DERIVED_DATA/Build/Products/Release/$ALAN_APP_BUNDLE_NAME"
@@ -118,7 +119,7 @@ require_signing_identity
 mkdir -p "$STAGING_DIR" "$ARTIFACT_DIR"
 
 printf 'Building release alan CLI for %s channel...\n' "$ALAN_CHANNEL_ID"
-cargo build --release -p alan
+cargo build --release -p alan --target-dir "$CARGO_TARGET_DIR"
 
 printf 'Building standalone %s...\n' "$ALAN_TUI_NAME"
 (
@@ -153,7 +154,7 @@ fi
 
 printf 'Embedding CLI and TUI into %s...\n' "$ALAN_APP_BUNDLE_NAME"
 mkdir -p "$EMBEDDED_BIN_DIR"
-cp "$REPO_ROOT/target/release/alan" "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME"
+cp "$CARGO_TARGET_DIR/release/alan" "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME"
 cp "$STAGING_DIR/$ALAN_TUI_NAME" "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME"
 chmod +x "$EMBEDDED_BIN_DIR/$ALAN_CLI_NAME" "$EMBEDDED_BIN_DIR/$ALAN_TUI_NAME"
 

--- a/scripts/check-dev-channel-install-contract.sh
+++ b/scripts/check-dev-channel-install-contract.sh
@@ -33,7 +33,9 @@ reject_pattern() {
 
 require_pattern "justfile" "^install-dev:" "justfile must expose install-dev"
 require_pattern "justfile" "^uninstall-dev:" "justfile must expose uninstall-dev"
+require_pattern "justfile" "^dev-channel-smoke:" "justfile must expose dev-channel-smoke"
 require_pattern "scripts/assemble-release-app.sh" "ALAN_APP_BUNDLE_NAME" "assembly must use channel app bundle name"
+require_pattern "scripts/assemble-release-app.sh" "ALAN_CARGO_TARGET_DIR" "assembly must allow repo-local cargo target override"
 require_pattern "scripts/assemble-release-app.sh" 'PRODUCT_BUNDLE_IDENTIFIER="\$ALAN_BUNDLE_ID"' "assembly must override channel bundle id"
 require_pattern "scripts/assemble-release-app.sh" 'INFOPLIST_KEY_CFBundleDisplayName="\$ALAN_DISPLAY_NAME"' "assembly must override channel display name"
 require_pattern "scripts/assemble-release-app.sh" 'ALAN_TUI_BINARY_OUTFILE="\$STAGING_DIR/\$ALAN_TUI_NAME"' "assembly must build channel-named TUI"
@@ -42,6 +44,8 @@ require_pattern "scripts/install.sh" "ALAN_CLI_NAME" "install script must link c
 require_pattern "scripts/install.sh" "ALAN_TUI_NAME" "install script must link channel TUI name"
 require_pattern "scripts/uninstall.sh" "ALAN_CLI_NAME" "uninstall script must remove channel CLI name"
 require_pattern "scripts/uninstall.sh" "ALAN_TUI_NAME" "uninstall script must remove channel TUI name"
+require_pattern "scripts/smoke-dev-channel-side-by-side.sh" "app.alanworks.macos.dev" "side-by-side smoke must identify dev bundle id"
+require_pattern "scripts/smoke-dev-channel-side-by-side.sh" ".alan/runtime/dev" "side-by-side smoke must verify dev workspace runtime state"
 require_pattern "packaging/homebrew/Casks/alan.rb.template" "app \"Alan\\.app\"" "Homebrew cask must remain stable-only"
 require_pattern "packaging/homebrew/Casks/alan.rb.template" "target: \"alan\"" "Homebrew cask must keep stable CLI target"
 reject_pattern "packaging/homebrew/Casks/alan.rb.template" "Alan Dev|alan-dev" "Homebrew cask must not publish dev artifacts"

--- a/scripts/release-env.sh
+++ b/scripts/release-env.sh
@@ -15,6 +15,7 @@ alan_release_env_allowed_key() {
         ALAN_NOTARIZE | \
         ALAN_CREATE_RELEASE_ARCHIVE | \
         ALAN_INSTALL_CHANNEL | \
+        ALAN_CARGO_TARGET_DIR | \
         ALAN_XCODE_DERIVED_DATA | \
         ALAN_RELEASE_ARTIFACT_DIR | \
         ALAN_APP_INSTALL_DIR | \

--- a/scripts/smoke-dev-channel-side-by-side.sh
+++ b/scripts/smoke-dev-channel-side-by-side.sh
@@ -152,6 +152,13 @@ fi
 [[ "$frontmost_after" != "$STABLE_BUNDLE_ID" ]] ||
     fail "launching Alan Dev activated stable Alan"
 
+info "Launching Alan Dev again to verify dev singleton reuse..."
+/usr/bin/open -g "$DEV_APP"
+sleep 2
+dev_pids_second="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+[[ "$dev_pids_second" == "$dev_pids_after" ]] ||
+    fail "second Alan Dev launch changed dev PID set: before '$dev_pids_after', after '$dev_pids_second'"
+
 tmp_root="${TMPDIR:-/tmp}"
 tmp_root="${tmp_root%/}"
 stable_shell_dir="$tmp_root/alan-shell-control"
@@ -169,6 +176,7 @@ assert_no_stable_workspace_runtime_state "$workspace"
 info "Dev channel side-by-side smoke passed."
 info "  stable pid(s): $stable_pids_after"
 info "  dev pid(s): $dev_pids_after"
+info "  dev pid(s) after duplicate launch: $dev_pids_second"
 info "  frontmost before dev launch: $frontmost_before"
 info "  frontmost after dev launch: $frontmost_after"
 info "  dev shell-control: $dev_shell_dir"

--- a/scripts/smoke-dev-channel-side-by-side.sh
+++ b/scripts/smoke-dev-channel-side-by-side.sh
@@ -98,6 +98,26 @@ wait_for_path() {
     fail "$label was not created: $path"
 }
 
+pid_count() {
+    local pids="$1"
+
+    if [[ -z "$pids" ]]; then
+        printf '0'
+        return 0
+    fi
+
+    printf '%s\n' "$pids" | wc -w | tr -d ' '
+}
+
+assert_single_pid_set() {
+    local pids="$1"
+    local label="$2"
+    local count
+
+    count="$(pid_count "$pids")"
+    [[ "$count" == "1" ]] || fail "$label expected exactly one process, got $count: '$pids'"
+}
+
 activate_finder() {
     /usr/bin/osascript -e 'tell application "Finder" to activate' >/dev/null
 }
@@ -200,6 +220,7 @@ if [[ -z "$stable_pids_before" ]]; then
     /usr/bin/open -g "$STABLE_APP"
     stable_pids_before="$(wait_for_bundle "$STABLE_BUNDLE_ID" "stable Alan")"
 fi
+assert_single_pid_set "$stable_pids_before" "stable Alan before dev launch"
 
 dev_pids_before="$(bundle_process_ids "$DEV_BUNDLE_ID")"
 if [[ -n "$dev_pids_before" ]]; then
@@ -220,6 +241,8 @@ info "Launching Alan Dev while stable Alan is running..."
 /usr/bin/open -g "$DEV_APP"
 dev_pids_after="$(wait_for_bundle "$DEV_BUNDLE_ID" "Alan Dev")"
 stable_pids_after="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
+assert_single_pid_set "$dev_pids_after" "Alan Dev after first launch"
+assert_single_pid_set "$stable_pids_after" "stable Alan after dev launch"
 wait_for_path "$dev_shell_window_dir" "dev shell-control window namespace"
 wait_for_path "$dev_shell_socket" "dev shell-control socket"
 frontmost_after="$(frontmost_bundle_id)"
@@ -236,6 +259,7 @@ frontmost_before_duplicate_dev="$(frontmost_bundle_id)"
 wait_for_frontmost_bundle "$DEV_BUNDLE_ID" "duplicate Alan Dev launch"
 frontmost_after_duplicate_dev="$(frontmost_bundle_id)"
 dev_pids_second="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+assert_single_pid_set "$dev_pids_second" "Alan Dev after duplicate launch"
 [[ "$dev_pids_second" == "$dev_pids_after" ]] ||
     fail "second Alan Dev launch changed dev PID set: before '$dev_pids_after', after '$dev_pids_second'"
 
@@ -247,6 +271,8 @@ wait_for_frontmost_bundle "$STABLE_BUNDLE_ID" "duplicate stable Alan launch"
 frontmost_after_duplicate_stable="$(frontmost_bundle_id)"
 stable_pids_second="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
 dev_pids_after_stable_relaunch="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+assert_single_pid_set "$stable_pids_second" "stable Alan after duplicate launch"
+assert_single_pid_set "$dev_pids_after_stable_relaunch" "Alan Dev after stable duplicate launch"
 [[ "$stable_pids_second" == "$stable_pids_after" ]] ||
     fail "second stable Alan launch changed stable PID set: before '$stable_pids_after', after '$stable_pids_second'"
 [[ "$dev_pids_after_stable_relaunch" == "$dev_pids_second" ]] ||

--- a/scripts/smoke-dev-channel-side-by-side.sh
+++ b/scripts/smoke-dev-channel-side-by-side.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STABLE_BUNDLE_ID="app.alanworks.macos"
+DEV_BUNDLE_ID="app.alanworks.macos.dev"
+STABLE_APP="${ALAN_STABLE_APP:-$HOME/Applications/Alan.app}"
+DEV_APP="${ALAN_DEV_APP:-$HOME/Applications/Alan Dev.app}"
+DEV_CLI="${ALAN_DEV_CLI:-}"
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '%s\n' "$*"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command '$1' was not found"
+}
+
+plist_value() {
+    local app="$1"
+    local key="$2"
+    /usr/bin/plutil -extract "$key" raw "$app/Contents/Info.plist"
+}
+
+bundle_process_ids() {
+    local bundle_id="$1"
+    /usr/bin/osascript - "$bundle_id" <<'APPLESCRIPT'
+on run argv
+    set targetBundleID to item 1 of argv
+    tell application "System Events"
+        set matches to unix id of every process whose bundle identifier is targetBundleID
+    end tell
+    set AppleScript's text item delimiters to " "
+    return matches as text
+end run
+APPLESCRIPT
+}
+
+frontmost_bundle_id() {
+    /usr/bin/osascript <<'APPLESCRIPT'
+tell application "System Events"
+    return bundle identifier of first process whose frontmost is true
+end tell
+APPLESCRIPT
+}
+
+wait_for_bundle() {
+    local bundle_id="$1"
+    local label="$2"
+    local attempt
+    local pids
+
+    for attempt in $(seq 1 20); do
+        pids="$(bundle_process_ids "$bundle_id")"
+        if [[ -n "$pids" ]]; then
+            printf '%s' "$pids"
+            return 0
+        fi
+        sleep 1
+    done
+
+    fail "$label did not appear as running bundle id $bundle_id"
+}
+
+resolve_dev_cli() {
+    if [[ -n "$DEV_CLI" ]]; then
+        [[ -x "$DEV_CLI" ]] || fail "ALAN_DEV_CLI is not executable: $DEV_CLI"
+        printf '%s' "$DEV_CLI"
+        return 0
+    fi
+
+    if [[ -x "$HOME/.local/bin/alan-dev" ]]; then
+        printf '%s' "$HOME/.local/bin/alan-dev"
+        return 0
+    fi
+
+    if command -v alan-dev >/dev/null 2>&1; then
+        command -v alan-dev
+        return 0
+    fi
+
+    fail "alan-dev was not found; run just install-dev or set ALAN_DEV_CLI"
+}
+
+assert_bundle_metadata() {
+    local app="$1"
+    local expected_bundle_id="$2"
+    local expected_display_name="$3"
+    local actual_bundle_id
+    local actual_display_name
+
+    [[ -d "$app" ]] || fail "app bundle does not exist: $app"
+    actual_bundle_id="$(plist_value "$app" CFBundleIdentifier)"
+    actual_display_name="$(plist_value "$app" CFBundleDisplayName)"
+    [[ "$actual_bundle_id" == "$expected_bundle_id" ]] ||
+        fail "$app bundle id: expected $expected_bundle_id, got $actual_bundle_id"
+    [[ "$actual_display_name" == "$expected_display_name" ]] ||
+        fail "$app display name: expected $expected_display_name, got $actual_display_name"
+}
+
+assert_no_stable_workspace_runtime_state() {
+    local workspace="$1"
+
+    [[ -d "$workspace/.alan/runtime/dev/sessions" ]] ||
+        fail "dev sessions directory was not created"
+    [[ -d "$workspace/.alan/runtime/dev/memory" ]] ||
+        fail "dev memory directory was not created"
+    [[ ! -e "$workspace/.alan/sessions" ]] ||
+        fail "legacy stable sessions path was created by dev smoke"
+    [[ ! -e "$workspace/.alan/memory" ]] ||
+        fail "legacy stable memory path was created by dev smoke"
+    [[ ! -e "$workspace/.alan/runtime/stable" ]] ||
+        fail "stable runtime namespace was created by dev smoke"
+}
+
+require_command osascript
+require_command open
+require_command plutil
+require_command mktemp
+
+DEV_CLI="$(resolve_dev_cli)"
+assert_bundle_metadata "$STABLE_APP" "$STABLE_BUNDLE_ID" "Alan"
+assert_bundle_metadata "$DEV_APP" "$DEV_BUNDLE_ID" "Alan Dev"
+
+stable_pids_before="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
+if [[ -z "$stable_pids_before" ]]; then
+    info "Launching stable Alan..."
+    /usr/bin/open -g "$STABLE_APP"
+    stable_pids_before="$(wait_for_bundle "$STABLE_BUNDLE_ID" "stable Alan")"
+fi
+
+dev_pids_before="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+
+/usr/bin/osascript -e 'tell application "Finder" to activate' >/dev/null
+frontmost_before="$(frontmost_bundle_id)"
+
+info "Launching Alan Dev while stable Alan is running..."
+/usr/bin/open -g "$DEV_APP"
+dev_pids_after="$(wait_for_bundle "$DEV_BUNDLE_ID" "Alan Dev")"
+stable_pids_after="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
+frontmost_after="$(frontmost_bundle_id)"
+
+[[ "$stable_pids_after" == "$stable_pids_before" ]] ||
+    fail "stable Alan PID changed: before '$stable_pids_before', after '$stable_pids_after'"
+if [[ -n "$dev_pids_before" && "$dev_pids_after" != "$dev_pids_before" ]]; then
+    fail "duplicate Alan Dev launch changed dev PID set: before '$dev_pids_before', after '$dev_pids_after'"
+fi
+[[ "$frontmost_after" != "$STABLE_BUNDLE_ID" ]] ||
+    fail "launching Alan Dev activated stable Alan"
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_root="${tmp_root%/}"
+stable_shell_dir="$tmp_root/alan-shell-control"
+dev_shell_dir="$tmp_root/alan-dev-shell-control"
+[[ "$stable_shell_dir" != "$dev_shell_dir" ]] || fail "stable and dev shell namespaces match"
+[[ -d "$dev_shell_dir" ]] || fail "dev shell-control namespace was not created: $dev_shell_dir"
+
+workspace="$(mktemp -d "$tmp_root/alan-dev-channel-smoke-workspace.XXXXXX")"
+workspace_alias="alan-dev-channel-smoke-$(basename "$workspace")"
+"$DEV_CLI" init --path "$workspace" --name "$workspace_alias" --silent
+assert_no_stable_workspace_runtime_state "$workspace"
+[[ -f "$HOME/.alan-dev/registry.json" ]] ||
+    fail "dev registry was not written under ~/.alan-dev"
+
+info "Dev channel side-by-side smoke passed."
+info "  stable pid(s): $stable_pids_after"
+info "  dev pid(s): $dev_pids_after"
+info "  frontmost before dev launch: $frontmost_before"
+info "  frontmost after dev launch: $frontmost_after"
+info "  dev shell-control: $dev_shell_dir"
+info "  dev workspace state: $workspace/.alan/runtime/dev"

--- a/scripts/smoke-dev-channel-side-by-side.sh
+++ b/scripts/smoke-dev-channel-side-by-side.sh
@@ -66,6 +66,42 @@ wait_for_bundle() {
     fail "$label did not appear as running bundle id $bundle_id"
 }
 
+wait_for_frontmost_bundle() {
+    local bundle_id="$1"
+    local label="$2"
+    local attempt
+    local frontmost
+
+    for attempt in $(seq 1 20); do
+        frontmost="$(frontmost_bundle_id)"
+        if [[ "$frontmost" == "$bundle_id" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    fail "$label did not become frontmost; last frontmost bundle id was '$frontmost'"
+}
+
+wait_for_path() {
+    local path="$1"
+    local label="$2"
+    local attempt
+
+    for attempt in $(seq 1 20); do
+        if [[ -e "$path" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    fail "$label was not created: $path"
+}
+
+activate_finder() {
+    /usr/bin/osascript -e 'tell application "Finder" to activate' >/dev/null
+}
+
 resolve_dev_cli() {
     if [[ -n "$DEV_CLI" ]]; then
         [[ -x "$DEV_CLI" ]] || fail "ALAN_DEV_CLI is not executable: $DEV_CLI"
@@ -117,6 +153,29 @@ assert_no_stable_workspace_runtime_state() {
         fail "stable runtime namespace was created by dev smoke"
 }
 
+assert_registry_contains_alias() {
+    local registry_path="$1"
+    local alias="$2"
+    local label="$3"
+
+    [[ -f "$registry_path" ]] || fail "$label registry was not written: $registry_path"
+    grep -Fq "\"alias\":\"$alias\"" "$registry_path" ||
+        grep -Fq "\"alias\": \"$alias\"" "$registry_path" ||
+        fail "$label registry does not contain current workspace alias '$alias'"
+}
+
+assert_registry_does_not_contain_alias() {
+    local registry_path="$1"
+    local alias="$2"
+    local label="$3"
+
+    if [[ -f "$registry_path" ]] &&
+        (grep -Fq "\"alias\":\"$alias\"" "$registry_path" ||
+            grep -Fq "\"alias\": \"$alias\"" "$registry_path"); then
+        fail "$label registry unexpectedly contains current workspace alias '$alias'"
+    fi
+}
+
 require_command osascript
 require_command open
 require_command plutil
@@ -126,6 +185,15 @@ DEV_CLI="$(resolve_dev_cli)"
 assert_bundle_metadata "$STABLE_APP" "$STABLE_BUNDLE_ID" "Alan"
 assert_bundle_metadata "$DEV_APP" "$DEV_BUNDLE_ID" "Alan Dev"
 
+tmp_root="${TMPDIR:-/tmp}"
+tmp_root="${tmp_root%/}"
+stable_shell_dir="$tmp_root/alan-shell-control"
+dev_shell_dir="$tmp_root/alan-dev-shell-control"
+dev_shell_window_dir="$dev_shell_dir/window_main"
+dev_shell_socket="$dev_shell_window_dir/shell.sock"
+stable_registry="$HOME/.alan/registry.json"
+dev_registry="$HOME/.alan-dev/registry.json"
+
 stable_pids_before="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
 if [[ -z "$stable_pids_before" ]]; then
     info "Launching stable Alan..."
@@ -134,50 +202,74 @@ if [[ -z "$stable_pids_before" ]]; then
 fi
 
 dev_pids_before="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+if [[ -n "$dev_pids_before" ]]; then
+    fail "Alan Dev is already running with PID(s) $dev_pids_before; quit it before running this smoke so current-launch namespace checks are meaningful"
+fi
 
-/usr/bin/osascript -e 'tell application "Finder" to activate' >/dev/null
+[[ "$stable_shell_dir" != "$dev_shell_dir" ]] || fail "stable and dev shell namespaces match"
+case "$dev_shell_dir" in
+    "$tmp_root"/alan-dev-shell-control) ;;
+    *) fail "refusing to clean unexpected dev shell-control path: $dev_shell_dir" ;;
+esac
+rm -rf "$dev_shell_dir"
+
+activate_finder
 frontmost_before="$(frontmost_bundle_id)"
 
 info "Launching Alan Dev while stable Alan is running..."
 /usr/bin/open -g "$DEV_APP"
 dev_pids_after="$(wait_for_bundle "$DEV_BUNDLE_ID" "Alan Dev")"
 stable_pids_after="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
+wait_for_path "$dev_shell_window_dir" "dev shell-control window namespace"
+wait_for_path "$dev_shell_socket" "dev shell-control socket"
 frontmost_after="$(frontmost_bundle_id)"
 
 [[ "$stable_pids_after" == "$stable_pids_before" ]] ||
     fail "stable Alan PID changed: before '$stable_pids_before', after '$stable_pids_after'"
-if [[ -n "$dev_pids_before" && "$dev_pids_after" != "$dev_pids_before" ]]; then
-    fail "duplicate Alan Dev launch changed dev PID set: before '$dev_pids_before', after '$dev_pids_after'"
-fi
 [[ "$frontmost_after" != "$STABLE_BUNDLE_ID" ]] ||
     fail "launching Alan Dev activated stable Alan"
 
-info "Launching Alan Dev again to verify dev singleton reuse..."
-/usr/bin/open -g "$DEV_APP"
-sleep 2
+info "Launching Alan Dev again to verify dev singleton reuse and activation..."
+activate_finder
+frontmost_before_duplicate_dev="$(frontmost_bundle_id)"
+/usr/bin/open "$DEV_APP"
+wait_for_frontmost_bundle "$DEV_BUNDLE_ID" "duplicate Alan Dev launch"
+frontmost_after_duplicate_dev="$(frontmost_bundle_id)"
 dev_pids_second="$(bundle_process_ids "$DEV_BUNDLE_ID")"
 [[ "$dev_pids_second" == "$dev_pids_after" ]] ||
     fail "second Alan Dev launch changed dev PID set: before '$dev_pids_after', after '$dev_pids_second'"
 
-tmp_root="${TMPDIR:-/tmp}"
-tmp_root="${tmp_root%/}"
-stable_shell_dir="$tmp_root/alan-shell-control"
-dev_shell_dir="$tmp_root/alan-dev-shell-control"
-[[ "$stable_shell_dir" != "$dev_shell_dir" ]] || fail "stable and dev shell namespaces match"
-[[ -d "$dev_shell_dir" ]] || fail "dev shell-control namespace was not created: $dev_shell_dir"
+info "Launching stable Alan again to verify stable singleton reuse while dev is running..."
+activate_finder
+frontmost_before_duplicate_stable="$(frontmost_bundle_id)"
+/usr/bin/open "$STABLE_APP"
+wait_for_frontmost_bundle "$STABLE_BUNDLE_ID" "duplicate stable Alan launch"
+frontmost_after_duplicate_stable="$(frontmost_bundle_id)"
+stable_pids_second="$(bundle_process_ids "$STABLE_BUNDLE_ID")"
+dev_pids_after_stable_relaunch="$(bundle_process_ids "$DEV_BUNDLE_ID")"
+[[ "$stable_pids_second" == "$stable_pids_after" ]] ||
+    fail "second stable Alan launch changed stable PID set: before '$stable_pids_after', after '$stable_pids_second'"
+[[ "$dev_pids_after_stable_relaunch" == "$dev_pids_second" ]] ||
+    fail "second stable Alan launch changed dev PID set: before '$dev_pids_second', after '$dev_pids_after_stable_relaunch'"
 
 workspace="$(mktemp -d "$tmp_root/alan-dev-channel-smoke-workspace.XXXXXX")"
 workspace_alias="alan-dev-channel-smoke-$(basename "$workspace")"
 "$DEV_CLI" init --path "$workspace" --name "$workspace_alias" --silent
 assert_no_stable_workspace_runtime_state "$workspace"
-[[ -f "$HOME/.alan-dev/registry.json" ]] ||
-    fail "dev registry was not written under ~/.alan-dev"
+assert_registry_contains_alias "$dev_registry" "$workspace_alias" "dev"
+assert_registry_does_not_contain_alias "$stable_registry" "$workspace_alias" "stable"
 
 info "Dev channel side-by-side smoke passed."
-info "  stable pid(s): $stable_pids_after"
+info "  stable pid(s): $stable_pids_second"
 info "  dev pid(s): $dev_pids_after"
 info "  dev pid(s) after duplicate launch: $dev_pids_second"
+info "  stable pid(s) after duplicate launch: $stable_pids_second"
 info "  frontmost before dev launch: $frontmost_before"
 info "  frontmost after dev launch: $frontmost_after"
+info "  frontmost before duplicate dev launch: $frontmost_before_duplicate_dev"
+info "  frontmost after duplicate dev launch: $frontmost_after_duplicate_dev"
+info "  frontmost before duplicate stable launch: $frontmost_before_duplicate_stable"
+info "  frontmost after duplicate stable launch: $frontmost_after_duplicate_stable"
 info "  dev shell-control: $dev_shell_dir"
+info "  dev registry: $dev_registry"
 info "  dev workspace state: $workspace/.alan/runtime/dev"

--- a/scripts/test-install-channel-descriptor.sh
+++ b/scripts/test-install-channel-descriptor.sh
@@ -54,5 +54,8 @@ fi
 if ! alan_release_env_allowed_key ALAN_INSTALL_CHANNEL; then
     fail "release env allowlist must include ALAN_INSTALL_CHANNEL"
 fi
+if ! alan_release_env_allowed_key ALAN_CARGO_TARGET_DIR; then
+    fail "release env allowlist must include ALAN_CARGO_TARGET_DIR"
+fi
 
 printf 'Install channel descriptor checks passed.\n'


### PR DESCRIPTION
## Summary
- add a local side-by-side smoke script and just recipe for stable Alan + Alan Dev
- document the dev-channel smoke workflow and latest local evidence
- allow release assembly to use ALAN_CARGO_TARGET_DIR so local smoke can avoid stale/root-owned target output without changing stable defaults
- mark OpenSpec side-by-side smoke tasks complete

Stacked on #485.

## Verification
- just dev-channel-smoke
- ./scripts/test-install-channel-descriptor.sh
- ./scripts/check-dev-channel-install-contract.sh
- bash -n scripts/smoke-dev-channel-side-by-side.sh scripts/assemble-release-app.sh scripts/release-env.sh scripts/check-dev-channel-install-contract.sh scripts/test-install-channel-descriptor.sh
- openspec validate add-macos-dev-channel-install --strict
- openspec validate --all --strict
- git diff --cached --check