### PR TITLE
Adjust macOS app icon scale

### DIFF
--- a/clients/apple/alan-macos/AppIcon.icon/icon.json
+++ b/clients/apple/alan-macos/AppIcon.icon/icon.json
@@ -34,7 +34,7 @@
           "image-name" : "logo.svg",
           "name" : "logo",
           "position" : {
-            "scale" : 1,
+            "scale" : 1.2,
             "translation-in-points" : [
               -16,
               0


### PR DESCRIPTION
## Summary
- increase the macOS app icon logo layer scale from 1.0 to 1.2

## Verification
- node --input-type=module -e JSON.parse(...)
- git diff --check