### PR TITLE
Fix macOS sidebar window drag interference

### DIFF
--- a/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
+++ b/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
@@ -853,7 +853,7 @@ enum AlanShellWindowPlacement {
         window.titlebarAppearsTransparent = true
         window.titlebarSeparatorStyle = .none
         window.styleMask.insert(.fullSizeContentView)
-        window.isMovableByWindowBackground = true
+        window.isMovableByWindowBackground = false
         window.minSize = ShellWindowSizing.minimumSize
         window.tabbingMode = .disallowed
 

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -23,11 +23,14 @@ private enum ShellWindowPlacementTests {
         try verifiesPendingFloatingSidebarRevealHidesTrafficLightsButReservesLayout()
         try verifiesFloatingSidebarRevealAfterPendingHiddenStateUsesSurfaceOrigin()
         try verifiesCollapsedSidebarRetentionIncludesLeftResizeFrame()
+        try verifiesPrimaryShellWindowDisablesGlobalBackgroundDragging()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
         try verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom()
         try verifiesTrafficLightControlsDoNotTriggerDoubleClickZoom()
         try verifiesTrafficLightGapsCanTriggerDoubleClickZoom()
         try verifiesSidebarChromeBlankAreaCanTriggerDoubleClickZoom()
+        try verifiesSidebarTabListDoesNotTriggerWindowDrag()
+        try verifiesSidebarSpaceDockDoesNotTriggerWindowDrag()
         try verifiesSidebarToolbarButtonsDoNotTriggerDoubleClickZoom()
         try verifiesTitlebarOverlayAcceptsTopBlankHit()
         try verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit()
@@ -342,6 +345,18 @@ private enum ShellWindowPlacementTests {
         )
     }
 
+    private static func verifiesPrimaryShellWindowDisablesGlobalBackgroundDragging() throws {
+        let window = makeTestWindow()
+        window.isMovableByWindowBackground = true
+
+        AlanShellWindowPlacement.configure(window, appearanceMode: .system)
+
+        expect(
+            !window.isMovableByWindowBackground,
+            "primary shell window must not use global background dragging"
+        )
+    }
+
     private static func verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
@@ -426,6 +441,48 @@ private enum ShellWindowPlacementTests {
                 chromeSurface: chromeSurface
             ),
             "blank sidebar chrome beside the traffic lights and toolbar controls must trigger double-click visible-frame zoom"
+        )
+    }
+
+    private static func verifiesSidebarTabListDoesNotTriggerWindowDrag() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(x: 128, y: window.frame.height - 128)
+
+        expect(
+            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "sidebar tab-list rows must not be treated as window drag or zoom candidates"
+        )
+    }
+
+    private static func verifiesSidebarSpaceDockDoesNotTriggerWindowDrag() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+        let location = CGPoint(x: 128, y: 56)
+
+        expect(
+            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                locationInWindow: location,
+                in: window,
+                chromeSurface: chromeSurface
+            ),
+            "sidebar space switcher rows must not be treated as window drag or zoom candidates"
         )
     }
 

--- a/docs/superpowers/plans/2026-05-24-macos-sidebar-window-drag-interference.md
+++ b/docs/superpowers/plans/2026-05-24-macos-sidebar-window-drag-interference.md
@@ -1,0 +1,178 @@
+# macOS Sidebar Window Drag Interference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent sidebar tab and space interactions from moving the Alan macOS shell window while preserving blank chrome drag and double-click zoom.
+
+**Architecture:** The main shell window should not use global background dragging. Window movement remains owned by the existing explicit top-chrome AppKit overlay, whose hit test already excludes sidebar controls, traffic lights, and terminal pane chrome.
+
+**Tech Stack:** Swift, SwiftUI/AppKit interop, OpenSpec, shell script Swift smoke tests.
+
+---
+
+## File Structure
+
+- Modify `clients/apple/alan-macos/Support/ShellWindowPlacement.swift`: disable global background dragging for the primary shell window configuration.
+- Modify `clients/apple/scripts/test-shell-window-placement.swift`: add regression coverage for sidebar tab-list and space-dock regions below the explicit draggable chrome band.
+- Modify `openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md`: mark completed implementation and verification tasks.
+
+### Task 1: Add Failing Placement Tests
+
+**Files:**
+- Modify: `clients/apple/scripts/test-shell-window-placement.swift`
+
+- [ ] **Step 1: Add the failing tests to the test runner**
+
+Add these calls near the other `ShellWindowDoubleClickZoomHitTesting` tests:
+
+```swift
+try verifiesSidebarTabListDoesNotTriggerWindowDrag()
+try verifiesSidebarSpaceDockDoesNotTriggerWindowDrag()
+```
+
+- [ ] **Step 2: Add concrete hit-testing scenarios**
+
+Add these methods near the existing sidebar chrome hit tests:
+
+```swift
+private static func verifiesSidebarTabListDoesNotTriggerWindowDrag() throws {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+        styleMask: [.titled, .closable, .miniaturizable, .resizable],
+        backing: .buffered,
+        defer: false
+    )
+    let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+    let location = CGPoint(x: 128, y: window.frame.height - 128)
+
+    expect(
+        !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+            locationInWindow: location,
+            in: window,
+            chromeSurface: chromeSurface
+        ),
+        "sidebar tab-list rows must not be treated as window drag or zoom candidates"
+    )
+}
+
+private static func verifiesSidebarSpaceDockDoesNotTriggerWindowDrag() throws {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
+        styleMask: [.titled, .closable, .miniaturizable, .resizable],
+        backing: .buffered,
+        defer: false
+    )
+    let chromeSurface = ShellWindowChromeSurface(width: 264)
+
+    let location = CGPoint(x: 128, y: 56)
+
+    expect(
+        !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+            locationInWindow: location,
+            in: window,
+            chromeSurface: chromeSurface
+        ),
+        "sidebar space switcher rows must not be treated as window drag or zoom candidates"
+    )
+}
+```
+
+- [ ] **Step 3: Run focused test and confirm the existing hit-testing tests pass**
+
+Run: `clients/apple/scripts/test-shell-window-placement.sh`
+
+Expected: the added hit-testing scenarios pass because the explicit overlay already rejects these points. The product bug still exists until global window background dragging is disabled.
+
+### Task 2: Disable Global Primary-Shell Background Dragging
+
+**Files:**
+- Modify: `clients/apple/alan-macos/Support/ShellWindowPlacement.swift`
+
+- [ ] **Step 1: Change the window configuration**
+
+Replace:
+
+```swift
+window.isMovableByWindowBackground = true
+```
+
+with:
+
+```swift
+window.isMovableByWindowBackground = false
+```
+
+in `AlanShellWindowPlacement.configure(_:, appearanceMode:)`.
+
+- [ ] **Step 2: Run focused placement tests**
+
+Run: `clients/apple/scripts/test-shell-window-placement.sh`
+
+Expected: PASS. Existing overlay tests still prove blank chrome hits are accepted, while sidebar interaction regions are rejected.
+
+### Task 3: Mark OpenSpec Tasks Complete
+
+**Files:**
+- Modify: `openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md`
+
+- [ ] **Step 1: Mark implementation tasks complete**
+
+Change completed task checkboxes for:
+
+```markdown
+- [x] 1.1 Disable global primary-shell background dragging for the main shell window.
+- [x] 1.2 Preserve blank top chrome drag-to-move through the existing explicit chrome overlay.
+- [x] 1.3 Verify traffic lights, sidebar titlebar controls, terminal pane titlebar controls, tab rows, and space controls are not treated as window-drag surfaces.
+- [x] 2.1 Add focused `test-shell-window-placement.swift` coverage for sidebar content points outside the draggable top chrome.
+- [x] 2.2 Run `clients/apple/scripts/test-shell-window-placement.sh`.
+- [x] 2.3 Run `openspec validate fix-macos-sidebar-window-drag-interference --strict`.
+```
+
+Leave visual acceptance incomplete until Alan Dev is installed and the user confirms the interaction:
+
+```markdown
+- [ ] 2.4 Capture or request running-app visual acceptance confirming tab reorder no longer moves the Alan Dev window.
+```
+
+- [ ] **Step 2: Validate the OpenSpec change**
+
+Run: `openspec validate fix-macos-sidebar-window-drag-interference --strict`
+
+Expected: `Change 'fix-macos-sidebar-window-drag-interference' is valid`
+
+### Task 4: Full Verification And Commit
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Run whitespace and OpenSpec validation**
+
+Run:
+
+```bash
+git diff --check
+openspec validate --all --strict
+```
+
+Expected: no whitespace errors and all OpenSpec items pass.
+
+- [ ] **Step 2: Review diff**
+
+Run: `git diff --stat && git diff`
+
+Expected: diff contains only the plan, focused Swift placement test updates, the `isMovableByWindowBackground` change, and OpenSpec task status updates.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add clients/apple/alan-macos/Support/ShellWindowPlacement.swift \
+  clients/apple/scripts/test-shell-window-placement.swift \
+  docs/superpowers/plans/2026-05-24-macos-sidebar-window-drag-interference.md \
+  openspec/changes/fix-macos-sidebar-window-drag-interference
+git commit -m "Fix sidebar window drag interference"
+```
+
+Expected: one implementation commit on `fix/macos-sidebar-window-drag-interference`.

--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/design.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The primary macOS shell currently configures its window as movable by background.
+That is convenient for a hidden-titlebar shell, but it makes AppKit treat more of
+the SwiftUI content background as a window-drag surface. Sidebar tab rows also
+own their own drag/drop gesture for reordering, which creates a conflict: a tab
+drag can be interpreted partly as a window move.
+
+Alan already has an explicit AppKit overlay for top blank chrome behavior:
+`ShellWindowDoubleClickZoomOverlayView` accepts hits only in the intended
+titlebar/chrome band and calls `performDrag(with:)` for non-double-click drags.
+That overlay is a better owner for window dragging than global background
+dragging because it can express the intended hit boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make tab reorder and sidebar space interactions never move the shell window.
+- Preserve blank titlebar/chrome drag-to-move behavior.
+- Preserve blank titlebar double-click visible-frame zoom behavior.
+- Keep the fix narrowly scoped to shell chrome hit testing.
+- Add focused regression coverage for the interaction boundary.
+
+**Non-Goals:**
+
+- Do not redesign tab reorder, drop targets, or space swipe behavior.
+- Do not change terminal surface input ownership.
+- Do not add a new visible drag handle.
+- Do not change quick terminal panel behavior unless the same bug is observed
+  there separately.
+
+## Decision
+
+Use the existing explicit chrome overlay as the only primary-shell window-drag
+owner. The primary shell window should not use full `isMovableByWindowBackground`
+behavior because that makes ordinary sidebar surfaces compete with window
+movement. Blank top chrome remains draggable because the overlay already calls
+`performDrag(with:)` for accepted non-double-click mouse-down events.
+
+This keeps window movement tied to visible chrome intent:
+
+- Blank top titlebar/chrome: can drag window and can double-click zoom.
+- Sidebar tab rows: own tab select/reorder/drop interactions.
+- Sidebar space controls and command launcher: own their own click/drag
+  interactions.
+- Traffic-light controls and lightweight sidebar titlebar buttons: remain
+  standard controls and are not consumed by the overlay.
+- Terminal surface and pane titlebar controls: keep existing terminal/pane
+  ownership and do not move the window.
+
+## Alternatives Considered
+
+1. **Disable full background dragging and rely on explicit chrome overlay.**
+   This is the selected approach. It is narrow, testable, and matches the
+   existing overlay architecture.
+
+2. **Keep full background dragging and add non-moving host views around sidebar
+   controls.** This is more local in appearance but easy to miss in SwiftUI
+   subtrees. Future sidebar controls could regress unless each one gets the same
+   AppKit protection.
+
+3. **Temporarily disable window background dragging only during tab drag.** This
+   handles reorder but not other sidebar drags, and it introduces state recovery
+   risk if drag cancellation or app deactivation interrupts the gesture.
+
+## Verification
+
+- Add shell window placement tests proving accepted blank top chrome still hits
+  the overlay.
+- Add tests proving sidebar content points below the blank chrome band are not
+  window drag or zoom candidates.
+- Keep existing tests proving traffic-light controls, sidebar titlebar controls,
+  and terminal pane titlebar controls are not consumed by the overlay.
+- Run focused macOS shell placement tests and strict OpenSpec validation.

--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/proposal.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Alan Dev visual acceptance found that dragging a sidebar tab to reorder it can
+also move the macOS window. The sidebar tab list and space controls are active
+workspace interaction surfaces, so window background dragging must not compete
+with tab reorder, space switching, or sidebar controls.
+
+The issue is separate from the content-container model work. It belongs in a
+small macOS chrome bug fix because the likely cause is the window-level
+background dragging contract, not tab ordering state.
+
+## What Changes
+
+- Limit primary shell window dragging to explicit blank titlebar/chrome areas.
+- Treat sidebar tab rows, space controls, command launcher, and sidebar titlebar
+  controls as interaction surfaces that do not move the window when dragged.
+- Preserve existing blank-titlebar drag and double-click visible-frame zoom
+  behavior.
+- Add focused placement tests for the drag-hit boundary so future sidebar
+  controls do not reintroduce window-drag interference.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: adds a contract that sidebar workspace
+  controls own their drag interactions and are excluded from window dragging.
+
+## Impact
+
+- Affected Swift code: `ShellWindowPlacement.swift` and, only if needed for
+  precise hit boundaries, sidebar AppKit/SwiftUI host wrappers.
+- Affected tests: `clients/apple/scripts/test-shell-window-placement.swift`.
+- User-visible effect: dragging tabs or space controls in the sidebar should no
+  longer move the Alan Dev window, while dragging blank top chrome still moves
+  the window.

--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Sidebar interactions do not drag the window
+The macOS shell SHALL limit primary-window drag movement to explicit blank
+titlebar/chrome areas. Sidebar workspace controls SHALL own their own
+interactions and MUST NOT move the window when the user drags them.
+
+#### Scenario: Tab row drag reorders without moving window
+- **WHEN** the user drags a tab row in the sidebar tab list
+- **THEN** alan treats the gesture as a tab selection, reorder, or drop-target
+  interaction according to the tab-list contract
+- **AND** the primary shell window does not move as part of that drag
+
+#### Scenario: Space controls are interaction surfaces
+- **WHEN** the user drags or clicks within the sidebar space switcher, command
+  launcher, or sidebar titlebar controls
+- **THEN** alan routes the event to the relevant sidebar control
+- **AND** the primary shell window does not move because of window-background
+  dragging
+
+#### Scenario: Blank chrome still moves the window
+- **WHEN** the user drags an empty, non-control area of the top titlebar/chrome
+  region
+- **THEN** alan moves the primary shell window using the native macOS window
+  drag behavior
+- **AND** double-clicking the same empty chrome region continues to toggle the
+  visible-frame zoom behavior

--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
@@ -1,0 +1,12 @@
+## 1. Window Drag Boundary
+
+- [ ] 1.1 Disable global primary-shell background dragging for the main shell window.
+- [ ] 1.2 Preserve blank top chrome drag-to-move through the existing explicit chrome overlay.
+- [ ] 1.3 Verify traffic lights, sidebar titlebar controls, terminal pane titlebar controls, tab rows, and space controls are not treated as window-drag surfaces.
+
+## 2. Verification
+
+- [ ] 2.1 Add focused `test-shell-window-placement.swift` coverage for sidebar content points outside the draggable top chrome.
+- [ ] 2.2 Run `clients/apple/scripts/test-shell-window-placement.sh`.
+- [ ] 2.3 Run `openspec validate fix-macos-sidebar-window-drag-interference --strict`.
+- [ ] 2.4 Capture or request running-app visual acceptance confirming tab reorder no longer moves the Alan Dev window.

--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Window Drag Boundary
 
-- [ ] 1.1 Disable global primary-shell background dragging for the main shell window.
-- [ ] 1.2 Preserve blank top chrome drag-to-move through the existing explicit chrome overlay.
-- [ ] 1.3 Verify traffic lights, sidebar titlebar controls, terminal pane titlebar controls, tab rows, and space controls are not treated as window-drag surfaces.
+- [x] 1.1 Disable global primary-shell background dragging for the main shell window.
+- [x] 1.2 Preserve blank top chrome drag-to-move through the existing explicit chrome overlay.
+- [x] 1.3 Verify traffic lights, sidebar titlebar controls, terminal pane titlebar controls, tab rows, and space controls are not treated as window-drag surfaces.
 
 ## 2. Verification
 
-- [ ] 2.1 Add focused `test-shell-window-placement.swift` coverage for sidebar content points outside the draggable top chrome.
-- [ ] 2.2 Run `clients/apple/scripts/test-shell-window-placement.sh`.
-- [ ] 2.3 Run `openspec validate fix-macos-sidebar-window-drag-interference --strict`.
+- [x] 2.1 Add focused `test-shell-window-placement.swift` coverage for sidebar content points outside the draggable top chrome.
+- [x] 2.2 Run `clients/apple/scripts/test-shell-window-placement.sh`.
+- [x] 2.3 Run `openspec validate fix-macos-sidebar-window-drag-interference --strict`.
 - [ ] 2.4 Capture or request running-app visual acceptance confirming tab reorder no longer moves the Alan Dev window.


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for the sidebar/window drag boundary.
- Disable global primary-shell background dragging so sidebar tab and space interactions own their drags.
- Add focused shell window placement tests for global background dragging and sidebar content hit boundaries.

## Test Plan
- clients/apple/scripts/test-shell-window-placement.sh
- openspec validate fix-macos-sidebar-window-drag-interference --strict
- openspec validate --all --strict
- git diff --check

## Visual Acceptance
- Alan Dev running-app validation is still needed for OpenSpec task 2.4.