### PR TITLE
Record macOS visual acceptance

### DIFF
--- a/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
+++ b/openspec/changes/fix-macos-sidebar-window-drag-interference/tasks.md
@@ -9,4 +9,6 @@
 - [x] 2.1 Add focused `test-shell-window-placement.swift` coverage for sidebar content points outside the draggable top chrome.
 - [x] 2.2 Run `clients/apple/scripts/test-shell-window-placement.sh`.
 - [x] 2.3 Run `openspec validate fix-macos-sidebar-window-drag-interference --strict`.
-- [ ] 2.4 Capture or request running-app visual acceptance confirming tab reorder no longer moves the Alan Dev window.
+- [x] 2.4 Capture or request running-app visual acceptance confirming tab reorder no longer moves the Alan Dev window.
+
+Visual acceptance: user confirmed on 2026-05-24 that Alan Dev tab dragging no longer moves the window.

--- a/openspec/changes/generalize-macos-shell-content-containers/tasks.md
+++ b/openspec/changes/generalize-macos-shell-content-containers/tasks.md
@@ -39,7 +39,9 @@
 - [x] 5.2 Update sidebar tab rows, toolbar titles, pane title bars, and command input labels to use user-facing content titles and type hints.
 - [x] 5.3 Keep terminal-only status, search, and input affordances visible only on terminal content panes.
 - [x] 5.4 Make settings content a singleton tab target in v1 so repeated Open Settings focuses the existing ContentInstance.
-- [ ] 5.5 Capture running-app visual evidence for light-mode mixed content tabs and split panes.
+- [x] 5.5 Capture running-app visual evidence for light-mode mixed content tabs and split panes.
+
+Visual acceptance: user confirmed on 2026-05-24 that light-mode mixed content tabs and split panes look correct in Alan Dev.
 
 ## 6. Verification And Archive Readiness
 


### PR DESCRIPTION
## Summary
- Mark sidebar window-drag visual acceptance complete based on Alan Dev validation.
- Mark mixed content light-mode visual acceptance complete based on Alan Dev validation.
- Leave content-container archive sync as the remaining follow-up task.

## Test Plan
- openspec validate fix-macos-sidebar-window-drag-interference --strict
- openspec validate generalize-macos-shell-content-containers --strict
- openspec validate --all --strict
- git diff --check