### PR TITLE
Add macOS shell automation command seams

### DIFF
--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -195,6 +195,9 @@ xcodebuild \
 # Shell control-plane contract smoke
 bash clients/apple/scripts/check-shell-contracts.sh
 
+# Shell automation command seam tests
+just apple-shell-automation-seams
+
 # Apple source architecture maintainability report
 bash clients/apple/scripts/check-architecture-maintainability.sh
 

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		000000000000000000000040 /* Services/Terminal/TerminalContentProjectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */; };
 		000000000000000000000041 /* Services/Terminal/TerminalContentLifecycleAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */; };
 		000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */; };
+		000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -131,6 +132,7 @@
 		000000000000000000000140 /* Services/Terminal/TerminalContentProjectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentProjectionAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000141 /* Services/Terminal/TerminalContentLifecycleAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Terminal/TerminalContentLifecycleAdapter.swift; sourceTree = "<group>"; };
 		000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellContentRenderingRegistry.swift; sourceTree = "<group>"; };
+		000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationCommand.swift; sourceTree = "<group>"; };
 		000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 				000000000000000000000123 /* Models/Shell/ShellTreeMutations.swift */,
 				000000000000000000000124 /* Models/Shell/ShellStateMutations.swift */,
 				00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */,
+				000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */,
 			);
 			name = Models/Shell;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 				000000000000000000000023 /* Models/Shell/ShellTreeMutations.swift in Sources */,
 				000000000000000000000024 /* Models/Shell/ShellStateMutations.swift in Sources */,
 				00000000000000000000003E /* Models/Shell/ShellActionRegistry.swift in Sources */,
+				000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */,
 				000000000000000000000025 /* Services/Shell/ShellPaneProjectionService.swift in Sources */,
 				000000000000000000000026 /* Services/Shell/ShellStatePersistenceStore.swift in Sources */,
 				000000000000000000000027 /* Services/Terminal/TerminalHostRuntimeReporter.swift in Sources */,

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -76,7 +76,7 @@ struct ShellAutomationCommandResult: Equatable {
     }
 
     var applied: Bool {
-        code == .accepted || code == .queued
+        code == .accepted
     }
 }
 
@@ -130,12 +130,12 @@ extension ShellStateSnapshot {
         return ShellAutomationPaneSummary(
             windowID: windowID,
             spaceID: pane.spaceID,
-            spaceTitle: safeDisplayTitle(space.title, fallback: "Space"),
+            spaceTitle: firstNonEmptyDisplayTitle([space.title], fallback: "Space"),
             tabID: pane.tabID,
-            tabTitle: safeDisplayTitle(tab.title, fallback: "Tab"),
+            tabTitle: firstNonEmptyDisplayTitle([tab.title], fallback: "Tab"),
             paneID: pane.paneID,
-            paneTitle: safeDisplayTitle(
-                pane.viewport?.title ?? pane.context?.displayName ?? pane.process?.program,
+            paneTitle: firstNonEmptyDisplayTitle(
+                [pane.viewport?.title, pane.context?.displayName, pane.process?.program],
                 fallback: "Pane"
             ),
             workingDirectory: pane.cwd,
@@ -145,10 +145,16 @@ extension ShellStateSnapshot {
         )
     }
 
-    private func safeDisplayTitle(_ value: String?, fallback: String) -> String {
-        guard let value else { return fallback }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? fallback : trimmed
+    private func firstNonEmptyDisplayTitle(_ candidates: [String?], fallback: String) -> String {
+        for candidate in candidates {
+            guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty
+            else {
+                continue
+            }
+            return trimmed
+        }
+        return fallback
     }
 }
 #endif

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+#if os(macOS)
+enum ShellAutomationCommand: Equatable {
+    case createTab(ShellAutomationCreateTabRequest)
+    case splitPane(ShellAutomationPaneSplitRequest)
+    case focusPane(paneID: String)
+    case closePane(paneID: String)
+    case closeTab(tabID: String)
+    case sendText(ShellAutomationSendTextRequest)
+    case readPaneSummary(paneID: String)
+    case activateAttentionItem(paneID: String)
+}
+
+struct ShellAutomationCreateTabRequest: Equatable {
+    let launchTarget: ShellLaunchTarget
+    let spaceID: String?
+    let title: String?
+    let workingDirectory: String?
+}
+
+struct ShellAutomationPaneSplitRequest: Equatable {
+    let paneID: String
+    let placement: ShellPaneSplitDirection
+}
+
+struct ShellAutomationSendTextRequest: Equatable {
+    let paneID: String
+    let text: String
+}
+
+enum ShellAutomationCommandResultCode: String, Codable, Equatable {
+    case accepted
+    case queued
+    case rejected
+    case missingTarget = "missing_target"
+    case invalidRequest = "invalid_request"
+    case unsupportedContent = "unsupported_content"
+    case runtimeUnavailable = "runtime_unavailable"
+    case timeout
+    case lastPane = "last_pane"
+    case lastTab = "last_tab"
+}
+
+struct ShellAutomationCommandResult: Equatable {
+    let code: ShellAutomationCommandResultCode
+    let summary: ShellAutomationPaneSummary?
+    let spaceID: String?
+    let tabID: String?
+    let paneID: String?
+    let acceptedBytes: Int?
+    let deliveryCode: String?
+    let errorCode: String?
+    let errorMessage: String?
+
+    init(
+        code: ShellAutomationCommandResultCode,
+        summary: ShellAutomationPaneSummary?,
+        spaceID: String? = nil,
+        tabID: String? = nil,
+        paneID: String? = nil,
+        acceptedBytes: Int? = nil,
+        deliveryCode: String? = nil,
+        errorCode: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.code = code
+        self.summary = summary
+        self.spaceID = spaceID
+        self.tabID = tabID
+        self.paneID = paneID
+        self.acceptedBytes = acceptedBytes
+        self.deliveryCode = deliveryCode
+        self.errorCode = errorCode
+        self.errorMessage = errorMessage
+    }
+
+    var applied: Bool {
+        code == .accepted || code == .queued
+    }
+}
+
+struct ShellAutomationPaneSummary: Equatable {
+    let windowID: String
+    let spaceID: String
+    let spaceTitle: String
+    let tabID: String
+    let tabTitle: String
+    let paneID: String
+    let paneTitle: String
+    let workingDirectory: String?
+    let processProgram: String?
+    let processState: String?
+    let attention: ShellAttentionState
+
+    var displayText: String {
+        [
+            paneTitle,
+            spaceTitle,
+            tabTitle,
+            workingDirectory,
+            processProgram,
+            processState,
+            attention.rawValue,
+        ]
+        .compactMap { value in
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed?.isEmpty == false ? trimmed : nil
+        }
+        .joined(separator: " - ")
+    }
+}
+
+@MainActor
+protocol ShellAutomationCommandHandling: AnyObject {
+    func performShellAutomationCommand(
+        _ command: ShellAutomationCommand
+    ) -> ShellAutomationCommandResult
+}
+
+extension ShellStateSnapshot {
+    func automationPaneSummary(paneID: String) -> ShellAutomationPaneSummary? {
+        guard let pane = pane(paneID: paneID),
+              let tab = tab(tabID: pane.tabID),
+              let space = space(spaceID: pane.spaceID)
+        else {
+            return nil
+        }
+
+        return ShellAutomationPaneSummary(
+            windowID: windowID,
+            spaceID: pane.spaceID,
+            spaceTitle: safeDisplayTitle(space.title, fallback: "Space"),
+            tabID: pane.tabID,
+            tabTitle: safeDisplayTitle(tab.title, fallback: "Tab"),
+            paneID: pane.paneID,
+            paneTitle: safeDisplayTitle(
+                pane.viewport?.title ?? pane.context?.displayName ?? pane.process?.program,
+                fallback: "Pane"
+            ),
+            workingDirectory: pane.cwd,
+            processProgram: pane.process?.program,
+            processState: pane.context?.processState,
+            attention: pane.attention
+        )
+    }
+
+    private func safeDisplayTitle(_ value: String?, fallback: String) -> String {
+        guard let value else { return fallback }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+}
+#endif

--- a/clients/apple/scripts/shell-automation-test-fixtures.swift
+++ b/clients/apple/scripts/shell-automation-test-fixtures.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+#if os(macOS)
+@MainActor
+final class FakeShellAutomationCommandHandler: ShellAutomationCommandHandling {
+    private(set) var recordedCommands: [ShellAutomationCommand] = []
+    var response: (ShellAutomationCommand) -> ShellAutomationCommandResult
+
+    init(
+        response: @escaping (ShellAutomationCommand) -> ShellAutomationCommandResult = { _ in
+            ShellAutomationCommandResult(code: .accepted, summary: nil)
+        }
+    ) {
+        self.response = response
+    }
+
+    func performShellAutomationCommand(
+        _ command: ShellAutomationCommand
+    ) -> ShellAutomationCommandResult {
+        recordedCommands.append(command)
+        return response(command)
+    }
+}
+
+final class FakeShellAutomationTextRuntime {
+    private(set) var deliveredText: [ShellAutomationSendTextRequest] = []
+    var result: ShellAutomationCommandResult
+
+    init(
+        result: ShellAutomationCommandResult = ShellAutomationCommandResult(
+            code: .accepted,
+            summary: nil
+        )
+    ) {
+        self.result = result
+    }
+
+    func sendText(_ request: ShellAutomationSendTextRequest) -> ShellAutomationCommandResult {
+        deliveredText.append(request)
+        return result
+    }
+}
+#endif

--- a/clients/apple/scripts/test-shell-automation-command-seams.sh
+++ b/clients/apple/scripts/test-shell-automation-command-seams.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-automation-command-seams-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-automation-command-seams-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift" \
+    "$REPO_ROOT/clients/apple/scripts/shell-automation-test-fixtures.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-automation-command-seams.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-automation-command-seams.swift
+++ b/clients/apple/scripts/test-shell-automation-command-seams.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+#if os(macOS)
+@main
+struct ShellAutomationCommandSeamsTestRunner {
+    static func main() async {
+        await MainActor.run {
+            ShellAutomationCommandSeamsTests.run()
+        }
+    }
+}
+
+@MainActor
+private enum ShellAutomationCommandSeamsTests {
+    static func run() {
+        verifiesCommandSurfaceCoversCoreAutomationActions()
+        verifiesFakeHandlerRecordsCommandsAndReturnsConfiguredResults()
+        verifiesFakeRuntimeRecordsTextDelivery()
+        verifiesPaneSummaryUsesSafeMetadata()
+        verifiesMissingPaneSummaryReturnsNil()
+        print("Shell automation command seam tests passed.")
+    }
+
+    private static func verifiesCommandSurfaceCoversCoreAutomationActions() {
+        let commands: [ShellAutomationCommand] = [
+            .createTab(
+                ShellAutomationCreateTabRequest(
+                    launchTarget: .shell,
+                    spaceID: "space_main",
+                    title: "Shell",
+                    workingDirectory: "/Users/morris"
+                )
+            ),
+            .createTab(
+                ShellAutomationCreateTabRequest(
+                    launchTarget: .alan,
+                    spaceID: "space_main",
+                    title: "alan",
+                    workingDirectory: "/Users/morris/Developer/alan"
+                )
+            ),
+            .splitPane(ShellAutomationPaneSplitRequest(paneID: "pane_1", placement: .right)),
+            .focusPane(paneID: "pane_1"),
+            .closePane(paneID: "pane_1"),
+            .closeTab(tabID: "tab_main"),
+            .sendText(ShellAutomationSendTextRequest(paneID: "pane_1", text: "printf test\\n")),
+            .readPaneSummary(paneID: "pane_1"),
+            .activateAttentionItem(paneID: "pane_1"),
+        ]
+
+        expect(commands.count == 9, "automation command surface must cover core shell actions")
+        expect(commands.contains(.focusPane(paneID: "pane_1")), "focus command must be equatable")
+        expect(
+            commands.contains(.activateAttentionItem(paneID: "pane_1")),
+            "attention activation must have an explicit command"
+        )
+    }
+
+    private static func verifiesFakeHandlerRecordsCommandsAndReturnsConfiguredResults() {
+        let expectedSummary = ShellAutomationPaneSummary(
+            windowID: "window_main",
+            spaceID: "space_main",
+            spaceTitle: "Terminal",
+            tabID: "tab_main",
+            tabTitle: "Shell",
+            paneID: "pane_1",
+            paneTitle: "Shell",
+            workingDirectory: "/Users/morris",
+            processProgram: "zsh",
+            processState: "running",
+            attention: .active
+        )
+        let handler = FakeShellAutomationCommandHandler { command in
+            guard command == .readPaneSummary(paneID: "pane_1") else {
+                return ShellAutomationCommandResult(
+                    code: .missingTarget,
+                    summary: nil,
+                    errorCode: "unexpected_command",
+                    errorMessage: "Unexpected command"
+                )
+            }
+            return ShellAutomationCommandResult(code: .accepted, summary: expectedSummary)
+        }
+
+        let result = handler.performShellAutomationCommand(.readPaneSummary(paneID: "pane_1"))
+
+        expect(
+            handler.recordedCommands == [.readPaneSummary(paneID: "pane_1")],
+            "fake must record commands"
+        )
+        expect(result.code == .accepted, "fake must return configured result")
+        expect(result.summary == expectedSummary, "fake must return configured summary")
+    }
+
+    private static func verifiesFakeRuntimeRecordsTextDelivery() {
+        let request = ShellAutomationSendTextRequest(paneID: "pane_1", text: "pwd\n")
+        let runtime = FakeShellAutomationTextRuntime(
+            result: ShellAutomationCommandResult(
+                code: .queued,
+                summary: nil,
+                paneID: "pane_1",
+                acceptedBytes: 4,
+                deliveryCode: "queued"
+            )
+        )
+
+        let result = runtime.sendText(request)
+
+        expect(runtime.deliveredText == [request], "fake runtime must record text deliveries")
+        expect(result.code == .queued, "fake runtime must preserve queued delivery status")
+        expect(result.acceptedBytes == 4, "fake runtime must preserve accepted byte count")
+    }
+
+    private static func verifiesPaneSummaryUsesSafeMetadata() {
+        let secretExcerpt = "SECRET_TOKEN=abc123"
+        let state = stateWithVisibleExcerpt(secretExcerpt)
+
+        guard let summary = state.automationPaneSummary(paneID: "pane_1") else {
+            fail("expected pane summary")
+        }
+
+        expect(summary.windowID == "window_main", "summary must retain window context")
+        expect(summary.spaceTitle == "Terminal", "summary must include user-facing space title")
+        expect(summary.tabTitle == "Shell", "summary must include user-facing tab title")
+        expect(summary.paneTitle == "Project shell", "summary must include user-facing pane title")
+        expect(summary.workingDirectory == "/Users/morris/Developer/alan", "summary must include cwd")
+        expect(summary.processProgram == "zsh", "summary must include process program")
+        expect(summary.attention == .awaitingUser, "summary must include attention state")
+        expect(
+            !summary.displayText.contains(secretExcerpt),
+            "summary display text must not expose terminal visible excerpts"
+        )
+        expect(
+            !summary.displayText.contains("pane_1"),
+            "summary display text must not expose raw pane IDs"
+        )
+    }
+
+    private static func verifiesMissingPaneSummaryReturnsNil() {
+        let state = ShellStateSnapshot.bootstrapDefault()
+        expect(
+            state.automationPaneSummary(paneID: "missing") == nil,
+            "missing pane summary must be nil"
+        )
+    }
+
+    private static func stateWithVisibleExcerpt(_ visibleExcerpt: String) -> ShellStateSnapshot {
+        let base = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/Users/morris/Developer/alan")
+        let updatedPanes = base.panes.map { pane in
+            ShellPane(
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                spaceID: pane.spaceID,
+                launchTarget: pane.launchTarget,
+                cwd: pane.cwd,
+                process: ShellProcessBinding(program: "zsh", argvPreview: ["zsh", "-l"]),
+                attention: .awaitingUser,
+                context: ShellContextSnapshot(
+                    workingDirectoryName: "alan",
+                    repositoryRoot: "/Users/morris/Developer/alan",
+                    gitBranch: "main",
+                    controlPath: "/tmp/alan-shell-control/window_main/panes/pane_1",
+                    alanBindingFile: nil,
+                    launchStrategy: "login_shell",
+                    shellIntegrationSource: "alan",
+                    processState: "running",
+                    lastMetadataAt: nil,
+                    lastCommandExitCode: nil
+                ),
+                viewport: ShellViewportSnapshot(
+                    title: "Project shell",
+                    summary: "ready",
+                    visibleExcerpt: visibleExcerpt,
+                    lastActivityAt: nil
+                ),
+                alanBinding: nil
+            )
+        }
+
+        return ShellStateSnapshot(
+            contractVersion: base.contractVersion,
+            windowID: base.windowID,
+            focusedSpaceID: base.focusedSpaceID,
+            focusedTabID: base.focusedTabID,
+            focusedPaneID: base.focusedPaneID,
+            spaces: base.spaces,
+            panes: updatedPanes,
+            paneSlots: base.paneSlots,
+            contents: base.contents,
+            quickTerminal: base.quickTerminal
+        )
+    }
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else { fail(message) }
+}
+
+private func fail(_ message: String) -> Never {
+    fputs("Test failed: \(message)\n", stderr)
+    exit(1)
+}
+#endif

--- a/clients/apple/scripts/test-shell-automation-command-seams.swift
+++ b/clients/apple/scripts/test-shell-automation-command-seams.swift
@@ -15,8 +15,10 @@ private enum ShellAutomationCommandSeamsTests {
     static func run() {
         verifiesCommandSurfaceCoversCoreAutomationActions()
         verifiesFakeHandlerRecordsCommandsAndReturnsConfiguredResults()
+        verifiesQueuedDeliveryDoesNotCountAsApplied()
         verifiesFakeRuntimeRecordsTextDelivery()
         verifiesPaneSummaryUsesSafeMetadata()
+        verifiesPaneSummaryFallsBackPastBlankTitles()
         verifiesMissingPaneSummaryReturnsNil()
         print("Shell automation command seam tests passed.")
     }
@@ -92,6 +94,21 @@ private enum ShellAutomationCommandSeamsTests {
         expect(result.summary == expectedSummary, "fake must return configured summary")
     }
 
+    private static func verifiesQueuedDeliveryDoesNotCountAsApplied() {
+        expect(
+            ShellAutomationCommandResult(code: .accepted, summary: nil).applied,
+            "accepted delivery must count as applied"
+        )
+        expect(
+            !ShellAutomationCommandResult(code: .queued, summary: nil).applied,
+            "queued delivery must not count as applied before runtime acceptance"
+        )
+        expect(
+            !ShellAutomationCommandResult(code: .rejected, summary: nil).applied,
+            "rejected delivery must not count as applied"
+        )
+    }
+
     private static func verifiesFakeRuntimeRecordsTextDelivery() {
         let request = ShellAutomationSendTextRequest(paneID: "pane_1", text: "pwd\n")
         let runtime = FakeShellAutomationTextRuntime(
@@ -108,6 +125,7 @@ private enum ShellAutomationCommandSeamsTests {
 
         expect(runtime.deliveredText == [request], "fake runtime must record text deliveries")
         expect(result.code == .queued, "fake runtime must preserve queued delivery status")
+        expect(!result.applied, "queued delivery must not count as applied")
         expect(result.acceptedBytes == 4, "fake runtime must preserve accepted byte count")
     }
 
@@ -136,6 +154,40 @@ private enum ShellAutomationCommandSeamsTests {
         )
     }
 
+    private static func verifiesPaneSummaryFallsBackPastBlankTitles() {
+        let displayState = stateWithPaneMetadata(
+            viewportTitle: "   ",
+            displayName: "Workspace shell",
+            processProgram: "zsh",
+            visibleExcerpt: "SECRET_TOKEN=abc123"
+        )
+
+        guard let displaySummary = displayState.automationPaneSummary(paneID: "pane_1") else {
+            fail("expected pane summary for display name fallback")
+        }
+
+        expect(
+            displaySummary.paneTitle == "Workspace shell",
+            "blank viewport title must fall back to display name"
+        )
+
+        let processState = stateWithPaneMetadata(
+            viewportTitle: "\n\t",
+            displayName: " ",
+            processProgram: "zsh",
+            visibleExcerpt: "SECRET_TOKEN=abc123"
+        )
+
+        guard let processSummary = processState.automationPaneSummary(paneID: "pane_1") else {
+            fail("expected pane summary for process fallback")
+        }
+
+        expect(
+            processSummary.paneTitle == "zsh",
+            "blank viewport and display titles must fall back to process program"
+        )
+    }
+
     private static func verifiesMissingPaneSummaryReturnsNil() {
         let state = ShellStateSnapshot.bootstrapDefault()
         expect(
@@ -145,6 +197,20 @@ private enum ShellAutomationCommandSeamsTests {
     }
 
     private static func stateWithVisibleExcerpt(_ visibleExcerpt: String) -> ShellStateSnapshot {
+        stateWithPaneMetadata(
+            viewportTitle: "Project shell",
+            displayName: nil,
+            processProgram: "zsh",
+            visibleExcerpt: visibleExcerpt
+        )
+    }
+
+    private static func stateWithPaneMetadata(
+        viewportTitle: String?,
+        displayName: String?,
+        processProgram: String,
+        visibleExcerpt: String
+    ) -> ShellStateSnapshot {
         let base = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/Users/morris/Developer/alan")
         let updatedPanes = base.panes.map { pane in
             ShellPane(
@@ -153,7 +219,10 @@ private enum ShellAutomationCommandSeamsTests {
                 spaceID: pane.spaceID,
                 launchTarget: pane.launchTarget,
                 cwd: pane.cwd,
-                process: ShellProcessBinding(program: "zsh", argvPreview: ["zsh", "-l"]),
+                process: ShellProcessBinding(
+                    program: processProgram,
+                    argvPreview: [processProgram, "-l"]
+                ),
                 attention: .awaitingUser,
                 context: ShellContextSnapshot(
                     workingDirectoryName: "alan",
@@ -164,11 +233,12 @@ private enum ShellAutomationCommandSeamsTests {
                     launchStrategy: "login_shell",
                     shellIntegrationSource: "alan",
                     processState: "running",
+                    displayName: displayName,
                     lastMetadataAt: nil,
                     lastCommandExitCode: nil
                 ),
                 viewport: ShellViewportSnapshot(
-                    title: "Project shell",
+                    title: viewportTitle,
                     summary: "ready",
                     visibleExcerpt: visibleExcerpt,
                     lastActivityAt: nil

--- a/justfile
+++ b/justfile
@@ -64,6 +64,10 @@ install-dev:
 dev-channel-smoke:
     ./scripts/smoke-dev-channel-side-by-side.sh
 
+# Run focused macOS shell automation command seam tests
+apple-shell-automation-seams:
+    bash clients/apple/scripts/test-shell-automation-command-seams.sh
+
 # Check release signing and notarization configuration without building
 release-check:
     ALAN_NOTARIZE=1 ./scripts/release-check.sh

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Shared Command And Test Seams
 
-- [ ] 1.1 Define shared shell command interfaces for create tab, split, focus, close, send text, read summary, and attention activation.
+- [x] 1.1 Define shared shell command interfaces for create tab, split, focus, close, send text, read summary, and attention activation.
 - [ ] 1.2 Route existing shell controller, control-plane, menu, and command UI paths through the shared command interface where practical.
-- [ ] 1.3 Add fake shell controller/runtime fixtures for command, intent, and control-plane tests.
-- [ ] 1.4 Add privacy-safe summary helpers for pane/tab/window metadata.
+- [x] 1.3 Add fake shell controller/runtime fixtures for command, intent, and control-plane tests.
+- [x] 1.4 Add privacy-safe summary helpers for pane/tab/window metadata.
 
 ## 2. App Intents
 


### PR DESCRIPTION
## Summary
- Add the shared macOS shell automation command/result interface for tab, split, focus, close, send text, summary, and attention activation actions.
- Add privacy-safe pane summary helpers that omit terminal visible excerpts from user-facing display text.
- Add fake command/runtime fixtures plus a focused Swift script test, wired through `just apple-shell-automation-seams` and documented in `clients/apple/README.md`.
- Mark OpenSpec tasks 1.1, 1.3, and 1.4 complete for `add-macos-shell-automation-tests`.

## Test Plan
- `just apple-shell-automation-seams`
- `bash clients/apple/scripts/test-shell-split-model.sh`
- `openspec validate add-macos-shell-automation-tests --strict`
- `git diff --check`
- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath debug/xcode-derived/automation-seams build`

Note: the first xcodebuild attempt failed inside the default sandbox at Xcode's `sandbox-exec` build phase; the same command passed when rerun outside the sandbox.