### PR TITLE
Route shell automation through shared commands

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -220,6 +220,41 @@ extension ShellHostController {
         )
     }
 
+    func terminalDeliveryResult(
+        from result: ShellAutomationCommandResult
+    ) -> TerminalRuntimeDeliveryResult {
+        let code = result.deliveryCode.flatMap(TerminalRuntimeDeliveryCode.init(rawValue:))
+            ?? terminalDeliveryCode(for: result.code)
+        return TerminalRuntimeDeliveryResult(
+            code: code,
+            acceptedBytes: result.acceptedBytes ?? 0,
+            runtimePhase: result.runtimePhase,
+            errorCode: result.errorCode,
+            errorMessage: result.errorMessage
+        )
+    }
+
+    private func terminalDeliveryCode(
+        for code: ShellAutomationCommandResultCode
+    ) -> TerminalRuntimeDeliveryCode {
+        switch code {
+        case .accepted:
+            return .accepted
+        case .queued:
+            return .queued
+        case .rejected:
+            return .rejected
+        case .missingTarget:
+            return .missingTarget
+        case .runtimeUnavailable:
+            return .unavailableRuntime
+        case .timeout:
+            return .timeout
+        case .invalidRequest, .unsupportedContent, .lastPane, .lastTab:
+            return .rejected
+        }
+    }
+
     func handleControlPlaneCommand(_ command: AlanShellControlCommand) -> AlanShellControlResponse {
         switch command.command {
         case .state:
@@ -273,25 +308,31 @@ extension ShellHostController {
             )
 
         case .tabOpen:
-            guard let tabID = openTerminalTab(
-                in: command.spaceID,
-                title: command.title,
-                workingDirectory: command.cwd
-            ) else {
+            let result = performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .shell,
+                        spaceID: command.spaceID,
+                        title: command.title,
+                        workingDirectory: command.cwd
+                    )
+                )
+            )
+            guard result.applied else {
                 return response(
                     requestID: command.requestID,
                     applied: false,
-                    spaceID: command.spaceID,
-                    errorCode: "space_not_found",
-                    errorMessage: "The requested space does not exist."
+                    spaceID: result.spaceID ?? command.spaceID,
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
                 )
             }
             return response(
                 requestID: command.requestID,
                 applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: tabID,
-                paneID: shellState.focusedPaneID
+                spaceID: result.spaceID,
+                tabID: result.tabID,
+                paneID: result.paneID
             )
 
         case .tabClose:
@@ -304,29 +345,39 @@ extension ShellHostController {
                 )
             }
 
-            switch closeTab(tabID: tabID) {
-            case .closed:
+            let result = performShellAutomationCommand(.closeTab(tabID: tabID))
+            switch result.code {
+            case .accepted:
                 return response(
                     requestID: command.requestID,
                     applied: true,
-                    tabID: tabID,
-                    paneID: shellState.focusedPaneID
+                    tabID: result.tabID ?? tabID,
+                    paneID: result.paneID
                 )
-            case .tabNotFound:
+            case .missingTarget:
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     tabID: tabID,
-                    errorCode: "tab_not_found",
-                    errorMessage: "The requested tab does not exist."
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
                 )
             case .lastTab:
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     tabID: tabID,
-                    errorCode: "last_tab",
-                    errorMessage: "alan terminal workspace must keep at least one tab open."
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
+                )
+            case .queued, .rejected, .invalidRequest, .unsupportedContent, .runtimeUnavailable,
+                    .timeout, .lastPane:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    tabID: tabID,
+                    errorCode: result.errorCode ?? result.code.rawValue,
+                    errorMessage: result.errorMessage
                 )
             }
 
@@ -530,13 +581,23 @@ extension ShellHostController {
                     errorMessage: "direction is required for pane.split."
                 )
             }
-            guard let newPaneID = splitPane(paneID: paneID, direction: direction) else {
+            let result = performShellAutomationCommand(
+                .splitPane(
+                    ShellAutomationPaneSplitRequest(
+                        paneID: paneID,
+                        placement: .defaultPlacement(for: direction)
+                    )
+                )
+            )
+            guard result.applied,
+                  let newPaneID = result.paneID
+            else {
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
                 )
             }
             return response(
@@ -559,30 +620,40 @@ extension ShellHostController {
                 )
             }
 
-            switch closePane(paneID: paneID) {
-            case .closed:
+            let result = performShellAutomationCommand(.closePane(paneID: paneID))
+            switch result.code {
+            case .accepted:
                 return response(
                     requestID: command.requestID,
                     applied: true,
-                    spaceID: shellState.focusedSpaceID,
-                    tabID: shellState.focusedTabID,
-                    paneID: shellState.focusedPaneID
+                    spaceID: result.spaceID,
+                    tabID: result.tabID,
+                    paneID: result.paneID
                 )
-            case .paneNotFound:
+            case .missingTarget:
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
                 )
             case .lastTab:
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: paneID,
-                    errorCode: "last_tab",
-                    errorMessage: "alan terminal workspace must keep at least one pane open."
+                    errorCode: result.errorCode,
+                    errorMessage: result.errorMessage
+                )
+            case .queued, .rejected, .invalidRequest, .unsupportedContent, .runtimeUnavailable,
+                    .timeout, .lastPane:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
+                    errorCode: result.errorCode ?? result.code.rawValue,
+                    errorMessage: result.errorMessage
                 )
             }
 
@@ -666,25 +737,32 @@ extension ShellHostController {
             return handlePaneMoveWithinTabCommand(command)
 
         case .paneFocus:
-            guard let paneID = command.paneID,
-                  shellState.panes.contains(where: { $0.paneID == paneID })
-            else {
+            guard let paneID = command.paneID else {
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: command.paneID,
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
+                )
+            }
+
+            let result = performShellAutomationCommand(.focusPane(paneID: paneID))
+            guard result.applied else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: paneID,
                     errorCode: "pane_not_found",
                     errorMessage: "The requested pane does not exist."
                 )
             }
-
-            focus(paneID: paneID)
             return response(
                 requestID: command.requestID,
                 applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: paneID
+                spaceID: result.spaceID,
+                tabID: result.tabID,
+                paneID: result.paneID
             )
 
         case .paneSpatialFocus:
@@ -760,11 +838,15 @@ extension ShellHostController {
                 )
             }
 
-            let text = command.text ?? ""
-            let delivery = terminalRuntimeRegistry.sendText(
-                toTerminalContentID: target.content.contentID,
-                text: text
+            let result = performShellAutomationCommand(
+                .sendText(
+                    ShellAutomationSendTextRequest(
+                        paneID: target.paneSlot.paneSlotID,
+                        text: command.text ?? ""
+                    )
+                )
             )
+            let delivery = terminalDeliveryResult(from: result)
             controlPlane.recordTextDelivery(
                 requestID: command.requestID,
                 spaceID: target.paneSlot.spaceID,
@@ -776,17 +858,17 @@ extension ShellHostController {
 
             return response(
                 requestID: command.requestID,
-                applied: delivery.applied,
+                applied: result.applied,
                 spaceID: target.paneSlot.spaceID,
                 tabID: target.paneSlot.tabID,
                 paneID: target.paneSlot.paneSlotID,
                 paneSlotID: target.paneSlot.paneSlotID,
                 contentID: target.content.contentID,
-                acceptedBytes: delivery.acceptedBytes,
-                deliveryCode: delivery.code.rawValue,
-                runtimePhase: delivery.runtimePhase,
-                errorCode: delivery.errorCode,
-                errorMessage: delivery.errorMessage
+                acceptedBytes: result.acceptedBytes,
+                deliveryCode: result.deliveryCode,
+                runtimePhase: result.runtimePhase,
+                errorCode: result.errorCode,
+                errorMessage: result.errorMessage
             )
 
         case .agentActivity:

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -50,6 +50,7 @@ struct ShellAutomationCommandResult: Equatable {
     let paneID: String?
     let acceptedBytes: Int?
     let deliveryCode: String?
+    let runtimePhase: String?
     let errorCode: String?
     let errorMessage: String?
 
@@ -61,6 +62,7 @@ struct ShellAutomationCommandResult: Equatable {
         paneID: String? = nil,
         acceptedBytes: Int? = nil,
         deliveryCode: String? = nil,
+        runtimePhase: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) {
@@ -71,6 +73,7 @@ struct ShellAutomationCommandResult: Equatable {
         self.paneID = paneID
         self.acceptedBytes = acceptedBytes
         self.deliveryCode = deliveryCode
+        self.runtimePhase = runtimePhase
         self.errorCode = errorCode
         self.errorMessage = errorMessage
     }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1222,17 +1222,35 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func performShellWorkspaceCommand(_ command: ShellWorkspaceCommand) -> Bool {
         switch command {
         case .newTerminalTab:
-            return openTerminalTab() != nil
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .shell,
+                        spaceID: nil,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .newAlanTab:
-            return openAlanTab() != nil
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .alan,
+                        spaceID: nil,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .splitLeft:
-            return splitFocusedPane(placement: .left) != nil
+            return performShellAutomationSplitFromFocusedPane(.left)
         case .splitRight:
-            return splitFocusedPane(placement: .right) != nil
+            return performShellAutomationSplitFromFocusedPane(.right)
         case .splitUp:
-            return splitFocusedPane(placement: .up) != nil
+            return performShellAutomationSplitFromFocusedPane(.up)
         case .splitDown:
-            return splitFocusedPane(placement: .down) != nil
+            return performShellAutomationSplitFromFocusedPane(.down)
         case .focusLeft:
             return focusAdjacentPane(direction: .left)
         case .focusRight:
@@ -1254,9 +1272,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .movePaneDown:
             return moveSelectedPaneWithinTab(.down)
         case .closePane:
-            return closeSelectedPane()
+            guard let paneID = selectedPane?.paneID else { return false }
+            return performShellAutomationCommand(.closePane(paneID: paneID)).applied
         case .closeTab:
-            return closeSelectedTab()
+            guard let tabID = selectedTabID else { return false }
+            return performShellAutomationCommand(.closeTab(tabID: tabID)).applied
         case .quickTerminalToggle:
             return toggleQuickTerminal() != nil
         case .quickTerminalShow:
@@ -1268,6 +1288,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .quickTerminalClose:
             return closeQuickTerminal()
         }
+    }
+
+    private func performShellAutomationSplitFromFocusedPane(
+        _ placement: ShellPaneSplitDirection
+    ) -> Bool {
+        guard let focusedPaneID = shellState.focusedPaneID else { return false }
+        return performShellAutomationCommand(
+            .splitPane(ShellAutomationPaneSplitRequest(paneID: focusedPaneID, placement: placement))
+        ).applied
     }
 
     func shellActionTitle(_ id: ShellActionID) -> String {
@@ -1314,18 +1343,22 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .workspaceCommand(let command):
             return performShellWorkspaceCommand(command)
         case .openTab(let launchTarget, let spaceID):
-            switch launchTarget {
-            case .shell:
-                return openTerminalTab(in: spaceID) != nil
-            case .alan:
-                return openAlanTab(in: spaceID) != nil
-            }
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: launchTarget,
+                        spaceID: spaceID,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .closeTab(let tabID):
-            guard let tabID else { return closeSelectedTab() }
-            return closeTab(tabID: tabID) == .closed
+            guard let tabID = tabID ?? selectedTabID else { return false }
+            return performShellAutomationCommand(.closeTab(tabID: tabID)).applied
         case .closePane(let paneID):
-            guard let paneID else { return closeSelectedPane() }
-            return closePane(paneID: paneID) == .closed
+            guard let paneID = paneID ?? selectedPane?.paneID else { return false }
+            return performShellAutomationCommand(.closePane(paneID: paneID)).applied
         case .selectAdjacentTab(let offset):
             return selectAdjacentTab(offset: offset)
         case .selectAdjacentSpace(let offset):
@@ -2592,6 +2625,211 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return 2
         case .awaitingUser:
             return 3
+        }
+    }
+}
+
+extension ShellHostController: ShellAutomationCommandHandling {
+    func performShellAutomationCommand(
+        _ command: ShellAutomationCommand
+    ) -> ShellAutomationCommandResult {
+        switch command {
+        case .createTab(let request):
+            let tabID: String?
+            switch request.launchTarget {
+            case .shell:
+                tabID = openTerminalTab(
+                    in: request.spaceID,
+                    title: request.title,
+                    workingDirectory: request.workingDirectory
+                )
+            case .alan:
+                tabID = openAlanTab(
+                    in: request.spaceID,
+                    title: request.title,
+                    workingDirectory: request.workingDirectory
+                )
+            }
+            guard let tabID else {
+                return shellAutomationResult(
+                    code: .missingTarget,
+                    spaceID: request.spaceID,
+                    errorCode: "space_not_found",
+                    errorMessage: "The requested space does not exist."
+                )
+            }
+            return shellAutomationResult(
+                code: .accepted,
+                spaceID: shellState.focusedSpaceID,
+                tabID: tabID,
+                paneID: shellState.focusedPaneID
+            )
+
+        case .splitPane(let request):
+            guard pane(paneID: request.paneID) != nil else {
+                return shellAutomationMissingPaneResult(request.paneID)
+            }
+            guard let paneID = splitPane(paneID: request.paneID, placement: request.placement) else {
+                return shellAutomationMissingPaneResult(request.paneID)
+            }
+            return shellAutomationResult(
+                code: .accepted,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: paneID
+            )
+
+        case .focusPane(let paneID):
+            guard pane(paneID: paneID) != nil else {
+                return shellAutomationMissingPaneResult(paneID)
+            }
+            focus(paneID: paneID)
+            return shellAutomationResult(
+                code: .accepted,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: paneID
+            )
+
+        case .closePane(let paneID):
+            switch closePane(paneID: paneID) {
+            case .closed:
+                return shellAutomationResult(
+                    code: .accepted,
+                    spaceID: shellState.focusedSpaceID,
+                    tabID: shellState.focusedTabID,
+                    paneID: shellState.focusedPaneID
+                )
+            case .paneNotFound:
+                return shellAutomationMissingPaneResult(paneID)
+            case .lastTab:
+                return shellAutomationResult(
+                    code: .lastTab,
+                    paneID: paneID,
+                    errorCode: "last_tab",
+                    errorMessage: "alan terminal workspace must keep at least one pane open."
+                )
+            }
+
+        case .closeTab(let tabID):
+            switch closeTab(tabID: tabID) {
+            case .closed:
+                return shellAutomationResult(
+                    code: .accepted,
+                    tabID: tabID,
+                    paneID: shellState.focusedPaneID
+                )
+            case .tabNotFound:
+                return shellAutomationResult(
+                    code: .missingTarget,
+                    tabID: tabID,
+                    errorCode: "tab_not_found",
+                    errorMessage: "The requested tab does not exist."
+                )
+            case .lastTab:
+                return shellAutomationResult(
+                    code: .lastTab,
+                    tabID: tabID,
+                    errorCode: "last_tab",
+                    errorMessage: "alan terminal workspace must keep at least one tab open."
+                )
+            }
+
+        case .sendText(let request):
+            let delivery = terminalRuntimeRegistry.sendText(
+                to: request.paneID,
+                text: request.text
+            )
+            return shellAutomationResult(
+                code: shellAutomationResultCode(for: delivery),
+                paneID: request.paneID,
+                acceptedBytes: delivery.acceptedBytes,
+                deliveryCode: delivery.code.rawValue,
+                runtimePhase: delivery.runtimePhase,
+                errorCode: delivery.errorCode,
+                errorMessage: delivery.errorMessage
+            )
+
+        case .readPaneSummary(let paneID):
+            guard let summary = shellState.automationPaneSummary(paneID: paneID) else {
+                return shellAutomationMissingPaneResult(paneID)
+            }
+            return shellAutomationResult(
+                code: .accepted,
+                summary: summary,
+                spaceID: summary.spaceID,
+                tabID: summary.tabID,
+                paneID: summary.paneID
+            )
+
+        case .activateAttentionItem(let paneID):
+            guard pane(paneID: paneID) != nil else {
+                return shellAutomationMissingPaneResult(paneID)
+            }
+            focus(paneID: paneID, requestTerminalFocus: true)
+            return shellAutomationResult(
+                code: .accepted,
+                spaceID: shellState.focusedSpaceID,
+                tabID: shellState.focusedTabID,
+                paneID: paneID
+            )
+        }
+    }
+
+    private func shellAutomationMissingPaneResult(_ paneID: String) -> ShellAutomationCommandResult {
+        shellAutomationResult(
+            code: .missingTarget,
+            paneID: paneID,
+            errorCode: "pane_not_found",
+            errorMessage: "The requested pane does not exist."
+        )
+    }
+
+    private func shellAutomationResult(
+        code: ShellAutomationCommandResultCode,
+        summary: ShellAutomationPaneSummary? = nil,
+        spaceID: String? = nil,
+        tabID: String? = nil,
+        paneID: String? = nil,
+        acceptedBytes: Int? = nil,
+        deliveryCode: String? = nil,
+        runtimePhase: String? = nil,
+        errorCode: String? = nil,
+        errorMessage: String? = nil
+    ) -> ShellAutomationCommandResult {
+        let resolvedSummary = summary ?? paneID.flatMap {
+            shellState.automationPaneSummary(paneID: $0)
+        }
+        return ShellAutomationCommandResult(
+            code: code,
+            summary: resolvedSummary,
+            spaceID: spaceID ?? resolvedSummary?.spaceID,
+            tabID: tabID ?? resolvedSummary?.tabID,
+            paneID: paneID ?? resolvedSummary?.paneID,
+            acceptedBytes: acceptedBytes,
+            deliveryCode: deliveryCode,
+            runtimePhase: runtimePhase,
+            errorCode: errorCode,
+            errorMessage: errorMessage
+        )
+    }
+
+    private func shellAutomationResultCode(
+        for delivery: TerminalRuntimeDeliveryResult
+    ) -> ShellAutomationCommandResultCode {
+        switch delivery.code {
+        case .accepted:
+            return .accepted
+        case .queued:
+            return .queued
+        case .rejected:
+            return .rejected
+        case .missingTarget:
+            return .missingTarget
+        case .unavailableRuntime:
+            return .runtimeUnavailable
+        case .timeout:
+            return .timeout
         }
     }
 }

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -54,7 +54,16 @@ struct TerminalPaneView: View {
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(ShellPalette.mutedInk)
                     Button {
-                        _ = host.openTerminalTab(in: displaySpaceID)
+                        _ = host.performShellAutomationCommand(
+                            .createTab(
+                                ShellAutomationCreateTabRequest(
+                                    launchTarget: .shell,
+                                    spaceID: displaySpaceID,
+                                    title: nil,
+                                    workingDirectory: nil
+                                )
+                            )
+                        )
                     } label: {
                         Label("New Tab", systemImage: "plus")
                             .font(.system(size: 12, weight: .semibold))
@@ -588,7 +597,7 @@ private struct ShellPaneTreeLayoutView: View {
                 ).isAvailable
             },
             onFocusPane: {
-                host.focus(paneID: paneSlotID)
+                _ = host.performShellAutomationCommand(.focusPane(paneID: paneSlotID))
             },
             onToggleZoom: {
                 if host.isPaneZoomed(paneSlotID) {

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -570,7 +570,7 @@ struct ShellSidebarView: View {
 
     private func focusPane(_ paneID: String, in tab: ShellTab) {
         host.select(tabID: tab.tabID)
-        host.focus(paneID: paneID)
+        _ = host.performShellAutomationCommand(.focusPane(paneID: paneID))
         host.refocusSelectedTerminalPane()
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -15,6 +15,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -33,6 +33,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesMovingLastPaneClosesSourceTabWithoutFinalizingMovedRuntime()
         verifiesWorkspaceLifecycleRetirementFinalizesTerminalContentAndRejectsDelivery()
         verifiesTerminalLifecycleShutdownFinalizesAllRuntimes()
+        verifiesShellHostControllerRoutesSharedAutomationCommands()
+        verifiesControlPlaneRoutesSharedAutomationCommandSemantics()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -1082,6 +1084,117 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.terminalRuntimeRegistry.registeredPaneIDs.isEmpty,
             "shutdown must clear terminal runtime registry state"
+        )
+    }
+
+    private static func verifiesShellHostControllerRoutesSharedAutomationCommands() {
+        let controller = makeController()
+        let handler: ShellAutomationCommandHandling = controller
+
+        let split = handler.performShellAutomationCommand(
+            .splitPane(ShellAutomationPaneSplitRequest(paneID: "pane_1", placement: .right))
+        )
+
+        guard split.code == .accepted,
+              let splitPaneID = split.paneID,
+              controller.pane(paneID: splitPaneID) != nil
+        else {
+            fail("shared split command must create and return the new pane")
+        }
+
+        let summary = handler.performShellAutomationCommand(.readPaneSummary(paneID: splitPaneID))
+        expect(
+            summary.code == .accepted && summary.summary?.paneID == splitPaneID,
+            "shared read-summary command must return safe pane metadata"
+        )
+
+        let focus = handler.performShellAutomationCommand(.focusPane(paneID: "pane_1"))
+        expect(
+            focus.code == .accepted && controller.shellState.focusedPaneID == "pane_1",
+            "shared focus command must update controller focus"
+        )
+
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let send = handler.performShellAutomationCommand(
+            .sendText(ShellAutomationSendTextRequest(paneID: "pane_1", text: "pwd\n"))
+        )
+        expect(
+            send.code == .accepted && send.deliveryCode == "accepted" && send.acceptedBytes == 4,
+            "shared send-text command must expose runtime delivery semantics"
+        )
+        expect(handle.deliveredText == ["pwd\n"], "shared send-text command must reach runtime")
+
+        let close = handler.performShellAutomationCommand(.closePane(paneID: splitPaneID))
+        expect(
+            close.code == .accepted && controller.pane(paneID: splitPaneID) == nil,
+            "shared close-pane command must close the target pane"
+        )
+
+        let missing = handler.performShellAutomationCommand(.focusPane(paneID: "missing"))
+        expect(
+            missing.code == .missingTarget && !missing.applied,
+            "shared command handler must report missing targets with stable semantics"
+        )
+    }
+
+    private static func verifiesControlPlaneRoutesSharedAutomationCommandSemantics() {
+        let controller = makeController()
+
+        let split = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "automation-split-1",
+                  "command": "pane.split",
+                  "pane_id": "pane_1",
+                  "direction": "vertical"
+                }
+                """
+            )
+        )
+        guard split.applied == true,
+              let splitPaneID = split.paneID,
+              controller.pane(paneID: splitPaneID) != nil
+        else {
+            fail("control-plane split must use accepted shared command semantics")
+        }
+
+        let missingFocus = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "automation-focus-missing-1",
+                  "command": "pane.focus",
+                  "pane_id": "missing"
+                }
+                """
+            )
+        )
+        expect(
+            missingFocus.applied == false && missingFocus.errorCode == "pane_not_found",
+            "control-plane focus must report shared missing-target semantics"
+        )
+
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        let send = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "automation-send-1",
+                  "command": "terminal.send_text",
+                  "pane_id": "pane_1",
+                  "text": "pwd\\n"
+                }
+                """
+            )
+        )
+        expect(
+            send.applied == true && send.deliveryCode == "accepted" && send.acceptedBytes == 4,
+            "control-plane send_text must expose shared runtime delivery semantics"
+        )
+        expect(
+            handle.deliveredText == ["pwd\n"],
+            "control-plane send_text must route through the shared runtime command path"
         )
     }
 

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Shared Command And Test Seams
 
 - [x] 1.1 Define shared shell command interfaces for create tab, split, focus, close, send text, read summary, and attention activation.
-- [ ] 1.2 Route existing shell controller, control-plane, menu, and command UI paths through the shared command interface where practical.
+- [x] 1.2 Route existing shell controller, control-plane, menu, and command UI paths through the shared command interface where practical.
 - [x] 1.3 Add fake shell controller/runtime fixtures for command, intent, and control-plane tests.
 - [x] 1.4 Add privacy-safe summary helpers for pane/tab/window metadata.
 


### PR DESCRIPTION
## Summary
- route native shell workspace/menu/command UI actions through ShellAutomationCommandHandling where practical
- route control-plane create/split/focus/close/send-text through the same shared command result semantics
- add regression coverage for controller conformance and control-plane command alignment
- mark OpenSpec task 1.2 complete

## Verification
- git diff --check
- git diff --cached --check
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- just apple-shell-automation-seams
- bash clients/apple/scripts/test-shell-action-registry.sh
- bash clients/apple/scripts/test-shell-split-model.sh
- openspec validate add-macos-shell-automation-tests --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath debug/xcode-derived/automation-routing build