### PR TITLE
Add shell model focus preservation tests

### DIFF
--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -311,8 +311,11 @@ extension ShellStateSnapshot {
             )
         }
 
-        let focusedPaneID = remainingPanes.first?.paneID
-        let focusedPane = focusedPaneID.flatMap { paneID in
+        let preferredFocusedPaneID =
+            focusedPaneID.flatMap { candidate in
+                remainingPanes.contains { $0.paneID == candidate } ? candidate : nil
+            } ?? remainingPanes.first?.paneID
+        let focusedPane = preferredFocusedPaneID.flatMap { paneID in
             remainingPanes.first { $0.paneID == paneID }
         }
         let retained = retainedContentRecords(in: remainingSpaces, panes: remainingPanes)
@@ -321,7 +324,7 @@ extension ShellStateSnapshot {
             windowID: windowID,
             focusedSpaceID: focusedPane?.spaceID ?? remainingSpaces.first?.spaceID,
             focusedTabID: focusedPane?.tabID,
-            focusedPaneID: focusedPaneID,
+            focusedPaneID: preferredFocusedPaneID,
             spaces: rebuildingAttention(in: remainingSpaces, panes: remainingPanes),
             panes: remainingPanes,
             paneSlots: retained.paneSlots,
@@ -1438,8 +1441,12 @@ extension ShellStateSnapshot {
         }
         let nextPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
         let targetSpaceAfterClose = nextSpaces.first { $0.spaceID == targetSpace.spaceID }
+        let retainedFocusedPaneID = focusedPaneID.flatMap { candidate in
+            nextPanes.contains { $0.paneID == candidate } ? candidate : nil
+        }
         let preferredPaneID =
-            targetSpaceAfterClose?.tabs
+            retainedFocusedPaneID
+            ?? targetSpaceAfterClose?.tabs
                 .flatMap(\.paneTree.paneIDs)
                 .first { paneID in nextPanes.contains { $0.paneID == paneID } }
             ?? nextPanes.first(where: { $0.spaceID == targetSpace.spaceID })?.paneID

--- a/clients/apple/scripts/test-shell-automation-command-seams.swift
+++ b/clients/apple/scripts/test-shell-automation-command-seams.swift
@@ -131,7 +131,18 @@ private enum ShellAutomationCommandSeamsTests {
 
     private static func verifiesPaneSummaryUsesSafeMetadata() {
         let secretExcerpt = "SECRET_TOKEN=abc123"
-        let state = stateWithVisibleExcerpt(secretExcerpt)
+        let secretViewportSummary = "viewport summary includes SECRET_TOKEN=def456"
+        let secretControlPath = "/tmp/alan-shell-control/window_main/panes/pane_1"
+        let secretBindingFile = "/tmp/alan-shell-bindings/SECRET_BINDING_FILE.json"
+        let state = stateWithPaneMetadata(
+            viewportTitle: "Project shell",
+            displayName: nil,
+            processProgram: "zsh",
+            viewportSummary: secretViewportSummary,
+            visibleExcerpt: secretExcerpt,
+            controlPath: secretControlPath,
+            alanBindingFile: secretBindingFile
+        )
 
         guard let summary = state.automationPaneSummary(paneID: "pane_1") else {
             fail("expected pane summary")
@@ -147,6 +158,18 @@ private enum ShellAutomationCommandSeamsTests {
         expect(
             !summary.displayText.contains(secretExcerpt),
             "summary display text must not expose terminal visible excerpts"
+        )
+        expect(
+            !summary.displayText.contains(secretViewportSummary),
+            "summary display text must not expose terminal viewport summaries"
+        )
+        expect(
+            !summary.displayText.contains(secretControlPath),
+            "summary display text must not expose control paths"
+        )
+        expect(
+            !summary.displayText.contains(secretBindingFile),
+            "summary display text must not expose binding file paths"
         )
         expect(
             !summary.displayText.contains("pane_1"),
@@ -209,7 +232,10 @@ private enum ShellAutomationCommandSeamsTests {
         viewportTitle: String?,
         displayName: String?,
         processProgram: String,
-        visibleExcerpt: String
+        viewportSummary: String = "ready",
+        visibleExcerpt: String,
+        controlPath: String? = "/tmp/alan-shell-control/window_main/panes/pane_1",
+        alanBindingFile: String? = nil
     ) -> ShellStateSnapshot {
         let base = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/Users/morris/Developer/alan")
         let updatedPanes = base.panes.map { pane in
@@ -228,8 +254,8 @@ private enum ShellAutomationCommandSeamsTests {
                     workingDirectoryName: "alan",
                     repositoryRoot: "/Users/morris/Developer/alan",
                     gitBranch: "main",
-                    controlPath: "/tmp/alan-shell-control/window_main/panes/pane_1",
-                    alanBindingFile: nil,
+                    controlPath: controlPath,
+                    alanBindingFile: alanBindingFile,
                     launchStrategy: "login_shell",
                     shellIntegrationSource: "alan",
                     processState: "running",
@@ -239,7 +265,7 @@ private enum ShellAutomationCommandSeamsTests {
                 ),
                 viewport: ShellViewportSnapshot(
                     title: viewportTitle,
-                    summary: "ready",
+                    summary: viewportSummary,
                     visibleExcerpt: visibleExcerpt,
                     lastActivityAt: nil
                 ),

--- a/clients/apple/scripts/test-shell-split-model.swift
+++ b/clients/apple/scripts/test-shell-split-model.swift
@@ -24,6 +24,8 @@ private enum ShellSplitModelTests {
         try verifiesPaneScopedCloseKeepsInactivePaneTargeting()
         try verifiesPaneScopedCloseClosesSinglePaneTab()
         try verifiesPaneScopedCloseLeavesFinalSpaceEmpty()
+        try verifiesClosingBackgroundSpaceTabPreservesCurrentFocus()
+        try verifiesDeletingBackgroundSpacePreservesCurrentFocus()
         try verifiesPaneAllocationSkipsReservedRuntimeIDs()
         try verifiesSplitDecodeRequiresPersistedRatio()
         print("Shell split model tests passed.")
@@ -407,6 +409,86 @@ private enum ShellSplitModelTests {
         expect(result.state.focusedSpaceID == "space_main", "closing the final pane must keep the empty space focused")
         expect(result.state.focusedTabID == nil, "closing the final pane must clear tab focus")
         expect(result.state.focusedPaneID == nil, "closing the final pane must clear pane focus")
+    }
+
+    private static func verifiesClosingBackgroundSpaceTabPreservesCurrentFocus() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp/main")
+        state = state.creatingTerminalSpace(
+            title: "Background",
+            workingDirectory: "/tmp/background"
+        ).state
+        state = try state.openingTerminalTab(
+            in: "space_main",
+            title: "Active second tab",
+            workingDirectory: "/tmp/active"
+        ).state
+
+        expect(state.focusedSpaceID == "space_main", "test setup must focus the main space")
+        expect(state.focusedTabID == "tab_3", "test setup must focus the active tab")
+        expect(state.focusedPaneID == "pane_3", "test setup must focus the active pane")
+
+        let result = try state.closingTab("tab_2")
+
+        expect(
+            result.state.tab(tabID: "tab_2") == nil,
+            "background tab close must remove the target tab"
+        )
+        expect(
+            result.state.pane(paneID: "pane_2") == nil,
+            "background tab close must remove its pane"
+        )
+        expect(
+            result.state.focusedSpaceID == "space_main",
+            "background tab close must preserve focused space"
+        )
+        expect(
+            result.state.focusedTabID == "tab_3",
+            "background tab close must preserve focused tab"
+        )
+        expect(
+            result.state.focusedPaneID == "pane_3",
+            "background tab close must preserve focused pane"
+        )
+    }
+
+    private static func verifiesDeletingBackgroundSpacePreservesCurrentFocus() throws {
+        var state = ShellStateSnapshot.bootstrapDefault(workingDirectory: "/tmp/main")
+        state = state.creatingTerminalSpace(
+            title: "Background",
+            workingDirectory: "/tmp/background"
+        ).state
+        state = try state.openingTerminalTab(
+            in: "space_main",
+            title: "Active second tab",
+            workingDirectory: "/tmp/active"
+        ).state
+
+        expect(state.focusedSpaceID == "space_main", "test setup must focus the main space")
+        expect(state.focusedTabID == "tab_3", "test setup must focus the active tab")
+        expect(state.focusedPaneID == "pane_3", "test setup must focus the active pane")
+
+        let result = try state.deletingSpace("space_2")
+
+        expect(
+            result.state.space(spaceID: "space_2") == nil,
+            "background space delete must remove target space"
+        )
+        expect(
+            result.state.pane(paneID: "pane_2") == nil,
+            "background space delete must remove target panes"
+        )
+        expect(
+            result.state.focusedSpaceID == "space_main",
+            "background space delete must preserve focused space"
+        )
+        expect(
+            result.state.focusedTabID == "tab_3",
+            "background space delete must preserve focused tab"
+        )
+        expect(
+            result.state.focusedPaneID == "pane_3",
+            "background space delete must preserve focused pane"
+        )
     }
 
     private static func verifiesPaneAllocationSkipsReservedRuntimeIDs() throws {

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -15,7 +15,7 @@
 
 ## 3. Focused Tests
 
-- [ ] 3.1 Add Apple-client unit tests for shell model mutations, split/focus/close behavior, and privacy-safe summaries.
+- [x] 3.1 Add Apple-client unit tests for shell model mutations, split/focus/close behavior, and privacy-safe summaries.
 - [x] 3.2 Add runtime service fake tests for text delivery, unavailable runtime, teardown, and metadata snapshots.
 - [ ] 3.3 Add control-plane tests for query/mutation success, malformed requests, missing targets, runtime unavailable, timeout, and IO diagnostics.
 - [ ] 3.4 Add App Intent routing tests using fake shell state and fake runtime outcomes.


### PR DESCRIPTION
## Summary
- preserve current focus when closing a background tab or deleting a background space
- add Apple shell model regression tests for background close/delete focus behavior
- strengthen automation pane summary privacy assertions and mark OpenSpec task 3.1 complete

## Verification
- git diff --check
- git diff --cached --check
- bash clients/apple/scripts/test-shell-split-model.sh
- bash clients/apple/scripts/test-shell-automation-command-seams.sh
- just apple-shell-automation-seams
- openspec validate add-macos-shell-automation-tests --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath debug/DerivedData/model-tests build