### PR TITLE
Cover unavailable terminal runtime delivery

### DIFF
--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -951,6 +951,14 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     func updateHostRuntimeSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {}
 
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
+        guard isSurfaceReady else {
+            let result = TerminalRuntimeDeliveryResult.unavailable(
+                errorMessage: "The requested pane is not ready to receive terminal input.",
+                runtimePhase: currentSnapshot.runtimePhase
+            )
+            updateSnapshot(lastDelivery: result)
+            return result
+        }
         guard !currentSnapshot.metadata.processExited else {
             let result = TerminalRuntimeDeliveryResult.rejected(
                 errorCode: "terminal_child_exited",

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -951,18 +951,18 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     func updateHostRuntimeSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {}
 
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult {
-        guard isSurfaceReady else {
-            let result = TerminalRuntimeDeliveryResult.unavailable(
-                errorMessage: "The requested pane is not ready to receive terminal input.",
+        guard !currentSnapshot.metadata.processExited else {
+            let result = TerminalRuntimeDeliveryResult.rejected(
+                errorCode: "terminal_child_exited",
+                errorMessage: "The terminal process has exited.",
                 runtimePhase: currentSnapshot.runtimePhase
             )
             updateSnapshot(lastDelivery: result)
             return result
         }
-        guard !currentSnapshot.metadata.processExited else {
-            let result = TerminalRuntimeDeliveryResult.rejected(
-                errorCode: "terminal_child_exited",
-                errorMessage: "The terminal process has exited.",
+        guard isSurfaceReady else {
+            let result = TerminalRuntimeDeliveryResult.unavailable(
+                errorMessage: "The requested pane is not ready to receive terminal input.",
                 runtimePhase: currentSnapshot.runtimePhase
             )
             updateSnapshot(lastDelivery: result)

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -27,6 +27,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesContentScopedDeliveryPreservesPendingDiagnostics()
         verifiesDeliveryAndMissingRuntimeResults()
         verifiesDeliveryRejectsExitedRuntime()
+        verifiesExitedRuntimeTakesPrecedenceOverUnavailableRuntime()
         verifiesUnavailableRuntimeDoesNotDeliverTextAndRecordsSnapshot()
         verifiesQueuedAndTimeoutDeliveryStates()
         verifiesControlResponseCarriesDeliveryDiagnostics()
@@ -422,6 +423,22 @@ private enum TerminalRuntimeServiceTests {
         expect(rejected.applied == false, "exited runtime delivery must not report applied")
         expect(rejected.errorCode == "terminal_child_exited", "exited runtime delivery must use stable error code")
         expect(handle.deliveredText.isEmpty, "exited runtime delivery must not reach the surface")
+    }
+
+    private static func verifiesExitedRuntimeTakesPrecedenceOverUnavailableRuntime() {
+        let service = FakeAlanTerminalRuntimeService()
+        let handle = service.surfaceHandle(for: "pane_1", bootProfile: nil) as! FakeAlanTerminalSurfaceHandle
+        handle.ready = false
+        handle.markProcessExited(exitCode: 0)
+
+        let rejected = service.sendText(to: "pane_1", text: "after exit")
+
+        expect(rejected.code == .rejected, "exited and unready runtime must report rejected")
+        expect(
+            rejected.errorCode == "terminal_child_exited",
+            "exited runtime must take precedence over unavailable runtime"
+        )
+        expect(handle.deliveredText.isEmpty, "exited and unready runtime delivery must not reach the surface")
     }
 
     private static func verifiesUnavailableRuntimeDoesNotDeliverTextAndRecordsSnapshot() {

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -27,6 +27,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesContentScopedDeliveryPreservesPendingDiagnostics()
         verifiesDeliveryAndMissingRuntimeResults()
         verifiesDeliveryRejectsExitedRuntime()
+        verifiesUnavailableRuntimeDoesNotDeliverTextAndRecordsSnapshot()
         verifiesQueuedAndTimeoutDeliveryStates()
         verifiesControlResponseCarriesDeliveryDiagnostics()
         verifiesTeardownOnce()
@@ -421,6 +422,26 @@ private enum TerminalRuntimeServiceTests {
         expect(rejected.applied == false, "exited runtime delivery must not report applied")
         expect(rejected.errorCode == "terminal_child_exited", "exited runtime delivery must use stable error code")
         expect(handle.deliveredText.isEmpty, "exited runtime delivery must not reach the surface")
+    }
+
+    private static func verifiesUnavailableRuntimeDoesNotDeliverTextAndRecordsSnapshot() {
+        let service = FakeAlanTerminalRuntimeService()
+        let handle = service.surfaceHandle(for: "pane_1", bootProfile: nil) as! FakeAlanTerminalSurfaceHandle
+        handle.ready = false
+
+        let unavailable = service.sendText(to: "pane_1", text: "while unavailable")
+
+        expect(unavailable.code == .unavailableRuntime, "unready runtime delivery must report unavailable")
+        expect(unavailable.applied == false, "unavailable runtime delivery must not report applied")
+        expect(
+            unavailable.errorCode == "terminal_runtime_unavailable",
+            "unavailable runtime delivery must use stable error code"
+        )
+        expect(handle.deliveredText.isEmpty, "unavailable runtime delivery must not reach the surface")
+        expect(
+            service.snapshot(for: "pane_1")?.lastDelivery == unavailable,
+            "unavailable runtime delivery must stay observable in the metadata snapshot"
+        )
     }
 
     private static func verifiesQueuedAndTimeoutDeliveryStates() {

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -16,7 +16,7 @@
 ## 3. Focused Tests
 
 - [ ] 3.1 Add Apple-client unit tests for shell model mutations, split/focus/close behavior, and privacy-safe summaries.
-- [ ] 3.2 Add runtime service fake tests for text delivery, unavailable runtime, teardown, and metadata snapshots.
+- [x] 3.2 Add runtime service fake tests for text delivery, unavailable runtime, teardown, and metadata snapshots.
 - [ ] 3.3 Add control-plane tests for query/mutation success, malformed requests, missing targets, runtime unavailable, timeout, and IO diagnostics.
 - [ ] 3.4 Add App Intent routing tests using fake shell state and fake runtime outcomes.
 - [ ] 3.5 Add a Ghostty-enabled integration lane that runs only when local Ghostty artifacts are prepared.


### PR DESCRIPTION
## Summary
- add a runtime service fake regression test for unavailable terminal delivery
- align fake terminal surface delivery behavior with production by returning unavailable_runtime when the surface is not ready
- mark OpenSpec task 3.2 complete

## Verification
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- just apple-shell-automation-seams
- openspec validate add-macos-shell-automation-tests --strict
- git diff --check
- git diff --cached --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'platform=macOS' -derivedDataPath debug/DerivedData/runtime-service-tests build