### PR TITLE
Add Ghostty shell integration lane

### DIFF
--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -198,6 +198,11 @@ bash clients/apple/scripts/check-shell-contracts.sh
 # Shell automation command seam tests
 just apple-shell-automation-seams
 
+# Ghostty-backed shell integration lane.
+# Skips when local Ghostty links are absent; set ALAN_REQUIRE_GHOSTTY_INTEGRATION=1
+# to make missing artifacts fail the command.
+just apple-shell-ghostty-integration
+
 # Apple source architecture maintainability report
 bash clients/apple/scripts/check-architecture-maintainability.sh
 

--- a/clients/apple/scripts/test-shell-ghostty-integration.sh
+++ b/clients/apple/scripts/test-shell-ghostty-integration.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SETUP_SCRIPT="$SCRIPT_DIR/setup-local-ghosttykit.sh"
+
+REQUIRE_GHOSTTY="${ALAN_REQUIRE_GHOSTTY_INTEGRATION:-0}"
+DERIVED_DATA_PATH="${ALAN_GHOSTTY_DERIVED_DATA_PATH:-$REPO_ROOT/debug/DerivedData/apple-shell-ghostty-integration}"
+DESTINATION="${ALAN_GHOSTTY_XCODE_DESTINATION:-platform=macOS}"
+
+if ! check_output="$("$SETUP_SCRIPT" --check 2>&1)"; then
+    printf '%s\n' "$check_output" >&2
+    if [ "$REQUIRE_GHOSTTY" = "1" ]; then
+        printf '\nerror: Ghostty integration lane requires prepared local artifacts.\n' >&2
+        exit 1
+    fi
+
+    printf '\nskip: Ghostty integration lane requires prepared local artifacts.\n' >&2
+    printf 'hint: run %s first, or set ALAN_REQUIRE_GHOSTTY_INTEGRATION=1 to fail instead of skip.\n' "$SETUP_SCRIPT" >&2
+    exit 0
+fi
+
+printf '%s\n' "$check_output"
+
+bash "$SCRIPT_DIR/test-terminal-runtime-service.sh"
+bash "$SCRIPT_DIR/test-terminal-surface-controller.sh"
+
+xcodebuild \
+    -project "$REPO_ROOT/clients/apple/alan-macos.xcodeproj" \
+    -scheme alan-macos \
+    -configuration Debug \
+    -destination "$DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    build

--- a/justfile
+++ b/justfile
@@ -68,6 +68,10 @@ dev-channel-smoke:
 apple-shell-automation-seams:
     bash clients/apple/scripts/test-shell-automation-command-seams.sh
 
+# Run Ghostty-backed macOS shell integration checks when local artifacts are prepared
+apple-shell-ghostty-integration:
+    bash clients/apple/scripts/test-shell-ghostty-integration.sh
+
 # Check release signing and notarization configuration without building
 release-check:
     ALAN_NOTARIZE=1 ./scripts/release-check.sh

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -19,7 +19,7 @@
 - [ ] 3.2 Add runtime service fake tests for text delivery, unavailable runtime, teardown, and metadata snapshots.
 - [ ] 3.3 Add control-plane tests for query/mutation success, malformed requests, missing targets, runtime unavailable, timeout, and IO diagnostics.
 - [ ] 3.4 Add App Intent routing tests using fake shell state and fake runtime outcomes.
-- [ ] 3.5 Add a Ghostty-enabled integration lane that runs only when local Ghostty artifacts are prepared.
+- [x] 3.5 Add a Ghostty-enabled integration lane that runs only when local Ghostty artifacts are prepared.
 
 ## 4. UI Smoke And Documentation
 


### PR DESCRIPTION
## Summary
- Add a Ghostty-backed shell integration script that checks local Ghostty links before running.
- Wire the lane into `just apple-shell-ghostty-integration` and document the command.
- Mark OpenSpec task 3.5 complete.

## Verification
- `bash clients/apple/scripts/test-shell-ghostty-integration.sh` with no local links: skipped with setup instructions
- `ALAN_REQUIRE_GHOSTTY_INTEGRATION=1 just apple-shell-ghostty-integration` with local Ghostty links: passed runtime service tests, terminal surface tests, and `alan-macos` Debug build
- `bash -n clients/apple/scripts/test-shell-ghostty-integration.sh`
- `openspec validate add-macos-shell-automation-tests --strict`
- `git diff --check`
- `git diff --cached --check`
