### PR TITLE
Route macOS shell automation through shared commands

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -26,8 +26,63 @@ private extension ShellContentStateSnapshot {
     }
 }
 
+private extension ShellAutomationCommandResultCode {
+    init(_ deliveryCode: TerminalRuntimeDeliveryCode) {
+        switch deliveryCode {
+        case .accepted:
+            self = .accepted
+        case .queued:
+            self = .queued
+        case .rejected:
+            self = .rejected
+        case .missingTarget:
+            self = .missingTarget
+        case .unavailableRuntime:
+            self = .runtimeUnavailable
+        case .timeout:
+            self = .timeout
+        }
+    }
+}
+
 @MainActor
-extension ShellHostController {
+extension ShellHostController: ShellAutomationCommandHandling {
+    func performShellAutomationCommand(
+        _ command: ShellAutomationCommand
+    ) -> ShellAutomationCommandResult {
+        switch command {
+        case .createTab(let request):
+            return performAutomationCreateTab(request)
+        case .splitPane(let request):
+            return performAutomationSplitPane(request)
+        case .focusPane(let paneID):
+            return performAutomationFocusPane(paneID: paneID)
+        case .closePane(let paneID):
+            return performAutomationClosePane(paneID: paneID)
+        case .closeTab(let tabID):
+            return performAutomationCloseTab(tabID: tabID)
+        case .sendText(let request):
+            return performAutomationSendText(request, requestID: nil)
+        case .readPaneSummary(let paneID):
+            guard let summary = shellState.automationPaneSummary(paneID: paneID) else {
+                return automationMissingTarget(
+                    paneID: paneID,
+                    errorCode: "pane_not_found",
+                    errorMessage: "The requested pane does not exist."
+                )
+            }
+            return ShellAutomationCommandResult(
+                code: .accepted,
+                summary: summary,
+                spaceID: summary.spaceID,
+                tabID: summary.tabID,
+                paneID: summary.paneID
+            )
+        case .activateAttentionItem(let paneID):
+            return performAutomationFocusPane(paneID: paneID, requestTerminalFocus: true)
+        }
+    }
+
     func attentionInboxRows() -> [AlanShellAttentionInboxItem] {
         attentionItems.map { item in
             AlanShellAttentionInboxItem(
@@ -220,6 +275,249 @@ extension ShellHostController {
         )
     }
 
+    private func performAutomationCreateTab(
+        _ request: ShellAutomationCreateTabRequest
+    ) -> ShellAutomationCommandResult {
+        if let spaceID = request.spaceID,
+           shellState.space(spaceID: spaceID) == nil
+        {
+            return ShellAutomationCommandResult(
+                code: .missingTarget,
+                summary: nil,
+                spaceID: spaceID,
+                errorCode: "space_not_found",
+                errorMessage: "The requested space does not exist."
+            )
+        }
+
+        let tabID: String?
+        switch request.launchTarget {
+        case .shell:
+            tabID = openTerminalTab(
+                in: request.spaceID,
+                title: request.title,
+                workingDirectory: request.workingDirectory
+            )
+        case .alan:
+            tabID = openAlanTab(
+                in: request.spaceID,
+                title: request.title,
+                workingDirectory: request.workingDirectory
+            )
+        }
+
+        guard let tabID else {
+            return ShellAutomationCommandResult(
+                code: .missingTarget,
+                summary: nil,
+                spaceID: request.spaceID,
+                errorCode: "space_not_found",
+                errorMessage: "The requested space does not exist."
+            )
+        }
+
+        return automationAccepted(tabID: tabID, paneID: shellState.focusedPaneID)
+    }
+
+    private func performAutomationSplitPane(
+        _ request: ShellAutomationPaneSplitRequest
+    ) -> ShellAutomationCommandResult {
+        guard pane(paneID: request.paneID) != nil else {
+            return automationMissingTarget(
+                paneID: request.paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
+        guard let newPaneID = splitPane(paneID: request.paneID, placement: request.placement) else {
+            return automationMissingTarget(
+                paneID: request.paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
+        return automationAccepted(paneID: newPaneID)
+    }
+
+    private func performAutomationFocusPane(
+        paneID: String,
+        requestTerminalFocus: Bool = false
+    ) -> ShellAutomationCommandResult {
+        guard pane(paneID: paneID) != nil else {
+            return automationMissingTarget(
+                paneID: paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        }
+        focus(paneID: paneID)
+        let focusedContent = shellState.contentStateProjection()
+            .terminalSendTextTarget(paneSlotID: paneID)?
+            .content
+        if requestTerminalFocus,
+           focusedContent?.kind == .terminal
+        {
+            terminalRuntimeRegistry.requestFocus(for: paneID)
+        }
+        return automationAccepted(paneID: paneID)
+    }
+
+    private func performAutomationClosePane(paneID: String) -> ShellAutomationCommandResult {
+        switch closePane(paneID: paneID) {
+        case .closed:
+            return automationAccepted(paneID: shellState.focusedPaneID)
+        case .paneNotFound:
+            return automationMissingTarget(
+                paneID: paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        case .lastTab:
+            return ShellAutomationCommandResult(
+                code: .lastTab,
+                summary: nil,
+                paneID: paneID,
+                errorCode: "last_tab",
+                errorMessage: "alan terminal workspace must keep at least one pane open."
+            )
+        }
+    }
+
+    private func performAutomationCloseTab(tabID: String) -> ShellAutomationCommandResult {
+        switch closeTab(tabID: tabID) {
+        case .closed:
+            return automationAccepted(paneID: shellState.focusedPaneID)
+        case .tabNotFound:
+            return automationMissingTarget(
+                tabID: tabID,
+                errorCode: "tab_not_found",
+                errorMessage: "The requested tab does not exist."
+            )
+        case .lastTab:
+            return ShellAutomationCommandResult(
+                code: .lastTab,
+                summary: nil,
+                tabID: tabID,
+                errorCode: "last_tab",
+                errorMessage: "alan terminal workspace must keep at least one tab open."
+            )
+        }
+    }
+
+    private func performAutomationSendText(
+        _ request: ShellAutomationSendTextRequest,
+        requestID: String?
+    ) -> ShellAutomationCommandResult {
+        let contentState = shellState.contentStateProjection()
+        guard let target = contentState.terminalSendTextTarget(paneSlotID: request.paneID) else {
+            return automationMissingTarget(
+                paneID: request.paneID,
+                errorCode: "pane_not_found",
+                errorMessage: "terminal.send_text requires an existing terminal content target."
+            )
+        }
+
+        guard target.content.kind == .terminal else {
+            let errorCode = "unsupported_content"
+            let errorMessage = "terminal.send_text requires terminal content."
+            controlPlane.recordContentCommandRejected(
+                requestID: requestID ?? "automation-\(UUID().uuidString)",
+                command: .terminalSendText,
+                spaceID: target.paneSlot.spaceID,
+                tabID: target.paneSlot.tabID,
+                paneSlotID: target.paneSlot.paneSlotID,
+                content: target.content,
+                errorCode: errorCode,
+                errorMessage: errorMessage
+            )
+            return ShellAutomationCommandResult(
+                code: .unsupportedContent,
+                summary: nil,
+                spaceID: target.paneSlot.spaceID,
+                tabID: target.paneSlot.tabID,
+                paneID: target.paneSlot.paneSlotID,
+                errorCode: errorCode,
+                errorMessage: errorMessage
+            )
+        }
+
+        let delivery = terminalRuntimeRegistry.sendText(
+            toTerminalContentID: target.content.contentID,
+            text: request.text
+        )
+        controlPlane.recordTextDelivery(
+            requestID: requestID ?? "automation-\(UUID().uuidString)",
+            spaceID: target.paneSlot.spaceID,
+            tabID: target.paneSlot.tabID,
+            paneID: target.paneSlot.paneSlotID,
+            contentID: target.content.contentID,
+            delivery: delivery
+        )
+        return ShellAutomationCommandResult(
+            code: ShellAutomationCommandResultCode(delivery.code),
+            summary: shellState.automationPaneSummary(paneID: target.paneSlot.paneSlotID),
+            spaceID: target.paneSlot.spaceID,
+            tabID: target.paneSlot.tabID,
+            paneID: target.paneSlot.paneSlotID,
+            acceptedBytes: delivery.acceptedBytes,
+            deliveryCode: delivery.code.rawValue,
+            runtimePhase: delivery.runtimePhase,
+            errorCode: delivery.errorCode,
+            errorMessage: delivery.errorMessage
+        )
+    }
+
+    private func automationAccepted(
+        tabID: String? = nil,
+        paneID: String?
+    ) -> ShellAutomationCommandResult {
+        let summary = paneID.flatMap { shellState.automationPaneSummary(paneID: $0) }
+        return ShellAutomationCommandResult(
+            code: .accepted,
+            summary: summary,
+            spaceID: summary?.spaceID ?? shellState.focusedSpaceID,
+            tabID: tabID ?? summary?.tabID ?? shellState.focusedTabID,
+            paneID: paneID
+        )
+    }
+
+    private func automationMissingTarget(
+        tabID: String? = nil,
+        paneID: String? = nil,
+        errorCode: String,
+        errorMessage: String
+    ) -> ShellAutomationCommandResult {
+        ShellAutomationCommandResult(
+            code: .missingTarget,
+            summary: nil,
+            tabID: tabID,
+            paneID: paneID,
+            errorCode: errorCode,
+            errorMessage: errorMessage
+        )
+    }
+
+    private func controlResponse(
+        for result: ShellAutomationCommandResult,
+        requestID: String,
+        state: ShellStateSnapshot? = nil
+    ) -> AlanShellControlResponse {
+        response(
+            requestID: requestID,
+            applied: result.applied,
+            state: state,
+            spaceID: result.spaceID,
+            tabID: result.tabID,
+            paneID: result.paneID,
+            paneSlotID: result.paneID,
+            acceptedBytes: result.acceptedBytes,
+            deliveryCode: result.deliveryCode,
+            runtimePhase: result.runtimePhase,
+            errorCode: result.errorCode,
+            errorMessage: result.errorMessage
+        )
+    }
+
     func handleControlPlaneCommand(_ command: AlanShellControlCommand) -> AlanShellControlResponse {
         switch command.command {
         case .state:
@@ -273,26 +571,17 @@ extension ShellHostController {
             )
 
         case .tabOpen:
-            guard let tabID = openTerminalTab(
-                in: command.spaceID,
-                title: command.title,
-                workingDirectory: command.cwd
-            ) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    spaceID: command.spaceID,
-                    errorCode: "space_not_found",
-                    errorMessage: "The requested space does not exist."
+            let result = performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .shell,
+                        spaceID: command.spaceID,
+                        title: command.title,
+                        workingDirectory: command.cwd
+                    )
                 )
-            }
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: tabID,
-                paneID: shellState.focusedPaneID
             )
+            return controlResponse(for: result, requestID: command.requestID)
 
         case .tabClose:
             guard let tabID = command.tabID else {
@@ -304,31 +593,8 @@ extension ShellHostController {
                 )
             }
 
-            switch closeTab(tabID: tabID) {
-            case .closed:
-                return response(
-                    requestID: command.requestID,
-                    applied: true,
-                    tabID: tabID,
-                    paneID: shellState.focusedPaneID
-                )
-            case .tabNotFound:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: tabID,
-                    errorCode: "tab_not_found",
-                    errorMessage: "The requested tab does not exist."
-                )
-            case .lastTab:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    tabID: tabID,
-                    errorCode: "last_tab",
-                    errorMessage: "alan terminal workspace must keep at least one tab open."
-                )
-            }
+            let result = performShellAutomationCommand(.closeTab(tabID: tabID))
+            return controlResponse(for: result, requestID: command.requestID)
 
         case .tabPin:
             let tabID = command.tabID ?? selectedTabID
@@ -530,23 +796,18 @@ extension ShellHostController {
                     errorMessage: "direction is required for pane.split."
                 )
             }
-            guard let newPaneID = splitPane(paneID: paneID, direction: direction) else {
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
+            let result = performShellAutomationCommand(
+                .splitPane(
+                    ShellAutomationPaneSplitRequest(
+                        paneID: paneID,
+                        placement: .defaultPlacement(for: direction)
+                    )
                 )
-            }
-            return response(
+            )
+            return controlResponse(
+                for: result,
                 requestID: command.requestID,
-                applied: true,
-                state: shellState,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: newPaneID,
-                paneSlotID: newPaneID
+                state: result.applied ? shellState : nil
             )
 
         case .paneClose:
@@ -559,32 +820,8 @@ extension ShellHostController {
                 )
             }
 
-            switch closePane(paneID: paneID) {
-            case .closed:
-                return response(
-                    requestID: command.requestID,
-                    applied: true,
-                    spaceID: shellState.focusedSpaceID,
-                    tabID: shellState.focusedTabID,
-                    paneID: shellState.focusedPaneID
-                )
-            case .paneNotFound:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
-                )
-            case .lastTab:
-                return response(
-                    requestID: command.requestID,
-                    applied: false,
-                    paneID: paneID,
-                    errorCode: "last_tab",
-                    errorMessage: "alan terminal workspace must keep at least one pane open."
-                )
-            }
+            let result = performShellAutomationCommand(.closePane(paneID: paneID))
+            return controlResponse(for: result, requestID: command.requestID)
 
         case .paneLift:
             guard let paneID = command.paneID else {
@@ -666,26 +903,18 @@ extension ShellHostController {
             return handlePaneMoveWithinTabCommand(command)
 
         case .paneFocus:
-            guard let paneID = command.paneID,
-                  shellState.panes.contains(where: { $0.paneID == paneID })
-            else {
+            guard let paneID = command.paneID else {
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     paneID: command.paneID,
-                    errorCode: "pane_not_found",
-                    errorMessage: "The requested pane does not exist."
+                    errorCode: "pane_required",
+                    errorMessage: "pane_id is required."
                 )
             }
 
-            focus(paneID: paneID)
-            return response(
-                requestID: command.requestID,
-                applied: true,
-                spaceID: shellState.focusedSpaceID,
-                tabID: shellState.focusedTabID,
-                paneID: paneID
-            )
+            let result = performShellAutomationCommand(.focusPane(paneID: paneID))
+            return controlResponse(for: result, requestID: command.requestID)
 
         case .paneSpatialFocus:
             return handlePaneSpatialFocusCommand(command)
@@ -703,6 +932,23 @@ extension ShellHostController {
             return handlePaneUnzoomCommand(command)
 
         case .terminalSendText:
+            if command.contentID == nil {
+                guard let paneID = command.paneSlotID ?? command.paneID else {
+                    return response(
+                        requestID: command.requestID,
+                        applied: false,
+                        errorCode: "terminal_target_required",
+                        errorMessage: "terminal.send_text requires an existing terminal content target."
+                    )
+                }
+
+                let result = performAutomationSendText(
+                    ShellAutomationSendTextRequest(paneID: paneID, text: command.text ?? ""),
+                    requestID: command.requestID
+                )
+                return controlResponse(for: result, requestID: command.requestID)
+            }
+
             let contentState = shellState.contentStateProjection()
             let requestedPaneSlotID = command.paneSlotID ?? command.paneID
             let target: TerminalSendTextTarget?

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -50,6 +50,7 @@ struct ShellAutomationCommandResult: Equatable {
     let paneID: String?
     let acceptedBytes: Int?
     let deliveryCode: String?
+    let runtimePhase: String?
     let errorCode: String?
     let errorMessage: String?
 
@@ -61,6 +62,7 @@ struct ShellAutomationCommandResult: Equatable {
         paneID: String? = nil,
         acceptedBytes: Int? = nil,
         deliveryCode: String? = nil,
+        runtimePhase: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) {
@@ -71,6 +73,7 @@ struct ShellAutomationCommandResult: Equatable {
         self.paneID = paneID
         self.acceptedBytes = acceptedBytes
         self.deliveryCode = deliveryCode
+        self.runtimePhase = runtimePhase
         self.errorCode = errorCode
         self.errorMessage = errorMessage
     }

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1222,17 +1222,35 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func performShellWorkspaceCommand(_ command: ShellWorkspaceCommand) -> Bool {
         switch command {
         case .newTerminalTab:
-            return openTerminalTab() != nil
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .shell,
+                        spaceID: nil,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .newAlanTab:
-            return openAlanTab() != nil
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: .alan,
+                        spaceID: nil,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .splitLeft:
-            return splitFocusedPane(placement: .left) != nil
+            return performFocusedPaneSplit(placement: .left)
         case .splitRight:
-            return splitFocusedPane(placement: .right) != nil
+            return performFocusedPaneSplit(placement: .right)
         case .splitUp:
-            return splitFocusedPane(placement: .up) != nil
+            return performFocusedPaneSplit(placement: .up)
         case .splitDown:
-            return splitFocusedPane(placement: .down) != nil
+            return performFocusedPaneSplit(placement: .down)
         case .focusLeft:
             return focusAdjacentPane(direction: .left)
         case .focusRight:
@@ -1254,9 +1272,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .movePaneDown:
             return moveSelectedPaneWithinTab(.down)
         case .closePane:
-            return closeSelectedPane()
+            guard let paneID = selectedPane?.paneID else { return false }
+            return performShellAutomationCommand(.closePane(paneID: paneID)).applied
         case .closeTab:
-            return closeSelectedTab()
+            guard let tabID = selectedTabID else { return false }
+            return performShellAutomationCommand(.closeTab(tabID: tabID)).applied
         case .quickTerminalToggle:
             return toggleQuickTerminal() != nil
         case .quickTerminalShow:
@@ -1268,6 +1288,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .quickTerminalClose:
             return closeQuickTerminal()
         }
+    }
+
+    @discardableResult
+    private func performFocusedPaneSplit(placement: ShellPaneSplitDirection) -> Bool {
+        guard let paneID = shellState.focusedPaneID else { return false }
+        return performShellAutomationCommand(
+            .splitPane(ShellAutomationPaneSplitRequest(paneID: paneID, placement: placement))
+        ).applied
     }
 
     func shellActionTitle(_ id: ShellActionID) -> String {
@@ -1314,18 +1342,22 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         case .workspaceCommand(let command):
             return performShellWorkspaceCommand(command)
         case .openTab(let launchTarget, let spaceID):
-            switch launchTarget {
-            case .shell:
-                return openTerminalTab(in: spaceID) != nil
-            case .alan:
-                return openAlanTab(in: spaceID) != nil
-            }
+            return performShellAutomationCommand(
+                .createTab(
+                    ShellAutomationCreateTabRequest(
+                        launchTarget: launchTarget,
+                        spaceID: spaceID,
+                        title: nil,
+                        workingDirectory: nil
+                    )
+                )
+            ).applied
         case .closeTab(let tabID):
-            guard let tabID else { return closeSelectedTab() }
-            return closeTab(tabID: tabID) == .closed
+            guard let tabID = tabID ?? selectedTabID else { return false }
+            return performShellAutomationCommand(.closeTab(tabID: tabID)).applied
         case .closePane(let paneID):
-            guard let paneID else { return closeSelectedPane() }
-            return closePane(paneID: paneID) == .closed
+            guard let paneID = paneID ?? selectedPane?.paneID else { return false }
+            return performShellAutomationCommand(.closePane(paneID: paneID)).applied
         case .selectAdjacentTab(let offset):
             return selectAdjacentTab(offset: offset)
         case .selectAdjacentSpace(let offset):

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -13,6 +13,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -35,6 +35,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalLifecycleShutdownFinalizesAllRuntimes()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
+        verifiesAutomationCommandsRouteThroughHostController()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
         verifiesOpeningTerminalTabHonorsExplicitCwd()
         verifiesQuickTerminalShowCreatesAndReusesGlobalPane()
@@ -1107,6 +1108,93 @@ private enum ShellRuntimeMetadataTests {
         expect(
             controller.selectedPane?.cwd == "/repo/app",
             "registry new-terminal action must inherit the focused pane runtime cwd"
+        )
+    }
+
+    private static func verifiesAutomationCommandsRouteThroughHostController() {
+        let controller = makeController()
+        let handler: ShellAutomationCommandHandling = controller
+
+        let createResult = handler.performShellAutomationCommand(
+            .createTab(
+                ShellAutomationCreateTabRequest(
+                    launchTarget: .shell,
+                    spaceID: controller.selectedSpaceID,
+                    title: "Automation",
+                    workingDirectory: "/automation/cwd"
+                )
+            )
+        )
+        guard let createdPaneID = createResult.paneID,
+              let createdTabID = createResult.tabID
+        else {
+            fail("automation create-tab command must return created tab and pane context")
+        }
+        expect(createResult.code == .accepted, "automation create-tab command must apply")
+        expect(
+            controller.selectedPane?.cwd == "/automation/cwd",
+            "automation create-tab command must route through host tab creation"
+        )
+
+        let splitResult = handler.performShellAutomationCommand(
+            .splitPane(ShellAutomationPaneSplitRequest(paneID: createdPaneID, placement: .right))
+        )
+        guard let splitPaneID = splitResult.paneID else {
+            fail("automation split command must return the new pane")
+        }
+        expect(splitResult.code == .accepted, "automation split command must apply")
+        expect(
+            controller.selectedPane?.paneID == splitPaneID,
+            "automation split command must route through host pane splitting"
+        )
+
+        let focusResult = handler.performShellAutomationCommand(.focusPane(paneID: createdPaneID))
+        expect(focusResult.code == .accepted, "automation focus command must apply")
+        expect(
+            controller.selectedPane?.paneID == createdPaneID,
+            "automation focus command must route through host focus"
+        )
+
+        let terminalHandle = fakeSurfaceHandle(for: createdPaneID, controller: controller)
+        let text = "printf automation\\n"
+        let sendResult = handler.performShellAutomationCommand(
+            .sendText(ShellAutomationSendTextRequest(paneID: createdPaneID, text: text))
+        )
+        expect(sendResult.code == .accepted, "automation send-text command must apply")
+        expect(
+            sendResult.acceptedBytes == text.lengthOfBytes(using: .utf8),
+            "automation send-text command must report accepted bytes"
+        )
+        expect(
+            terminalHandle.deliveredText == [text],
+            "automation send-text command must route through terminal runtime delivery"
+        )
+
+        let summaryResult = handler.performShellAutomationCommand(.readPaneSummary(paneID: createdPaneID))
+        expect(summaryResult.code == .accepted, "automation summary command must apply")
+        expect(
+            summaryResult.summary?.paneID == createdPaneID,
+            "automation summary command must return safe pane metadata"
+        )
+
+        let closePaneResult = handler.performShellAutomationCommand(.closePane(paneID: splitPaneID))
+        expect(closePaneResult.code == .accepted, "automation close-pane command must apply")
+        expect(
+            controller.pane(paneID: splitPaneID) == nil,
+            "automation close-pane command must route through host pane close"
+        )
+
+        let closeTabResult = handler.performShellAutomationCommand(.closeTab(tabID: createdTabID))
+        expect(closeTabResult.code == .accepted, "automation close-tab command must apply")
+        expect(
+            controller.shellState.tab(tabID: createdTabID) == nil,
+            "automation close-tab command must route through host tab close"
+        )
+
+        let missingResult = handler.performShellAutomationCommand(.focusPane(paneID: "missing"))
+        expect(
+            missingResult.code == .missingTarget && missingResult.errorCode == "pane_not_found",
+            "automation commands must preserve stable missing-target semantics"
         )
     }
 

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Shared Command And Test Seams
 
 - [x] 1.1 Define shared shell command interfaces for create tab, split, focus, close, send text, read summary, and attention activation.
-- [ ] 1.2 Route existing shell controller, control-plane, menu, and command UI paths through the shared command interface where practical.
+- [x] 1.2 Route existing shell controller, control-plane, menu, and command UI paths through the shared command interface where practical.
 - [x] 1.3 Add fake shell controller/runtime fixtures for command, intent, and control-plane tests.
 - [x] 1.4 Add privacy-safe summary helpers for pane/tab/window metadata.
 


### PR DESCRIPTION
Summary
- Makes `ShellHostController` implement `ShellAutomationCommandHandling` for create tab, split pane, focus pane, close pane/tab, send text, read pane summary, and attention activation.
- Routes menu/keyboard workspace actions and matching control-plane commands through the shared automation command path where practical.
- Preserves control-plane content-id send-text handling while sharing pane-targeted send-text semantics.
- Adds focused runtime metadata coverage for the production automation handler and marks OpenSpec task 1.2 complete.

Validation
- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
- `bash clients/apple/scripts/test-shell-automation-command-seams.sh`
- `bash clients/apple/scripts/check-shell-action-registry-integration.sh`
- `git diff --check`
- `openspec validate add-macos-shell-automation-tests --strict`

Known baseline note
- `bash clients/apple/scripts/check-shell-contracts.sh` still fails on the current `main` baseline because the script expects `window.isMovableByWindowBackground = true` while the accepted tab/space drag fix changed the code to `false`. PR #500 already carries the matching contract update, so this PR keeps the 1.2 routing scope separate.