### PR TITLE
Add macOS shell App Intents

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		000000000000000000000042 /* Services/Shell/ShellContentRenderingRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */; };
 		000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */; };
 		000000000000000000000044 /* Models/Shell/ShellAutomationEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */; };
+		000000000000000000000045 /* Models/Shell/ShellAutomationIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -135,6 +136,7 @@
 		000000000000000000000142 /* Services/Shell/ShellContentRenderingRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellContentRenderingRegistry.swift; sourceTree = "<group>"; };
 		000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationCommand.swift; sourceTree = "<group>"; };
 		000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationEntities.swift; sourceTree = "<group>"; };
+		000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellAutomationIntents.swift; sourceTree = "<group>"; };
 		000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/Console/AlanConsoleViewModel.swift; sourceTree = "<group>"; };
 		000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/Console/ConsoleSupportViews.swift; sourceTree = "<group>"; };
 		000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ConsoleAdaptiveColor.swift; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 				00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */,
 				000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */,
 				000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */,
+				000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */,
 			);
 			name = Models/Shell;
 			sourceTree = "<group>";
@@ -478,6 +481,7 @@
 				00000000000000000000003E /* Models/Shell/ShellActionRegistry.swift in Sources */,
 				000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */,
 				000000000000000000000044 /* Models/Shell/ShellAutomationEntities.swift in Sources */,
+				000000000000000000000045 /* Models/Shell/ShellAutomationIntents.swift in Sources */,
 				000000000000000000000025 /* Services/Shell/ShellPaneProjectionService.swift in Sources */,
 				000000000000000000000026 /* Services/Shell/ShellStatePersistenceStore.swift in Sources */,
 				000000000000000000000027 /* Services/Terminal/TerminalHostRuntimeReporter.swift in Sources */,

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -32,7 +32,7 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
             resolvedHost?.shellState
         })
         ShellAutomationIntentStore.install(
-            commandHandler: resolvedHost as? ShellAutomationCommandHandling
+            commandHandler: resolvedHost
         )
         #endif
         host = resolvedHost

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -31,6 +31,9 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
         ShellAutomationEntityStore.install(snapshotProvider: { [weak resolvedHost] in
             resolvedHost?.shellState
         })
+        ShellAutomationIntentStore.install(
+            commandHandler: resolvedHost as? ShellAutomationCommandHandling
+        )
         #endif
         host = resolvedHost
         quickTerminalPeakWindow = peakWindow

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
@@ -27,6 +27,12 @@ struct ShellAutomationIntentOutcome: Equatable, Sendable {
         dialog = ShellAutomationIntentOutcome.dialog(for: command, result: result)
     }
 
+    func requireSuccessfulIntentResult() throws {
+        guard code == .accepted else {
+            throw ShellAutomationIntentError(code: code, dialog: dialog)
+        }
+    }
+
     private static func dialog(
         for command: ShellAutomationCommand,
         result: ShellAutomationCommandResult
@@ -92,6 +98,15 @@ struct ShellAutomationIntentOutcome: Equatable, Sendable {
         let byteSuffix = result?.acceptedBytes.map { " (\($0) bytes)" } ?? ""
         let codeSuffix = result?.deliveryCode.map { " [\($0)]" } ?? ""
         return "\(prefix)\(byteSuffix)\(codeSuffix)."
+    }
+}
+
+struct ShellAutomationIntentError: LocalizedError, Equatable {
+    let code: ShellAutomationCommandResultCode
+    let dialog: String
+
+    var errorDescription: String? {
+        dialog
     }
 }
 
@@ -244,7 +259,7 @@ struct AlanCreateTerminalTabIntent: AppIntent {
             title: tabTitle,
             workingDirectory: workingDirectory
         )
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -268,7 +283,7 @@ struct AlanCreateAlanTabIntent: AppIntent {
             title: tabTitle,
             workingDirectory: workingDirectory
         )
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -288,7 +303,7 @@ struct AlanSplitPaneIntent: AppIntent {
             pane,
             direction: direction.shellDirection
         )
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -302,7 +317,7 @@ struct AlanFocusPaneIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.focusPane(pane)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -316,7 +331,7 @@ struct AlanClosePaneIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.closePane(pane)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -330,7 +345,7 @@ struct AlanCloseTabIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.closeTab(tab)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -347,7 +362,7 @@ struct AlanSendTextToPaneIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.sendText(text, to: pane)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -361,7 +376,7 @@ struct AlanReadPaneSummaryIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.readPaneSummary(for: pane)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
 }
 
@@ -375,8 +390,16 @@ struct AlanOpenAttentionItemIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.openAttentionItem(item)
-        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+        return try shellAutomationIntentResult(outcome)
     }
+}
+
+@available(macOS 13.0, *)
+private func shellAutomationIntentResult(
+    _ outcome: ShellAutomationIntentOutcome
+) throws -> some IntentResult & ProvidesDialog {
+    try outcome.requireSuccessfulIntentResult()
+    return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
 }
 
 private func shellAutomationIntentDialog(_ text: String) -> IntentDialog {

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+#if os(macOS) && canImport(AppIntents)
+import AppIntents
+
+enum ShellAutomationIntentAvailability {
+    static let minimumSupportedMacOS = "macOS 13.0"
+    static let fallbackDescription =
+        "When App Intents are unavailable, use alan's shell control plane or native shell UI commands."
+}
+
+struct ShellAutomationIntentOutcome: Equatable, Sendable {
+    let code: ShellAutomationCommandResultCode
+    let dialog: String
+    let summary: ShellAutomationPaneSummary?
+    let acceptedBytes: Int?
+    let deliveryCode: String?
+
+    init(
+        command: ShellAutomationCommand,
+        result: ShellAutomationCommandResult
+    ) {
+        code = result.code
+        summary = result.summary
+        acceptedBytes = result.acceptedBytes
+        deliveryCode = result.deliveryCode
+        dialog = ShellAutomationIntentOutcome.dialog(for: command, result: result)
+    }
+
+    private static func dialog(
+        for command: ShellAutomationCommand,
+        result: ShellAutomationCommandResult
+    ) -> String {
+        switch result.code {
+        case .accepted:
+            return acceptedDialog(for: command, summary: result.summary)
+        case .queued:
+            return deliveryDialog(prefix: "Text delivery queued", result: result)
+        case .rejected:
+            return "Command rejected."
+        case .missingTarget:
+            return "Missing shell target."
+        case .invalidRequest:
+            return "Invalid shell request."
+        case .unsupportedContent:
+            return "Unsupported shell content."
+        case .runtimeUnavailable:
+            return "Terminal runtime unavailable."
+        case .timeout:
+            return "Shell command timed out."
+        case .lastPane:
+            return "Cannot close the last pane."
+        case .lastTab:
+            return "Cannot close the last tab."
+        }
+    }
+
+    private static func acceptedDialog(
+        for command: ShellAutomationCommand,
+        summary: ShellAutomationPaneSummary?
+    ) -> String {
+        let safeSummary = summary.map { ": \($0.displayText)" } ?? "."
+        switch command {
+        case let .createTab(request):
+            switch request.launchTarget {
+            case .shell:
+                return "Created terminal tab\(safeSummary)"
+            case .alan:
+                return "Created alan tab\(safeSummary)"
+            }
+        case .splitPane:
+            return "Split pane\(safeSummary)"
+        case .focusPane:
+            return "Focused pane\(safeSummary)"
+        case .closePane:
+            return "Closed pane."
+        case .closeTab:
+            return "Closed tab."
+        case .sendText:
+            return deliveryDialog(prefix: "Text delivery accepted", result: nil)
+        case .readPaneSummary:
+            return "Pane summary\(safeSummary)"
+        case .activateAttentionItem:
+            return "Opened attention item\(safeSummary)"
+        }
+    }
+
+    private static func deliveryDialog(
+        prefix: String,
+        result: ShellAutomationCommandResult?
+    ) -> String {
+        let byteSuffix = result?.acceptedBytes.map { " (\($0) bytes)" } ?? ""
+        let codeSuffix = result?.deliveryCode.map { " [\($0)]" } ?? ""
+        return "\(prefix)\(byteSuffix)\(codeSuffix)."
+    }
+}
+
+@MainActor
+enum ShellAutomationIntentStore {
+    private static var commandHandler: ShellAutomationCommandHandling?
+
+    static func install(commandHandler: ShellAutomationCommandHandling?) {
+        self.commandHandler = commandHandler
+    }
+
+    static func reset() {
+        commandHandler = nil
+    }
+
+    static func perform(_ command: ShellAutomationCommand) -> ShellAutomationCommandResult {
+        guard let commandHandler else {
+            return ShellAutomationCommandResult(
+                code: .runtimeUnavailable,
+                summary: nil,
+                errorCode: "intent_handler_unavailable",
+                errorMessage: "Shell automation command handler unavailable"
+            )
+        }
+        return commandHandler.performShellAutomationCommand(command)
+    }
+}
+
+@MainActor
+enum ShellAutomationIntentRouter {
+    static func createTerminalTab(
+        spaceID: String? = nil,
+        title: String? = nil,
+        workingDirectory: String? = nil
+    ) -> ShellAutomationIntentOutcome {
+        perform(.createTab(ShellAutomationCreateTabRequest(
+            launchTarget: .shell,
+            spaceID: spaceID,
+            title: title,
+            workingDirectory: workingDirectory
+        )))
+    }
+
+    static func createAlanTab(
+        spaceID: String? = nil,
+        title: String? = nil,
+        workingDirectory: String? = nil
+    ) -> ShellAutomationIntentOutcome {
+        perform(.createTab(ShellAutomationCreateTabRequest(
+            launchTarget: .alan,
+            spaceID: spaceID,
+            title: title,
+            workingDirectory: workingDirectory
+        )))
+    }
+
+    static func splitPane(
+        _ pane: AlanShellPaneEntity,
+        direction: ShellPaneSplitDirection
+    ) -> ShellAutomationIntentOutcome {
+        perform(.splitPane(ShellAutomationPaneSplitRequest(
+            paneID: pane.id,
+            placement: direction
+        )))
+    }
+
+    static func focusPane(_ pane: AlanShellPaneEntity) -> ShellAutomationIntentOutcome {
+        perform(.focusPane(paneID: pane.id))
+    }
+
+    static func closePane(_ pane: AlanShellPaneEntity) -> ShellAutomationIntentOutcome {
+        perform(.closePane(paneID: pane.id))
+    }
+
+    static func closeTab(_ tab: AlanShellTabEntity) -> ShellAutomationIntentOutcome {
+        perform(.closeTab(tabID: tab.id))
+    }
+
+    static func sendText(
+        _ text: String,
+        to pane: AlanShellPaneEntity
+    ) -> ShellAutomationIntentOutcome {
+        perform(.sendText(ShellAutomationSendTextRequest(paneID: pane.id, text: text)))
+    }
+
+    static func readPaneSummary(for pane: AlanShellPaneEntity) -> ShellAutomationIntentOutcome {
+        perform(.readPaneSummary(paneID: pane.id))
+    }
+
+    static func openAttentionItem(
+        _ attentionItem: AlanShellAttentionItemEntity
+    ) -> ShellAutomationIntentOutcome {
+        perform(.activateAttentionItem(paneID: attentionItem.paneID))
+    }
+
+    private static func perform(_ command: ShellAutomationCommand) -> ShellAutomationIntentOutcome {
+        ShellAutomationIntentOutcome(
+            command: command,
+            result: ShellAutomationIntentStore.perform(command)
+        )
+    }
+}
+
+@available(macOS 13.0, *)
+enum AlanShellPaneSplitDirectionOption: String, AppEnum {
+    case left
+    case right
+    case up
+    case down
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Split Direction")
+    static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .left: "Left",
+        .right: "Right",
+        .up: "Up",
+        .down: "Down",
+    ]
+
+    var shellDirection: ShellPaneSplitDirection {
+        switch self {
+        case .left:
+            return .left
+        case .right:
+            return .right
+        case .up:
+            return .up
+        case .down:
+            return .down
+        }
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanCreateTerminalTabIntent: AppIntent {
+    static var title: LocalizedStringResource = "Create Terminal Tab"
+    static var description = IntentDescription("Create a terminal tab in alan.")
+
+    @Parameter(title: "Space")
+    var space: AlanShellSpaceEntity?
+
+    @Parameter(title: "Title")
+    var tabTitle: String?
+
+    @Parameter(title: "Working Directory")
+    var workingDirectory: String?
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.createTerminalTab(
+            spaceID: space?.id,
+            title: tabTitle,
+            workingDirectory: workingDirectory
+        )
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanCreateAlanTabIntent: AppIntent {
+    static var title: LocalizedStringResource = "Create Alan Tab"
+    static var description = IntentDescription("Create an alan tab in alan.")
+
+    @Parameter(title: "Space")
+    var space: AlanShellSpaceEntity?
+
+    @Parameter(title: "Title")
+    var tabTitle: String?
+
+    @Parameter(title: "Working Directory")
+    var workingDirectory: String?
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.createAlanTab(
+            spaceID: space?.id,
+            title: tabTitle,
+            workingDirectory: workingDirectory
+        )
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanSplitPaneIntent: AppIntent {
+    static var title: LocalizedStringResource = "Split Shell Pane"
+    static var description = IntentDescription("Split an alan shell pane.")
+
+    @Parameter(title: "Pane")
+    var pane: AlanShellPaneEntity
+
+    @Parameter(title: "Direction")
+    var direction: AlanShellPaneSplitDirectionOption
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.splitPane(
+            pane,
+            direction: direction.shellDirection
+        )
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanFocusPaneIntent: AppIntent {
+    static var title: LocalizedStringResource = "Focus Shell Pane"
+    static var description = IntentDescription("Focus an alan shell pane.")
+
+    @Parameter(title: "Pane")
+    var pane: AlanShellPaneEntity
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.focusPane(pane)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanClosePaneIntent: AppIntent {
+    static var title: LocalizedStringResource = "Close Shell Pane"
+    static var description = IntentDescription("Close an alan shell pane.")
+
+    @Parameter(title: "Pane")
+    var pane: AlanShellPaneEntity
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.closePane(pane)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanCloseTabIntent: AppIntent {
+    static var title: LocalizedStringResource = "Close Shell Tab"
+    static var description = IntentDescription("Close an alan shell tab.")
+
+    @Parameter(title: "Tab")
+    var tab: AlanShellTabEntity
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.closeTab(tab)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanSendTextToPaneIntent: AppIntent {
+    static var title: LocalizedStringResource = "Send Text To Shell Pane"
+    static var description = IntentDescription("Send text to an alan shell pane.")
+
+    @Parameter(title: "Pane")
+    var pane: AlanShellPaneEntity
+
+    @Parameter(title: "Text")
+    var text: String
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.sendText(text, to: pane)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanReadPaneSummaryIntent: AppIntent {
+    static var title: LocalizedStringResource = "Read Shell Pane Summary"
+    static var description = IntentDescription("Read safe metadata for an alan shell pane.")
+
+    @Parameter(title: "Pane")
+    var pane: AlanShellPaneEntity
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.readPaneSummary(for: pane)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+@available(macOS 13.0, *)
+struct AlanOpenAttentionItemIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Shell Attention Item"
+    static var description = IntentDescription("Open an alan shell attention item.")
+
+    @Parameter(title: "Attention Item")
+    var item: AlanShellAttentionItemEntity
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let outcome = await ShellAutomationIntentRouter.openAttentionItem(item)
+        return .result(dialog: shellAutomationIntentDialog(outcome.dialog))
+    }
+}
+
+private func shellAutomationIntentDialog(_ text: String) -> IntentDialog {
+    "\(text)"
+}
+#endif

--- a/clients/apple/scripts/test-shell-automation-command-seams.sh
+++ b/clients/apple/scripts/test-shell-automation-command-seams.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationEntities.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift" \
     "$REPO_ROOT/clients/apple/scripts/shell-automation-test-fixtures.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-automation-command-seams.swift" \
     -o "$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-automation-command-seams.swift
+++ b/clients/apple/scripts/test-shell-automation-command-seams.swift
@@ -20,6 +20,10 @@ private enum ShellAutomationCommandSeamsTests {
         verifiesMissingPaneSummaryReturnsNil()
         verifiesAppEntityProjectionUsesSafeDisplayNames()
         await verifiesAppEntityQueriesReadActiveSnapshotState()
+        verifiesAppIntentRoutingUsesFakeCommandHandler()
+        verifiesAppIntentOutcomeAlignsWithCommandResultCategories()
+        verifiesAppIntentDialogRedactsSubmittedTextAndRawTargets()
+        verifiesAppIntentAvailabilityDocumentsFallback()
         print("Shell automation command seam tests passed.")
     }
 
@@ -305,6 +309,189 @@ private enum ShellAutomationCommandSeamsTests {
         } catch {
             fail("entity query failed: \(error)")
         }
+    }
+
+    private static func verifiesAppIntentRoutingUsesFakeCommandHandler() {
+        let summary = sampleSummary()
+        let pane = AlanShellPaneEntity(summary: summary, isFocused: true)
+        let attentionItem = AlanShellAttentionItemEntity(pane: pane)
+        let handler = FakeShellAutomationCommandHandler { command in
+            switch command {
+            case .createTab:
+                return ShellAutomationCommandResult(
+                    code: .accepted,
+                    summary: summary,
+                    spaceID: summary.spaceID,
+                    tabID: summary.tabID,
+                    paneID: summary.paneID
+                )
+            case .sendText:
+                return ShellAutomationCommandResult(
+                    code: .queued,
+                    summary: nil,
+                    paneID: summary.paneID,
+                    acceptedBytes: 11,
+                    deliveryCode: "queued"
+                )
+            default:
+                return ShellAutomationCommandResult(code: .accepted, summary: summary)
+            }
+        }
+
+        ShellAutomationIntentStore.install(commandHandler: handler)
+        defer { ShellAutomationIntentStore.reset() }
+
+        _ = ShellAutomationIntentRouter.createTerminalTab(
+            spaceID: "space_main",
+            title: "Shell",
+            workingDirectory: "/Users/morris/Developer/alan"
+        )
+        _ = ShellAutomationIntentRouter.createAlanTab(spaceID: "space_main", title: "alan")
+        _ = ShellAutomationIntentRouter.splitPane(pane, direction: .right)
+        _ = ShellAutomationIntentRouter.focusPane(pane)
+        _ = ShellAutomationIntentRouter.closePane(pane)
+        _ = ShellAutomationIntentRouter.closeTab(AlanShellTabEntity(
+            id: summary.tabID,
+            windowID: summary.windowID,
+            spaceID: summary.spaceID,
+            spaceTitle: summary.spaceTitle,
+            displayTitle: summary.tabTitle,
+            displaySubtitle: nil,
+            kind: ShellTabKind.terminal.rawValue,
+            isPinned: false,
+            isFocused: true
+        ))
+        _ = ShellAutomationIntentRouter.sendText("pwd\n", to: pane)
+        _ = ShellAutomationIntentRouter.readPaneSummary(for: pane)
+        _ = ShellAutomationIntentRouter.openAttentionItem(attentionItem)
+
+        expect(
+            handler.recordedCommands == [
+                .createTab(ShellAutomationCreateTabRequest(
+                    launchTarget: .shell,
+                    spaceID: "space_main",
+                    title: "Shell",
+                    workingDirectory: "/Users/morris/Developer/alan"
+                )),
+                .createTab(ShellAutomationCreateTabRequest(
+                    launchTarget: .alan,
+                    spaceID: "space_main",
+                    title: "alan",
+                    workingDirectory: nil
+                )),
+                .splitPane(ShellAutomationPaneSplitRequest(paneID: summary.paneID, placement: .right)),
+                .focusPane(paneID: summary.paneID),
+                .closePane(paneID: summary.paneID),
+                .closeTab(tabID: summary.tabID),
+                .sendText(ShellAutomationSendTextRequest(paneID: summary.paneID, text: "pwd\n")),
+                .readPaneSummary(paneID: summary.paneID),
+                .activateAttentionItem(paneID: summary.paneID),
+            ],
+            "App Intent router must call the shared shell automation command surface"
+        )
+    }
+
+    private static func verifiesAppIntentOutcomeAlignsWithCommandResultCategories() {
+        let missing = ShellAutomationIntentOutcome(
+            command: .focusPane(paneID: "pane_missing"),
+            result: ShellAutomationCommandResult(
+                code: .missingTarget,
+                summary: nil,
+                paneID: "pane_missing",
+                errorCode: "missing_target",
+                errorMessage: "Missing pane"
+            )
+        )
+        expect(missing.code == .missingTarget, "intent outcome must preserve missing-target code")
+        expect(missing.dialog.contains("target"), "missing-target dialog must explain the category")
+
+        let unavailable = ShellAutomationIntentOutcome(
+            command: .sendText(ShellAutomationSendTextRequest(
+                paneID: "pane_1",
+                text: "printf secret\n"
+            )),
+            result: ShellAutomationCommandResult(
+                code: .runtimeUnavailable,
+                summary: nil,
+                paneID: "pane_1",
+                errorCode: "runtime_unavailable",
+                errorMessage: "Runtime unavailable"
+            )
+        )
+        expect(
+            unavailable.code == .runtimeUnavailable,
+            "intent outcome must preserve runtime-unavailable code"
+        )
+        expect(
+            unavailable.dialog.contains("runtime"),
+            "runtime-unavailable dialog must explain the category"
+        )
+    }
+
+    private static func verifiesAppIntentDialogRedactsSubmittedTextAndRawTargets() {
+        let secretText = "SECRET_TOKEN=abc123\n"
+        let outcome = ShellAutomationIntentOutcome(
+            command: .sendText(ShellAutomationSendTextRequest(
+                paneID: "pane_secret",
+                text: secretText
+            )),
+            result: ShellAutomationCommandResult(
+                code: .queued,
+                summary: nil,
+                paneID: "pane_secret",
+                acceptedBytes: secretText.utf8.count,
+                deliveryCode: "queued"
+            )
+        )
+
+        expect(outcome.code == .queued, "intent outcome must preserve queued delivery")
+        expect(outcome.dialog.contains("queued"), "intent outcome must report queued delivery")
+        expect(
+            !outcome.dialog.contains(secretText.trimmingCharacters(in: .whitespacesAndNewlines)),
+            "intent dialog must not echo submitted text"
+        )
+        expect(!outcome.dialog.contains("pane_secret"), "intent dialog must not expose raw pane IDs")
+
+        let summary = sampleSummary()
+        let summaryOutcome = ShellAutomationIntentOutcome(
+            command: .readPaneSummary(paneID: summary.paneID),
+            result: ShellAutomationCommandResult(code: .accepted, summary: summary)
+        )
+        expect(
+            !summaryOutcome.dialog.contains(summary.paneID),
+            "summary dialog must not expose raw pane IDs"
+        )
+        expect(
+            summaryOutcome.dialog.contains(summary.paneTitle),
+            "summary dialog must include display-safe pane metadata"
+        )
+    }
+
+    private static func verifiesAppIntentAvailabilityDocumentsFallback() {
+        expect(
+            ShellAutomationIntentAvailability.minimumSupportedMacOS == "macOS 13.0",
+            "App Intent availability must declare the supported macOS floor"
+        )
+        expect(
+            ShellAutomationIntentAvailability.fallbackDescription.contains("control plane"),
+            "App Intent fallback documentation must point to the control plane"
+        )
+    }
+
+    private static func sampleSummary() -> ShellAutomationPaneSummary {
+        ShellAutomationPaneSummary(
+            windowID: "window_main",
+            spaceID: "space_main",
+            spaceTitle: "Terminal",
+            tabID: "tab_main",
+            tabTitle: "Shell",
+            paneID: "pane_1",
+            paneTitle: "Project shell",
+            workingDirectory: "/Users/morris/Developer/alan",
+            processProgram: "zsh",
+            processState: "running",
+            attention: .awaitingUser
+        )
     }
 
     private static func stateWithVisibleExcerpt(_ visibleExcerpt: String) -> ShellStateSnapshot {

--- a/clients/apple/scripts/test-shell-automation-command-seams.swift
+++ b/clients/apple/scripts/test-shell-automation-command-seams.swift
@@ -22,6 +22,7 @@ private enum ShellAutomationCommandSeamsTests {
         await verifiesAppEntityQueriesReadActiveSnapshotState()
         verifiesAppIntentRoutingUsesFakeCommandHandler()
         verifiesAppIntentOutcomeAlignsWithCommandResultCategories()
+        verifiesAppIntentFailureOutcomesThrow()
         verifiesAppIntentDialogRedactsSubmittedTextAndRawTargets()
         verifiesAppIntentAvailabilityDocumentsFallback()
         print("Shell automation command seam tests passed.")
@@ -426,6 +427,61 @@ private enum ShellAutomationCommandSeamsTests {
             unavailable.dialog.contains("runtime"),
             "runtime-unavailable dialog must explain the category"
         )
+    }
+
+    private static func verifiesAppIntentFailureOutcomesThrow() {
+        let accepted = ShellAutomationIntentOutcome(
+            command: .focusPane(paneID: "pane_1"),
+            result: ShellAutomationCommandResult(code: .accepted, summary: sampleSummary())
+        )
+        do {
+            try accepted.requireSuccessfulIntentResult()
+        } catch {
+            fail("accepted intent outcome must not throw: \(error)")
+        }
+
+        let queued = ShellAutomationIntentOutcome(
+            command: .sendText(ShellAutomationSendTextRequest(paneID: "pane_1", text: "pwd\n")),
+            result: ShellAutomationCommandResult(
+                code: .queued,
+                summary: nil,
+                paneID: "pane_1",
+                acceptedBytes: 4,
+                deliveryCode: "queued"
+            )
+        )
+        expectIntentFailure(queued, code: .queued, messageFragment: "queued")
+
+        let missing = ShellAutomationIntentOutcome(
+            command: .focusPane(paneID: "pane_missing"),
+            result: ShellAutomationCommandResult(
+                code: .missingTarget,
+                summary: nil,
+                paneID: "pane_missing",
+                errorCode: "pane_not_found",
+                errorMessage: "The requested pane does not exist."
+            )
+        )
+        expectIntentFailure(missing, code: .missingTarget, messageFragment: "target")
+    }
+
+    private static func expectIntentFailure(
+        _ outcome: ShellAutomationIntentOutcome,
+        code: ShellAutomationCommandResultCode,
+        messageFragment: String
+    ) {
+        do {
+            try outcome.requireSuccessfulIntentResult()
+            fail("non-success intent outcome \(code.rawValue) must throw")
+        } catch let error as ShellAutomationIntentError {
+            expect(error.code == code, "intent error must preserve the command result code")
+            expect(
+                error.errorDescription?.contains(messageFragment) == true,
+                "intent error must expose the safe failure dialog"
+            )
+        } catch {
+            fail("intent outcome must throw ShellAutomationIntentError, got \(error)")
+        }
     }
 
     private static func verifiesAppIntentDialogRedactsSubmittedTextAndRawTargets() {

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -8,17 +8,17 @@
 ## 2. App Intents
 
 - [x] 2.1 Add App Entity types and queries for shell windows, spaces, tabs, panes, and attention items.
-- [ ] 2.2 Add intents for creating terminal tabs, creating alan tabs, splitting panes, focusing panes, closing panes/tabs, sending text, reading pane summaries, and opening attention items.
-- [ ] 2.3 Align intent success and failure results with shared shell command/control-plane result categories.
-- [ ] 2.4 Gate App Intent availability by supported macOS versions and document fallback behavior.
-- [ ] 2.5 Verify secure-input and privacy restrictions in intent summaries and logs.
+- [x] 2.2 Add intents for creating terminal tabs, creating alan tabs, splitting panes, focusing panes, closing panes/tabs, sending text, reading pane summaries, and opening attention items.
+- [x] 2.3 Align intent success and failure results with shared shell command/control-plane result categories.
+- [x] 2.4 Gate App Intent availability by supported macOS versions and document fallback behavior.
+- [x] 2.5 Verify secure-input and privacy restrictions in intent summaries and logs.
 
 ## 3. Focused Tests
 
 - [x] 3.1 Add Apple-client unit tests for shell model mutations, split/focus/close behavior, and privacy-safe summaries.
 - [x] 3.2 Add runtime service fake tests for text delivery, unavailable runtime, teardown, and metadata snapshots.
 - [x] 3.3 Add control-plane tests for query/mutation success, malformed requests, missing targets, runtime unavailable, timeout, and IO diagnostics.
-- [ ] 3.4 Add App Intent routing tests using fake shell state and fake runtime outcomes.
+- [x] 3.4 Add App Intent routing tests using fake shell state and fake runtime outcomes.
 - [x] 3.5 Add a Ghostty-enabled integration lane that runs only when local Ghostty artifacts are prepared.
 
 ## 4. UI Smoke And Documentation


### PR DESCRIPTION
## Summary
- add shell App Intents for create tab, split/focus/close, send text, read summary, and attention activation
- route intents through a shared command handler store with privacy-safe outcome dialogs
- add App Intent routing/outcome/privacy tests and mark OpenSpec tasks 2.2-2.5 and 3.4 complete

## Verification
- git diff --check
- bash clients/apple/scripts/test-shell-automation-command-seams.sh
- openspec validate add-macos-shell-automation-tests --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination 'generic/platform=macOS' -derivedDataPath debug/DerivedData/app-intents-routing build

Stacked on #495.