### PR TITLE
Add focused shell verification targets

### DIFF
--- a/clients/apple/README.md
+++ b/clients/apple/README.md
@@ -244,13 +244,23 @@ The client uses the existing `/api/v1/sessions/*` compatibility layer:
 xcodebuild \
   -project clients/apple/alan-macos.xcodeproj \
   -scheme alan-macos \
-  -destination 'generic/platform=macOS' build
+  -configuration Debug \
+  -destination 'generic/platform=macOS' \
+  -derivedDataPath debug/xcode-derived/alan-macos-build \
+  build
 
 # Shell control-plane contract smoke
 bash clients/apple/scripts/check-shell-contracts.sh
 
+# Focused shell tests: model, fake runtime, control-plane, and App Intent routing.
+# This target does not require real Ghostty artifacts.
+just apple-shell-focused-tests
+
 # Shell automation command seam tests
 just apple-shell-automation-seams
+
+# App Intents metadata review after building alan-macos with the command above.
+just apple-shell-app-intents-metadata
 
 # Ghostty-backed shell integration lane.
 # Skips when local Ghostty links are absent; set ALAN_REQUIRE_GHOSTTY_INTEGRATION=1

--- a/clients/apple/scripts/check-shell-app-intents-metadata.sh
+++ b/clients/apple/scripts/check-shell-app-intents-metadata.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEFAULT_APP_PATH="$REPO_ROOT/debug/xcode-derived/alan-macos-build/Build/Products/Debug/Alan.app"
+APP_PATH="${ALAN_APP_INTENTS_APP_PATH:-$DEFAULT_APP_PATH}"
+ACTIONS_DATA="$APP_PATH/Contents/Resources/Metadata.appintents/extract.actionsdata"
+
+fail() {
+    printf 'check-shell-app-intents-metadata: %s\n' "$*" >&2
+    exit 1
+}
+
+json_get() {
+    local key_path="$1"
+    plutil -extract "$key_path" raw -o - "$ACTIONS_DATA" 2>/dev/null \
+        || fail "missing metadata key: $key_path"
+}
+
+expect_value() {
+    local key_path="$1"
+    local expected="$2"
+    local actual
+    actual="$(json_get "$key_path")"
+    if [[ "$actual" != "$expected" ]]; then
+        fail "expected $key_path to be '$expected', got '$actual'"
+    fi
+}
+
+expect_action() {
+    local intent="$1"
+    local title="$2"
+    local description="$3"
+    local parameters="$4"
+    local index=0
+    local parameter
+
+    expect_value "actions.$intent.title.key" "$title"
+    expect_value "actions.$intent.descriptionMetadata.descriptionText.key" "$description"
+    expect_value "actions.$intent.availabilityAnnotations.LNPlatformNameMACOS.introducedVersion" "13.0"
+    expect_value "actions.$intent.visibilityMetadata.isDiscoverable" "true"
+
+    IFS='|' read -r -a parameter_names <<<"$parameters"
+    for parameter in "${parameter_names[@]}"; do
+        [[ -n "$parameter" ]] || continue
+        expect_value "actions.$intent.parameters.$index.title.key" "$parameter"
+        index=$((index + 1))
+    done
+}
+
+command -v plutil >/dev/null 2>&1 || fail "plutil is required"
+[[ -f "$ACTIONS_DATA" ]] || fail "missing App Intents metadata: $ACTIONS_DATA; build alan-macos first or set ALAN_APP_INTENTS_APP_PATH"
+
+expect_action "AlanCreateTerminalTabIntent" \
+    "Create Terminal Tab" \
+    "Create a terminal tab in alan." \
+    "Space|Title|Working Directory"
+expect_action "AlanCreateAlanTabIntent" \
+    "Create Alan Tab" \
+    "Create an alan tab in alan." \
+    "Space|Title|Working Directory"
+expect_action "AlanSplitPaneIntent" \
+    "Split Shell Pane" \
+    "Split an alan shell pane." \
+    "Pane|Direction"
+expect_action "AlanFocusPaneIntent" \
+    "Focus Shell Pane" \
+    "Focus an alan shell pane." \
+    "Pane"
+expect_action "AlanClosePaneIntent" \
+    "Close Shell Pane" \
+    "Close an alan shell pane." \
+    "Pane"
+expect_action "AlanCloseTabIntent" \
+    "Close Shell Tab" \
+    "Close an alan shell tab." \
+    "Tab"
+expect_action "AlanSendTextToPaneIntent" \
+    "Send Text To Shell Pane" \
+    "Send text to an alan shell pane." \
+    "Pane|Text"
+expect_action "AlanReadPaneSummaryIntent" \
+    "Read Shell Pane Summary" \
+    "Read safe metadata for an alan shell pane." \
+    "Pane"
+expect_action "AlanOpenAttentionItemIntent" \
+    "Open Shell Attention Item" \
+    "Open an alan shell attention item." \
+    "Attention Item"
+
+expect_value "entities.AlanShellWindowEntity.displayTypeName.key" "Shell Window"
+expect_value "entities.AlanShellSpaceEntity.displayTypeName.key" "Shell Space"
+expect_value "entities.AlanShellTabEntity.displayTypeName.key" "Shell Tab"
+expect_value "entities.AlanShellPaneEntity.displayTypeName.key" "Shell Pane"
+expect_value "entities.AlanShellAttentionItemEntity.displayTypeName.key" "Shell Attention Item"
+
+if grep -Eq 'SECRET|secret_|pane_[0-9]|pane_secret|alan-shell-control|/tmp/alan|binding file|socket path|controlPath|visibleExcerpt' "$ACTIONS_DATA"; then
+    fail "generated App Intents metadata contains private terminal/debug strings"
+fi
+
+printf 'Shell App Intents metadata checks passed.\n'

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1901,6 +1901,26 @@ require_pattern \
     "UI smoke must keep an app bundle override for CI and one-off built app validation"
 
 require_pattern \
+    "justfile" \
+    "^apple-shell-focused-tests:" \
+    "focused Apple shell tests must have a single everyday just target"
+
+require_pattern \
+    "justfile" \
+    "test-shell-runtime-metadata\\.sh" \
+    "focused Apple shell tests must include runtime and control-plane metadata coverage"
+
+require_pattern \
+    "clients/apple/scripts/check-shell-app-intents-metadata.sh" \
+    "AlanCreateTerminalTabIntent" \
+    "App Intent metadata review must cover generated Shortcuts action names"
+
+require_pattern \
+    "clients/apple/README.md" \
+    "just apple-shell-focused-tests" \
+    "Apple README must document the aggregate focused shell test target"
+
+require_pattern \
     "clients/apple/README.md" \
     "stable .*window_main.* identity" \
     "Apple client docs must describe the singleton primary shell identity"

--- a/justfile
+++ b/justfile
@@ -64,9 +64,18 @@ install-dev:
 dev-channel-smoke:
     ./scripts/smoke-dev-channel-side-by-side.sh
 
+# Run focused macOS shell tests that do not require real Ghostty artifacts
+apple-shell-focused-tests:
+    bash clients/apple/scripts/test-shell-automation-command-seams.sh
+    bash clients/apple/scripts/test-shell-runtime-metadata.sh
+
 # Run focused macOS shell automation command seam tests
 apple-shell-automation-seams:
     bash clients/apple/scripts/test-shell-automation-command-seams.sh
+
+# Review generated App Intents metadata from a built alan-macos app
+apple-shell-app-intents-metadata:
+    bash clients/apple/scripts/check-shell-app-intents-metadata.sh
 
 # Run Ghostty-backed macOS shell integration checks when local artifacts are prepared
 apple-shell-ghostty-integration:

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -30,15 +30,15 @@
 
 ## 5. Verification
 
-- [ ] 5.1 Run `git diff --check`.
-- [ ] 5.2 Run the focused Apple shell test command added by this change.
-- [ ] 5.3 Run the UI smoke/screenshot command added by this change.
-- [ ] 5.4 Run the Ghostty integration lane when local artifacts are prepared.
-- [ ] 5.5 Run the renamed `alan-macos` macOS build command.
+- [x] 5.1 Run `git diff --check`.
+- [x] 5.2 Run the focused Apple shell test command added by this change.
+- [x] 5.3 Run the UI smoke/screenshot command added by this change.
+- [x] 5.4 Run the Ghostty integration lane when local artifacts are prepared.
+- [x] 5.5 Run the renamed `alan-macos` macOS build command.
 
 ## 6. PR And Archive Readiness
 
-- [ ] 6.1 Review App Intent names, display representations, and privacy behavior in Shortcuts/Spotlight where available.
-- [ ] 6.2 Confirm tests are layered so everyday checks do not require real Ghostty artifacts.
+- [x] 6.1 Review App Intent names, display representations, and privacy behavior in Shortcuts/Spotlight where available.
+- [x] 6.2 Confirm tests are layered so everyday checks do not require real Ghostty artifacts.
 - [ ] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
 - [ ] 6.4 Archive the OpenSpec change after implementation is merged.

--- a/openspec/changes/add-macos-shell-automation-tests/tasks.md
+++ b/openspec/changes/add-macos-shell-automation-tests/tasks.md
@@ -40,5 +40,5 @@
 
 - [x] 6.1 Review App Intent names, display representations, and privacy behavior in Shortcuts/Spotlight where available.
 - [x] 6.2 Confirm tests are layered so everyday checks do not require real Ghostty artifacts.
-- [ ] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
+- [x] 6.3 Before archive, sync accepted delta requirements into `openspec/specs/`.
 - [ ] 6.4 Archive the OpenSpec change after implementation is merged.

--- a/openspec/specs/macos-shell-automation-surfaces/spec.md
+++ b/openspec/specs/macos-shell-automation-surfaces/spec.md
@@ -1,0 +1,73 @@
+# macos-shell-automation-surfaces Specification
+
+## Purpose
+Define native macOS automation surfaces for alan's shell, including App Entity
+representations, App Intents, command-result semantics, and privacy boundaries.
+## Requirements
+### Requirement: Shell entities are available to App Intents
+alan's macOS app SHALL expose App Entity representations for shell windows,
+spaces, tabs, panes, and attention items using stable identifiers and
+user-facing display names.
+
+#### Scenario: Query active tabs
+- **WHEN** an App Intent query asks for tabs in the active shell window
+- **THEN** alan returns tab entities with user-facing titles, space context, and stable internal identifiers
+
+#### Scenario: Query panes with secure input
+- **WHEN** an App Intent query includes a pane whose terminal is in secure-input state
+- **THEN** alan returns safe metadata and does not expose sensitive terminal input content
+
+#### Scenario: No shell window available
+- **WHEN** App Intent resolution runs while no shell window is active
+- **THEN** alan returns an empty or needs-app state instead of crashing or fabricating entities
+
+### Requirement: Core shell actions have App Intents
+alan's macOS app SHALL provide App Intents for creating terminal tabs, creating
+alan tabs, splitting panes, focusing panes, closing panes or tabs, sending text,
+reading pane summaries, and opening attention items.
+
+#### Scenario: Create terminal tab intent
+- **WHEN** the user runs the create terminal tab intent
+- **THEN** alan creates a terminal tab through the shell controller and returns the created tab summary
+
+#### Scenario: Split pane intent
+- **WHEN** the user runs a split pane intent with a direction and target pane
+- **THEN** alan performs the same split mutation as the native command path and returns the resulting focused pane
+
+#### Scenario: Send text intent
+- **WHEN** the user runs a send text intent for a target pane
+- **THEN** alan routes delivery through the terminal runtime service and reports accepted, queued, or rejected state truthfully
+
+#### Scenario: Open attention item intent
+- **WHEN** the user runs an intent for an attention item
+- **THEN** alan activates the owning window, space, tab, and pane without exposing raw debug identifiers in the result text
+
+### Requirement: App Intent outcomes align with shell commands
+App Intent handlers SHALL use the same shell controller mutations and result
+semantics as native commands and control-plane operations unless a documented
+availability or privacy restriction applies.
+
+#### Scenario: Missing target
+- **WHEN** an intent targets a missing pane or tab
+- **THEN** it returns the same stable missing-target category used by the shell command/control-plane path
+
+#### Scenario: Runtime unavailable
+- **WHEN** an intent depends on terminal runtime availability and the runtime service reports non-ready state
+- **THEN** the intent returns a user-facing failure result aligned with control-plane runtime status
+
+#### Scenario: Command succeeds
+- **WHEN** an intent completes a shell mutation
+- **THEN** shell state, event stream, and intent result reflect the same accepted mutation
+
+### Requirement: Automation respects terminal privacy
+Automation surfaces SHALL avoid exposing raw terminal content, secure input,
+private socket paths, raw pane IDs, or debug payloads unless the user explicitly
+opens a debug context outside App Intents.
+
+#### Scenario: Read pane summary
+- **WHEN** an App Intent reads a pane summary
+- **THEN** the summary includes safe metadata such as title, cwd, process status, and attention state, but not arbitrary terminal buffer text
+
+#### Scenario: Secure input active
+- **WHEN** a pane is in secure-input state
+- **THEN** automation summaries redact sensitive fields and command results do not echo submitted secret text

--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -671,6 +671,65 @@ shell-control boundaries.
 - **AND** the smoke verifies both apps can be identified independently by bundle id
 - **AND** the smoke verifies dev session/config/auth state is written only to dev-channel paths
 
+### Requirement: Apple quality gate includes focused macOS shell tests
+The Apple client SHALL provide repeatable commands for focused macOS shell tests
+covering shell model mutations, runtime service fakes, control-plane command
+execution, App Intent routing, and UI smoke flows.
+
+#### Scenario: Developer runs Apple shell tests
+- **WHEN** a developer runs the documented focused Apple shell test command
+- **THEN** model, fake runtime, control-plane, and intent-routing tests run without requiring the full app UI
+
+#### Scenario: Ghostty artifacts absent
+- **WHEN** Ghostty artifacts are absent and the focused test command runs
+- **THEN** tests that do not require real Ghostty run normally and Ghostty integration tests are skipped or fail with documented setup instructions
+
+#### Scenario: Ghostty artifacts present
+- **WHEN** Ghostty artifacts are prepared and the integration lane is requested
+- **THEN** the macOS app builds with Ghostty and runs terminal-host integration checks
+
+### Requirement: UI smoke coverage is repeatable
+The Apple client SHALL provide a repeatable UI smoke or screenshot flow for
+launch, space/tab switching, split creation, command UI, pane-scoped Find
+behavior, and basic terminal input when terminal runtime is available.
+
+#### Scenario: Launch smoke
+- **WHEN** the UI smoke flow starts the macOS app
+- **THEN** it verifies that the default light-mode window shows the unified sidebar column, active-space tab list, bottom space switcher, terminal content area, and no persistent inspector pane or toggle
+
+#### Scenario: Split smoke
+- **WHEN** the UI smoke flow creates a split
+- **THEN** it verifies that multiple panes are visible and no raw pane IDs or debug labels dominate the default UI
+
+#### Scenario: Find smoke
+- **WHEN** the UI smoke flow opens pane-scoped Find for the focused terminal pane
+- **THEN** it verifies that a focused text field appears in pane chrome, result feedback is visible without raw debug labels, and dismissing Find returns focus to the owning terminal surface
+
+### Requirement: Test fixtures share production command paths
+Apple tests SHALL exercise shell mutations through the same controller command
+interfaces used by menus, command UI, App Intents, and control-plane handlers.
+
+#### Scenario: Split command fixture
+- **WHEN** a test invokes split through the shared command interface
+- **THEN** the resulting shell state matches the state produced by native command and control-plane paths
+
+#### Scenario: Close command fixture
+- **WHEN** a test invokes close pane through the shared command interface
+- **THEN** shell state updates and runtime fake finalization are both asserted
+
+### Requirement: Build and test documentation stays current
+Apple build/test scripts, `just` commands, and `clients/apple/README.md` SHALL
+document local dependency setup, focused test commands, UI smoke commands, and
+Ghostty integration prerequisites.
+
+#### Scenario: Command added
+- **WHEN** a new Apple shell test or smoke command is added
+- **THEN** the README and just/script references are updated in the same change
+
+#### Scenario: Dependency changes
+- **WHEN** Ghostty or App Intent test prerequisites change
+- **THEN** the documented setup and failure messages are updated together
+
 ### Requirement: Content container model has focused tests
 Apple client SHALL 为 v0.2 content-container model、旧状态迁移、mixed split、content-aware
 command validation 和 content-keyed terminal runtime continuity 提供 focused 自动化测试或明确的人工验证记录。

--- a/openspec/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/specs/macos-shell-control-plane-reliability/spec.md
@@ -283,3 +283,41 @@ Control-plane shell state responses SHALL 为每个 PaneSlot 暴露 `pane_slot_i
 - **WHEN** agent 对不支持的 content 执行 content-specific command
 - **THEN** response 包含稳定错误码和目标 content kind
 - **AND** event/diagnostic surface 可以显示该 rejected command
+
+### Requirement: Control plane and App Intents share command semantics
+The macOS shell control plane SHALL use the same shell command result categories
+as App Intents and native command routing for create, split, focus, close, send
+text, read summary, and attention activation actions.
+
+#### Scenario: Intent and control command create split
+- **WHEN** an App Intent and a control-plane command create the same directional split from equivalent starting state
+- **THEN** both paths report aligned success semantics and produce equivalent shell state
+
+#### Scenario: Intent and control command miss target
+- **WHEN** both paths target a missing pane
+- **THEN** both paths report an aligned missing-target category without mutating shell state
+
+### Requirement: Automation command events are observable
+Shell mutations initiated by App Intents SHALL publish the same kind of shell
+events as equivalent menu, keyboard, command UI, or control-plane mutations.
+
+#### Scenario: Intent focuses pane
+- **WHEN** an App Intent focuses a pane
+- **THEN** the shell event stream records the focus change with previous and new pane identity
+
+#### Scenario: Intent sends text
+- **WHEN** an App Intent sends text to a pane
+- **THEN** the shell event stream records delivery status without logging sensitive text content
+
+### Requirement: Control fixtures cover failure cases
+The control-plane test fixtures SHALL cover missing targets, malformed requests,
+runtime unavailable, timeout, permission/privacy restrictions, and IO diagnostic
+paths that App Intents may also encounter.
+
+#### Scenario: Runtime unavailable fixture
+- **WHEN** a fixture command targets a pane whose fake runtime is unavailable
+- **THEN** the test asserts stable runtime-unavailable semantics shared by control and intent paths
+
+#### Scenario: Privacy restriction fixture
+- **WHEN** a fixture command tries to read sensitive terminal content
+- **THEN** the test asserts that only safe metadata is returned

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1025,3 +1025,32 @@ interactions and MUST NOT move the window when the user drags them.
   drag behavior
 - **AND** double-clicking the same empty chrome region continues to toggle the
   visible-frame zoom behavior
+
+### Requirement: UI conformance has repeatable smoke evidence
+Mac shell UI conformance work SHALL include repeatable smoke or screenshot
+evidence for launch, space/tab switching, split creation, command UI, and
+pane-scoped Find behavior.
+
+#### Scenario: Default launch evidence
+- **WHEN** a UI conformance implementation is ready
+- **THEN** maintainers can run or inspect a smoke artifact showing the light-mode default window with material sidebar and terminal-first content
+
+#### Scenario: Command UI evidence
+- **WHEN** command UI behavior changes
+- **THEN** maintainers can run or inspect evidence showing `Go to or Command...` results with user-facing labels
+
+#### Scenario: Find evidence
+- **WHEN** pane-scoped Find behavior changes
+- **THEN** maintainers can run or inspect evidence confirming the active pane shows a native-feeling Find surface without restoring inspector chrome or debug-first panels
+
+### Requirement: Automation surfaces do not add default chrome
+Adding App Intents and automation support SHALL not add visible default UI chrome
+or explanatory panels to the terminal workflow.
+
+#### Scenario: App Intents installed
+- **WHEN** automation support is present in the app
+- **THEN** the default shell window remains terminal-first and does not show automation setup cards, implementation jargon, or dashboard sections
+
+#### Scenario: Intent result activates app
+- **WHEN** an App Intent activates a shell target
+- **THEN** the window opens to the relevant space, tab, or pane using normal shell UI rather than a special automation debug surface


### PR DESCRIPTION
## Summary
- add an everyday `just apple-shell-focused-tests` target covering automation seams plus runtime/control-plane metadata tests without Ghostty artifacts
- add `check-shell-app-intents-metadata.sh` and `just apple-shell-app-intents-metadata` to review generated Shortcuts/App Intents names, display types, availability, and privacy strings
- update Apple docs and contract checks, and mark OpenSpec verification tasks 5.1-6.2 complete

## Verification
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `just apple-shell-focused-tests`
- `just apple-shell-app-intents-metadata`
- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath debug/xcode-derived/alan-macos-build build`
- `ALAN_UI_SMOKE_OUTPUT_DIR=/private/tmp/alan-worktrees/add-shell-focused-verification-target/debug/artifacts/apple-shell-ui-smoke-focused-followup ALAN_UI_SMOKE_APP_PATH=/private/tmp/alan-worktrees/add-shell-focused-verification-target/debug/xcode-derived/alan-macos-build/Build/Products/Debug/Alan.app just apple-shell-ui-smoke`
- `just apple-shell-ghostty-integration`
- temporarily moved local Ghostty links aside, then re-ran `just apple-shell-focused-tests`
- `openspec validate --all --strict`
- `git diff --check`

## Notes
- Stacked on #503 because this relies on the smoke command/docs cleanup there.
- Remaining OpenSpec tasks are 6.3 long-lived spec sync and 6.4 archive after implementation PRs merge.
