### PR TITLE
Fix Rust TUI follow-up review issues

### DIFF
--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -71,6 +71,7 @@ pub struct TuiApp {
     pub composer: Composer,
     pub should_quit: bool,
     last_sequence: Option<u64>,
+    committed_rendered_lines: usize,
 }
 
 impl TuiApp {
@@ -81,6 +82,7 @@ impl TuiApp {
             composer: Composer::default(),
             should_quit: false,
             last_sequence: None,
+            committed_rendered_lines: 0,
         }
     }
 
@@ -92,6 +94,7 @@ impl TuiApp {
                 None
             }
             AppEvent::Terminal(TerminalEvent::Resize(width, height)) => {
+                self.committed_rendered_lines = 0;
                 self.reducer.cells.push(HistoryCell::Status(format!(
                     "terminal resized to {width}x{height}"
                 )));
@@ -140,18 +143,34 @@ impl TuiApp {
         &self.reducer.cells
     }
 
-    pub fn drain_committed_scrollback(&mut self, viewport_height: usize) -> Vec<String> {
-        let max_cells = viewport_height.saturating_sub(4).max(4);
-        if self.reducer.cells.len() <= max_cells {
+    pub fn rendered_history_lines(&self, width: usize) -> Vec<String> {
+        let committed = self.committed_rendered_lines;
+        self.render_history_lines(width)
+            .into_iter()
+            .skip(committed)
+            .collect()
+    }
+
+    pub fn drain_committed_scrollback(
+        &mut self,
+        viewport_width: usize,
+        viewport_height: usize,
+    ) -> Vec<String> {
+        let max_lines = viewport_height.saturating_sub(4).max(4);
+        let lines = self.render_history_lines(viewport_width);
+        let committed = self.committed_rendered_lines.min(lines.len());
+        let visible_lines = lines.len().saturating_sub(committed);
+        if visible_lines <= max_lines {
+            self.committed_rendered_lines = committed;
             return Vec::new();
         }
-        let remove_count = self.reducer.cells.len() - max_cells;
-        let removed: Vec<_> = self.reducer.cells.drain(..remove_count).collect();
-        let mut lines = Vec::new();
-        for cell in removed {
-            lines.extend(cell.render_lines(96));
-        }
+        let drain_count = visible_lines - max_lines;
+        self.committed_rendered_lines = committed + drain_count;
         lines
+            .into_iter()
+            .skip(committed)
+            .take(drain_count)
+            .collect()
     }
 
     pub fn clear_pending_yield(&mut self, request_id: &str) {
@@ -229,6 +248,13 @@ impl TuiApp {
         }
         self.reducer.cells.push(HistoryCell::User(text.clone()));
         Some(AppAction::SubmitTurn(text))
+    }
+
+    fn render_history_lines(&self, width: usize) -> Vec<String> {
+        self.history_cells()
+            .iter()
+            .flat_map(|cell| cell.render_lines(width))
+            .collect()
     }
 }
 
@@ -348,6 +374,20 @@ mod tests {
         assert!(app.reducer.pending_yield.is_some());
         app.clear_pending_yield("r-1");
         assert!(app.reducer.pending_yield.is_none());
+    }
+
+    #[test]
+    fn scrollback_drains_by_rendered_lines() {
+        let mut app = app();
+        app.reducer
+            .cells
+            .push(HistoryCell::Assistant("long streamed output ".repeat(40)));
+
+        let drained = app.drain_committed_scrollback(32, 8);
+
+        assert!(!drained.is_empty());
+        assert!(app.rendered_history_lines(32).len() <= 4);
+        assert!(matches!(app.history_cells()[0], HistoryCell::Assistant(_)));
     }
 
     fn envelope(sequence: u64) -> alan_protocol::EventEnvelope {

--- a/crates/tui/src/daemon_client.rs
+++ b/crates/tui/src/daemon_client.rs
@@ -1,6 +1,7 @@
 use alan_protocol::{ContentPart, EventEnvelope, Op, Submission};
 use anyhow::{Context, Result};
 use futures::{Stream, StreamExt};
+use reqwest::StatusCode;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -101,12 +102,40 @@ impl DaemonClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
+            if status == StatusCode::CONFLICT
+                && let Some(session_id) = active_workspace_session_id_from_body(&body)
+            {
+                return self
+                    .read_session_summary(&session_id)
+                    .await
+                    .with_context(|| {
+                        format!("failed to attach existing workspace session {session_id}")
+                    });
+            }
             anyhow::bail!("failed to create session ({status}): {body}");
         }
         response
             .json::<CreateSession>()
             .await
             .context("failed to parse create-session response")
+    }
+
+    async fn read_session_summary(&self, session_id: &str) -> Result<CreateSession> {
+        let response = self
+            .http
+            .get(self.url(&self.endpoints.session_read(session_id)))
+            .send()
+            .await
+            .with_context(|| format!("failed to read session {session_id}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("failed to read session {session_id} ({status}): {body}");
+        }
+        response
+            .json::<CreateSession>()
+            .await
+            .with_context(|| format!("failed to parse session {session_id} summary"))
     }
 
     pub async fn submit_turn(&self, session_id: &str, text: String) -> Result<()> {
@@ -366,6 +395,25 @@ fn parse_event_line(line: String) -> Result<EventEnvelope> {
     serde_json::from_str(&line).with_context(|| format!("invalid event envelope: {line}"))
 }
 
+fn active_workspace_session_id_from_body(body: &str) -> Option<String> {
+    let message = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| body.to_string());
+    let prefix = "Workspace already has an active session runtime:";
+    let (_, session_id) = message.split_once(prefix)?;
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    session_id.split_whitespace().next().map(str::to_string)
+}
+
 #[derive(Default)]
 struct NdjsonLineParser {
     buffer: Vec<u8>,
@@ -477,5 +525,35 @@ mod tests {
             parser.push(b"{\"b\":2}\r\n"),
             vec![r#"{"b":2}"#.to_string()]
         );
+    }
+
+    #[test]
+    fn parses_active_workspace_conflict_session_id() {
+        let body = serde_json::json!({
+            "error": "Workspace already has an active session runtime: sess-existing"
+        })
+        .to_string();
+        assert_eq!(
+            active_workspace_session_id_from_body(&body).as_deref(),
+            Some("sess-existing")
+        );
+    }
+
+    #[test]
+    fn create_session_shape_accepts_session_read_payload() {
+        let session: CreateSession = serde_json::from_value(serde_json::json!({
+            "session_id": "sess-existing",
+            "workspace_id": "abc123",
+            "active": true,
+            "profile_id": "chatgpt-main",
+            "resolved_model": "gpt-5.3-codex",
+            "durability": { "durable": false, "required": false },
+            "messages": []
+        }))
+        .unwrap();
+
+        assert_eq!(session.session_id, "sess-existing");
+        assert_eq!(session.profile_id.as_deref(), Some("chatgpt-main"));
+        assert_eq!(session.resolved_model.as_deref(), Some("gpt-5.3-codex"));
     }
 }

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -148,7 +148,8 @@ pub async fn run(config: RunConfig) -> Result<()> {
                 dirty = true;
             }
             _ = frame_tick.tick(), if dirty => {
-                let committed = app.drain_committed_scrollback(terminal.viewport_height());
+                let (viewport_width, viewport_height) = terminal.viewport_size();
+                let committed = app.drain_committed_scrollback(viewport_width, viewport_height);
                 terminal.write_scrollback(&committed)?;
                 terminal.draw(&app)?;
                 dirty = false;

--- a/crates/tui/src/terminal.rs
+++ b/crates/tui/src/terminal.rs
@@ -29,12 +29,14 @@ pub struct TerminalSession {
 impl TerminalSession {
     pub fn enter() -> Result<Self> {
         crossterm_terminal::enable_raw_mode().context("failed to enable raw terminal mode")?;
+        let startup_guard = TerminalStartupGuard::new();
         let mut out = stdout();
         execute!(out, EnableBracketedPaste, EnableMouseCapture)
             .context("failed to enable terminal input modes")?;
         let backend = CrosstermBackend::new(out);
         let mut terminal = Terminal::new(backend).context("failed to initialize terminal")?;
         terminal.clear().context("failed to clear terminal")?;
+        startup_guard.disarm();
         Ok(Self { terminal })
     }
 
@@ -52,6 +54,13 @@ impl TerminalSession {
             .unwrap_or(24)
     }
 
+    pub fn viewport_size(&self) -> (usize, usize) {
+        self.terminal
+            .size()
+            .map(|area| (area.width as usize, area.height as usize))
+            .unwrap_or((80, 24))
+    }
+
     pub fn write_scrollback(&mut self, lines: &[String]) -> Result<()> {
         if lines.is_empty() {
             return Ok(());
@@ -62,6 +71,31 @@ impl TerminalSession {
         }
         out.flush()?;
         Ok(())
+    }
+}
+
+struct TerminalStartupGuard {
+    armed: bool,
+}
+
+impl TerminalStartupGuard {
+    fn new() -> Self {
+        Self { armed: true }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalStartupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let mut out = stdout();
+        let _ = execute!(out, DisableMouseCapture, DisableBracketedPaste);
+        let _ = crossterm_terminal::disable_raw_mode();
     }
 }
 

--- a/crates/tui/src/ui.rs
+++ b/crates/tui/src/ui.rs
@@ -20,14 +20,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &TuiApp) {
         ])
         .split(area);
 
-    let mut transcript = Vec::new();
-    for cell in app.history_cells() {
-        transcript.extend(
-            cell.render_lines(chunks[0].width as usize)
-                .into_iter()
-                .map(Line::from),
-        );
-    }
+    let mut transcript: Vec<Line<'_>> = app
+        .rendered_history_lines(chunks[0].width as usize)
+        .into_iter()
+        .map(Line::from)
+        .collect();
     if transcript.is_empty() {
         transcript.push(Line::from(vec![
             Span::styled("alan", Style::default().add_modifier(Modifier::BOLD)),

--- a/scripts/check-rust-inline-tui-contract.sh
+++ b/scripts/check-rust-inline-tui-contract.sh
@@ -45,16 +45,14 @@ reject_pattern 'ALAN_TUI_PATH|clients/tui|\bBun\b|\bInk\b' \
     crates \
     clients/apple \
     README.md \
-    AGENTS.md \
-    openspec/specs
+    AGENTS.md
 
 reject_pattern 'alan chat|alan ask' \
     .github \
     crates \
     clients/apple \
     README.md \
-    AGENTS.md \
-    openspec/specs
+    AGENTS.md
 
 reject_pattern 'TUI Lint / Test / Typecheck|clients/tui|ALAN_TUI_PATH' \
     .github \


### PR DESCRIPTION
## Summary
- attach to an existing workspace session when create-session returns the workspace-active conflict
- restore terminal raw/input modes on startup failure before TerminalSession is fully constructed
- drain TUI scrollback by rendered lines so long streamed cells keep the newest output visible
- keep the Rust inline TUI contract script focused on production paths now that long-lived OpenSpec specs mention legacy names normatively

## Verification
- cargo fmt --all
- cargo test -p alan-terminal-ui
- cargo test -p alan
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- bash scripts/check-rust-inline-tui-contract.sh
- openspec validate --all --strict
- git diff --check