### PR TITLE
Fix TUI scrollback pruning after resize

### DIFF
--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -71,7 +71,6 @@ pub struct TuiApp {
     pub composer: Composer,
     pub should_quit: bool,
     last_sequence: Option<u64>,
-    committed_rendered_lines: usize,
 }
 
 impl TuiApp {
@@ -82,7 +81,6 @@ impl TuiApp {
             composer: Composer::default(),
             should_quit: false,
             last_sequence: None,
-            committed_rendered_lines: 0,
         }
     }
 
@@ -94,7 +92,6 @@ impl TuiApp {
                 None
             }
             AppEvent::Terminal(TerminalEvent::Resize(width, height)) => {
-                self.committed_rendered_lines = 0;
                 self.reducer.cells.push(HistoryCell::Status(format!(
                     "terminal resized to {width}x{height}"
                 )));
@@ -144,11 +141,7 @@ impl TuiApp {
     }
 
     pub fn rendered_history_lines(&self, width: usize) -> Vec<String> {
-        let committed = self.committed_rendered_lines;
         self.render_history_lines(width)
-            .into_iter()
-            .skip(committed)
-            .collect()
     }
 
     pub fn drain_committed_scrollback(
@@ -158,19 +151,13 @@ impl TuiApp {
     ) -> Vec<String> {
         let max_lines = viewport_height.saturating_sub(4).max(4);
         let lines = self.render_history_lines(viewport_width);
-        let committed = self.committed_rendered_lines.min(lines.len());
-        let visible_lines = lines.len().saturating_sub(committed);
-        if visible_lines <= max_lines {
-            self.committed_rendered_lines = committed;
+        if lines.len() <= max_lines {
             return Vec::new();
         }
-        let drain_count = visible_lines - max_lines;
-        self.committed_rendered_lines = committed + drain_count;
-        lines
-            .into_iter()
-            .skip(committed)
-            .take(drain_count)
-            .collect()
+        let drain_count = lines.len() - max_lines;
+        let drained = lines.into_iter().take(drain_count).collect::<Vec<_>>();
+        self.prune_rendered_prefix(viewport_width, drain_count);
+        drained
     }
 
     pub fn clear_pending_yield(&mut self, request_id: &str) {
@@ -255,6 +242,33 @@ impl TuiApp {
             .iter()
             .flat_map(|cell| cell.render_lines(width))
             .collect()
+    }
+
+    fn prune_rendered_prefix(&mut self, width: usize, lines_to_prune: usize) {
+        let mut remaining = lines_to_prune;
+        let mut cells_to_remove = 0;
+
+        while remaining > 0 && cells_to_remove < self.reducer.cells.len() {
+            let cell_lines = self.reducer.cells[cells_to_remove]
+                .render_lines(width)
+                .len();
+            if cell_lines > remaining {
+                break;
+            }
+
+            remaining -= cell_lines;
+            cells_to_remove += 1;
+        }
+
+        if cells_to_remove > 0 {
+            self.reducer.cells.drain(0..cells_to_remove);
+        }
+
+        if remaining > 0
+            && let Some(cell) = self.reducer.cells.first_mut()
+        {
+            cell.trim_rendered_prefix(width, remaining);
+        }
     }
 }
 
@@ -387,7 +401,60 @@ mod tests {
 
         assert!(!drained.is_empty());
         assert!(app.rendered_history_lines(32).len() <= 4);
-        assert!(matches!(app.history_cells()[0], HistoryCell::Assistant(_)));
+        assert!(matches!(app.history_cells()[0], HistoryCell::Rendered(_)));
+    }
+
+    #[test]
+    fn scrollback_prunes_committed_cells_from_active_state() {
+        let mut app = app();
+        for idx in 0..20 {
+            app.reducer
+                .cells
+                .push(HistoryCell::Status(format!("status {idx}")));
+        }
+
+        let drained = app.drain_committed_scrollback(80, 8);
+
+        assert_eq!(drained.len(), 16);
+        assert_eq!(app.history_cells().len(), 4);
+        assert_eq!(app.rendered_history_lines(80).len(), 4);
+    }
+
+    #[test]
+    fn resize_does_not_replay_committed_scrollback() {
+        let mut app = app();
+        for idx in 0..12 {
+            app.reducer
+                .cells
+                .push(HistoryCell::Status(format!("status {idx}")));
+        }
+
+        let first_drained = app.drain_committed_scrollback(80, 8);
+        app.dispatch(AppEvent::Terminal(TerminalEvent::Resize(100, 8)));
+        let second_drained = app.drain_committed_scrollback(100, 8);
+
+        assert_eq!(first_drained.len(), 8);
+        assert_eq!(second_drained.len(), 1);
+        assert!(
+            !second_drained
+                .iter()
+                .any(|line| first_drained.contains(line))
+        );
+        assert!(app.rendered_history_lines(100).len() <= 4);
+    }
+
+    #[test]
+    fn pruned_render_tail_wraps_at_resized_width() {
+        let mut app = app();
+        app.reducer
+            .cells
+            .push(HistoryCell::Assistant("long streamed output ".repeat(40)));
+
+        app.drain_committed_scrollback(80, 8);
+        let drained_after_narrow_resize = app.drain_committed_scrollback(20, 8);
+
+        assert!(!drained_after_narrow_resize.is_empty());
+        assert!(app.rendered_history_lines(20).len() <= 4);
     }
 
     fn envelope(sequence: u64) -> alan_protocol::EventEnvelope {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -249,9 +249,12 @@ impl TuiApp {
         let mut pruned = 0;
 
         while remaining > 0 && cells_to_remove < self.reducer.cells.len() {
-            let cell_lines = self.reducer.cells[cells_to_remove]
-                .render_lines(width)
-                .len();
+            let cell = &self.reducer.cells[cells_to_remove];
+            if !cell.can_prune_from_active_state() {
+                break;
+            }
+
+            let cell_lines = cell.render_lines(width).len();
             if cell_lines > remaining {
                 break;
             }
@@ -507,6 +510,60 @@ mod tests {
                 preview: Some(preview),
                 ..
             }) if id == "tool-1" && preview == "done"
+        ));
+    }
+
+    #[test]
+    fn full_scrollback_prune_preserves_running_tool_identity() {
+        let mut app = app();
+        for idx in 0..8 {
+            app.reducer
+                .cells
+                .push(HistoryCell::Status(format!("before {idx}")));
+        }
+        app.reducer.cells.push(HistoryCell::Tool {
+            id: "tool-1".into(),
+            name: "read_file".into(),
+            status: crate::history::ToolStatus::Running,
+            preview: None,
+        });
+        for idx in 0..4 {
+            app.reducer
+                .cells
+                .push(HistoryCell::Status(format!("after {idx}")));
+        }
+
+        let drained = app.drain_committed_scrollback(80, 8);
+
+        assert_eq!(drained.len(), 8);
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Tool {
+                id,
+                status: crate::history::ToolStatus::Running,
+                ..
+            }) if id == "tool-1"
+        ));
+
+        app.reducer.apply_envelope(envelope_with_event(
+            2,
+            alan_protocol::Event::ToolCallCompleted {
+                id: "tool-1".into(),
+                name: Some("read_file".into()),
+                success: Some(false),
+                result_preview: Some("failed".into()),
+                audit: None,
+            },
+        ));
+
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Tool {
+                id,
+                status: crate::history::ToolStatus::Failed,
+                preview: Some(preview),
+                ..
+            }) if id == "tool-1" && preview == "failed"
         ));
     }
 

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -155,9 +155,8 @@ impl TuiApp {
             return Vec::new();
         }
         let drain_count = lines.len() - max_lines;
-        let drained = lines.into_iter().take(drain_count).collect::<Vec<_>>();
-        self.prune_rendered_prefix(viewport_width, drain_count);
-        drained
+        let pruned_count = self.prune_rendered_prefix(viewport_width, drain_count);
+        lines.into_iter().take(pruned_count).collect()
     }
 
     pub fn clear_pending_yield(&mut self, request_id: &str) {
@@ -244,9 +243,10 @@ impl TuiApp {
             .collect()
     }
 
-    fn prune_rendered_prefix(&mut self, width: usize, lines_to_prune: usize) {
+    fn prune_rendered_prefix(&mut self, width: usize, lines_to_prune: usize) -> usize {
         let mut remaining = lines_to_prune;
         let mut cells_to_remove = 0;
+        let mut pruned = 0;
 
         while remaining > 0 && cells_to_remove < self.reducer.cells.len() {
             let cell_lines = self.reducer.cells[cells_to_remove]
@@ -257,6 +257,7 @@ impl TuiApp {
             }
 
             remaining -= cell_lines;
+            pruned += cell_lines;
             cells_to_remove += 1;
         }
 
@@ -266,9 +267,12 @@ impl TuiApp {
 
         if remaining > 0
             && let Some(cell) = self.reducer.cells.first_mut()
+            && cell.trim_rendered_prefix(width, remaining)
         {
-            cell.trim_rendered_prefix(width, remaining);
+            pruned += remaining;
         }
+
+        pruned
     }
 }
 
@@ -455,6 +459,55 @@ mod tests {
 
         assert!(!drained_after_narrow_resize.is_empty());
         assert!(app.rendered_history_lines(20).len() <= 4);
+    }
+
+    #[test]
+    fn partial_scrollback_prune_preserves_running_tool_identity() {
+        let mut app = app();
+        for idx in 0..8 {
+            app.reducer
+                .cells
+                .push(HistoryCell::Status(format!("status {idx}")));
+        }
+        app.reducer.cells.push(HistoryCell::Tool {
+            id: "tool-1".into(),
+            name: "long-tool-name".into(),
+            status: crate::history::ToolStatus::Running,
+            preview: Some("streamed preview ".repeat(20)),
+        });
+
+        let drained = app.drain_committed_scrollback(24, 8);
+
+        assert_eq!(drained.len(), 8);
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Tool {
+                id,
+                status: crate::history::ToolStatus::Running,
+                ..
+            }) if id == "tool-1"
+        ));
+
+        app.reducer.apply_envelope(envelope_with_event(
+            2,
+            alan_protocol::Event::ToolCallCompleted {
+                id: "tool-1".into(),
+                name: Some("long-tool-name".into()),
+                success: Some(true),
+                result_preview: Some("done".into()),
+                audit: None,
+            },
+        ));
+
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Tool {
+                id,
+                status: crate::history::ToolStatus::Complete,
+                preview: Some(preview),
+                ..
+            }) if id == "tool-1" && preview == "done"
+        ));
     }
 
     fn envelope(sequence: u64) -> alan_protocol::EventEnvelope {

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -408,7 +408,7 @@ mod tests {
 
         assert!(!drained.is_empty());
         assert!(app.rendered_history_lines(32).len() <= 4);
-        assert!(matches!(app.history_cells()[0], HistoryCell::Rendered(_)));
+        assert!(matches!(app.history_cells()[0], HistoryCell::Assistant(_)));
     }
 
     #[test]
@@ -462,6 +462,54 @@ mod tests {
 
         assert!(!drained_after_narrow_resize.is_empty());
         assert!(app.rendered_history_lines(20).len() <= 4);
+    }
+
+    #[test]
+    fn partial_scrollback_prune_preserves_streaming_text_cell() {
+        let mut app = app();
+        app.reducer
+            .cells
+            .push(HistoryCell::Assistant("long streamed output ".repeat(40)));
+
+        let drained = app.drain_committed_scrollback(32, 8);
+        app.reducer.apply_envelope(envelope_with_event(
+            2,
+            alan_protocol::Event::TextDelta {
+                chunk: "tail".into(),
+                is_final: false,
+            },
+        ));
+
+        assert!(!drained.is_empty());
+        assert_eq!(app.history_cells().len(), 1);
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Assistant(text)) if text.ends_with("tail")
+        ));
+    }
+
+    #[test]
+    fn partial_scrollback_prune_preserves_streaming_thinking_cell() {
+        let mut app = app();
+        app.reducer
+            .cells
+            .push(HistoryCell::Thinking("long hidden reasoning ".repeat(40)));
+
+        let drained = app.drain_committed_scrollback(32, 8);
+        app.reducer.apply_envelope(envelope_with_event(
+            2,
+            alan_protocol::Event::ThinkingDelta {
+                chunk: "tail".into(),
+                is_final: false,
+            },
+        ));
+
+        assert!(!drained.is_empty());
+        assert_eq!(app.history_cells().len(), 1);
+        assert!(matches!(
+            app.history_cells().first(),
+            Some(HistoryCell::Thinking(text)) if text.ends_with("tail")
+        ));
     }
 
     #[test]

--- a/crates/tui/src/history.rs
+++ b/crates/tui/src/history.rs
@@ -124,9 +124,19 @@ impl HistoryCell {
             .collect()
     }
 
-    pub fn trim_rendered_prefix(&mut self, width: usize, lines_to_trim: usize) {
+    pub fn trim_rendered_prefix(&mut self, width: usize, lines_to_trim: usize) -> bool {
         if lines_to_trim == 0 {
-            return;
+            return true;
+        }
+
+        if matches!(
+            self,
+            Self::Tool {
+                status: ToolStatus::Running,
+                ..
+            }
+        ) {
+            return false;
         }
 
         let remaining = self
@@ -135,6 +145,7 @@ impl HistoryCell {
             .skip(lines_to_trim)
             .collect::<Vec<_>>();
         *self = Self::Rendered(remaining);
+        true
     }
 }
 

--- a/crates/tui/src/history.rs
+++ b/crates/tui/src/history.rs
@@ -129,13 +129,7 @@ impl HistoryCell {
             return true;
         }
 
-        if matches!(
-            self,
-            Self::Tool {
-                status: ToolStatus::Running,
-                ..
-            }
-        ) {
+        if !self.can_prune_from_active_state() {
             return false;
         }
 
@@ -146,6 +140,16 @@ impl HistoryCell {
             .collect::<Vec<_>>();
         *self = Self::Rendered(remaining);
         true
+    }
+
+    pub fn can_prune_from_active_state(&self) -> bool {
+        !matches!(
+            self,
+            Self::Tool {
+                status: ToolStatus::Running,
+                ..
+            }
+        )
     }
 }
 

--- a/crates/tui/src/history.rs
+++ b/crates/tui/src/history.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HistoryCell {
+    Rendered(Vec<String>),
     User(String),
     Assistant(String),
     Thinking(String),
@@ -44,7 +45,16 @@ pub struct PendingYieldCell {
 impl HistoryCell {
     pub fn render_lines(&self, width: usize) -> Vec<String> {
         let width = width.max(16);
+        if let Self::Rendered(lines) = self {
+            return lines
+                .iter()
+                .flat_map(|line| textwrap::wrap(line, width))
+                .map(Into::into)
+                .collect();
+        }
+
         let (prefix, body) = match self {
+            Self::Rendered(_) => unreachable!("rendered cells returned before prefix formatting"),
             Self::User(text) => ("you", text.clone()),
             Self::Assistant(text) => ("alan", text.clone()),
             Self::Thinking(text) => ("thinking", text.clone()),
@@ -112,6 +122,19 @@ impl HistoryCell {
                 }
             })
             .collect()
+    }
+
+    pub fn trim_rendered_prefix(&mut self, width: usize, lines_to_trim: usize) {
+        if lines_to_trim == 0 {
+            return;
+        }
+
+        let remaining = self
+            .render_lines(width)
+            .into_iter()
+            .skip(lines_to_trim)
+            .collect::<Vec<_>>();
+        *self = Self::Rendered(remaining);
     }
 }
 

--- a/crates/tui/src/history.rs
+++ b/crates/tui/src/history.rs
@@ -133,6 +133,18 @@ impl HistoryCell {
             return false;
         }
 
+        match self {
+            Self::Assistant(text) => {
+                *text = trim_wrapped_body("alan", text, width, lines_to_trim);
+                return true;
+            }
+            Self::Thinking(text) => {
+                *text = trim_wrapped_body("thinking", text, width, lines_to_trim);
+                return true;
+            }
+            _ => {}
+        }
+
         let remaining = self
             .render_lines(width)
             .into_iter()
@@ -151,6 +163,16 @@ impl HistoryCell {
             }
         )
     }
+}
+
+fn trim_wrapped_body(prefix: &str, text: &str, width: usize, lines_to_trim: usize) -> String {
+    let body_width = width.max(16).saturating_sub(prefix.len() + 3);
+    textwrap::wrap(text, body_width)
+        .into_iter()
+        .skip(lines_to_trim)
+        .map(|line| line.into_owned())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
Summary: fixes PR #513 review findings by pruning committed scrollback from active TUI render state and avoiding replay after resize. Adds regression coverage for committed-cell pruning, resize replay prevention, and narrow-width wrapping of pruned tails. 

Verification: 
- cargo test -p alan-terminal-ui
- cargo clippy -p alan-terminal-ui --all-targets -- -D warnings
- cargo test -p alan
- bash scripts/check-rust-inline-tui-contract.sh
- git diff --check