### PR TITLE
Add Sparkle auto-update metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ lcov.info
 .env.release.local
 .release.env
 .release.env.local
+release-secrets/*
+!release-secrets/README.md
 
 # Python local caches and coverage artifacts
 **/__pycache__/

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		000000000000000000000043 /* Models/Shell/ShellAutomationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */; };
 		000000000000000000000044 /* Models/Shell/ShellAutomationEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */; };
 		000000000000000000000045 /* Models/Shell/ShellAutomationIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */; };
+		000000000000000000000046 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 000000000000000000000802 /* Sparkle */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -149,6 +150,7 @@
 		00000000000000000000013D /* Support/ShellSidebarPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarPresentation.swift; sourceTree = "<group>"; };
 		00000000000000000000013E /* Models/Shell/ShellActionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellActionRegistry.swift; sourceTree = "<group>"; };
 		00000000000000000000013F /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		000000000000000000000150 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				00000000000000000000000B /* GhosttyKit.xcframework in Frameworks */,
+				000000000000000000000046 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,6 +181,7 @@
 			isa = PBXGroup;
 			children = (
 				00000000000000000000013F /* AppIcon.icon */,
+				000000000000000000000150 /* Info.plist */,
 				000000000000000000000304 /* App */,
 				00000000000000000000030E /* Controllers/Console */,
 				00000000000000000000030F /* Controllers/Shell */,
@@ -368,6 +372,9 @@
 			dependencies = (
 			);
 			name = "alan-macos";
+			packageProductDependencies = (
+				000000000000000000000802 /* Sparkle */,
+			);
 			productName = "alan-macos";
 			productReference = 0000000000000000000000F1 /* Alan.app */;
 			productType = "com.apple.product-type.application";
@@ -396,6 +403,9 @@
 				Base,
 			);
 			mainGroup = 000000000000000000000301;
+			packageReferences = (
+				000000000000000000000801 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			productRefGroup = 000000000000000000000303 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -613,13 +623,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = Alan;
-				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = Alan;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "alan-macos/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -652,13 +657,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = Alan;
-				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = Alan;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "alan-macos/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -704,6 +704,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		000000000000000000000801 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.7.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		000000000000000000000802 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 000000000000000000000801 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 000000000000000000000501 /* Project object */;
 }

--- a/clients/apple/alan-macos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/clients/apple/alan-macos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/clients/apple/alan-macos/Info.plist
+++ b/clients/apple/alan-macos/Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Alan</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>SUFeedURL</key>
+	<string>https://alanworks.app/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>iwnkEodtOvllOw7nNZPXS9aMXhlQxXtqqgsgtf5CBXQ=</string>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -1816,6 +1816,21 @@ require_pattern \
     "release app validation must compare manifest checksums with embedded binaries"
 
 require_pattern \
+    "justfile" \
+    "^guard-macos-auto-update:" \
+    "macOS auto-update metadata must have a focused guard target"
+
+require_pattern \
+    "scripts/check-macos-auto-update-config.sh" \
+    "SUPublicEDKey" \
+    "macOS auto-update guard must verify the Sparkle public key metadata"
+
+require_pattern \
+    "scripts/check-macos-auto-update-config.sh" \
+    "https://alanworks\\.app/appcast\\.xml" \
+    "macOS auto-update guard must pin the stable appcast URL"
+
+require_pattern \
     "scripts/assemble-release-app.sh" \
     "Recording signed embedded binary checksums" \
     "release assembly must record manifest checksums after embedded binaries are signed"

--- a/justfile
+++ b/justfile
@@ -28,6 +28,10 @@ guard-agent-root-layout:
 guard-daemon-api-contract:
     ./scripts/check-daemon-api-route-strings.sh
 
+# Check macOS Sparkle auto-update project metadata
+guard-macos-auto-update:
+    ./scripts/check-macos-auto-update-config.sh
+
 # Run clippy
 lint:
     cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/openspec/changes/add-macos-app-auto-update/design.md
+++ b/openspec/changes/add-macos-app-auto-update/design.md
@@ -86,15 +86,16 @@ Releases，并从 app bundle 内链接 `alan`。
   Homebrew 管理路径或链接，禁用 Sparkle 安装路径或给出 Homebrew 更新提示。
 - **[Risk] 版本号漂移导致 Sparkle 不提示更新或错误降级。** -> 发布脚本检查
   Cargo、Xcode、zip、GitHub tag 和 appcast 版本一致，并检查 build number 单调递增。
-- **[Risk] Sparkle EdDSA private key 泄漏。** -> 私钥不进入 repo；本地或 CI
-  通过安全文件、Keychain 或 secrets 注入，release 日志不得打印私钥内容。
+- **[Risk] Sparkle EdDSA private key 泄漏。** -> 私钥不进入 repo；本地开发使用
+  ignored 的 `release-secrets/` 目录，CI 通过安全文件、Keychain 或 secrets 注入，
+  release 日志不得打印私钥内容。
 - **[Risk] 首次发布没有旧版样本，无法证明更新。** -> 在真正公开前保留一个旧版
   signed/notarized fixture 或通过临时较低 build number 的安装包验证旧版到新版流程。
 
 ## Migration Plan
 
 1. 创建 Sparkle EdDSA key，把 public key 写入 app Info.plist 配置，private key
-   存在本地安全位置或未来 CI secret。
+   存在 ignored 的本地 `release-secrets/` 目录或未来 CI secret。
 2. 给 Xcode project 增加 Sparkle 2 依赖和 `Check for Updates...` 菜单入口。
 3. 更新 release assembly/signing validation，覆盖 Sparkle 嵌套代码和版本一致性。
 4. 增加 appcast 生成脚本：读取 release zip、GitHub release URL、版本号、长度、

--- a/openspec/changes/add-macos-app-auto-update/tasks.md
+++ b/openspec/changes/add-macos-app-auto-update/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Sparkle Integration
 
-- [ ] 1.1 Add Sparkle 2 to the macOS Xcode project using the repo's chosen dependency mechanism.
-- [ ] 1.2 Generate a Sparkle EdDSA key pair and store only the public key in tracked app configuration.
-- [ ] 1.3 Configure the release app bundle with `SUFeedURL=https://alanworks.app/appcast.xml`.
-- [ ] 1.4 Configure Sparkle public-key metadata and any required updater bundle metadata in the generated Info.plist surface.
-- [ ] 1.5 Add a focused project/configuration check that fails when the release app is missing Sparkle feed URL or public-key metadata.
+- [x] 1.1 Add Sparkle 2 to the macOS Xcode project using the repo's chosen dependency mechanism.
+- [x] 1.2 Generate a Sparkle EdDSA key pair and store only the public key in tracked app configuration.
+- [x] 1.3 Configure the release app bundle with `SUFeedURL=https://alanworks.app/appcast.xml`.
+- [x] 1.4 Configure Sparkle public-key metadata and any required updater bundle metadata in the generated Info.plist surface.
+- [x] 1.5 Add a focused project/configuration check that fails when the release app is missing Sparkle feed URL or public-key metadata.
 
 ## 2. App Update Behavior
 
@@ -43,7 +43,7 @@
 ## 6. Documentation And Change Closure
 
 - [ ] 6.1 Update README and packaging docs to describe direct-app Sparkle updates and Homebrew `brew upgrade --cask alan` updates separately.
-- [ ] 6.2 Document the Sparkle private-key handling rule without committing private material.
+- [x] 6.2 Document the Sparkle private-key handling rule without committing private material.
 - [ ] 6.3 Add PR notes summarizing Cloudflare Pages, GitHub Releases, Sparkle, and Homebrew ownership boundaries.
 - [ ] 6.4 Run `openspec validate add-macos-app-auto-update --strict`.
 - [ ] 6.5 Before archiving, sync accepted delta specs into `openspec/specs/` and run `openspec validate --all --strict`.

--- a/release-secrets/README.md
+++ b/release-secrets/README.md
@@ -1,0 +1,13 @@
+# Local Release Secrets
+
+Store local-only release credentials and signing material here.
+
+Expected Sparkle private key path:
+
+```text
+release-secrets/sparkle_ed25519_private.pem
+```
+
+The Sparkle public key is tracked in the macOS app `Info.plist`; the private key
+must stay local or be injected by CI secret storage. Do not commit private key
+files or print their contents in release logs.

--- a/scripts/check-macos-auto-update-config.sh
+++ b/scripts/check-macos-auto-update-config.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_FILE="$REPO_ROOT/clients/apple/alan-macos.xcodeproj/project.pbxproj"
+INFO_PLIST="$REPO_ROOT/clients/apple/alan-macos/Info.plist"
+RELEASE_SECRETS_DIR="$REPO_ROOT/release-secrets"
+APPCAST_URL="https://alanworks.app/appcast.xml"
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_pattern() {
+    local pattern="$1"
+    local path="$2"
+    local message="$3"
+
+    rg -n "$pattern" "$path" >/dev/null || fail "$message"
+}
+
+[[ -f "$PROJECT_FILE" ]] || fail "missing Xcode project file: $PROJECT_FILE"
+[[ -f "$INFO_PLIST" ]] || fail "missing app Info.plist: $INFO_PLIST"
+[[ -f "$RELEASE_SECRETS_DIR/README.md" ]] || fail "missing release secrets README"
+
+require_pattern \
+    'repositoryURL = "https://github\.com/sparkle-project/Sparkle";' \
+    "$PROJECT_FILE" \
+    "Sparkle package URL is not configured"
+
+require_pattern \
+    'productName = Sparkle;' \
+    "$PROJECT_FILE" \
+    "Sparkle package product dependency is not configured"
+
+require_pattern \
+    '/\* Sparkle in Frameworks \*/' \
+    "$PROJECT_FILE" \
+    "Sparkle is not linked in the app framework phase"
+
+plist_binding_count="$(
+    rg -c 'INFOPLIST_FILE = "alan-macos/Info.plist";' "$PROJECT_FILE" || true
+)"
+if [[ "$plist_binding_count" -lt 2 ]]; then
+    fail "Debug and Release app builds must use the explicit app Info.plist"
+fi
+
+generated_plist_count="$(
+    rg -c 'GENERATE_INFOPLIST_FILE = NO;' "$PROJECT_FILE" || true
+)"
+if [[ "$generated_plist_count" -lt 2 ]]; then
+    fail "Debug and Release app builds must not rely on generated Info.plist metadata"
+fi
+
+feed_url="$(plutil -extract SUFeedURL raw -o - "$INFO_PLIST" 2>/dev/null || true)"
+if [[ "$feed_url" != "$APPCAST_URL" ]]; then
+    fail "Sparkle feed URL must be pinned in app Info.plist"
+fi
+
+public_key="$(plutil -extract SUPublicEDKey raw -o - "$INFO_PLIST" 2>/dev/null || true)"
+if [[ ! "$public_key" =~ ^[A-Za-z0-9+/]{43}=$ ]]; then
+    fail "Sparkle public key must be a 44-character base64 EdDSA public key"
+fi
+
+require_pattern \
+    '^release-secrets/\*$' \
+    "$REPO_ROOT/.gitignore" \
+    "release-secrets must be ignored"
+
+require_pattern \
+    '^!release-secrets/README\.md$' \
+    "$REPO_ROOT/.gitignore" \
+    "release-secrets README must stay tracked as the local key location marker"
+
+require_pattern \
+    'release-secrets/sparkle_ed25519_private\.pem' \
+    "$RELEASE_SECRETS_DIR/README.md" \
+    "release secrets README must document the Sparkle private key location"
+
+if ! git -C "$REPO_ROOT" check-ignore -q -- release-secrets/sparkle_ed25519_private.pem; then
+    fail "Sparkle private key path under release-secrets must be ignored"
+fi
+
+if [[ -e "$REPO_ROOT/target/local-secrets/sparkle_ed25519_private.pem" ]]; then
+    fail "Sparkle private key must live under release-secrets/, not target/"
+fi
+
+tracked_release_secret_count="$(
+    git -C "$REPO_ROOT" ls-files release-secrets |
+        awk '$0 != "release-secrets/README.md" { count++ } END { print count + 0 }'
+)"
+if [[ "$tracked_release_secret_count" != "0" ]]; then
+    fail "release-secrets must not track secret material"
+fi
+
+if git -C "$REPO_ROOT" ls-files | rg -i 'sparkle.*(private|secret)|ed25519.*private' >/dev/null; then
+    fail "Sparkle private key material must not be tracked"
+fi
+
+printf 'macOS auto-update config check passed\n'


### PR DESCRIPTION
## Summary
- add Sparkle 2 SwiftPM dependency to the macOS app target
- switch the app to an explicit Info.plist with Sparkle feed URL and public EdDSA key
- add a focused auto-update config guard and document the ignored release-secrets private key location

## Verification
- just guard-macos-auto-update
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate add-macos-app-auto-update --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Release -destination generic/platform=macOS -derivedDataPath target/xcode-derived CODE_SIGNING_ALLOWED=NO build
- verified built Alan.app contains SUFeedURL, SUPublicEDKey, and Sparkle.framework