### PR TITLE
Improve macOS settings surface spec

### DIFF
--- a/openspec/changes/improve-macos-settings-surface/.openspec.yaml
+++ b/openspec/changes/improve-macos-settings-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/improve-macos-settings-surface/design.md
+++ b/openspec/changes/improve-macos-settings-surface/design.md
@@ -1,0 +1,143 @@
+## Context
+
+The current macOS Settings content is a shell tab rendered by
+`ShellSettingsContentView`. It exposes three `@AppStorage` preferences:
+appearance, sidebar visibility, and inactive split dimming. That matches the
+current implementation but no longer matches the amount of user-relevant state
+Alan needs to explain: connection profiles, session defaults, skill exposure,
+install channel, daemon URL, CLI tool installation, update policy, and local
+data roots.
+
+Existing contracts already define the lower-level surfaces:
+
+- settings content stays inside shell workspace chrome rather than becoming a
+  separate settings window or dashboard
+- connection profile metadata and credential material stay separated, with
+  daemon/CLI control surfaces owning profile operations
+- skills expose `enabled` and `allow_implicit_invocation` through the daemon
+  catalog and override APIs
+- stable and dev install channels have separate app identity, alan home,
+  command name, daemon defaults, and shell-control namespace
+
+The Settings change should therefore organize and expose configuration state,
+not create a new configuration authority.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Turn Settings into a useful macOS shell control surface with clear sections:
+  Interface, Accounts, Sessions, Capabilities, and Local.
+- Preserve the existing tab-hosted Settings model and calm Arc-like shell
+  visual language.
+- Keep first-phase editing safe: local UI preferences are editable; connection,
+  skill, runtime, daemon, and install details are summarized or routed through
+  existing dedicated actions.
+- Show status and sources in user-facing language while avoiding raw IDs,
+  secrets, implementation class names, and unbounded debug details.
+- Create a structure that can later accept editable Accounts, Session Defaults,
+  and Capabilities controls without another IA rewrite.
+
+**Non-Goals:**
+
+- Adding a native macOS `Settings` scene or replacing the shell-tab Settings
+  contract.
+- Building a full `agent.toml`, `connections.toml`, `host.toml`, or
+  `models.toml` editor.
+- Introducing a new secret storage backend or reading secret values into the UI.
+- Implementing every advanced runtime option in the first Settings pass.
+- Changing provider, skills, daemon, or install-channel contracts.
+
+## Decisions
+
+1. **Settings remains a shell content tab.**
+
+   The user opens Settings through the existing command path and receives a
+   singleton shell content tab. This preserves workspace context, sidebar
+   selection, split behavior, and the existing OpenSpec content-container
+   contract. A separate `Settings` scene would fight the current shell model and
+   split configuration across multiple windows.
+
+2. **Use sections by user task, not by storage file.**
+
+   The visible grouping is:
+
+   - Interface: immediate app presentation preferences
+   - Accounts: current profile, provider, model, credential state, test/login
+   - Sessions: governance, reasoning, streaming, recovery defaults
+   - Capabilities: skill exposure summaries and future override controls
+   - Local: channel, daemon, CLI, updates, data paths, reset/diagnostic actions
+
+   This avoids exposing storage names such as `agent.toml`, `connections.toml`,
+   or `host.toml` as the primary navigation model. Storage paths can appear as
+   secondary detail only when they help diagnose local state.
+
+3. **First-phase editing is intentionally conservative.**
+
+   Interface rows keep direct controls because they are local, reversible, and
+   already implemented through `@AppStorage`. Accounts and Local rows begin as
+   summaries plus explicit actions, because they touch auth, secrets, daemon
+   routing, CLI installation, or update policy. Session defaults and
+   Capabilities can start as read-only or collapsed advanced sections until the
+   persistence and daemon flows are wired.
+
+4. **Settings reads from existing authorities.**
+
+   UI preferences use `@AppStorage`. Connection summaries use the daemon
+   connection API when available. Skills use the daemon skill catalog. Local
+   install status uses `AlanInstallChannel`, `AlanCommandLineToolInstaller`,
+   `AlanMacUpdatePolicy`, and host-config resolution helpers. Settings should
+   not parse or mutate TOML directly except through existing control APIs.
+
+5. **Use quiet row groups rather than cards or a dashboard.**
+
+   Each section should be a compact macOS-like row group with a clear label,
+   restrained secondary text, and one focused trailing control or action where
+   needed. Avoid nested cards, marketing copy, hero metrics, large icons, or
+   debug-first composition. The content should remain scan-friendly inside a
+   terminal workspace.
+
+## Risks / Trade-offs
+
+- **[Risk] Settings becomes a dumping ground for every runtime knob.** ->
+  Keep Advanced collapsed and require each exposed control to map to a user
+  task, not merely to an available config field.
+- **[Risk] Read-only summaries feel non-functional.** -> Pair summaries with
+  focused actions such as Test, Login, Set Key, Install CLI, Check Updates, or
+  Reveal Data, but keep unsafe editing out of the first pass.
+- **[Risk] Connection status leaks secrets or provider internals.** -> Show
+  credential kind/status and profile/model labels only; never render secret
+  values, bearer tokens, or managed auth contents.
+- **[Risk] Direct file parsing diverges from runtime behavior.** -> Prefer
+  existing daemon/CLI/control APIs and channel helpers. If a needed read API is
+  missing, add a typed helper rather than ad hoc path parsing in the view.
+- **[Risk] Section count adds visual weight.** -> Keep headings small, rows
+  compact, and sections separated by rhythm rather than heavy card chrome.
+
+## Migration Plan
+
+1. Refactor `ShellSettingsContentView` into small section and row components
+   while preserving existing `@AppStorage` behavior.
+2. Add Interface, Accounts, Sessions, Capabilities, and Local sections with
+   first-phase controls and summaries.
+3. Wire Local summaries from existing install-channel, update-policy, and CLI
+   installer helpers.
+4. Add typed Apple-client read models for connection and skill summaries only
+   when the implementation uses daemon APIs instead of file parsing.
+5. Add focused tests for section presence, singleton Settings behavior,
+   non-terminal lifecycle, redaction, and first-phase read-only rows.
+6. Validate with focused shell scripts, Swift tests, and a fresh installed app
+   relaunch before visual acceptance.
+
+Rollback: if a data source proves unreliable, keep the section but show an
+unavailable status with no mutation path. The existing Interface preferences can
+remain functional independently of Accounts, Capabilities, or Local summaries.
+
+## Open Questions
+
+- Should Session defaults persist first in Apple client preferences or through
+  the daemon's existing session-default/config surface once one is available?
+- Should Capabilities show all skills immediately or start with a compact
+  summary plus a searchable expanded view?
+- Should Local data actions include destructive reset controls in this change,
+  or only reveal/copy paths and diagnostics?

--- a/openspec/changes/improve-macos-settings-surface/proposal.md
+++ b/openspec/changes/improve-macos-settings-surface/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Alan's macOS Settings tab currently exposes only three local UI preferences, even
+though the app already has user-relevant configuration and status surfaces for
+connections, session defaults, skills, install channel, daemon access, CLI tools,
+and updates. This makes Settings feel too thin for a terminal-first app that now
+depends on both local shell behavior and agent/runtime configuration.
+
+## What Changes
+
+- Reorganize the macOS Settings tab into stable, task-oriented sections:
+  Interface, Accounts, Sessions, Capabilities, and Local.
+- Keep Settings inside the existing shell tab model and avoid turning it into a
+  separate preference window, page-like dashboard, or nested navigation shell.
+- Keep first-phase editing conservative: Interface preferences remain editable,
+  Accounts and Local start as read-only summaries with focused actions, and
+  advanced runtime/skill controls use progressive disclosure.
+- Surface connection profile, provider, model, credential status, install
+  channel, daemon URL, CLI tool, update policy, and local data locations without
+  exposing secrets or raw implementation IDs.
+- Clarify which configuration surfaces are safe for everyday users and which are
+  advanced agent/runtime controls.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Add requirements for a grouped, calm,
+  terminal-first Settings tab that presents local UI preferences, connection
+  summaries, session defaults, capability summaries, and local install/runtime
+  status without adding dashboard chrome or leaking low-level configuration
+  details.
+
+## Impact
+
+- `clients/apple/alan-macos/TerminalPaneView.swift` settings content will need to
+  move from a single three-row group to sectioned settings content.
+- The Apple client may need small read-only model/view helpers for current
+  connection, install channel, daemon, CLI, update, and data-path summaries.
+- `AlanAPIClient` may need connection and skills read endpoints before editable
+  Accounts or Capabilities controls are added.
+- Tests should cover Settings section presence, singleton Settings behavior,
+  non-terminal content lifecycle, secret redaction, and first-phase read-only
+  behavior for connection/local status rows.

--- a/openspec/changes/improve-macos-settings-surface/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/improve-macos-settings-surface/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Settings Surface Uses Task-Oriented Sections
+Alan macOS Settings SHALL organize configuration and local status into
+task-oriented sections rather than exposing storage files, raw implementation
+IDs, or one-off controls as the primary information architecture.
+
+The default section order SHALL be:
+
+- Interface
+- Accounts
+- Sessions
+- Capabilities
+- Local
+
+#### Scenario: Settings tab renders grouped sections
+- **WHEN** the user opens the Settings content tab
+- **THEN** alan shows Interface, Accounts, Sessions, Capabilities, and Local as
+  distinct settings sections in the shell content area
+- **AND** Interface appears before advanced or diagnostic sections
+- **AND** the content remains inside the existing shell tab chrome
+
+#### Scenario: Existing interface preferences remain available
+- **WHEN** the Settings tab is active
+- **THEN** alan exposes appearance mode, sidebar visibility, and inactive split
+  pane dimming as editable Interface preferences
+- **AND** changing those preferences updates the same app-level preference state
+  used by the main shell surface
+
+#### Scenario: Storage details are secondary
+- **WHEN** Settings presents profile, session, skill, daemon, CLI, update, or
+  local data information
+- **THEN** alan uses user-facing labels for the primary row text
+- **AND** raw file names such as `agent.toml`, `connections.toml`, `host.toml`,
+  and raw content identifiers appear only as secondary diagnostic detail when
+  needed
+
+### Requirement: Settings Surface Preserves Configuration Boundaries
+Alan macOS Settings SHALL present configuration through the existing authority
+for each configuration family and MUST NOT become an independent parser/editor
+for runtime or credential files.
+
+#### Scenario: Account summary uses connection control surfaces
+- **WHEN** Settings presents connection profile, provider, model, credential, or
+  connection-test state
+- **THEN** alan uses the connection control-plane surface or typed client model
+  derived from that surface
+- **AND** Settings does not read secret material or display secret values
+
+#### Scenario: Capability summary uses skill catalog state
+- **WHEN** Settings presents skill or capability state
+- **THEN** alan uses the resolved skill catalog and override state exposed by
+  the skill management surface
+- **AND** Settings presents `enabled` and `allow_implicit_invocation` as
+  user-facing capability state rather than legacy mount-mode labels
+
+#### Scenario: Local summary uses install-channel helpers
+- **WHEN** Settings presents local app identity, channel, daemon, CLI, update,
+  shell-control, or alan-home status
+- **THEN** alan derives those values from install-channel, host-config, CLI
+  installer, update-policy, or shell-control helpers
+- **AND** dev-channel Settings uses dev-channel labels and locations rather than
+  silently falling back to stable-channel state
+
+### Requirement: Settings Editing Is Progressive And Safe
+Alan macOS Settings SHALL distinguish immediately editable preferences from
+summaries and advanced controls whose writes affect credentials, daemon routing,
+agent runtime behavior, skills, or local install state.
+
+#### Scenario: First-phase editable controls are limited
+- **WHEN** the first grouped Settings implementation ships
+- **THEN** local Interface preferences are directly editable
+- **AND** Accounts, Capabilities, and Local rows default to read-only summaries
+  or focused actions unless their existing control-plane write path is wired
+- **AND** Settings avoids freeform editing of `agent.toml`, `connections.toml`,
+  `host.toml`, `models.toml`, or credential stores
+
+#### Scenario: Advanced runtime controls use disclosure
+- **WHEN** Settings exposes runtime controls such as reasoning effort,
+  streaming, recovery, tool limits, timeouts, compaction, prompt snapshots, or
+  skill overrides
+- **THEN** alan places advanced controls behind progressive disclosure or a
+  compact advanced section
+- **AND** the default view remains focused on everyday app, account, session,
+  capability, and local status tasks
+
+#### Scenario: Sensitive account actions are explicit
+- **WHEN** the user performs account actions such as login, logout, set key, or
+  test connection from Settings
+- **THEN** alan presents those actions as explicit commands with provider and
+  profile context
+- **AND** Settings does not expose raw token or API-key contents after the
+  action completes
+
+### Requirement: Settings Surface Keeps Shell-Native Density
+Alan macOS Settings SHALL use compact native-feeling row groups, restrained
+typography, and calm hierarchy that fit the terminal-first shell instead of a
+page-like dashboard or marketing/settings portal.
+
+#### Scenario: Settings rows stay scannable
+- **WHEN** Settings renders multiple sections
+- **THEN** each row has one primary label and at most one focused trailing
+  control, value, or action
+- **AND** secondary text is concise and does not repeat the section heading
+
+#### Scenario: Settings avoids dashboard chrome
+- **WHEN** Settings is active
+- **THEN** alan does not add a hero header, metric cards, nested cards,
+  decorative gradients, or a separate settings navigation shell
+- **AND** the Settings surface remains visually subordinate to the surrounding
+  shell workspace
+
+#### Scenario: Unavailable status is calm and actionable
+- **WHEN** a Settings data source such as daemon connection state, skill catalog,
+  update policy, or CLI install status is unavailable
+- **THEN** alan shows a compact unavailable status in the relevant row or
+  section
+- **AND** alan avoids raw stack traces or debug payloads in the default Settings
+  view

--- a/openspec/changes/improve-macos-settings-surface/tasks.md
+++ b/openspec/changes/improve-macos-settings-surface/tasks.md
@@ -1,0 +1,79 @@
+## 1. Inventory And Boundaries
+
+- [ ] 1.1 Confirm the current Settings entry path, singleton behavior, and
+  non-terminal lifecycle tests still match the existing content-container
+  contract.
+- [ ] 1.2 Inventory the concrete data sources for Interface, Accounts,
+  Sessions, Capabilities, and Local rows, and classify each as editable,
+  read-only, action-only, or deferred.
+- [ ] 1.3 Decide the first implementation slice for Sessions and Capabilities:
+  summary-only, collapsed advanced, or fully hidden until daemon persistence is
+  available.
+
+## 2. Settings Information Architecture
+
+- [ ] 2.1 Refactor `ShellSettingsContentView` into small section and row
+  components without changing current Interface preference behavior.
+- [ ] 2.2 Add the default section order: Interface, Accounts, Sessions,
+  Capabilities, and Local.
+- [ ] 2.3 Update row labels and secondary text so primary labels are
+  user-facing and raw config filenames or IDs appear only as diagnostic detail.
+- [ ] 2.4 Keep the visual treatment compact and shell-native: no page hero,
+  nested cards, dashboard metrics, decorative gradients, or separate settings
+  navigation shell.
+
+## 3. First-Phase Data And Controls
+
+- [ ] 3.1 Keep appearance mode, sidebar visibility, and inactive split dimming
+  directly editable through the existing app preference state.
+- [ ] 3.2 Add read-only Local rows for install channel, CLI tool name, daemon
+  URL/default bind, update policy, and relevant data roots using existing
+  channel/update/host helpers.
+- [ ] 3.3 Add Accounts summary rows for current/default connection profile,
+  provider, model, credential status, and test/login/set-key action availability
+  through typed connection-control data rather than direct TOML parsing.
+- [ ] 3.4 Add Sessions summary or controls for governance, reasoning effort,
+  streaming mode, and recovery mode without exposing deprecated
+  `thinking_budget_tokens`.
+- [ ] 3.5 Add Capabilities summary state from the skill catalog when available,
+  using `enabled` and `allow_implicit_invocation` terminology and avoiding
+  legacy mount-mode labels.
+- [ ] 3.6 Ensure unavailable data sources render compact unavailable states
+  instead of stack traces, debug payloads, or empty sections.
+
+## 4. Safety And Redaction
+
+- [ ] 4.1 Ensure Settings never displays bearer tokens, API keys, refresh
+  tokens, managed auth file contents, or raw secret-store values.
+- [ ] 4.2 Ensure first-phase Accounts, Capabilities, and Local rows do not offer
+  freeform editing of `agent.toml`, `connections.toml`, `host.toml`,
+  `models.toml`, or credential stores.
+- [ ] 4.3 Verify dev-channel Settings displays dev labels and locations
+  (`Alan Dev`, `alan-dev`, `~/.alan-dev`, dev daemon defaults) without falling
+  back to stable channel state.
+
+## 5. Verification
+
+- [ ] 5.1 Add or update focused Swift/script tests for Settings section
+  presence, Interface preference bindings, and singleton Settings behavior.
+- [ ] 5.2 Add tests or fixtures proving non-terminal Settings content does not
+  create a shell process or Ghostty host.
+- [ ] 5.3 Add tests for redaction and read-only behavior for Accounts, Local,
+  and Capabilities rows.
+- [ ] 5.4 Run `bash clients/apple/scripts/test-shell-runtime-metadata.sh`.
+- [ ] 5.5 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 5.6 Run the relevant macOS build or focused Apple client validation from a
+  repo-local DerivedData path.
+- [ ] 5.7 Install or launch a fresh app build and manually verify the Settings
+  tab after relaunching the current Alan channel.
+
+## 6. Review And Archive Readiness
+
+- [ ] 6.1 Review the implementation against
+  `openspec/specs/macos-shell-ui-ux-conformance/spec.md` and this change's
+  delta spec for duplicate or conflicting Settings requirements.
+- [ ] 6.2 Run `openspec validate improve-macos-settings-surface --strict`.
+- [ ] 6.3 Before archiving after merge, sync the accepted delta requirements into
+  `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
+- [ ] 6.4 Archive the completed change only after implementation, verification,
+  and PR merge are complete.

--- a/openspec/changes/improve-macos-settings-surface/tasks.md
+++ b/openspec/changes/improve-macos-settings-surface/tasks.md
@@ -7,8 +7,8 @@
   Sessions, Capabilities, and Local rows, and classify each as editable,
   read-only, action-only, or deferred.
 - [ ] 1.3 Decide the first implementation slice for Sessions and Capabilities:
-  summary-only, collapsed advanced, or fully hidden until daemon persistence is
-  available.
+  summary-only or collapsed advanced, while keeping both required sections
+  visible in the default Settings layout.
 
 ## 2. Settings Information Architecture
 


### PR DESCRIPTION
## Summary
- Add OpenSpec change for a grouped macOS Settings surface.
- Define task-oriented Settings IA, configuration boundaries, safe first-phase editing, and verification tasks.
- Add macos-shell-ui-ux-conformance delta requirements for Settings sections, redaction, and shell-native density.

## Test Plan
- openspec validate improve-macos-settings-surface --strict
- git diff HEAD~1 --check