### PR TITLE
Add terminal session snapshot persistence OpenSpec

### DIFF
--- a/openspec/changes/persist-macos-terminal-session-snapshots/.openspec.yaml
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/persist-macos-terminal-session-snapshots/design.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/design.md
@@ -1,0 +1,187 @@
+## Context
+
+Alan already separates terminal runtime identity from transient SwiftUI/AppKit
+views. Terminal ContentInstances survive tab switches, spaces, split zoom, and
+view reconstruction, and the workspace manifest restores spaces, tabs, split
+layout, cwd, launch target, title, and lifecycle metadata after app restart.
+
+Two gaps remain:
+
+1. Close paths can finalize terminal runtimes without first asking when the
+   affected terminal has active user work.
+2. Restart restore creates a new shell at the last restorable cwd but does not
+   restore the visible terminal history that gave the user context before
+   closing the app.
+
+Ghostty is a useful reference for safe close confirmation: its macOS controller
+uses one `NSAlert` before closing a terminal surface, tab, window, or app when a
+surface reports it needs quit confirmation. Ghostty's macOS restorable state,
+however, currently centers on pwd, uuid, and title rather than terminal
+transcript restore. Warp is a better product reference for restart continuity:
+it snapshots window/tab/pane structure, terminal cwd and launch metadata, and
+separately restores serialized completed command blocks before creating a fresh
+input block. Alan should adopt the same product shape without copying Warp's
+block model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent destructive pane, tab, window, app, and Quick Terminal close paths
+  from silently killing active terminal work.
+- Keep the default idle-shell close path fast and confirmation-free.
+- Persist a bounded terminal transcript snapshot before confirmed close or app
+  teardown.
+- Restore terminal panes after app restart with their prior visible transcript,
+  scrollback tail, title, cwd, layout, and focus context.
+- Start a new shell in the restored cwd after restart so the pane remains usable.
+- Avoid extra restored-session banners or normal-mode UI chrome; restored state
+  is visible as terminal history, with metadata reserved for debug/control
+  surfaces.
+- Preserve the existing terminal ContentInstance and workspace manifest
+  authority boundaries.
+
+**Non-Goals:**
+
+- Do not keep PTYs, child processes, Ghostty surfaces, or renderer objects alive
+  after the app exits.
+- Do not implement tmux-like session attach or daemon-owned terminal processes.
+- Do not persist unbounded scrollback, binary renderer state, images, selection
+  objects, delivery queues, or secrets.
+- Do not change pinned-tab structural restore into automatic template mutation.
+- Do not add a user preference UI in this change.
+
+## Decisions
+
+### Close guard owns destructive close decisions
+
+Alan will route pane, tab, window, app, Quick Terminal, menu, shortcut, command
+UI, and control-plane close intents through a small close guard before applying
+the existing shell mutation. The guard gathers affected terminal ContentInstances
+and classifies active work from terminal-aware metadata.
+
+Active work includes foreground commands, running alan sessions, pending yields,
+and unknown active-task states when the runtime is still alive. Idle shell
+prompts, exited processes, and non-terminal content do not require
+confirmation.
+
+Alternative considered: let each close button or command path decide
+independently. That would be easy to start but would drift quickly across menu,
+keyboard, sidebar, pane title-bar, quick terminal, and automation paths.
+
+### Interactive close confirms once per requested scope
+
+For interactive close, Alan presents one confirmation sheet for the requested
+scope. Cancelling the sheet leaves shell state, workspace manifest, and terminal
+runtimes unchanged. Confirming runs snapshot capture first, then applies the
+existing close mutation and runtime finalization.
+
+Alternative considered: confirm per terminal pane. That gives more detail but is
+annoying for split tabs and app quit, and it makes app termination harder to
+reason about.
+
+### Automation close is non-destructive by default
+
+Control-plane close commands will return a stable confirmation-required result
+when a target contains active terminal work. The command does not mutate shell
+state or tear down runtimes. A future explicit force-close contract can opt into
+destructive behavior, but this change does not add it.
+
+Alternative considered: allow automation commands to bypass confirmation because
+they are usually agent-driven. That creates the highest data-loss risk: an agent
+or script can close a pane without seeing the user's running command.
+
+### Transcript restore is a bounded product snapshot
+
+Alan will persist a terminal transcript snapshot in the workspace manifest, not
+serialize Ghostty surface or renderer objects. The snapshot stores restorable
+terminal history only: dimensions, transcript lines or cells, viewport anchor,
+cursor approximation, cwd, title, process summary, last command exit code, and
+capture metadata. Size is bounded by row count and encoded byte budget.
+
+Alternative considered: serialize Ghostty terminal state. That could be more
+faithful but couples Alan's durable manifest to Ghostty internals, risks
+renderer-version incompatibility, and still cannot restore dead child processes.
+
+### Runtime service owns capture and replay seams
+
+The terminal runtime service will expose a snapshot capture API for live
+ContentInstance handles and a restore API for startup. Capture first asks the
+live terminal surface for a text/scrollback range. If that is unavailable, Alan
+can use a lightweight transcript ring buffer maintained by the runtime handle.
+App/window teardown performs a best-effort flush before finalization.
+
+On restart, materialization passes the saved snapshot to runtime creation. The
+new runtime presents the restored transcript as initial terminal history and
+then starts a new shell in the restored cwd. The normal UI does not add a
+"restored session" banner; debug metadata may record that the runtime was seeded
+from a snapshot.
+
+Alternative considered: render snapshots as a separate non-terminal placeholder
+until the user explicitly restarts. That would make process loss clearer, but it
+adds visible chrome and blocks the user's next terminal input.
+
+### Pinned templates remain stable
+
+Pinned tab structural restore remains governed by explicit pin snapshots. A
+close-time transcript snapshot is session continuity metadata, not a pin-template
+mutation. When a pinned tab's saved pin snapshot and close-time live snapshot
+share matching terminal ContentInstance identities, Alan may overlay the
+transcript snapshot during restart. It must not silently update split layout,
+launch target, or cwd in the pin snapshot.
+
+Alternative considered: always restore pinned tabs from close-time live
+snapshots. That would satisfy short-term continuity but breaks the existing
+contract that pinning creates an explicit stable template.
+
+### Snapshot failure is observable but not close-blocking
+
+After the user confirms a destructive close, failure to capture or write a
+snapshot records diagnostics and proceeds with the close. Blocking confirmed
+close on persistence failure could trap the user during quit, shutdown, or
+corrupt-manifest recovery.
+
+Alternative considered: fail closed and keep the pane alive when snapshot
+capture fails. That preserves data in theory but can make app quit unreliable
+and conflicts with explicit user confirmation.
+
+## Risks / Trade-offs
+
+- Restored transcript may not be byte-for-byte equivalent to the original
+  terminal state -> bound the contract to readable transcript/history, not
+  Ghostty renderer fidelity.
+- Alternate-screen apps such as editors and pagers can be restored only as their
+  last captured text -> record active screen metadata and degrade to transcript
+  restore instead of claiming live app recovery.
+- Snapshot capture during app quit can race late output -> flush runtime state
+  before capture and accept best-effort tail fidelity.
+- Large scrollback can make manifest writes slow or huge -> cap row count and
+  encoded bytes, prefer tail content, and record truncation metadata.
+- Pinned live transcript overlay can be confusing if the pin template no longer
+  matches live structure -> only overlay when identities match; otherwise keep
+  the pin snapshot behavior.
+- No visible restored-session banner can make process loss less obvious -> keep
+  process/restored metadata available through debug/control surfaces while
+  preserving a normal terminal-first UI.
+
+## Migration Plan
+
+1. Add the manifest model changes with optional snapshot fields and verify old
+   manifests decode and restore without snapshots.
+2. Add close guard classification and non-mutating confirmation-required results
+   behind existing close entry points.
+3. Add runtime snapshot capture and replay seams with fake runtime coverage.
+4. Wire confirmed close/app teardown to capture bounded snapshots before
+   finalization.
+5. Materialize restored snapshots into newly created terminal runtimes before
+   the new shell becomes interactive.
+6. Add focused tests and a running-app quit/relaunch smoke.
+
+Rollback is local to the Apple client: ignore optional transcript snapshot
+fields during materialization and route close commands directly to existing
+mutations. Old manifests remain readable because the new fields are optional.
+
+## Open Questions
+
+No blocking OpenSpec questions. Exact transcript row and byte limits should be
+chosen during implementation with focused performance and UI smoke evidence.

--- a/openspec/changes/persist-macos-terminal-session-snapshots/proposal.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+Closing a pane, tab, window, or the app can currently tear down terminal
+runtimes even when a foreground command or agent session is still doing useful
+work. After restart, Alan restores layout and cwd, but it loses the user's
+terminal screen context, so a pane that previously showed useful output opens as
+a fresh shell with no visible session history.
+
+## What Changes
+
+- Add a unified close guard for pane, tab, window, app, and Quick Terminal close
+  requests that detects active terminal work before mutating shell state or
+  releasing terminal runtimes.
+- Require interactive close paths to present one confirmation when any affected
+  terminal has a foreground command, running alan session, pending yield, or
+  unknown active-task state.
+- Require automation/control-plane close paths to report `requires_confirmation`
+  instead of silently killing active terminal work unless a future explicit force
+  mechanism is added.
+- Persist bounded terminal transcript snapshots in the workspace manifest before
+  confirmed close, app quit, or lifecycle teardown.
+- Restore terminal panes after app restart with the saved transcript, cwd, title,
+  layout, focus, and shell metadata, then start a new shell in the restored cwd
+  without presenting extra user-facing "restored session" chrome.
+- Keep true cross-app-quit PTY/session attach as a future capability; this
+  change does not keep processes alive after the app closes.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-terminal-lifecycle`: Add safe close confirmation and bounded
+  terminal transcript snapshot requirements while preserving the existing
+  explicit close finalization model.
+- `macos-shell-workspace-persistence`: Extend workspace manifest restore
+  snapshots with bounded terminal transcript state and require restart restore
+  to materialize that state.
+- `macos-terminal-runtime-foundation`: Add runtime service responsibilities for
+  capturing terminal transcript snapshots and bootstrapping restored transcript
+  history into a newly created runtime.
+- `macos-shell-control-plane-reliability`: Require automation close commands to
+  report confirmation-required results for active terminal work instead of
+  silently applying destructive close mutations.
+- `macos-shell-build-test-contract`: Add focused tests and UI smoke verification
+  for close guard behavior, manifest round trips, and restart transcript restore.
+
+## Impact
+
+- `clients/apple/alan-macos/ShellHostController.swift` needs a close guard path
+  around pane, tab, window, app, Quick Terminal, menu, shortcut, command UI, and
+  control-plane close intents.
+- `clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift` and
+  snapshot materialization need a manifest-compatible terminal transcript
+  payload with bounded size and old-manifest compatibility.
+- `clients/apple/alan-macos/TerminalRuntimeService.swift`,
+  `TerminalRuntimeRegistry.swift`, `GhosttyLiveHost.swift`, and terminal surface
+  adapters need a snapshot extraction seam and a restored-transcript startup
+  path.
+- `clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift`
+  and shell control DTOs need a stable confirmation-required response for
+  guarded close commands.
+- Focused Apple scripts and UI smoke coverage need scenarios for active close
+  confirmation, idle close bypass, manifest snapshot round trip, restart with
+  restored terminal output, and continued input in the new shell.

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Safe terminal close and transcript restore are verified
+The Apple client SHALL include focused automated tests and running-app smoke
+evidence for terminal close guarding, bounded transcript snapshot persistence,
+and app-restart transcript restore.
+
+#### Scenario: Active close guard tested
+- **WHEN** tests request pane, tab, window, app, or Quick Terminal close for terminal content with active work
+- **THEN** tests verify that close requires confirmation and does not mutate shell state or finalize runtimes before confirmation
+
+#### Scenario: Idle close bypass tested
+- **WHEN** tests request close for idle shell, exited terminal, or non-terminal content
+- **THEN** tests verify that Alan does not require active-work confirmation solely because a shell process exists
+
+#### Scenario: Manifest transcript round trip tested
+- **WHEN** tests persist a workspace manifest containing terminal transcript snapshots
+- **THEN** tests verify old manifests without snapshots still decode
+- **AND** new manifests preserve bounded transcript lines, dimensions, cwd, title, focus, truncation metadata, and content identity through a round trip
+
+#### Scenario: Restart transcript restore smoke tested
+- **WHEN** a running-app smoke produces visible terminal output, closes or quits Alan through a confirmed path, and relaunches the freshly installed app
+- **THEN** verification confirms the restored terminal shows the prior output without an extra restored-session banner
+- **AND** the restored terminal accepts new input in a newly started shell at the restored cwd

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-control-plane-reliability/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Destructive close commands report confirmation requirements
+The macOS shell control plane SHALL route destructive PaneSlot and Tab close
+commands through the same active-work guard used by interactive close paths and
+MUST NOT silently apply a guarded close mutation when terminal work is active.
+
+#### Scenario: Control close pane requires confirmation
+- **WHEN** a control client requests close for a PaneSlot whose terminal content has active work
+- **THEN** the response reports `applied: false` with a stable `requires_confirmation` result
+- **AND** the response identifies the guarded PaneSlot or terminal ContentInstance when available
+- **AND** shell state and terminal runtime state remain unchanged
+
+#### Scenario: Control close tab requires confirmation
+- **WHEN** a control client requests close for a Tab containing at least one terminal ContentInstance with active work
+- **THEN** the response reports `applied: false` with a stable `requires_confirmation` result
+- **AND** no terminal ContentInstance in that Tab is finalized by the rejected command
+
+#### Scenario: Control close idle target succeeds
+- **WHEN** a control client requests close for a PaneSlot or Tab whose terminal content is idle, exited, or absent
+- **THEN** Alan may apply the existing close mutation and return an authoritative result
+
+#### Scenario: Force close is not implicit
+- **WHEN** a control client sends an existing close command without an explicit future force-close contract
+- **THEN** Alan treats the command as non-forcing and applies confirmation-required semantics for active terminal work

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Destructive terminal close requests are guarded
+The macOS shell host SHALL guard destructive pane, tab, window, app, and Quick
+Terminal close requests before mutating authoritative shell state or releasing
+terminal ContentInstance runtimes.
+
+#### Scenario: Closing a pane with active work
+- **WHEN** the user requests close for a PaneSlot that mounts terminal content with a foreground command, running alan session, pending yield, or unknown live active-task state
+- **THEN** Alan asks for confirmation before removing the PaneSlot or finalizing the terminal ContentInstance runtime
+- **AND** cancelling the confirmation leaves shell state, workspace manifest state, and terminal runtime state unchanged
+
+#### Scenario: Closing an idle terminal pane
+- **WHEN** the user requests close for a PaneSlot whose terminal content is an idle shell prompt or an exited process
+- **THEN** Alan may close the PaneSlot without an active-work confirmation
+
+#### Scenario: Closing a tab with multiple terminal panes
+- **WHEN** the user requests close for a tab containing multiple terminal ContentInstances and at least one has active work
+- **THEN** Alan presents at most one confirmation for the tab close request
+- **AND** the tab is removed only after the user confirms
+
+#### Scenario: Closing a window or quitting the app
+- **WHEN** the user requests window close or app quit while any affected terminal ContentInstance has active work
+- **THEN** Alan presents at most one confirmation for that requested close scope
+- **AND** no affected terminal runtime is finalized until the user confirms
+
+#### Scenario: Quick Terminal close has active work
+- **WHEN** the user requests Quick Terminal close while its terminal content has active work
+- **THEN** Alan applies the same close guard semantics used for regular shell terminal panes
+
+### Requirement: Confirmed close captures terminal session snapshots
+The macOS shell host SHALL attempt to capture bounded terminal transcript
+snapshots for affected live terminal ContentInstances after a destructive
+terminal close request is confirmed and before finalizing their runtimes.
+
+#### Scenario: Confirmed pane close captures a snapshot
+- **WHEN** the user confirms closing a terminal PaneSlot with restorable terminal history
+- **THEN** Alan captures a bounded transcript snapshot for the mounted terminal ContentInstance before invoking runtime finalization
+- **AND** the snapshot is associated with the terminal ContentInstance identity and close reason
+
+#### Scenario: Snapshot capture fails after confirmation
+- **WHEN** the user has confirmed a destructive close and snapshot capture or persistence fails
+- **THEN** Alan records a diagnostic for debugging
+- **AND** Alan may continue the confirmed close instead of trapping the user in the closing surface
+
+#### Scenario: App restart restores history but not process continuity
+- **WHEN** Alan restarts after terminal ContentInstances were closed or interrupted in the prior app instance
+- **THEN** restored terminal panes may present saved transcript history from the prior session
+- **AND** Alan creates new terminal runtimes and child processes instead of claiming continuity with the prior app instance's PTYs, child processes, or Ghostty surfaces

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Workspace manifest stores content-container restore snapshots
+After `generalize-macos-shell-content-containers`, the macOS shell workspace manifest SHALL
+remain the workspace restore authority and SHALL store restorable PaneSlot / ContentInstance
+snapshots instead of terminal-only pane snapshots.
+
+#### Scenario: Terminal-only manifest upgrades to content-container shape
+- **WHEN** alan 读取 `persist-macos-shell-workspaces` 产生的 terminal-only workspace manifest
+- **THEN** alan 将每个 terminal restore leaf 升级为 PaneSlot 加 `terminal` ContentInstance restore payload
+- **AND** Space/Tab IDs、ordering、selected Space/Tab、pin 状态、TTL anchor 和 active-task metadata 保持一致
+- **AND** 后续 manifest 写入只使用 content-container restore shape
+
+#### Scenario: Pinned mixed tab snapshot is saved
+- **WHEN** 用户 pin 或 update-pin 一个包含 terminal、markdown 或 settings content 的 split tab
+- **THEN** workspace manifest 保存 split tree、PaneSlot restore identity、ContentInstance kind 和每个 content 的 restorable payload
+- **AND** terminal payload 保存 cwd、launch target 和用户可见 title
+- **AND** terminal payload MAY save a bounded terminal transcript snapshot as session-continuity metadata when one is available
+- **AND** markdown/settings payload 保存对应文件引用或 settings surface identity
+- **AND** manifest 不保存 terminal process、PTY、renderer object、Ghostty surface object、unbounded scrollback 或 delivery queue
+
+#### Scenario: Unpinned mixed tab live snapshot is saved
+- **WHEN** 未 pin tab 包含 terminal、markdown 或 settings content 且仍在 TTL 内
+- **THEN** workspace manifest 的 live snapshot 保存 content-aware restore state
+- **AND** terminal content MAY include a bounded transcript snapshot with visible history, viewport, cwd, title, dimensions, process summary, and capture metadata
+- **AND** lifecycle pruning 继续使用原有 `max(lastActivatedAt, lastActivityAt)`、pin 状态和 active-task metadata
+- **AND** 非 terminal content 不会被误判为 terminal active task
+
+#### Scenario: ShellStateSnapshot stays a runtime projection
+- **WHEN** content-container migration 已经完成且 app 重新启动
+- **THEN** alan 从 workspace manifest materialize v0.2 shell state
+- **AND** `ShellStateSnapshot` 只发布当前 UI、control-plane 和 runtime projection
+- **AND** `shell-state-window_main.json` 不重新成为 workspace restore authority
+
+## ADDED Requirements
+
+### Requirement: Terminal transcript snapshots restore the prior visible session context
+The macOS shell workspace manifest SHALL persist terminal transcript snapshots
+as bounded session-continuity state that can seed newly created terminal
+runtimes after app restart.
+
+#### Scenario: App closes with visible terminal output
+- **WHEN** Alan closes or quits while a retained terminal ContentInstance has visible output and restorable transcript history
+- **THEN** the workspace manifest stores a bounded transcript snapshot for that terminal content
+- **AND** the snapshot preserves enough text, dimensions, title, cwd, focus, and viewport context to show the prior terminal state after restart
+
+#### Scenario: App restarts after transcript snapshot
+- **WHEN** Alan restores a terminal ContentInstance from a workspace manifest that contains a terminal transcript snapshot
+- **THEN** Alan materializes the terminal with the saved transcript history before or during new runtime startup
+- **AND** the restored terminal remains usable by starting a new shell in the restored cwd
+- **AND** the normal terminal UI does not show an additional restored-session banner or warning surface solely because the transcript was restored
+
+#### Scenario: Transcript snapshot is too large
+- **WHEN** terminal history exceeds the configured row or encoded-byte snapshot limit
+- **THEN** Alan stores a bounded tail snapshot and records truncation metadata
+- **AND** manifest persistence remains bounded in size and time
+
+### Requirement: Pinned tab templates are not silently rewritten by session snapshots
+Pinned Tab structural restore SHALL remain governed by explicit pin snapshots,
+while close-time terminal transcript snapshots MAY provide last-session history
+without silently changing the pinned template.
+
+#### Scenario: Pinned tab has matching live transcript
+- **WHEN** a pinned Tab restores from its pin snapshot and a close-time transcript snapshot exists for matching terminal ContentInstance identity
+- **THEN** Alan may seed the restored terminal runtime with that transcript history
+- **AND** the pin snapshot's split layout, launch target, and explicit cwd template are not replaced by transient live-session state
+
+#### Scenario: Pinned tab live structure no longer matches the pin snapshot
+- **WHEN** a close-time transcript snapshot refers to terminal content that is not present in the pinned restore snapshot
+- **THEN** Alan preserves the pinned restore snapshot behavior and ignores the unmatched transcript for that restored tab

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Terminal runtime service captures bounded transcript snapshots
+The terminal runtime service SHALL expose a service-owned snapshot capture path
+for live terminal ContentInstances that returns bounded terminal transcript
+state without exposing durable manifests to Ghostty renderer internals.
+
+#### Scenario: Live terminal snapshot is requested
+- **WHEN** the shell close guard or workspace manifest sync requests a snapshot for a live terminal ContentInstance
+- **THEN** the runtime service returns a bounded transcript snapshot containing restorable text history, dimensions, viewport, cwd, title, process summary, and capture metadata when available
+- **AND** the snapshot is keyed by terminal ContentInstance identity
+
+#### Scenario: Surface extraction is unavailable
+- **WHEN** a live Ghostty surface cannot provide a text or scrollback extraction range
+- **THEN** the runtime service may use a bounded transcript ring buffer maintained by the terminal handle
+- **AND** the absence of high-fidelity renderer state does not cause Alan to persist Ghostty renderer objects
+
+#### Scenario: Snapshot excludes non-restorable runtime objects
+- **WHEN** a terminal transcript snapshot is produced
+- **THEN** it does not include PTY file descriptors, child process handles, Ghostty surface pointers, renderer objects, delivery queues, or unbounded scrollback
+
+### Requirement: Restored transcript history seeds newly created terminal runtimes
+The terminal runtime service SHALL seed newly created terminal runtimes with
+restored transcript history when a terminal ContentInstance is materialized from
+a workspace manifest with a terminal transcript snapshot and before treating the
+pane as ready for normal user input.
+
+#### Scenario: Runtime starts with restored transcript
+- **WHEN** a restored terminal ContentInstance has a terminal transcript snapshot
+- **THEN** the runtime service presents the transcript as initial terminal history for the new runtime
+- **AND** the new shell starts in the restored cwd and can accept subsequent input
+
+#### Scenario: Restored alternate-screen snapshot
+- **WHEN** a transcript snapshot was captured from alternate-screen terminal mode
+- **THEN** Alan records the captured mode metadata
+- **AND** the restored runtime may present the captured text as transcript history without claiming that the prior alternate-screen application is still running
+
+#### Scenario: Snapshot metadata is debug-only
+- **WHEN** a runtime is seeded from a restored transcript snapshot
+- **THEN** debug or control-plane metadata may indicate that the runtime was restored from a snapshot
+- **AND** the normal terminal UI is not required to show additional restored-session chrome

--- a/openspec/changes/persist-macos-terminal-session-snapshots/tasks.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/tasks.md
@@ -1,0 +1,53 @@
+## 1. Manifest And Restore Model
+
+- [ ] 1.1 Add optional bounded terminal transcript snapshot fields to the terminal workspace manifest payload.
+- [ ] 1.2 Keep old workspace manifests decodable when transcript snapshot fields are absent.
+- [ ] 1.3 Enforce transcript row and encoded-byte limits, tail truncation, and truncation metadata during manifest encoding.
+- [ ] 1.4 Preserve pinned-tab structural snapshots while storing close-time transcript continuity metadata separately or as an overlay.
+
+## 2. Runtime Snapshot Capture
+
+- [ ] 2.1 Add a `TerminalTranscriptSnapshot` model with content identity, cwd, title, dimensions, viewport, transcript text, process summary, capture time, and truncation metadata.
+- [ ] 2.2 Add a terminal runtime service capture API keyed by terminal ContentInstance identity.
+- [ ] 2.3 Capture transcript state from Ghostty surfaces when available and fall back to a bounded service-owned transcript ring buffer when needed.
+- [ ] 2.4 Return explicit capture failures and diagnostics without exposing Ghostty renderer objects, PTY handles, child process handles, or delivery queues.
+
+## 3. Close Guard
+
+- [ ] 3.1 Add a close-impact collector for PaneSlot, Tab, window, app, and Quick Terminal close intents.
+- [ ] 3.2 Classify active terminal work from foreground command, alan session, pending yield, exited process, idle shell, and unknown live runtime metadata.
+- [ ] 3.3 Route pane title-bar, sidebar, menu, keyboard shortcut, window close, app quit, and Quick Terminal close paths through the close guard.
+- [ ] 3.4 Present one interactive confirmation per requested close scope when active terminal work is present.
+- [ ] 3.5 Ensure cancelling confirmation leaves shell state, workspace manifest state, and terminal runtime state unchanged.
+- [ ] 3.6 After confirmation, capture affected terminal transcript snapshots before applying close mutation and runtime finalization.
+
+## 4. Control Plane Close Semantics
+
+- [ ] 4.1 Add stable `requires_confirmation` result semantics to close command DTOs when the target contains active terminal work.
+- [ ] 4.2 Route control-plane PaneSlot and Tab close commands through the close guard.
+- [ ] 4.3 Ensure confirmation-required control close responses do not mutate shell state or finalize terminal runtimes.
+- [ ] 4.4 Preserve existing authoritative close responses for idle, exited, missing, and non-terminal targets.
+
+## 5. Restart Restore
+
+- [ ] 5.1 Materialize manifest transcript snapshots into terminal runtime creation payloads.
+- [ ] 5.2 Seed newly created terminal runtimes with restored transcript history before normal user input is accepted.
+- [ ] 5.3 Start a fresh shell in the restored cwd after seeding transcript history.
+- [ ] 5.4 Restore transcript history without adding normal-mode restored-session banners or warning chrome.
+- [ ] 5.5 Degrade alternate-screen snapshots to captured readable transcript history without claiming the prior application is still running.
+
+## 6. Verification
+
+- [ ] 6.1 Add focused tests for active close confirmation, idle close bypass, cancel-no-mutation behavior, and one confirmation for multi-pane scopes.
+- [ ] 6.2 Add control-plane tests for `requires_confirmation`, idle close success, and unchanged shell/runtime state after guarded close rejection.
+- [ ] 6.3 Add manifest round-trip tests for old manifests, bounded snapshot payloads, truncation metadata, pinned-template overlays, and unmatched transcript discard.
+- [ ] 6.4 Add runtime service tests for live snapshot capture, ring-buffer fallback, explicit capture failure, and restored transcript seeding.
+- [ ] 6.5 Run a running-app smoke that produces visible output, quits through a confirmed path, relaunches a fresh installed app, verifies prior output is visible, and verifies new input goes to a fresh shell at the restored cwd.
+- [ ] 6.6 Run `openspec validate persist-macos-terminal-session-snapshots --strict`.
+- [ ] 6.7 Run the focused Apple build/test commands touched by the implementation.
+
+## 7. Review And Archive Readiness
+
+- [ ] 7.1 Document that true PTY/process survival and daemon-backed terminal attach remain future work.
+- [ ] 7.2 Prepare PR review notes covering close guard scope, transcript bounds, old-manifest compatibility, and restart smoke evidence.
+- [ ] 7.3 After implementation is merged, sync accepted spec deltas into `openspec/specs/` before archiving the change.


### PR DESCRIPTION
## Summary
- propose durable terminal session snapshot persistence for relaunch recovery
- define shell lifecycle, workspace persistence, runtime foundation, control plane, and test-contract requirements
- keep this PR spec-only; implementation remains future work

## Verification
- openspec validate persist-macos-terminal-session-snapshots --strict
- openspec validate --all --strict