### PR TITLE
Improve macOS settings surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -873,6 +873,19 @@ OpenSpec.
    for current implementation details, use `docs/skills_and_tools.md` and
    `docs/skill_authoring.md`.
 
+### macOS App Testing Safety
+
+For macOS app testing, scripted operation, visual QA, and Computer Use, use the
+dev channel as the default target: `Alan Dev.app`,
+`app.alanworks.macos.dev`, `alan-dev`, `~/.alan-dev`, and
+`alan-dev-shell-control`.
+
+Do not launch, quit, install over, inspect, or otherwise operate the user's
+stable/native Alan app (`Alan.app`, `app.alanworks.macos`, `alan`, `~/.alan`)
+for testing unless the user explicitly asks to work on the stable channel. The
+stable/native app is the user's normal work environment; automation against it
+can interrupt active work.
+
 ---
 
 ## Installation

--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		000000000000000000000046 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 000000000000000000000802 /* Sparkle */; };
 		000000000000000000000047 /* App/AlanMacUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000151 /* App/AlanMacUpdateController.swift */; };
 		000000000000000000000048 /* Support/AlanMacUpdatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000152 /* Support/AlanMacUpdatePolicy.swift */; };
+		000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -153,6 +154,7 @@
 		000000000000000000000150 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		000000000000000000000151 /* App/AlanMacUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AlanMacUpdateController.swift; sourceTree = "<group>"; };
 		000000000000000000000152 /* Support/AlanMacUpdatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/AlanMacUpdatePolicy.swift; sourceTree = "<group>"; };
+		000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellSettingsSurfaceModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -306,6 +308,7 @@
 				000000000000000000000143 /* Models/Shell/ShellAutomationCommand.swift */,
 				000000000000000000000144 /* Models/Shell/ShellAutomationEntities.swift */,
 				000000000000000000000145 /* Models/Shell/ShellAutomationIntents.swift */,
+				000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */,
 			);
 			name = Models/Shell;
 			sourceTree = "<group>";
@@ -522,6 +525,7 @@
 				00000000000000000000003C /* Support/AlanCommandLineToolInstaller.swift in Sources */,
 				000000000000000000000048 /* Support/AlanMacUpdatePolicy.swift in Sources */,
 				000000000000000000000047 /* App/AlanMacUpdateController.swift in Sources */,
+				000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */,
 				000000000000000000000039 /* Models/Shell/ShellWorkspaceManifest.swift in Sources */,
 				00000000000000000000003A /* Services/Shell/ShellWorkspaceManifestStore.swift in Sources */,
 			);

--- a/clients/apple/alan-macos/Models/API/DaemonAPIModels.swift
+++ b/clients/apple/alan-macos/Models/API/DaemonAPIModels.swift
@@ -226,6 +226,94 @@ struct ReadEventsResponse: Decodable {
     }
 }
 
+struct ConnectionCatalogResponse: Decodable {
+    let providers: [ConnectionProviderDescriptorResponse]
+}
+
+struct ConnectionProviderDescriptorResponse: Decodable {
+    let providerID: String
+    let displayName: String
+    let supportsBrowserLogin: Bool
+    let supportsDeviceLogin: Bool
+    let supportsSecretEntry: Bool
+    let supportsLogout: Bool
+    let supportsTest: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case providerID = "provider_id"
+        case displayName = "display_name"
+        case supportsBrowserLogin = "supports_browser_login"
+        case supportsDeviceLogin = "supports_device_login"
+        case supportsSecretEntry = "supports_secret_entry"
+        case supportsLogout = "supports_logout"
+        case supportsTest = "supports_test"
+    }
+}
+
+struct ConnectionProfilesResponse: Decodable {
+    let defaultProfile: String?
+    let profiles: [ConnectionProfileSummaryResponse]
+
+    private enum CodingKeys: String, CodingKey {
+        case defaultProfile = "default_profile"
+        case profiles
+    }
+}
+
+struct ConnectionProfileSummaryResponse: Decodable {
+    let profileID: String
+    let label: String?
+    let provider: String
+    let credentialID: String?
+    let settings: [String: String]
+    let credentialStatus: String
+    let isDefault: Bool
+    let source: String
+
+    private enum CodingKeys: String, CodingKey {
+        case profileID = "profile_id"
+        case label
+        case provider
+        case credentialID = "credential_id"
+        case settings
+        case credentialStatus = "credential_status"
+        case isDefault = "is_default"
+        case source
+    }
+}
+
+struct ConnectionCurrentStateResponse: Decodable {
+    let defaultProfile: String?
+    let effectiveProfile: String?
+    let effectiveSource: String
+
+    private enum CodingKeys: String, CodingKey {
+        case defaultProfile = "default_profile"
+        case effectiveProfile = "effective_profile"
+        case effectiveSource = "effective_source"
+    }
+}
+
+struct SkillCatalogSnapshotResponse: Decodable {
+    let skills: [SkillCatalogSkillResponse]
+}
+
+struct SkillCatalogSkillResponse: Decodable {
+    let id: String
+    let name: String
+    let enabled: Bool
+    let allowImplicitInvocation: Bool
+    let available: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case enabled
+        case allowImplicitInvocation = "allow_implicit_invocation"
+        case available
+    }
+}
+
 struct ToolDecisionAudit: Decodable {
     let policySource: String
     let ruleID: String?

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -612,11 +612,13 @@ struct ShellSettingsLocalSummary: Equatable {
 struct ShellSettingsWorkspaceContext: Equatable {
     let connectionWorkspaceDir: String?
     let skillCatalogWorkspaceDir: String?
+    let skillCatalogUnavailableReason: String?
     let agentName: String?
 
     static let none = ShellSettingsWorkspaceContext(
         connectionWorkspaceDir: nil,
         skillCatalogWorkspaceDir: nil,
+        skillCatalogUnavailableReason: nil,
         agentName: nil
     )
 
@@ -631,6 +633,7 @@ struct ShellSettingsWorkspaceContext: Equatable {
             return ShellSettingsWorkspaceContext(
                 connectionWorkspaceDir: nil,
                 skillCatalogWorkspaceDir: nil,
+                skillCatalogUnavailableReason: nil,
                 agentName: normalizedNonEmpty(agentName)
             )
         }
@@ -644,16 +647,21 @@ struct ShellSettingsWorkspaceContext: Equatable {
             return ShellSettingsWorkspaceContext(
                 connectionWorkspaceDir: registered.path,
                 skillCatalogWorkspaceDir: registered.catalogIdentifier,
+                skillCatalogUnavailableReason: nil,
                 agentName: normalizedNonEmpty(agentName)
             )
         }
 
+        let discoveredWorkspaceRoot = workspaceRootContainingAlanDirectory(
+            activeDirectory,
+            fileManager: fileManager
+        )
         return ShellSettingsWorkspaceContext(
-            connectionWorkspaceDir: workspaceRootContainingAlanDirectory(
-                activeDirectory,
-                fileManager: fileManager
-            ) ?? activeDirectory,
+            connectionWorkspaceDir: discoveredWorkspaceRoot ?? activeDirectory,
             skillCatalogWorkspaceDir: nil,
+            skillCatalogUnavailableReason: discoveredWorkspaceRoot.map { _ in
+                "Register this workspace to show workspace skills."
+            },
             agentName: normalizedNonEmpty(agentName)
         )
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -308,7 +308,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 id: "daemonEndpoint",
                 systemName: "server.rack",
                 title: "Daemon endpoint",
-                detail: "Default bind \(local.daemonBindAddress)",
+                detail: "Bind \(local.daemonBindAddress)",
                 value: local.daemonURL
             ),
             ShellSettingsRowModel(
@@ -564,8 +564,11 @@ struct ShellSettingsLocalSummary: Equatable {
         updateDecision: AlanMacUpdateDecision = AlanMacUpdatePolicy.decision(),
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> ShellSettingsLocalSummary {
-        let daemonBindAddress = channel.daemonBindAddress(environment: environment)
-        let daemonURL = channel.daemonURL(environment: environment, bindAddress: daemonBindAddress)
+        let hostConfig = ShellSettingsHostConfig.resolve(
+            channel: channel,
+            environment: environment,
+            homeDirectory: homeDirectory
+        )
         return ShellSettingsLocalSummary(
             channel: channel,
             appDisplayName: channel.appDisplayName,
@@ -573,8 +576,8 @@ struct ShellSettingsLocalSummary: Equatable {
             bundleIdentifier: channel.bundleIdentifier,
             channelLabel: channel.settingsChannelLabel,
             cliToolName: channel.cliToolName,
-            daemonURL: daemonURL,
-            daemonBindAddress: daemonBindAddress,
+            daemonURL: hostConfig.daemonURL,
+            daemonBindAddress: hostConfig.bindAddress,
             updateSummary: updateSummary(for: updateDecision),
             updateDetail: updateDetail(for: updateDecision),
             alanHomeDisplayPath: channel.alanHomeDisplayPath,
@@ -603,6 +606,88 @@ struct ShellSettingsLocalSummary: Equatable {
             return trimmed
         }
         return "Use \(decision.menuTitle) for this install."
+    }
+}
+
+struct ShellSettingsWorkspaceContext: Equatable {
+    let connectionWorkspaceDir: String?
+    let skillCatalogWorkspaceDir: String?
+    let agentName: String?
+
+    static let none = ShellSettingsWorkspaceContext(
+        connectionWorkspaceDir: nil,
+        skillCatalogWorkspaceDir: nil,
+        agentName: nil
+    )
+
+    static func resolve(
+        activeWorkingDirectory: String?,
+        channel: AlanInstallChannel = .current(),
+        agentName: String? = nil,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileManager: FileManager = .default
+    ) -> ShellSettingsWorkspaceContext {
+        guard let activeDirectory = normalizedPath(activeWorkingDirectory) else {
+            return ShellSettingsWorkspaceContext(
+                connectionWorkspaceDir: nil,
+                skillCatalogWorkspaceDir: nil,
+                agentName: normalizedNonEmpty(agentName)
+            )
+        }
+
+        if let registered = ShellSettingsWorkspaceRegistry.load(
+            channel: channel,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        )
+        .mostSpecificEntry(containing: activeDirectory) {
+            return ShellSettingsWorkspaceContext(
+                connectionWorkspaceDir: registered.path,
+                skillCatalogWorkspaceDir: registered.catalogIdentifier,
+                agentName: normalizedNonEmpty(agentName)
+            )
+        }
+
+        return ShellSettingsWorkspaceContext(
+            connectionWorkspaceDir: workspaceRootContainingAlanDirectory(
+                activeDirectory,
+                fileManager: fileManager
+            ) ?? activeDirectory,
+            skillCatalogWorkspaceDir: nil,
+            agentName: normalizedNonEmpty(agentName)
+        )
+    }
+
+    private static func normalizedNonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func normalizedPath(_ path: String?) -> String? {
+        guard let trimmed = normalizedNonEmpty(path) else {
+            return nil
+        }
+        return URL(fileURLWithPath: trimmed, isDirectory: true)
+            .standardizedFileURL
+            .path
+    }
+
+    private static func workspaceRootContainingAlanDirectory(
+        _ path: String,
+        fileManager: FileManager
+    ) -> String? {
+        var url = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        while url.path != "/" {
+            let alanDirectory = url.appendingPathComponent(".alan", isDirectory: true).path
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: alanDirectory, isDirectory: &isDirectory),
+               isDirectory.boolValue
+            {
+                return url.path
+            }
+            url.deleteLastPathComponent()
+        }
+        return nil
     }
 }
 
@@ -643,6 +728,15 @@ private extension AlanInstallChannel {
         }
     }
 
+    var alanHomeDirectoryName: String {
+        switch self {
+        case .stable:
+            return ".alan"
+        case .dev:
+            return ".alan-dev"
+        }
+    }
+
     var globalSkillsDisplayPath: String {
         switch self {
         case .stable:
@@ -679,25 +773,201 @@ private extension AlanInstallChannel {
         return "~/" + suffix
     }
 
-    func daemonBindAddress(environment: [String: String]) -> String {
-        let override = environment["BIND_ADDRESS"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return override?.isEmpty == false ? override! : defaultDaemonBindAddress
-    }
-
-    func daemonURL(environment: [String: String], bindAddress: String) -> String {
-        let override = environment["ALAN_AGENTD_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if override?.isEmpty == false {
-            return override!
-        }
-        if bindAddress == defaultDaemonBindAddress {
-            return defaultDaemonURL
-        }
-        return Self.localDaemonURL(for: bindAddress)
-    }
-
     static func localDaemonURL(for bindAddress: String) -> String {
         let port = bindAddress.split(separator: ":").last.flatMap { UInt16($0) } ?? 8090
         return "http://127.0.0.1:\(port)"
+    }
+}
+
+private struct ShellSettingsHostConfig {
+    let bindAddress: String
+    let daemonURL: String
+
+    static func resolve(
+        channel: AlanInstallChannel,
+        environment: [String: String],
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> ShellSettingsHostConfig {
+        let fileConfig = load(channel: channel, homeDirectory: homeDirectory, fileManager: fileManager)
+        let bindAddress =
+            nonEmpty(environment["BIND_ADDRESS"])
+            ?? fileConfig?.bindAddress
+            ?? channel.defaultDaemonBindAddress
+        let daemonURL =
+            nonEmpty(environment["ALAN_AGENTD_URL"])
+            ?? fileConfig?.daemonURL
+            ?? channel.defaultDaemonURL
+        return ShellSettingsHostConfig(bindAddress: bindAddress, daemonURL: daemonURL)
+    }
+
+    private static func load(
+        channel: AlanInstallChannel,
+        homeDirectory: URL,
+        fileManager: FileManager
+    ) -> ShellSettingsHostConfig? {
+        let path = homeDirectory
+            .appendingPathComponent(channel.alanHomeDirectoryName, isDirectory: true)
+            .appendingPathComponent("host.toml", isDirectory: false)
+            .path
+        guard fileManager.fileExists(atPath: path),
+              let content = try? String(contentsOfFile: path, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        let values = ShellSettingsTopLevelTOMLParser.parse(content)
+        let bindAddress = nonEmpty(values["bind_address"]) ?? channel.defaultDaemonBindAddress
+        let daemonURL = nonEmpty(values["daemon_url"]) ?? AlanInstallChannel.localDaemonURL(
+            for: bindAddress
+        )
+        return ShellSettingsHostConfig(bindAddress: bindAddress, daemonURL: daemonURL)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
+private enum ShellSettingsTopLevelTOMLParser {
+    static func parse(_ content: String) -> [String: String] {
+        var values: [String: String] = [:]
+        for line in content.components(separatedBy: .newlines) {
+            let stripped = stripComment(from: line).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !stripped.isEmpty,
+                  !stripped.hasPrefix("["),
+                  let separator = stripped.firstIndex(of: "=")
+            else {
+                continue
+            }
+
+            let key = String(stripped[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let rawValue = String(stripped[stripped.index(after: separator)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !key.isEmpty,
+               let value = parsedScalar(rawValue)
+            {
+                values[key] = value
+            }
+        }
+        return values
+    }
+
+    private static func parsedScalar(_ rawValue: String) -> String? {
+        if rawValue.count >= 2,
+           let first = rawValue.first,
+           let last = rawValue.last,
+           (first == "\"" && last == "\"") || (first == "'" && last == "'")
+        {
+            return String(rawValue.dropFirst().dropLast())
+        }
+        return rawValue.isEmpty ? nil : rawValue
+    }
+
+    private static func stripComment(from line: String) -> String {
+        var isInSingleQuotedString = false
+        var isInDoubleQuotedString = false
+        var previousCharacter: Character?
+
+        for index in line.indices {
+            let character = line[index]
+            if character == "\"",
+               !isInSingleQuotedString,
+               previousCharacter != "\\"
+            {
+                isInDoubleQuotedString.toggle()
+            } else if character == "'",
+                      !isInDoubleQuotedString
+            {
+                isInSingleQuotedString.toggle()
+            } else if character == "#",
+                      !isInSingleQuotedString,
+                      !isInDoubleQuotedString
+            {
+                return String(line[..<index])
+            }
+            previousCharacter = character
+        }
+        return line
+    }
+}
+
+private struct ShellSettingsWorkspaceRegistry {
+    struct Entry: Decodable, Equatable {
+        let id: String
+        let path: String
+        let alias: String
+
+        var catalogIdentifier: String {
+            let trimmedAlias = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedAlias.isEmpty ? id : trimmedAlias
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case path
+            case alias
+        }
+    }
+
+    let entries: [Entry]
+
+    static func load(
+        channel: AlanInstallChannel,
+        homeDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> ShellSettingsWorkspaceRegistry {
+        let path = homeDirectory
+            .appendingPathComponent(channel.alanHomeDirectoryName, isDirectory: true)
+            .appendingPathComponent("registry.json", isDirectory: false)
+            .path
+        guard fileManager.fileExists(atPath: path),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let file = try? JSONDecoder().decode(File.self, from: data)
+        else {
+            return ShellSettingsWorkspaceRegistry(entries: [])
+        }
+        let entries = file.workspaces.map { entry in
+            Entry(
+                id: entry.id,
+                path: normalizedPath(entry.path) ?? entry.path,
+                alias: entry.alias
+            )
+        }
+        return ShellSettingsWorkspaceRegistry(entries: entries)
+    }
+
+    func mostSpecificEntry(containing activeDirectory: String) -> Entry? {
+        entries
+            .filter { contains(path: activeDirectory, inWorkspaceRoot: $0.path) }
+            .sorted { lhs, rhs in
+                lhs.path.count > rhs.path.count
+            }
+            .first
+    }
+
+    private static func normalizedPath(_ path: String) -> String? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL.path
+    }
+
+    private func contains(path: String, inWorkspaceRoot root: String) -> Bool {
+        guard !root.isEmpty else {
+            return false
+        }
+        if path == root {
+            return true
+        }
+        let normalizedRoot = root.hasSuffix("/") ? root : root + "/"
+        return path.hasPrefix(normalizedRoot)
+    }
+
+    private struct File: Decodable {
+        let workspaces: [Entry]
     }
 }
 #endif

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -1,0 +1,703 @@
+import Foundation
+
+#if os(macOS)
+enum ShellSettingsSectionID: String, CaseIterable, Equatable {
+    case interface
+    case accounts
+    case sessions
+    case capabilities
+    case local
+
+    static let defaultOrder: [ShellSettingsSectionID] = [
+        .interface,
+        .accounts,
+        .sessions,
+        .capabilities,
+        .local,
+    ]
+
+    var title: String {
+        switch self {
+        case .interface:
+            return "Interface"
+        case .accounts:
+            return "Accounts"
+        case .sessions:
+            return "Sessions"
+        case .capabilities:
+            return "Capabilities"
+        case .local:
+            return "Local"
+        }
+    }
+}
+
+enum ShellSettingsRowMutability: Equatable {
+    case editable
+    case readOnly
+    case actionOnly
+    case deferred
+}
+
+struct ShellSettingsRowModel: Identifiable, Equatable {
+    let id: String
+    let systemName: String
+    let title: String
+    let detail: String?
+    let value: String?
+    let mutability: ShellSettingsRowMutability
+    let offersFreeformEditing: Bool
+
+    init(
+        id: String,
+        systemName: String,
+        title: String,
+        detail: String? = nil,
+        value: String? = nil,
+        mutability: ShellSettingsRowMutability = .readOnly,
+        offersFreeformEditing: Bool = false
+    ) {
+        self.id = id
+        self.systemName = systemName
+        self.title = title
+        self.detail = detail
+        self.value = value
+        self.mutability = mutability
+        self.offersFreeformEditing = offersFreeformEditing
+    }
+
+    var visibleText: [String] {
+        [title, value, detail].compactMap { text in
+            let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed?.isEmpty == false ? trimmed : nil
+        }
+    }
+}
+
+struct ShellSettingsSectionModel: Identifiable, Equatable {
+    let id: ShellSettingsSectionID
+    let rows: [ShellSettingsRowModel]
+
+    var title: String { id.title }
+
+    var visibleText: [String] {
+        [title] + rows.flatMap(\.visibleText)
+    }
+}
+
+struct ShellSettingsSurfaceSnapshot: Equatable {
+    let sections: [ShellSettingsSectionModel]
+
+    static func make(
+        remote: ShellSettingsRemoteSnapshot,
+        local: ShellSettingsLocalSummary
+    ) -> ShellSettingsSurfaceSnapshot {
+        ShellSettingsSurfaceSnapshot(
+            sections: [
+                ShellSettingsSectionModel(id: .interface, rows: interfaceRows()),
+                ShellSettingsSectionModel(id: .accounts, rows: accountRows(remote.accounts)),
+                ShellSettingsSectionModel(id: .sessions, rows: sessionRows()),
+                ShellSettingsSectionModel(id: .capabilities, rows: capabilityRows(remote.capabilities)),
+                ShellSettingsSectionModel(id: .local, rows: localRows(local)),
+            ]
+        )
+    }
+
+    var visibleText: [String] {
+        sections.flatMap(\.visibleText)
+    }
+
+    private static func interfaceRows() -> [ShellSettingsRowModel] {
+        [
+            ShellSettingsRowModel(
+                id: "appearance",
+                systemName: "circle.lefthalf.filled",
+                title: "Appearance",
+                mutability: .editable
+            ),
+            ShellSettingsRowModel(
+                id: "sidebar",
+                systemName: "sidebar.left",
+                title: "Sidebar",
+                mutability: .editable
+            ),
+            ShellSettingsRowModel(
+                id: "inactiveSplitDimming",
+                systemName: "rectangle.split.2x1",
+                title: "Inactive split dimming",
+                mutability: .editable
+            ),
+        ]
+    }
+
+    private static func accountRows(
+        _ summary: ShellSettingsAccountsSummary
+    ) -> [ShellSettingsRowModel] {
+        if let reason = summary.compactUnavailableReason {
+            return [
+                unavailableRow(
+                    id: "accountsUnavailable",
+                    systemName: "person.crop.circle.badge.exclamationmark",
+                    title: "Connection profile",
+                    reason: reason
+                ),
+            ]
+        }
+
+        guard let profile = summary.effectiveProfile else {
+            return [
+                ShellSettingsRowModel(
+                    id: "selectedProfile",
+                    systemName: "person.crop.circle",
+                    title: "Selected profile",
+                    detail: "Add one with alan connection add.",
+                    value: "Not configured"
+                ),
+                ShellSettingsRowModel(
+                    id: "accountActions",
+                    systemName: "arrowshape.turn.up.right",
+                    title: "Account actions",
+                    detail: "Login, key entry, and connection tests run through alan connection.",
+                    value: "Command line"
+                ),
+            ]
+        }
+
+        let provider = summary.provider(for: profile.provider)
+        return [
+            ShellSettingsRowModel(
+                id: "selectedProfile",
+                systemName: "person.crop.circle",
+                title: "Selected profile",
+                detail: "Profile ID: \(profile.profileID)",
+                value: profile.displayName
+            ),
+            ShellSettingsRowModel(
+                id: "provider",
+                systemName: "network",
+                title: "Provider",
+                detail: profile.provider,
+                value: provider?.displayName ?? displayProviderName(profile.provider)
+            ),
+            ShellSettingsRowModel(
+                id: "model",
+                systemName: "cpu",
+                title: "Model",
+                detail: "Resolved by the connection profile.",
+                value: profile.modelDisplayValue
+            ),
+            ShellSettingsRowModel(
+                id: "credential",
+                systemName: "key",
+                title: "Credential",
+                detail: "Secret values stay in the host credential store.",
+                value: displayCredentialStatus(profile.credentialStatus)
+            ),
+            ShellSettingsRowModel(
+                id: "accountActions",
+                systemName: "arrowshape.turn.up.right",
+                title: "Account actions",
+                detail: "Login, key entry, and connection tests run through alan connection.",
+                value: provider?.supportedActionLabel ?? "Command line",
+                mutability: .actionOnly
+            ),
+        ]
+    }
+
+    private static func sessionRows() -> [ShellSettingsRowModel] {
+        [
+            ShellSettingsRowModel(
+                id: "governance",
+                systemName: "checkmark.shield",
+                title: "Governance",
+                detail: "Default new-session policy.",
+                value: "Conservative"
+            ),
+            ShellSettingsRowModel(
+                id: "reasoningEffort",
+                systemName: "brain.head.profile",
+                title: "Reasoning effort",
+                detail: "Uses model defaults when no session override is selected.",
+                value: "Model default"
+            ),
+            ShellSettingsRowModel(
+                id: "streamingMode",
+                systemName: "dot.radiowaves.left.and.right",
+                title: "Streaming",
+                detail: "New sessions follow the daemon default.",
+                value: "Auto"
+            ),
+            ShellSettingsRowModel(
+                id: "recoveryMode",
+                systemName: "arrow.clockwise",
+                title: "Stream recovery",
+                detail: "Partial stream recovery continues once by default.",
+                value: "Continue once"
+            ),
+        ]
+    }
+
+    private static func capabilityRows(
+        _ summary: ShellSettingsCapabilitiesSummary
+    ) -> [ShellSettingsRowModel] {
+        if let reason = summary.compactUnavailableReason {
+            return [
+                unavailableRow(
+                    id: "capabilitiesUnavailable",
+                    systemName: "puzzlepiece.extension",
+                    title: "Skill catalog",
+                    reason: reason
+                ),
+            ]
+        }
+
+        let total = summary.skills.count
+        let enabled = summary.skills.filter(\.enabled).count
+        let implicit = summary.skills.filter(\.allowImplicitInvocation).count
+        let unavailable = summary.skills.filter { !$0.available }.count
+
+        return [
+            ShellSettingsRowModel(
+                id: "enabledSkills",
+                systemName: "puzzlepiece.extension",
+                title: "Enabled skills",
+                detail: "Resolved from the skill catalog.",
+                value: total == 0 ? "No skills" : "\(enabled) of \(total)"
+            ),
+            ShellSettingsRowModel(
+                id: "implicitInvocation",
+                systemName: "sparkle.magnifyingglass",
+                title: "Implicit invocation",
+                detail: "Shows how many skills may be invoked without an explicit mention.",
+                value: "\(implicit) allowed"
+            ),
+            ShellSettingsRowModel(
+                id: "unavailableSkills",
+                systemName: "exclamationmark.triangle",
+                title: "Unavailable skills",
+                detail: "Unavailable packages stay visible without blocking Settings.",
+                value: unavailable == 0 ? "None" : "\(unavailable)"
+            ),
+        ]
+    }
+
+    private static func localRows(_ local: ShellSettingsLocalSummary) -> [ShellSettingsRowModel] {
+        [
+            ShellSettingsRowModel(
+                id: "appIdentity",
+                systemName: "app",
+                title: "App",
+                detail: local.bundleIdentifier,
+                value: local.appDisplayName
+            ),
+            ShellSettingsRowModel(
+                id: "installChannel",
+                systemName: "shippingbox",
+                title: "Install channel",
+                detail: local.appBundleName,
+                value: local.channelLabel
+            ),
+            ShellSettingsRowModel(
+                id: "cliTool",
+                systemName: "terminal",
+                title: "Command line tool",
+                detail: "Installed into /usr/local/bin when requested.",
+                value: local.cliToolName
+            ),
+            ShellSettingsRowModel(
+                id: "daemonEndpoint",
+                systemName: "server.rack",
+                title: "Daemon endpoint",
+                detail: "Default bind \(local.daemonBindAddress)",
+                value: local.daemonURL
+            ),
+            ShellSettingsRowModel(
+                id: "updates",
+                systemName: "arrow.down.circle",
+                title: "Updates",
+                detail: local.updateDetail,
+                value: local.updateSummary
+            ),
+            ShellSettingsRowModel(
+                id: "dataRoot",
+                systemName: "folder",
+                title: "Alan home",
+                detail: "Credentials and auth are stored separately; values are not shown.",
+                value: local.alanHomeDisplayPath
+            ),
+            ShellSettingsRowModel(
+                id: "publicSkills",
+                systemName: "folder.badge.gearshape",
+                title: "Public skills",
+                detail: "Package install root for this channel.",
+                value: local.globalSkillsDisplayPath
+            ),
+            ShellSettingsRowModel(
+                id: "applicationSupport",
+                systemName: "externaldrive",
+                title: "Shell state",
+                detail: "Workspace manifests and local shell state.",
+                value: local.applicationSupportDisplayPath
+            ),
+            ShellSettingsRowModel(
+                id: "shellControl",
+                systemName: "point.3.connected.trianglepath.dotted",
+                title: "Shell control",
+                detail: "Local control namespace.",
+                value: local.shellControlNamespace
+            ),
+        ]
+    }
+
+    private static func unavailableRow(
+        id: String,
+        systemName: String,
+        title: String,
+        reason: String
+    ) -> ShellSettingsRowModel {
+        ShellSettingsRowModel(
+            id: id,
+            systemName: systemName,
+            title: title,
+            detail: sanitizedUnavailableReason(reason),
+            value: "Unavailable"
+        )
+    }
+
+    private static func sanitizedUnavailableReason(_ reason: String) -> String {
+        let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return "The daemon did not return this summary."
+        }
+        if trimmed.contains("\n") || trimmed.contains("{") || trimmed.contains("}") {
+            return "The daemon did not return this summary."
+        }
+        return trimmed
+    }
+
+    private static func displayCredentialStatus(_ status: String) -> String {
+        switch status {
+        case "available":
+            return "Available"
+        case "missing":
+            return "Missing"
+        case "pending":
+            return "Pending"
+        case "expired":
+            return "Expired"
+        case "error":
+            return "Needs attention"
+        default:
+            return "Unknown"
+        }
+    }
+
+    private static func displayProviderName(_ provider: String) -> String {
+        provider
+            .split(separator: "_")
+            .map { part in
+                part.prefix(1).uppercased() + part.dropFirst()
+            }
+            .joined(separator: " ")
+    }
+}
+
+struct ShellSettingsRemoteSnapshot: Equatable {
+    let accounts: ShellSettingsAccountsSummary
+    let capabilities: ShellSettingsCapabilitiesSummary
+
+    static func unavailable(reason: String) -> ShellSettingsRemoteSnapshot {
+        ShellSettingsRemoteSnapshot(
+            accounts: .unavailable(reason: reason),
+            capabilities: .unavailable(reason: reason)
+        )
+    }
+}
+
+struct ShellSettingsAccountsSummary: Equatable {
+    let current: ShellSettingsConnectionSelection?
+    let profiles: [ShellSettingsConnectionProfile]
+    let providers: [ShellSettingsConnectionProvider]
+    let unavailableReason: String?
+
+    static func unavailable(reason: String) -> ShellSettingsAccountsSummary {
+        ShellSettingsAccountsSummary(
+            current: nil,
+            profiles: [],
+            providers: [],
+            unavailableReason: reason
+        )
+    }
+
+    var compactUnavailableReason: String? {
+        unavailableReason
+    }
+
+    var effectiveProfile: ShellSettingsConnectionProfile? {
+        if let effectiveProfile = current?.effectiveProfile {
+            return profiles.first { $0.profileID == effectiveProfile }
+        }
+        if let defaultProfile = current?.defaultProfile {
+            return profiles.first { $0.profileID == defaultProfile }
+        }
+        return profiles.first { $0.isDefault } ?? profiles.first
+    }
+
+    func provider(for providerID: String) -> ShellSettingsConnectionProvider? {
+        providers.first { $0.providerID == providerID }
+    }
+}
+
+struct ShellSettingsConnectionSelection: Equatable {
+    let defaultProfile: String?
+    let effectiveProfile: String?
+    let effectiveSource: String
+}
+
+struct ShellSettingsConnectionProfile: Equatable {
+    let profileID: String
+    let label: String?
+    let provider: String
+    let credentialStatus: String
+    let settings: [String: String]
+    let isDefault: Bool
+
+    var displayName: String {
+        let trimmedLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedLabel, !trimmedLabel.isEmpty {
+            return trimmedLabel
+        }
+        return profileID
+    }
+
+    var modelDisplayValue: String {
+        sanitizedSettingValue(for: "model") ?? "Model default"
+    }
+
+    private func sanitizedSettingValue(for key: String) -> String? {
+        guard !Self.isSensitiveSettingKey(key),
+              let value = settings[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+
+    private static func isSensitiveSettingKey(_ key: String) -> Bool {
+        let normalized = key.lowercased()
+        return normalized.contains("key")
+            || normalized.contains("token")
+            || normalized.contains("secret")
+            || normalized.contains("credential")
+            || normalized.contains("authorization")
+    }
+}
+
+struct ShellSettingsConnectionProvider: Equatable {
+    let providerID: String
+    let displayName: String
+    let supportsBrowserLogin: Bool
+    let supportsDeviceLogin: Bool
+    let supportsSecretEntry: Bool
+    let supportsLogout: Bool
+    let supportsTest: Bool
+
+    var supportedActionLabel: String {
+        var actions: [String] = []
+        if supportsBrowserLogin || supportsDeviceLogin {
+            actions.append("Login")
+        }
+        if supportsSecretEntry {
+            actions.append("Set Key")
+        }
+        if supportsTest {
+            actions.append("Test")
+        }
+        if supportsLogout {
+            actions.append("Logout")
+        }
+        return actions.isEmpty ? "Command line" : actions.joined(separator: ", ")
+    }
+}
+
+struct ShellSettingsCapabilitiesSummary: Equatable {
+    let skills: [ShellSettingsSkillSummary]
+    let unavailableReason: String?
+
+    static func unavailable(reason: String) -> ShellSettingsCapabilitiesSummary {
+        ShellSettingsCapabilitiesSummary(skills: [], unavailableReason: reason)
+    }
+
+    var compactUnavailableReason: String? {
+        unavailableReason
+    }
+}
+
+struct ShellSettingsSkillSummary: Equatable {
+    let id: String
+    let name: String
+    let enabled: Bool
+    let allowImplicitInvocation: Bool
+    let available: Bool
+}
+
+struct ShellSettingsLocalSummary: Equatable {
+    let channel: AlanInstallChannel
+    let appDisplayName: String
+    let appBundleName: String
+    let bundleIdentifier: String
+    let channelLabel: String
+    let cliToolName: String
+    let daemonURL: String
+    let daemonBindAddress: String
+    let updateSummary: String
+    let updateDetail: String
+    let alanHomeDisplayPath: String
+    let applicationSupportDisplayPath: String
+    let globalSkillsDisplayPath: String
+    let shellControlNamespace: String
+
+    static func current(
+        channel: AlanInstallChannel = .current(),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        updateDecision: AlanMacUpdateDecision = AlanMacUpdatePolicy.decision(),
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> ShellSettingsLocalSummary {
+        let daemonBindAddress = channel.daemonBindAddress(environment: environment)
+        let daemonURL = channel.daemonURL(environment: environment, bindAddress: daemonBindAddress)
+        return ShellSettingsLocalSummary(
+            channel: channel,
+            appDisplayName: channel.appDisplayName,
+            appBundleName: channel.appBundleName,
+            bundleIdentifier: channel.bundleIdentifier,
+            channelLabel: channel.settingsChannelLabel,
+            cliToolName: channel.cliToolName,
+            daemonURL: daemonURL,
+            daemonBindAddress: daemonBindAddress,
+            updateSummary: updateSummary(for: updateDecision),
+            updateDetail: updateDetail(for: updateDecision),
+            alanHomeDisplayPath: channel.alanHomeDisplayPath,
+            applicationSupportDisplayPath: channel.applicationSupportDisplayPath(
+                homeDirectory: homeDirectory
+            ),
+            globalSkillsDisplayPath: channel.globalSkillsDisplayPath,
+            shellControlNamespace: channel.shellControlNamespace
+        )
+    }
+
+    private static func updateSummary(for decision: AlanMacUpdateDecision) -> String {
+        switch decision.installation {
+        case .direct:
+            return decision.allowsSparkleUpdates ? "Sparkle updates available" : "Manual updates"
+        case .homebrewManaged:
+            return "Homebrew managed"
+        case .unsupportedChannel:
+            return "Manual local build"
+        }
+    }
+
+    private static func updateDetail(for decision: AlanMacUpdateDecision) -> String {
+        let trimmed = decision.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return trimmed
+        }
+        return "Use \(decision.menuTitle) for this install."
+    }
+}
+
+private extension AlanInstallChannel {
+    var appDisplayName: String {
+        switch self {
+        case .stable:
+            return "Alan"
+        case .dev:
+            return "Alan Dev"
+        }
+    }
+
+    var appBundleName: String {
+        switch self {
+        case .stable:
+            return "Alan.app"
+        case .dev:
+            return "Alan Dev.app"
+        }
+    }
+
+    var settingsChannelLabel: String {
+        switch self {
+        case .stable:
+            return "Stable"
+        case .dev:
+            return "Dev"
+        }
+    }
+
+    var alanHomeDisplayPath: String {
+        switch self {
+        case .stable:
+            return "~/.alan"
+        case .dev:
+            return "~/.alan-dev"
+        }
+    }
+
+    var globalSkillsDisplayPath: String {
+        switch self {
+        case .stable:
+            return "~/.agents/skills"
+        case .dev:
+            return "~/.agents-dev/skills"
+        }
+    }
+
+    var defaultDaemonBindAddress: String {
+        switch self {
+        case .stable:
+            return "0.0.0.0:8090"
+        case .dev:
+            return "127.0.0.1:8091"
+        }
+    }
+
+    var defaultDaemonURL: String {
+        switch self {
+        case .stable:
+            return "http://127.0.0.1:8090"
+        case .dev:
+            return "http://127.0.0.1:8091"
+        }
+    }
+
+    func applicationSupportDisplayPath(homeDirectory: URL) -> String {
+        let suffix = "Library/Application Support/\(applicationSupportDirectoryName)"
+        let homePath = homeDirectory.standardizedFileURL.path
+        if homePath == "/" {
+            return "/\(suffix)"
+        }
+        return "~/" + suffix
+    }
+
+    func daemonBindAddress(environment: [String: String]) -> String {
+        let override = environment["BIND_ADDRESS"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return override?.isEmpty == false ? override! : defaultDaemonBindAddress
+    }
+
+    func daemonURL(environment: [String: String], bindAddress: String) -> String {
+        let override = environment["ALAN_AGENTD_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if override?.isEmpty == false {
+            return override!
+        }
+        if bindAddress == defaultDaemonBindAddress {
+            return defaultDaemonURL
+        }
+        return Self.localDaemonURL(for: bindAddress)
+    }
+
+    static func localDaemonURL(for bindAddress: String) -> String {
+        let port = bindAddress.split(separator: ":").last.flatMap { UInt16($0) } ?? 8090
+        return "http://127.0.0.1:\(port)"
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Services/Daemon/AlanAPIClient.swift
+++ b/clients/apple/alan-macos/Services/Daemon/AlanAPIClient.swift
@@ -199,6 +199,62 @@ struct AlanAPIClient {
         return try decoder.decode(ReadEventsResponse.self, from: data)
     }
 
+    func connectionCatalog() async throws -> ConnectionCatalogResponse {
+        let requestURL = endpointURL(pathComponents: ["api", "v1", "connections", "catalog"])
+        let data = try await request(url: requestURL)
+        return try decoder.decode(ConnectionCatalogResponse.self, from: data)
+    }
+
+    func listConnectionProfiles() async throws -> ConnectionProfilesResponse {
+        let requestURL = endpointURL(pathComponents: ["api", "v1", "connections"])
+        let data = try await request(url: requestURL)
+        return try decoder.decode(ConnectionProfilesResponse.self, from: data)
+    }
+
+    func currentConnection(workspaceDir: String? = nil) async throws -> ConnectionCurrentStateResponse {
+        var components = URLComponents(
+            url: endpointURL(pathComponents: ["api", "v1", "connections", "current"]),
+            resolvingAgainstBaseURL: false
+        )
+        if let workspaceDir,
+           !workspaceDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            components?.queryItems = [URLQueryItem(name: "workspace_dir", value: workspaceDir)]
+        }
+        guard let requestURL = components?.url else {
+            throw AlanAPIError.invalidURL(baseURL.absoluteString)
+        }
+        let data = try await request(url: requestURL)
+        return try decoder.decode(ConnectionCurrentStateResponse.self, from: data)
+    }
+
+    func skillCatalog(
+        workspaceDir: String? = nil,
+        agentName: String? = nil
+    ) async throws -> SkillCatalogSnapshotResponse {
+        var components = URLComponents(
+            url: endpointURL(pathComponents: ["api", "v1", "skills", "catalog"]),
+            resolvingAgainstBaseURL: false
+        )
+        var queryItems: [URLQueryItem] = []
+        if let workspaceDir,
+           !workspaceDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            queryItems.append(URLQueryItem(name: "workspace_dir", value: workspaceDir))
+        }
+        if let agentName,
+           !agentName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            queryItems.append(URLQueryItem(name: "agent_name", value: agentName))
+        }
+        components?.queryItems = queryItems.isEmpty ? nil : queryItems
+        guard let requestURL = components?.url else {
+            throw AlanAPIError.invalidURL(baseURL.absoluteString)
+        }
+        let data = try await request(url: requestURL)
+        return try decoder.decode(SkillCatalogSnapshotResponse.self, from: data)
+    }
+
     private func endpointURL(pathComponents: [String]) -> URL {
         pathComponents.reduce(baseURL) { partial, component in
             partial.appendingPathComponent(component)

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -2981,6 +2981,74 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             ?? nonEmptyWorkingDirectory(pane.cwd)
     }
 
+    func settingsWorkspaceContext(forPaneSlotID paneSlotID: String) -> ShellSettingsWorkspaceContext {
+        ShellSettingsWorkspaceContext.resolve(
+            activeWorkingDirectory: settingsWorkspaceWorkingDirectory(forPaneSlotID: paneSlotID),
+            channel: windowContext.installChannel,
+            fileManager: fileManager
+        )
+    }
+
+    private func settingsWorkspaceWorkingDirectory(forPaneSlotID paneSlotID: String) -> String? {
+        let contentState = shellState.contentStateProjection()
+        var candidates: [ShellPane] = []
+
+        func appendCandidate(_ pane: ShellPane?) {
+            guard let pane,
+                  !candidates.contains(where: { $0.paneID == pane.paneID })
+            else {
+                return
+            }
+            candidates.append(pane)
+        }
+
+        let targetPane = pane(paneID: paneSlotID)
+        appendCandidate(targetPane)
+
+        if focusedPane?.paneID != paneSlotID {
+            appendCandidate(focusedPane)
+        }
+        if selectedPane?.paneID != paneSlotID {
+            appendCandidate(selectedPane)
+        }
+
+        let targetTabID = targetPane?.tabID ?? selectedTab?.tabID
+        if let targetTabID {
+            shellState.panes
+                .filter { $0.tabID == targetTabID && $0.paneID != paneSlotID }
+                .forEach { appendCandidate($0) }
+        }
+
+        shellState.panes
+            .filter { $0.paneID != paneSlotID }
+            .forEach { appendCandidate($0) }
+
+        for candidate in candidates {
+            if let workingDirectory = terminalWorkingDirectory(
+                for: candidate,
+                contentState: contentState
+            ) {
+                return workingDirectory
+            }
+        }
+        return nil
+    }
+
+    private func terminalWorkingDirectory(
+        for pane: ShellPane,
+        contentState: ShellContentStateSnapshot
+    ) -> String? {
+        if let content = contentState.contentMounted(in: pane.paneID),
+           content.kind != .terminal
+        {
+            return nil
+        }
+
+        let runtimeCwd = runtime(for: pane.paneID).paneMetadata.workingDirectory
+        return nonEmptyWorkingDirectory(runtimeCwd)
+            ?? nonEmptyWorkingDirectory(pane.cwd)
+    }
+
     private func nonEmptyWorkingDirectory(_ path: String?) -> String? {
         guard let path else { return nil }
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1138,6 +1138,14 @@ private struct ShellSettingsContentView: View {
     @AppStorage("alanShellAppearanceMode") private var appearanceMode = ShellAppearanceMode.system
     @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
     @AppStorage("alanShellDimsInactiveSplitPanes") private var dimsInactiveSplitPanes = true
+    @State private var localSummary = ShellSettingsLocalSummary.current()
+    @State private var remoteSnapshot = ShellSettingsRemoteSnapshot.unavailable(
+        reason: "Daemon unavailable"
+    )
+
+    private var snapshot: ShellSettingsSurfaceSnapshot {
+        ShellSettingsSurfaceSnapshot.make(remote: remoteSnapshot, local: localSummary)
+    }
 
     var body: some View {
         ZStack {
@@ -1145,72 +1153,23 @@ private struct ShellSettingsContentView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    header
-
-                    VStack(spacing: 0) {
-                        ShellSettingsRow(
-                            systemName: "circle.lefthalf.filled",
-                            title: "Appearance"
-                        ) {
-                            Picker("Appearance", selection: $appearanceMode) {
-                                ForEach(ShellAppearanceMode.allCases) { mode in
-                                    Text(mode.label).tag(mode)
-                                }
-                            }
-                            .labelsHidden()
-                            .pickerStyle(.segmented)
-                            .frame(maxWidth: 240)
-                        }
-
-                        ShellSettingsDivider()
-
-                        ShellSettingsRow(
-                            systemName: "sidebar.left",
-                            title: "Sidebar"
-                        ) {
-                            Toggle("Show", isOn: sidebarVisible)
-                                .toggleStyle(.switch)
-                        }
-
-                        ShellSettingsDivider()
-
-                        ShellSettingsRow(
-                            systemName: "rectangle.split.2x1",
-                            title: "Inactive split dimming"
-                        ) {
-                            Toggle("Enabled", isOn: $dimsInactiveSplitPanes)
-                                .toggleStyle(.switch)
-                        }
-                    }
-                    .background {
-                        RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                            .fill(ShellPalette.panel.opacity(0.72))
-                    }
-                    .overlay {
-                        RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
-                            .stroke(ShellPalette.line.opacity(0.26), lineWidth: 0.8)
+                    ForEach(snapshot.sections) { section in
+                        ShellSettingsSectionView(
+                            section: section,
+                            appearanceMode: $appearanceMode,
+                            sidebarVisible: sidebarVisible,
+                            dimsInactiveSplitPanes: $dimsInactiveSplitPanes
+                        )
                     }
                 }
-                .frame(maxWidth: 680, alignment: .leading)
+                .frame(maxWidth: 720, alignment: .leading)
                 .padding(.horizontal, 28)
                 .padding(.vertical, 24)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
         }
-    }
-
-    private var header: some View {
-        HStack(spacing: 10) {
-            Image(systemName: descriptor.iconName)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(ShellPalette.mutedInk)
-                .frame(width: 22, height: 22)
-
-            Text(descriptor.title)
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(ShellPalette.ink)
-                .lineLimit(1)
-                .truncationMode(.tail)
+        .task(id: descriptor.contentID ?? descriptor.title) {
+            await refreshSettingsSummaries()
         }
     }
 
@@ -1220,11 +1179,159 @@ private struct ShellSettingsContentView: View {
             set: { isSidebarCollapsed = !$0 }
         )
     }
+
+    @MainActor
+    private func refreshSettingsSummaries() async {
+        let local = ShellSettingsLocalSummary.current()
+        localSummary = local
+
+        do {
+            let client = try AlanAPIClient(baseURLString: local.daemonURL)
+            async let catalogResponse = client.connectionCatalog()
+            async let profilesResponse = client.listConnectionProfiles()
+            async let currentResponse = client.currentConnection()
+            async let skillsResponse = client.skillCatalog()
+
+            let (catalog, profiles, current, skills) = try await (
+                catalogResponse,
+                profilesResponse,
+                currentResponse,
+                skillsResponse
+            )
+            remoteSnapshot = ShellSettingsRemoteSnapshot(
+                accounts: ShellSettingsAccountsSummary(
+                    current: ShellSettingsConnectionSelection(
+                        defaultProfile: current.defaultProfile ?? profiles.defaultProfile,
+                        effectiveProfile: current.effectiveProfile,
+                        effectiveSource: current.effectiveSource
+                    ),
+                    profiles: profiles.profiles.map { profile in
+                        ShellSettingsConnectionProfile(
+                            profileID: profile.profileID,
+                            label: profile.label,
+                            provider: profile.provider,
+                            credentialStatus: profile.credentialStatus,
+                            settings: profile.settings,
+                            isDefault: profile.isDefault
+                        )
+                    },
+                    providers: catalog.providers.map { provider in
+                        ShellSettingsConnectionProvider(
+                            providerID: provider.providerID,
+                            displayName: provider.displayName,
+                            supportsBrowserLogin: provider.supportsBrowserLogin,
+                            supportsDeviceLogin: provider.supportsDeviceLogin,
+                            supportsSecretEntry: provider.supportsSecretEntry,
+                            supportsLogout: provider.supportsLogout,
+                            supportsTest: provider.supportsTest
+                        )
+                    },
+                    unavailableReason: nil
+                ),
+                capabilities: ShellSettingsCapabilitiesSummary(
+                    skills: skills.skills.map { skill in
+                        ShellSettingsSkillSummary(
+                            id: skill.id,
+                            name: skill.name,
+                            enabled: skill.enabled,
+                            allowImplicitInvocation: skill.allowImplicitInvocation,
+                            available: skill.available
+                        )
+                    },
+                    unavailableReason: nil
+                )
+            )
+        } catch {
+            remoteSnapshot = .unavailable(reason: "Daemon unavailable")
+        }
+    }
+}
+
+private struct ShellSettingsSectionView: View {
+    let section: ShellSettingsSectionModel
+    @Binding var appearanceMode: ShellAppearanceMode
+    let sidebarVisible: Binding<Bool>
+    @Binding var dimsInactiveSplitPanes: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text(section.title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(ShellPalette.mutedInk)
+                .textCase(.uppercase)
+
+            VStack(spacing: 0) {
+                ForEach(Array(section.rows.enumerated()), id: \.element.id) { index, row in
+                    if index > 0 {
+                        ShellSettingsDivider()
+                    }
+
+                    rowView(row)
+                }
+            }
+            .background {
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                    .fill(ShellPalette.panel.opacity(0.72))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: ShellRadii.row, style: .continuous)
+                    .stroke(ShellPalette.line.opacity(0.26), lineWidth: 0.8)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: ShellSettingsRowModel) -> some View {
+        switch row.id {
+        case "appearance":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                Picker("Appearance", selection: $appearanceMode) {
+                    ForEach(ShellAppearanceMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 240)
+            }
+        case "sidebar":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                Toggle("Show", isOn: sidebarVisible)
+                    .toggleStyle(.switch)
+            }
+        case "inactiveSplitDimming":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                Toggle("Enabled", isOn: $dimsInactiveSplitPanes)
+                    .toggleStyle(.switch)
+            }
+        default:
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                ShellSettingsValueLabel(value: row.value, mutability: row.mutability)
+            }
+        }
+    }
 }
 
 private struct ShellSettingsRow<Accessory: View>: View {
     let systemName: String
     let title: String
+    let detail: String?
     @ViewBuilder let accessory: () -> Accessory
 
     var body: some View {
@@ -1234,10 +1341,22 @@ private struct ShellSettingsRow<Accessory: View>: View {
                 .foregroundStyle(ShellPalette.mutedInk)
                 .frame(width: 18, height: 18)
 
-            Text(title)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(ShellPalette.ink)
-                .lineLimit(1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(ShellPalette.ink)
+                    .lineLimit(1)
+
+                if let detail,
+                   !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    Text(detail)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(ShellPalette.mutedInk)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
 
             Spacer(minLength: 16)
 
@@ -1245,7 +1364,38 @@ private struct ShellSettingsRow<Accessory: View>: View {
                 .font(.system(size: 12, weight: .medium))
         }
         .padding(.horizontal, 14)
+        .padding(.vertical, 8)
         .frame(minHeight: 48)
+    }
+}
+
+private struct ShellSettingsValueLabel: View {
+    let value: String?
+    let mutability: ShellSettingsRowMutability
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if mutability == .actionOnly {
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(ShellPalette.mutedInk)
+            }
+
+            Text(value ?? "Unavailable")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(valueStyle)
+                .lineLimit(2)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: 230, alignment: .trailing)
+    }
+
+    private var valueStyle: some ShapeStyle {
+        if value == "Unavailable" {
+            return AnyShapeStyle(ShellPalette.mutedInk)
+        }
+        return AnyShapeStyle(ShellPalette.ink)
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1188,6 +1188,7 @@ private struct ShellSettingsContentView: View {
             descriptor.contentID ?? descriptor.title,
             workspaceContext.connectionWorkspaceDir,
             workspaceContext.skillCatalogWorkspaceDir,
+            workspaceContext.skillCatalogUnavailableReason,
             workspaceContext.agentName,
         ]
         .compactMap { $0 }
@@ -1213,17 +1214,33 @@ private struct ShellSettingsContentView: View {
             async let currentResponse = client.currentConnection(
                 workspaceDir: workspaceContext.connectionWorkspaceDir
             )
-            async let skillsResponse = client.skillCatalog(
-                workspaceDir: workspaceContext.skillCatalogWorkspaceDir,
-                agentName: workspaceContext.agentName
-            )
 
-            let (catalog, profiles, current, skills) = try await (
+            let (catalog, profiles, current) = try await (
                 catalogResponse,
                 profilesResponse,
-                currentResponse,
-                skillsResponse
+                currentResponse
             )
+            let capabilitiesSummary: ShellSettingsCapabilitiesSummary
+            if let reason = workspaceContext.skillCatalogUnavailableReason {
+                capabilitiesSummary = .unavailable(reason: reason)
+            } else {
+                let skills = try await client.skillCatalog(
+                    workspaceDir: workspaceContext.skillCatalogWorkspaceDir,
+                    agentName: workspaceContext.agentName
+                )
+                capabilitiesSummary = ShellSettingsCapabilitiesSummary(
+                    skills: skills.skills.map { skill in
+                        ShellSettingsSkillSummary(
+                            id: skill.id,
+                            name: skill.name,
+                            enabled: skill.enabled,
+                            allowImplicitInvocation: skill.allowImplicitInvocation,
+                            available: skill.available
+                        )
+                    },
+                    unavailableReason: nil
+                )
+            }
             remoteSnapshot = ShellSettingsRemoteSnapshot(
                 accounts: ShellSettingsAccountsSummary(
                     current: ShellSettingsConnectionSelection(
@@ -1254,18 +1271,7 @@ private struct ShellSettingsContentView: View {
                     },
                     unavailableReason: nil
                 ),
-                capabilities: ShellSettingsCapabilitiesSummary(
-                    skills: skills.skills.map { skill in
-                        ShellSettingsSkillSummary(
-                            id: skill.id,
-                            name: skill.name,
-                            enabled: skill.enabled,
-                            allowImplicitInvocation: skill.allowImplicitInvocation,
-                            available: skill.available
-                        )
-                    },
-                    unavailableReason: nil
-                )
+                capabilities: capabilitiesSummary
             )
         } catch {
             remoteSnapshot = .unavailable(reason: "Daemon unavailable")

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -582,9 +582,14 @@ private struct ShellPaneTreeLayoutView: View {
         paneSlotID: String,
         backingPane: ShellPane?
     ) -> some View {
-        ShellBoundedContentLeafView(
+        let settingsWorkspaceContext =
+            descriptor.renderKind == .settings
+            ? host.settingsWorkspaceContext(forPaneSlotID: paneSlotID)
+            : .none
+        return ShellBoundedContentLeafView(
             descriptor: descriptor,
             paneSlotID: paneSlotID,
+            settingsWorkspaceContext: settingsWorkspaceContext,
             isSelected: selectedPaneID == paneSlotID,
             isZoomed: host.isPaneZoomed(paneSlotID),
             canZoom: host.canZoomPane(paneSlotID),
@@ -938,6 +943,7 @@ private enum ShellPaneTitleBarAccessoryMode: Equatable {
 private struct ShellBoundedContentLeafView: View {
     let descriptor: ShellContentRenderDescriptor
     let paneSlotID: String
+    let settingsWorkspaceContext: ShellSettingsWorkspaceContext
     let isSelected: Bool
     let isZoomed: Bool
     let canZoom: Bool
@@ -967,7 +973,10 @@ private struct ShellBoundedContentLeafView: View {
                     .contentShape(Rectangle())
                     .onTapGesture(perform: onFocusPane)
             case .settings:
-                ShellSettingsContentView(descriptor: descriptor)
+                ShellSettingsContentView(
+                    descriptor: descriptor,
+                    workspaceContext: settingsWorkspaceContext
+                )
                     .contentShape(Rectangle())
                     .onTapGesture(perform: onFocusPane)
             case .terminal, .unavailable:
@@ -1134,6 +1143,7 @@ private enum ShellMarkdownContentLoadResult {
 
 private struct ShellSettingsContentView: View {
     let descriptor: ShellContentRenderDescriptor
+    let workspaceContext: ShellSettingsWorkspaceContext
 
     @AppStorage("alanShellAppearanceMode") private var appearanceMode = ShellAppearanceMode.system
     @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
@@ -1168,9 +1178,20 @@ private struct ShellSettingsContentView: View {
                 .frame(maxWidth: .infinity, alignment: .topLeading)
             }
         }
-        .task(id: descriptor.contentID ?? descriptor.title) {
+        .task(id: refreshTaskID) {
             await refreshSettingsSummaries()
         }
+    }
+
+    private var refreshTaskID: String {
+        [
+            descriptor.contentID ?? descriptor.title,
+            workspaceContext.connectionWorkspaceDir,
+            workspaceContext.skillCatalogWorkspaceDir,
+            workspaceContext.agentName,
+        ]
+        .compactMap { $0 }
+        .joined(separator: "|")
     }
 
     private var sidebarVisible: Binding<Bool> {
@@ -1189,8 +1210,13 @@ private struct ShellSettingsContentView: View {
             let client = try AlanAPIClient(baseURLString: local.daemonURL)
             async let catalogResponse = client.connectionCatalog()
             async let profilesResponse = client.listConnectionProfiles()
-            async let currentResponse = client.currentConnection()
-            async let skillsResponse = client.skillCatalog()
+            async let currentResponse = client.currentConnection(
+                workspaceDir: workspaceContext.connectionWorkspaceDir
+            )
+            async let skillsResponse = client.skillCatalog(
+                workspaceDir: workspaceContext.skillCatalogWorkspaceDir,
+                agentName: workspaceContext.agentName
+            )
 
             let (catalog, profiles, current, skills) = try await (
                 catalogResponse,

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -2045,6 +2045,11 @@ require_pattern \
     "focused Apple shell tests must include runtime and control-plane metadata coverage"
 
 require_pattern \
+    "justfile" \
+    "test-shell-settings-surface\\.sh" \
+    "focused Apple shell tests must include settings surface coverage"
+
+require_pattern \
     "clients/apple/scripts/check-shell-app-intents-metadata.sh" \
     "AlanCreateTerminalTabIntent" \
     "App Intent metadata review must cover generated Shortcuts action names"

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -32,6 +32,8 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellStatePersistenceStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanMacUpdatePolicy.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/TerminalHostRuntime.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentLifecycleAdapter.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift" \

--- a/clients/apple/scripts/test-shell-settings-surface.sh
+++ b/clients/apple/scripts/test-shell-settings-surface.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-settings-surface-tests"
+MODULE_CACHE_DIR="$BUILD_DIR/clang-module-cache"
+TEST_BINARY="$BUILD_DIR/shell-settings-surface-tests"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/AlanMacUpdatePolicy.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-settings-surface.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -264,6 +264,10 @@ private func testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot() throws {
         context.skillCatalogWorkspaceDir == nil,
         "unregistered workspaces must not be sent to the skill catalog alias-only endpoint"
     )
+    try expect(
+        context.skillCatalogUnavailableReason == "Register this workspace to show workspace skills.",
+        "unregistered workspaces with .alan state must not fall back to the default skill catalog"
+    )
 }
 
 private func testUnavailableRemoteSummariesStayCompact() throws {

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -25,6 +25,9 @@ struct ShellSettingsSurfaceTestRunner {
             try testDefaultSectionOrderAndInterfaceMutability()
             try testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted()
             try testDevChannelLocalRowsUseDevIdentity()
+            try testLocalSummaryReadsHostConfigForDaemonEndpoint()
+            try testWorkspaceContextUsesRegistryForWorkspaceScopedRequests()
+            try testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot()
             try testUnavailableRemoteSummariesStayCompact()
             print("Shell settings surface tests passed.")
         } catch {
@@ -167,6 +170,102 @@ private func testDevChannelLocalRowsUseDevIdentity() throws {
     )
 }
 
+private func testLocalSummaryReadsHostConfigForDaemonEndpoint() throws {
+    let homeDirectory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: homeDirectory) }
+
+    let alanHome = homeDirectory.appendingPathComponent(".alan-dev", isDirectory: true)
+    try FileManager.default.createDirectory(at: alanHome, withIntermediateDirectories: true)
+    try """
+    bind_address = "127.0.0.1:9123"
+    """
+    .write(to: alanHome.appendingPathComponent("host.toml"), atomically: true, encoding: .utf8)
+
+    let summary = ShellSettingsLocalSummary.current(
+        channel: .dev,
+        environment: [:],
+        updateDecision: unsupportedDevUpdateDecision(),
+        homeDirectory: homeDirectory
+    )
+
+    try expect(
+        summary.daemonBindAddress == "127.0.0.1:9123",
+        "settings must display the bind address from the channel host.toml"
+    )
+    try expect(
+        summary.daemonURL == "http://127.0.0.1:9123",
+        "settings must query the daemon URL derived from host.toml"
+    )
+}
+
+private func testWorkspaceContextUsesRegistryForWorkspaceScopedRequests() throws {
+    let homeDirectory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: homeDirectory) }
+
+    let workspace = homeDirectory.appendingPathComponent("repo", isDirectory: true)
+    let nestedDirectory = workspace.appendingPathComponent("Sources", isDirectory: true)
+    try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+
+    let alanHome = homeDirectory.appendingPathComponent(".alan-dev", isDirectory: true)
+    try FileManager.default.createDirectory(at: alanHome, withIntermediateDirectories: true)
+    let registry: [String: Any] = [
+        "version": 1,
+        "workspaces": [
+            [
+                "id": "abc123",
+                "path": workspace.standardizedFileURL.path,
+                "alias": "repo",
+                "created_at": "2026-05-27T00:00:00Z",
+            ],
+        ],
+    ]
+    let registryData = try JSONSerialization.data(withJSONObject: registry, options: [.prettyPrinted])
+    try registryData.write(to: alanHome.appendingPathComponent("registry.json"))
+
+    let context = ShellSettingsWorkspaceContext.resolve(
+        activeWorkingDirectory: nestedDirectory.path,
+        channel: .dev,
+        homeDirectory: homeDirectory
+    )
+
+    try expect(
+        context.connectionWorkspaceDir == workspace.standardizedFileURL.path,
+        "connection state must use the registered workspace root, not a nested terminal cwd"
+    )
+    try expect(
+        context.skillCatalogWorkspaceDir == "repo",
+        "skill catalog requests must use a registered workspace alias or short id"
+    )
+}
+
+private func testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot() throws {
+    let homeDirectory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: homeDirectory) }
+
+    let workspace = homeDirectory.appendingPathComponent("unregistered", isDirectory: true)
+    let nestedDirectory = workspace.appendingPathComponent("Sources", isDirectory: true)
+    try FileManager.default.createDirectory(
+        at: workspace.appendingPathComponent(".alan", isDirectory: true),
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+
+    let context = ShellSettingsWorkspaceContext.resolve(
+        activeWorkingDirectory: nestedDirectory.path,
+        channel: .dev,
+        homeDirectory: homeDirectory
+    )
+
+    try expect(
+        context.connectionWorkspaceDir == workspace.standardizedFileURL.path,
+        "connection state must fall back to the discovered workspace root"
+    )
+    try expect(
+        context.skillCatalogWorkspaceDir == nil,
+        "unregistered workspaces must not be sent to the skill catalog alias-only endpoint"
+    )
+}
+
 private func testUnavailableRemoteSummariesStayCompact() throws {
     let snapshot = ShellSettingsSurfaceSnapshot.make(
         remote: .unavailable(reason: "Connection refused"),
@@ -210,13 +309,24 @@ private func devLocalSummary() -> ShellSettingsLocalSummary {
     ShellSettingsLocalSummary.current(
         channel: .dev,
         environment: [:],
-        updateDecision: AlanMacUpdateDecision(
-            installation: .unsupportedChannel,
-            allowsSparkleUpdates: false,
-            menuTitle: "Check for Updates...",
-            userMessage: "This local dev build does not use Sparkle updates."
-        ),
+        updateDecision: unsupportedDevUpdateDecision(),
         homeDirectory: URL(fileURLWithPath: "/Users/test", isDirectory: true)
     )
+}
+
+private func unsupportedDevUpdateDecision() -> AlanMacUpdateDecision {
+    AlanMacUpdateDecision(
+        installation: .unsupportedChannel,
+        allowsSparkleUpdates: false,
+        menuTitle: "Check for Updates...",
+        userMessage: "This local dev build does not use Sparkle updates."
+    )
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("alan-shell-settings-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
 }
 #endif

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+#if os(macOS)
+private enum TestFailure: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let message):
+            return message
+        }
+    }
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() {
+        throw TestFailure.message(message)
+    }
+}
+
+@main
+struct ShellSettingsSurfaceTestRunner {
+    static func main() {
+        do {
+            try testDefaultSectionOrderAndInterfaceMutability()
+            try testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted()
+            try testDevChannelLocalRowsUseDevIdentity()
+            try testUnavailableRemoteSummariesStayCompact()
+            print("Shell settings surface tests passed.")
+        } catch {
+            fputs("Shell settings surface tests failed: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private func testDefaultSectionOrderAndInterfaceMutability() throws {
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: .unavailable(reason: "Daemon unavailable"),
+        local: stableLocalSummary()
+    )
+
+    try expect(
+        snapshot.sections.map(\.id) == ShellSettingsSectionID.defaultOrder,
+        "settings sections must render in Interface, Accounts, Sessions, Capabilities, Local order"
+    )
+
+    let interface = try requireSection(.interface, in: snapshot)
+    try expect(
+        interface.rows.map(\.id) == ["appearance", "sidebar", "inactiveSplitDimming"],
+        "interface section must keep existing appearance/sidebar/dimming preferences"
+    )
+    try expect(
+        interface.rows.allSatisfy { $0.mutability == .editable },
+        "interface preferences must remain directly editable"
+    )
+}
+
+private func testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted() throws {
+    let account = ShellSettingsConnectionProfile(
+        profileID: "openai-main",
+        label: "Work account",
+        provider: "openai_responses",
+        credentialStatus: "available",
+        settings: [
+            "model": "gpt-5.3",
+            "api_key": "sk-test-should-not-render",
+            "refresh_token": "refresh-token-should-not-render",
+        ],
+        isDefault: true
+    )
+    let provider = ShellSettingsConnectionProvider(
+        providerID: "openai_responses",
+        displayName: "OpenAI Responses",
+        supportsBrowserLogin: false,
+        supportsDeviceLogin: false,
+        supportsSecretEntry: true,
+        supportsLogout: true,
+        supportsTest: true
+    )
+    let accounts = ShellSettingsAccountsSummary(
+        current: ShellSettingsConnectionSelection(
+            defaultProfile: "openai-main",
+            effectiveProfile: "openai-main",
+            effectiveSource: "default_profile"
+        ),
+        profiles: [account],
+        providers: [provider],
+        unavailableReason: nil
+    )
+    let capabilities = ShellSettingsCapabilitiesSummary(
+        skills: [
+            ShellSettingsSkillSummary(
+                id: "memory",
+                name: "Memory",
+                enabled: true,
+                allowImplicitInvocation: false,
+                available: true
+            ),
+            ShellSettingsSkillSummary(
+                id: "plan",
+                name: "Plan",
+                enabled: false,
+                allowImplicitInvocation: false,
+                available: true
+            ),
+        ],
+        unavailableReason: nil
+    )
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: ShellSettingsRemoteSnapshot(accounts: accounts, capabilities: capabilities),
+        local: stableLocalSummary()
+    )
+    let visibleText = snapshot.visibleText.joined(separator: "\n")
+
+    try expect(
+        !visibleText.contains("sk-test-should-not-render"),
+        "settings must not render API key values"
+    )
+    try expect(
+        !visibleText.contains("refresh-token-should-not-render"),
+        "settings must not render refresh token values"
+    )
+    try expect(
+        !visibleText.contains("api_key") && !visibleText.contains("refresh_token"),
+        "settings must not render raw secret setting names"
+    )
+    try expect(
+        !visibleText.localizedCaseInsensitiveContains("mount"),
+        "capabilities must use enabled and implicit-invocation terminology instead of mount labels"
+    )
+
+    for sectionID in [ShellSettingsSectionID.accounts, .capabilities, .local] {
+        let section = try requireSection(sectionID, in: snapshot)
+        try expect(
+            section.rows.allSatisfy { $0.mutability != .editable },
+            "\(sectionID.rawValue) rows must not be directly editable in the first settings phase"
+        )
+        try expect(
+            section.rows.allSatisfy { !$0.offersFreeformEditing },
+            "\(sectionID.rawValue) rows must not expose freeform file or credential editing"
+        )
+    }
+}
+
+private func testDevChannelLocalRowsUseDevIdentity() throws {
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: .unavailable(reason: "Daemon unavailable"),
+        local: devLocalSummary()
+    )
+    let localText = try requireSection(.local, in: snapshot).visibleText.joined(separator: "\n")
+
+    try expect(localText.contains("Alan Dev"), "dev settings must identify the Alan Dev app")
+    try expect(localText.contains("alan-dev"), "dev settings must show the alan-dev CLI tool")
+    try expect(localText.contains("~/.alan-dev"), "dev settings must show the dev alan home")
+    try expect(
+        localText.contains("~/.agents-dev/skills"),
+        "dev settings must show the dev public skill root"
+    )
+    try expect(
+        localText.contains("127.0.0.1:8091"),
+        "dev settings must show the dev daemon bind or endpoint"
+    )
+    try expect(
+        localText.contains("alan-dev-shell-control"),
+        "dev settings must show the dev shell-control namespace"
+    )
+}
+
+private func testUnavailableRemoteSummariesStayCompact() throws {
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: .unavailable(reason: "Connection refused"),
+        local: stableLocalSummary()
+    )
+    let text = snapshot.visibleText.joined(separator: "\n")
+
+    try expect(text.contains("Unavailable"), "unavailable remote sources must render a compact state")
+    try expect(!text.contains("Error("), "unavailable state must not render raw debug payloads")
+    try expect(
+        !text.contains("thinking_budget_tokens"),
+        "sessions summary must not expose deprecated thinking budget controls"
+    )
+}
+
+private func requireSection(
+    _ id: ShellSettingsSectionID,
+    in snapshot: ShellSettingsSurfaceSnapshot
+) throws -> ShellSettingsSectionModel {
+    guard let section = snapshot.sections.first(where: { $0.id == id }) else {
+        throw TestFailure.message("missing settings section \(id.rawValue)")
+    }
+    return section
+}
+
+private func stableLocalSummary() -> ShellSettingsLocalSummary {
+    ShellSettingsLocalSummary.current(
+        channel: .stable,
+        environment: [:],
+        updateDecision: AlanMacUpdateDecision(
+            installation: .direct,
+            allowsSparkleUpdates: true,
+            menuTitle: "Check for Updates...",
+            userMessage: ""
+        ),
+        homeDirectory: URL(fileURLWithPath: "/Users/test", isDirectory: true)
+    )
+}
+
+private func devLocalSummary() -> ShellSettingsLocalSummary {
+    ShellSettingsLocalSummary.current(
+        channel: .dev,
+        environment: [:],
+        updateDecision: AlanMacUpdateDecision(
+            installation: .unsupportedChannel,
+            allowsSparkleUpdates: false,
+            menuTitle: "Check for Updates...",
+            userMessage: "This local dev build does not use Sparkle updates."
+        ),
+        homeDirectory: URL(fileURLWithPath: "/Users/test", isDirectory: true)
+    )
+}
+#endif

--- a/justfile
+++ b/justfile
@@ -80,6 +80,7 @@ apple-shell-focused-tests:
     bash clients/apple/scripts/test-terminal-runtime-service.sh
     bash clients/apple/scripts/test-shell-automation-command-seams.sh
     bash clients/apple/scripts/test-shell-runtime-metadata.sh
+    bash clients/apple/scripts/test-shell-settings-surface.sh
     bash clients/apple/scripts/test-macos-auto-update-policy.sh
     ./scripts/test-appcast-tools.sh
 

--- a/openspec/changes/improve-macos-settings-surface/tasks.md
+++ b/openspec/changes/improve-macos-settings-surface/tasks.md
@@ -1,78 +1,78 @@
 ## 1. Inventory And Boundaries
 
-- [ ] 1.1 Confirm the current Settings entry path, singleton behavior, and
+- [x] 1.1 Confirm the current Settings entry path, singleton behavior, and
   non-terminal lifecycle tests still match the existing content-container
   contract.
-- [ ] 1.2 Inventory the concrete data sources for Interface, Accounts,
+- [x] 1.2 Inventory the concrete data sources for Interface, Accounts,
   Sessions, Capabilities, and Local rows, and classify each as editable,
   read-only, action-only, or deferred.
-- [ ] 1.3 Decide the first implementation slice for Sessions and Capabilities:
+- [x] 1.3 Decide the first implementation slice for Sessions and Capabilities:
   summary-only or collapsed advanced, while keeping both required sections
   visible in the default Settings layout.
 
 ## 2. Settings Information Architecture
 
-- [ ] 2.1 Refactor `ShellSettingsContentView` into small section and row
+- [x] 2.1 Refactor `ShellSettingsContentView` into small section and row
   components without changing current Interface preference behavior.
-- [ ] 2.2 Add the default section order: Interface, Accounts, Sessions,
+- [x] 2.2 Add the default section order: Interface, Accounts, Sessions,
   Capabilities, and Local.
-- [ ] 2.3 Update row labels and secondary text so primary labels are
+- [x] 2.3 Update row labels and secondary text so primary labels are
   user-facing and raw config filenames or IDs appear only as diagnostic detail.
-- [ ] 2.4 Keep the visual treatment compact and shell-native: no page hero,
+- [x] 2.4 Keep the visual treatment compact and shell-native: no page hero,
   nested cards, dashboard metrics, decorative gradients, or separate settings
   navigation shell.
 
 ## 3. First-Phase Data And Controls
 
-- [ ] 3.1 Keep appearance mode, sidebar visibility, and inactive split dimming
+- [x] 3.1 Keep appearance mode, sidebar visibility, and inactive split dimming
   directly editable through the existing app preference state.
-- [ ] 3.2 Add read-only Local rows for install channel, CLI tool name, daemon
+- [x] 3.2 Add read-only Local rows for install channel, CLI tool name, daemon
   URL/default bind, update policy, and relevant data roots using existing
   channel/update/host helpers.
-- [ ] 3.3 Add Accounts summary rows for current/default connection profile,
+- [x] 3.3 Add Accounts summary rows for current/default connection profile,
   provider, model, credential status, and test/login/set-key action availability
   through typed connection-control data rather than direct TOML parsing.
-- [ ] 3.4 Add Sessions summary or controls for governance, reasoning effort,
+- [x] 3.4 Add Sessions summary or controls for governance, reasoning effort,
   streaming mode, and recovery mode without exposing deprecated
   `thinking_budget_tokens`.
-- [ ] 3.5 Add Capabilities summary state from the skill catalog when available,
+- [x] 3.5 Add Capabilities summary state from the skill catalog when available,
   using `enabled` and `allow_implicit_invocation` terminology and avoiding
   legacy mount-mode labels.
-- [ ] 3.6 Ensure unavailable data sources render compact unavailable states
+- [x] 3.6 Ensure unavailable data sources render compact unavailable states
   instead of stack traces, debug payloads, or empty sections.
 
 ## 4. Safety And Redaction
 
-- [ ] 4.1 Ensure Settings never displays bearer tokens, API keys, refresh
+- [x] 4.1 Ensure Settings never displays bearer tokens, API keys, refresh
   tokens, managed auth file contents, or raw secret-store values.
-- [ ] 4.2 Ensure first-phase Accounts, Capabilities, and Local rows do not offer
+- [x] 4.2 Ensure first-phase Accounts, Capabilities, and Local rows do not offer
   freeform editing of `agent.toml`, `connections.toml`, `host.toml`,
   `models.toml`, or credential stores.
-- [ ] 4.3 Verify dev-channel Settings displays dev labels and locations
+- [x] 4.3 Verify dev-channel Settings displays dev labels and locations
   (`Alan Dev`, `alan-dev`, `~/.alan-dev`, dev daemon defaults) without falling
   back to stable channel state.
 
 ## 5. Verification
 
-- [ ] 5.1 Add or update focused Swift/script tests for Settings section
+- [x] 5.1 Add or update focused Swift/script tests for Settings section
   presence, Interface preference bindings, and singleton Settings behavior.
-- [ ] 5.2 Add tests or fixtures proving non-terminal Settings content does not
+- [x] 5.2 Add tests or fixtures proving non-terminal Settings content does not
   create a shell process or Ghostty host.
-- [ ] 5.3 Add tests for redaction and read-only behavior for Accounts, Local,
+- [x] 5.3 Add tests for redaction and read-only behavior for Accounts, Local,
   and Capabilities rows.
-- [ ] 5.4 Run `bash clients/apple/scripts/test-shell-runtime-metadata.sh`.
-- [ ] 5.5 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.6 Run the relevant macOS build or focused Apple client validation from a
+- [x] 5.4 Run `bash clients/apple/scripts/test-shell-runtime-metadata.sh`.
+- [x] 5.5 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.6 Run the relevant macOS build or focused Apple client validation from a
   repo-local DerivedData path.
-- [ ] 5.7 Install or launch a fresh app build and manually verify the Settings
+- [x] 5.7 Install or launch a fresh app build and manually verify the Settings
   tab after relaunching the current Alan channel.
 
 ## 6. Review And Archive Readiness
 
-- [ ] 6.1 Review the implementation against
+- [x] 6.1 Review the implementation against
   `openspec/specs/macos-shell-ui-ux-conformance/spec.md` and this change's
   delta spec for duplicate or conflicting Settings requirements.
-- [ ] 6.2 Run `openspec validate improve-macos-settings-surface --strict`.
+- [x] 6.2 Run `openspec validate improve-macos-settings-surface --strict`.
 - [ ] 6.3 Before archiving after merge, sync the accepted delta requirements into
   `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
 - [ ] 6.4 Archive the completed change only after implementation, verification,


### PR DESCRIPTION
## Summary
- reorganize macOS Settings into Interface, Accounts, Sessions, Capabilities, and Local sections
- add typed Apple client reads for connection and skill catalog summaries, with read-only/redacted settings rows
- record Alan Dev as the default macOS app test target and add focused settings-surface coverage

## Verification
- just apple-shell-focused-tests
- openspec validate improve-macos-settings-surface --strict
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath clients/apple/build/dev-debug-derived PRODUCT_BUNDLE_IDENTIFIER=app.alanworks.macos.dev "PRODUCT_NAME=Alan Dev" "INFOPLIST_KEY_CFBundleDisplayName=Alan Dev" build

## Notes
- OpenSpec tasks remain 25/27 by design: 6.3 and 6.4 are post-merge canonical spec sync and archive steps.