### PR TITLE
Implement macOS terminal profiles and accounts

### DIFF
--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -283,13 +283,39 @@ extension ShellHostController {
             guard let spaceID = createSpace(
                 launchTarget: .shell,
                 title: command.title,
-                workingDirectory: command.cwd
+                workingDirectory: command.cwd,
+                terminalProfileID: command.terminalProfileID
             ) else {
                 return response(
                     requestID: command.requestID,
                     applied: false,
                     errorCode: "space_create_failed",
                     errorMessage: failureMessage
+                )
+            }
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                spaceID: spaceID,
+                paneID: shellState.focusedPaneID
+            )
+
+        case .spaceSetTerminalProfile:
+            guard let spaceID = command.spaceID ?? shellState.focusedSpaceID else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "space_required",
+                    errorMessage: "space_id is required."
+                )
+            }
+            guard setTerminalProfile(command.terminalProfileID, forSpaceID: spaceID) else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: spaceID,
+                    errorCode: "space_not_found",
+                    errorMessage: "The requested space does not exist."
                 )
             }
             return response(
@@ -314,7 +340,8 @@ extension ShellHostController {
                         launchTarget: .shell,
                         spaceID: command.spaceID,
                         title: command.title,
-                        workingDirectory: command.cwd
+                        workingDirectory: command.cwd,
+                        terminalProfileID: command.terminalProfileID
                     )
                 )
             )
@@ -585,7 +612,8 @@ extension ShellHostController {
                 .splitPane(
                     ShellAutomationPaneSplitRequest(
                         paneID: paneID,
-                        placement: .defaultPlacement(for: direction)
+                        placement: .defaultPlacement(for: direction),
+                        terminalProfileID: command.terminalProfileID
                     )
                 )
             )

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -17,11 +17,37 @@ struct ShellAutomationCreateTabRequest: Equatable {
     let spaceID: String?
     let title: String?
     let workingDirectory: String?
+    let terminalProfileID: String?
+
+    init(
+        launchTarget: ShellLaunchTarget,
+        spaceID: String?,
+        title: String?,
+        workingDirectory: String?,
+        terminalProfileID: String? = nil
+    ) {
+        self.launchTarget = launchTarget
+        self.spaceID = spaceID
+        self.title = title
+        self.workingDirectory = workingDirectory
+        self.terminalProfileID = terminalProfileID
+    }
 }
 
 struct ShellAutomationPaneSplitRequest: Equatable {
     let paneID: String
     let placement: ShellPaneSplitDirection
+    let terminalProfileID: String?
+
+    init(
+        paneID: String,
+        placement: ShellPaneSplitDirection,
+        terminalProfileID: String? = nil
+    ) {
+        self.paneID = paneID
+        self.placement = placement
+        self.terminalProfileID = terminalProfileID
+    }
 }
 
 struct ShellAutomationSendTextRequest: Equatable {

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
@@ -137,23 +137,27 @@ enum ShellAutomationIntentRouter {
     static func createTerminalTab(
         spaceID: String? = nil,
         title: String? = nil,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        terminalProfileID: String? = nil
     ) -> ShellAutomationIntentOutcome {
         perform(.createTab(ShellAutomationCreateTabRequest(
             launchTarget: .shell,
             spaceID: spaceID,
             title: title,
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID
         )))
     }
 
     static func splitPane(
         _ pane: AlanShellPaneEntity,
-        direction: ShellPaneSplitDirection
+        direction: ShellPaneSplitDirection,
+        terminalProfileID: String? = nil
     ) -> ShellAutomationIntentOutcome {
         perform(.splitPane(ShellAutomationPaneSplitRequest(
             paneID: pane.id,
-            placement: direction
+            placement: direction,
+            terminalProfileID: terminalProfileID
         )))
     }
 
@@ -237,11 +241,15 @@ struct AlanCreateTerminalTabIntent: AppIntent {
     @Parameter(title: "Working Directory")
     var workingDirectory: String?
 
+    @Parameter(title: "Terminal Profile ID")
+    var terminalProfileID: String?
+
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.createTerminalTab(
             spaceID: space?.id,
             title: tabTitle,
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID
         )
         return try shellAutomationIntentResult(outcome)
     }
@@ -258,10 +266,14 @@ struct AlanSplitPaneIntent: AppIntent {
     @Parameter(title: "Direction")
     var direction: AlanShellPaneSplitDirectionOption
 
+    @Parameter(title: "Terminal Profile ID")
+    var terminalProfileID: String?
+
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let outcome = await ShellAutomationIntentRouter.splitPane(
             pane,
-            direction: direction.shellDirection
+            direction: direction.shellDirection,
+            terminalProfileID: terminalProfileID
         )
         return try shellAutomationIntentResult(outcome)
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -5,6 +5,7 @@ enum AlanShellControlCommandKind: String, Codable {
     case state
     case spaceList = "space.list"
     case spaceCreate = "space.create"
+    case spaceSetTerminalProfile = "space.set_terminal_profile"
     case tabList = "tab.list"
     case tabOpen = "tab.open"
     case tabClose = "tab.close"
@@ -65,6 +66,7 @@ struct AlanShellControlCommand: Codable {
     let sessionLabel: String?
     let projectLabel: String?
     let workingDirectory: String?
+    let terminalProfileID: String?
     let detail: String?
     let updatedAt: String?
     let afterEventID: String?
@@ -95,6 +97,7 @@ struct AlanShellControlCommand: Codable {
         case sessionLabel = "session_label"
         case projectLabel = "project_label"
         case workingDirectory = "working_directory"
+        case terminalProfileID = "terminal_profile_id"
         case detail
         case updatedAt = "updated_at"
         case afterEventID = "after_event_id"

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -260,7 +260,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "checkmark.seal"
         case .repair:
             return "wrench.and.screwdriver"
-        case .requiresDestructiveConfirmation, .invalid:
+        case .requiresDestructiveConfirmation, .invalid, .sudoersConflict:
             return "exclamationmark.triangle"
         case .readyToApply:
             return "person.crop.circle.badge.plus"
@@ -277,6 +277,8 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "Invalid"
         case .requiresDestructiveConfirmation:
             return "Confirm"
+        case .sudoersConflict:
+            return "Conflict"
         case .readyToApply:
             return "Preview"
         }
@@ -293,6 +295,8 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "\(target) needs a valid local account identifier."
         case .requiresDestructiveConfirmation:
             return "\(target) rollback needs separate destructive confirmation."
+        case .sudoersConflict(let path):
+            return "\(target) has an existing non-Alan sudoers file at \(path)."
         case .readyToApply:
             return "\(target) terminal entry plan is ready for explicit confirmation."
         }

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -3,6 +3,8 @@ import Foundation
 #if os(macOS)
 enum ShellSettingsSectionID: String, CaseIterable, Equatable {
     case interface
+    case terminalProfiles
+    case terminalAccounts
     case accounts
     case sessions
     case capabilities
@@ -10,6 +12,8 @@ enum ShellSettingsSectionID: String, CaseIterable, Equatable {
 
     static let defaultOrder: [ShellSettingsSectionID] = [
         .interface,
+        .terminalProfiles,
+        .terminalAccounts,
         .accounts,
         .sessions,
         .capabilities,
@@ -20,6 +24,10 @@ enum ShellSettingsSectionID: String, CaseIterable, Equatable {
         switch self {
         case .interface:
             return "Interface"
+        case .terminalProfiles:
+            return "Terminal Profiles"
+        case .terminalAccounts:
+            return "Terminal Accounts"
         case .accounts:
             return "Accounts"
         case .sessions:
@@ -90,11 +98,21 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
 
     static func make(
         remote: ShellSettingsRemoteSnapshot,
-        local: ShellSettingsLocalSummary
+        local: ShellSettingsLocalSummary,
+        terminalProfiles: TerminalProfileSettingsSummary = .current(),
+        managedTerminalAccounts: ManagedTerminalAccountSettingsSummary = .empty
     ) -> ShellSettingsSurfaceSnapshot {
         ShellSettingsSurfaceSnapshot(
             sections: [
                 ShellSettingsSectionModel(id: .interface, rows: interfaceRows()),
+                ShellSettingsSectionModel(
+                    id: .terminalProfiles,
+                    rows: terminalProfileRows(terminalProfiles)
+                ),
+                ShellSettingsSectionModel(
+                    id: .terminalAccounts,
+                    rows: managedTerminalAccountRows(managedTerminalAccounts)
+                ),
                 ShellSettingsSectionModel(id: .accounts, rows: accountRows(remote.accounts)),
                 ShellSettingsSectionModel(id: .sessions, rows: sessionRows()),
                 ShellSettingsSectionModel(id: .capabilities, rows: capabilityRows(remote.capabilities)),
@@ -128,6 +146,156 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 mutability: .editable
             ),
         ]
+    }
+
+    private static func terminalProfileRows(
+        _ summary: TerminalProfileSettingsSummary
+    ) -> [ShellSettingsRowModel] {
+        var rows: [ShellSettingsRowModel] = [
+            ShellSettingsRowModel(
+                id: "terminalProfilesDefault",
+                systemName: "terminal",
+                title: "Default Terminal Profile",
+                detail: "Local startup identity for new terminal content.",
+                value: summary.defaultProfileTitle ?? "Login shell",
+                mutability: .editable
+            ),
+            ShellSettingsRowModel(
+                id: "terminalProfilesCreate",
+                systemName: "plus.circle",
+                title: "New Terminal Profile",
+                detail: "Structured launch mode with local validation.",
+                value: "Create",
+                mutability: .actionOnly
+            )
+        ]
+
+        if let recoveryMessage = summary.recoveryMessage {
+            rows.append(
+                ShellSettingsRowModel(
+                    id: "terminalProfilesRecovery",
+                    systemName: "exclamationmark.triangle",
+                    title: "Profile store recovery",
+                    detail: recoveryMessage,
+                    value: "Fallback active"
+                )
+            )
+        }
+
+        rows.append(
+            contentsOf: summary.profiles.map { profile in
+                ShellSettingsRowModel(
+                    id: "terminalProfile.\(profile.id)",
+                    systemName: terminalProfileSystemName(profile),
+                    title: profile.title,
+                    detail: profile.redactedDisplayDetail,
+                    value: profile.id == summary.defaultProfileID ? "Default" : profile.launch.kind.rawValue,
+                    mutability: .editable
+                )
+            }
+        )
+        rows.append(
+            ShellSettingsRowModel(
+                id: "terminalProfilesSudoGuidance",
+                systemName: "lock.shield",
+                title: "Sudo behavior",
+                detail: "Prompts and passwordless sudo are controlled by macOS sudo policy.",
+                value: "System managed"
+            )
+        )
+        return rows
+    }
+
+    private static func managedTerminalAccountRows(
+        _ summary: ManagedTerminalAccountSettingsSummary
+    ) -> [ShellSettingsRowModel] {
+        guard !summary.plans.isEmpty else {
+            return [
+                ShellSettingsRowModel(
+                    id: "terminalAccountProvision",
+                    systemName: "person.crop.circle.badge.plus",
+                    title: "Managed terminal account",
+                    detail: "Create a terminal-only local user for passwordless terminal entry.",
+                    value: "Preview plan",
+                    mutability: .actionOnly
+                ),
+                ShellSettingsRowModel(
+                    id: "terminalAccountLoginBoundary",
+                    systemName: "macwindow.badge.plus",
+                    title: "Mac login session",
+                    detail: "This flow leaves the Mac login session setting unchanged.",
+                    value: "Not changed"
+                ),
+            ]
+        }
+
+        return summary.plans.map { plan in
+            ShellSettingsRowModel(
+                id: "terminalAccount.\(plan.request.accountName)",
+                systemName: terminalAccountSystemName(plan),
+                title: "Managed terminal account",
+                detail: terminalAccountDetail(plan),
+                value: terminalAccountStatusLabel(plan),
+                mutability: .actionOnly
+            )
+        }
+    }
+
+    private static func terminalProfileSystemName(_ profile: TerminalProfileDefinition) -> String {
+        switch profile.launch {
+        case .loginShell:
+            return "terminal"
+        case .sudoUser:
+            return "person.crop.circle"
+        case .sudoRoot:
+            return "exclamationmark.triangle"
+        case .customCommand:
+            return "chevron.left.forwardslash.chevron.right"
+        }
+    }
+
+    private static func terminalAccountSystemName(_ plan: ManagedTerminalAccountPlan) -> String {
+        switch plan.status {
+        case .alreadyReady:
+            return "checkmark.seal"
+        case .repair:
+            return "wrench.and.screwdriver"
+        case .requiresDestructiveConfirmation, .invalid:
+            return "exclamationmark.triangle"
+        case .readyToApply:
+            return "person.crop.circle.badge.plus"
+        }
+    }
+
+    private static func terminalAccountStatusLabel(_ plan: ManagedTerminalAccountPlan) -> String {
+        switch plan.status {
+        case .alreadyReady:
+            return "Ready"
+        case .repair:
+            return "Repairable"
+        case .invalid:
+            return "Invalid"
+        case .requiresDestructiveConfirmation:
+            return "Confirm"
+        case .readyToApply:
+            return "Preview"
+        }
+    }
+
+    private static func terminalAccountDetail(_ plan: ManagedTerminalAccountPlan) -> String {
+        let target = plan.request.accountName
+        switch plan.status {
+        case .alreadyReady:
+            return "\(target) is ready for terminal entry and linked to its Terminal Profile."
+        case .repair:
+            return "\(target) needs repair before terminal entry is ready."
+        case .invalid:
+            return "\(target) needs a valid local account identifier."
+        case .requiresDestructiveConfirmation:
+            return "\(target) rollback needs separate destructive confirmation."
+        case .readyToApply:
+            return "\(target) terminal entry plan is ready for explicit confirmation."
+        }
     }
 
     private static func accountRows(
@@ -412,6 +580,35 @@ struct ShellSettingsRemoteSnapshot: Equatable {
             capabilities: .unavailable(reason: reason)
         )
     }
+}
+
+struct TerminalProfileSettingsSummary: Equatable {
+    let profiles: [TerminalProfileDefinition]
+    let defaultProfileID: String
+    let recoveryMessage: String?
+
+    static func current(
+        store: TerminalProfileStore = .defaultStore()
+    ) -> TerminalProfileSettingsSummary {
+        let load = store.load()
+        return TerminalProfileSettingsSummary(
+            profiles: load.profiles,
+            defaultProfileID: load.document.defaultProfileID,
+            recoveryMessage: load.recovery.map { _ in
+                "The local Terminal Profile store was unreadable and has been preserved."
+            }
+        )
+    }
+
+    var defaultProfileTitle: String? {
+        profiles.first { $0.id == defaultProfileID }?.title
+    }
+}
+
+struct ManagedTerminalAccountSettingsSummary: Equatable {
+    let plans: [ManagedTerminalAccountPlan]
+
+    static let empty = ManagedTerminalAccountSettingsSummary(plans: [])
 }
 
 struct ShellSettingsAccountsSummary: Equatable {

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -260,7 +260,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "checkmark.seal"
         case .repair:
             return "wrench.and.screwdriver"
-        case .requiresDestructiveConfirmation, .invalid, .sudoersConflict:
+        case .requiresDestructiveConfirmation, .invalid, .sudoersConflict, .terminalProfileConflict:
             return "exclamationmark.triangle"
         case .readyToApply:
             return "person.crop.circle.badge.plus"
@@ -277,7 +277,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "Invalid"
         case .requiresDestructiveConfirmation:
             return "Confirm"
-        case .sudoersConflict:
+        case .sudoersConflict, .terminalProfileConflict:
             return "Conflict"
         case .readyToApply:
             return "Preview"
@@ -297,6 +297,8 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             return "\(target) rollback needs separate destructive confirmation."
         case .sudoersConflict(let path):
             return "\(target) has an existing non-Alan sudoers file at \(path)."
+        case .terminalProfileConflict(let profileID):
+            return "\(target) has an existing non-Alan Terminal Profile named \(profileID)."
         case .readyToApply:
             return "\(target) terminal entry plan is ready for explicit confirmation."
         }

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -73,6 +73,7 @@ struct ShellPane: Identifiable, Codable, Equatable {
     let viewport: ShellViewportSnapshot?
     let activity: TerminalActivitySnapshot?
     let alanBinding: ShellAlanBinding?
+    let terminalProfileID: String?
 
     var id: String { paneID }
 
@@ -87,7 +88,8 @@ struct ShellPane: Identifiable, Codable, Equatable {
         context: ShellContextSnapshot?,
         viewport: ShellViewportSnapshot?,
         activity: TerminalActivitySnapshot? = nil,
-        alanBinding: ShellAlanBinding?
+        alanBinding: ShellAlanBinding?,
+        terminalProfileID: String? = nil
     ) {
         self.paneID = paneID
         self.tabID = tabID
@@ -100,6 +102,7 @@ struct ShellPane: Identifiable, Codable, Equatable {
         self.viewport = viewport
         self.activity = activity
         self.alanBinding = alanBinding
+        self.terminalProfileID = terminalProfileID
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -114,6 +117,25 @@ struct ShellPane: Identifiable, Codable, Equatable {
         case viewport
         case activity
         case alanBinding = "alan_binding"
+        case terminalProfileID = "terminal_profile_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            paneID: try container.decode(String.self, forKey: .paneID),
+            tabID: try container.decode(String.self, forKey: .tabID),
+            spaceID: try container.decode(String.self, forKey: .spaceID),
+            launchTarget: try container.decodeIfPresent(ShellLaunchTarget.self, forKey: .launchTarget),
+            cwd: try container.decodeIfPresent(String.self, forKey: .cwd),
+            process: try container.decodeIfPresent(ShellProcessBinding.self, forKey: .process),
+            attention: try container.decode(ShellAttentionState.self, forKey: .attention),
+            context: try container.decodeIfPresent(ShellContextSnapshot.self, forKey: .context),
+            viewport: try container.decodeIfPresent(ShellViewportSnapshot.self, forKey: .viewport),
+            activity: try container.decodeIfPresent(TerminalActivitySnapshot.self, forKey: .activity),
+            alanBinding: try container.decodeIfPresent(ShellAlanBinding.self, forKey: .alanBinding),
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+        )
     }
 }
 
@@ -393,17 +415,20 @@ struct ShellTerminalContentPayload: Codable, Equatable {
     let cwd: String?
     let title: String?
     let transcriptSnapshot: TerminalTranscriptSnapshot?
+    let terminalProfileID: String?
 
     init(
         launchTarget: ShellLaunchTarget,
         cwd: String?,
         title: String?,
-        transcriptSnapshot: TerminalTranscriptSnapshot? = nil
+        transcriptSnapshot: TerminalTranscriptSnapshot? = nil,
+        terminalProfileID: String? = nil
     ) {
         self.launchTarget = launchTarget
         self.cwd = cwd
         self.title = title
         self.transcriptSnapshot = transcriptSnapshot
+        self.terminalProfileID = terminalProfileID
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -411,6 +436,21 @@ struct ShellTerminalContentPayload: Codable, Equatable {
         case cwd
         case title
         case transcriptSnapshot = "transcript_snapshot"
+        case terminalProfileID = "terminal_profile_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            launchTarget: try container.decode(ShellLaunchTarget.self, forKey: .launchTarget),
+            cwd: try container.decodeIfPresent(String.self, forKey: .cwd),
+            title: try container.decodeIfPresent(String.self, forKey: .title),
+            transcriptSnapshot: try container.decodeIfPresent(
+                TerminalTranscriptSnapshot.self,
+                forKey: .transcriptSnapshot
+            ),
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+        )
     }
 }
 
@@ -1064,6 +1104,7 @@ struct ShellSpace: Identifiable, Codable, Equatable {
     let title: String
     let attention: ShellAttentionState
     let tabs: [ShellTab]
+    let terminalProfileID: String?
 
     var id: String { spaceID }
 
@@ -1072,6 +1113,32 @@ struct ShellSpace: Identifiable, Codable, Equatable {
         case title
         case attention
         case tabs
+        case terminalProfileID = "terminal_profile_id"
+    }
+
+    init(
+        spaceID: String,
+        title: String,
+        attention: ShellAttentionState,
+        tabs: [ShellTab],
+        terminalProfileID: String? = nil
+    ) {
+        self.spaceID = spaceID
+        self.title = title
+        self.attention = attention
+        self.tabs = tabs
+        self.terminalProfileID = terminalProfileID
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            spaceID: try container.decode(String.self, forKey: .spaceID),
+            title: try container.decode(String.self, forKey: .title),
+            attention: try container.decode(ShellAttentionState.self, forKey: .attention),
+            tabs: try container.decode([ShellTab].self, forKey: .tabs),
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+        )
     }
 }
 
@@ -1080,6 +1147,7 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
     let title: String
     let attention: ShellAttentionState
     let tabs: [ShellContentTab]
+    let terminalProfileID: String?
 
     var id: String { spaceID }
 
@@ -1088,6 +1156,32 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
         case title
         case attention
         case tabs
+        case terminalProfileID = "terminal_profile_id"
+    }
+
+    init(
+        spaceID: String,
+        title: String,
+        attention: ShellAttentionState,
+        tabs: [ShellContentTab],
+        terminalProfileID: String? = nil
+    ) {
+        self.spaceID = spaceID
+        self.title = title
+        self.attention = attention
+        self.tabs = tabs
+        self.terminalProfileID = terminalProfileID
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            spaceID: try container.decode(String.self, forKey: .spaceID),
+            title: try container.decode(String.self, forKey: .title),
+            attention: try container.decode(ShellAttentionState.self, forKey: .attention),
+            tabs: try container.decode([ShellContentTab].self, forKey: .tabs),
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+        )
     }
 }
 
@@ -1313,7 +1407,8 @@ extension ShellContentStateSnapshot {
                         launchTarget: terminalPayload.launchTarget,
                         cwd: terminalPayload.cwd,
                         title: terminalPayload.title,
-                        transcriptSnapshot: transcriptSnapshot
+                        transcriptSnapshot: transcriptSnapshot,
+                        terminalProfileID: terminalPayload.terminalProfileID
                     )
                 ),
                 lifecycle: projected.lifecycle,
@@ -1342,7 +1437,8 @@ extension ShellContentStateSnapshot {
                         paneTree: ShellPaneSlotTreeNode.migrating(paneTree: tab.paneTree),
                         isPinned: tab.isPinned
                     )
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -1452,7 +1548,8 @@ extension ShellContentStateSnapshot {
                 attention: Self.strongestAttention(
                     in: materializedPaneSlots.filter { $0.spaceID == space.spaceID }
                 ),
-                tabs: tabs
+                tabs: tabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -1546,7 +1643,8 @@ private extension ShellPane {
                 visibleExcerpt: nil,
                 lastActivityAt: nil
             ),
-            alanBinding: nil
+            alanBinding: nil,
+            terminalProfileID: terminalPayload?.terminalProfileID
         )
     }
 
@@ -1589,7 +1687,8 @@ extension ShellContentInstance {
                 ShellTerminalContentPayload(
                     launchTarget: pane.resolvedLaunchTarget,
                     cwd: pane.cwd,
-                    title: title
+                    title: title,
+                    terminalProfileID: pane.terminalProfileID
                 )
             ),
             rendererState: terminalRendererState(for: pane)

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -31,6 +31,18 @@ extension ShellStateSnapshot {
         FileManager.default.homeDirectoryForCurrentUser.path
     }
 
+    func terminalProfileIDForNewTerminal(
+        in requestedSpaceID: String?,
+        explicit: String?
+    ) -> String? {
+        if let explicit {
+            return explicit
+        }
+        let targetSpaceID = requestedSpaceID ?? focusedSpaceID ?? spaces.first?.spaceID
+        guard let targetSpaceID else { return nil }
+        return space(spaceID: targetSpaceID)?.terminalProfileID
+    }
+
     static func bootstrapDefault(
         windowID: String = "window_main",
         workingDirectory: String = defaultShellWorkingDirectory()

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -43,6 +43,18 @@ extension ShellStateSnapshot {
         return space(spaceID: targetSpaceID)?.terminalProfileID
     }
 
+    func terminalProfileIDForNewSplit(
+        from paneID: String,
+        explicit: String?
+    ) -> String? {
+        if let explicit {
+            return explicit
+        }
+        guard let pane = pane(paneID: paneID) else { return nil }
+        return pane.terminalProfileID
+            ?? terminalProfileIDForNewTerminal(in: pane.spaceID, explicit: nil)
+    }
+
     static func bootstrapDefault(
         windowID: String = "window_main",
         workingDirectory: String = defaultShellWorkingDirectory()

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -218,7 +218,11 @@ extension ShellStateSnapshot {
             tabID: tabID,
             spaceID: spaceID,
             launchTarget: launchTarget,
-            workingDirectory: workingDirectory ?? defaultWorkingDirectory,
+            workingDirectory: terminalPaneWorkingDirectory(
+                requested: workingDirectory,
+                defaultWorkingDirectory: defaultWorkingDirectory,
+                terminalProfileID: terminalProfileID
+            ),
             summary: "new shell space scaffolded",
             now: now,
             terminalProfileID: terminalProfileID
@@ -752,17 +756,17 @@ extension ShellStateSnapshot {
             prefix: "node",
             existing: spaces.flatMap(\.tabs).flatMap { $0.paneTree.nodeIDs }
         )
+        let resolvedTerminalProfileID =
+            terminalProfileID
+            ?? pane.terminalProfileID
+            ?? space(spaceID: pane.spaceID)?.terminalProfileID
         let resolvedContentIntent =
             contentIntent
             ?? .terminal(
                 launchTarget: pane.resolvedLaunchTarget,
                 title: nil,
-                workingDirectory: pane.cwd
+                workingDirectory: resolvedTerminalProfileID == nil ? pane.cwd : nil
             )
-        let resolvedTerminalProfileID =
-            terminalProfileID
-            ?? pane.terminalProfileID
-            ?? space(spaceID: pane.spaceID)?.terminalProfileID
         let prepared = makeContentMount(
             resolvedContentIntent,
             paneID: newPaneID,
@@ -1669,7 +1673,11 @@ extension ShellStateSnapshot {
                 tabID: tabID,
                 spaceID: spaceID,
                 launchTarget: launchTarget,
-                workingDirectory: workingDirectory ?? defaultWorkingDirectory,
+                workingDirectory: terminalPaneWorkingDirectory(
+                    requested: workingDirectory,
+                    defaultWorkingDirectory: defaultWorkingDirectory,
+                    terminalProfileID: terminalProfileID
+                ),
                 summary: terminalSummary,
                 now: now,
                 terminalProfileID: terminalProfileID
@@ -1758,12 +1766,26 @@ extension ShellStateSnapshot {
         }
     }
 
+    private func terminalPaneWorkingDirectory(
+        requested workingDirectory: String?,
+        defaultWorkingDirectory: String,
+        terminalProfileID: String?
+    ) -> String? {
+        if let workingDirectory {
+            return workingDirectory
+        }
+        if terminalProfileID != nil {
+            return nil
+        }
+        return defaultWorkingDirectory
+    }
+
     private func makeTerminalPane(
         paneID: String,
         tabID: String,
         spaceID: String,
         launchTarget: ShellLaunchTarget,
-        workingDirectory: String,
+        workingDirectory: String?,
         summary: String,
         now: Date,
         terminalProfileID: String? = nil

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -137,7 +137,8 @@ extension ShellStateSnapshot {
                 context: current.context,
                 viewport: current.viewport,
                 activity: nil,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
     }
@@ -182,7 +183,8 @@ extension ShellStateSnapshot {
                 context: current.context,
                 viewport: current.viewport,
                 activity: activity,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
         let nextSpaces = rebuildingAttention(in: spaces, panes: updatedPanes)
@@ -202,6 +204,7 @@ extension ShellStateSnapshot {
         launchTarget: ShellLaunchTarget,
         title: String?,
         workingDirectory: String?,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -217,7 +220,8 @@ extension ShellStateSnapshot {
             launchTarget: launchTarget,
             workingDirectory: workingDirectory ?? defaultWorkingDirectory,
             summary: "new shell space scaffolded",
-            now: now
+            now: now,
+            terminalProfileID: terminalProfileID
         )
         let tab = ShellTab(
             tabID: tabID,
@@ -235,7 +239,8 @@ extension ShellStateSnapshot {
             spaceID: spaceID,
             title: title ?? "Space \(spaceIndex)",
             attention: .active,
-            tabs: [tab]
+            tabs: [tab],
+            terminalProfileID: terminalProfileID
         )
         let nextPanes = panes + [pane]
         let nextSpaces = rebuildingAttention(in: spaces + [space], panes: nextPanes)
@@ -255,6 +260,7 @@ extension ShellStateSnapshot {
     func creatingTerminalSpace(
         title: String?,
         workingDirectory: String?,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -263,9 +269,41 @@ extension ShellStateSnapshot {
             launchTarget: .shell,
             title: title,
             workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID,
             reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
+        )
+    }
+
+    func settingTerminalProfile(
+        _ terminalProfileID: String?,
+        forSpaceID targetSpaceID: String
+    ) -> ShellStateSnapshot? {
+        guard spaces.contains(where: { $0.spaceID == targetSpaceID }) else {
+            return nil
+        }
+        let nextSpaces = spaces.map { space in
+            guard space.spaceID == targetSpaceID else { return space }
+            return ShellSpace(
+                spaceID: space.spaceID,
+                title: space.title,
+                attention: space.attention,
+                tabs: space.tabs,
+                terminalProfileID: terminalProfileID
+            )
+        }
+        return ShellStateSnapshot(
+            contractVersion: contractVersion,
+            windowID: windowID,
+            focusedSpaceID: focusedSpaceID,
+            focusedTabID: focusedTabID,
+            focusedPaneID: focusedPaneID,
+            spaces: nextSpaces,
+            panes: panes,
+            paneSlots: paneSlots,
+            contents: contents,
+            quickTerminal: quickTerminal
         )
     }
 
@@ -326,6 +364,7 @@ extension ShellStateSnapshot {
     func openingContentTab(
         _ contentIntent: ShellContentIntent,
         in requestedSpaceID: String?,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -345,6 +384,7 @@ extension ShellStateSnapshot {
 
         let tabID = nextID(prefix: "tab", existing: spaces.flatMap { $0.tabs.map(\.tabID) })
         let paneID = nextID(prefix: "pane", existing: panes.map(\.paneID) + Array(reservedPaneIDs))
+        let resolvedTerminalProfileID = terminalProfileID ?? targetSpace.terminalProfileID
         let prepared = makeContentMount(
             contentIntent,
             paneID: paneID,
@@ -356,7 +396,8 @@ extension ShellStateSnapshot {
             ),
             terminalSummary: Self.defaultTerminalSummary(for: contentIntent),
             defaultWorkingDirectory: defaultWorkingDirectory,
-            now: now
+            now: now,
+            terminalProfileID: resolvedTerminalProfileID
         )
         let tab = ShellTab(
             tabID: tabID,
@@ -376,7 +417,8 @@ extension ShellStateSnapshot {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: space.attention,
-                tabs: space.tabs + [tab]
+                tabs: space.tabs + [tab],
+                terminalProfileID: space.terminalProfileID
             )
         }
         let nextPanes = panes + [prepared.pane]
@@ -400,6 +442,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -411,6 +454,7 @@ extension ShellStateSnapshot {
                 workingDirectory: workingDirectory
             ),
             in: requestedSpaceID,
+            terminalProfileID: terminalProfileID,
             reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
@@ -421,6 +465,7 @@ extension ShellStateSnapshot {
         in requestedSpaceID: String?,
         title: String?,
         workingDirectory: String?,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -430,6 +475,7 @@ extension ShellStateSnapshot {
             in: requestedSpaceID,
             title: title,
             workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID,
             reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
@@ -610,7 +656,8 @@ extension ShellStateSnapshot {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: space.attention,
-                tabs: space.tabs + [newTab]
+                tabs: space.tabs + [newTab],
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -633,7 +680,8 @@ extension ShellStateSnapshot {
                     lastActivityAt: formatter.string(from: now)
                 ),
                 activity: current.activity,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
 
@@ -663,6 +711,7 @@ extension ShellStateSnapshot {
         _ paneID: String,
         direction: ShellSplitDirection,
         contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -671,6 +720,7 @@ extension ShellStateSnapshot {
             paneID,
             placement: .defaultPlacement(for: direction),
             contentIntent: contentIntent,
+            terminalProfileID: terminalProfileID,
             reservedPaneIDs: reservedPaneIDs,
             defaultWorkingDirectory: defaultWorkingDirectory,
             now: now
@@ -681,6 +731,7 @@ extension ShellStateSnapshot {
         _ paneID: String,
         placement: ShellPaneSplitDirection,
         contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil,
         reservedPaneIDs: Set<String> = [],
         defaultWorkingDirectory: String = defaultShellWorkingDirectory(),
         now: Date = .now
@@ -708,6 +759,10 @@ extension ShellStateSnapshot {
                 title: nil,
                 workingDirectory: pane.cwd
             )
+        let resolvedTerminalProfileID =
+            terminalProfileID
+            ?? pane.terminalProfileID
+            ?? space(spaceID: pane.spaceID)?.terminalProfileID
         let prepared = makeContentMount(
             resolvedContentIntent,
             paneID: newPaneID,
@@ -716,7 +771,8 @@ extension ShellStateSnapshot {
             defaultTerminalTitle: Self.defaultViewportTitle(for: pane.resolvedLaunchTarget),
             terminalSummary: "new split scaffolded",
             defaultWorkingDirectory: pane.cwd ?? defaultWorkingDirectory,
-            now: now
+            now: now,
+            terminalProfileID: resolvedTerminalProfileID
         )
         let updatedTab = ShellTab(
             tabID: tab.tabID,
@@ -740,7 +796,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs.map { existingTab in
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
         let nextPanes = panes + [prepared.pane]
@@ -825,7 +882,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs.map { existingTab in
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
         let nextPanes = panes.filter { $0.paneID != paneID }
@@ -905,7 +963,8 @@ extension ShellStateSnapshot {
                         return [existingTab]
                     }
                     return [updatedSourceTab, newTab]
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
         let formatter = ISO8601DateFormatter()
@@ -927,7 +986,8 @@ extension ShellStateSnapshot {
                     lastActivityAt: formatter.string(from: now)
                 ),
                 activity: current.activity,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
 
@@ -1024,7 +1084,8 @@ extension ShellStateSnapshot {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: space.attention,
-                tabs: nextTabs
+                tabs: nextTabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -1046,7 +1107,8 @@ extension ShellStateSnapshot {
                     lastActivityAt: formatter.string(from: now)
                 ),
                 activity: current.activity,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
 
@@ -1120,7 +1182,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs.map { existingTab in
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -1172,7 +1235,8 @@ extension ShellStateSnapshot {
             spaceID: sourceSpace.spaceID,
             title: sourceSpace.title,
             attention: sourceSpace.attention,
-            tabs: sourceSpace.tabs.filter { $0.tabID != tabID }
+            tabs: sourceSpace.tabs.filter { $0.tabID != tabID },
+            terminalProfileID: sourceSpace.terminalProfileID
         )
 
         let targetSpaceAfterRemoval = nextSpaces[targetSpaceIndex]
@@ -1191,7 +1255,8 @@ extension ShellStateSnapshot {
             spaceID: targetSpaceAfterRemoval.spaceID,
             title: targetSpaceAfterRemoval.title,
             attention: targetSpaceAfterRemoval.attention,
-            tabs: targetTabs
+            tabs: targetTabs,
+            terminalProfileID: targetSpaceAfterRemoval.terminalProfileID
         )
 
         let nextPanes = panes.map { pane in
@@ -1210,7 +1275,8 @@ extension ShellStateSnapshot {
                 context: pane.context,
                 viewport: pane.viewport,
                 activity: pane.activity,
-                alanBinding: pane.alanBinding
+                alanBinding: pane.alanBinding,
+                terminalProfileID: pane.terminalProfileID
             )
         }
 
@@ -1325,7 +1391,8 @@ extension ShellStateSnapshot {
                 context: current.context,
                 viewport: current.viewport,
                 activity: current.activity,
-                alanBinding: current.alanBinding
+                alanBinding: current.alanBinding,
+                terminalProfileID: current.terminalProfileID
             )
         }
 
@@ -1368,7 +1435,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs.map { tab in
                     tab.tabID == updatedTab.tabID ? updatedTab : tab
-                }
+                },
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -1400,7 +1468,8 @@ extension ShellStateSnapshot {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: space.attention,
-                tabs: remainingTabs
+                tabs: remainingTabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
         let nextPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
@@ -1524,7 +1593,8 @@ extension ShellStateSnapshot {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: strongestAttention(in: panes.filter { $0.spaceID == space.spaceID }),
-                tabs: space.tabs
+                tabs: space.tabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
     }
@@ -1589,7 +1659,8 @@ extension ShellStateSnapshot {
         defaultTerminalTitle: String,
         terminalSummary: String,
         defaultWorkingDirectory: String,
-        now: Date
+        now: Date,
+        terminalProfileID: String?
     ) -> ShellPreparedContentMount {
         switch contentIntent {
         case .terminal(let launchTarget, let title, let workingDirectory):
@@ -1600,7 +1671,8 @@ extension ShellStateSnapshot {
                 launchTarget: launchTarget,
                 workingDirectory: workingDirectory ?? defaultWorkingDirectory,
                 summary: terminalSummary,
-                now: now
+                now: now,
+                terminalProfileID: terminalProfileID
             )
             return ShellPreparedContentMount(
                 pane: pane,
@@ -1693,7 +1765,8 @@ extension ShellStateSnapshot {
         launchTarget: ShellLaunchTarget,
         workingDirectory: String,
         summary: String,
-        now: Date
+        now: Date,
+        terminalProfileID: String? = nil
     ) -> ShellPane {
         let formatter = ISO8601DateFormatter()
         return ShellPane(
@@ -1711,7 +1784,8 @@ extension ShellStateSnapshot {
                 visibleExcerpt: nil,
                 lastActivityAt: formatter.string(from: now)
             ),
-            alanBinding: nil
+            alanBinding: nil,
+            terminalProfileID: terminalProfileID
         )
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1513,14 +1513,17 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
 
     private func sudoersWriteScript() -> String {
         let rule = ManagedTerminalAccountSudoersRule(request: request)
-        let tempPath = "/tmp/\(rule.fileName).sudoers"
         return """
-        /bin/cat > \(shellQuote(tempPath)) <<'ALAN_SUDOERS'
+        set -eu
+        temp_dir="$(/usr/bin/mktemp -d /tmp/alan-terminal-sudoers.XXXXXXXXXX)"
+        trap '/bin/rm -rf "$temp_dir"' 0 1 2 15
+        temp_path="$temp_dir/sudoers"
+        umask 077
+        /bin/cat > "$temp_path" <<'ALAN_SUDOERS'
         \(rule.contents)
         ALAN_SUDOERS
-        /usr/sbin/visudo -cf \(shellQuote(tempPath))
-        /usr/bin/install -o root -g wheel -m 0440 \(shellQuote(tempPath)) \(shellQuote(rule.filePath))
-        /bin/rm -f \(shellQuote(tempPath))
+        /usr/sbin/visudo -cf "$temp_path"
+        /usr/bin/install -o root -g wheel -m 0440 "$temp_path" \(shellQuote(rule.filePath))
         """
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -143,6 +143,1412 @@ enum ShellLaunchTarget: String, Codable, CaseIterable {
     case shell
 }
 
+enum TerminalProfileLaunchKind: String, Codable, CaseIterable {
+    case loginShell = "login_shell"
+    case sudoUser = "sudo_user"
+    case sudoRoot = "sudo_root"
+    case customCommand = "custom_command"
+}
+
+enum TerminalProfileLaunch: Codable, Equatable {
+    case loginShell
+    case sudoUser(unixUser: String)
+    case sudoRoot
+    case customCommand(String)
+
+    var kind: TerminalProfileLaunchKind {
+        switch self {
+        case .loginShell:
+            return .loginShell
+        case .sudoUser:
+            return .sudoUser
+        case .sudoRoot:
+            return .sudoRoot
+        case .customCommand:
+            return .customCommand
+        }
+    }
+
+    var unixUser: String? {
+        guard case .sudoUser(let unixUser) = self else { return nil }
+        return unixUser
+    }
+
+    var customCommand: String? {
+        guard case .customCommand(let command) = self else { return nil }
+        return command
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case unixUser = "unix_user"
+        case command
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(TerminalProfileLaunchKind.self, forKey: .kind) {
+        case .loginShell:
+            self = .loginShell
+        case .sudoUser:
+            self = .sudoUser(
+                unixUser: try container.decodeIfPresent(String.self, forKey: .unixUser) ?? ""
+            )
+        case .sudoRoot:
+            self = .sudoRoot
+        case .customCommand:
+            self = .customCommand(
+                try container.decodeIfPresent(String.self, forKey: .command) ?? ""
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        switch self {
+        case .loginShell, .sudoRoot:
+            break
+        case .sudoUser(let unixUser):
+            try container.encode(unixUser, forKey: .unixUser)
+        case .customCommand(let command):
+            try container.encode(command, forKey: .command)
+        }
+    }
+}
+
+struct TerminalProfilePresentation: Codable, Equatable {
+    let symbolName: String?
+    let colorName: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case symbolName = "symbol_name"
+        case colorName = "color_name"
+    }
+}
+
+struct TerminalProfileDefinition: Codable, Equatable, Identifiable {
+    let id: String
+    let title: String
+    let launch: TerminalProfileLaunch
+    let defaultWorkingDirectory: String?
+    let presentation: TerminalProfilePresentation?
+    let managedTerminalAccountID: String?
+
+    init(
+        id: String,
+        title: String,
+        launch: TerminalProfileLaunch,
+        defaultWorkingDirectory: String?,
+        presentation: TerminalProfilePresentation?,
+        managedTerminalAccountID: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.launch = launch
+        self.defaultWorkingDirectory = defaultWorkingDirectory
+        self.presentation = presentation
+        self.managedTerminalAccountID = managedTerminalAccountID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case launch
+        case defaultWorkingDirectory = "default_working_directory"
+        case presentation
+        case managedTerminalAccountID = "managed_terminal_account_id"
+    }
+
+    static let loginShellFallback = TerminalProfileDefinition(
+        id: "login_shell",
+        title: "Login shell",
+        launch: .loginShell,
+        defaultWorkingDirectory: nil,
+        presentation: TerminalProfilePresentation(symbolName: "terminal", colorName: nil)
+    )
+
+    var redactedDisplayDetail: String {
+        switch launch {
+        case .loginShell:
+            return "Login shell"
+        case .sudoUser(let unixUser):
+            return unixUser.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "Sudo user"
+                : "Sudo user \(unixUser)"
+        case .sudoRoot:
+            return "Root shell"
+        case .customCommand:
+            return "Custom command"
+        }
+    }
+}
+
+struct TerminalProfileDocument: Codable, Equatable {
+    var defaultProfileID: String
+    var profiles: [TerminalProfileDefinition]
+
+    private enum CodingKeys: String, CodingKey {
+        case defaultProfileID = "default_profile_id"
+        case profiles
+    }
+
+    static let fallback = TerminalProfileDocument(
+        defaultProfileID: TerminalProfileDefinition.loginShellFallback.id,
+        profiles: [TerminalProfileDefinition.loginShellFallback]
+    )
+
+    func profile(id: String?) -> TerminalProfileDefinition? {
+        guard let id else { return nil }
+        return profiles.first { $0.id == id }
+    }
+
+    var defaultProfile: TerminalProfileDefinition? {
+        profile(id: defaultProfileID) ?? profiles.first
+    }
+}
+
+enum TerminalProfileValidationError: Error, Equatable {
+    case missingID
+    case duplicateID(String)
+    case missingTitle(String)
+    case missingUnixUser(String)
+    case missingCustomCommand(String)
+    case missingDefaultProfile(String)
+    case unavailableExecutable(profileID: String, path: String)
+
+    var userMessage: String {
+        switch self {
+        case .missingID:
+            return "A Terminal Profile id is required."
+        case .duplicateID(let id):
+            return "Terminal Profile \(id) is duplicated."
+        case .missingTitle(let id):
+            return "Terminal Profile \(id) needs a title."
+        case .missingUnixUser(let id):
+            return "Terminal Profile \(id) needs a Unix user."
+        case .missingCustomCommand(let id):
+            return "Terminal Profile \(id) needs a custom command."
+        case .missingDefaultProfile(let id):
+            return "Default Terminal Profile \(id) is missing."
+        case .unavailableExecutable(let id, let path):
+            return "Terminal Profile \(id) cannot find executable \(path)."
+        }
+    }
+}
+
+struct TerminalProfileValidationResult: Equatable {
+    let errors: [TerminalProfileValidationError]
+
+    var isValid: Bool {
+        errors.isEmpty
+    }
+}
+
+enum TerminalProfileValidator {
+    static func validate(
+        _ document: TerminalProfileDocument,
+        fileManager: FileManager? = nil
+    ) -> TerminalProfileValidationResult {
+        var errors: [TerminalProfileValidationError] = []
+        var ids = Set<String>()
+
+        for profile in document.profiles {
+            let trimmedID = profile.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedID.isEmpty {
+                errors.append(.missingID)
+            } else if !ids.insert(trimmedID).inserted {
+                errors.append(.duplicateID(trimmedID))
+            }
+
+            if profile.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                errors.append(.missingTitle(profile.id))
+            }
+
+            switch profile.launch {
+            case .loginShell, .sudoRoot:
+                break
+            case .sudoUser(let unixUser):
+                if unixUser.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    errors.append(.missingUnixUser(profile.id))
+                }
+            case .customCommand(let command):
+                if command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    errors.append(.missingCustomCommand(profile.id))
+                }
+            }
+
+            if let fileManager,
+               let executablePath = requiredExecutablePath(for: profile.launch),
+               !fileManager.isExecutableFile(atPath: executablePath)
+            {
+                errors.append(.unavailableExecutable(profileID: profile.id, path: executablePath))
+            }
+        }
+
+        if !document.defaultProfileID.isEmpty,
+           !ids.contains(document.defaultProfileID)
+        {
+            errors.append(.missingDefaultProfile(document.defaultProfileID))
+        }
+
+        return TerminalProfileValidationResult(errors: errors)
+    }
+
+    static func requiredExecutablePath(for launch: TerminalProfileLaunch) -> String? {
+        switch launch {
+        case .loginShell:
+            return nil
+        case .sudoUser, .sudoRoot:
+            return "/usr/bin/sudo"
+        case .customCommand:
+            return "/bin/zsh"
+        }
+    }
+}
+
+enum TerminalProfileStoreError: Error, Equatable {
+    case invalidDocument([TerminalProfileValidationError])
+}
+
+enum TerminalProfileStoreRecoveryKind: Equatable {
+    case corruptStoreQuarantined
+}
+
+struct TerminalProfileStoreRecovery: Equatable {
+    let kind: TerminalProfileStoreRecoveryKind
+    let evidenceURL: URL
+}
+
+struct TerminalProfileLoadResult: Equatable {
+    let document: TerminalProfileDocument
+    let recovery: TerminalProfileStoreRecovery?
+
+    var profiles: [TerminalProfileDefinition] {
+        document.profiles
+    }
+
+    func profile(id: String?) -> TerminalProfileDefinition? {
+        document.profile(id: id)
+    }
+}
+
+struct TerminalProfileEditorDraft: Equatable {
+    var id: String
+    var title: String
+    var launchKind: TerminalProfileLaunchKind
+    var unixUser: String
+    var customCommand: String
+    var defaultWorkingDirectory: String?
+    var presentation: TerminalProfilePresentation?
+    var managedTerminalAccountID: String?
+
+    init(
+        id: String = "",
+        title: String = "",
+        launchKind: TerminalProfileLaunchKind = .loginShell,
+        unixUser: String = "",
+        customCommand: String = "",
+        defaultWorkingDirectory: String? = nil,
+        presentation: TerminalProfilePresentation? = nil,
+        managedTerminalAccountID: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.launchKind = launchKind
+        self.unixUser = unixUser
+        self.customCommand = customCommand
+        self.defaultWorkingDirectory = defaultWorkingDirectory
+        self.presentation = presentation
+        self.managedTerminalAccountID = managedTerminalAccountID
+    }
+
+    init(profile: TerminalProfileDefinition) {
+        self.id = profile.id
+        self.title = profile.title
+        self.launchKind = profile.launch.kind
+        self.unixUser = profile.launch.unixUser ?? ""
+        self.customCommand = profile.launch.customCommand ?? ""
+        self.defaultWorkingDirectory = profile.defaultWorkingDirectory
+        self.presentation = profile.presentation
+        self.managedTerminalAccountID = profile.managedTerminalAccountID
+    }
+}
+
+struct TerminalProfileEditorResult: Equatable {
+    let definition: TerminalProfileDefinition?
+    let errors: [TerminalProfileValidationError]
+
+    var isValid: Bool {
+        definition != nil && errors.isEmpty
+    }
+}
+
+struct TerminalProfileDocumentEditorResult: Equatable {
+    let document: TerminalProfileDocument?
+    let errors: [TerminalProfileValidationError]
+
+    var isValid: Bool {
+        document != nil && errors.isEmpty
+    }
+}
+
+enum TerminalProfileEditor {
+    static func makeDefinition(from draft: TerminalProfileEditorDraft) -> TerminalProfileEditorResult {
+        let launch: TerminalProfileLaunch
+        switch draft.launchKind {
+        case .loginShell:
+            launch = .loginShell
+        case .sudoUser:
+            launch = .sudoUser(unixUser: draft.unixUser)
+        case .sudoRoot:
+            launch = .sudoRoot
+        case .customCommand:
+            launch = .customCommand(draft.customCommand)
+        }
+
+        let definition = TerminalProfileDefinition(
+            id: draft.id.trimmingCharacters(in: .whitespacesAndNewlines),
+            title: draft.title.trimmingCharacters(in: .whitespacesAndNewlines),
+            launch: launch,
+            defaultWorkingDirectory: normalizedOptional(draft.defaultWorkingDirectory),
+            presentation: draft.presentation,
+            managedTerminalAccountID: normalizedOptional(draft.managedTerminalAccountID)
+        )
+        let document = TerminalProfileDocument(
+            defaultProfileID: definition.id,
+            profiles: [definition]
+        )
+        let validation = TerminalProfileValidator.validate(document)
+        return TerminalProfileEditorResult(
+            definition: validation.isValid ? definition : nil,
+            errors: validation.errors
+        )
+    }
+
+    static func upserting(
+        draft: TerminalProfileEditorDraft,
+        into document: TerminalProfileDocument
+    ) -> TerminalProfileDocumentEditorResult {
+        let editorResult = makeDefinition(from: draft)
+        guard let definition = editorResult.definition else {
+            return TerminalProfileDocumentEditorResult(
+                document: nil,
+                errors: editorResult.errors
+            )
+        }
+
+        var profiles = document.profiles
+        if let index = profiles.firstIndex(where: { $0.id == definition.id }) {
+            profiles[index] = definition
+        } else {
+            profiles.append(definition)
+        }
+        let nextDocument = TerminalProfileDocument(
+            defaultProfileID: document.defaultProfileID.isEmpty
+                ? definition.id
+                : document.defaultProfileID,
+            profiles: profiles
+        )
+        let validation = TerminalProfileValidator.validate(nextDocument)
+        return TerminalProfileDocumentEditorResult(
+            document: validation.isValid ? nextDocument : nil,
+            errors: validation.errors
+        )
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
+struct TerminalProfileStore {
+    let fileManager: FileManager
+    let storeURL: URL
+
+    init(fileManager: FileManager = .default, storeURL: URL) {
+        self.fileManager = fileManager
+        self.storeURL = storeURL
+    }
+
+    static func defaultStore(
+        channelApplicationSupportDirectoryName: String = currentChannelApplicationSupportDirectoryName(),
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> TerminalProfileStore {
+        let supportRoot = localApplicationSupportDirectory(
+            fileManager: fileManager,
+            environment: environment
+        )
+        let storeURL = supportRoot
+            .appendingPathComponent(channelApplicationSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent("terminal-profiles.json", isDirectory: false)
+        return TerminalProfileStore(fileManager: fileManager, storeURL: storeURL)
+    }
+
+    static func currentChannelApplicationSupportDirectoryName(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        if bundleIdentifier == "app.alanworks.macos.dev" || environment["ALAN_INSTALL_CHANNEL"] == "dev" {
+            return "alan-macos-dev"
+        }
+        return "alan-macos"
+    }
+
+    private static func localApplicationSupportDirectory(
+        fileManager: FileManager,
+        environment: [String: String]
+    ) -> URL {
+        if let override = environment["ALAN_MACOS_APPLICATION_SUPPORT_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !override.isEmpty
+        {
+            return URL(fileURLWithPath: NSString(string: override).expandingTildeInPath, isDirectory: true)
+        }
+
+        return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+    }
+
+    func load() -> TerminalProfileLoadResult {
+        guard fileManager.fileExists(atPath: storeURL.path) else {
+            return TerminalProfileLoadResult(document: .fallback, recovery: nil)
+        }
+
+        do {
+            let data = try Data(contentsOf: storeURL)
+            let document = try JSONDecoder().decode(TerminalProfileDocument.self, from: data)
+            let validation = TerminalProfileValidator.validate(document)
+            guard validation.isValid else {
+                return TerminalProfileLoadResult(document: .fallback, recovery: nil)
+            }
+            return TerminalProfileLoadResult(document: document, recovery: nil)
+        } catch {
+            let evidenceURL = quarantineCorruptStore()
+            return TerminalProfileLoadResult(
+                document: .fallback,
+                recovery: TerminalProfileStoreRecovery(
+                    kind: .corruptStoreQuarantined,
+                    evidenceURL: evidenceURL
+                )
+            )
+        }
+    }
+
+    func save(_ document: TerminalProfileDocument) throws {
+        let validation = TerminalProfileValidator.validate(document)
+        guard validation.isValid else {
+            throw TerminalProfileStoreError.invalidDocument(validation.errors)
+        }
+        try fileManager.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try data.write(to: storeURL, options: .atomic)
+    }
+
+    private func quarantineCorruptStore() -> URL {
+        let stamp = ISO8601DateFormatter()
+            .string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let evidenceURL = storeURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("terminal-profiles.corrupt-\(stamp).json")
+        do {
+            if fileManager.fileExists(atPath: evidenceURL.path) {
+                try fileManager.removeItem(at: evidenceURL)
+            }
+            try fileManager.moveItem(at: storeURL, to: evidenceURL)
+        } catch {
+            try? fileManager.copyItem(at: storeURL, to: evidenceURL)
+        }
+        return evidenceURL
+    }
+}
+
+enum TerminalProfileResolutionState: Equatable {
+    case absent
+    case resolved
+    case missing(requestedID: String)
+    case unavailable(requestedID: String, reason: String)
+
+    var environmentValue: String {
+        switch self {
+        case .absent:
+            return "absent"
+        case .resolved:
+            return "resolved"
+        case .missing:
+            return "missing"
+        case .unavailable:
+            return "unavailable"
+        }
+    }
+}
+
+struct ManagedTerminalAccountRequest: Equatable {
+    let accountName: String
+    let guiUserName: String
+    let fullName: String?
+    let shell: String
+    let homeDirectory: String
+    let hideFromLoginWindow: Bool
+    let bindCurrentSpaceAfterSuccess: Bool
+
+    init(
+        accountName: String,
+        guiUserName: String,
+        fullName: String? = nil,
+        shell: String = "/bin/zsh",
+        homeDirectory: String? = nil,
+        hideFromLoginWindow: Bool = true,
+        bindCurrentSpaceAfterSuccess: Bool = false
+    ) {
+        self.accountName = accountName
+        self.guiUserName = guiUserName
+        self.fullName = fullName
+        self.shell = shell
+        self.homeDirectory = homeDirectory ?? "/Users/\(accountName)"
+        self.hideFromLoginWindow = hideFromLoginWindow
+        self.bindCurrentSpaceAfterSuccess = bindCurrentSpaceAfterSuccess
+    }
+
+    var terminalProfileID: String {
+        accountName
+    }
+}
+
+enum ManagedTerminalAccountValidationError: Equatable {
+    case invalidAccountName(String)
+    case invalidGUIUserName(String)
+    case reservedAccountName(String)
+    case invalidShell(String)
+}
+
+enum ManagedTerminalAccountIdentifierValidator {
+    private static let identifierPattern = #"^[A-Za-z_][A-Za-z0-9_-]{0,31}$"#
+    private static let reservedAccountNames: Set<String> = ["root", "daemon", "nobody"]
+
+    static func validate(_ request: ManagedTerminalAccountRequest) -> [ManagedTerminalAccountValidationError] {
+        var errors: [ManagedTerminalAccountValidationError] = []
+        if !matchesIdentifier(request.accountName) {
+            errors.append(.invalidAccountName(request.accountName))
+        }
+        if reservedAccountNames.contains(request.accountName.lowercased()) {
+            errors.append(.reservedAccountName(request.accountName))
+        }
+        if !matchesIdentifier(request.guiUserName) {
+            errors.append(.invalidGUIUserName(request.guiUserName))
+        }
+        if request.shell.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || request.shell.contains("\n")
+        {
+            errors.append(.invalidShell(request.shell))
+        }
+        return errors
+    }
+
+    private static func matchesIdentifier(_ value: String) -> Bool {
+        value.range(of: identifierPattern, options: .regularExpression) != nil
+    }
+}
+
+struct ManagedTerminalAccountCommandResult: Equatable {
+    let exitCode: Int32
+    let standardOutput: String
+    let standardError: String
+
+    var succeeded: Bool {
+        exitCode == 0
+    }
+
+    var combinedOutput: String {
+        [standardOutput, standardError]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}
+
+protocol ManagedTerminalAccountCommandRunning {
+    func run(
+        executablePath: String,
+        arguments: [String]
+    ) -> ManagedTerminalAccountCommandResult
+}
+
+struct ManagedTerminalAccountProcessRunner: ManagedTerminalAccountCommandRunning {
+    func run(
+        executablePath: String,
+        arguments: [String]
+    ) -> ManagedTerminalAccountCommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ManagedTerminalAccountCommandResult(
+                exitCode: 127,
+                standardOutput: "",
+                standardError: "\(error)"
+            )
+        }
+
+        let output = String(
+            data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let error = String(
+            data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return ManagedTerminalAccountCommandResult(
+            exitCode: process.terminationStatus,
+            standardOutput: output,
+            standardError: error
+        )
+    }
+}
+
+enum ManagedTerminalAccountRecord: Equatable {
+    case missing
+    case standard(homeDirectory: String, shell: String, hidden: Bool)
+    case admin(homeDirectory: String, shell: String, hidden: Bool)
+    case invalid(reason: String)
+}
+
+enum ManagedTerminalAccountSudoersState: Equatable {
+    case missing
+    case alanOwnedValid(path: String)
+    case alanOwnedInvalid(path: String, message: String)
+    case unmanaged(path: String)
+}
+
+enum ManagedTerminalAccountProfileState: Equatable {
+    case missing
+    case existingManaged(profileID: String)
+    case existingUnmanaged(profileID: String)
+}
+
+enum ManagedTerminalAccountVerificationStep: String, Equatable {
+    case accountLookup = "account_lookup"
+    case nonAdminAccount = "non_admin_account"
+    case homeDirectory = "home_directory"
+    case shell
+    case sudoersValidation = "sudoers_validation"
+    case nonInteractiveSudo = "non_interactive_sudo"
+}
+
+enum ManagedTerminalAccountVerificationStatus: Equatable {
+    case notRun
+    case passed
+    case failed(step: ManagedTerminalAccountVerificationStep, message: String)
+}
+
+struct ManagedTerminalAccountState: Equatable {
+    let account: ManagedTerminalAccountRecord
+    let sudoers: ManagedTerminalAccountSudoersState
+    let terminalProfile: ManagedTerminalAccountProfileState
+    let verification: ManagedTerminalAccountVerificationStatus
+}
+
+struct ManagedTerminalAccountSudoersValidationResult: Equatable {
+    let isValid: Bool
+    let message: String?
+
+    static let passed = ManagedTerminalAccountSudoersValidationResult(isValid: true, message: nil)
+
+    static func failed(_ message: String) -> ManagedTerminalAccountSudoersValidationResult {
+        ManagedTerminalAccountSudoersValidationResult(isValid: false, message: message)
+    }
+}
+
+protocol ManagedTerminalAccountSudoersSyntaxChecking {
+    func validateSudoersFile(atPath path: String) -> ManagedTerminalAccountSudoersValidationResult
+}
+
+struct ManagedTerminalAccountVisudoSyntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking {
+    let commandRunner: ManagedTerminalAccountCommandRunning
+
+    init(commandRunner: ManagedTerminalAccountCommandRunning = ManagedTerminalAccountProcessRunner()) {
+        self.commandRunner = commandRunner
+    }
+
+    func validateSudoersFile(atPath path: String) -> ManagedTerminalAccountSudoersValidationResult {
+        let result = commandRunner.run(
+            executablePath: "/usr/sbin/visudo",
+            arguments: ["-cf", path]
+        )
+        guard result.succeeded else {
+            let message = result.combinedOutput.isEmpty ? "visudo validation failed." : result.combinedOutput
+            return .failed(message)
+        }
+        return .passed
+    }
+}
+
+enum ManagedTerminalAccountSudoersValidator {
+    static func state(
+        request: ManagedTerminalAccountRequest,
+        fileManager: FileManager,
+        syntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking
+    ) -> ManagedTerminalAccountSudoersState {
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
+        guard fileManager.fileExists(atPath: rule.filePath) else {
+            return .missing
+        }
+
+        guard let data = fileManager.contents(atPath: rule.filePath),
+              let contents = String(data: data, encoding: .utf8)
+        else {
+            return .alanOwnedInvalid(path: rule.filePath, message: "Unable to read sudoers drop-in.")
+        }
+
+        guard contents.contains(ManagedTerminalAccountSudoersRule.managedMarker) else {
+            return .unmanaged(path: rule.filePath)
+        }
+
+        let validation = validate(contents: contents, rule: rule, syntaxChecker: syntaxChecker)
+        if validation.isValid {
+            return .alanOwnedValid(path: rule.filePath)
+        }
+        return .alanOwnedInvalid(
+            path: rule.filePath,
+            message: validation.message ?? "Sudoers validation failed."
+        )
+    }
+
+    static func validate(
+        contents: String,
+        rule: ManagedTerminalAccountSudoersRule,
+        syntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking
+    ) -> ManagedTerminalAccountSudoersValidationResult {
+        let normalizedExpected = normalizedSudoersContents(rule.contents)
+        let normalizedActual = normalizedSudoersContents(contents)
+        guard normalizedActual == normalizedExpected else {
+            return .failed("Alan-owned sudoers drop-in does not match the requested terminal account.")
+        }
+        return syntaxChecker.validateSudoersFile(atPath: rule.filePath)
+    }
+
+    private static func normalizedSudoersContents(_ contents: String) -> String {
+        contents.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct ManagedTerminalAccountLocalStateDiscoverer {
+    let fileManager: FileManager
+    let commandRunner: ManagedTerminalAccountCommandRunning
+    let sudoersSyntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking
+
+    init(
+        fileManager: FileManager = .default,
+        commandRunner: ManagedTerminalAccountCommandRunning = ManagedTerminalAccountProcessRunner(),
+        sudoersSyntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking = ManagedTerminalAccountVisudoSyntaxChecker()
+    ) {
+        self.fileManager = fileManager
+        self.commandRunner = commandRunner
+        self.sudoersSyntaxChecker = sudoersSyntaxChecker
+    }
+
+    func discover(
+        request: ManagedTerminalAccountRequest,
+        terminalProfiles: TerminalProfileDocument
+    ) -> ManagedTerminalAccountState {
+        let validationErrors = ManagedTerminalAccountIdentifierValidator.validate(request)
+        guard validationErrors.isEmpty else {
+            return ManagedTerminalAccountState(
+                account: .invalid(reason: "Invalid managed terminal account request."),
+                sudoers: .missing,
+                terminalProfile: .missing,
+                verification: .notRun
+            )
+        }
+
+        return ManagedTerminalAccountState(
+            account: accountRecord(for: request),
+            sudoers: ManagedTerminalAccountSudoersValidator.state(
+                request: request,
+                fileManager: fileManager,
+                syntaxChecker: sudoersSyntaxChecker
+            ),
+            terminalProfile: terminalProfileState(for: request, document: terminalProfiles),
+            verification: .notRun
+        )
+    }
+
+    private func accountRecord(for request: ManagedTerminalAccountRequest) -> ManagedTerminalAccountRecord {
+        let dscl = commandRunner.run(
+            executablePath: "/usr/bin/dscl",
+            arguments: [
+                ".",
+                "-read",
+                "/Users/\(request.accountName)",
+                "NFSHomeDirectory",
+                "UserShell",
+                "IsHidden",
+            ]
+        )
+        guard dscl.succeeded else {
+            return .missing
+        }
+
+        let output = dscl.standardOutput
+        let home = propertyValue("NFSHomeDirectory", in: output) ?? request.homeDirectory
+        let shell = propertyValue("UserShell", in: output) ?? request.shell
+        let hidden = propertyValue("IsHidden", in: output) == "1"
+        let isAdmin = adminMembership(for: request.accountName)
+        if isAdmin {
+            return .admin(homeDirectory: home, shell: shell, hidden: hidden)
+        }
+        return .standard(homeDirectory: home, shell: shell, hidden: hidden)
+    }
+
+    private func adminMembership(for accountName: String) -> Bool {
+        let result = commandRunner.run(
+            executablePath: "/usr/sbin/dseditgroup",
+            arguments: ["-o", "checkmember", "-m", accountName, "admin"]
+        )
+        guard result.succeeded else { return false }
+        let output = result.combinedOutput.lowercased()
+        return output.contains("yes") || (output.contains("is a member") && !output.contains("not a member"))
+    }
+
+    private func propertyValue(_ key: String, in output: String) -> String? {
+        output
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .compactMap { line -> String? in
+                let prefix = "\(key):"
+                guard line.hasPrefix(prefix) else { return nil }
+                let value = line.dropFirst(prefix.count)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return value.isEmpty ? nil : value
+            }
+            .first
+    }
+
+    private func terminalProfileState(
+        for request: ManagedTerminalAccountRequest,
+        document: TerminalProfileDocument
+    ) -> ManagedTerminalAccountProfileState {
+        guard let profile = document.profile(id: request.terminalProfileID) else {
+            return .missing
+        }
+        if profile.managedTerminalAccountID == request.accountName,
+           profile.launch == .sudoUser(unixUser: request.accountName)
+        {
+            return .existingManaged(profileID: profile.id)
+        }
+        return .existingUnmanaged(profileID: profile.id)
+    }
+}
+
+protocol ManagedTerminalAccountEntryVerifying {
+    func verifyTerminalEntry(
+        request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountSudoersValidationResult
+}
+
+struct ManagedTerminalAccountSudoEntryVerifier: ManagedTerminalAccountEntryVerifying {
+    let commandRunner: ManagedTerminalAccountCommandRunning
+
+    init(commandRunner: ManagedTerminalAccountCommandRunning = ManagedTerminalAccountProcessRunner()) {
+        self.commandRunner = commandRunner
+    }
+
+    func verifyTerminalEntry(
+        request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountSudoersValidationResult {
+        let result = commandRunner.run(
+            executablePath: "/usr/bin/sudo",
+            arguments: ["-n", "-iu", request.accountName, "true"]
+        )
+        guard result.succeeded else {
+            let message = result.combinedOutput.isEmpty
+                ? "Non-interactive sudo verification failed."
+                : result.combinedOutput
+            return .failed(message)
+        }
+        return .passed
+    }
+}
+
+enum ManagedTerminalAccountReadinessVerifier {
+    static func verify(
+        request: ManagedTerminalAccountRequest,
+        state: ManagedTerminalAccountState,
+        entryVerifier: ManagedTerminalAccountEntryVerifying
+    ) -> ManagedTerminalAccountVerificationStatus {
+        switch state.account {
+        case .missing:
+            return .failed(step: .accountLookup, message: "Managed terminal account is missing.")
+        case .admin:
+            return .failed(step: .nonAdminAccount, message: "Managed terminal account must be standard.")
+        case .invalid(let reason):
+            return .failed(step: .accountLookup, message: reason)
+        case .standard(let homeDirectory, let shell, _):
+            if homeDirectory != request.homeDirectory {
+                return .failed(step: .homeDirectory, message: "Home directory does not match the plan.")
+            }
+            if shell != request.shell {
+                return .failed(step: .shell, message: "Login shell does not match the plan.")
+            }
+        }
+
+        switch state.sudoers {
+        case .alanOwnedValid:
+            break
+        case .alanOwnedInvalid(_, let message):
+            return .failed(step: .sudoersValidation, message: message)
+        case .missing:
+            return .failed(step: .sudoersValidation, message: "Alan-owned sudoers drop-in is missing.")
+        case .unmanaged:
+            return .failed(step: .sudoersValidation, message: "Sudoers drop-in is not Alan-owned.")
+        }
+
+        let entry = entryVerifier.verifyTerminalEntry(request: request)
+        guard entry.isValid else {
+            return .failed(
+                step: .nonInteractiveSudo,
+                message: entry.message ?? "Non-interactive sudo verification failed."
+            )
+        }
+        return .passed
+    }
+}
+
+enum ManagedTerminalAccountPlanStepKind: Equatable {
+    case createStandardAccount
+    case repairAccountType
+    case repairHomeDirectory
+    case repairShell
+    case hideAccount
+    case writeSudoersDropIn
+    case validateSudoers
+    case verifyTerminalEntry
+    case createOrUpdateTerminalProfile
+    case bindCurrentSpace
+    case removeSudoersDropIn
+    case removeManagedTerminalProfile
+    case deleteAccount
+    case deleteHomeDirectory
+}
+
+struct ManagedTerminalAccountPlanStep: Equatable {
+    let kind: ManagedTerminalAccountPlanStepKind
+    let summary: String
+    let requiresPrivilege: Bool
+}
+
+enum ManagedTerminalAccountPlanStatus: Equatable {
+    case readyToApply
+    case alreadyReady
+    case repair
+    case invalid([ManagedTerminalAccountValidationError])
+    case requiresDestructiveConfirmation
+}
+
+struct ManagedTerminalAccountPlan: Equatable {
+    let request: ManagedTerminalAccountRequest
+    let status: ManagedTerminalAccountPlanStatus
+    let steps: [ManagedTerminalAccountPlanStep]
+}
+
+enum ManagedTerminalAccountRollbackScope: Equatable {
+    case alanIntegrationOnly
+    case deleteAccountAndHome(confirmation: String?)
+}
+
+enum ManagedTerminalAccountPlanner {
+    static func plan(
+        request: ManagedTerminalAccountRequest,
+        state: ManagedTerminalAccountState
+    ) -> ManagedTerminalAccountPlan {
+        let validationErrors = ManagedTerminalAccountIdentifierValidator.validate(request)
+        guard validationErrors.isEmpty else {
+            return ManagedTerminalAccountPlan(request: request, status: .invalid(validationErrors), steps: [])
+        }
+
+        var steps: [ManagedTerminalAccountPlanStep] = []
+        var needsCreate = false
+        var repairNeeded = false
+
+        switch state.account {
+        case .missing:
+            needsCreate = true
+            steps.append(step(.createStandardAccount, "Create standard local terminal account", true))
+            if request.hideFromLoginWindow {
+                steps.append(step(.hideAccount, "Hide terminal account from login window lists", true))
+            }
+        case .admin:
+            repairNeeded = true
+            steps.append(step(.repairAccountType, "Repair account so it is not an administrator", true))
+        case .invalid(let reason):
+            repairNeeded = true
+            steps.append(step(.repairAccountType, "Repair account state: \(reason)", true))
+        case .standard(let homeDirectory, let shell, let hidden):
+            if homeDirectory != request.homeDirectory {
+                repairNeeded = true
+                steps.append(step(.repairHomeDirectory, "Repair terminal account home directory", true))
+            }
+            if shell != request.shell {
+                repairNeeded = true
+                steps.append(step(.repairShell, "Repair terminal account shell", true))
+            }
+            if request.hideFromLoginWindow && !hidden {
+                repairNeeded = true
+                steps.append(step(.hideAccount, "Hide terminal account from login window lists", true))
+            }
+        }
+
+        switch state.sudoers {
+        case .missing, .alanOwnedInvalid, .unmanaged:
+            if !needsCreate {
+                repairNeeded = true
+            }
+            steps.append(step(.writeSudoersDropIn, "Write Alan-owned sudoers drop-in", true))
+            steps.append(step(.validateSudoers, "Validate sudoers syntax", true))
+        case .alanOwnedValid:
+            break
+        }
+
+        if state.verification != .passed {
+            if !needsCreate {
+                repairNeeded = true
+            }
+            steps.append(step(.verifyTerminalEntry, "Verify passwordless terminal entry", true))
+        }
+
+        switch state.terminalProfile {
+        case .missing, .existingUnmanaged:
+            steps.append(step(.createOrUpdateTerminalProfile, "Create matching Terminal Profile", false))
+        case .existingManaged:
+            if state.verification != .passed {
+                steps.append(step(.createOrUpdateTerminalProfile, "Refresh matching Terminal Profile", false))
+            }
+        }
+
+        if request.bindCurrentSpaceAfterSuccess {
+            steps.append(step(.bindCurrentSpace, "Bind current Space after confirmation", false))
+        }
+
+        let status: ManagedTerminalAccountPlanStatus =
+            steps.isEmpty ? .alreadyReady : (repairNeeded ? .repair : .readyToApply)
+        return ManagedTerminalAccountPlan(request: request, status: status, steps: steps)
+    }
+
+    static func rollbackPlan(
+        request: ManagedTerminalAccountRequest,
+        state: ManagedTerminalAccountState,
+        scope: ManagedTerminalAccountRollbackScope
+    ) -> ManagedTerminalAccountPlan {
+        var steps: [ManagedTerminalAccountPlanStep] = []
+        if case .alanOwnedValid = state.sudoers {
+            steps.append(step(.removeSudoersDropIn, "Remove Alan-owned sudoers drop-in", true))
+        }
+        if case .existingManaged = state.terminalProfile {
+            steps.append(step(.removeManagedTerminalProfile, "Remove managed Terminal Profile", false))
+        }
+
+        switch scope {
+        case .alanIntegrationOnly:
+            return ManagedTerminalAccountPlan(request: request, status: .readyToApply, steps: steps)
+        case .deleteAccountAndHome(let confirmation):
+            guard confirmation == request.accountName else {
+                return ManagedTerminalAccountPlan(
+                    request: request,
+                    status: .requiresDestructiveConfirmation,
+                    steps: steps
+                )
+            }
+            return ManagedTerminalAccountPlan(
+                request: request,
+                status: .readyToApply,
+                steps: steps + [
+                    step(.deleteAccount, "Delete terminal account", true),
+                    step(.deleteHomeDirectory, "Delete terminal account home directory", true),
+                ]
+            )
+        }
+    }
+
+    private static func step(
+        _ kind: ManagedTerminalAccountPlanStepKind,
+        _ summary: String,
+        _ requiresPrivilege: Bool
+    ) -> ManagedTerminalAccountPlanStep {
+        ManagedTerminalAccountPlanStep(
+            kind: kind,
+            summary: summary,
+            requiresPrivilege: requiresPrivilege
+        )
+    }
+}
+
+struct ManagedTerminalAccountSudoersRule: Equatable {
+    static let managedMarker = "# Managed by Alan for terminal account entry. Do not edit by hand."
+
+    let request: ManagedTerminalAccountRequest
+
+    var fileName: String {
+        "alan-terminal-\(request.guiUserName)-to-\(request.accountName)"
+    }
+
+    var filePath: String {
+        "/etc/sudoers.d/\(fileName)"
+    }
+
+    var contents: String {
+        """
+        \(Self.managedMarker)
+        \(request.guiUserName) ALL=(\(request.accountName)) NOPASSWD: ALL
+        """
+    }
+}
+
+struct ManagedTerminalAccountApplyResult: Equatable {
+    let completedSteps: [ManagedTerminalAccountPlanStepKind]
+    let failedStep: ManagedTerminalAccountPlanStepKind?
+    let cancelled: Bool
+    let visibleDiagnostics: [String]
+
+    static func cancelled(before steps: [ManagedTerminalAccountPlanStepKind]) -> ManagedTerminalAccountApplyResult {
+        ManagedTerminalAccountApplyResult(
+            completedSteps: [],
+            failedStep: steps.first,
+            cancelled: true,
+            visibleDiagnostics: ["Provisioning cancelled before privileged changes."]
+        )
+    }
+}
+
+protocol ManagedTerminalAccountPrivilegedExecuting {
+    func apply(_ plan: ManagedTerminalAccountPlan) -> ManagedTerminalAccountApplyResult
+}
+
+final class ManagedTerminalAccountFakeExecutor: ManagedTerminalAccountPrivilegedExecuting {
+    var failAt: ManagedTerminalAccountPlanStepKind?
+    var cancelBeforeApply = false
+
+    func apply(_ plan: ManagedTerminalAccountPlan) -> ManagedTerminalAccountApplyResult {
+        let stepKinds = plan.steps.map(\.kind)
+        if cancelBeforeApply {
+            return .cancelled(before: stepKinds)
+        }
+
+        var completed: [ManagedTerminalAccountPlanStepKind] = []
+        for step in plan.steps {
+            if step.kind == failAt {
+                return ManagedTerminalAccountApplyResult(
+                    completedSteps: completed,
+                    failedStep: step.kind,
+                    cancelled: false,
+                    visibleDiagnostics: ["Step failed: \(step.summary). Credentials redacted."]
+                )
+            }
+            completed.append(step.kind)
+        }
+        return ManagedTerminalAccountApplyResult(
+            completedSteps: completed,
+            failedStep: nil,
+            cancelled: false,
+            visibleDiagnostics: ["Provisioning plan applied. Credentials redacted."]
+        )
+    }
+}
+
+struct ManagedTerminalAccountPrivilegedCommandResult: Equatable {
+    let succeeded: Bool
+    let redactedMessage: String
+}
+
+protocol ManagedTerminalAccountPrivilegedCommandRunning {
+    func runPrivilegedShellScript(
+        _ script: String,
+        redactedDescription: String
+    ) -> ManagedTerminalAccountPrivilegedCommandResult
+}
+
+struct ManagedTerminalAccountAppleScriptPrivilegeRunner: ManagedTerminalAccountPrivilegedCommandRunning {
+    let commandRunner: ManagedTerminalAccountCommandRunning
+
+    init(commandRunner: ManagedTerminalAccountCommandRunning = ManagedTerminalAccountProcessRunner()) {
+        self.commandRunner = commandRunner
+    }
+
+    func runPrivilegedShellScript(
+        _ script: String,
+        redactedDescription: String
+    ) -> ManagedTerminalAccountPrivilegedCommandResult {
+        let result = commandRunner.run(
+            executablePath: "/usr/bin/osascript",
+            arguments: [
+                "-e",
+                "do shell script \(appleScriptStringLiteral(script)) with administrator privileges",
+            ]
+        )
+        return ManagedTerminalAccountPrivilegedCommandResult(
+            succeeded: result.succeeded,
+            redactedMessage: result.succeeded
+                ? "\(redactedDescription) completed."
+                : "\(redactedDescription) failed. Credentials redacted."
+        )
+    }
+
+    private func appleScriptStringLiteral(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return "\"\(escaped)\""
+    }
+}
+
+struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPrivilegedExecuting {
+    let request: ManagedTerminalAccountRequest
+    let commandRunner: ManagedTerminalAccountPrivilegedCommandRunning
+    let passwordGenerator: () -> String
+
+    init(
+        request: ManagedTerminalAccountRequest,
+        commandRunner: ManagedTerminalAccountPrivilegedCommandRunning =
+            ManagedTerminalAccountAppleScriptPrivilegeRunner(),
+        passwordGenerator: @escaping () -> String = {
+            UUID().uuidString + UUID().uuidString
+        }
+    ) {
+        self.request = request
+        self.commandRunner = commandRunner
+        self.passwordGenerator = passwordGenerator
+    }
+
+    func apply(_ plan: ManagedTerminalAccountPlan) -> ManagedTerminalAccountApplyResult {
+        var completed: [ManagedTerminalAccountPlanStepKind] = []
+        var diagnostics: [String] = []
+
+        for step in plan.steps {
+            guard let script = script(for: step.kind) else {
+                completed.append(step.kind)
+                continue
+            }
+            let result = commandRunner.runPrivilegedShellScript(
+                script,
+                redactedDescription: step.summary
+            )
+            diagnostics.append(result.redactedMessage)
+            guard result.succeeded else {
+                return ManagedTerminalAccountApplyResult(
+                    completedSteps: completed,
+                    failedStep: step.kind,
+                    cancelled: false,
+                    visibleDiagnostics: diagnostics
+                )
+            }
+            completed.append(step.kind)
+        }
+
+        return ManagedTerminalAccountApplyResult(
+            completedSteps: completed,
+            failedStep: nil,
+            cancelled: false,
+            visibleDiagnostics: diagnostics.isEmpty
+                ? ["Provisioning plan completed. Credentials redacted."]
+                : diagnostics
+        )
+    }
+
+    private func script(for step: ManagedTerminalAccountPlanStepKind) -> String? {
+        let account = shellQuote(request.accountName)
+        let home = shellQuote(request.homeDirectory)
+        let shell = shellQuote(request.shell)
+        switch step {
+        case .createStandardAccount:
+            let fullName = shellQuote(request.fullName ?? request.accountName)
+            let password = shellQuote(passwordGenerator())
+            return """
+            /usr/sbin/sysadminctl -addUser \(account) -fullName \(fullName) -home \(home) -shell \(shell) -password \(password)
+            /usr/sbin/createhomedir -c -u \(account) >/dev/null 2>&1 || true
+            /usr/sbin/dseditgroup -o edit -d \(account) -t user admin >/dev/null 2>&1 || true
+            """
+        case .repairAccountType:
+            return "/usr/sbin/dseditgroup -o edit -d \(account) -t user admin >/dev/null 2>&1 || true"
+        case .repairHomeDirectory:
+            return """
+            /usr/bin/dscl . -create /Users/\(request.accountName) NFSHomeDirectory \(home)
+            /usr/sbin/createhomedir -c -u \(account) >/dev/null 2>&1 || true
+            """
+        case .repairShell:
+            return "/usr/bin/dscl . -create /Users/\(request.accountName) UserShell \(shell)"
+        case .hideAccount:
+            return "/usr/bin/dscl . -create /Users/\(request.accountName) IsHidden 1"
+        case .writeSudoersDropIn:
+            return sudoersWriteScript()
+        case .validateSudoers:
+            return "/usr/sbin/visudo -cf \(shellQuote(ManagedTerminalAccountSudoersRule(request: request).filePath))"
+        case .verifyTerminalEntry:
+            return "/usr/bin/sudo -n -iu \(account) true"
+        case .removeSudoersDropIn:
+            return "/bin/rm -f \(shellQuote(ManagedTerminalAccountSudoersRule(request: request).filePath))"
+        case .deleteAccount:
+            return "/usr/sbin/sysadminctl -deleteUser \(account)"
+        case .deleteHomeDirectory:
+            return "/bin/rm -rf \(home)"
+        case .createOrUpdateTerminalProfile, .bindCurrentSpace, .removeManagedTerminalProfile:
+            return nil
+        }
+    }
+
+    private func sudoersWriteScript() -> String {
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
+        let tempPath = "/tmp/\(rule.fileName).sudoers"
+        return """
+        /bin/cat > \(shellQuote(tempPath)) <<'ALAN_SUDOERS'
+        \(rule.contents)
+        ALAN_SUDOERS
+        /usr/sbin/visudo -cf \(shellQuote(tempPath))
+        /usr/bin/install -o root -g wheel -m 0440 \(shellQuote(tempPath)) \(shellQuote(rule.filePath))
+        /bin/rm -f \(shellQuote(tempPath))
+        """
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+enum ManagedTerminalAccountProfileHandoff {
+    static func profileDefinition(
+        for request: ManagedTerminalAccountRequest,
+        state: ManagedTerminalAccountState
+    ) -> TerminalProfileDefinition? {
+        guard state.verification == .passed else { return nil }
+        return TerminalProfileDefinition(
+            id: request.terminalProfileID,
+            title: request.fullName ?? request.accountName,
+            launch: .sudoUser(unixUser: request.accountName),
+            defaultWorkingDirectory: request.homeDirectory,
+            presentation: TerminalProfilePresentation(
+                symbolName: "person.crop.circle",
+                colorName: nil
+            ),
+            managedTerminalAccountID: request.accountName
+        )
+    }
+}
+
 enum ShellTabActiveTaskState: String, Codable, Equatable, CaseIterable {
     case inactive
     case foregroundCommand = "foreground_command"
@@ -744,6 +2150,11 @@ struct ShellContextSnapshot: Codable, Equatable {
     let alanBindingFile: String?
     let launchCommand: String?
     let launchStrategy: String?
+    let terminalProfileState: String?
+    let terminalProfileRequestedID: String?
+    let terminalProfileID: String?
+    let terminalProfileKind: String?
+    let terminalProfileTitle: String?
     let shellIntegrationSource: String?
     let processState: String?
     let rendererPhase: String?
@@ -767,6 +2178,11 @@ struct ShellContextSnapshot: Codable, Equatable {
         alanBindingFile: String?,
         launchCommand: String? = nil,
         launchStrategy: String?,
+        terminalProfileState: String? = nil,
+        terminalProfileRequestedID: String? = nil,
+        terminalProfileID: String? = nil,
+        terminalProfileKind: String? = nil,
+        terminalProfileTitle: String? = nil,
         shellIntegrationSource: String?,
         processState: String?,
         rendererPhase: String? = nil,
@@ -789,6 +2205,11 @@ struct ShellContextSnapshot: Codable, Equatable {
         self.alanBindingFile = alanBindingFile
         self.launchCommand = launchCommand
         self.launchStrategy = launchStrategy
+        self.terminalProfileState = terminalProfileState
+        self.terminalProfileRequestedID = terminalProfileRequestedID
+        self.terminalProfileID = terminalProfileID
+        self.terminalProfileKind = terminalProfileKind
+        self.terminalProfileTitle = terminalProfileTitle
         self.shellIntegrationSource = shellIntegrationSource
         self.processState = processState
         self.rendererPhase = rendererPhase
@@ -813,6 +2234,11 @@ struct ShellContextSnapshot: Codable, Equatable {
         case alanBindingFile = "alan_binding_file"
         case launchCommand = "launch_command"
         case launchStrategy = "launch_strategy"
+        case terminalProfileState = "terminal_profile_state"
+        case terminalProfileRequestedID = "terminal_profile_requested_id"
+        case terminalProfileID = "terminal_profile_id"
+        case terminalProfileKind = "terminal_profile_kind"
+        case terminalProfileTitle = "terminal_profile_title"
         case shellIntegrationSource = "shell_integration_source"
         case processState = "process_state"
         case rendererPhase = "renderer_phase"

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -308,6 +308,31 @@ struct TerminalProfileDocument: Codable, Equatable {
     }
 }
 
+func terminalProfileIDForWorkingDirectoryDeferral(
+    channelApplicationSupportDirectoryName: String = TerminalProfileStore
+        .currentChannelApplicationSupportDirectoryName(),
+    fileManager: FileManager = .default,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> String? {
+    let document = TerminalProfileStore.defaultStore(
+        channelApplicationSupportDirectoryName: channelApplicationSupportDirectoryName,
+        fileManager: fileManager,
+        environment: environment
+    ).load().document
+    guard let profile = document.defaultProfile,
+          nonEmptyTerminalProfileWorkingDirectory(profile.defaultWorkingDirectory) != nil
+    else {
+        return nil
+    }
+    return profile.id
+}
+
+private func nonEmptyTerminalProfileWorkingDirectory(_ path: String?) -> String? {
+    guard let path else { return nil }
+    let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
 enum TerminalProfileValidationError: Error, Equatable {
     case missingID
     case duplicateID(String)

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -914,7 +914,10 @@ enum ManagedTerminalAccountSudoersValidator {
         guard let data = fileManager.contents(atPath: rule.filePath),
               let contents = String(data: data, encoding: .utf8)
         else {
-            return .alanOwnedInvalid(path: rule.filePath, message: "Unable to read sudoers drop-in.")
+            // Alan installs sudoers drop-ins as root:wheel 0440, so the GUI user
+            // may be unable to read contents during ordinary discovery. Readiness
+            // is still proven by the non-interactive sudo terminal-entry check.
+            return .alanOwnedValid(path: rule.filePath)
         }
 
         guard contents.contains(ManagedTerminalAccountSudoersRule.managedMarker) else {

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1165,6 +1165,7 @@ enum ManagedTerminalAccountPlanStatus: Equatable {
     case invalid([ManagedTerminalAccountValidationError])
     case requiresDestructiveConfirmation
     case sudoersConflict(path: String)
+    case terminalProfileConflict(profileID: String)
 }
 
 struct ManagedTerminalAccountPlan: Equatable {
@@ -1191,6 +1192,13 @@ enum ManagedTerminalAccountPlanner {
             return ManagedTerminalAccountPlan(
                 request: request,
                 status: .sudoersConflict(path: path),
+                steps: []
+            )
+        }
+        if case .existingUnmanaged(let profileID) = state.terminalProfile {
+            return ManagedTerminalAccountPlan(
+                request: request,
+                status: .terminalProfileConflict(profileID: profileID),
                 steps: []
             )
         }
@@ -1250,12 +1258,14 @@ enum ManagedTerminalAccountPlanner {
         }
 
         switch state.terminalProfile {
-        case .missing, .existingUnmanaged:
+        case .missing:
             steps.append(step(.createOrUpdateTerminalProfile, "Create matching Terminal Profile", false))
         case .existingManaged:
             if state.verification != .passed {
                 steps.append(step(.createOrUpdateTerminalProfile, "Refresh matching Terminal Profile", false))
             }
+        case .existingUnmanaged:
+            break
         }
 
         if request.bindCurrentSpaceAfterSuccess {

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -718,6 +718,10 @@ struct ManagedTerminalAccountRequest: Equatable {
         self.bindCurrentSpaceAfterSuccess = bindCurrentSpaceAfterSuccess
     }
 
+    static func canonicalHomeDirectory(for accountName: String) -> String {
+        "/Users/\(accountName)"
+    }
+
     var terminalProfileID: String {
         accountName
     }
@@ -1287,14 +1291,36 @@ enum ManagedTerminalAccountPlanner {
                     steps: steps
                 )
             }
+            var destructiveSteps = [
+                step(.deleteAccount, "Delete terminal account", true),
+            ]
+            if canDeleteHomeDirectory(request: request, state: state) {
+                destructiveSteps.append(
+                    step(.deleteHomeDirectory, "Delete terminal account home directory", true)
+                )
+            }
             return ManagedTerminalAccountPlan(
                 request: request,
                 status: .readyToApply,
-                steps: steps + [
-                    step(.deleteAccount, "Delete terminal account", true),
-                    step(.deleteHomeDirectory, "Delete terminal account home directory", true),
-                ]
+                steps: steps + destructiveSteps
             )
+        }
+    }
+
+    private static func canDeleteHomeDirectory(
+        request: ManagedTerminalAccountRequest,
+        state: ManagedTerminalAccountState
+    ) -> Bool {
+        guard request.homeDirectory == ManagedTerminalAccountRequest.canonicalHomeDirectory(
+            for: request.accountName
+        ) else {
+            return false
+        }
+        switch state.account {
+        case .standard(let homeDirectory, _, _), .admin(let homeDirectory, _, _):
+            return homeDirectory == request.homeDirectory
+        case .missing, .invalid:
+            return false
         }
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -308,7 +308,7 @@ struct TerminalProfileDocument: Codable, Equatable {
     }
 }
 
-func terminalProfileIDForWorkingDirectoryDeferral(
+func terminalProfileIDForGlobalDefaultPaneCapture(
     channelApplicationSupportDirectoryName: String = TerminalProfileStore
         .currentChannelApplicationSupportDirectoryName(),
     fileManager: FileManager = .default,
@@ -320,11 +320,25 @@ func terminalProfileIDForWorkingDirectoryDeferral(
         environment: environment
     ).load().document
     guard let profile = document.defaultProfile,
-          nonEmptyTerminalProfileWorkingDirectory(profile.defaultWorkingDirectory) != nil
+          shouldCaptureGlobalDefaultTerminalProfile(profile)
     else {
         return nil
     }
     return profile.id
+}
+
+private func shouldCaptureGlobalDefaultTerminalProfile(
+    _ profile: TerminalProfileDefinition
+) -> Bool {
+    if nonEmptyTerminalProfileWorkingDirectory(profile.defaultWorkingDirectory) != nil {
+        return true
+    }
+    switch profile.launch {
+    case .loginShell:
+        return false
+    case .sudoUser, .sudoRoot, .customCommand:
+        return true
+    }
 }
 
 private func nonEmptyTerminalProfileWorkingDirectory(_ path: String?) -> String? {

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1679,7 +1679,6 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
     let commandRunner: ManagedTerminalAccountPrivilegedCommandRunning
     let localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting
     let entryVerifier: ManagedTerminalAccountEntryVerifying
-    let passwordGenerator: () -> String
 
     init(
         request: ManagedTerminalAccountRequest,
@@ -1688,16 +1687,12 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting =
             ManagedTerminalAccountTerminalProfileEffectExecutor(),
         entryVerifier: ManagedTerminalAccountEntryVerifying =
-            ManagedTerminalAccountSudoEntryVerifier(),
-        passwordGenerator: @escaping () -> String = {
-            UUID().uuidString + UUID().uuidString
-        }
+            ManagedTerminalAccountSudoEntryVerifier()
     ) {
         self.request = request
         self.commandRunner = commandRunner
         self.localEffectExecutor = localEffectExecutor
         self.entryVerifier = entryVerifier
-        self.passwordGenerator = passwordGenerator
     }
 
     func apply(_ plan: ManagedTerminalAccountPlan) -> ManagedTerminalAccountApplyResult {
@@ -1770,28 +1765,50 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
 
     private func script(for step: ManagedTerminalAccountPlanStepKind) -> String? {
         let account = shellQuote(request.accountName)
+        let accountRecord = shellQuote("/Users/\(request.accountName)")
         let home = shellQuote(request.homeDirectory)
         let shell = shellQuote(request.shell)
         switch step {
         case .createStandardAccount:
             let fullName = shellQuote(request.fullName ?? request.accountName)
-            let password = shellQuote(passwordGenerator())
+            let disabledAuthentication = shellQuote(";DisabledUser;")
             return """
-            /usr/sbin/sysadminctl -addUser \(account) -fullName \(fullName) -home \(home) -shell \(shell) -password \(password)
-            /usr/sbin/createhomedir -c -u \(account) >/dev/null 2>&1 || true
+            set -eu
+            account_name=\(account)
+            account_record=\(accountRecord)
+            account_home=\(home)
+            account_shell=\(shell)
+            account_full_name=\(fullName)
+            disabled_auth=\(disabledAuthentication)
+            next_uid="$(
+              /usr/bin/dscl . -list /Users UniqueID |
+                /usr/bin/awk '$2 ~ /^[0-9]+$/ && $2 >= 501 { if ($2 >= max) max=$2 } END { print (max ? max + 1 : 501) }'
+            )"
+            while /usr/bin/dscl . -search /Users UniqueID "$next_uid" >/dev/null 2>&1; do
+              next_uid=$((next_uid + 1))
+            done
+            /usr/bin/dscl . -create "$account_record"
+            /usr/bin/dscl . -create "$account_record" UserShell "$account_shell"
+            /usr/bin/dscl . -create "$account_record" RealName "$account_full_name"
+            /usr/bin/dscl . -create "$account_record" NFSHomeDirectory "$account_home"
+            /usr/bin/dscl . -create "$account_record" PrimaryGroupID 20
+            /usr/bin/dscl . -create "$account_record" UniqueID "$next_uid"
+            /usr/bin/dscl . -create "$account_record" GeneratedUID "$(/usr/bin/uuidgen)"
+            /usr/bin/dscl . -create "$account_record" AuthenticationAuthority "$disabled_auth"
+            /usr/sbin/createhomedir -c -u "$account_name" >/dev/null 2>&1 || true
             /usr/sbin/dseditgroup -o edit -d \(account) -t user admin >/dev/null 2>&1 || true
             """
         case .repairAccountType:
             return "/usr/sbin/dseditgroup -o edit -d \(account) -t user admin >/dev/null 2>&1 || true"
         case .repairHomeDirectory:
             return """
-            /usr/bin/dscl . -create /Users/\(request.accountName) NFSHomeDirectory \(home)
+            /usr/bin/dscl . -create \(accountRecord) NFSHomeDirectory \(home)
             /usr/sbin/createhomedir -c -u \(account) >/dev/null 2>&1 || true
             """
         case .repairShell:
-            return "/usr/bin/dscl . -create /Users/\(request.accountName) UserShell \(shell)"
+            return "/usr/bin/dscl . -create \(accountRecord) UserShell \(shell)"
         case .hideAccount:
-            return "/usr/bin/dscl . -create /Users/\(request.accountName) IsHidden 1"
+            return "/usr/bin/dscl . -create \(accountRecord) IsHidden 1"
         case .writeSudoersDropIn:
             return sudoersWriteScript()
         case .validateSudoers:

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -870,6 +870,7 @@ enum ManagedTerminalAccountSudoersState: Equatable {
 enum ManagedTerminalAccountProfileState: Equatable {
     case missing
     case existingManaged(profileID: String)
+    case existingManagedOutdated(profileID: String)
     case existingUnmanaged(profileID: String)
 }
 
@@ -1080,6 +1081,9 @@ struct ManagedTerminalAccountLocalStateDiscoverer {
         if profile.managedTerminalAccountID == request.accountName,
            profile.launch == .sudoUser(unixUser: request.accountName)
         {
+            if profile.defaultWorkingDirectory != request.homeDirectory {
+                return .existingManagedOutdated(profileID: profile.id)
+            }
             return .existingManaged(profileID: profile.id)
         }
         return .existingUnmanaged(profileID: profile.id)
@@ -1289,6 +1293,9 @@ enum ManagedTerminalAccountPlanner {
             if state.verification != .passed {
                 steps.append(step(.createOrUpdateTerminalProfile, "Refresh matching Terminal Profile", false))
             }
+        case .existingManagedOutdated:
+            repairNeeded = true
+            steps.append(step(.createOrUpdateTerminalProfile, "Refresh matching Terminal Profile", false))
         case .existingUnmanaged:
             break
         }
@@ -1312,6 +1319,8 @@ enum ManagedTerminalAccountPlanner {
             steps.append(step(.removeSudoersDropIn, "Remove Alan-owned sudoers drop-in", true))
         }
         if case .existingManaged = state.terminalProfile {
+            steps.append(step(.removeManagedTerminalProfile, "Remove managed Terminal Profile", false))
+        } else if case .existingManagedOutdated = state.terminalProfile {
             steps.append(step(.removeManagedTerminalProfile, "Remove managed Terminal Profile", false))
         }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1160,6 +1160,7 @@ enum ManagedTerminalAccountPlanStatus: Equatable {
     case repair
     case invalid([ManagedTerminalAccountValidationError])
     case requiresDestructiveConfirmation
+    case sudoersConflict(path: String)
 }
 
 struct ManagedTerminalAccountPlan: Equatable {
@@ -1181,6 +1182,13 @@ enum ManagedTerminalAccountPlanner {
         let validationErrors = ManagedTerminalAccountIdentifierValidator.validate(request)
         guard validationErrors.isEmpty else {
             return ManagedTerminalAccountPlan(request: request, status: .invalid(validationErrors), steps: [])
+        }
+        if case .unmanaged(let path) = state.sudoers {
+            return ManagedTerminalAccountPlan(
+                request: request,
+                status: .sudoersConflict(path: path),
+                steps: []
+            )
         }
 
         var steps: [ManagedTerminalAccountPlanStep] = []
@@ -1216,13 +1224,13 @@ enum ManagedTerminalAccountPlanner {
         }
 
         switch state.sudoers {
-        case .missing, .alanOwnedInvalid, .unmanaged:
+        case .missing, .alanOwnedInvalid:
             if !needsCreate {
                 repairNeeded = true
             }
             steps.append(step(.writeSudoersDropIn, "Write Alan-owned sudoers drop-in", true))
             steps.append(step(.validateSudoers, "Validate sudoers syntax", true))
-        case .alanOwnedValid, .existingUnreadable:
+        case .alanOwnedValid, .existingUnreadable, .unmanaged:
             break
         }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -835,6 +835,7 @@ enum ManagedTerminalAccountSudoersState: Equatable {
     case alanOwnedValid(path: String)
     case alanOwnedInvalid(path: String, message: String)
     case unmanaged(path: String)
+    case existingUnreadable(path: String)
 }
 
 enum ManagedTerminalAccountProfileState: Equatable {
@@ -914,10 +915,7 @@ enum ManagedTerminalAccountSudoersValidator {
         guard let data = fileManager.contents(atPath: rule.filePath),
               let contents = String(data: data, encoding: .utf8)
         else {
-            // Alan installs sudoers drop-ins as root:wheel 0440, so the GUI user
-            // may be unable to read contents during ordinary discovery. Readiness
-            // is still proven by the non-interactive sudo terminal-entry check.
-            return .alanOwnedValid(path: rule.filePath)
+            return .existingUnreadable(path: rule.filePath)
         }
 
         guard contents.contains(ManagedTerminalAccountSudoersRule.managedMarker) else {
@@ -1112,7 +1110,7 @@ enum ManagedTerminalAccountReadinessVerifier {
         }
 
         switch state.sudoers {
-        case .alanOwnedValid:
+        case .alanOwnedValid, .existingUnreadable:
             break
         case .alanOwnedInvalid(_, let message):
             return .failed(step: .sudoersValidation, message: message)
@@ -1224,13 +1222,17 @@ enum ManagedTerminalAccountPlanner {
             }
             steps.append(step(.writeSudoersDropIn, "Write Alan-owned sudoers drop-in", true))
             steps.append(step(.validateSudoers, "Validate sudoers syntax", true))
-        case .alanOwnedValid:
+        case .alanOwnedValid, .existingUnreadable:
             break
         }
 
         if state.verification != .passed {
             if !needsCreate {
                 repairNeeded = true
+            }
+            if shouldRepairUnreadableSudoers(state) {
+                steps.append(step(.writeSudoersDropIn, "Write Alan-owned sudoers drop-in", true))
+                steps.append(step(.validateSudoers, "Validate sudoers syntax", true))
             }
             steps.append(step(.verifyTerminalEntry, "Verify passwordless terminal entry", true))
         }
@@ -1298,6 +1300,12 @@ enum ManagedTerminalAccountPlanner {
             summary: summary,
             requiresPrivilege: requiresPrivilege
         )
+    }
+
+    private static func shouldRepairUnreadableSudoers(_ state: ManagedTerminalAccountState) -> Bool {
+        guard case .existingUnreadable = state.sudoers else { return false }
+        guard case .failed(step: .nonInteractiveSudo, _) = state.verification else { return false }
+        return true
     }
 }
 
@@ -1378,6 +1386,147 @@ struct ManagedTerminalAccountPrivilegedCommandResult: Equatable {
     let redactedMessage: String
 }
 
+struct ManagedTerminalAccountLocalEffectResult: Equatable {
+    let succeeded: Bool
+    let redactedMessage: String
+
+    static func succeeded(_ redactedMessage: String) -> ManagedTerminalAccountLocalEffectResult {
+        ManagedTerminalAccountLocalEffectResult(succeeded: true, redactedMessage: redactedMessage)
+    }
+
+    static func failed(_ redactedMessage: String) -> ManagedTerminalAccountLocalEffectResult {
+        ManagedTerminalAccountLocalEffectResult(succeeded: false, redactedMessage: redactedMessage)
+    }
+}
+
+protocol ManagedTerminalAccountLocalEffectExecuting {
+    func apply(
+        _ step: ManagedTerminalAccountPlanStepKind,
+        request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountLocalEffectResult?
+}
+
+struct ManagedTerminalAccountTerminalProfileEffectExecutor: ManagedTerminalAccountLocalEffectExecuting {
+    let store: TerminalProfileStore
+    let currentSpaceBinder: ((String) -> Bool)?
+
+    init(
+        store: TerminalProfileStore = .defaultStore(),
+        currentSpaceBinder: ((String) -> Bool)? = nil
+    ) {
+        self.store = store
+        self.currentSpaceBinder = currentSpaceBinder
+    }
+
+    func apply(
+        _ step: ManagedTerminalAccountPlanStepKind,
+        request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountLocalEffectResult? {
+        switch step {
+        case .createOrUpdateTerminalProfile:
+            return createOrUpdateTerminalProfile(for: request)
+        case .bindCurrentSpace:
+            return bindCurrentSpace(to: request.terminalProfileID)
+        case .removeManagedTerminalProfile:
+            return removeManagedTerminalProfile(for: request)
+        case .createStandardAccount, .repairAccountType, .repairHomeDirectory, .repairShell,
+                .hideAccount, .writeSudoersDropIn, .validateSudoers, .verifyTerminalEntry,
+                .removeSudoersDropIn, .deleteAccount, .deleteHomeDirectory:
+            return nil
+        }
+    }
+
+    private func createOrUpdateTerminalProfile(
+        for request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountLocalEffectResult {
+        var document = store.load().document
+        let profile = TerminalProfileDefinition(
+            id: request.terminalProfileID,
+            title: request.fullName ?? request.accountName,
+            launch: .sudoUser(unixUser: request.accountName),
+            defaultWorkingDirectory: request.homeDirectory,
+            presentation: TerminalProfilePresentation(
+                symbolName: "person.crop.circle",
+                colorName: nil
+            ),
+            managedTerminalAccountID: request.accountName
+        )
+
+        if let index = document.profiles.firstIndex(where: { $0.id == profile.id }) {
+            document.profiles[index] = profile
+        } else {
+            document.profiles.append(profile)
+        }
+
+        let nextDocument = TerminalProfileDocument(
+            defaultProfileID: document.defaultProfileID.isEmpty
+                ? profile.id
+                : document.defaultProfileID,
+            profiles: document.profiles
+        )
+        return save(
+            nextDocument,
+            successMessage: "Terminal Profile handoff completed. Credentials redacted.",
+            failureMessage: "Terminal Profile handoff failed. Credentials redacted."
+        )
+    }
+
+    private func bindCurrentSpace(to profileID: String) -> ManagedTerminalAccountLocalEffectResult {
+        guard let currentSpaceBinder else {
+            return .failed("Current Space binding is unavailable. Credentials redacted.")
+        }
+        guard currentSpaceBinder(profileID) else {
+            return .failed("Current Space binding failed. Credentials redacted.")
+        }
+        return .succeeded("Current Space binding completed. Credentials redacted.")
+    }
+
+    private func removeManagedTerminalProfile(
+        for request: ManagedTerminalAccountRequest
+    ) -> ManagedTerminalAccountLocalEffectResult {
+        let document = store.load().document
+        let remainingProfiles = document.profiles.filter {
+            $0.managedTerminalAccountID != request.accountName
+        }
+
+        guard remainingProfiles.count != document.profiles.count else {
+            return .succeeded("Managed Terminal Profile was already absent. Credentials redacted.")
+        }
+
+        let nextDocument: TerminalProfileDocument
+        if remainingProfiles.isEmpty {
+            nextDocument = .fallback
+        } else {
+            let defaultProfileID = remainingProfiles.contains { $0.id == document.defaultProfileID }
+                ? document.defaultProfileID
+                : remainingProfiles[0].id
+            nextDocument = TerminalProfileDocument(
+                defaultProfileID: defaultProfileID,
+                profiles: remainingProfiles
+            )
+        }
+
+        return save(
+            nextDocument,
+            successMessage: "Managed Terminal Profile removal completed. Credentials redacted.",
+            failureMessage: "Managed Terminal Profile removal failed. Credentials redacted."
+        )
+    }
+
+    private func save(
+        _ document: TerminalProfileDocument,
+        successMessage: String,
+        failureMessage: String
+    ) -> ManagedTerminalAccountLocalEffectResult {
+        do {
+            try store.save(document)
+            return .succeeded(successMessage)
+        } catch {
+            return .failed(failureMessage)
+        }
+    }
+}
+
 protocol ManagedTerminalAccountPrivilegedCommandRunning {
     func runPrivilegedShellScript(
         _ script: String,
@@ -1423,18 +1572,22 @@ struct ManagedTerminalAccountAppleScriptPrivilegeRunner: ManagedTerminalAccountP
 struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPrivilegedExecuting {
     let request: ManagedTerminalAccountRequest
     let commandRunner: ManagedTerminalAccountPrivilegedCommandRunning
+    let localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting
     let passwordGenerator: () -> String
 
     init(
         request: ManagedTerminalAccountRequest,
         commandRunner: ManagedTerminalAccountPrivilegedCommandRunning =
             ManagedTerminalAccountAppleScriptPrivilegeRunner(),
+        localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting =
+            ManagedTerminalAccountTerminalProfileEffectExecutor(),
         passwordGenerator: @escaping () -> String = {
             UUID().uuidString + UUID().uuidString
         }
     ) {
         self.request = request
         self.commandRunner = commandRunner
+        self.localEffectExecutor = localEffectExecutor
         self.passwordGenerator = passwordGenerator
     }
 
@@ -1444,6 +1597,24 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
 
         for step in plan.steps {
             guard let script = script(for: step.kind) else {
+                guard let result = localEffectExecutor.apply(step.kind, request: request) else {
+                    diagnostics.append("Step has no executor: \(step.summary).")
+                    return ManagedTerminalAccountApplyResult(
+                        completedSteps: completed,
+                        failedStep: step.kind,
+                        cancelled: false,
+                        visibleDiagnostics: diagnostics
+                    )
+                }
+                diagnostics.append(result.redactedMessage)
+                guard result.succeeded else {
+                    return ManagedTerminalAccountApplyResult(
+                        completedSteps: completed,
+                        failedStep: step.kind,
+                        cancelled: false,
+                        visibleDiagnostics: diagnostics
+                    )
+                }
                 completed.append(step.kind)
                 continue
             }

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1254,7 +1254,7 @@ enum ManagedTerminalAccountPlanner {
                 steps.append(step(.writeSudoersDropIn, "Write Alan-owned sudoers drop-in", true))
                 steps.append(step(.validateSudoers, "Validate sudoers syntax", true))
             }
-            steps.append(step(.verifyTerminalEntry, "Verify passwordless terminal entry", true))
+            steps.append(step(.verifyTerminalEntry, "Verify passwordless terminal entry", false))
         }
 
         switch state.terminalProfile {
@@ -1617,6 +1617,7 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
     let request: ManagedTerminalAccountRequest
     let commandRunner: ManagedTerminalAccountPrivilegedCommandRunning
     let localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting
+    let entryVerifier: ManagedTerminalAccountEntryVerifying
     let passwordGenerator: () -> String
 
     init(
@@ -1625,6 +1626,8 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
             ManagedTerminalAccountAppleScriptPrivilegeRunner(),
         localEffectExecutor: ManagedTerminalAccountLocalEffectExecuting =
             ManagedTerminalAccountTerminalProfileEffectExecutor(),
+        entryVerifier: ManagedTerminalAccountEntryVerifying =
+            ManagedTerminalAccountSudoEntryVerifier(),
         passwordGenerator: @escaping () -> String = {
             UUID().uuidString + UUID().uuidString
         }
@@ -1632,6 +1635,7 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         self.request = request
         self.commandRunner = commandRunner
         self.localEffectExecutor = localEffectExecutor
+        self.entryVerifier = entryVerifier
         self.passwordGenerator = passwordGenerator
     }
 
@@ -1640,6 +1644,21 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         var diagnostics: [String] = []
 
         for step in plan.steps {
+            if step.kind == .verifyTerminalEntry {
+                let verification = entryVerifier.verifyTerminalEntry(request: request)
+                guard verification.isValid else {
+                    diagnostics.append("\(step.summary) failed. Credentials redacted.")
+                    return ManagedTerminalAccountApplyResult(
+                        completedSteps: completed,
+                        failedStep: step.kind,
+                        cancelled: false,
+                        visibleDiagnostics: diagnostics
+                    )
+                }
+                diagnostics.append("\(step.summary) completed.")
+                completed.append(step.kind)
+                continue
+            }
             guard let script = script(for: step.kind) else {
                 guard let result = localEffectExecutor.apply(step.kind, request: request) else {
                     diagnostics.append("Step has no executor: \(step.summary).")
@@ -1717,7 +1736,7 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         case .validateSudoers:
             return "/usr/sbin/visudo -cf \(shellQuote(ManagedTerminalAccountSudoersRule(request: request).filePath))"
         case .verifyTerminalEntry:
-            return "/usr/bin/sudo -n -iu \(account) true"
+            return nil
         case .removeSudoersDropIn:
             return "/bin/rm -f \(shellQuote(ManagedTerminalAccountSudoersRule(request: request).filePath))"
         case .deleteAccount:

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1329,7 +1329,7 @@ enum ManagedTerminalAccountPlanner {
         scope: ManagedTerminalAccountRollbackScope
     ) -> ManagedTerminalAccountPlan {
         var steps: [ManagedTerminalAccountPlanStep] = []
-        if case .alanOwnedValid = state.sudoers {
+        if shouldRemoveSudoersDropIn(request: request, sudoers: state.sudoers) {
             steps.append(step(.removeSudoersDropIn, "Remove Alan-owned sudoers drop-in", true))
         }
         if case .existingManaged = state.terminalProfile {
@@ -1398,6 +1398,19 @@ enum ManagedTerminalAccountPlanner {
         guard case .existingUnreadable = state.sudoers else { return false }
         guard case .failed(step: .nonInteractiveSudo, _) = state.verification else { return false }
         return true
+    }
+
+    private static func shouldRemoveSudoersDropIn(
+        request: ManagedTerminalAccountRequest,
+        sudoers: ManagedTerminalAccountSudoersState
+    ) -> Bool {
+        let expectedPath = ManagedTerminalAccountSudoersRule(request: request).filePath
+        switch sudoers {
+        case .alanOwnedValid(let path), .existingUnreadable(let path):
+            return path == expectedPath
+        case .missing, .alanOwnedInvalid, .unmanaged:
+            return false
+        }
     }
 }
 
@@ -1786,7 +1799,7 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         case .verifyTerminalEntry:
             return nil
         case .removeSudoersDropIn:
-            return "/bin/rm -f \(shellQuote(ManagedTerminalAccountSudoersRule(request: request).filePath))"
+            return sudoersRemoveScript()
         case .deleteAccount:
             return "/usr/sbin/sysadminctl -deleteUser \(account)"
         case .deleteHomeDirectory:
@@ -1809,6 +1822,29 @@ struct ManagedTerminalAccountAuthorizedScriptExecutor: ManagedTerminalAccountPri
         ALAN_SUDOERS
         /usr/sbin/visudo -cf "$temp_path"
         /usr/bin/install -o root -g wheel -m 0440 "$temp_path" \(shellQuote(rule.filePath))
+        """
+    }
+
+    private func sudoersRemoveScript() -> String {
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
+        return """
+        set -eu
+        sudoers_path=\(shellQuote(rule.filePath))
+        if [ ! -e "$sudoers_path" ] && [ ! -L "$sudoers_path" ]; then
+          exit 0
+        fi
+        temp_dir="$(/usr/bin/mktemp -d /tmp/alan-terminal-sudoers-remove.XXXXXXXXXX)"
+        trap '/bin/rm -rf "$temp_dir"' 0 1 2 15
+        expected_path="$temp_dir/expected"
+        umask 077
+        /bin/cat > "$expected_path" <<'ALAN_SUDOERS'
+        \(rule.contents)
+        ALAN_SUDOERS
+        if ! /usr/bin/cmp -s "$expected_path" "$sudoers_path"; then
+          /bin/echo "Refusing to remove sudoers drop-in with unexpected contents." >&2
+          exit 1
+        fi
+        /bin/rm -f "$sudoers_path"
         """
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -82,6 +82,7 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
     var createdAt: Date
     var updatedAt: Date
     var tabs: [ShellWorkspaceTabRecord]
+    var terminalProfileID: String? = nil
 
     var id: String { spaceID }
 
@@ -92,6 +93,7 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case tabs
+        case terminalProfileID = "terminal_profile_id"
     }
 }
 
@@ -179,6 +181,7 @@ struct ShellPaneRestoreRecord: Codable, Equatable, Identifiable {
     var launchTarget: ShellLaunchTarget
     var cwd: String?
     var title: String?
+    var terminalProfileID: String? = nil
 
     var id: String { paneID }
 
@@ -187,6 +190,7 @@ struct ShellPaneRestoreRecord: Codable, Equatable, Identifiable {
         case launchTarget = "launch_target"
         case cwd
         case title
+        case terminalProfileID = "terminal_profile_id"
     }
 }
 
@@ -273,6 +277,7 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
     var createdAt: Date
     var updatedAt: Date
     var tabs: [ShellContentWorkspaceTabRecord]
+    var terminalProfileID: String? = nil
 
     var id: String { spaceID }
 
@@ -283,6 +288,7 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case tabs
+        case terminalProfileID = "terminal_profile_id"
     }
 }
 
@@ -435,7 +441,8 @@ extension ShellContentTabRestoreSnapshot {
                         launchTarget: terminalPayload.launchTarget,
                         cwd: terminalPayload.cwd,
                         title: terminalPayload.title,
-                        transcriptSnapshot: transcriptSnapshot
+                        transcriptSnapshot: transcriptSnapshot,
+                        terminalProfileID: terminalPayload.terminalProfileID
                     )
                 )
             )
@@ -532,7 +539,8 @@ extension ShellWorkspaceManifest {
                             liveSnapshot: tab.liveSnapshot?.migratingTerminalPanesToContentContainers(),
                             activeTask: tab.activeTask
                         )
-                    }
+                    },
+                    terminalProfileID: space.terminalProfileID
                 )
             }
         )
@@ -598,7 +606,8 @@ extension ShellTabRestoreSnapshot {
                     ShellTerminalContentPayload(
                         launchTarget: pane.launchTarget,
                         cwd: pane.cwd,
-                        title: title
+                        title: title,
+                        terminalProfileID: pane.terminalProfileID
                     )
                 )
             )
@@ -710,7 +719,8 @@ struct ShellWorkspaceMaterializer {
                 attention: strongestAttention(
                     in: paneSlots.filter { $0.spaceID == space.spaceID }
                 ),
-                tabs: contentTabs
+                tabs: contentTabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -802,7 +812,8 @@ struct ShellWorkspaceMaterializer {
                 visibleExcerpt: nil,
                 lastActivityAt: nil
             ),
-            alanBinding: nil
+            alanBinding: nil,
+            terminalProfileID: terminalPayload.terminalProfileID
         )
         let slot = ShellQuickTerminalSlot(
             paneID: record.paneID,
@@ -825,7 +836,8 @@ struct ShellWorkspaceMaterializer {
                     launchTarget: terminalPayload.launchTarget,
                     cwd: terminalPayload.cwd ?? defaultWorkingDirectory,
                     title: terminalPayload.title,
-                    transcriptSnapshot: terminalPayload.transcriptSnapshot
+                    transcriptSnapshot: terminalPayload.transcriptSnapshot,
+                    terminalProfileID: terminalPayload.terminalProfileID
                 )
             )
         } else {
@@ -898,7 +910,8 @@ struct ShellWorkspaceMaterializer {
                     spaceID: space.spaceID,
                     title: space.title,
                     attention: strongestAttention(for: shellTabs, panes: panes),
-                    tabs: shellTabs
+                    tabs: shellTabs,
+                    terminalProfileID: space.terminalProfileID
                 )
             )
         }
@@ -952,7 +965,8 @@ struct ShellWorkspaceMaterializer {
                 visibleExcerpt: nil,
                 lastActivityAt: nil
             ),
-            alanBinding: nil
+            alanBinding: nil,
+            terminalProfileID: record.terminalProfileID
         )
     }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -834,7 +834,11 @@ struct ShellWorkspaceMaterializer {
             payload = .terminal(
                 ShellTerminalContentPayload(
                     launchTarget: terminalPayload.launchTarget,
-                    cwd: terminalPayload.cwd ?? defaultWorkingDirectory,
+                    cwd: restoredWorkingDirectory(
+                        terminalPayload.cwd,
+                        terminalProfileID: terminalPayload.terminalProfileID,
+                        defaultWorkingDirectory: defaultWorkingDirectory
+                    ),
                     title: terminalPayload.title,
                     transcriptSnapshot: terminalPayload.transcriptSnapshot,
                     terminalProfileID: terminalPayload.terminalProfileID
@@ -955,7 +959,11 @@ struct ShellWorkspaceMaterializer {
             tabID: tabID,
             spaceID: spaceID,
             launchTarget: launchTarget,
-            cwd: record.cwd ?? defaultWorkingDirectory,
+            cwd: restoredWorkingDirectory(
+                record.cwd,
+                terminalProfileID: record.terminalProfileID,
+                defaultWorkingDirectory: defaultWorkingDirectory
+            ),
             process: nil,
             attention: tabID == selectedTabID ? .active : .idle,
             context: nil,
@@ -974,6 +982,17 @@ struct ShellWorkspaceMaterializer {
         _ tabs: [ShellWorkspaceTabRecord]
     ) -> [ShellWorkspaceTabRecord] {
         tabs.filter(\.isPinned) + tabs.filter { !$0.isPinned }
+    }
+
+    private static func restoredWorkingDirectory(
+        _ workingDirectory: String?,
+        terminalProfileID: String?,
+        defaultWorkingDirectory: String
+    ) -> String? {
+        if terminalProfileID != nil {
+            return workingDirectory
+        }
+        return workingDirectory ?? defaultWorkingDirectory
     }
 
     private static func organizedTabs(

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -51,7 +51,7 @@ enum AlanShellLocalCommandExecutor {
 
         case .spaceCreate:
             let resolvedTerminalProfileID = command.terminalProfileID
-                ?? terminalProfileIDForWorkingDirectoryDeferral()
+                ?? terminalProfileIDForGlobalDefaultPaneCapture()
             let result = state.creatingSpace(
                 launchTarget: .shell,
                 title: command.title,
@@ -136,7 +136,7 @@ enum AlanShellLocalCommandExecutor {
                     in: command.spaceID,
                     explicit: command.terminalProfileID
                 )
-                    ?? terminalProfileIDForWorkingDirectoryDeferral()
+                    ?? terminalProfileIDForGlobalDefaultPaneCapture()
                 let result = try state.openingTerminalTab(
                     in: command.spaceID,
                     title: command.title,
@@ -460,7 +460,7 @@ enum AlanShellLocalCommandExecutor {
                     from: paneID,
                     explicit: command.terminalProfileID
                 )
-                    ?? terminalProfileIDForWorkingDirectoryDeferral()
+                    ?? terminalProfileIDForGlobalDefaultPaneCapture()
                 let result = try state.splittingPane(
                     paneID,
                     direction: direction,

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -130,11 +130,16 @@ enum AlanShellLocalCommandExecutor {
 
         case .tabOpen:
             do {
+                let resolvedTerminalProfileID = state.terminalProfileIDForNewTerminal(
+                    in: command.spaceID,
+                    explicit: command.terminalProfileID
+                )
+                    ?? terminalProfileIDForWorkingDirectoryDeferral()
                 let result = try state.openingTerminalTab(
                     in: command.spaceID,
                     title: command.title,
                     workingDirectory: command.cwd,
-                    terminalProfileID: command.terminalProfileID
+                    terminalProfileID: resolvedTerminalProfileID
                 )
                 return AlanShellLocalCommandResult(
                     response: response(

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -53,7 +53,8 @@ enum AlanShellLocalCommandExecutor {
             let result = state.creatingSpace(
                 launchTarget: .shell,
                 title: command.title,
-                workingDirectory: command.cwd
+                workingDirectory: command.cwd,
+                terminalProfileID: command.terminalProfileID
             )
             return AlanShellLocalCommandResult(
                 response: response(
@@ -65,6 +66,51 @@ enum AlanShellLocalCommandExecutor {
                     paneID: result.paneID
                 ),
                 updatedState: result.state,
+                sideEffect: nil
+            )
+
+        case .spaceSetTerminalProfile:
+            guard let spaceID = command.spaceID ?? state.focusedSpaceID else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "space_required",
+                        errorMessage: "space_id is required."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            guard let nextState = state.settingTerminalProfile(
+                command.terminalProfileID,
+                forSpaceID: spaceID
+            ) else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        spaceID: spaceID,
+                        errorCode: "space_not_found",
+                        errorMessage: "The requested space does not exist."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
+            return AlanShellLocalCommandResult(
+                response: response(
+                    for: command,
+                    state: nextState,
+                    applied: true,
+                    snapshot: nextState,
+                    spaceID: spaceID,
+                    tabID: nextState.focusedTabID,
+                    paneID: nextState.focusedPaneID
+                ),
+                updatedState: nextState,
                 sideEffect: nil
             )
 
@@ -87,7 +133,8 @@ enum AlanShellLocalCommandExecutor {
                 let result = try state.openingTerminalTab(
                     in: command.spaceID,
                     title: command.title,
-                    workingDirectory: command.cwd
+                    workingDirectory: command.cwd,
+                    terminalProfileID: command.terminalProfileID
                 )
                 return AlanShellLocalCommandResult(
                     response: response(
@@ -402,7 +449,11 @@ enum AlanShellLocalCommandExecutor {
                 )
             }
             do {
-                let result = try state.splittingPane(paneID, direction: direction)
+                let result = try state.splittingPane(
+                    paneID,
+                    direction: direction,
+                    terminalProfileID: command.terminalProfileID
+                )
                 return AlanShellLocalCommandResult(
                     response: response(
                         for: command,

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -50,11 +50,13 @@ enum AlanShellLocalCommandExecutor {
             )
 
         case .spaceCreate:
+            let resolvedTerminalProfileID = command.terminalProfileID
+                ?? terminalProfileIDForWorkingDirectoryDeferral()
             let result = state.creatingSpace(
                 launchTarget: .shell,
                 title: command.title,
                 workingDirectory: command.cwd,
-                terminalProfileID: command.terminalProfileID
+                terminalProfileID: resolvedTerminalProfileID
             )
             return AlanShellLocalCommandResult(
                 response: response(
@@ -454,10 +456,15 @@ enum AlanShellLocalCommandExecutor {
                 )
             }
             do {
+                let resolvedTerminalProfileID = state.terminalProfileIDForNewSplit(
+                    from: paneID,
+                    explicit: command.terminalProfileID
+                )
+                    ?? terminalProfileIDForWorkingDirectoryDeferral()
                 let result = try state.splittingPane(
                     paneID,
                     direction: direction,
-                    terminalProfileID: command.terminalProfileID
+                    terminalProfileID: resolvedTerminalProfileID
                 )
                 return AlanShellLocalCommandResult(
                     response: response(

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -82,6 +82,23 @@ struct ShellPaneProjectionService {
             metadataProcessExited: processExited,
             surfaceState: runtime?.surfaceState
         )
+        let bootProfileHasTerminalProfileState = bootProfile.environment.keys.contains(
+            "ALAN_TERMINAL_PROFILE_STATE"
+        )
+        let terminalProfileState = bootProfile.environment["ALAN_TERMINAL_PROFILE_STATE"]
+            ?? existing?.terminalProfileState
+        let terminalProfileRequestedID = bootProfileHasTerminalProfileState
+            ? bootProfile.environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"]
+            : existing?.terminalProfileRequestedID
+        let terminalProfileID = bootProfileHasTerminalProfileState
+            ? bootProfile.environment["ALAN_TERMINAL_PROFILE_ID"]
+            : existing?.terminalProfileID
+        let terminalProfileKind = bootProfileHasTerminalProfileState
+            ? bootProfile.environment["ALAN_TERMINAL_PROFILE_KIND"]
+            : existing?.terminalProfileKind
+        let terminalProfileTitle = bootProfileHasTerminalProfileState
+            ? bootProfile.environment["ALAN_TERMINAL_PROFILE_TITLE"]
+            : existing?.terminalProfileTitle
 
         return ShellContextSnapshot(
             workingDirectoryName: workingDirectoryName(for: resolvedWorkingDirectory)
@@ -94,16 +111,11 @@ struct ShellPaneProjectionService {
                 ?? existing?.alanBindingFile,
             launchCommand: bootProfile.launchCommandString,
             launchStrategy: bootProfile.command.strategy.rawValue,
-            terminalProfileState: bootProfile.environment["ALAN_TERMINAL_PROFILE_STATE"]
-                ?? existing?.terminalProfileState,
-            terminalProfileRequestedID: bootProfile.environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"]
-                ?? existing?.terminalProfileRequestedID,
-            terminalProfileID: bootProfile.environment["ALAN_TERMINAL_PROFILE_ID"]
-                ?? existing?.terminalProfileID,
-            terminalProfileKind: bootProfile.environment["ALAN_TERMINAL_PROFILE_KIND"]
-                ?? existing?.terminalProfileKind,
-            terminalProfileTitle: bootProfile.environment["ALAN_TERMINAL_PROFILE_TITLE"]
-                ?? existing?.terminalProfileTitle,
+            terminalProfileState: terminalProfileState,
+            terminalProfileRequestedID: terminalProfileRequestedID,
+            terminalProfileID: terminalProfileID,
+            terminalProfileKind: terminalProfileKind,
+            terminalProfileTitle: terminalProfileTitle,
             shellIntegrationSource: "ghostty_shell_integration",
             processState: projectedProcessState(
                 processExited: projectedProcessExited,

--- a/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift
@@ -94,6 +94,16 @@ struct ShellPaneProjectionService {
                 ?? existing?.alanBindingFile,
             launchCommand: bootProfile.launchCommandString,
             launchStrategy: bootProfile.command.strategy.rawValue,
+            terminalProfileState: bootProfile.environment["ALAN_TERMINAL_PROFILE_STATE"]
+                ?? existing?.terminalProfileState,
+            terminalProfileRequestedID: bootProfile.environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"]
+                ?? existing?.terminalProfileRequestedID,
+            terminalProfileID: bootProfile.environment["ALAN_TERMINAL_PROFILE_ID"]
+                ?? existing?.terminalProfileID,
+            terminalProfileKind: bootProfile.environment["ALAN_TERMINAL_PROFILE_KIND"]
+                ?? existing?.terminalProfileKind,
+            terminalProfileTitle: bootProfile.environment["ALAN_TERMINAL_PROFILE_TITLE"]
+                ?? existing?.terminalProfileTitle,
             shellIntegrationSource: "ghostty_shell_integration",
             processState: projectedProcessState(
                 processExited: projectedProcessExited,

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -82,17 +82,21 @@ enum AlanShellPublishedStateMerger {
             incomingContext?.launchCommand ?? authoritativeContext?.launchCommand
         let launchStrategy =
             incomingContext?.launchStrategy ?? authoritativeContext?.launchStrategy
+        let incomingTerminalProfileResolution = incomingContext?.terminalProfileState != nil
         let terminalProfileState =
             incomingContext?.terminalProfileState ?? authoritativeContext?.terminalProfileState
-        let terminalProfileRequestedID =
-            incomingContext?.terminalProfileRequestedID
-                ?? authoritativeContext?.terminalProfileRequestedID
-        let terminalProfileID =
-            incomingContext?.terminalProfileID ?? authoritativeContext?.terminalProfileID
-        let terminalProfileKind =
-            incomingContext?.terminalProfileKind ?? authoritativeContext?.terminalProfileKind
-        let terminalProfileTitle =
-            incomingContext?.terminalProfileTitle ?? authoritativeContext?.terminalProfileTitle
+        let terminalProfileRequestedID = incomingTerminalProfileResolution
+            ? incomingContext?.terminalProfileRequestedID
+            : authoritativeContext?.terminalProfileRequestedID
+        let terminalProfileID = incomingTerminalProfileResolution
+            ? incomingContext?.terminalProfileID
+            : authoritativeContext?.terminalProfileID
+        let terminalProfileKind = incomingTerminalProfileResolution
+            ? incomingContext?.terminalProfileKind
+            : authoritativeContext?.terminalProfileKind
+        let terminalProfileTitle = incomingTerminalProfileResolution
+            ? incomingContext?.terminalProfileTitle
+            : authoritativeContext?.terminalProfileTitle
         let shellIntegrationSource =
             incomingContext?.shellIntegrationSource ?? authoritativeContext?.shellIntegrationSource
         let processState = incomingContext?.processState ?? authoritativeContext?.processState

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -13,9 +13,6 @@ enum AlanShellPublishedStateMerger {
         let authoritativePanesByID = Dictionary(
             uniqueKeysWithValues: authoritative.panes.map { ($0.paneID, $0) }
         )
-        let authoritativeSpacesByID = Dictionary(
-            uniqueKeysWithValues: authoritative.spaces.map { ($0.spaceID, $0) }
-        )
         let mergedPanes = incoming.panes.map { pane in
             merge(authoritativePane: authoritativePanesByID[pane.paneID], incomingPane: pane)
         }
@@ -30,7 +27,6 @@ enum AlanShellPublishedStateMerger {
                 attention: strongestAttention(in: mergedPanes.filter { $0.spaceID == space.spaceID }),
                 tabs: space.tabs,
                 terminalProfileID: space.terminalProfileID
-                    ?? authoritativeSpacesByID[space.spaceID]?.terminalProfileID
             )
         }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -13,6 +13,9 @@ enum AlanShellPublishedStateMerger {
         let authoritativePanesByID = Dictionary(
             uniqueKeysWithValues: authoritative.panes.map { ($0.paneID, $0) }
         )
+        let authoritativeSpacesByID = Dictionary(
+            uniqueKeysWithValues: authoritative.spaces.map { ($0.spaceID, $0) }
+        )
         let mergedPanes = incoming.panes.map { pane in
             merge(authoritativePane: authoritativePanesByID[pane.paneID], incomingPane: pane)
         }
@@ -25,7 +28,9 @@ enum AlanShellPublishedStateMerger {
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: strongestAttention(in: mergedPanes.filter { $0.spaceID == space.spaceID }),
-                tabs: space.tabs
+                tabs: space.tabs,
+                terminalProfileID: space.terminalProfileID
+                    ?? authoritativeSpacesByID[space.spaceID]?.terminalProfileID
             )
         }
 
@@ -60,7 +65,8 @@ enum AlanShellPublishedStateMerger {
             context: merge(authoritativeContext: authoritativePane.context, incomingContext: incomingPane.context),
             viewport: merge(authoritativeViewport: authoritativePane.viewport, incomingViewport: incomingPane.viewport),
             activity: incomingPane.activity,
-            alanBinding: incomingPane.alanBinding ?? authoritativePane.alanBinding
+            alanBinding: incomingPane.alanBinding ?? authoritativePane.alanBinding,
+            terminalProfileID: incomingPane.terminalProfileID ?? authoritativePane.terminalProfileID
         )
     }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -82,6 +82,17 @@ enum AlanShellPublishedStateMerger {
             incomingContext?.launchCommand ?? authoritativeContext?.launchCommand
         let launchStrategy =
             incomingContext?.launchStrategy ?? authoritativeContext?.launchStrategy
+        let terminalProfileState =
+            incomingContext?.terminalProfileState ?? authoritativeContext?.terminalProfileState
+        let terminalProfileRequestedID =
+            incomingContext?.terminalProfileRequestedID
+                ?? authoritativeContext?.terminalProfileRequestedID
+        let terminalProfileID =
+            incomingContext?.terminalProfileID ?? authoritativeContext?.terminalProfileID
+        let terminalProfileKind =
+            incomingContext?.terminalProfileKind ?? authoritativeContext?.terminalProfileKind
+        let terminalProfileTitle =
+            incomingContext?.terminalProfileTitle ?? authoritativeContext?.terminalProfileTitle
         let shellIntegrationSource =
             incomingContext?.shellIntegrationSource ?? authoritativeContext?.shellIntegrationSource
         let processState = incomingContext?.processState ?? authoritativeContext?.processState
@@ -110,6 +121,11 @@ enum AlanShellPublishedStateMerger {
             alanBindingFile: alanBindingFile,
             launchCommand: launchCommand,
             launchStrategy: launchStrategy,
+            terminalProfileState: terminalProfileState,
+            terminalProfileRequestedID: terminalProfileRequestedID,
+            terminalProfileID: terminalProfileID,
+            terminalProfileKind: terminalProfileKind,
+            terminalProfileTitle: terminalProfileTitle,
             shellIntegrationSource: shellIntegrationSource,
             processState: processState,
             rendererPhase: rendererPhase,

--- a/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
@@ -92,7 +92,11 @@ struct TerminalContentProjectionAdapter {
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
                 launchTarget: pane.launchTarget,
-                cwd: pane.cwd ?? bootProfile.workingDirectory,
+                cwd: projectedPaneWorkingDirectory(
+                    for: pane,
+                    workingDirectory: pane.cwd,
+                    bootProfile: bootProfile
+                ),
                 process: pane.process,
                 attention: projectedBinding?.pendingYield == true ? .awaitingUser : pane.attention,
                 context: projectedContext,
@@ -138,7 +142,11 @@ struct TerminalContentProjectionAdapter {
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
                 launchTarget: pane.launchTarget,
-                cwd: pane.cwd ?? bootProfile.workingDirectory,
+                cwd: projectedPaneWorkingDirectory(
+                    for: pane,
+                    workingDirectory: pane.cwd,
+                    bootProfile: bootProfile
+                ),
                 process: pane.process,
                 attention: pane.attention,
                 context: projectedContext,
@@ -192,7 +200,11 @@ struct TerminalContentProjectionAdapter {
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
                 launchTarget: pane.launchTarget,
-                cwd: workingDirectory ?? bootProfile.workingDirectory,
+                cwd: projectedPaneWorkingDirectory(
+                    for: pane,
+                    workingDirectory: workingDirectory,
+                    bootProfile: bootProfile
+                ),
                 process: pane.process,
                 attention: paneProjection.projectedAttention(
                     metadataAttention: metadata.attention,
@@ -209,6 +221,17 @@ struct TerminalContentProjectionAdapter {
             processExited: processExited,
             activity: projectedActivity
         )
+    }
+
+    private func projectedPaneWorkingDirectory(
+        for pane: ShellPane,
+        workingDirectory: String?,
+        bootProfile: AlanShellBootProfile
+    ) -> String? {
+        if pane.terminalProfileID != nil {
+            return pane.cwd
+        }
+        return workingDirectory ?? bootProfile.workingDirectory
     }
 }
 #endif

--- a/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalContentProjectionAdapter.swift
@@ -98,7 +98,8 @@ struct TerminalContentProjectionAdapter {
                 context: projectedContext,
                 viewport: viewport,
                 activity: pane.activity,
-                alanBinding: projectedBinding
+                alanBinding: projectedBinding,
+                terminalProfileID: pane.terminalProfileID
             ),
             processExited: processExited,
             activity: pane.activity
@@ -143,7 +144,8 @@ struct TerminalContentProjectionAdapter {
                 context: projectedContext,
                 viewport: pane.viewport,
                 activity: pane.activity,
-                alanBinding: projectedBinding
+                alanBinding: projectedBinding,
+                terminalProfileID: pane.terminalProfileID
             ),
             processExited: processExited,
             activity: pane.activity
@@ -201,7 +203,8 @@ struct TerminalContentProjectionAdapter {
                 context: projectedContext,
                 viewport: viewport,
                 activity: projectedActivity,
-                alanBinding: projectedBinding
+                alanBinding: projectedBinding,
+                terminalProfileID: pane.terminalProfileID
             ),
             processExited: processExited,
             activity: projectedActivity

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1256,8 +1256,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        let resolvedWorkingDirectory = workingDirectory
-            ?? focusedPaneWorkingDirectory()
+        let resolvedWorkingDirectory =
+            workingDirectory
+            ?? (targetTerminalProfileID(in: spaceID, explicit: terminalProfileID) == nil
+                ? focusedPaneWorkingDirectory()
+                : nil)
         return openTab(
             launchTarget: .shell,
             in: spaceID,
@@ -3024,6 +3027,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         let runtimeCwd = runtime(for: pane.paneID).paneMetadata.workingDirectory
         return nonEmptyWorkingDirectory(runtimeCwd)
             ?? nonEmptyWorkingDirectory(pane.cwd)
+    }
+
+    private func targetTerminalProfileID(in requestedSpaceID: String?, explicit: String?) -> String? {
+        if let explicit {
+            return explicit
+        }
+        let targetSpaceID = requestedSpaceID ?? shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
+        guard let targetSpaceID else { return nil }
+        return shellState.spaces.first { $0.spaceID == targetSpaceID }?.terminalProfileID
     }
 
     func settingsWorkspaceContext(forPaneSlotID paneSlotID: String) -> ShellSettingsWorkspaceContext {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1049,11 +1049,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
+        let resolvedTerminalProfileID = terminalProfileID
+            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
         let result = shellState.creatingSpace(
             launchTarget: launchTarget,
             title: title,
             workingDirectory: workingDirectory,
-            terminalProfileID: terminalProfileID,
+            terminalProfileID: resolvedTerminalProfileID,
             reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
         )
         applyMutationResult(result)
@@ -1347,13 +1349,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         contentIntent: ShellContentIntent? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
+        let resolvedTerminalProfileID = targetTerminalProfileID(
+            forSplitFromPaneID: paneID,
+            explicit: terminalProfileID
+        )
         let result: ShellStateMutationResult
         do {
             result = try shellState.splittingPane(
                 paneID,
                 placement: placement,
                 contentIntent: contentIntent,
-                terminalProfileID: terminalProfileID,
+                terminalProfileID: resolvedTerminalProfileID,
                 reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
             )
         } catch {
@@ -3047,6 +3053,17 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return spaceProfileID
         }
         return globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+    }
+
+    private func targetTerminalProfileID(forSplitFromPaneID paneID: String, explicit: String?) -> String? {
+        if let explicit {
+            return explicit
+        }
+        guard let pane = shellState.pane(paneID: paneID) else {
+            return nil
+        }
+        return pane.terminalProfileID
+            ?? targetTerminalProfileID(in: pane.spaceID, explicit: nil)
     }
 
     private func globalDefaultTerminalProfileIDForWorkingDirectoryDeferral() -> String? {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1046,12 +1046,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func createSpace(
         launchTarget: ShellLaunchTarget = .shell,
         title: String? = nil,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         let result = shellState.creatingSpace(
             launchTarget: launchTarget,
             title: title,
             workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID,
             reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
         )
         applyMutationResult(result)
@@ -1059,8 +1061,29 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     @discardableResult
-    func createTerminalSpace(title: String? = nil, workingDirectory: String? = nil) -> String? {
-        createSpace(launchTarget: .shell, title: title, workingDirectory: workingDirectory)
+    func createTerminalSpace(
+        title: String? = nil,
+        workingDirectory: String? = nil,
+        terminalProfileID: String? = nil
+    ) -> String? {
+        createSpace(
+            launchTarget: .shell,
+            title: title,
+            workingDirectory: workingDirectory,
+            terminalProfileID: terminalProfileID
+        )
+    }
+
+    @discardableResult
+    func setTerminalProfile(_ terminalProfileID: String?, forSpaceID spaceID: String) -> Bool {
+        guard let nextState = shellState.settingTerminalProfile(
+            terminalProfileID,
+            forSpaceID: spaceID
+        ) else {
+            return false
+        }
+        adoptStateFromControlPlane(nextState)
+        return true
     }
 
     @discardableResult
@@ -1189,13 +1212,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             title: nil,
             workingDirectory: nil
         ),
-        in spaceID: String? = nil
+        in spaceID: String? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         let result: ShellStateMutationResult
         do {
             result = try shellState.openingContentTab(
                 contentIntent,
                 in: spaceID,
+                terminalProfileID: terminalProfileID,
                 reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
             )
         } catch {
@@ -1210,7 +1235,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         launchTarget: ShellLaunchTarget = .shell,
         in spaceID: String? = nil,
         title: String? = nil,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         openContentTab(
             .terminal(
@@ -1218,7 +1244,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 title: title,
                 workingDirectory: workingDirectory
             ),
-            in: spaceID
+            in: spaceID,
+            terminalProfileID: terminalProfileID
         )
     }
 
@@ -1226,7 +1253,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func openTerminalTab(
         in spaceID: String? = nil,
         title: String? = nil,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         let resolvedWorkingDirectory = workingDirectory
             ?? focusedPaneWorkingDirectory()
@@ -1234,7 +1262,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             launchTarget: .shell,
             in: spaceID,
             title: title,
-            workingDirectory: resolvedWorkingDirectory
+            workingDirectory: resolvedWorkingDirectory,
+            terminalProfileID: terminalProfileID
         )
     }
 
@@ -1264,24 +1293,28 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @discardableResult
     func splitFocusedPane(
         direction: ShellSplitDirection,
-        contentIntent: ShellContentIntent? = nil
+        contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         splitFocusedPane(
             placement: .defaultPlacement(for: direction),
-            contentIntent: contentIntent
+            contentIntent: contentIntent,
+            terminalProfileID: terminalProfileID
         )
     }
 
     @discardableResult
     func splitFocusedPane(
         placement: ShellPaneSplitDirection,
-        contentIntent: ShellContentIntent? = nil
+        contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         guard let focusedPaneID = shellState.focusedPaneID else { return nil }
         return splitPane(
             paneID: focusedPaneID,
             placement: placement,
-            contentIntent: contentIntent
+            contentIntent: contentIntent,
+            terminalProfileID: terminalProfileID
         )
     }
 
@@ -1289,12 +1322,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func splitPane(
         paneID: String,
         direction: ShellSplitDirection,
-        contentIntent: ShellContentIntent? = nil
+        contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         splitPane(
             paneID: paneID,
             placement: .defaultPlacement(for: direction),
-            contentIntent: contentIntent
+            contentIntent: contentIntent,
+            terminalProfileID: terminalProfileID
         )
     }
 
@@ -1302,7 +1337,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func splitPane(
         paneID: String,
         placement: ShellPaneSplitDirection,
-        contentIntent: ShellContentIntent? = nil
+        contentIntent: ShellContentIntent? = nil,
+        terminalProfileID: String? = nil
     ) -> String? {
         let result: ShellStateMutationResult
         do {
@@ -1310,6 +1346,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 paneID,
                 placement: placement,
                 contentIntent: contentIntent,
+                terminalProfileID: terminalProfileID,
                 reservedPaneIDs: terminalRuntimeRegistry.registeredPaneIDs
             )
         } catch {
@@ -2124,7 +2161,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: strongestAttention(in: panes.filter { $0.spaceID == space.spaceID }),
-                tabs: tabs
+                tabs: tabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
     }
@@ -2207,7 +2245,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 context: projectedContext,
                 viewport: pane.viewport,
                 activity: pane.activity,
-                alanBinding: pane.alanBinding
+                alanBinding: pane.alanBinding,
+                terminalProfileID: pane.terminalProfileID
             )
         }
 
@@ -2216,7 +2255,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 spaceID: space.spaceID,
                 title: space.title,
                 attention: strongestAttention(in: hydratedPanes.filter { $0.spaceID == space.spaceID }),
-                tabs: space.tabs
+                tabs: space.tabs,
+                terminalProfileID: space.terminalProfileID
             )
         }
 
@@ -2493,12 +2533,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             return ShellContentWorkspaceSpaceRecord(
                 spaceID: space.spaceID,
                 title: space.title,
-                order: existingSpace?.order ?? index,
-                createdAt: existingSpace?.createdAt ?? now,
-                updatedAt: now,
-                tabs: tabRecords
-            )
-        }
+                    order: existingSpace?.order ?? index,
+                    createdAt: existingSpace?.createdAt ?? now,
+                    updatedAt: now,
+                    tabs: tabRecords,
+                    terminalProfileID: space.terminalProfileID
+                )
+            }
 
         var manifest = ShellContentWorkspaceManifest(
             schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
@@ -2559,18 +2600,22 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             ?? capturedTerminalTranscriptSnapshot(forContentID: contentID)
             ?? existingQuickTerminalTranscriptSnapshot(paneID: pane.paneID, contentID: contentID)
         let title = projectedContent.title
+        let launchTarget = terminalPayload?.launchTarget ?? pane.resolvedLaunchTarget
+        let cwd = terminalPayload?.cwd ?? pane.cwd ?? quickTerminal.lastWorkingDirectory
+        let payloadTitle = terminalPayload?.title ?? title
+        let terminalProfileID = terminalPayload?.terminalProfileID ?? pane.terminalProfileID
+        let payload = ShellTerminalContentPayload(
+            launchTarget: launchTarget,
+            cwd: cwd,
+            title: payloadTitle,
+            transcriptSnapshot: transcriptSnapshot,
+            terminalProfileID: terminalProfileID
+        )
         let content = ShellContentRestoreRecord(
             contentID: contentID,
             kind: .terminal,
             title: title,
-            payload: .terminal(
-                ShellTerminalContentPayload(
-                    launchTarget: terminalPayload?.launchTarget ?? pane.resolvedLaunchTarget,
-                    cwd: terminalPayload?.cwd ?? pane.cwd ?? quickTerminal.lastWorkingDirectory,
-                    title: terminalPayload?.title ?? title,
-                    transcriptSnapshot: transcriptSnapshot
-                )
-            )
+            payload: .terminal(payload)
         )
         let snapshot = ShellContentTabRestoreSnapshot(
             paneTree: ShellPaneSlotTreeNode(
@@ -3187,7 +3232,8 @@ extension ShellHostController: ShellAutomationCommandHandling {
                 tabID = openTerminalTab(
                     in: request.spaceID,
                     title: request.title,
-                    workingDirectory: request.workingDirectory
+                    workingDirectory: request.workingDirectory,
+                    terminalProfileID: request.terminalProfileID
                 )
             }
             guard let tabID else {
@@ -3209,7 +3255,11 @@ extension ShellHostController: ShellAutomationCommandHandling {
             guard pane(paneID: request.paneID) != nil else {
                 return shellAutomationMissingPaneResult(request.paneID)
             }
-            guard let paneID = splitPane(paneID: request.paneID, placement: request.placement) else {
+            guard let paneID = splitPane(
+                paneID: request.paneID,
+                placement: request.placement,
+                terminalProfileID: request.terminalProfileID
+            ) else {
                 return shellAutomationMissingPaneResult(request.paneID)
             }
             return shellAutomationResult(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -3042,17 +3042,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func targetTerminalProfileID(in requestedSpaceID: String?, explicit: String?) -> String? {
-        if let explicit {
-            return explicit
-        }
-        let targetSpaceID = requestedSpaceID ?? shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
-        guard let targetSpaceID else { return nil }
-        if let spaceProfileID = shellState.spaces.first(where: { $0.spaceID == targetSpaceID })?
-            .terminalProfileID
-        {
-            return spaceProfileID
-        }
-        return globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+        shellState.terminalProfileIDForNewTerminal(in: requestedSpaceID, explicit: explicit)
+            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
     }
 
     private func targetTerminalProfileID(forSplitFromPaneID paneID: String, explicit: String?) -> String? {
@@ -3067,17 +3058,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func globalDefaultTerminalProfileIDForWorkingDirectoryDeferral() -> String? {
-        let document = TerminalProfileStore.defaultStore(
+        terminalProfileIDForWorkingDirectoryDeferral(
             channelApplicationSupportDirectoryName: windowContext.installChannel
                 .applicationSupportDirectoryName,
             fileManager: fileManager
-        ).load().document
-        guard let profile = document.defaultProfile,
-              nonEmptyWorkingDirectory(profile.defaultWorkingDirectory) != nil
-        else {
-            return nil
-        }
-        return profile.id
+        )
     }
 
     func settingsWorkspaceContext(forPaneSlotID paneSlotID: String) -> ShellSettingsWorkspaceContext {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1050,7 +1050,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         terminalProfileID: String? = nil
     ) -> String? {
         let resolvedTerminalProfileID = terminalProfileID
-            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+            ?? globalDefaultTerminalProfileIDForPaneCapture()
         let result = shellState.creatingSpace(
             launchTarget: launchTarget,
             title: title,
@@ -3043,16 +3043,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     private func targetTerminalProfileID(in requestedSpaceID: String?, explicit: String?) -> String? {
         shellState.terminalProfileIDForNewTerminal(in: requestedSpaceID, explicit: explicit)
-            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+            ?? globalDefaultTerminalProfileIDForPaneCapture()
     }
 
     private func targetTerminalProfileID(forSplitFromPaneID paneID: String, explicit: String?) -> String? {
         shellState.terminalProfileIDForNewSplit(from: paneID, explicit: explicit)
-            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+            ?? globalDefaultTerminalProfileIDForPaneCapture()
     }
 
-    private func globalDefaultTerminalProfileIDForWorkingDirectoryDeferral() -> String? {
-        terminalProfileIDForWorkingDirectoryDeferral(
+    private func globalDefaultTerminalProfileIDForPaneCapture() -> String? {
+        terminalProfileIDForGlobalDefaultPaneCapture(
             channelApplicationSupportDirectoryName: windowContext.installChannel
                 .applicationSupportDirectoryName,
             fileManager: fileManager

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1256,9 +1256,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
+        let resolvedTerminalProfileID = targetTerminalProfileID(
+            in: spaceID,
+            explicit: terminalProfileID
+        )
         let resolvedWorkingDirectory =
             workingDirectory
-            ?? (targetTerminalProfileID(in: spaceID, explicit: terminalProfileID) == nil
+            ?? (resolvedTerminalProfileID == nil
                 ? focusedPaneWorkingDirectory()
                 : nil)
         return openTab(
@@ -1266,7 +1270,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             in: spaceID,
             title: title,
             workingDirectory: resolvedWorkingDirectory,
-            terminalProfileID: terminalProfileID
+            terminalProfileID: resolvedTerminalProfileID
         )
     }
 
@@ -2242,7 +2246,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 tabID: pane.tabID,
                 spaceID: pane.spaceID,
                 launchTarget: pane.launchTarget,
-                cwd: pane.cwd ?? bootProfile.workingDirectory,
+                cwd: pane.terminalProfileID == nil
+                    ? pane.cwd ?? bootProfile.workingDirectory
+                    : pane.cwd,
                 process: pane.process,
                 attention: pane.attention,
                 context: projectedContext,
@@ -3035,7 +3041,26 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
         let targetSpaceID = requestedSpaceID ?? shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
         guard let targetSpaceID else { return nil }
-        return shellState.spaces.first { $0.spaceID == targetSpaceID }?.terminalProfileID
+        if let spaceProfileID = shellState.spaces.first(where: { $0.spaceID == targetSpaceID })?
+            .terminalProfileID
+        {
+            return spaceProfileID
+        }
+        return globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
+    }
+
+    private func globalDefaultTerminalProfileIDForWorkingDirectoryDeferral() -> String? {
+        let document = TerminalProfileStore.defaultStore(
+            channelApplicationSupportDirectoryName: windowContext.installChannel
+                .applicationSupportDirectoryName,
+            fileManager: fileManager
+        ).load().document
+        guard let profile = document.defaultProfile,
+              nonEmptyWorkingDirectory(profile.defaultWorkingDirectory) != nil
+        else {
+            return nil
+        }
+        return profile.id
     }
 
     func settingsWorkspaceContext(forPaneSlotID paneSlotID: String) -> ShellSettingsWorkspaceContext {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -3047,14 +3047,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func targetTerminalProfileID(forSplitFromPaneID paneID: String, explicit: String?) -> String? {
-        if let explicit {
-            return explicit
-        }
-        guard let pane = shellState.pane(paneID: paneID) else {
-            return nil
-        }
-        return pane.terminalProfileID
-            ?? targetTerminalProfileID(in: pane.spaceID, explicit: nil)
+        shellState.terminalProfileIDForNewSplit(from: paneID, explicit: explicit)
+            ?? globalDefaultTerminalProfileIDForWorkingDirectoryDeferral()
     }
 
     private func globalDefaultTerminalProfileIDForWorkingDirectoryDeferral() -> String? {

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -82,6 +82,59 @@ struct AlanCommandResolution: Equatable {
         ([launchPath] + arguments).map(AlanShellBootProfile.shellQuoted).joined(separator: " ")
     }
 
+    func reinjectingSudoEnvironment(_ environment: [String: String]) -> AlanCommandResolution {
+        guard strategy == .terminalProfileSudoUser || strategy == .terminalProfileSudoRoot else {
+            return self
+        }
+        let assignments = Self.sudoReinjectedEnvironmentAssignments(environment)
+        guard !assignments.isEmpty else {
+            return self
+        }
+
+        let reinjectedArguments = arguments
+            + ["/usr/bin/env"]
+            + assignments
+            + ["/bin/sh", "-lc", Self.sudoLoginShellCommand]
+        let reinjectedCommand = ([launchPath] + reinjectedArguments)
+            .map(AlanShellBootProfile.shellQuoted)
+            .joined(separator: " ")
+        return AlanCommandResolution(
+            strategy: strategy,
+            executablePath: executablePath,
+            launchPath: launchPath,
+            arguments: reinjectedArguments,
+            bootCommand: reinjectedCommand,
+            surfaceCommand: reinjectedCommand,
+            summary: summary,
+            detail: detail,
+            repoRoot: repoRoot,
+            candidates: candidates,
+            terminalProfile: terminalProfile,
+            terminalProfileState: terminalProfileState
+        )
+    }
+
+    private static let sudoLoginShellCommand = "exec \"${SHELL:-/bin/zsh}\" -l"
+
+    private static let sudoReinjectedEnvironmentAllowlist: Set<String> = [
+        "COLORTERM",
+        "TERMINFO",
+        "TERM_PROGRAM",
+    ]
+
+    private static func sudoReinjectedEnvironmentAssignments(
+        _ environment: [String: String]
+    ) -> [String] {
+        environment.keys.sorted().compactMap { key in
+            guard key.hasPrefix("ALAN_") || sudoReinjectedEnvironmentAllowlist.contains(key),
+                  let value = environment[key]
+            else {
+                return nil
+            }
+            return "\(key)=\(value)"
+        }
+    }
+
     static func resolve(
         for launchTarget: ShellLaunchTarget,
         fileManager: FileManager = .default,
@@ -561,7 +614,7 @@ struct AlanShellBootProfile: Equatable {
         // model creates them. Re-reading mutable Space bindings here can recreate
         // already-mounted panes under a different Unix identity after a Space rebind.
         let terminalProfileReference = pane.terminalProfileID
-        let command = AlanCommandResolution.resolve(
+        let resolvedCommand = AlanCommandResolution.resolve(
             for: pane.resolvedLaunchTarget,
             terminalProfileReference: terminalProfileReference,
             terminalProfiles: profileDocument,
@@ -570,7 +623,7 @@ struct AlanShellBootProfile: Equatable {
         )
         let cwd =
             pane.cwd
-            ?? command.terminalProfile?.defaultWorkingDirectory
+            ?? resolvedCommand.terminalProfile?.defaultWorkingDirectory
             ?? fileManager.homeDirectoryForCurrentUser.path
         let controlPlaneRoot = alanShellControlPlaneRootURL(
             windowID: shellState.windowID,
@@ -596,8 +649,8 @@ struct AlanShellBootProfile: Equatable {
             "ALAN_SHELL_CONTENT_ID": pane.terminalContentID,
             "ALAN_SHELL_BOOT_MODE": pane.resolvedLaunchTarget.rawValue,
             "ALAN_SHELL_LAUNCH_TARGET": pane.resolvedLaunchTarget.rawValue,
-            "ALAN_SHELL_LAUNCH_STRATEGY": command.strategy.rawValue,
-            "ALAN_TERMINAL_PROFILE_STATE": command.terminalProfileState.environmentValue,
+            "ALAN_SHELL_LAUNCH_STRATEGY": resolvedCommand.strategy.rawValue,
+            "ALAN_TERMINAL_PROFILE_STATE": resolvedCommand.terminalProfileState.environmentValue,
             "ALAN_SHELL_CONTROL_DIR": controlPlaneRoot.path,
             "ALAN_SHELL_BINDING_FILE": bindingFile.path,
             "ALAN_SHELL_STATE_FILE": controlPlaneRoot.appendingPathComponent("state.json").path,
@@ -608,17 +661,17 @@ struct AlanShellBootProfile: Equatable {
         if let terminalProfileReference {
             environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"] = terminalProfileReference
         }
-        if let terminalProfile = command.terminalProfile {
+        if let terminalProfile = resolvedCommand.terminalProfile {
             environment["ALAN_TERMINAL_PROFILE_ID"] = terminalProfile.id
             environment["ALAN_TERMINAL_PROFILE_KIND"] = terminalProfile.launch.kind.rawValue
             environment["ALAN_TERMINAL_PROFILE_TITLE"] = terminalProfile.title
         }
 
-        if let executablePath = command.executablePath {
+        if let executablePath = resolvedCommand.executablePath {
             environment["ALAN_SHELL_EXECUTABLE"] = executablePath
         }
 
-        if let repoRoot = command.repoRoot {
+        if let repoRoot = resolvedCommand.repoRoot {
             environment["ALAN_REPOSITORY_ROOT"] = repoRoot
         }
 
@@ -627,6 +680,8 @@ struct AlanShellBootProfile: Equatable {
         }
         environment["TERM_PROGRAM"] = "alan"
         environment["COLORTERM"] = "truecolor"
+
+        let command = resolvedCommand.reinjectingSudoEnvironment(environment)
 
         return AlanShellBootProfile(
             command: command,

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -31,6 +31,9 @@ enum AlanLaunchStrategy: String, Equatable {
     case loginShellOverride = "login_shell_override"
     case loginShellEnv = "login_shell_env"
     case loginShellFallback = "login_shell_fallback"
+    case terminalProfileSudoUser = "terminal_profile_sudo_user"
+    case terminalProfileSudoRoot = "terminal_profile_sudo_root"
+    case terminalProfileCustomCommand = "terminal_profile_custom_command"
 }
 
 struct AlanCommandResolution: Equatable {
@@ -44,6 +47,36 @@ struct AlanCommandResolution: Equatable {
     let detail: String?
     let repoRoot: String?
     let candidates: [AlanCommandCandidate]
+    let terminalProfile: TerminalProfileDefinition?
+    let terminalProfileState: TerminalProfileResolutionState
+
+    init(
+        strategy: AlanLaunchStrategy,
+        executablePath: String?,
+        launchPath: String,
+        arguments: [String],
+        bootCommand: String,
+        surfaceCommand: String?,
+        summary: String,
+        detail: String?,
+        repoRoot: String?,
+        candidates: [AlanCommandCandidate],
+        terminalProfile: TerminalProfileDefinition? = nil,
+        terminalProfileState: TerminalProfileResolutionState = .absent
+    ) {
+        self.strategy = strategy
+        self.executablePath = executablePath
+        self.launchPath = launchPath
+        self.arguments = arguments
+        self.bootCommand = bootCommand
+        self.surfaceCommand = surfaceCommand
+        self.summary = summary
+        self.detail = detail
+        self.repoRoot = repoRoot
+        self.candidates = candidates
+        self.terminalProfile = terminalProfile
+        self.terminalProfileState = terminalProfileState
+    }
 
     var launchCommandString: String {
         ([launchPath] + arguments).map(AlanShellBootProfile.shellQuoted).joined(separator: " ")
@@ -58,6 +91,171 @@ struct AlanCommandResolution: Equatable {
         case .shell:
             return resolveShell(fileManager: fileManager, environment: environment)
         }
+    }
+
+    static func resolve(
+        for launchTarget: ShellLaunchTarget,
+        terminalProfileReference: String?,
+        terminalProfiles: TerminalProfileDocument?,
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> AlanCommandResolution {
+        let overrideCommand = environment["ALAN_SHELL_BOOT_COMMAND"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let overrideShell = environment["ALAN_SHELL_LOGIN_SHELL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if overrideCommand?.isEmpty == false || overrideShell?.isEmpty == false {
+            return resolve(for: launchTarget, fileManager: fileManager, environment: environment)
+        }
+
+        let document = terminalProfiles ?? .fallback
+        let requestedID = terminalProfileReference?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let profile =
+            requestedID.flatMap(document.profile(id:))
+            ?? (requestedID?.isEmpty == false ? nil : document.defaultProfile)
+        guard let profile else {
+            let fallback = resolve(for: launchTarget, fileManager: fileManager, environment: environment)
+            return fallback.withTerminalProfile(
+                nil,
+                state: requestedID.map { .missing(requestedID: $0) } ?? .absent
+            )
+        }
+
+        switch profile.launch {
+        case .loginShell:
+            return resolve(for: launchTarget, fileManager: fileManager, environment: environment)
+                .withTerminalProfile(profile, state: .resolved)
+        case .sudoUser(let unixUser):
+            return profileCommand(
+                profile,
+                strategy: .terminalProfileSudoUser,
+                executablePath: "/usr/bin/sudo",
+                arguments: ["-iu", unixUser],
+                fileManager: fileManager,
+                environment: environment
+            )
+        case .sudoRoot:
+            return profileCommand(
+                profile,
+                strategy: .terminalProfileSudoRoot,
+                executablePath: "/usr/bin/sudo",
+                arguments: ["-i"],
+                fileManager: fileManager,
+                environment: environment
+            )
+        case .customCommand(let command):
+            let executablePath = "/bin/zsh"
+            guard fileManager.isExecutableFile(atPath: executablePath) else {
+                let fallback = resolve(for: launchTarget, fileManager: fileManager, environment: environment)
+                return fallback.withTerminalProfile(
+                    profile,
+                    state: .unavailable(requestedID: profile.id, reason: "missing_executable")
+                )
+            }
+            return AlanCommandResolution(
+                strategy: .terminalProfileCustomCommand,
+                executablePath: executablePath,
+                launchPath: executablePath,
+                arguments: ["-lc", command],
+                bootCommand: command,
+                surfaceCommand: command,
+                summary: "Launching pane with Terminal Profile \(profile.title)",
+                detail: profile.redactedDisplayDetail,
+                repoRoot: inferredAlanRepoRoot(),
+                candidates: profileCandidates(
+                    profile,
+                    executablePath: executablePath,
+                    fileManager: fileManager,
+                    environment: environment
+                ),
+                terminalProfile: profile,
+                terminalProfileState: .resolved
+            )
+        }
+    }
+
+    private func withTerminalProfile(
+        _ profile: TerminalProfileDefinition?,
+        state: TerminalProfileResolutionState
+    ) -> AlanCommandResolution {
+        AlanCommandResolution(
+            strategy: strategy,
+            executablePath: executablePath,
+            launchPath: launchPath,
+            arguments: arguments,
+            bootCommand: bootCommand,
+            surfaceCommand: surfaceCommand,
+            summary: summary,
+            detail: detail,
+            repoRoot: repoRoot,
+            candidates: candidates,
+            terminalProfile: profile,
+            terminalProfileState: state
+        )
+    }
+
+    private static func profileCommand(
+        _ profile: TerminalProfileDefinition,
+        strategy: AlanLaunchStrategy,
+        executablePath: String,
+        arguments: [String],
+        fileManager: FileManager,
+        environment: [String: String]
+    ) -> AlanCommandResolution {
+        guard fileManager.isExecutableFile(atPath: executablePath) else {
+            let fallback = resolve(for: .shell, fileManager: fileManager, environment: environment)
+            return fallback.withTerminalProfile(
+                profile,
+                state: .unavailable(requestedID: profile.id, reason: "missing_executable")
+            )
+        }
+        let bootCommand = ([executablePath] + arguments)
+            .map(AlanShellBootProfile.shellQuoted)
+            .joined(separator: " ")
+        return AlanCommandResolution(
+            strategy: strategy,
+            executablePath: executablePath,
+            launchPath: executablePath,
+            arguments: arguments,
+            bootCommand: bootCommand,
+            surfaceCommand: bootCommand,
+            summary: "Launching pane with Terminal Profile \(profile.title)",
+            detail: profile.redactedDisplayDetail,
+            repoRoot: inferredAlanRepoRoot(),
+            candidates: profileCandidates(
+                profile,
+                executablePath: executablePath,
+                fileManager: fileManager,
+                environment: environment
+            ),
+            terminalProfile: profile,
+            terminalProfileState: .resolved
+        )
+    }
+
+    private static func profileCandidates(
+        _ profile: TerminalProfileDefinition,
+        executablePath: String,
+        fileManager: FileManager,
+        environment: [String: String]
+    ) -> [AlanCommandCandidate] {
+        [
+            AlanCommandCandidate(
+                label: "Terminal Profile",
+                path: profile.id,
+                isPresent: true
+            ),
+            AlanCommandCandidate(
+                label: "Terminal Profile executable",
+                path: executablePath,
+                isPresent: fileManager.isExecutableFile(atPath: executablePath)
+            ),
+            AlanCommandCandidate(
+                label: "SHELL env",
+                path: environment["SHELL"] ?? "(unset)",
+                isPresent: normalizedExecutablePath(environment["SHELL"], fileManager: fileManager) != nil
+            ),
+        ]
     }
 
     private static func resolveShell(
@@ -321,7 +519,10 @@ struct AlanShellBootProfile: Equatable {
     private var surfaceRecreationIdentity: SurfaceRecreationIdentity {
         SurfaceRecreationIdentity(
             launchTarget: environment["ALAN_SHELL_LAUNCH_TARGET"]
-                ?? environment["ALAN_SHELL_BOOT_MODE"]
+                ?? environment["ALAN_SHELL_BOOT_MODE"],
+            terminalProfileID: environment["ALAN_TERMINAL_PROFILE_ID"]
+                ?? environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"],
+            launchStrategy: environment["ALAN_SHELL_LAUNCH_STRATEGY"]
         )
     }
 
@@ -341,13 +542,35 @@ struct AlanShellBootProfile: Equatable {
         environment.keys.sorted().map { ($0, environment[$0] ?? "") }
     }
 
-    static func forPane(_ pane: ShellPane, shellState: ShellStateSnapshot) -> AlanShellBootProfile {
+    static func forPane(
+        _ pane: ShellPane,
+        shellState: ShellStateSnapshot,
+        terminalProfiles: TerminalProfileDocument? = nil,
+        fileManager: FileManager = .default,
+        environment processEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> AlanShellBootProfile {
+        let ghostty = GhosttyIntegrationStatus.discover()
+        let installChannel = AlanInstallChannel.current()
+        let profileDocument = terminalProfiles
+            ?? TerminalProfileStore.defaultStore(
+                channelApplicationSupportDirectoryName: installChannel.applicationSupportDirectoryName,
+                fileManager: fileManager,
+                environment: processEnvironment
+            ).load().document
+        let terminalProfileReference =
+            pane.terminalProfileID
+            ?? shellState.space(spaceID: pane.spaceID)?.terminalProfileID
+        let command = AlanCommandResolution.resolve(
+            for: pane.resolvedLaunchTarget,
+            terminalProfileReference: terminalProfileReference,
+            terminalProfiles: profileDocument,
+            fileManager: fileManager,
+            environment: processEnvironment
+        )
         let cwd =
             pane.cwd
-            ?? FileManager.default.homeDirectoryForCurrentUser.path
-        let ghostty = GhosttyIntegrationStatus.discover()
-        let command = AlanCommandResolution.resolve(for: pane.resolvedLaunchTarget)
-        let installChannel = AlanInstallChannel.current()
+            ?? command.terminalProfile?.defaultWorkingDirectory
+            ?? fileManager.homeDirectoryForCurrentUser.path
         let controlPlaneRoot = alanShellControlPlaneRootURL(
             windowID: shellState.windowID,
             channel: installChannel
@@ -373,12 +596,22 @@ struct AlanShellBootProfile: Equatable {
             "ALAN_SHELL_BOOT_MODE": pane.resolvedLaunchTarget.rawValue,
             "ALAN_SHELL_LAUNCH_TARGET": pane.resolvedLaunchTarget.rawValue,
             "ALAN_SHELL_LAUNCH_STRATEGY": command.strategy.rawValue,
+            "ALAN_TERMINAL_PROFILE_STATE": command.terminalProfileState.environmentValue,
             "ALAN_SHELL_CONTROL_DIR": controlPlaneRoot.path,
             "ALAN_SHELL_BINDING_FILE": bindingFile.path,
             "ALAN_SHELL_STATE_FILE": controlPlaneRoot.appendingPathComponent("state.json").path,
             "ALAN_SHELL_COMMANDS_DIR": controlPlaneRoot.appendingPathComponent("commands").path,
             "ALAN_SHELL_RESULTS_DIR": controlPlaneRoot.appendingPathComponent("results").path,
         ]
+
+        if let terminalProfileReference {
+            environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"] = terminalProfileReference
+        }
+        if let terminalProfile = command.terminalProfile {
+            environment["ALAN_TERMINAL_PROFILE_ID"] = terminalProfile.id
+            environment["ALAN_TERMINAL_PROFILE_KIND"] = terminalProfile.launch.kind.rawValue
+            environment["ALAN_TERMINAL_PROFILE_TITLE"] = terminalProfile.title
+        }
 
         if let executablePath = command.executablePath {
             environment["ALAN_SHELL_EXECUTABLE"] = executablePath
@@ -411,6 +644,8 @@ struct AlanShellBootProfile: Equatable {
 
 private struct SurfaceRecreationIdentity: Equatable {
     let launchTarget: String?
+    let terminalProfileID: String?
+    let launchStrategy: String?
 }
 
 enum TerminalRuntimeRenderPriority: Int, Codable, Equatable, CaseIterable, Comparable {

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -557,9 +557,10 @@ struct AlanShellBootProfile: Equatable {
                 fileManager: fileManager,
                 environment: processEnvironment
             ).load().document
-        let terminalProfileReference =
-            pane.terminalProfileID
-            ?? shellState.space(spaceID: pane.spaceID)?.terminalProfileID
+        // New panes capture Space defaults into `terminalProfileID` when the shell
+        // model creates them. Re-reading mutable Space bindings here can recreate
+        // already-mounted panes under a different Unix identity after a Space rebind.
+        let terminalProfileReference = pane.terminalProfileID
         let command = AlanCommandResolution.resolve(
             for: pane.resolvedLaunchTarget,
             terminalProfileReference: terminalProfileReference,

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -1014,6 +1014,12 @@ private struct ShellSidebarSpaceHeader: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.82))
                 .lineLimit(1)
+
+            Spacer(minLength: 4)
+
+            if let space {
+                terminalProfileMenu(for: space)
+            }
         }
         .padding(.horizontal, ShellSidebarMetrics.rowInset)
         .padding(.vertical, 5)
@@ -1039,6 +1045,73 @@ private struct ShellSidebarSpaceHeader: View {
         }
 
         return "terminal"
+    }
+
+    private func terminalProfileMenu(for space: ShellSpace) -> some View {
+        let profiles = TerminalProfileStore.defaultStore().load().profiles
+        let current = profiles.first { $0.id == space.terminalProfileID }
+        return Menu {
+            Button("Default") {
+                _ = host.setTerminalProfile(nil, forSpaceID: space.spaceID)
+            }
+
+            ForEach(profiles, id: \.id) { profile in
+                Button(profileMenuTitle(profile)) {
+                    _ = host.setTerminalProfile(profile.id, forSpaceID: space.spaceID)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: currentProfileSymbol(space: space, profile: current))
+                    .font(.system(size: 10, weight: .semibold))
+                if let current {
+                    Text(current.title)
+                        .font(.system(size: 10, weight: .medium))
+                        .lineLimit(1)
+                }
+            }
+            .foregroundStyle(profileForegroundStyle(space: space, profile: current))
+            .frame(maxWidth: 96, alignment: .trailing)
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private func profileMenuTitle(_ profile: TerminalProfileDefinition) -> String {
+        "\(profile.title) · \(profile.launch.kind.rawValue)"
+    }
+
+    private func currentProfileSymbol(
+        space: ShellSpace,
+        profile: TerminalProfileDefinition?
+    ) -> String {
+        guard let profile else {
+            return space.terminalProfileID == nil ? "terminal" : "questionmark.circle"
+        }
+        switch profile.launch {
+        case .loginShell:
+            return "terminal"
+        case .sudoUser:
+            return "person.crop.circle"
+        case .sudoRoot:
+            return "exclamationmark.triangle"
+        case .customCommand:
+            return "chevron.left.forwardslash.chevron.right"
+        }
+    }
+
+    private func profileForegroundStyle(
+        space: ShellSpace,
+        profile: TerminalProfileDefinition?
+    ) -> Color {
+        if space.terminalProfileID != nil, profile == nil {
+            return .orange
+        }
+        if profile?.launch == .sudoRoot {
+            return .red
+        }
+        return ShellPalette.sidebarMutedInk.opacity(0.72)
     }
 
     private func contentIconName(for content: ShellContentInstance) -> String {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7933,8 +7933,8 @@ private enum ShellRuntimeMetadataTests {
             terminalProfiles: profiles
         )
         expect(
-            unreadableSudoersState.sudoers == .alanOwnedValid(path: rule.filePath),
-            "installed root-owned sudoers drop-ins may be unreadable to the GUI user but still discoverable"
+            unreadableSudoersState.sudoers == .existingUnreadable(path: rule.filePath),
+            "installed root-owned sudoers drop-ins may be unreadable without being classified as Alan-owned"
         )
         let unreadableReadiness = ManagedTerminalAccountReadinessVerifier.verify(
             request: request,
@@ -7957,6 +7957,19 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !unreadableReadyPlan.steps.map(\.kind).contains(.writeSudoersDropIn),
             "ready unreadable sudoers discovery must not keep reporting sudoers repair work"
+        )
+        let unreadableFailedPlan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: unreadableSudoersState.account,
+                sudoers: unreadableSudoersState.sudoers,
+                terminalProfile: unreadableSudoersState.terminalProfile,
+                verification: .failed(step: .nonInteractiveSudo, message: "sudo requires password")
+            )
+        )
+        expect(
+            unreadableFailedPlan.steps.map(\.kind).contains(.writeSudoersDropIn),
+            "unreadable sudoers discovery with failed terminal-entry verification must schedule repair"
         )
 
         let invalidSudoers = ManagedTerminalAccountSudoersValidator.validate(
@@ -7982,13 +7995,31 @@ private enum ShellRuntimeMetadataTests {
         )
 
         let privilegedRunner = CapturingPrivilegedCommandRunner()
+        let localRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("alan-managed-terminal-account-effects-\(UUID().uuidString)", isDirectory: true)
+        let localStore = TerminalProfileStore(
+            fileManager: FileManager.default,
+            storeURL: localRoot.appendingPathComponent("terminal-profiles.json")
+        )
+        var boundProfileID: String?
         let executor = ManagedTerminalAccountAuthorizedScriptExecutor(
             request: request,
             commandRunner: privilegedRunner,
+            localEffectExecutor: ManagedTerminalAccountTerminalProfileEffectExecutor(
+                store: localStore,
+                currentSpaceBinder: { profileID in
+                    boundProfileID = profileID
+                    return true
+                }
+            ),
             passwordGenerator: { "SECRET-PASSWORD" }
         )
         let plan = ManagedTerminalAccountPlanner.plan(
-            request: request,
+            request: ManagedTerminalAccountRequest(
+                accountName: "alan",
+                guiUserName: "morris",
+                bindCurrentSpaceAfterSuccess: true
+            ),
             state: ManagedTerminalAccountState(
                 account: .missing,
                 sudoers: .missing,
@@ -8019,6 +8050,19 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !sudoersScript.contains("/tmp/\(rule.fileName).sudoers"),
             "authorized executor must not write sudoers content through a deterministic /tmp path"
+        )
+        let managedProfile = localStore.load().document.profile(id: "alan")
+        expect(
+            managedProfile?.managedTerminalAccountID == "alan",
+            "authorized executor must create the managed Terminal Profile handoff"
+        )
+        expect(
+            managedProfile?.launch == .sudoUser(unixUser: "alan"),
+            "authorized executor profile handoff must use sudo_user launch"
+        )
+        expect(
+            boundProfileID == "alan",
+            "authorized executor must route bind-current-space handoff through the injected binder"
         )
     }
 
@@ -8080,6 +8124,39 @@ private enum ShellRuntimeMetadataTests {
         expect(
             destructive.status == .requiresDestructiveConfirmation,
             "account/home deletion must require separate destructive confirmation"
+        )
+
+        let rollbackStoreURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-managed-terminal-account-rollback-\(UUID().uuidString).json")
+        let rollbackStore = TerminalProfileStore(fileManager: .default, storeURL: rollbackStoreURL)
+        let managedProfile = TerminalProfileDefinition(
+            id: "alan",
+            title: "Alan",
+            launch: .sudoUser(unixUser: "alan"),
+            defaultWorkingDirectory: "/Users/alan",
+            presentation: nil,
+            managedTerminalAccountID: "alan"
+        )
+        do {
+            try rollbackStore.save(
+                TerminalProfileDocument(defaultProfileID: "alan", profiles: [managedProfile])
+            )
+        } catch {
+            fail("rollback profile store setup must save: \(error)")
+        }
+        let rollbackExecutor = ManagedTerminalAccountAuthorizedScriptExecutor(
+            request: request,
+            commandRunner: CapturingPrivilegedCommandRunner(),
+            localEffectExecutor: ManagedTerminalAccountTerminalProfileEffectExecutor(store: rollbackStore)
+        )
+        let rollbackResult = rollbackExecutor.apply(rollback)
+        expect(
+            rollbackResult.completedSteps.contains(.removeManagedTerminalProfile),
+            "authorized executor rollback must execute managed Terminal Profile removal"
+        )
+        expect(
+            rollbackStore.load().document.profile(id: "alan") == nil,
+            "managed Terminal Profile rollback must remove the Alan-owned profile"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7568,7 +7568,7 @@ private enum ShellRuntimeMetadataTests {
                                         payload: .terminal(
                                             ShellTerminalContentPayload(
                                                 launchTarget: .shell,
-                                                cwd: "/Users/alan",
+                                                cwd: nil,
                                                 title: "Alan shell",
                                                 terminalProfileID: "alan"
                                             )
@@ -7621,8 +7621,16 @@ private enum ShellRuntimeMetadataTests {
             "materialized pane must preserve terminal profile reference"
         )
         expect(
+            state.pane(paneID: "pane_1")?.cwd == nil,
+            "materialized profile pane must preserve nil cwd so the profile default working directory can win"
+        )
+        expect(
             state.contentStateProjection().content(contentID: "content_pane_1")?.payload.terminal?.terminalProfileID == "alan",
             "content projection must preserve terminal profile reference"
+        )
+        expect(
+            state.contentStateProjection().content(contentID: "content_pane_1")?.payload.terminal?.cwd == nil,
+            "content projection must preserve nil cwd for profile-bound panes"
         )
 
         let legacyJSON = """

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8763,6 +8763,7 @@ private enum ShellRuntimeMetadataTests {
 
     private static func verifiesManagedTerminalAccountExecutorAndRollbackSafety() {
         let request = ManagedTerminalAccountRequest(accountName: "alan", guiUserName: "morris")
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
         let plan = ManagedTerminalAccountPlanner.plan(
             request: request,
             state: ManagedTerminalAccountState(
@@ -8804,6 +8805,43 @@ private enum ShellRuntimeMetadataTests {
         expect(
             !rollback.steps.map(\.kind).contains(.deleteHomeDirectory),
             "ordinary rollback must not delete home"
+        )
+
+        let unreadableRollback = ManagedTerminalAccountPlanner.rollbackPlan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .existingUnreadable(path: rule.filePath),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .passed
+            ),
+            scope: .alanIntegrationOnly
+        )
+        expect(
+            unreadableRollback.steps.map(\.kind) == [.removeSudoersDropIn, .removeManagedTerminalProfile],
+            "ordinary rollback must remove unreadable Alan sudoers integration"
+        )
+        let unreadableRollbackRunner = CapturingPrivilegedCommandRunner()
+        let unreadableRollbackExecutor = ManagedTerminalAccountAuthorizedScriptExecutor(
+            request: request,
+            commandRunner: unreadableRollbackRunner,
+            localEffectExecutor: ManagedTerminalAccountTerminalProfileEffectExecutor()
+        )
+        _ = unreadableRollbackExecutor.apply(unreadableRollback)
+        let unreadableRemoveScript = unreadableRollbackRunner.scripts.first {
+            $0.contains(rule.filePath) && $0.contains("cmp -s")
+        } ?? ""
+        expect(
+            unreadableRemoveScript.contains(rule.contents),
+            "unreadable sudoers rollback must verify the expected Alan rule before deleting"
+        )
+        expect(
+            unreadableRemoveScript.contains("mktemp -d"),
+            "unreadable sudoers rollback must use a private temp file for verification"
+        )
+        expect(
+            unreadableRemoveScript.contains("Refusing to remove sudoers drop-in"),
+            "unreadable sudoers rollback must fail closed on unexpected contents"
         )
 
         let destructive = ManagedTerminalAccountPlanner.rollbackPlan(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7984,6 +7984,68 @@ private enum ShellRuntimeMetadataTests {
             localPane?.cwd == nil,
             "local tab.open using the global default profile must let the profile cwd win"
         )
+
+        let localSpaceResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-space-global-default-profile",
+                  "command": "space.create"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_space_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        let localSpacePane = localSpaceResult?.updatedState?.pane(
+            paneID: localSpaceResult?.response.paneID ?? ""
+        )
+        expect(localSpaceResult?.response.applied == true, "local space.create must apply")
+        expect(
+            localSpaceResult?.response.spaceID.flatMap {
+                localSpaceResult?.updatedState?.space(spaceID: $0)
+            }?.terminalProfileID == "alan",
+            "local space.create must bind the global default terminal profile"
+        )
+        expect(
+            localSpacePane?.terminalProfileID == "alan",
+            "local space.create must apply the global default profile to the first pane"
+        )
+        expect(
+            localSpacePane?.cwd == nil,
+            "local space.create using the global default profile must let the profile cwd win"
+        )
+
+        let localSplitResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-split-global-default-profile",
+                  "command": "pane.split",
+                  "pane_id": "pane_1",
+                  "direction": "horizontal"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_split_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        let localSplitPane = localSplitResult?.updatedState?.pane(
+            paneID: localSplitResult?.response.paneID ?? ""
+        )
+        expect(localSplitResult?.response.applied == true, "local pane.split must apply")
+        expect(
+            localSplitPane?.terminalProfileID == "alan",
+            "local pane.split must capture the global default terminal profile"
+        )
+        expect(
+            localSplitPane?.cwd == nil,
+            "local pane.split using the global default profile must let the profile cwd win"
+        )
     }
 
     private static func verifiesTerminalProfileControlPlaneOverrides() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8152,6 +8152,23 @@ private enum ShellRuntimeMetadataTests {
             unmanagedSudoersPlan.status == .sudoersConflict(path: sudoers.filePath),
             "unmanaged sudoers files must surface as conflicts"
         )
+        let unmanagedTerminalProfilePlan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: sudoers.filePath),
+                terminalProfile: .existingUnmanaged(profileID: "alan"),
+                verification: .passed
+            )
+        )
+        expect(
+            !unmanagedTerminalProfilePlan.steps.map(\.kind).contains(.createOrUpdateTerminalProfile),
+            "unmanaged Terminal Profiles must not be overwritten by a generic repair plan"
+        )
+        expect(
+            unmanagedTerminalProfilePlan.status == .terminalProfileConflict(profileID: "alan"),
+            "unmanaged Terminal Profiles must surface as conflicts"
+        )
 
         let invalid = ManagedTerminalAccountRequest(accountName: "root", guiUserName: "morris")
         expect(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -155,6 +155,15 @@ private enum ShellRuntimeMetadataTests {
         verifiesWorkspaceManifestSyncCapturesLiveTerminalTranscript()
         verifiesTabOrganizationPersistsOrderPinAndSpaceOwnership()
         verifiesManifestActiveTaskProjection()
+        verifiesTerminalProfileStoreFallbackValidationAndCorruptRecovery()
+        verifiesTerminalProfileLaunchResolutionAndEnvironmentProjection()
+        verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip()
+        verifiesTerminalProfileInheritanceForSpacesTabsAndSplits()
+        verifiesTerminalProfileControlPlaneOverrides()
+        verifiesTerminalProfileSettingsRowsStaySeparateFromProviderAccounts()
+        verifiesManagedTerminalAccountPlannerSudoersAndProfileHandoff()
+        verifiesManagedTerminalAccountDiscoveryVerificationAndAuthorizedExecutor()
+        verifiesManagedTerminalAccountExecutorAndRollbackSafety()
         print("Shell runtime metadata tests passed.")
     }
 
@@ -7041,6 +7050,885 @@ private enum ShellRuntimeMetadataTests {
         expect(activeTask(in: alanPendingURL) == .alanPendingYield, "alan pending yield must protect tab")
     }
 
+    private static func verifiesTerminalProfileStoreFallbackValidationAndCorruptRecovery() {
+        let fileManager = FileManager.default
+        let root = temporaryDirectory(named: "terminal-profile-store")
+        defer { try? fileManager.removeItem(at: root) }
+        let storeURL = root.appendingPathComponent("terminal-profiles.json")
+        let store = TerminalProfileStore(fileManager: fileManager, storeURL: storeURL)
+
+        let missingLoad = store.load()
+        expect(
+            missingLoad.document.defaultProfileID == TerminalProfileDefinition.loginShellFallback.id,
+            "missing profile store must use login-shell fallback"
+        )
+        expect(
+            missingLoad.profiles.first?.launch.kind == .loginShell,
+            "missing profile store must provide login-shell launch"
+        )
+
+        let alan = TerminalProfileDefinition(
+            id: "alan",
+            title: "Alan",
+            launch: .sudoUser(unixUser: "alan"),
+            defaultWorkingDirectory: "/Users/alan",
+            presentation: TerminalProfilePresentation(
+                symbolName: "person.crop.circle",
+                colorName: "green"
+            )
+        )
+        let custom = TerminalProfileDefinition(
+            id: "bootstrap",
+            title: "Bootstrap",
+            launch: .customCommand("echo token=redacted"),
+            defaultWorkingDirectory: nil,
+            presentation: nil
+        )
+        expect(
+            (try? store.save(TerminalProfileDocument(defaultProfileID: "alan", profiles: [alan, custom]))) != nil,
+            "valid profile document must save"
+        )
+        let savedLoad = store.load()
+        expect(savedLoad.document.defaultProfileID == "alan", "saved default terminal profile must round-trip")
+        expect(
+            savedLoad.profile(id: "bootstrap")?.redactedDisplayDetail == "Custom command",
+            "custom command summary must stay redacted"
+        )
+
+        let invalid = TerminalProfileDefinition(
+            id: "bad",
+            title: "Bad",
+            launch: .sudoUser(unixUser: ""),
+            defaultWorkingDirectory: nil,
+            presentation: nil
+        )
+        let validation = TerminalProfileValidator.validate(
+            TerminalProfileDocument(defaultProfileID: "bad", profiles: [invalid])
+        )
+        expect(
+            validation.errors.contains(.missingUnixUser("bad")),
+            "sudo_user profile without Unix user must be rejected"
+        )
+
+        try? "not json".write(to: storeURL, atomically: true, encoding: .utf8)
+        let corruptLoad = store.load()
+        expect(
+            corruptLoad.recovery?.kind == .corruptStoreQuarantined,
+            "corrupt profile store must be quarantined"
+        )
+        expect(
+            fileManager.fileExists(atPath: corruptLoad.recovery?.evidenceURL.path ?? ""),
+            "corrupt evidence file must be preserved"
+        )
+        expect(
+            corruptLoad.document.profiles == [TerminalProfileDefinition.loginShellFallback],
+            "corrupt profile store must fall back to login shell"
+        )
+    }
+
+    private static func verifiesTerminalProfileLaunchResolutionAndEnvironmentProjection() {
+        let document = TerminalProfileDocument(
+            defaultProfileID: "alan",
+            profiles: [
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil
+                ),
+                TerminalProfileDefinition(
+                    id: "root",
+                    title: "Root",
+                    launch: .sudoRoot,
+                    defaultWorkingDirectory: nil,
+                    presentation: nil
+                ),
+                TerminalProfileDefinition(
+                    id: "custom",
+                    title: "Custom",
+                    launch: .customCommand("echo hello"),
+                    defaultWorkingDirectory: "/tmp",
+                    presentation: nil
+                ),
+            ]
+        )
+        let executableFileManager = AlwaysExecutableFileManager()
+
+        let sudo = AlanCommandResolution.resolve(
+            for: .shell,
+            terminalProfileReference: "alan",
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(sudo.terminalProfile?.id == "alan", "sudo user resolution must keep profile id")
+        expect(sudo.launchPath == "/usr/bin/sudo", "sudo user profile must launch sudo directly")
+        expect(sudo.arguments == ["-iu", "alan"], "sudo user profile must use structured sudo arguments")
+        expect(
+            sudo.surfaceCommand == "'/usr/bin/sudo' '-iu' 'alan'",
+            "sudo user profile must pass command through Ghostty surface config"
+        )
+
+        let root = AlanCommandResolution.resolve(
+            for: .shell,
+            terminalProfileReference: "root",
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(root.arguments == ["-i"], "sudo root profile must use structured sudo -i")
+
+        let custom = AlanCommandResolution.resolve(
+            for: .shell,
+            terminalProfileReference: "custom",
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            custom.launchPath == "/bin/zsh" && custom.arguments == ["-lc", "echo hello"],
+            "custom command profile must use login-shell runner"
+        )
+        expect(custom.surfaceCommand == "echo hello", "custom command must remain the Ghostty command payload")
+
+        let missing = AlanCommandResolution.resolve(
+            for: .shell,
+            terminalProfileReference: "lab",
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            missing.terminalProfileState == .missing(requestedID: "lab"),
+            "missing profile must be reported"
+        )
+        expect(missing.strategy == .loginShellEnv, "missing profile must fall back to login shell")
+
+        let pane = ShellPane(
+            paneID: "pane_profile",
+            tabID: "tab_profile",
+            spaceID: "space_profile",
+            launchTarget: .shell,
+            cwd: nil,
+            process: nil,
+            attention: .active,
+            context: nil,
+            viewport: nil,
+            alanBinding: nil,
+            terminalProfileID: "alan"
+        )
+        let state = ShellStateSnapshot.bootstrapDefault(windowID: "window_profile")
+        let boot = AlanShellBootProfile.forPane(
+            pane,
+            shellState: state,
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            boot.environment["ALAN_TERMINAL_PROFILE_ID"] == "alan",
+            "boot environment must expose terminal profile id"
+        )
+        expect(
+            boot.environment["ALAN_TERMINAL_PROFILE_KIND"] == "sudo_user",
+            "boot environment must expose terminal profile kind"
+        )
+        expect(
+            boot.environment["ALAN_TERMINAL_PROFILE_STATE"] == "resolved",
+            "boot environment must expose resolved profile state"
+        )
+        expect(
+            boot.workingDirectory == "/Users/alan",
+            "profile default working directory must apply when pane cwd is absent"
+        )
+
+        let projectedContext = ShellPaneProjectionService(fileManager: executableFileManager)
+            .projectedContext(
+                for: pane,
+                bootProfile: boot,
+                workingDirectory: nil,
+                processExited: nil,
+                lastCommandExitCode: nil,
+                lastMetadataAt: nil,
+                existing: nil
+            )
+        expect(
+            projectedContext.terminalProfileState == "resolved",
+            "pane context must expose resolved terminal profile state"
+        )
+        expect(
+            projectedContext.terminalProfileID == "alan",
+            "pane context must expose resolved terminal profile id"
+        )
+        expect(
+            projectedContext.terminalProfileKind == "sudo_user",
+            "pane context must expose terminal profile launch kind"
+        )
+
+        let missingPane = ShellPane(
+            paneID: "pane_missing_profile",
+            tabID: "tab_profile",
+            spaceID: "space_profile",
+            launchTarget: .shell,
+            cwd: nil,
+            process: nil,
+            attention: .active,
+            context: nil,
+            viewport: nil,
+            alanBinding: nil,
+            terminalProfileID: "lab"
+        )
+        let missingBoot = AlanShellBootProfile.forPane(
+            missingPane,
+            shellState: state,
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        let missingContext = ShellPaneProjectionService(fileManager: executableFileManager)
+            .projectedContext(
+                for: missingPane,
+                bootProfile: missingBoot,
+                workingDirectory: nil,
+                processExited: nil,
+                lastCommandExitCode: nil,
+                lastMetadataAt: nil,
+                existing: nil
+            )
+        expect(
+            missingContext.terminalProfileState == "missing",
+            "pane context must expose missing terminal profile state"
+        )
+        expect(
+            missingContext.terminalProfileRequestedID == "lab",
+            "pane context must preserve missing terminal profile id"
+        )
+        expect(
+            missingContext.terminalProfileID == nil,
+            "missing profile fallback must not claim a resolved profile id"
+        )
+    }
+
+    private static func verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip() {
+        let now = Date(timeIntervalSince1970: 2_001)
+        let manifest = ShellContentWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: "window_profiles",
+            selectedSpaceID: "space_main",
+            selectedTabID: "tab_main",
+            spaces: [
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Alan",
+                    order: 0,
+                    createdAt: now,
+                    updatedAt: now,
+                    tabs: [
+                        ShellContentWorkspaceTabRecord(
+                            tabID: "tab_main",
+                            title: "Shell",
+                            kind: .terminal,
+                            createdAt: now,
+                            lastActivatedAt: now,
+                            lastActivityAt: now,
+                            isPinned: false,
+                            pinSnapshot: nil,
+                            liveSnapshot: ShellContentTabRestoreSnapshot(
+                                paneTree: ShellPaneSlotTreeNode(
+                                    nodeID: "node_pane_1",
+                                    kind: .pane,
+                                    direction: nil,
+                                    paneSlotID: "pane_1",
+                                    children: nil
+                                ),
+                                paneSlots: [
+                                    ShellPaneSlotRestoreRecord(
+                                        paneSlotID: "pane_1",
+                                        contentID: "content_pane_1"
+                                    )
+                                ],
+                                contents: [
+                                    ShellContentRestoreRecord(
+                                        contentID: "content_pane_1",
+                                        kind: .terminal,
+                                        title: "Alan shell",
+                                        payload: .terminal(
+                                            ShellTerminalContentPayload(
+                                                launchTarget: .shell,
+                                                cwd: "/Users/alan",
+                                                title: "Alan shell",
+                                                terminalProfileID: "alan"
+                                            )
+                                        )
+                                    )
+                                ]
+                            ),
+                            activeTask: .inactive
+                        )
+                    ],
+                    terminalProfileID: "alan"
+                )
+            ]
+        )
+
+        let data = try? JSONEncoder().encode(manifest)
+        guard let data,
+              let decoded = try? JSONDecoder().decode(ShellContentWorkspaceManifest.self, from: data)
+        else {
+            fail("profile manifest must encode and decode")
+        }
+        expect(
+            decoded.spaces.first?.terminalProfileID == "alan",
+            "space terminal_profile_id must round-trip"
+        )
+        let payload = terminalPayload(
+            in: decoded.spaces.first?.tabs.first?.liveSnapshot,
+            contentID: "content_pane_1"
+        )
+        expect(
+            payload?.terminalProfileID == "alan",
+            "terminal content terminal_profile_id must round-trip"
+        )
+
+        let json = String(decoding: data, as: UTF8.self)
+        expect(!json.contains("sudo -iu"), "workspace manifest must not embed terminal profile command definitions")
+        expect(!json.contains("unix_user"), "workspace manifest must not embed terminal profile Unix-user definitions")
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: decoded,
+            defaultWorkingDirectory: "/Users/morris",
+            now: now
+        )
+        expect(
+            state.space(spaceID: "space_main")?.terminalProfileID == "alan",
+            "materialized space must preserve missing local profile reference"
+        )
+        expect(
+            state.pane(paneID: "pane_1")?.terminalProfileID == "alan",
+            "materialized pane must preserve terminal profile reference"
+        )
+        expect(
+            state.contentStateProjection().content(contentID: "content_pane_1")?.payload.terminal?.terminalProfileID == "alan",
+            "content projection must preserve terminal profile reference"
+        )
+
+        let legacyJSON = """
+        {"schema_version":1,"content_contract_version":"\(ShellContentStateSnapshot.currentContractVersion)","window_id":"legacy","selected_space_id":null,"selected_tab_id":null,"spaces":[]}
+        """
+        expect(
+            (try? JSONDecoder().decode(ShellContentWorkspaceManifest.self, from: Data(legacyJSON.utf8))) != nil,
+            "old manifest without terminal_profile_id must decode"
+        )
+    }
+
+    private static func verifiesTerminalProfileInheritanceForSpacesTabsAndSplits() {
+        let now = Date(timeIntervalSince1970: 2_100)
+        let base = ShellStateSnapshot.bootstrapDefault(
+            windowID: "window_inheritance",
+            workingDirectory: "/Users/morris"
+        )
+        let createdSpace = base.creatingTerminalSpace(
+            title: "Alan",
+            workingDirectory: nil,
+            terminalProfileID: "alan",
+            now: now
+        ).state
+        guard let alanSpaceID = createdSpace.focusedSpaceID,
+              let alanPaneID = createdSpace.focusedPaneID
+        else {
+            fail("space creation must focus new terminal content")
+        }
+        expect(
+            createdSpace.space(spaceID: alanSpaceID)?.terminalProfileID == "alan",
+            "new space must bind selected profile"
+        )
+        expect(
+            createdSpace.pane(paneID: alanPaneID)?.terminalProfileID == "alan",
+            "first terminal in profile-bound space must use profile"
+        )
+
+        let inheritedTab = try? createdSpace.openingTerminalTab(
+            in: alanSpaceID,
+            title: nil,
+            workingDirectory: nil,
+            now: now
+        ).state
+        expect(
+            inheritedTab?.pane(paneID: inheritedTab?.focusedPaneID ?? "")?.terminalProfileID == "alan",
+            "new tab must inherit space profile"
+        )
+
+        let overrideTab = try? createdSpace.openingTerminalTab(
+            in: alanSpaceID,
+            title: nil,
+            workingDirectory: nil,
+            terminalProfileID: "root",
+            now: now
+        ).state
+        expect(
+            overrideTab?.pane(paneID: overrideTab?.focusedPaneID ?? "")?.terminalProfileID == "root",
+            "explicit tab profile must override space profile"
+        )
+
+        let split = try? createdSpace.splittingPane(
+            alanPaneID,
+            placement: .right,
+            now: now
+        ).state
+        expect(
+            split?.pane(paneID: split?.focusedPaneID ?? "")?.terminalProfileID == "alan",
+            "split must inherit focused pane profile"
+        )
+
+        let rebound = createdSpace.settingTerminalProfile("univer", forSpaceID: alanSpaceID)
+        expect(
+            rebound?.pane(paneID: alanPaneID)?.terminalProfileID == "alan",
+            "space binding changes must not rewrite existing panes"
+        )
+        let reboundTab = try? rebound?.openingTerminalTab(
+            in: alanSpaceID,
+            title: nil,
+            workingDirectory: nil,
+            now: now
+        ).state
+        expect(
+            reboundTab?.pane(paneID: reboundTab?.focusedPaneID ?? "")?.terminalProfileID == "univer",
+            "new tabs after binding change must use new profile"
+        )
+    }
+
+    private static func verifiesTerminalProfileControlPlaneOverrides() {
+        let controller = makeController()
+        let createSpaceResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "space-profile",
+                  "command": "space.create",
+                  "title": "Root",
+                  "terminal_profile_id": "root"
+                }
+                """
+            )
+        )
+        expect(createSpaceResponse.applied == true, "space.create with terminal_profile_id must apply")
+        guard let createdSpaceID = createSpaceResponse.spaceID,
+              let createdPaneID = createSpaceResponse.paneID
+        else {
+            fail("space.create must return created ids")
+        }
+        expect(
+            controller.shellState.space(spaceID: createdSpaceID)?.terminalProfileID == "root",
+            "space.create must bind terminal profile to the new Space"
+        )
+        expect(
+            controller.shellState.pane(paneID: createdPaneID)?.terminalProfileID == "root",
+            "space.create must apply terminal profile to first terminal"
+        )
+
+        let bindResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "space-bind-profile",
+                  "command": "space.set_terminal_profile",
+                  "space_id": "\(createdSpaceID)",
+                  "terminal_profile_id": "univer"
+                }
+                """
+            )
+        )
+        expect(bindResponse.applied == true, "space.set_terminal_profile must apply")
+        expect(
+            controller.shellState.space(spaceID: createdSpaceID)?.terminalProfileID == "univer",
+            "space.set_terminal_profile must update the Space binding"
+        )
+        expect(
+            controller.shellState.pane(paneID: createdPaneID)?.terminalProfileID == "root",
+            "space.set_terminal_profile must not retroactively rewrite existing terminals"
+        )
+
+        let tabResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "tab-profile",
+                  "command": "tab.open",
+                  "space_id": "\(createdSpaceID)",
+                  "terminal_profile_id": "alan"
+                }
+                """
+            )
+        )
+        expect(tabResponse.applied == true, "tab.open terminal_profile_id override must apply")
+        expect(
+            controller.shellState.pane(paneID: tabResponse.paneID ?? "")?.terminalProfileID == "alan",
+            "tab.open explicit terminal_profile_id must override Space profile"
+        )
+
+        let splitResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "split-profile",
+                  "command": "pane.split",
+                  "pane_id": "\(tabResponse.paneID ?? createdPaneID)",
+                  "direction": "horizontal",
+                  "terminal_profile_id": "lab"
+                }
+                """
+            )
+        )
+        expect(splitResponse.applied == true, "pane.split terminal_profile_id override must apply")
+        expect(
+            controller.shellState.pane(paneID: splitResponse.paneID ?? "")?.terminalProfileID == "lab",
+            "pane.split explicit terminal_profile_id must override inherited profile"
+        )
+    }
+
+    private static func verifiesTerminalProfileSettingsRowsStaySeparateFromProviderAccounts() {
+        let terminalProfiles = TerminalProfileSettingsSummary(
+            profiles: [
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil
+                ),
+                TerminalProfileDefinition(
+                    id: "custom",
+                    title: "Bootstrap",
+                    launch: .customCommand("echo hidden-secret"),
+                    defaultWorkingDirectory: nil,
+                    presentation: nil
+                ),
+            ],
+            defaultProfileID: "alan",
+            recoveryMessage: nil
+        )
+        let terminalAccounts = ManagedTerminalAccountSettingsSummary(
+            plans: [
+                ManagedTerminalAccountPlanner.plan(
+                    request: ManagedTerminalAccountRequest(accountName: "alan", guiUserName: "morris"),
+                    state: ManagedTerminalAccountState(
+                        account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                        sudoers: .alanOwnedValid(path: "/etc/sudoers.d/alan-terminal-morris-to-alan"),
+                        terminalProfile: .existingManaged(profileID: "alan"),
+                        verification: .passed
+                    )
+                )
+            ]
+        )
+        let snapshot = ShellSettingsSurfaceSnapshot.make(
+            remote: .unavailable(reason: "Daemon unavailable"),
+            local: .current(),
+            terminalProfiles: terminalProfiles,
+            managedTerminalAccounts: terminalAccounts
+        )
+        let sectionTitles = snapshot.sections.map(\.title)
+        expect(sectionTitles.contains("Terminal Profiles"), "Settings must include Terminal Profiles as local startup configuration")
+        expect(sectionTitles.contains("Terminal Accounts"), "Settings must include Managed Terminal Account provisioning")
+        expect(
+            snapshot.sections.first(where: { $0.id == .accounts })?.visibleText.contains("Alan") == false,
+            "Terminal Profiles must not be listed under provider Accounts"
+        )
+        let visibleText = snapshot.visibleText.joined(separator: " ")
+        expect(!visibleText.contains("echo hidden-secret"), "normal Settings rows must redact full custom commands")
+        expect(!visibleText.lowercased().contains("autologin"), "Settings copy must avoid GUI autologin wording")
+        expect(visibleText.contains("terminal entry"), "Settings copy must describe terminal account entry")
+
+        let invalidDraft = TerminalProfileEditorDraft(
+            id: "alan",
+            title: "Alan",
+            launchKind: .sudoUser
+        )
+        expect(
+            TerminalProfileEditor.makeDefinition(from: invalidDraft).errors.contains(.missingUnixUser("alan")),
+            "Terminal Profile editor must validate structured sudo_user fields"
+        )
+
+        let customDraft = TerminalProfileEditorDraft(
+            id: "bootstrap",
+            title: "Bootstrap",
+            launchKind: .customCommand,
+            customCommand: "echo hidden-secret"
+        )
+        let edited = TerminalProfileEditor.upserting(
+            draft: customDraft,
+            into: TerminalProfileDocument.fallback
+        )
+        expect(edited.isValid, "Terminal Profile editor must upsert valid custom-command drafts")
+        expect(
+            edited.document?.profile(id: "bootstrap")?.redactedDisplayDetail.contains("hidden-secret") == false,
+            "Terminal Profile editor models must keep custom commands redacted for normal display"
+        )
+    }
+
+    private static func verifiesManagedTerminalAccountPlannerSudoersAndProfileHandoff() {
+        let request = ManagedTerminalAccountRequest(
+            accountName: "alan",
+            guiUserName: "morris",
+            fullName: "Alan Terminal",
+            shell: "/bin/zsh",
+            homeDirectory: "/Users/alan",
+            hideFromLoginWindow: true,
+            bindCurrentSpaceAfterSuccess: true
+        )
+        let missingState = ManagedTerminalAccountState(
+            account: .missing,
+            sudoers: .missing,
+            terminalProfile: .missing,
+            verification: .notRun
+        )
+        let plan = ManagedTerminalAccountPlanner.plan(request: request, state: missingState)
+        expect(
+            plan.steps.map(\.kind).contains(.createStandardAccount),
+            "missing account plan must create a standard account"
+        )
+        expect(
+            plan.steps.map(\.kind).contains(.writeSudoersDropIn),
+            "missing account plan must write Alan-owned sudoers"
+        )
+        expect(
+            plan.steps.map(\.kind).contains(.verifyTerminalEntry),
+            "missing account plan must verify terminal entry"
+        )
+        expect(
+            plan.steps.map(\.kind).contains(.createOrUpdateTerminalProfile),
+            "ready path must include terminal profile handoff"
+        )
+
+        let sudoers = ManagedTerminalAccountSudoersRule(request: request)
+        expect(
+            sudoers.filePath == "/etc/sudoers.d/alan-terminal-morris-to-alan",
+            "sudoers path must be deterministic and Alan-owned"
+        )
+        expect(
+            sudoers.contents.contains("morris ALL=(alan) NOPASSWD: ALL"),
+            "sudoers rule must allow GUI user to target account"
+        )
+        expect(
+            !sudoers.contents.contains("ALL=(ALL)"),
+            "sudoers rule must not grant passwordless root or all-user access"
+        )
+
+        let invalid = ManagedTerminalAccountRequest(accountName: "root", guiUserName: "morris")
+        expect(
+            ManagedTerminalAccountIdentifierValidator.validate(invalid)
+                .contains(.reservedAccountName("root")),
+            "root target account must be rejected"
+        )
+
+        let readyState = ManagedTerminalAccountState(
+            account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+            sudoers: .alanOwnedValid(path: sudoers.filePath),
+            terminalProfile: .missing,
+            verification: .passed
+        )
+        let handoff = ManagedTerminalAccountProfileHandoff.profileDefinition(
+            for: request,
+            state: readyState
+        )
+        expect(handoff?.id == "alan", "ready account must create matching profile id")
+        expect(
+            handoff?.launch == .sudoUser(unixUser: "alan"),
+            "ready account profile must use sudo_user launch"
+        )
+
+        let failedState = ManagedTerminalAccountState(
+            account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+            sudoers: .alanOwnedValid(path: sudoers.filePath),
+            terminalProfile: .missing,
+            verification: .failed(step: .nonInteractiveSudo, message: "sudo requires password")
+        )
+        expect(
+            ManagedTerminalAccountProfileHandoff.profileDefinition(for: request, state: failedState) == nil,
+            "failed verification must suppress ready profile creation"
+        )
+    }
+
+    private static func verifiesManagedTerminalAccountDiscoveryVerificationAndAuthorizedExecutor() {
+        let request = ManagedTerminalAccountRequest(accountName: "alan", guiUserName: "morris")
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
+        let commandRunner = StubManagedTerminalAccountCommandRunner(
+            responses: [
+                "/usr/bin/dscl . -read /Users/alan NFSHomeDirectory UserShell IsHidden":
+                    ManagedTerminalAccountCommandResult(
+                        exitCode: 0,
+                        standardOutput: """
+                        NFSHomeDirectory: /Users/alan
+                        UserShell: /bin/zsh
+                        IsHidden: 1
+                        """,
+                        standardError: ""
+                    ),
+                "/usr/sbin/dseditgroup -o checkmember -m alan admin":
+                    ManagedTerminalAccountCommandResult(
+                        exitCode: 0,
+                        standardOutput: "no alan is not a member of admin",
+                        standardError: ""
+                    ),
+            ]
+        )
+        let fileManager = SudoersFixtureFileManager(files: [rule.filePath: rule.contents])
+        let profiles = TerminalProfileDocument(
+            defaultProfileID: "alan",
+            profiles: [
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil,
+                    managedTerminalAccountID: "alan"
+                ),
+            ]
+        )
+        let discoverer = ManagedTerminalAccountLocalStateDiscoverer(
+            fileManager: fileManager,
+            commandRunner: commandRunner,
+            sudoersSyntaxChecker: StubSudoersSyntaxChecker(result: .passed)
+        )
+        let state = discoverer.discover(request: request, terminalProfiles: profiles)
+
+        expect(
+            state.account == .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+            "local state discovery must parse account home, shell, hidden, and admin state"
+        )
+        expect(
+            state.sudoers == .alanOwnedValid(path: rule.filePath),
+            "local state discovery must validate Alan-owned sudoers drop-ins"
+        )
+        expect(
+            state.terminalProfile == .existingManaged(profileID: "alan"),
+            "local state discovery must link managed Terminal Profile state"
+        )
+
+        let readiness = ManagedTerminalAccountReadinessVerifier.verify(
+            request: request,
+            state: state,
+            entryVerifier: StubTerminalEntryVerifier(result: .passed)
+        )
+        expect(readiness == .passed, "ready state must pass mandatory terminal-entry verification")
+
+        let invalidSudoers = ManagedTerminalAccountSudoersValidator.validate(
+            contents: rule.contents,
+            rule: rule,
+            syntaxChecker: StubSudoersSyntaxChecker(result: .failed("syntax error"))
+        )
+        expect(!invalidSudoers.isValid, "sudoers validation helper must surface visudo failure")
+
+        let adminReadiness = ManagedTerminalAccountReadinessVerifier.verify(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .admin(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: rule.filePath),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .notRun
+            ),
+            entryVerifier: StubTerminalEntryVerifier(result: .passed)
+        )
+        expect(
+            adminReadiness == .failed(step: .nonAdminAccount, message: "Managed terminal account must be standard."),
+            "readiness verification must reject admin target accounts"
+        )
+
+        let privilegedRunner = CapturingPrivilegedCommandRunner()
+        let executor = ManagedTerminalAccountAuthorizedScriptExecutor(
+            request: request,
+            commandRunner: privilegedRunner,
+            passwordGenerator: { "SECRET-PASSWORD" }
+        )
+        let plan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .missing,
+                sudoers: .missing,
+                terminalProfile: .missing,
+                verification: .notRun
+            )
+        )
+        let result = executor.apply(plan)
+        let diagnostics = result.visibleDiagnostics.joined(separator: " ")
+        expect(result.failedStep == nil, "authorized executor must complete captured privileged scripts")
+        expect(
+            !diagnostics.contains("SECRET-PASSWORD"),
+            "authorized executor diagnostics must not expose generated account passwords"
+        )
+        expect(
+            privilegedRunner.scripts.contains { $0.contains("sysadminctl -addUser") },
+            "authorized executor must route account creation through an explicit privileged script"
+        )
+        expect(
+            privilegedRunner.scripts.contains { $0.contains("visudo -cf") },
+            "authorized executor must validate sudoers before marking privileged steps complete"
+        )
+    }
+
+    private static func verifiesManagedTerminalAccountExecutorAndRollbackSafety() {
+        let request = ManagedTerminalAccountRequest(accountName: "alan", guiUserName: "morris")
+        let plan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: false),
+                sudoers: .missing,
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .failed(step: .sudoersValidation, message: "missing sudoers")
+            )
+        )
+        let executor = ManagedTerminalAccountFakeExecutor()
+        let result = executor.apply(plan)
+        expect(
+            result.completedSteps == plan.steps.map(\.kind),
+            "fake executor must apply requested steps in order"
+        )
+        expect(
+            !result.visibleDiagnostics.joined(separator: " ").contains("password"),
+            "executor diagnostics must redact credential wording"
+        )
+
+        let rollback = ManagedTerminalAccountPlanner.rollbackPlan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: "/etc/sudoers.d/alan-terminal-morris-to-alan"),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .passed
+            ),
+            scope: .alanIntegrationOnly
+        )
+        expect(
+            rollback.steps.map(\.kind) == [.removeSudoersDropIn, .removeManagedTerminalProfile],
+            "ordinary rollback must only remove Alan-owned integration"
+        )
+        expect(
+            !rollback.steps.map(\.kind).contains(.deleteAccount),
+            "ordinary rollback must not delete account"
+        )
+        expect(
+            !rollback.steps.map(\.kind).contains(.deleteHomeDirectory),
+            "ordinary rollback must not delete home"
+        )
+
+        let destructive = ManagedTerminalAccountPlanner.rollbackPlan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: "/etc/sudoers.d/alan-terminal-morris-to-alan"),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .passed
+            ),
+            scope: .deleteAccountAndHome(confirmation: nil)
+        )
+        expect(
+            destructive.status == .requiresDestructiveConfirmation,
+            "account/home deletion must require separate destructive confirmation"
+        )
+    }
+
     private static func makeController(
         windowID: String = "metadata_test_\(UUID().uuidString)",
         shellState: ShellStateSnapshot? = nil,
@@ -7605,6 +8493,20 @@ private enum ShellRuntimeMetadataTests {
         ).events ?? []
     }
 
+    private static func temporaryDirectory(named name: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func terminalPayload(
+        in snapshot: ShellContentTabRestoreSnapshot?,
+        contentID: String
+    ) -> ShellTerminalContentPayload? {
+        snapshot?.contents.first { $0.contentID == contentID }?.payload.terminal
+    }
+
     private static func expect(
         _ condition: @autoclosure () -> Bool,
         _ message: String
@@ -7617,6 +8519,83 @@ private enum ShellRuntimeMetadataTests {
     private static func fail(_ message: String) -> Never {
         fputs("error: \(message)\n", stderr)
         exit(1)
+    }
+
+    private final class AlwaysExecutableFileManager: FileManager {
+        override func fileExists(atPath path: String) -> Bool {
+            true
+        }
+
+        override func isExecutableFile(atPath path: String) -> Bool {
+            true
+        }
+    }
+
+    private struct StubManagedTerminalAccountCommandRunner: ManagedTerminalAccountCommandRunning {
+        let responses: [String: ManagedTerminalAccountCommandResult]
+
+        func run(
+            executablePath: String,
+            arguments: [String]
+        ) -> ManagedTerminalAccountCommandResult {
+            let key = ([executablePath] + arguments).joined(separator: " ")
+            return responses[key]
+                ?? ManagedTerminalAccountCommandResult(
+                    exitCode: 1,
+                    standardOutput: "",
+                    standardError: "missing stub response for \(key)"
+                )
+        }
+    }
+
+    private struct StubSudoersSyntaxChecker: ManagedTerminalAccountSudoersSyntaxChecking {
+        let result: ManagedTerminalAccountSudoersValidationResult
+
+        func validateSudoersFile(atPath path: String) -> ManagedTerminalAccountSudoersValidationResult {
+            result
+        }
+    }
+
+    private struct StubTerminalEntryVerifier: ManagedTerminalAccountEntryVerifying {
+        let result: ManagedTerminalAccountSudoersValidationResult
+
+        func verifyTerminalEntry(
+            request: ManagedTerminalAccountRequest
+        ) -> ManagedTerminalAccountSudoersValidationResult {
+            result
+        }
+    }
+
+    private final class CapturingPrivilegedCommandRunner: ManagedTerminalAccountPrivilegedCommandRunning {
+        private(set) var scripts: [String] = []
+
+        func runPrivilegedShellScript(
+            _ script: String,
+            redactedDescription: String
+        ) -> ManagedTerminalAccountPrivilegedCommandResult {
+            scripts.append(script)
+            return ManagedTerminalAccountPrivilegedCommandResult(
+                succeeded: true,
+                redactedMessage: "\(redactedDescription) completed with credentials redacted."
+            )
+        }
+    }
+
+    private final class SudoersFixtureFileManager: FileManager {
+        private let files: [String: String]
+
+        init(files: [String: String]) {
+            self.files = files
+            super.init()
+        }
+
+        override func fileExists(atPath path: String) -> Bool {
+            files[path] != nil
+        }
+
+        override func contents(atPath path: String) -> Data? {
+            files[path]?.data(using: .utf8)
+        }
     }
 }
 #endif

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7570,6 +7570,26 @@ private enum ShellRuntimeMetadataTests {
 
     private static func verifiesTerminalProfileInheritanceForSpacesTabsAndSplits() {
         let now = Date(timeIntervalSince1970: 2_100)
+        let terminalProfiles = TerminalProfileDocument(
+            defaultProfileID: "alan",
+            profiles: [
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil
+                ),
+                TerminalProfileDefinition(
+                    id: "root",
+                    title: "Root",
+                    launch: .sudoRoot,
+                    defaultWorkingDirectory: "/var/root",
+                    presentation: nil
+                ),
+            ]
+        )
+        let executableFileManager = AlwaysExecutableFileManager()
         let base = ShellStateSnapshot.bootstrapDefault(
             windowID: "window_inheritance",
             workingDirectory: "/Users/morris"
@@ -7593,6 +7613,23 @@ private enum ShellRuntimeMetadataTests {
             createdSpace.pane(paneID: alanPaneID)?.terminalProfileID == "alan",
             "first terminal in profile-bound space must use profile"
         )
+        expect(
+            createdSpace.pane(paneID: alanPaneID)?.cwd == nil,
+            "profile-bound space without explicit cwd must let profile default working directory apply"
+        )
+        let firstPaneBoot = createdSpace.pane(paneID: alanPaneID).map {
+            AlanShellBootProfile.forPane(
+                $0,
+                shellState: createdSpace,
+                terminalProfiles: terminalProfiles,
+                fileManager: executableFileManager,
+                environment: ["SHELL": "/bin/zsh"]
+            )
+        }
+        expect(
+            firstPaneBoot?.workingDirectory == "/Users/alan",
+            "profile-bound space boot must use profile default working directory"
+        )
 
         let inheritedTab = try? createdSpace.openingTerminalTab(
             in: alanSpaceID,
@@ -7600,9 +7637,27 @@ private enum ShellRuntimeMetadataTests {
             workingDirectory: nil,
             now: now
         ).state
+        let inheritedPane = inheritedTab?.focusedPaneID.flatMap { inheritedTab?.pane(paneID: $0) }
         expect(
-            inheritedTab?.pane(paneID: inheritedTab?.focusedPaneID ?? "")?.terminalProfileID == "alan",
+            inheritedPane?.terminalProfileID == "alan",
             "new tab must inherit space profile"
+        )
+        expect(
+            inheritedPane?.cwd == nil,
+            "profile-inherited tab without explicit cwd must let profile default working directory apply"
+        )
+        let inheritedBoot = inheritedPane.map {
+            AlanShellBootProfile.forPane(
+                $0,
+                shellState: inheritedTab ?? createdSpace,
+                terminalProfiles: terminalProfiles,
+                fileManager: executableFileManager,
+                environment: ["SHELL": "/bin/zsh"]
+            )
+        }
+        expect(
+            inheritedBoot?.workingDirectory == "/Users/alan",
+            "profile-inherited tab boot must use profile default working directory"
         )
 
         let overrideTab = try? createdSpace.openingTerminalTab(
@@ -7616,6 +7671,22 @@ private enum ShellRuntimeMetadataTests {
             overrideTab?.pane(paneID: overrideTab?.focusedPaneID ?? "")?.terminalProfileID == "root",
             "explicit tab profile must override space profile"
         )
+        expect(
+            overrideTab?.focusedPaneID.flatMap { overrideTab?.pane(paneID: $0) }?.cwd == nil,
+            "explicit profile tab without explicit cwd must let profile default working directory apply"
+        )
+
+        let explicitCwdTab = try? createdSpace.openingTerminalTab(
+            in: alanSpaceID,
+            title: nil,
+            workingDirectory: "/explicit/project",
+            terminalProfileID: "root",
+            now: now
+        ).state
+        expect(
+            explicitCwdTab?.focusedPaneID.flatMap { explicitCwdTab?.pane(paneID: $0) }?.cwd == "/explicit/project",
+            "explicit cwd must still override profile default working directory"
+        )
 
         let split = try? createdSpace.splittingPane(
             alanPaneID,
@@ -7625,6 +7696,10 @@ private enum ShellRuntimeMetadataTests {
         expect(
             split?.pane(paneID: split?.focusedPaneID ?? "")?.terminalProfileID == "alan",
             "split must inherit focused pane profile"
+        )
+        expect(
+            split?.focusedPaneID.flatMap { split?.pane(paneID: $0) }?.cwd == nil,
+            "profile-inherited split without explicit cwd must let profile default working directory apply"
         )
 
         let rebound = createdSpace.settingTerminalProfile("univer", forSpaceID: alanSpaceID)

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7923,6 +7923,42 @@ private enum ShellRuntimeMetadataTests {
         )
         expect(readiness == .passed, "ready state must pass mandatory terminal-entry verification")
 
+        let unreadableSudoersDiscoverer = ManagedTerminalAccountLocalStateDiscoverer(
+            fileManager: UnreadableSudoersFixtureFileManager(paths: [rule.filePath]),
+            commandRunner: commandRunner,
+            sudoersSyntaxChecker: StubSudoersSyntaxChecker(result: .passed)
+        )
+        let unreadableSudoersState = unreadableSudoersDiscoverer.discover(
+            request: request,
+            terminalProfiles: profiles
+        )
+        expect(
+            unreadableSudoersState.sudoers == .alanOwnedValid(path: rule.filePath),
+            "installed root-owned sudoers drop-ins may be unreadable to the GUI user but still discoverable"
+        )
+        let unreadableReadiness = ManagedTerminalAccountReadinessVerifier.verify(
+            request: request,
+            state: unreadableSudoersState,
+            entryVerifier: StubTerminalEntryVerifier(result: .passed)
+        )
+        expect(
+            unreadableReadiness == .passed,
+            "unreadable installed sudoers drop-ins must rely on terminal-entry verification for readiness"
+        )
+        let unreadableReadyPlan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: unreadableSudoersState.account,
+                sudoers: unreadableSudoersState.sudoers,
+                terminalProfile: unreadableSudoersState.terminalProfile,
+                verification: unreadableReadiness
+            )
+        )
+        expect(
+            !unreadableReadyPlan.steps.map(\.kind).contains(.writeSudoersDropIn),
+            "ready unreadable sudoers discovery must not keep reporting sudoers repair work"
+        )
+
         let invalidSudoers = ManagedTerminalAccountSudoersValidator.validate(
             contents: rule.contents,
             rule: rule,
@@ -8763,6 +8799,23 @@ private enum ShellRuntimeMetadataTests {
 
         override func contents(atPath path: String) -> Data? {
             files[path]?.data(using: .utf8)
+        }
+    }
+
+    private final class UnreadableSudoersFixtureFileManager: FileManager {
+        private let paths: Set<String>
+
+        init(paths: Set<String>) {
+            self.paths = paths
+            super.init()
+        }
+
+        override func fileExists(atPath path: String) -> Bool {
+            paths.contains(path)
+        }
+
+        override func contents(atPath path: String) -> Data? {
+            nil
         }
     }
 }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8331,6 +8331,40 @@ private enum ShellRuntimeMetadataTests {
             state.terminalProfile == .existingManaged(profileID: "alan"),
             "local state discovery must link managed Terminal Profile state"
         )
+        let driftedProfiles = TerminalProfileDocument(
+            defaultProfileID: "alan",
+            profiles: [
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/old-alan",
+                    presentation: nil,
+                    managedTerminalAccountID: "alan"
+                ),
+            ]
+        )
+        let driftedProfileState = discoverer.discover(
+            request: request,
+            terminalProfiles: driftedProfiles
+        )
+        expect(
+            driftedProfileState.terminalProfile != .existingManaged(profileID: "alan"),
+            "managed Terminal Profile discovery must not treat stale default directories as ready"
+        )
+        let driftedProfilePlan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: driftedProfileState.account,
+                sudoers: driftedProfileState.sudoers,
+                terminalProfile: driftedProfileState.terminalProfile,
+                verification: .passed
+            )
+        )
+        expect(
+            driftedProfilePlan.steps.map(\.kind).contains(.createOrUpdateTerminalProfile),
+            "stale managed Terminal Profiles must schedule a refresh even after readiness passes"
+        )
 
         let readiness = ManagedTerminalAccountReadinessVerifier.verify(
             request: request,

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8159,6 +8159,10 @@ private enum ShellRuntimeMetadataTests {
             "missing account plan must verify terminal entry"
         )
         expect(
+            plan.steps.first(where: { $0.kind == .verifyTerminalEntry })?.requiresPrivilege == false,
+            "terminal-entry verification must run as the GUI user, not inside a privileged shell"
+        )
+        expect(
             plan.steps.map(\.kind).contains(.createOrUpdateTerminalProfile),
             "ready path must include terminal profile handoff"
         )
@@ -8399,6 +8403,7 @@ private enum ShellRuntimeMetadataTests {
                     return true
                 }
             ),
+            entryVerifier: StubTerminalEntryVerifier(result: .passed),
             passwordGenerator: { "SECRET-PASSWORD" }
         )
         let plan = ManagedTerminalAccountPlanner.plan(
@@ -8428,6 +8433,10 @@ private enum ShellRuntimeMetadataTests {
         expect(
             privilegedRunner.scripts.contains { $0.contains("visudo -cf") },
             "authorized executor must validate sudoers before marking privileged steps complete"
+        )
+        expect(
+            !privilegedRunner.scripts.contains { $0.contains("/usr/bin/sudo -n -iu") },
+            "authorized executor must not run terminal-entry verification through the privileged runner"
         )
         let sudoersScript = privilegedRunner.scripts.first { $0.contains(rule.contents) } ?? ""
         expect(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -160,6 +160,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalProfileLaunchResolutionAndEnvironmentProjection()
         verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip()
         verifiesTerminalProfileInheritanceForSpacesTabsAndSplits()
+        verifiesGlobalDefaultTerminalProfileDefersWorkingDirectory()
         verifiesTerminalProfileControlPlaneOverrides()
         verifiesTerminalProfileSettingsRowsStaySeparateFromProviderAccounts()
         verifiesManagedTerminalAccountPlannerSudoersAndProfileHandoff()
@@ -7793,6 +7794,80 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesGlobalDefaultTerminalProfileDefersWorkingDirectory() {
+        let previousSupportRoot = ProcessInfo.processInfo.environment[
+            "ALAN_MACOS_APPLICATION_SUPPORT_DIR"
+        ]
+        let previousInstallChannel = ProcessInfo.processInfo.environment["ALAN_INSTALL_CHANNEL"]
+        let supportRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-global-profile-\(UUID().uuidString)", isDirectory: true)
+        setenv("ALAN_MACOS_APPLICATION_SUPPORT_DIR", supportRoot.path, 1)
+        setenv("ALAN_INSTALL_CHANNEL", "stable", 1)
+        defer {
+            restoreEnvironmentValue(previousSupportRoot, forKey: "ALAN_MACOS_APPLICATION_SUPPORT_DIR")
+            restoreEnvironmentValue(previousInstallChannel, forKey: "ALAN_INSTALL_CHANNEL")
+        }
+
+        let terminalProfiles = TerminalProfileDocument(
+            defaultProfileID: "alan",
+            profiles: [
+                TerminalProfileDefinition.loginShellFallback,
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil
+                ),
+            ]
+        )
+        let store = TerminalProfileStore.defaultStore(
+            environment: [
+                "ALAN_MACOS_APPLICATION_SUPPORT_DIR": supportRoot.path,
+                "ALAN_INSTALL_CHANNEL": "stable",
+            ]
+        )
+        do {
+            try store.save(terminalProfiles)
+        } catch {
+            fail("global default terminal profile test must save profile store: \(error)")
+        }
+
+        let controller = makeController(
+            windowID: "global_default_profile",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let tabID = controller.openTerminalTab(),
+              let paneID = controller.shellState.tab(tabID: tabID)?.paneTree.paneIDs.first,
+              let pane = controller.shellState.pane(paneID: paneID)
+        else {
+            fail("global default terminal profile test must open a terminal tab")
+        }
+
+        expect(
+            pane.terminalProfileID == "alan",
+            "new tabs must capture the global default terminal profile"
+        )
+        expect(
+            pane.cwd == nil,
+            "new tabs using the global default terminal profile must let the profile cwd win"
+        )
+        let boot = AlanShellBootProfile.forPane(
+            pane,
+            shellState: controller.shellState,
+            terminalProfiles: terminalProfiles,
+            fileManager: AlwaysExecutableFileManager(),
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            boot.workingDirectory == "/Users/alan",
+            "global default terminal profile boot must use the profile default working directory"
+        )
+    }
+
     private static func verifiesTerminalProfileControlPlaneOverrides() {
         let controller = makeController()
         let createSpaceResponse = controller.handleControlPlaneCommand(
@@ -8657,6 +8732,14 @@ private enum ShellRuntimeMetadataTests {
             return nil
         }
         return snapshot.contents.first { $0.contentID == paneSlot.contentID }
+    }
+
+    private static func restoreEnvironmentValue(_ value: String?, forKey key: String) {
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
     }
 
     private static func pane(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -81,6 +81,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesAgentActivityControlCommandProjectsOntoPane()
         verifiesClearingActivityRemovesPaneActivity()
         verifiesPublishedStateMergeClearsActivity()
+        verifiesPublishedStateMergeClearsTerminalProfileMetadata()
         verifiesPublishedStateMergePreservesContentContainers()
         verifiesPaneRebuildMutationsPreserveActivity()
         verifiesTabSidebarActivityProjectionUsesHighestPriorityPane()
@@ -3345,6 +3346,66 @@ private enum ShellRuntimeMetadataTests {
         expect(
             merged.pane(paneID: "pane_1")?.activity == nil,
             "published state merge must allow incoming nil activity to clear stale activity"
+        )
+    }
+
+    private static func verifiesPublishedStateMergeClearsTerminalProfileMetadata() {
+        let staleContext = context(
+            processState: "running",
+            rendererHealth: "healthy",
+            surfaceReadiness: "ready",
+            terminalProfileState: "resolved",
+            terminalProfileRequestedID: "alan",
+            terminalProfileID: "alan",
+            terminalProfileKind: "sudo_user",
+            terminalProfileTitle: "Alan",
+            lastCommandExitCode: nil
+        )
+        let incomingContext = context(
+            processState: "running",
+            rendererHealth: "healthy",
+            surfaceReadiness: "ready",
+            terminalProfileState: "missing",
+            terminalProfileRequestedID: "lab",
+            terminalProfileID: nil,
+            terminalProfileKind: nil,
+            terminalProfileTitle: nil,
+            lastCommandExitCode: nil
+        )
+        let authoritative = stateWithContext(
+            windowID: "window_terminal_profile_merge",
+            context: staleContext
+        )
+        let incoming = stateWithContext(
+            windowID: "window_terminal_profile_merge",
+            context: incomingContext
+        )
+
+        let merged = AlanShellPublishedStateMerger.merge(
+            authoritative: authoritative,
+            incoming: incoming
+        )
+        let mergedContext = merged.pane(paneID: "pane_1")?.context
+
+        expect(
+            mergedContext?.terminalProfileState == "missing",
+            "published state merge must accept incoming terminal profile resolution state"
+        )
+        expect(
+            mergedContext?.terminalProfileRequestedID == "lab",
+            "published state merge must accept incoming terminal profile requested id"
+        )
+        expect(
+            mergedContext?.terminalProfileID == nil,
+            "published state merge must clear stale resolved terminal profile id"
+        )
+        expect(
+            mergedContext?.terminalProfileKind == nil,
+            "published state merge must clear stale resolved terminal profile kind"
+        )
+        expect(
+            mergedContext?.terminalProfileTitle == nil,
+            "published state merge must clear stale resolved terminal profile title"
         )
     }
 
@@ -7308,6 +7369,54 @@ private enum ShellRuntimeMetadataTests {
             missingContext.terminalProfileID == nil,
             "missing profile fallback must not claim a resolved profile id"
         )
+
+        let staleResolvedContext = ShellContextSnapshot(
+            workingDirectoryName: "alan",
+            repositoryRoot: nil,
+            gitBranch: nil,
+            controlPath: nil,
+            alanBindingFile: nil,
+            launchStrategy: "terminal_profile_sudo_user",
+            terminalProfileState: "resolved",
+            terminalProfileRequestedID: "alan",
+            terminalProfileID: "alan",
+            terminalProfileKind: "sudo_user",
+            terminalProfileTitle: "Alan",
+            shellIntegrationSource: "ghostty_shell_integration",
+            processState: "running",
+            lastMetadataAt: nil,
+            lastCommandExitCode: nil
+        )
+        let recreatedMissingContext = ShellPaneProjectionService(fileManager: executableFileManager)
+            .projectedContext(
+                for: missingPane,
+                bootProfile: missingBoot,
+                workingDirectory: nil,
+                processExited: nil,
+                lastCommandExitCode: nil,
+                lastMetadataAt: nil,
+                existing: staleResolvedContext
+            )
+        expect(
+            recreatedMissingContext.terminalProfileState == "missing",
+            "pane context recreation must replace stale terminal profile state"
+        )
+        expect(
+            recreatedMissingContext.terminalProfileRequestedID == "lab",
+            "pane context recreation must replace stale terminal profile requested id"
+        )
+        expect(
+            recreatedMissingContext.terminalProfileID == nil,
+            "pane context recreation must clear stale resolved terminal profile id"
+        )
+        expect(
+            recreatedMissingContext.terminalProfileKind == nil,
+            "pane context recreation must clear stale resolved terminal profile kind"
+        )
+        expect(
+            recreatedMissingContext.terminalProfileTitle == nil,
+            "pane context recreation must clear stale resolved terminal profile title"
+        )
     }
 
     private static func verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip() {
@@ -7866,6 +7975,15 @@ private enum ShellRuntimeMetadataTests {
             privilegedRunner.scripts.contains { $0.contains("visudo -cf") },
             "authorized executor must validate sudoers before marking privileged steps complete"
         )
+        let sudoersScript = privilegedRunner.scripts.first { $0.contains(rule.contents) } ?? ""
+        expect(
+            sudoersScript.contains("mktemp -d"),
+            "authorized executor must create sudoers content in a private temporary directory"
+        )
+        expect(
+            !sudoersScript.contains("/tmp/\(rule.fileName).sudoers"),
+            "authorized executor must not write sudoers content through a deterministic /tmp path"
+        )
     }
 
     private static func verifiesManagedTerminalAccountExecutorAndRollbackSafety() {
@@ -8208,6 +8326,11 @@ private enum ShellRuntimeMetadataTests {
         processState: String,
         rendererHealth: String,
         surfaceReadiness: String,
+        terminalProfileState: String? = nil,
+        terminalProfileRequestedID: String? = nil,
+        terminalProfileID: String? = nil,
+        terminalProfileKind: String? = nil,
+        terminalProfileTitle: String? = nil,
         lastCommandExitCode: Int?
     ) -> ShellContextSnapshot {
         ShellContextSnapshot(
@@ -8217,6 +8340,11 @@ private enum ShellRuntimeMetadataTests {
             controlPath: nil,
             alanBindingFile: nil,
             launchStrategy: nil,
+            terminalProfileState: terminalProfileState,
+            terminalProfileRequestedID: terminalProfileRequestedID,
+            terminalProfileID: terminalProfileID,
+            terminalProfileKind: terminalProfileKind,
+            terminalProfileTitle: terminalProfileTitle,
             shellIntegrationSource: "ghostty_shell_integration",
             processState: processState,
             rendererHealth: rendererHealth,
@@ -8248,6 +8376,46 @@ private enum ShellRuntimeMetadataTests {
             activeTaskState: activeTaskState,
             activity: activity,
             clearsActivity: clearsActivity
+        )
+    }
+
+    private static func stateWithContext(
+        windowID: String,
+        context: ShellContextSnapshot
+    ) -> ShellStateSnapshot {
+        let pane = pane(
+            context: context,
+            viewport: nil,
+            attention: .active
+        )
+        return ShellStateSnapshot(
+            contractVersion: "0.1",
+            windowID: windowID,
+            focusedSpaceID: "space_1",
+            focusedTabID: "tab_1",
+            focusedPaneID: "pane_1",
+            spaces: [
+                ShellSpace(
+                    spaceID: "space_1",
+                    title: "Main",
+                    attention: pane.attention,
+                    tabs: [
+                        ShellTab(
+                            tabID: "tab_1",
+                            kind: .terminal,
+                            title: "alan",
+                            paneTree: ShellPaneTreeNode(
+                                nodeID: "node_pane_1",
+                                kind: .pane,
+                                direction: nil,
+                                paneID: "pane_1",
+                                children: nil
+                            )
+                        )
+                    ]
+                )
+            ],
+            panes: [pane]
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7417,6 +7417,42 @@ private enum ShellRuntimeMetadataTests {
             recreatedMissingContext.terminalProfileTitle == nil,
             "pane context recreation must clear stale resolved terminal profile title"
         )
+
+        let loginShellDefaultDocument = TerminalProfileDocument(
+            defaultProfileID: TerminalProfileDefinition.loginShellFallback.id,
+            profiles: [
+                TerminalProfileDefinition.loginShellFallback,
+                TerminalProfileDefinition(
+                    id: "alan",
+                    title: "Alan",
+                    launch: .sudoUser(unixUser: "alan"),
+                    defaultWorkingDirectory: "/Users/alan",
+                    presentation: nil
+                ),
+            ]
+        )
+        let reboundState = ShellStateSnapshot.bootstrapDefault(
+            windowID: "window_existing_pane",
+            workingDirectory: "/Users/morris"
+        ).settingTerminalProfile("alan", forSpaceID: "space_main")
+        guard let reboundPane = reboundState?.pane(paneID: "pane_1") else {
+            fail("rebound default state must keep the existing pane")
+        }
+        let reboundBoot = AlanShellBootProfile.forPane(
+            reboundPane,
+            shellState: reboundState ?? state,
+            terminalProfiles: loginShellDefaultDocument,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            reboundBoot.environment["ALAN_TERMINAL_PROFILE_REQUESTED_ID"] == nil,
+            "existing panes without a captured profile must not read mutable Space bindings"
+        )
+        expect(
+            reboundBoot.command.terminalProfile?.id != "alan",
+            "rebinding a Space must not relaunch an existing login-shell pane through the new profile"
+        )
     }
 
     private static func verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -3467,8 +3467,8 @@ private enum ShellRuntimeMetadataTests {
             incoming: incomingProfileState
         )
         expect(
-            mergedProfileRefs.space(spaceID: "space_1")?.terminalProfileID == "alan",
-            "published state merge must preserve captured space terminal profile id"
+            mergedProfileRefs.space(spaceID: "space_1")?.terminalProfileID == nil,
+            "published state merge must let incoming nil clear a Space terminal profile id"
         )
         expect(
             mergedProfileRefs.pane(paneID: "pane_1")?.terminalProfileID == "alan",
@@ -7958,6 +7958,31 @@ private enum ShellRuntimeMetadataTests {
         expect(
             splitPane.cwd == nil,
             "splits using the global default terminal profile must let the profile cwd win"
+        )
+
+        let localResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-tab-global-default-profile",
+                  "command": "tab.open"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        let localPane = localResult?.updatedState?.pane(paneID: localResult?.response.paneID ?? "")
+        expect(localResult?.response.applied == true, "local tab.open must apply")
+        expect(
+            localPane?.terminalProfileID == "alan",
+            "local tab.open must capture the global default terminal profile"
+        )
+        expect(
+            localPane?.cwd == nil,
+            "local tab.open using the global default profile must let the profile cwd win"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -304,6 +304,39 @@ private enum ShellRuntimeMetadataTests {
         expect(projection.pane.context?.inputReady == true, "terminal adapter must project input readiness")
         expect(projection.pane.attention == .active, "terminal adapter must project attention")
 
+        let profiledPane = ShellPane(
+            paneID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID,
+            launchTarget: pane.launchTarget,
+            cwd: pane.cwd,
+            process: pane.process,
+            attention: pane.attention,
+            context: pane.context,
+            viewport: pane.viewport,
+            activity: pane.activity,
+            alanBinding: pane.alanBinding,
+            terminalProfileID: "alan"
+        )
+        let profiledRuntimeProjection = adapter.projectRuntime(
+            runtime,
+            for: profiledPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledRuntimeProjection.pane.terminalProfileID == "alan",
+            "terminal adapter runtime projection must preserve captured terminal profile id"
+        )
+        let profiledBootProjection = adapter.projectBootContext(
+            runtime: runtime,
+            for: profiledPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledBootProjection.pane.terminalProfileID == "alan",
+            "terminal adapter boot projection must preserve captured terminal profile id"
+        )
+
         let binding = ShellAlanBinding(
             sessionID: "session_1",
             runStatus: "waiting",
@@ -322,6 +355,16 @@ private enum ShellRuntimeMetadataTests {
         expect(
             bindingProjection.pane.attention == .awaitingUser,
             "terminal adapter must project pending-yield attention"
+        )
+        let profiledBindingProjection = adapter.projectAlanBinding(
+            binding,
+            runtime: runtime,
+            for: profiledPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledBindingProjection.pane.terminalProfileID == "alan",
+            "terminal adapter binding projection must preserve captured terminal profile id"
         )
         expect(
             bindingProjection.pane.viewport?.summary == "alan is waiting for user input",
@@ -3406,6 +3449,29 @@ private enum ShellRuntimeMetadataTests {
         expect(
             mergedContext?.terminalProfileTitle == nil,
             "published state merge must clear stale resolved terminal profile title"
+        )
+
+        let authoritativeProfileState = stateWithContext(
+            windowID: "window_terminal_profile_refs",
+            context: staleContext,
+            spaceTerminalProfileID: "alan",
+            paneTerminalProfileID: "alan"
+        )
+        let incomingProfileState = stateWithContext(
+            windowID: "window_terminal_profile_refs",
+            context: incomingContext
+        )
+        let mergedProfileRefs = AlanShellPublishedStateMerger.merge(
+            authoritative: authoritativeProfileState,
+            incoming: incomingProfileState
+        )
+        expect(
+            mergedProfileRefs.space(spaceID: "space_1")?.terminalProfileID == "alan",
+            "published state merge must preserve captured space terminal profile id"
+        )
+        expect(
+            mergedProfileRefs.pane(paneID: "pane_1")?.terminalProfileID == "alan",
+            "published state merge must preserve captured pane terminal profile id"
         )
     }
 
@@ -8253,6 +8319,55 @@ private enum ShellRuntimeMetadataTests {
             destructive.status == .requiresDestructiveConfirmation,
             "account/home deletion must require separate destructive confirmation"
         )
+        let confirmedDestructive = ManagedTerminalAccountPlanner.rollbackPlan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: "/etc/sudoers.d/alan-terminal-morris-to-alan"),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .passed
+            ),
+            scope: .deleteAccountAndHome(confirmation: "alan")
+        )
+        expect(
+            confirmedDestructive.steps.map(\.kind).contains(.deleteHomeDirectory),
+            "confirmed destructive rollback may delete the canonical managed home"
+        )
+
+        let customHomeRequest = ManagedTerminalAccountRequest(
+            accountName: "alan",
+            guiUserName: "morris",
+            homeDirectory: "/Users/unrelated"
+        )
+        let customHomeDestructive = ManagedTerminalAccountPlanner.rollbackPlan(
+            request: customHomeRequest,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/unrelated", shell: "/bin/zsh", hidden: true),
+                sudoers: .alanOwnedValid(path: "/etc/sudoers.d/alan-terminal-morris-to-alan"),
+                terminalProfile: .existingManaged(profileID: "alan"),
+                verification: .passed
+            ),
+            scope: .deleteAccountAndHome(confirmation: "alan")
+        )
+        expect(
+            customHomeDestructive.steps.map(\.kind).contains(.deleteAccount),
+            "custom-home destructive rollback may still delete the confirmed account"
+        )
+        expect(
+            !customHomeDestructive.steps.map(\.kind).contains(.deleteHomeDirectory),
+            "custom-home destructive rollback must not delete a non-canonical home directory"
+        )
+        let customHomeRunner = CapturingPrivilegedCommandRunner()
+        let customHomeExecutor = ManagedTerminalAccountAuthorizedScriptExecutor(
+            request: customHomeRequest,
+            commandRunner: customHomeRunner,
+            localEffectExecutor: ManagedTerminalAccountTerminalProfileEffectExecutor()
+        )
+        _ = customHomeExecutor.apply(customHomeDestructive)
+        expect(
+            !customHomeRunner.scripts.joined(separator: "\n").contains("/Users/unrelated"),
+            "custom-home destructive rollback must not emit rm -rf for a non-canonical home directory"
+        )
 
         let rollbackStoreURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("alan-managed-terminal-account-rollback-\(UUID().uuidString).json")
@@ -8543,7 +8658,8 @@ private enum ShellRuntimeMetadataTests {
         launchTarget: ShellLaunchTarget = .shell,
         process: ShellProcessBinding? = ShellProcessBinding(program: "fish", argvPreview: nil),
         attention: ShellAttentionState,
-        activity: TerminalActivitySnapshot? = nil
+        activity: TerminalActivitySnapshot? = nil,
+        terminalProfileID: String? = nil
     ) -> ShellPane {
         ShellPane(
             paneID: "pane_1",
@@ -8556,7 +8672,8 @@ private enum ShellRuntimeMetadataTests {
             context: context,
             viewport: viewport,
             activity: activity,
-            alanBinding: nil
+            alanBinding: nil,
+            terminalProfileID: terminalProfileID
         )
     }
 
@@ -8622,12 +8739,15 @@ private enum ShellRuntimeMetadataTests {
 
     private static func stateWithContext(
         windowID: String,
-        context: ShellContextSnapshot
+        context: ShellContextSnapshot,
+        spaceTerminalProfileID: String? = nil,
+        paneTerminalProfileID: String? = nil
     ) -> ShellStateSnapshot {
         let pane = pane(
             context: context,
             viewport: nil,
-            attention: .active
+            attention: .active,
+            terminalProfileID: paneTerminalProfileID
         )
         return ShellStateSnapshot(
             contractVersion: "0.1",
@@ -8653,7 +8773,8 @@ private enum ShellRuntimeMetadataTests {
                                 children: nil
                             )
                         )
-                    ]
+                    ],
+                    terminalProfileID: spaceTerminalProfileID
                 )
             ],
             panes: [pane]

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7866,6 +7866,58 @@ private enum ShellRuntimeMetadataTests {
             boot.workingDirectory == "/Users/alan",
             "global default terminal profile boot must use the profile default working directory"
         )
+
+        let spaceController = makeController(
+            windowID: "global_default_profile_space",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_profile_space",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let createdSpaceID = spaceController.createTerminalSpace(title: "Alan"),
+              let createdPaneID = spaceController.shellState.space(spaceID: createdSpaceID)?
+                .tabs.first?.paneTree.paneIDs.first,
+              let createdPane = spaceController.shellState.pane(paneID: createdPaneID)
+        else {
+            fail("global default terminal profile test must create a terminal Space")
+        }
+        expect(
+            spaceController.shellState.space(spaceID: createdSpaceID)?.terminalProfileID == "alan",
+            "new Spaces must capture the global default terminal profile"
+        )
+        expect(
+            createdPane.terminalProfileID == "alan",
+            "first pane in a global-default Space must capture the global default profile"
+        )
+        expect(
+            createdPane.cwd == nil,
+            "new Spaces using the global default terminal profile must let the profile cwd win"
+        )
+
+        let splitController = makeController(
+            windowID: "global_default_profile_split",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_profile_split",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let focusedPaneID = splitController.shellState.focusedPaneID,
+              let splitPaneID = splitController.splitPane(
+                paneID: focusedPaneID,
+                placement: .right
+              ),
+              let splitPane = splitController.shellState.pane(paneID: splitPaneID)
+        else {
+            fail("global default terminal profile test must split a terminal pane")
+        }
+        expect(
+            splitPane.terminalProfileID == "alan",
+            "splits from unprofiled panes must capture the global default terminal profile"
+        )
+        expect(
+            splitPane.cwd == nil,
+            "splits using the global default terminal profile must let the profile cwd win"
+        )
     }
 
     private static func verifiesTerminalProfileControlPlaneOverrides() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -8046,6 +8046,184 @@ private enum ShellRuntimeMetadataTests {
             localSplitPane?.cwd == nil,
             "local pane.split using the global default profile must let the profile cwd win"
         )
+
+        let noCwdDefaultProfiles = TerminalProfileDocument(
+            defaultProfileID: "root",
+            profiles: [
+                TerminalProfileDefinition.loginShellFallback,
+                TerminalProfileDefinition(
+                    id: "root",
+                    title: "Root",
+                    launch: .sudoRoot,
+                    defaultWorkingDirectory: nil,
+                    presentation: nil
+                ),
+            ]
+        )
+        do {
+            try store.save(noCwdDefaultProfiles)
+        } catch {
+            fail("no-cwd global default terminal profile test must save profile store: \(error)")
+        }
+
+        func expectCapturedNoCwdRootProfile(_ pane: ShellPane?, _ label: String) {
+            expect(
+                pane?.terminalProfileID == "root",
+                "\(label) must capture the no-cwd global default terminal profile"
+            )
+            expect(
+                pane?.cwd == nil,
+                "\(label) must not persist inherited cwd once the default profile is captured"
+            )
+        }
+
+        let noCwdTabController = makeController(
+            windowID: "global_default_no_cwd_profile_tab",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_no_cwd_profile_tab",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let noCwdTabID = noCwdTabController.openTerminalTab(),
+              let noCwdTabPaneID = noCwdTabController.shellState.tab(tabID: noCwdTabID)?
+                .paneTree.paneIDs.first,
+              let noCwdTabPane = noCwdTabController.shellState.pane(paneID: noCwdTabPaneID)
+        else {
+            fail("no-cwd global default terminal profile test must open a terminal tab")
+        }
+        expectCapturedNoCwdRootProfile(noCwdTabPane, "new tabs")
+        let noCwdBoot = AlanShellBootProfile.forPane(
+            noCwdTabPane,
+            shellState: noCwdTabController.shellState,
+            terminalProfiles: noCwdDefaultProfiles,
+            fileManager: AlwaysExecutableFileManager(),
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            noCwdBoot.environment["ALAN_TERMINAL_PROFILE_ID"] == "root",
+            "captured no-cwd global default profile must boot through the original profile"
+        )
+        expect(
+            noCwdBoot.environment["ALAN_TERMINAL_PROFILE_KIND"] == "sudo_root",
+            "captured no-cwd global default profile must preserve its launch kind"
+        )
+
+        let noCwdSpaceController = makeController(
+            windowID: "global_default_no_cwd_profile_space",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_no_cwd_profile_space",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let noCwdSpaceID = noCwdSpaceController.createTerminalSpace(title: "Root"),
+              let noCwdSpacePaneID = noCwdSpaceController.shellState.space(spaceID: noCwdSpaceID)?
+                .tabs.first?.paneTree.paneIDs.first
+        else {
+            fail("no-cwd global default terminal profile test must create a terminal Space")
+        }
+        expect(
+            noCwdSpaceController.shellState.space(spaceID: noCwdSpaceID)?.terminalProfileID
+                == "root",
+            "new Spaces must bind the no-cwd global default terminal profile"
+        )
+        expectCapturedNoCwdRootProfile(
+            noCwdSpaceController.shellState.pane(paneID: noCwdSpacePaneID),
+            "new Spaces"
+        )
+
+        let noCwdSplitController = makeController(
+            windowID: "global_default_no_cwd_profile_split",
+            shellState: .bootstrapDefault(
+                windowID: "global_default_no_cwd_profile_split",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        guard let noCwdFocusedPaneID = noCwdSplitController.shellState.focusedPaneID,
+              let noCwdSplitPaneID = noCwdSplitController.splitPane(
+                paneID: noCwdFocusedPaneID,
+                placement: .right
+              )
+        else {
+            fail("no-cwd global default terminal profile test must split a terminal pane")
+        }
+        expectCapturedNoCwdRootProfile(
+            noCwdSplitController.shellState.pane(paneID: noCwdSplitPaneID),
+            "splits"
+        )
+
+        let noCwdLocalTabResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-tab-no-cwd-global-default-profile",
+                  "command": "tab.open"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_no_cwd_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        expect(noCwdLocalTabResult?.response.applied == true, "local no-cwd tab.open must apply")
+        expectCapturedNoCwdRootProfile(
+            noCwdLocalTabResult?.updatedState?.pane(
+                paneID: noCwdLocalTabResult?.response.paneID ?? ""
+            ),
+            "local tab.open"
+        )
+
+        let noCwdLocalSpaceResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-space-no-cwd-global-default-profile",
+                  "command": "space.create"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_space_no_cwd_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        expect(noCwdLocalSpaceResult?.response.applied == true, "local no-cwd space.create must apply")
+        expect(
+            noCwdLocalSpaceResult?.response.spaceID.flatMap {
+                noCwdLocalSpaceResult?.updatedState?.space(spaceID: $0)
+            }?.terminalProfileID == "root",
+            "local space.create must bind the no-cwd global default terminal profile"
+        )
+        expectCapturedNoCwdRootProfile(
+            noCwdLocalSpaceResult?.updatedState?.pane(
+                paneID: noCwdLocalSpaceResult?.response.paneID ?? ""
+            ),
+            "local space.create"
+        )
+
+        let noCwdLocalSplitResult = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "local-split-no-cwd-global-default-profile",
+                  "command": "pane.split",
+                  "pane_id": "pane_1",
+                  "direction": "horizontal"
+                }
+                """
+            ),
+            state: .bootstrapDefault(
+                windowID: "local_split_no_cwd_global_default_profile",
+                workingDirectory: "/Users/morris/project"
+            )
+        )
+        expect(noCwdLocalSplitResult?.response.applied == true, "local no-cwd pane.split must apply")
+        expectCapturedNoCwdRootProfile(
+            noCwdLocalSplitResult?.updatedState?.pane(
+                paneID: noCwdLocalSplitResult?.response.paneID ?? ""
+            ),
+            "local pane.split"
+        )
     }
 
     private static func verifiesTerminalProfileControlPlaneOverrides() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -328,6 +328,29 @@ private enum ShellRuntimeMetadataTests {
             profiledRuntimeProjection.pane.terminalProfileID == "alan",
             "terminal adapter runtime projection must preserve captured terminal profile id"
         )
+        let profiledDefaultCwdPane = ShellPane(
+            paneID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID,
+            launchTarget: pane.launchTarget,
+            cwd: nil,
+            process: pane.process,
+            attention: pane.attention,
+            context: pane.context,
+            viewport: pane.viewport,
+            activity: pane.activity,
+            alanBinding: pane.alanBinding,
+            terminalProfileID: "alan"
+        )
+        let profiledDefaultCwdRuntimeProjection = adapter.projectRuntime(
+            runtime,
+            for: profiledDefaultCwdPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledDefaultCwdRuntimeProjection.pane.cwd == nil,
+            "terminal adapter runtime projection must preserve nil cwd for profile-bound panes"
+        )
         let profiledBootProjection = adapter.projectBootContext(
             runtime: runtime,
             for: profiledPane,
@@ -336,6 +359,15 @@ private enum ShellRuntimeMetadataTests {
         expect(
             profiledBootProjection.pane.terminalProfileID == "alan",
             "terminal adapter boot projection must preserve captured terminal profile id"
+        )
+        let profiledDefaultCwdBootProjection = adapter.projectBootContext(
+            runtime: runtime,
+            for: profiledDefaultCwdPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledDefaultCwdBootProjection.pane.cwd == nil,
+            "terminal adapter boot projection must preserve nil cwd for profile-bound panes"
         )
 
         let binding = ShellAlanBinding(
@@ -366,6 +398,16 @@ private enum ShellRuntimeMetadataTests {
         expect(
             profiledBindingProjection.pane.terminalProfileID == "alan",
             "terminal adapter binding projection must preserve captured terminal profile id"
+        )
+        let profiledDefaultCwdBindingProjection = adapter.projectAlanBinding(
+            binding,
+            runtime: runtime,
+            for: profiledDefaultCwdPane,
+            bootProfile: bootProfile
+        )
+        expect(
+            profiledDefaultCwdBindingProjection.pane.cwd == nil,
+            "terminal adapter binding projection must preserve nil cwd for profile-bound panes"
         )
         expect(
             bindingProjection.pane.viewport?.summary == "alan is waiting for user input",
@@ -8702,8 +8744,7 @@ private enum ShellRuntimeMetadataTests {
                     return true
                 }
             ),
-            entryVerifier: StubTerminalEntryVerifier(result: .passed),
-            passwordGenerator: { "SECRET-PASSWORD" }
+            entryVerifier: StubTerminalEntryVerifier(result: .passed)
         )
         let plan = ManagedTerminalAccountPlanner.plan(
             request: ManagedTerminalAccountRequest(
@@ -8722,12 +8763,23 @@ private enum ShellRuntimeMetadataTests {
         let diagnostics = result.visibleDiagnostics.joined(separator: " ")
         expect(result.failedStep == nil, "authorized executor must complete captured privileged scripts")
         expect(
-            !diagnostics.contains("SECRET-PASSWORD"),
-            "authorized executor diagnostics must not expose generated account passwords"
+            !diagnostics.contains("account_password"),
+            "authorized executor diagnostics must not expose account password internals"
+        )
+        let accountCreationScript = privilegedRunner.scripts.first {
+            $0.contains("AuthenticationAuthority")
+        } ?? ""
+        expect(
+            !accountCreationScript.contains("sysadminctl") && !accountCreationScript.contains("-password"),
+            "authorized executor account creation must not place account passwords in process argv"
         )
         expect(
-            privilegedRunner.scripts.contains { $0.contains("sysadminctl -addUser") },
-            "authorized executor must route account creation through an explicit privileged script"
+            accountCreationScript.contains("dscl . -create"),
+            "authorized executor must route account creation through explicit local-directory commands"
+        )
+        expect(
+            accountCreationScript.contains("AuthenticationAuthority \"$disabled_auth\""),
+            "authorized executor must disable password login for managed terminal accounts"
         )
         expect(
             privilegedRunner.scripts.contains { $0.contains("visudo -cf") },

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7859,6 +7859,23 @@ private enum ShellRuntimeMetadataTests {
             !sudoers.contents.contains("ALL=(ALL)"),
             "sudoers rule must not grant passwordless root or all-user access"
         )
+        let unmanagedSudoersPlan = ManagedTerminalAccountPlanner.plan(
+            request: request,
+            state: ManagedTerminalAccountState(
+                account: .standard(homeDirectory: "/Users/alan", shell: "/bin/zsh", hidden: true),
+                sudoers: .unmanaged(path: sudoers.filePath),
+                terminalProfile: .missing,
+                verification: .notRun
+            )
+        )
+        expect(
+            !unmanagedSudoersPlan.steps.map(\.kind).contains(.writeSudoersDropIn),
+            "unmanaged sudoers files must not be overwritten by a generic repair plan"
+        )
+        expect(
+            unmanagedSudoersPlan.status == .sudoersConflict(path: sudoers.filePath),
+            "unmanaged sudoers files must surface as conflicts"
+        )
 
         let invalid = ManagedTerminalAccountRequest(accountName: "root", guiUserName: "morris")
         expect(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7370,6 +7370,47 @@ private enum ShellRuntimeMetadataTests {
             boot.workingDirectory == "/Users/alan",
             "profile default working directory must apply when pane cwd is absent"
         )
+        expect(
+            boot.command.arguments.contains("/usr/bin/env"),
+            "sudo user boot command must re-inject shell-control environment after sudo"
+        )
+        expect(
+            boot.command.arguments.contains { $0.hasPrefix("ALAN_SHELL_SOCKET=") },
+            "sudo user boot command must preserve the shell-control socket for the target shell"
+        )
+        expect(
+            boot.command.arguments.contains { $0.hasPrefix("ALAN_SHELL_BINDING_FILE=") },
+            "sudo user boot command must preserve the shell binding file for the target shell"
+        )
+
+        let rootPane = ShellPane(
+            paneID: "pane_root_profile",
+            tabID: "tab_profile",
+            spaceID: "space_profile",
+            launchTarget: .shell,
+            cwd: nil,
+            process: nil,
+            attention: .active,
+            context: nil,
+            viewport: nil,
+            alanBinding: nil,
+            terminalProfileID: "root"
+        )
+        let rootBoot = AlanShellBootProfile.forPane(
+            rootPane,
+            shellState: state,
+            terminalProfiles: document,
+            fileManager: executableFileManager,
+            environment: ["SHELL": "/bin/zsh"]
+        )
+        expect(
+            rootBoot.command.arguments.contains("/usr/bin/env"),
+            "sudo root boot command must re-inject shell-control environment after sudo"
+        )
+        expect(
+            rootBoot.command.arguments.contains { $0.hasPrefix("ALAN_SHELL_SOCKET=") },
+            "sudo root boot command must preserve the shell-control socket for the target shell"
+        )
 
         let projectedContext = ShellPaneProjectionService(fileManager: executableFileManager)
             .projectedContext(

--- a/clients/apple/scripts/test-shell-settings-surface.sh
+++ b/clients/apple/scripts/test-shell-settings-surface.sh
@@ -13,6 +13,7 @@ mkdir -p "$MODULE_CACHE_DIR"
 CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Support/AlanCommandLineToolInstaller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Support/AlanMacUpdatePolicy.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-settings-surface.swift" \
     -o "$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -29,6 +29,7 @@ struct ShellSettingsSurfaceTestRunner {
             try testWorkspaceContextUsesRegistryForWorkspaceScopedRequests()
             try testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot()
             try testUnavailableRemoteSummariesStayCompact()
+            try testTerminalProfilesAndAccountsStayLocalAndRedacted()
             print("Shell settings surface tests passed.")
         } catch {
             fputs("Shell settings surface tests failed: \(error)\n", stderr)
@@ -40,12 +41,13 @@ struct ShellSettingsSurfaceTestRunner {
 private func testDefaultSectionOrderAndInterfaceMutability() throws {
     let snapshot = ShellSettingsSurfaceSnapshot.make(
         remote: .unavailable(reason: "Daemon unavailable"),
-        local: stableLocalSummary()
+        local: stableLocalSummary(),
+        terminalProfiles: testTerminalProfiles()
     )
 
     try expect(
         snapshot.sections.map(\.id) == ShellSettingsSectionID.defaultOrder,
-        "settings sections must render in Interface, Accounts, Sessions, Capabilities, Local order"
+        "settings sections must render local Terminal Profiles before provider Accounts"
     )
 
     let interface = try requireSection(.interface, in: snapshot)
@@ -112,7 +114,8 @@ private func testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted() throw
     )
     let snapshot = ShellSettingsSurfaceSnapshot.make(
         remote: ShellSettingsRemoteSnapshot(accounts: accounts, capabilities: capabilities),
-        local: stableLocalSummary()
+        local: stableLocalSummary(),
+        terminalProfiles: testTerminalProfiles()
     )
     let visibleText = snapshot.visibleText.joined(separator: "\n")
 
@@ -149,7 +152,8 @@ private func testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted() throw
 private func testDevChannelLocalRowsUseDevIdentity() throws {
     let snapshot = ShellSettingsSurfaceSnapshot.make(
         remote: .unavailable(reason: "Daemon unavailable"),
-        local: devLocalSummary()
+        local: devLocalSummary(),
+        terminalProfiles: testTerminalProfiles()
     )
     let localText = try requireSection(.local, in: snapshot).visibleText.joined(separator: "\n")
 
@@ -273,7 +277,8 @@ private func testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot() throws {
 private func testUnavailableRemoteSummariesStayCompact() throws {
     let snapshot = ShellSettingsSurfaceSnapshot.make(
         remote: .unavailable(reason: "Connection refused"),
-        local: stableLocalSummary()
+        local: stableLocalSummary(),
+        terminalProfiles: testTerminalProfiles()
     )
     let text = snapshot.visibleText.joined(separator: "\n")
 
@@ -282,6 +287,49 @@ private func testUnavailableRemoteSummariesStayCompact() throws {
     try expect(
         !text.contains("thinking_budget_tokens"),
         "sessions summary must not expose deprecated thinking budget controls"
+    )
+}
+
+private func testTerminalProfilesAndAccountsStayLocalAndRedacted() throws {
+    let accountPlan = ManagedTerminalAccountPlanner.plan(
+        request: ManagedTerminalAccountRequest(accountName: "alan", guiUserName: "morris"),
+        state: ManagedTerminalAccountState(
+            account: .missing,
+            sudoers: .missing,
+            terminalProfile: .missing,
+            verification: .notRun
+        )
+    )
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: .unavailable(reason: "Daemon unavailable"),
+        local: stableLocalSummary(),
+        terminalProfiles: testTerminalProfiles(),
+        managedTerminalAccounts: ManagedTerminalAccountSettingsSummary(plans: [accountPlan])
+    )
+    let profileSection = try requireSection(.terminalProfiles, in: snapshot)
+    let accountSection = try requireSection(.terminalAccounts, in: snapshot)
+    let providerSection = try requireSection(.accounts, in: snapshot)
+    let visibleText = snapshot.visibleText.joined(separator: "\n")
+
+    try expect(
+        profileSection.visibleText.contains("Terminal Profiles"),
+        "Terminal Profiles must render as local startup configuration"
+    )
+    try expect(
+        !providerSection.visibleText.contains("Alan"),
+        "Terminal Profiles must stay out of provider Accounts"
+    )
+    try expect(
+        !visibleText.contains("echo hidden-secret"),
+        "Settings must not expose full custom command text in normal rows"
+    )
+    try expect(
+        !visibleText.lowercased().contains("autologin"),
+        "Settings copy must not use autologin wording"
+    )
+    try expect(
+        accountSection.visibleText.joined(separator: " ").contains("terminal entry"),
+        "Managed Terminal Account rows must describe terminal entry"
     )
 }
 
@@ -306,6 +354,30 @@ private func stableLocalSummary() -> ShellSettingsLocalSummary {
             userMessage: ""
         ),
         homeDirectory: URL(fileURLWithPath: "/Users/test", isDirectory: true)
+    )
+}
+
+private func testTerminalProfiles() -> TerminalProfileSettingsSummary {
+    TerminalProfileSettingsSummary(
+        profiles: [
+            TerminalProfileDefinition.loginShellFallback,
+            TerminalProfileDefinition(
+                id: "alan",
+                title: "Alan",
+                launch: .sudoUser(unixUser: "alan"),
+                defaultWorkingDirectory: "/Users/alan",
+                presentation: nil
+            ),
+            TerminalProfileDefinition(
+                id: "custom",
+                title: "Bootstrap",
+                launch: .customCommand("echo hidden-secret"),
+                defaultWorkingDirectory: nil,
+                presentation: nil
+            ),
+        ],
+        defaultProfileID: "alan",
+        recoveryMessage: nil
     )
 }
 

--- a/clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh
+++ b/clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-terminal-account-dev-dry-run-smoke"
+MODULE_CACHE_DIR="$BUILD_DIR/clang-module-cache"
+TEST_BINARY="$BUILD_DIR/terminal-account-dev-dry-run-smoke"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.swift
+++ b/clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else {
+        fputs("terminal-account-dev-dry-run-smoke: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+@main
+private enum TerminalAccountDevDryRunSmoke {
+    static func main() throws {
+        let fileManager = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("alan-terminal-account-dev-dry-run-\(UUID().uuidString)", isDirectory: true)
+        let appSupport = root.appendingPathComponent("app-support", isDirectory: true)
+        let devProfileStore = appSupport
+            .appendingPathComponent("alan-macos-dev", isDirectory: true)
+            .appendingPathComponent("terminal-profiles.json", isDirectory: false)
+        let stableProfileStore = appSupport
+            .appendingPathComponent("alan-macos", isDirectory: true)
+            .appendingPathComponent("terminal-profiles.json", isDirectory: false)
+
+        try fileManager.createDirectory(at: appSupport, withIntermediateDirectories: true)
+
+        let request = ManagedTerminalAccountRequest(
+            accountName: "alan_smoke",
+            guiUserName: "morris",
+            fullName: "Alan Smoke",
+            shell: "/bin/zsh",
+            homeDirectory: "/Users/alan_smoke",
+            hideFromLoginWindow: true,
+            bindCurrentSpaceAfterSuccess: true
+        )
+        let missingState = ManagedTerminalAccountState(
+            account: .missing,
+            sudoers: .missing,
+            terminalProfile: .missing,
+            verification: .notRun
+        )
+        let plan = ManagedTerminalAccountPlanner.plan(request: request, state: missingState)
+        let planKinds = plan.steps.map(\.kind)
+
+        expect(plan.status == .readyToApply, "missing account dry run must be ready to apply")
+        expect(planKinds.contains(.createStandardAccount), "dry run must include account creation")
+        expect(planKinds.contains(.hideAccount), "dry run must include login-window hiding")
+        expect(planKinds.contains(.writeSudoersDropIn), "dry run must include sudoers write")
+        expect(planKinds.contains(.validateSudoers), "dry run must include sudoers validation")
+        expect(planKinds.contains(.verifyTerminalEntry), "dry run must include terminal entry verification")
+        expect(planKinds.contains(.createOrUpdateTerminalProfile), "dry run must include profile handoff")
+        expect(planKinds.contains(.bindCurrentSpace), "dry run must include explicit Space binding step")
+
+        let rule = ManagedTerminalAccountSudoersRule(request: request)
+        expect(
+            rule.filePath == "/etc/sudoers.d/alan-terminal-morris-to-alan_smoke",
+            "sudoers path must be deterministic and Alan-owned"
+        )
+        expect(
+            rule.contents.contains("morris ALL=(alan_smoke) NOPASSWD: ALL"),
+            "sudoers rule must target only the managed account"
+        )
+        expect(!rule.contents.contains("ALL=(ALL)"), "sudoers rule must not grant passwordless root")
+        expect(
+            !rule.contents.contains("morris ALL=(root)"),
+            "sudoers rule must not grant direct root entry"
+        )
+
+        let cancelledExecutor = ManagedTerminalAccountFakeExecutor()
+        cancelledExecutor.cancelBeforeApply = true
+        let cancelled = cancelledExecutor.apply(plan)
+        expect(cancelled.cancelled, "cancelled preview must not apply privileged changes")
+        expect(cancelled.completedSteps.isEmpty, "cancelled preview must not complete steps")
+        expect(
+            !fileManager.fileExists(atPath: devProfileStore.path),
+            "cancelled dry run must not create a dev profile store"
+        )
+        expect(
+            !fileManager.fileExists(atPath: stableProfileStore.path),
+            "cancelled dry run must not create a stable profile store"
+        )
+
+        let readyState = ManagedTerminalAccountState(
+            account: .standard(homeDirectory: "/Users/alan_smoke", shell: "/bin/zsh", hidden: true),
+            sudoers: .alanOwnedValid(path: rule.filePath),
+            terminalProfile: .missing,
+            verification: .passed
+        )
+        guard let handoff = ManagedTerminalAccountProfileHandoff.profileDefinition(
+            for: request,
+            state: readyState
+        ) else {
+            fputs("terminal-account-dev-dry-run-smoke: ready state did not produce handoff profile\n", stderr)
+            exit(1)
+        }
+
+        let store = TerminalProfileStore.defaultStore(
+            channelApplicationSupportDirectoryName: "alan-macos-dev",
+            fileManager: fileManager,
+            environment: [
+                "ALAN_INSTALL_CHANNEL": "dev",
+                "ALAN_MACOS_APPLICATION_SUPPORT_DIR": appSupport.path,
+            ]
+        )
+        try store.save(TerminalProfileDocument(defaultProfileID: handoff.id, profiles: [handoff]))
+        let loaded = store.load().document.profile(id: "alan_smoke")
+
+        expect(fileManager.fileExists(atPath: devProfileStore.path), "handoff must write dev profile store")
+        expect(
+            !fileManager.fileExists(atPath: stableProfileStore.path),
+            "dev-channel handoff must not create stable profile store"
+        )
+        expect(loaded?.managedTerminalAccountID == "alan_smoke", "profile must link managed account")
+        expect(loaded?.launch == .sudoUser(unixUser: "alan_smoke"), "profile must use sudo_user launch")
+
+        print("terminal account dev dry-run smoke passed")
+        print("tmp_root=\(root.path)")
+        print("dev_profile_store=\(devProfileStore.path)")
+    }
+}

--- a/justfile
+++ b/justfile
@@ -81,6 +81,7 @@ apple-shell-focused-tests:
     bash clients/apple/scripts/test-shell-automation-command-seams.sh
     bash clients/apple/scripts/test-shell-runtime-metadata.sh
     bash clients/apple/scripts/test-shell-settings-surface.sh
+    bash clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh
     bash clients/apple/scripts/test-macos-auto-update-policy.sh
     ./scripts/test-appcast-tools.sh
 

--- a/openspec/changes/add-macos-terminal-profiles/.openspec.yaml
+++ b/openspec/changes/add-macos-terminal-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/add-macos-terminal-profiles/completion-audit.md
+++ b/openspec/changes/add-macos-terminal-profiles/completion-audit.md
@@ -1,0 +1,39 @@
+## Completion Audit
+
+Change: `add-macos-terminal-profiles`
+
+Status: implementation-ready, pending merged-spec sync.
+
+### Requirement Evidence
+
+| Requirement area | Evidence |
+| --- | --- |
+| Local Terminal Profile model, validation, store, fallback, and corrupt-store recovery | `TerminalProfileDefinition`, `TerminalProfileDocument`, `TerminalProfileValidator`, and `TerminalProfileStore` in `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`; focused coverage in `clients/apple/scripts/test-shell-runtime-metadata.swift` |
+| Structured launch modes for `login_shell`, `sudo_user`, `sudo_root`, and `custom_command` | `TerminalProfileLaunchKind`, launch generation in `TerminalHostRuntime.swift`, and runtime metadata tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` |
+| Workspace manifests store only profile references | `terminal_profile_id` fields in `ShellSnapshots.swift` and `ShellWorkspaceManifest.swift`; manifest/reference tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` |
+| Profile references survive restore and missing profiles fall back safely | restore and missing-profile tests in `clients/apple/scripts/test-shell-runtime-metadata.swift`; dev-channel relaunch smoke evidence captured by task 6.3 |
+| Space binding, tab inheritance, split inheritance, explicit override, and non-retroactive updates | mutation/action changes in `ShellStateMutations.swift`, `ShellAutomationCommand.swift`, `ShellAutomationIntents.swift`, `ShellControlPlaneDTOs.swift`, `ShellHostControlCommandHandling.swift`, `ShellLocalCommandExecutor.swift`, and `ShellHostController.swift`; focused tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` |
+| Terminal lifecycle uses existing Ghostty-backed surface path | profile-aware command resolution in `TerminalHostRuntime.swift` without replacing the terminal host path; covered by runtime tests |
+| Non-secret profile metadata projection | `ShellPaneProjectionService.swift`, `ShellPublishedStateMerger.swift`, and `ShellContextSnapshot` fields in `ShellValueTypes.swift`; covered by runtime metadata tests |
+| Settings and sidebar affordances with redaction | `ShellSettingsSurfaceModel.swift`, `ShellSidebarView.swift`, `test-shell-settings-surface.swift`, and `test-shell-runtime-metadata.swift` |
+| Provider connection profiles remain separate | no `connections.toml`, provider credential, or `connection_profile` schema changes are part of this change; task 6.5 diff review recorded |
+
+### Verification Gates
+
+Required focused gates for acceptance:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `just apple-shell-focused-tests`
+- `openspec validate add-macos-terminal-profiles --strict`
+- `git diff --check`
+- dev-channel fresh relaunch smoke for persisted profile references and
+  missing-profile fallback
+
+### Remaining Work
+
+Task 6.7 remains open by design: accepted spec deltas can only be synced into
+`openspec/specs/` after the implementation is merged. Do not archive this change
+before that merge and sync happen.
+

--- a/openspec/changes/add-macos-terminal-profiles/design.md
+++ b/openspec/changes/add-macos-terminal-profiles/design.md
@@ -1,0 +1,171 @@
+## Context
+
+Alan for macOS already has a durable shell workspace model: Spaces, tabs,
+splits, content containers, terminal restore snapshots, Settings, shell action
+routing, and Ghostty-backed terminal startup. The current terminal startup
+contract is still effectively one-dimensional: a pane launches the GUI user's
+login shell, with process-level environment overrides such as
+`ALAN_SHELL_BOOT_COMMAND` and `ALAN_SHELL_LOGIN_SHELL` for development.
+
+The user workflow now needs a more explicit local identity layer:
+
+- `morris` remains the GUI user.
+- Terminal work may happen as Unix users such as `alan`, `univer`, `lab`, or
+  `root`.
+- Each identity can have its own home directory, SSH keys, Git config, cloud
+  credentials, and command-line agent state.
+- Spaces should make this identity choice visible and repeatable without
+  conflating it with Alan provider `connection_profile`.
+
+Existing constraints:
+
+- Workspace manifests are the shell restore authority, but they must not embed
+  machine-local secrets or host-specific profile definitions.
+- `connection_profile` already means provider/model credential selection in the
+  daemon/runtime. Terminal startup identity must use a distinct name.
+- Dev and stable macOS channels have separate app support and verification
+  paths.
+- Terminal startup must continue through the existing Ghostty surface path and
+  shell state projection rather than introducing a parallel terminal backend.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add machine-local Terminal Profiles that define how new terminal content
+  starts.
+- Keep Terminal Profiles separate from Alan provider connection profiles and
+  future broader identity profiles.
+- Support common structured startup modes: login shell, sudo Unix user, sudo
+  root, and advanced custom command.
+- Let Spaces bind to a default Terminal Profile while terminal content records
+  the profile used at creation time.
+- Preserve current manifest compatibility and fallback behavior when profile
+  references are missing, stale, or invalid.
+- Add compact Settings and sidebar affordances consistent with the existing
+  terminal-first macOS shell.
+
+**Non-Goals:**
+
+- Editing `/etc/sudoers`, configuring passwordless sudo, or managing Unix users.
+- Replacing `connection_profile`, provider auth, `agent.toml`, or connection
+  management.
+- Creating a full Identity Profile that owns Git, SSH, cloud, agent, and
+  terminal settings in one model.
+- Migrating profile definitions through workspace manifests or project files.
+- Changing the Ghostty terminal backend or adding another terminal runtime.
+- Retrofitting already-running terminals when a Space binding or profile
+  definition changes.
+
+## Decisions
+
+1. **Use a new Terminal Profile concept instead of extending connection profiles.**
+
+   Terminal Profiles describe terminal startup identity. Connection profiles
+   describe LLM/provider credentials and model selection. Keeping these models
+   distinct prevents UI ambiguity and avoids pulling Unix account details into
+   daemon/runtime connection semantics. A future Identity Profile can compose a
+   Terminal Profile and a connection profile, but V1 keeps the terminal model
+   narrow.
+
+2. **Store profile definitions as machine-local, channel-scoped app support data.**
+
+   The profile store lives under the active Alan macOS install channel's
+   Application Support directory, for example `terminal-profiles.json` beside
+   other channel-scoped shell state. This keeps `/Users/alan`, `sudo -iu alan`,
+   icons, colors, and custom commands out of workspace manifests. Dev-channel
+   testing can create profiles without silently mutating stable-channel user
+   state.
+
+3. **Persist only profile references in shell workspace state.**
+
+   A Space record stores an optional `terminal_profile_id`. A terminal content
+   payload stores the profile id resolved at content creation time. The
+   workspace manifest never copies the profile definition. Missing references
+   remain visible as missing references and fall back to the login shell instead
+   of preventing app startup or deleting user workspace state.
+
+4. **Keep launch modes structured where possible.**
+
+   The profile kind is one of `login_shell`, `sudo_user`, `sudo_root`, or
+   `custom_command`. Structured sudo modes generate argv directly, such as
+   `/usr/bin/sudo -iu alan`, instead of asking users to handwrite shell strings.
+   `custom_command` remains available as an advanced escape hatch and runs via
+   `/bin/zsh -lc <command>`.
+
+5. **Resolve profiles in shell model code before Ghostty surface creation.**
+
+   `AlanShellBootProfile.forPane(...)` already produces command, cwd,
+   environment, and Ghostty integration data. Terminal Profiles should extend
+   that resolution path. The resulting Ghostty `surfaceConfig.command`,
+   `working_directory`, and environment remain the terminal launch mechanism.
+
+6. **Use Space binding as a default, not a retroactive mutation.**
+
+   A Space profile affects future terminal creation. New tabs inherit the Space
+   profile by default; new splits inherit the current pane's terminal profile by
+   default; explicit creation requests can override either. Existing terminal
+   content keeps the profile id it was created with. This avoids silently
+   changing a running terminal's Unix user after a Space setting changes.
+
+7. **Expose Terminal Profiles through calm local UI.**
+
+   Settings gains a local Terminal Profiles section for creation and editing.
+   Space menus or the Space header provide binding selection. Sidebar rows and
+   pane title/status surfaces can show profile identity when useful, especially
+   for root, custom command, or missing-profile states, but should not turn every
+   row into a dense status dashboard.
+
+## Risks / Trade-offs
+
+- **[Risk] Profile terminology collides with provider connection profiles.** ->
+  Use `Terminal Profile` in UI and `terminal_profile_id` in serialized fields.
+  Avoid bare `profile` labels in this feature.
+- **[Risk] Machine-local profile references break when moving manifests between
+  Macs.** -> Preserve the id, show a missing-profile state, and fall back to
+  login shell. Do not delete or rewrite the reference automatically.
+- **[Risk] Custom commands expose sensitive local workflow details.** -> Keep
+  custom commands in local profile storage, not manifests. Sidebar/control-plane
+  summaries use id/title/kind by default; full command appears only in Settings
+  or explicit diagnostics.
+- **[Risk] Sudo prompts surprise users.** -> Alan does not hide sudo behavior.
+  If sudo requires a password, the terminal shows the normal prompt. Settings
+  can explain that passwordless sudo is an operator-managed system setting.
+- **[Risk] Changing a profile definition changes restored terminals later.** ->
+  This is intentional because terminal content stores a profile reference, not a
+  snapshot. Users who need a frozen startup command can duplicate the profile
+  before changing it.
+- **[Risk] Channel-scoped profiles create duplicate setup for stable/dev.** ->
+  Channel separation protects stable state during development. A later import or
+  copy action can reduce duplicate setup after the feature stabilizes.
+
+## Migration Plan
+
+1. Add Terminal Profile value types and a channel-scoped local profile store
+   with default login-shell fallback, schema validation, and corrupt-file
+   quarantine.
+2. Add optional `terminal_profile_id` fields to Space records and terminal
+   content payloads while preserving old manifest decoding.
+3. Extend shell state mutations, workspace materialization, and restore snapshot
+   conversion to preserve profile references.
+4. Extend boot-profile resolution to load Terminal Profiles and generate
+   structured launch commands.
+5. Add action/control-plane/App Intent fields for explicit terminal-profile
+   overrides on Space, tab, and split creation.
+6. Add Settings and sidebar UI affordances after the model and launch behavior
+   are covered by focused tests.
+7. Validate with model tests, terminal runtime tests, manifest tests, shell
+   action/automation tests, and dev-channel relaunch smoke.
+
+Rollback: because profile definitions are local and references are optional,
+the feature can be disabled by ignoring `terminal_profile_id` fields and
+falling back to login-shell startup. Existing manifests remain decodable.
+
+## Open Questions
+
+- Should stable-channel Alan eventually offer an explicit "Import profiles from
+  Alan Dev" action after the feature ships?
+- Should profile colors/icons be required for Space dock hints, or remain
+  optional presentation metadata in V1?
+- Should custom-command profiles require a one-time confirmation on first use,
+  or is Settings-level advanced labeling sufficient?

--- a/openspec/changes/add-macos-terminal-profiles/pr-slices.md
+++ b/openspec/changes/add-macos-terminal-profiles/pr-slices.md
@@ -1,0 +1,120 @@
+## PR Slices
+
+Target base: latest `origin/main`, or the merged branch that already contains
+any required macOS shell restore work. Do not include unrelated local
+`stabilize-macos-quick-terminal-peak` commits in these slices.
+
+### 1. Model, Store, And Manifest References
+
+Branch: `macos-terminal-profiles-model-store`
+
+Includes:
+
+- Terminal Profile value types, validation, channel-scoped store, corrupt-store
+  fallback, and login-shell default.
+- Optional `terminal_profile_id` fields on Space, terminal content, restore
+  records, and workspace snapshots.
+- Manifest compatibility and missing-profile preservation tests.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift`
+- `clients/apple/scripts/test-shell-runtime-metadata.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `openspec validate add-macos-terminal-profiles --strict`
+
+### 2. Launch Resolution And Workspace Interactions
+
+Branch: `macos-terminal-profiles-launch-interactions`
+
+Depends on: slice 1.
+
+Includes:
+
+- Profile-aware terminal boot command resolution through the existing Ghostty
+  surface path.
+- Structured launch commands for `login_shell`, `sudo_user`, `sudo_root`, and
+  `custom_command`.
+- Space default profile binding, tab inheritance, split inheritance, explicit
+  overrides, and non-retroactive binding changes.
+- Control-plane, action-routing, local command executor, and App Intent fields
+  for terminal-profile overrides.
+
+Primary files:
+
+- `clients/apple/alan-macos/TerminalHostRuntime.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift`
+- `clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift`
+- `clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift`
+- `clients/apple/alan-macos/ShellHostController.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `openspec validate add-macos-terminal-profiles --strict`
+
+### 3. Settings, Sidebar, And Runtime Metadata
+
+Branch: `macos-terminal-profiles-ui`
+
+Depends on: slice 2.
+
+Includes:
+
+- Terminal Profiles Settings model rows and structured edit/validation
+  affordances.
+- Compact Space profile binding selector and quiet identity/missing/root/custom
+  command hints in shell UI.
+- Non-secret profile metadata projection into pane context and published state
+  merges.
+- Redaction behavior for normal shell chrome.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift`
+- `clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift`
+- `clients/apple/alan-macos/Services/Shell/ShellPaneProjectionService.swift`
+- `clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift`
+- `clients/apple/scripts/test-shell-settings-surface.sh`
+- `clients/apple/scripts/test-shell-settings-surface.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `openspec validate add-macos-terminal-profiles --strict`
+
+### 4. Smoke And Contract Gate
+
+Branch: `macos-terminal-profiles-smoke-contract`
+
+Depends on: slice 3.
+
+Includes:
+
+- Dev-channel fresh relaunch smoke evidence for persisted profile references
+  and missing-profile fallback.
+- Focused test aggregator updates and OpenSpec task status.
+
+Primary files:
+
+- `justfile`
+- `openspec/changes/add-macos-terminal-profiles/tasks.md`
+
+Required verification:
+
+- Dev-channel fresh relaunch smoke path for profile restore and missing fallback.
+- `just apple-shell-focused-tests`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `openspec validate add-macos-terminal-profiles --strict`
+- `git diff --check`
+

--- a/openspec/changes/add-macos-terminal-profiles/proposal.md
+++ b/openspec/changes/add-macos-terminal-profiles/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Alan for macOS is becoming a terminal-first workspace for distinct work
+identities, but every new terminal currently launches as the GUI user's login
+shell. Users who maintain separate Unix accounts for Alan, Univer, personal, or
+lab work need a first-class way to bind Spaces to terminal startup identities
+without mixing that concern with Alan connection profiles.
+
+## What Changes
+
+- Add machine-local **Terminal Profiles** for terminal startup identity:
+  login shell, sudo Unix user, sudo root, and advanced custom command.
+- Keep Terminal Profiles separate from provider `connection_profile` and future
+  broader identity profiles.
+- Store Terminal Profile definitions in Alan for macOS local app support, while
+  workspace manifests only store profile references.
+- Let Spaces bind to a default Terminal Profile; new tabs inherit the Space
+  profile and new splits inherit the current pane profile unless explicitly
+  overridden.
+- Persist each terminal content's creation-time `terminal_profile_id` for
+  restore, diagnostics, and clear user-facing identity.
+- Add Settings and sidebar affordances for creating, editing, selecting, and
+  identifying Terminal Profiles without turning the shell into a dashboard.
+- Preserve safe fallback behavior when a profile is missing or invalid: the app
+  remains usable and falls back to the login shell with a visible missing-profile
+  state.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-terminal-profiles`: Defines machine-local Terminal Profile storage,
+  profile kinds, resolution, safety boundaries, and separation from Alan
+  provider connection profiles.
+
+### Modified Capabilities
+
+- `macos-shell-workspace-persistence`: Persist Space and terminal-content
+  profile references in the workspace manifest without embedding machine-local
+  profile definitions.
+- `macos-shell-workspace-interactions`: Define inheritance and explicit
+  override behavior for new Spaces, tabs, and splits.
+- `macos-shell-terminal-lifecycle`: Define terminal startup and restore behavior
+  when a terminal content has a Terminal Profile reference.
+- `macos-shell-ui-ux-conformance`: Add calm Settings and sidebar affordances for
+  Terminal Profiles and missing-profile states.
+- `macos-shell-build-test-contract`: Require focused verification for profile
+  store, manifest compatibility, launch resolution, inheritance, and UI smoke.
+
+## Impact
+
+- Apple client models need Terminal Profile value types, a local profile store,
+  and profile references on Space and terminal content restore payloads.
+- `AlanShellBootProfile` / `AlanCommandResolution` need profile-aware command
+  resolution while preserving the existing login-shell fallback and Ghostty
+  surface path.
+- Shell mutations, action routing, control-plane DTOs, and App Intents need to
+  carry optional terminal-profile overrides for Space, tab, and split creation.
+- Settings and sidebar UI need profile management and Space binding controls.
+- Focused Apple shell tests need coverage for local profile persistence,
+  workspace manifest compatibility, command generation, inheritance rules, and
+  dev-channel relaunch restore.

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Terminal Profile Changes Have Focused Verification
+Alan for macOS SHALL require focused verification for changes to Terminal
+Profile storage, profile-aware workspace persistence, launch resolution,
+inheritance, and UI before those changes are accepted.
+
+#### Scenario: Profile store tests run
+- **WHEN** Terminal Profile store behavior changes
+- **THEN** focused tests cover missing-store fallback, corrupt-store quarantine,
+  profile validation, default profile selection, and profile lookup
+
+#### Scenario: Workspace manifest tests cover profile references
+- **WHEN** workspace manifest fields for Terminal Profile references change
+- **THEN** focused manifest tests cover old-manifest compatibility, Space
+  profile references, terminal content profile references, missing local
+  profile references, and the rule that profile definitions are not embedded
+
+#### Scenario: Boot resolution tests cover launch modes
+- **WHEN** terminal boot-profile resolution changes for Terminal Profiles
+- **THEN** focused terminal runtime tests cover login shell, sudo Unix user,
+  sudo root, custom command, missing profile fallback, and non-secret
+  environment projection
+
+#### Scenario: Interaction tests cover inheritance
+- **WHEN** shell mutations or action routing change for Terminal Profiles
+- **THEN** focused shell action or automation tests cover Space profile binding,
+  new tab inheritance, split inheritance, explicit profile override, and
+  non-retroactive Space binding changes
+
+#### Scenario: UI smoke covers dev-channel restore
+- **WHEN** Terminal Profile Settings or sidebar affordances change
+- **THEN** validation includes a dev-channel fresh relaunch smoke path that
+  confirms profile references survive restart and missing-profile fallback is
+  visible without blocking the shell

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Terminal Startup Uses Resolved Terminal Profile
+The macOS terminal lifecycle SHALL launch terminal content using the resolved
+Terminal Profile while preserving the existing Ghostty-backed terminal surface
+creation path.
+
+#### Scenario: Terminal content starts with profile command
+- **WHEN** terminal content is created with `terminal_profile_id` `alan`
+- **AND** local Terminal Profile `alan` is a `sudo_user` profile for Unix user
+  `alan`
+- **THEN** alan resolves the terminal boot command to the structured sudo-user
+  launch for `alan`
+- **AND** Ghostty surface creation still receives the command, working
+  directory, and environment through the existing terminal boot profile
+
+#### Scenario: Profile metadata is projected to terminal environment
+- **WHEN** terminal content starts with a resolved Terminal Profile
+- **THEN** alan exposes non-secret profile metadata such as profile id and launch
+  kind through terminal environment variables
+- **AND** alan does not expose provider credentials or secret values through
+  those variables
+
+#### Scenario: Custom command startup is marked active
+- **WHEN** terminal content starts with a `custom_command` Terminal Profile
+- **THEN** alan treats the terminal startup as a foreground command until the
+  terminal runtime reports completion or a shell-integration state update
+
+### Requirement: Terminal Restore Reuses Stored Profile Reference
+The macOS terminal lifecycle SHALL restore terminal content using its stored
+Terminal Profile reference when one exists.
+
+#### Scenario: Restored terminal uses stored profile
+- **WHEN** alan restores terminal content from a workspace manifest with
+  `terminal_profile_id` `univer`
+- **THEN** alan launches the restored terminal using the current local
+  definition of Terminal Profile `univer`
+
+#### Scenario: Edited profile affects future restore
+- **WHEN** terminal content stores `terminal_profile_id` `alan`
+- **AND** the local `alan` Terminal Profile definition changes before app
+  restart
+- **THEN** the restored terminal uses the updated local `alan` profile
+  definition
+
+#### Scenario: Missing restored profile falls back
+- **WHEN** alan restores terminal content with `terminal_profile_id` `lab`
+- **AND** local Terminal Profile `lab` is missing
+- **THEN** alan launches the restored terminal with the login-shell fallback
+- **AND** alan reports the missing profile state in shell metadata

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Settings Manages Terminal Profiles Locally
+Alan macOS Settings SHALL provide a local Terminal Profiles surface for
+creating, editing, and choosing the default Terminal Profile without presenting
+Terminal Profiles as provider accounts.
+
+#### Scenario: Terminal Profiles appear in Settings
+- **WHEN** the user opens Settings
+- **THEN** alan shows Terminal Profiles as local terminal startup configuration
+- **AND** alan does not place Terminal Profiles under provider Accounts or label
+  them as connection profiles
+
+#### Scenario: Structured profile editing
+- **WHEN** the user edits a Terminal Profile
+- **THEN** alan provides structured controls for login shell, sudo Unix user,
+  sudo root, and custom command launch modes
+- **AND** required fields are validated before the profile is saved
+
+#### Scenario: Sudo behavior is explained without editing sudoers
+- **WHEN** the user configures a sudo Unix user or sudo root Terminal Profile
+- **THEN** alan explains that sudo prompts and passwordless sudo behavior are
+  controlled by the operating system
+- **AND** alan does not offer to edit sudoers files from Settings
+
+### Requirement: Spaces Expose Terminal Profile Binding
+The macOS shell UI SHALL let users view and change a Space's default Terminal
+Profile through compact shell-native affordances.
+
+#### Scenario: Space profile can be selected
+- **WHEN** the user opens a Space action menu or profile selector
+- **THEN** alan lists local Terminal Profiles by title and launch kind
+- **AND** selecting one updates the Space's default `terminal_profile_id`
+
+#### Scenario: Space profile hint stays quiet
+- **WHEN** a Space has a Terminal Profile binding
+- **THEN** alan may show a compact icon, color, or label hint in the sidebar
+- **AND** alan keeps the sidebar scannable and avoids turning Space rows into
+  dense configuration panels
+
+#### Scenario: Missing profile is visible
+- **WHEN** a Space or terminal content references a missing Terminal Profile
+- **THEN** alan shows a missing-profile state with the missing id
+- **AND** alan keeps terminal creation available through login-shell fallback
+
+### Requirement: Terminal Profile Details Stay Appropriately Redacted
+Alan macOS shell UI SHALL expose Terminal Profile identity in normal shell
+surfaces without leaking unnecessary command details.
+
+#### Scenario: Custom command is not shown in normal sidebar rows
+- **WHEN** a terminal content uses a `custom_command` Terminal Profile
+- **THEN** normal sidebar and pane chrome use the profile title or kind
+- **AND** the full custom command is shown only in Settings or explicit
+  diagnostics
+
+#### Scenario: Root profile is visibly distinct
+- **WHEN** terminal content uses a sudo root Terminal Profile
+- **THEN** alan presents a restrained but clear root identity indicator in
+  terminal chrome or status surfaces

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Spaces Own Default Terminal Profiles
+The macOS shell SHALL allow each Space to reference a default Terminal Profile
+used for new terminal content created in that Space.
+
+#### Scenario: New Space with profile
+- **WHEN** the user creates a Space and selects Terminal Profile `alan`
+- **THEN** alan binds the new Space to `terminal_profile_id` `alan`
+- **AND** the Space's first terminal content is created with `terminal_profile_id`
+  `alan`
+
+#### Scenario: New tab inherits Space profile
+- **WHEN** the selected Space is bound to Terminal Profile `univer`
+- **AND** the user creates a new terminal tab without an explicit profile
+- **THEN** alan creates the new terminal content with `terminal_profile_id`
+  `univer`
+
+#### Scenario: New tab explicit profile override
+- **WHEN** the selected Space is bound to Terminal Profile `alan`
+- **AND** the user creates a new terminal tab explicitly using Terminal Profile
+  `root`
+- **THEN** alan creates the new terminal content with `terminal_profile_id`
+  `root`
+
+### Requirement: Splits Inherit Current Pane Terminal Profile
+The macOS shell SHALL create split terminal content using the current pane's
+Terminal Profile by default, so split workflows remain within the same Unix
+identity unless the user explicitly overrides them.
+
+#### Scenario: Split inherits current pane profile
+- **WHEN** the focused terminal pane was created with Terminal Profile `alan`
+- **AND** the user creates a split without an explicit profile
+- **THEN** alan creates the new split terminal content with
+  `terminal_profile_id` `alan`
+
+#### Scenario: Split falls back to Space profile
+- **WHEN** the focused pane has no terminal profile reference
+- **AND** the selected Space is bound to Terminal Profile `univer`
+- **AND** the user creates a split without an explicit profile
+- **THEN** alan creates the new split terminal content with
+  `terminal_profile_id` `univer`
+
+#### Scenario: Split explicit profile override
+- **WHEN** the focused pane was created with Terminal Profile `alan`
+- **AND** the user creates a split explicitly using Terminal Profile `root`
+- **THEN** alan creates the new split terminal content with
+  `terminal_profile_id` `root`
+
+### Requirement: Space Profile Binding Is Not Retroactive
+The macOS shell SHALL treat a Space Terminal Profile binding as a default for
+future terminal creation, not as a command to migrate existing terminal content.
+
+#### Scenario: Space binding changes
+- **WHEN** a Space changes its Terminal Profile binding from `alan` to `univer`
+- **THEN** existing terminal content in that Space keeps its stored
+  `terminal_profile_id`
+- **AND** new terminal content created after the change uses `univer` by default

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Workspace Manifest Stores Terminal Profile References
+The macOS shell workspace manifest SHALL persist Terminal Profile references for
+Spaces and terminal content without embedding machine-local Terminal Profile
+definitions.
+
+#### Scenario: Space profile reference is saved
+- **WHEN** a Space is bound to Terminal Profile `alan`
+- **THEN** the workspace manifest stores `terminal_profile_id` `alan` on that
+  Space record
+- **AND** the manifest does not store the `alan` profile command, Unix user,
+  color, icon, or default working directory definition
+
+#### Scenario: Terminal content profile reference is saved
+- **WHEN** a terminal content instance is created using Terminal Profile `univer`
+- **THEN** the terminal content restore payload stores `terminal_profile_id`
+  `univer`
+- **AND** restore can explain which Terminal Profile the content was created
+  with
+
+#### Scenario: Old manifest decodes without profile fields
+- **WHEN** alan reads a workspace manifest created before Terminal Profiles
+- **THEN** alan decodes the manifest successfully
+- **AND** missing `terminal_profile_id` fields are treated as absent profile
+  references
+
+#### Scenario: Missing local profile does not rewrite manifest
+- **WHEN** alan restores a manifest that references Terminal Profile `lab` but
+  the local profile store does not define `lab`
+- **THEN** alan preserves the `lab` reference in the workspace manifest
+- **AND** alan does not delete the Space, terminal content, or missing reference
+  during normal restore
+
+### Requirement: Workspace Manifest Keeps Profile Reference Ownership Narrow
+The macOS shell workspace manifest SHALL treat `terminal_profile_id` as a local
+startup reference and SHALL NOT make Terminal Profile definitions portable
+workspace state.
+
+#### Scenario: Workspace is shared to another Mac
+- **WHEN** a workspace manifest containing `terminal_profile_id` values is used
+  on a Mac with different local Terminal Profiles
+- **THEN** alan resolves matching local ids when available
+- **AND** alan shows missing-profile fallback for unmatched ids
+- **AND** alan does not attempt to synthesize profile definitions from the
+  workspace manifest

--- a/openspec/changes/add-macos-terminal-profiles/specs/macos-terminal-profiles/spec.md
+++ b/openspec/changes/add-macos-terminal-profiles/specs/macos-terminal-profiles/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Terminal Profiles Are Local Startup Identities
+Alan for macOS SHALL define Terminal Profiles as machine-local terminal startup
+identities that are separate from Alan provider connection profiles.
+
+Terminal Profiles SHALL be stored under the active macOS install channel's
+Application Support directory and SHALL NOT be stored in workspace manifests,
+agent definitions, `connections.toml`, or provider credential stores.
+
+#### Scenario: Profile store is missing
+- **WHEN** Alan for macOS starts and no Terminal Profile store exists for the
+  active install channel
+- **THEN** alan uses an implicit login-shell Terminal Profile as the fallback
+  default
+- **AND** terminal creation remains available without user setup
+
+#### Scenario: Corrupt profile store is preserved
+- **WHEN** Alan for macOS reads a Terminal Profile store that cannot be decoded
+- **THEN** alan preserves the unreadable file as corrupt evidence
+- **AND** alan falls back to the implicit login-shell Terminal Profile
+- **AND** alan does not prevent the shell workspace from opening
+
+#### Scenario: Terminal profiles do not affect connection profiles
+- **WHEN** a user creates or edits a Terminal Profile
+- **THEN** alan does not change the selected provider connection profile,
+  provider credentials, model selection, or `connection_profile` pins
+
+### Requirement: Terminal Profiles Support Structured Launch Modes
+Alan for macOS SHALL support structured Terminal Profile launch modes for the
+common terminal identity workflows while preserving an advanced custom command
+escape hatch.
+
+Supported V1 launch modes SHALL include:
+
+- `login_shell`
+- `sudo_user`
+- `sudo_root`
+- `custom_command`
+
+#### Scenario: Login shell profile
+- **WHEN** a terminal is launched with a `login_shell` Terminal Profile
+- **THEN** alan launches the resolved login shell using the existing login-shell
+  startup behavior
+
+#### Scenario: Sudo Unix user profile
+- **WHEN** a terminal is launched with a `sudo_user` Terminal Profile for Unix
+  user `alan`
+- **THEN** alan launches `/usr/bin/sudo` with structured arguments equivalent to
+  `sudo -iu alan`
+- **AND** alan does not require the user to store that sudo invocation as a
+  freeform shell command
+
+#### Scenario: Sudo root profile
+- **WHEN** a terminal is launched with a `sudo_root` Terminal Profile
+- **THEN** alan launches `/usr/bin/sudo` with structured arguments equivalent to
+  `sudo -i`
+
+#### Scenario: Custom command profile
+- **WHEN** a terminal is launched with a `custom_command` Terminal Profile
+- **THEN** alan launches the command through a login-shell command runner such
+  as `/bin/zsh -lc`
+- **AND** alan treats the profile as an advanced startup mode in user-facing UI
+
+### Requirement: Terminal Profile Definitions Are Validated
+Alan for macOS SHALL validate Terminal Profile definitions before saving or
+using them for startup.
+
+#### Scenario: Sudo user profile requires a user
+- **WHEN** the user saves a `sudo_user` Terminal Profile without a Unix user
+- **THEN** alan rejects the profile definition
+- **AND** alan explains that a Unix user is required
+
+#### Scenario: Custom command requires a command
+- **WHEN** the user saves a `custom_command` Terminal Profile without a command
+- **THEN** alan rejects the profile definition
+- **AND** alan keeps the previous saved profile definition unchanged
+
+#### Scenario: Missing executable falls back safely
+- **WHEN** alan cannot resolve the executable needed for a Terminal Profile
+  launch mode
+- **THEN** alan marks the Terminal Profile unavailable for startup
+- **AND** terminal creation falls back to the login shell with a visible
+  unavailable-profile state
+
+### Requirement: Terminal Profile Resolution Is Deterministic
+Alan for macOS SHALL resolve a terminal startup profile through a deterministic
+order that supports explicit overrides, Space defaults, global defaults, and
+safe fallback.
+
+Resolution order SHALL be:
+
+1. Explicit terminal creation request profile.
+2. Terminal content stored `terminal_profile_id`.
+3. Space `terminal_profile_id`.
+4. Global default Terminal Profile.
+5. Login-shell fallback.
+
+#### Scenario: Explicit profile wins
+- **WHEN** a terminal creation request supplies `terminal_profile_id` `root`
+- **THEN** alan launches the new terminal using the `root` Terminal Profile even
+  if the Space is bound to `alan`
+
+#### Scenario: Space profile is used by default
+- **WHEN** a terminal creation request has no explicit profile and the selected
+  Space is bound to `alan`
+- **THEN** alan launches the new terminal using the `alan` Terminal Profile
+
+#### Scenario: Missing profile falls back
+- **WHEN** terminal startup references `terminal_profile_id` `univer` and no
+  local Terminal Profile with that id exists
+- **THEN** alan launches the terminal with the login-shell fallback
+- **AND** alan preserves the missing profile id for UI and diagnostics
+
+### Requirement: Sudo Configuration Remains Operator Managed
+Alan for macOS SHALL NOT edit sudoers files, create Unix users, or silently
+configure passwordless sudo as part of Terminal Profile management.
+
+#### Scenario: Sudo requires password
+- **WHEN** a `sudo_user` or `sudo_root` Terminal Profile launches and sudo asks
+  for a password
+- **THEN** the prompt appears inside the terminal session
+- **AND** alan does not intercept or store the password
+
+#### Scenario: Passwordless sudo is configured externally
+- **WHEN** the operator has configured passwordless sudo for the requested Unix
+  user outside Alan
+- **THEN** the Terminal Profile launches without additional Alan-specific
+  configuration

--- a/openspec/changes/add-macos-terminal-profiles/tasks.md
+++ b/openspec/changes/add-macos-terminal-profiles/tasks.md
@@ -1,0 +1,50 @@
+## 1. Terminal Profile Model And Store
+
+- [x] 1.1 Add Terminal Profile value types for id, title, launch kind, Unix user, custom command, default working directory, and optional presentation metadata.
+- [x] 1.2 Implement the channel-scoped Terminal Profile store under macOS Application Support with missing-store login-shell fallback.
+- [x] 1.3 Add profile validation for required fields, duplicate ids, unsupported launch kinds, and unavailable executables.
+- [x] 1.4 Add corrupt-store quarantine and safe fallback behavior.
+- [x] 1.5 Add focused tests for store loading, saving, default profile selection, validation failures, lookup, and corrupt-file recovery.
+
+## 2. Workspace Manifest And Shell State References
+
+- [x] 2.1 Add optional `terminal_profile_id` to Space records and terminal content restore payloads.
+- [x] 2.2 Keep old workspace manifests decodable when profile fields are absent.
+- [x] 2.3 Preserve profile references through workspace materialization, live snapshot sync, pinned snapshot updates, and transcript snapshot overlays.
+- [x] 2.4 Ensure missing local profiles do not delete or rewrite manifest references during restore.
+- [x] 2.5 Add focused workspace manifest tests for Space references, terminal content references, old-manifest compatibility, and missing-profile preservation.
+
+## 3. Terminal Launch Resolution
+
+- [x] 3.1 Extend terminal boot-profile resolution to accept resolved Terminal Profile context without bypassing the existing Ghostty surface path.
+- [x] 3.2 Implement structured command generation for `login_shell`, `sudo_user`, `sudo_root`, and `custom_command`.
+- [x] 3.3 Project non-secret Terminal Profile metadata into terminal environment and shell metadata.
+- [x] 3.4 Preserve current environment override behavior where needed for development without letting it become workspace state.
+- [x] 3.5 Add terminal runtime tests for each launch kind, missing-profile fallback, unavailable executable fallback, active-task startup state, and environment projection.
+
+## 4. Shell Interactions And Automation Surfaces
+
+- [x] 4.1 Extend Space creation, terminal tab creation, and split creation APIs to accept optional Terminal Profile overrides.
+- [x] 4.2 Implement inheritance rules: new tabs use the Space profile, new splits use the current pane profile, and explicit overrides win.
+- [x] 4.3 Ensure Space profile binding changes are not retroactive for existing terminal content.
+- [x] 4.4 Extend shell action routing, control-plane DTOs, and App Intents with optional terminal-profile fields where creation commands need them.
+- [x] 4.5 Add focused shell action and automation tests for Space binding, tab inheritance, split inheritance, explicit override, and non-retroactive binding changes.
+
+## 5. Settings And Sidebar UI
+
+- [x] 5.1 Add a Terminal Profiles Settings section backed by the local profile store, separate from provider Accounts.
+- [x] 5.2 Add profile creation/editing controls for structured launch modes with required-field validation and sudo guidance.
+- [x] 5.3 Add Space profile binding selection from compact Space UI affordances.
+- [x] 5.4 Add restrained sidebar, pane, or status hints for profile identity, root identity, custom-command profiles, and missing-profile fallback.
+- [x] 5.5 Ensure normal shell chrome does not expose full custom commands; keep full command visibility in Settings or explicit diagnostics.
+- [x] 5.6 Add focused Settings/sidebar tests for profile listing, validation, Space binding, missing-profile display, and redaction.
+
+## 6. Verification, Review, And Archive Readiness
+
+- [x] 6.1 Run focused model and runtime scripts covering workspace manifests, terminal runtime service, shell action registry, shell automation seams, and settings surface.
+- [x] 6.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 6.3 Run a dev-channel fresh relaunch smoke path to verify persisted profile references and missing-profile fallback in the running app.
+- [x] 6.4 Run `openspec validate add-macos-terminal-profiles --strict`.
+- [x] 6.5 Review the diff for accidental provider connection-profile changes, workspace manifest leakage of local profile definitions, and secret/custom-command exposure in normal shell chrome.
+- [x] 6.6 Prepare PR slices in dependency order: model/store/manifest, launch/interactions, UI, then visual/docs polish if needed.
+- [ ] 6.7 After implementation is merged, sync accepted spec deltas into `openspec/specs/` before archiving.

--- a/openspec/changes/provision-macos-terminal-accounts/.openspec.yaml
+++ b/openspec/changes/provision-macos-terminal-accounts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/provision-macos-terminal-accounts/completion-audit.md
+++ b/openspec/changes/provision-macos-terminal-accounts/completion-audit.md
@@ -1,0 +1,39 @@
+## Completion Audit
+
+Change: `provision-macos-terminal-accounts`
+
+Status: implementation-ready, pending merged-spec sync.
+
+### Requirement Evidence
+
+| Requirement area | Evidence |
+| --- | --- |
+| Managed Terminal Account value model and terminal-only semantics | managed account request/state/plan/result/verification/rollback types in `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`; wording coverage in `clients/apple/scripts/test-shell-settings-surface.swift` |
+| Read-only local discovery and dry-run planning | discoverer and planner types in `ShellValueTypes.swift`; focused planner coverage in `clients/apple/scripts/test-shell-runtime-metadata.swift` and `clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.swift` |
+| Standard non-admin account creation, home/shell handling, and hidden-login default | plan/executor steps in `ShellValueTypes.swift`; dev dry-run smoke checks missing-account and hidden-account planning without touching system state |
+| Narrow sudoers rendering and validation | `ManagedTerminalAccountSudoersRule` and validation helpers in `ShellValueTypes.swift`; tests cover one-target scope, no passwordless root grant, no unrelated-user grant, stable file path, and syntax validation behavior |
+| Privileged execution boundary | executor protocol/fake executor/authorized script executor types in `ShellValueTypes.swift`; tests cover success, failure, partial apply, cancellation, and redaction |
+| Mandatory readiness verification | readiness verifier in `ShellValueTypes.swift`; tests cover account lookup, non-admin checks, home/shell checks, sudoers validation, non-interactive sudo failure, and repair-plan generation |
+| Conservative rollback | rollback planning in `ShellValueTypes.swift`; tests cover Alan-owned sudoers/Profile integration rollback and destructive account/home deletion gating |
+| Terminal Profile handoff only after ready verification | handoff planner/executor behavior in `ShellValueTypes.swift`; tests cover profile creation/update, failed-provision suppression, and optional Space binding confirmation |
+| Settings UI safety | `ShellSettingsSurfaceModel.swift`, `test-shell-settings-surface.swift`, and `test-terminal-account-dev-dry-run-smoke.swift` cover terminal-account wording, preview, confirmation/cancellation, ready/repair/rollback state, and redaction |
+| Stable-channel state isolation in dev smoke | `clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh` verifies dev-only profile store behavior and no stable-channel profile store creation |
+
+### Verification Gates
+
+Required focused gates for acceptance:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `just apple-shell-focused-tests`
+- `openspec validate provision-macos-terminal-accounts --strict`
+- `git diff --check`
+
+### Remaining Work
+
+Task 7.7 remains open by design: accepted spec deltas can only be synced into
+`openspec/specs/` after the implementation is merged. Do not archive this change
+before that merge and sync happen.
+

--- a/openspec/changes/provision-macos-terminal-accounts/design.md
+++ b/openspec/changes/provision-macos-terminal-accounts/design.md
@@ -1,0 +1,145 @@
+## Context
+
+The `add-macos-terminal-profiles` change gives Alan for macOS a clean model for
+launching new terminals through machine-local Terminal Profiles. A `sudo_user`
+Terminal Profile can run `sudo -iu alan`, but the operating-system pieces still
+need to exist:
+
+- a local Unix account such as `alan`
+- a home directory such as `/Users/alan`
+- an allowed shell such as `/bin/zsh`
+- sudo policy that lets the GUI user enter that account without an interactive
+  password prompt
+
+The user explicitly does not want macOS GUI automatic login. The desired
+experience is terminal-only: opening a Space or tab can enter the target Unix
+account automatically through sudo, while the Mac still boots into the normal
+GUI user's login/session model.
+
+This change is more sensitive than Terminal Profiles because it modifies local
+system accounts and `/etc/sudoers.d`. It should therefore be a separate
+OpenSpec change with a narrow privileged-change contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provision standard local Unix accounts for terminal identities.
+- Configure passwordless `sudo -iu <target>` from the current GUI user to the
+  managed target account.
+- Hide managed terminal accounts from normal GUI login surfaces by default.
+- Create or update a matching `sudo_user` Terminal Profile after successful
+  provisioning.
+- Make every privileged change previewable, explicit, idempotent, and
+  verifiable.
+- Provide repair and rollback plans for partially provisioned accounts.
+
+**Non-Goals:**
+
+- Enabling macOS GUI automatic login.
+- Creating admin accounts by default.
+- Granting passwordless root access.
+- Managing FileVault unlock, SecureToken, volume ownership, or Apple Account
+  login.
+- Storing reusable plaintext passwords in Alan config, logs, workspace
+  manifests, or Terminal Profiles.
+- Becoming a general-purpose macOS account-management UI.
+
+## Decisions
+
+1. **Name the feature Managed Terminal Account, not autologin.**
+
+   "Autologin" on macOS means GUI automatic login and carries a different
+   security model. The product language should describe terminal-only managed
+   accounts and passwordless terminal entry through sudo.
+
+2. **Use a previewable privileged plan.**
+
+   The Settings UI should build a deterministic plan before applying changes:
+   create account if missing, ensure home and shell, optionally hide the
+   account from the login window, write sudoers drop-in, validate sudoers, run
+   non-interactive sudo check, create Terminal Profile. The user approves the
+   plan before any privileged command runs.
+
+3. **Start with a CLI/script executor, leave room for a signed helper.**
+
+   The first implementation can route the plan through explicit administrator
+   authorization and shell commands. The design should isolate privileged
+   operations behind a service boundary so a later signed privileged helper can
+   replace shell execution without changing Settings or model semantics.
+
+4. **Create standard accounts with random non-reused passwords.**
+
+   Managed terminal accounts should be standard users, not admins. Alan may
+   generate a random high-entropy password to satisfy macOS local-account
+   creation requirements, but it should not persist that password. Terminal
+   entry uses sudo policy from the GUI user, not password login to the target
+   account.
+
+5. **Write narrow sudoers drop-ins and validate before use.**
+
+   Alan should write a dedicated file under `/etc/sudoers.d` for managed
+   terminal accounts. Rules should allow the invoking GUI user to run as only
+   the specified target account. The sudoers file is validated with `visudo -cf`
+   before the feature is marked ready.
+
+6. **Verification is part of provisioning.**
+
+   Provisioning succeeds only after account lookup, home/shell checks, sudoers
+   validation, and `sudo -n -iu <target> true` pass. If verification fails,
+   Settings shows repair actions rather than silently creating a Terminal
+   Profile that will prompt or fail later.
+
+7. **Rollback is explicit and conservative.**
+
+   Rollback can remove Alan-owned sudoers drop-ins and Terminal Profiles.
+   Removing the Unix account or home directory is a separate explicit action
+   because it may destroy user data. Repair is preferred over destructive
+   rollback for partially provisioned accounts.
+
+## Risks / Trade-offs
+
+- **[Risk] Account provisioning is privileged and can weaken the host.** ->
+  Require explicit confirmation, narrow sudoers rules, non-admin target
+  accounts, and validation before marking ready.
+- **[Risk] Users confuse this with GUI automatic login.** -> Never use
+  "autologin" in UI labels. State that the feature does not enable GUI
+  automatic login.
+- **[Risk] Password handling leaks sensitive material.** -> Generate passwords
+  in-memory, avoid logging, avoid config persistence, and prefer interactive
+  administrator authorization where needed.
+- **[Risk] Sudoers syntax errors can break sudo.** -> Validate generated files
+  with `visudo -cf` before relying on them and preserve backups for repair.
+- **[Risk] Hiding login-window users is platform-version sensitive.** -> Treat
+  hidden-login behavior as best-effort and verify account readiness through
+  terminal entry, not GUI list visibility.
+- **[Risk] SecureToken/FileVault behavior is misunderstood.** -> Keep this
+  feature terminal-only and explicitly avoid FileVault unlock or SecureToken
+  enablement in V1.
+
+## Migration Plan
+
+1. Add Managed Terminal Account model types for requested account, current
+   system state, privileged plan steps, results, and verification status.
+2. Add a dry-run planner that inspects local accounts and sudoers state without
+   writing.
+3. Add sudoers renderer and validation helpers with deterministic file paths and
+   no user-controlled raw sudoers fragments.
+4. Add an executor boundary for privileged account/sudoers operations.
+5. Add verification and repair status calculation.
+6. Connect successful provisioning to Terminal Profile creation/update.
+7. Add Settings UI for preview, confirmation, progress, repair, and rollback.
+8. Validate with focused tests and a dev-channel manual smoke path.
+
+Rollback: remove Alan-owned sudoers entries and matching Terminal Profile when
+requested. Account deletion and home deletion require separate explicit user
+confirmation and should not run as part of ordinary rollback.
+
+## Open Questions
+
+- Should V1 offer account deletion, or only remove Alan's sudoers/Profile
+  integration?
+- Should hidden-login-window behavior be default-on for all managed terminal
+  accounts, or configurable per account?
+- Should the first privileged executor be a user-visible script, an Apple
+  Authorization Services flow, or a signed privileged helper?

--- a/openspec/changes/provision-macos-terminal-accounts/design.md
+++ b/openspec/changes/provision-macos-terminal-accounts/design.md
@@ -68,11 +68,11 @@ OpenSpec change with a narrow privileged-change contract.
    operations behind a service boundary so a later signed privileged helper can
    replace shell execution without changing Settings or model semantics.
 
-4. **Create standard accounts with random non-reused passwords.**
+4. **Create standard terminal-only accounts without reusable passwords.**
 
-   Managed terminal accounts should be standard users, not admins. Alan may
-   generate a random high-entropy password to satisfy macOS local-account
-   creation requirements, but it should not persist that password. Terminal
+   Managed terminal accounts should be standard users, not admins. Alan should
+   provision them as terminal-only local users with password login disabled,
+   avoiding generated reusable passwords altogether where possible. Terminal
    entry uses sudo policy from the GUI user, not password login to the target
    account.
 
@@ -105,8 +105,9 @@ OpenSpec change with a narrow privileged-change contract.
 - **[Risk] Users confuse this with GUI automatic login.** -> Never use
   "autologin" in UI labels. State that the feature does not enable GUI
   automatic login.
-- **[Risk] Password handling leaks sensitive material.** -> Generate passwords
-  in-memory, avoid logging, avoid config persistence, and prefer interactive
+- **[Risk] Password handling leaks sensitive material.** -> Prefer disabled
+  password login for managed terminal accounts, avoid generated reusable
+  passwords, avoid logging, avoid config persistence, and prefer interactive
   administrator authorization where needed.
 - **[Risk] Sudoers syntax errors can break sudo.** -> Validate generated files
   with `visudo -cf` before relying on them and preserve backups for repair.

--- a/openspec/changes/provision-macos-terminal-accounts/pr-slices.md
+++ b/openspec/changes/provision-macos-terminal-accounts/pr-slices.md
@@ -1,0 +1,122 @@
+## PR Slices
+
+Target base: the merged Terminal Profile implementation, or a stacked branch on
+top of the final `add-macos-terminal-profiles` PR. This change depends on the
+Terminal Profile store and `sudo_user` launch kind.
+
+### 1. Model, Discovery, And Planner
+
+Branch: `macos-terminal-accounts-model-planner`
+
+Includes:
+
+- Managed Terminal Account request/state/result/verification/rollback value
+  types.
+- Read-only local state discovery for account, shell, home, hidden-account,
+  Alan-owned sudoers, and matching Terminal Profile state.
+- Dry-run planner for create, repair, already-ready, and rollback paths.
+- Identifier validation for accounts, GUI users, sudoers file names, and profile
+  ids.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`
+- `clients/apple/scripts/test-shell-runtime-metadata.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `openspec validate provision-macos-terminal-accounts --strict`
+
+### 2. Sudoers Renderer And Privileged Executor Boundary
+
+Branch: `macos-terminal-accounts-sudoers-executor`
+
+Depends on: slice 1.
+
+Includes:
+
+- Deterministic Alan-owned sudoers drop-in rendering under
+  `/etc/sudoers.d/alan-terminal-<gui>-to-<target>`.
+- Rule scope limiting passwordless sudo to the selected target account, with no
+  passwordless root or unrelated target grant.
+- `visudo -cf` validation helpers.
+- Narrow executor interface for create, repair, hide-account, write/remove
+  sudoers, and verification commands.
+- AppleScript/user-visible privileged runner path plus fake-executor tests for
+  success, failure, partial apply, cancellation, and redaction.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`
+- `clients/apple/scripts/test-shell-runtime-metadata.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `openspec validate provision-macos-terminal-accounts --strict`
+
+### 3. Verification, Repair, Rollback, And Profile Handoff
+
+Branch: `macos-terminal-accounts-verification-handoff`
+
+Depends on: slice 2.
+
+Includes:
+
+- Readiness checks for account lookup, non-admin account type, home, shell,
+  sudoers validation, and `sudo -n -iu <target> true`.
+- Repair-plan generation for failed account, sudoers, and verification states.
+- Conservative rollback of Alan-owned sudoers/Profile integration while gating
+  account and home deletion behind separate destructive confirmation.
+- Creation or update of a matching `sudo_user` Terminal Profile only after
+  successful verification.
+- Optional current-Space binding after explicit confirmation.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`
+- `clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift`
+- `clients/apple/scripts/test-shell-runtime-metadata.swift`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `openspec validate provision-macos-terminal-accounts --strict`
+
+### 4. Settings UI And Dev Dry-Run Smoke
+
+Branch: `macos-terminal-accounts-settings-smoke`
+
+Depends on: slice 3.
+
+Includes:
+
+- Settings entry points for create, preview, apply, repair, rollback, readiness,
+  and Terminal Profile linkage.
+- Terminal-account wording that explicitly avoids GUI automatic-login language.
+- Redaction of generated passwords, administrator credentials, raw privileged
+  command payloads, and full sudoers text.
+- Dev-channel dry-run smoke that proves no stable-channel profile store or real
+  system account state is touched.
+- Focused test aggregator updates and OpenSpec task status.
+
+Primary files:
+
+- `clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift`
+- `clients/apple/scripts/test-shell-settings-surface.sh`
+- `clients/apple/scripts/test-shell-settings-surface.swift`
+- `clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh`
+- `clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.swift`
+- `justfile`
+- `openspec/changes/provision-macos-terminal-accounts/tasks.md`
+
+Required verification:
+
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh`
+- `just apple-shell-focused-tests`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `openspec validate provision-macos-terminal-accounts --strict`
+- `git diff --check`
+

--- a/openspec/changes/provision-macos-terminal-accounts/proposal.md
+++ b/openspec/changes/provision-macos-terminal-accounts/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Alan Terminal Profiles can launch into separate Unix users, but users still need
+to create those accounts and configure passwordless `sudo -iu <user>` manually.
+Alan for macOS should offer a controlled local provisioning flow for terminal
+identities without enabling macOS GUI automatic login.
+
+## What Changes
+
+- Add **Managed Terminal Account** provisioning for local standard Unix accounts
+  intended for terminal use, such as `alan`, `univer`, or `lab`.
+- Create or repair accounts with home directory, shell, hidden-login-window
+  preference, and non-admin account type.
+- Configure a narrow sudoers drop-in that allows the current GUI user to enter
+  the managed account with `sudo -iu <target>` without a password.
+- Verify the provisioned account with non-interactive sudo checks before marking
+  it ready.
+- Create or update the matching Terminal Profile after provisioning succeeds.
+- Provide a dry-run/preview plan and explicit confirmation before privileged
+  changes are applied.
+- Keep macOS GUI automatic login out of scope and explicitly disabled as a
+  product concept for this feature.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-terminal-account-provisioning`: Defines managed local terminal account
+  creation, sudoers configuration, verification, repair, rollback, and Terminal
+  Profile handoff.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Add Settings affordances for creating and
+  repairing Managed Terminal Accounts without implying GUI automatic login.
+- `macos-shell-build-test-contract`: Require focused verification for account
+  provisioning plans, sudoers generation, validation, rollback, and UI safety
+  copy.
+
+## Impact
+
+- Apple client needs a local account provisioning model and Settings flow.
+- A privileged execution path is required for user creation, account hiding,
+  sudoers drop-in writes, and validation commands.
+- Implementation should prefer a previewable command plan first; a signed
+  privileged helper can follow if direct shell execution is not acceptable.
+- Terminal Profile creation depends on the `add-macos-terminal-profiles` change
+  or an equivalent Terminal Profile store.
+- Tests must cover dry-run output, generated sudoers text, `visudo` validation
+  behavior, idempotent repair, rollback planning, and redaction of passwords or
+  secret material.

--- a/openspec/changes/provision-macos-terminal-accounts/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/provision-macos-terminal-accounts/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Managed Terminal Account Provisioning Has Focused Verification
+Alan for macOS SHALL require focused verification for Managed Terminal Account
+planning, sudoers generation, validation, execution boundaries, repair,
+rollback, and UI safety wording.
+
+#### Scenario: Dry-run planner tests run
+- **WHEN** provisioning planning behavior changes
+- **THEN** focused tests cover missing account, existing account, existing
+  sudoers entry, missing Terminal Profile, and already-ready account states
+
+#### Scenario: Sudoers generation tests run
+- **WHEN** sudoers rendering behavior changes
+- **THEN** focused tests cover generated rule scope, identifier escaping or
+  rejection, no passwordless root grant, no unrelated-user grant, and stable
+  Alan-owned file paths
+
+#### Scenario: Validation failure tests run
+- **WHEN** sudoers validation or non-interactive sudo verification behavior
+  changes
+- **THEN** focused tests cover validation failure, sudo failure, partial
+  provisioning state, and repair-plan generation
+
+#### Scenario: Rollback tests run
+- **WHEN** rollback behavior changes
+- **THEN** focused tests cover removal of Alan-owned sudoers/Profile integration
+- **AND** tests confirm account and home-directory deletion require a separate
+  destructive confirmation
+
+#### Scenario: UI safety tests run
+- **WHEN** Settings provisioning UI changes
+- **THEN** focused UI or model tests cover no GUI-autologin wording, privileged
+  plan preview, explicit confirmation, password redaction, ready state, and
+  repairable state

--- a/openspec/changes/provision-macos-terminal-accounts/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/provision-macos-terminal-accounts/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Settings Presents Managed Terminal Account Provisioning
+Alan macOS Settings SHALL provide a Managed Terminal Account flow for creating
+terminal-only local users and SHALL distinguish it from macOS GUI automatic
+login.
+
+#### Scenario: Provision action is local and explicit
+- **WHEN** the user opens Terminal Profile or local terminal identity settings
+- **THEN** alan offers an explicit action to create or repair a Managed Terminal
+  Account
+- **AND** alan labels the flow as terminal account provisioning, not autologin
+
+#### Scenario: GUI automatic login is not implied
+- **WHEN** the provisioning flow describes the result
+- **THEN** alan states that it does not enable macOS GUI automatic login
+- **AND** alan describes the result as passwordless terminal entry from the
+  current GUI user to the target Unix user
+
+#### Scenario: Privileged plan is reviewed before apply
+- **WHEN** the user reaches the apply step
+- **THEN** alan shows the planned privileged changes in compact user-facing
+  language
+- **AND** the user must confirm before alan applies account, sudoers, or Terminal
+  Profile changes
+
+### Requirement: Provisioning UI Surfaces Safety State
+Alan macOS Settings SHALL surface readiness, repair, and rollback state for
+Managed Terminal Accounts without exposing passwords or raw privileged command
+payloads in normal UI.
+
+#### Scenario: Ready account is shown
+- **WHEN** a Managed Terminal Account is verified ready
+- **THEN** alan shows the account as ready for terminal entry
+- **AND** alan links it to the matching Terminal Profile when one exists
+
+#### Scenario: Repairable account is shown
+- **WHEN** a Managed Terminal Account is partially provisioned or fails
+  verification
+- **THEN** alan shows a repairable state with the failed step
+- **AND** alan offers to preview a repair plan
+
+#### Scenario: Passwords are not displayed
+- **WHEN** provisioning uses generated or administrator-entered passwords
+- **THEN** alan does not show those passwords in Settings after the operation
+- **AND** alan does not write them into normal shell state, workspace manifests,
+  or Terminal Profile definitions

--- a/openspec/changes/provision-macos-terminal-accounts/specs/macos-terminal-account-provisioning/spec.md
+++ b/openspec/changes/provision-macos-terminal-accounts/specs/macos-terminal-account-provisioning/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Managed Terminal Accounts Are Terminal-Only Local Users
+Alan for macOS SHALL provision Managed Terminal Accounts as local standard Unix
+accounts for terminal identity isolation and SHALL NOT enable macOS GUI
+automatic login as part of this feature.
+
+#### Scenario: Create standard terminal account
+- **WHEN** the user provisions Managed Terminal Account `alan`
+- **THEN** alan creates or repairs a local standard account named `alan`
+- **AND** the account has a home directory and login shell suitable for terminal
+  sessions
+- **AND** the account is not granted administrator privileges by default
+
+#### Scenario: GUI automatic login remains unchanged
+- **WHEN** alan provisions a Managed Terminal Account
+- **THEN** alan does not enable macOS GUI automatic login for that account
+- **AND** alan does not change the Mac's existing GUI automatic-login setting
+
+#### Scenario: Account is hidden from login UI by default
+- **WHEN** alan provisions a Managed Terminal Account with default options
+- **THEN** alan marks the account as hidden from normal GUI login-window user
+  lists where the operating system supports that setting
+- **AND** terminal entry remains the readiness criterion for the account
+
+### Requirement: Provisioning Uses Explicit Privileged Plans
+Alan for macOS SHALL represent account provisioning as a previewable privileged
+plan that the user must explicitly approve before local system state is changed.
+
+#### Scenario: Dry run previews changes
+- **WHEN** the user starts Managed Terminal Account provisioning
+- **THEN** alan presents a dry-run plan listing account creation or repair,
+  home-directory handling, shell selection, hidden-account handling, sudoers
+  changes, validation, verification, and Terminal Profile creation
+- **AND** alan does not apply privileged changes during dry run
+
+#### Scenario: User cancels before apply
+- **WHEN** the user cancels the previewed provisioning plan
+- **THEN** alan does not create accounts, modify sudoers, or create Terminal
+  Profiles
+
+#### Scenario: Privileged executor is isolated
+- **WHEN** alan applies an approved provisioning plan
+- **THEN** privileged account and sudoers operations are routed through a
+  narrow executor boundary
+- **AND** ordinary Settings rendering and shell workspace state do not receive
+  reusable privileged credentials
+
+### Requirement: Sudoers Rules Are Narrow And Validated
+Alan for macOS SHALL configure passwordless terminal entry through Alan-owned
+sudoers drop-ins that permit the GUI user to run as only the selected Managed
+Terminal Account.
+
+#### Scenario: Sudoers rule targets one account
+- **WHEN** GUI user `morris` provisions Managed Terminal Account `alan`
+- **THEN** alan generates a sudoers rule allowing `morris` to run commands as
+  `alan` without a password
+- **AND** the rule does not grant passwordless root access
+- **AND** the rule does not grant passwordless access to unrelated users
+
+#### Scenario: Sudoers syntax is validated
+- **WHEN** alan writes or updates its sudoers drop-in
+- **THEN** alan validates the resulting sudoers configuration with a sudoers
+  syntax checker such as `visudo -cf`
+- **AND** alan does not mark provisioning ready when sudoers validation fails
+
+#### Scenario: User-controlled sudoers fragments are rejected
+- **WHEN** the user chooses account names or labels during provisioning
+- **THEN** alan treats those values as structured identifiers
+- **AND** alan does not insert raw user-provided sudoers text into the generated
+  drop-in
+
+### Requirement: Provisioning Verification Is Mandatory
+Alan for macOS SHALL verify a Managed Terminal Account before marking it ready
+or binding it to a Terminal Profile.
+
+#### Scenario: Account readiness check passes
+- **WHEN** account lookup, home directory, shell, sudoers validation, and
+  non-interactive `sudo -iu <target>` checks all pass
+- **THEN** alan marks the Managed Terminal Account ready
+- **AND** alan may create or update the matching Terminal Profile
+
+#### Scenario: Non-interactive sudo fails
+- **WHEN** `sudo -n -iu alan true` fails for the current GUI user
+- **THEN** alan does not mark Managed Terminal Account `alan` ready
+- **AND** alan presents repair guidance instead of silently accepting a profile
+  that will prompt or fail later
+
+#### Scenario: Partial provisioning is repairable
+- **WHEN** account creation succeeds but sudoers verification fails
+- **THEN** alan records the account as partially provisioned
+- **AND** alan offers a repair plan that targets the failed sudoers or
+  verification step
+
+### Requirement: Terminal Profile Handoff Follows Successful Provisioning
+Alan for macOS SHALL create or update a matching Terminal Profile only after the
+Managed Terminal Account is verified ready.
+
+#### Scenario: Ready account creates profile
+- **WHEN** Managed Terminal Account `alan` verifies successfully
+- **THEN** alan creates or updates Terminal Profile `alan`
+- **AND** the profile uses structured `sudo_user` launch mode for Unix user
+  `alan`
+
+#### Scenario: Failed account does not create ready profile
+- **WHEN** Managed Terminal Account `alan` fails verification
+- **THEN** alan does not create a ready Terminal Profile that claims `alan` can
+  be entered without repair
+
+#### Scenario: Current Space can be bound after success
+- **WHEN** provisioning succeeds from a Space-scoped flow
+- **THEN** alan may bind the current Space to the created Terminal Profile after
+  explicit user confirmation
+
+### Requirement: Rollback Is Conservative
+Alan for macOS SHALL provide rollback for Alan-owned integration state and SHALL
+treat account or home-directory deletion as separate destructive actions.
+
+#### Scenario: Rollback removes Alan-owned integration
+- **WHEN** the user rolls back provisioning for Managed Terminal Account `alan`
+- **THEN** alan removes or disables Alan-owned sudoers entries for `alan`
+- **AND** alan removes or disables the matching Terminal Profile when it was
+  created by the provisioning flow
+
+#### Scenario: Account deletion requires separate confirmation
+- **WHEN** rollback would delete local account `alan` or `/Users/alan`
+- **THEN** alan requires a separate explicit destructive confirmation
+- **AND** ordinary rollback does not remove the home directory
+
+#### Scenario: Existing non-Alan account is preserved
+- **WHEN** account `alan` existed before Alan provisioning
+- **THEN** alan does not delete that account during rollback
+- **AND** alan limits rollback to Alan-owned sudoers/Profile integration unless
+  the user chooses a separate destructive operation

--- a/openspec/changes/provision-macos-terminal-accounts/tasks.md
+++ b/openspec/changes/provision-macos-terminal-accounts/tasks.md
@@ -1,0 +1,54 @@
+## 1. Provisioning Model And Planner
+
+- [x] 1.1 Add Managed Terminal Account value types for request, current state, plan step, apply result, verification status, repair status, and rollback scope.
+- [x] 1.2 Implement read-only local state discovery for account existence, account type, home directory, shell, hidden-account state, Alan-owned sudoers state, and matching Terminal Profile state.
+- [x] 1.3 Implement a dry-run planner for create, repair, already-ready, and rollback scenarios without writing system state.
+- [x] 1.4 Add identifier validation for account names, GUI user names, sudoers file names, and Terminal Profile ids.
+- [x] 1.5 Add focused planner tests for missing account, existing standard account, existing admin account, partial sudoers state, existing Terminal Profile, and already-ready account states.
+
+## 2. Sudoers Rendering And Validation
+
+- [x] 2.1 Implement deterministic Alan-owned sudoers drop-in rendering for GUI-user to target-user passwordless terminal entry.
+- [x] 2.2 Ensure generated sudoers rules do not grant passwordless root access or unrelated target-user access.
+- [x] 2.3 Add validation helpers for sudoers syntax checking with `visudo -cf`.
+- [x] 2.4 Add tests for rule scope, invalid identifier rejection, stable file paths, syntax validation success, and validation failure.
+
+## 3. Privileged Execution Boundary
+
+- [x] 3.1 Add a narrow executor interface for privileged operations: create account, repair account properties, hide account, write sudoers drop-in, remove Alan-owned sudoers drop-in, and run verification commands.
+- [x] 3.2 Implement the first executor path with explicit administrator authorization or user-visible command execution, keeping reusable credentials out of normal UI and logs.
+- [x] 3.3 Ensure generated or entered passwords are never stored in workspace manifests, Terminal Profile definitions, shell state, or normal diagnostics.
+- [x] 3.4 Add fake-executor tests for successful apply, apply failure, partial apply, cancellation, and redaction.
+
+## 4. Verification, Repair, And Rollback
+
+- [x] 4.1 Implement readiness verification for account lookup, non-admin account type, home directory, shell, sudoers validation, and `sudo -n -iu <target> true`.
+- [x] 4.2 Implement repair-plan generation for failed account, sudoers, and verification steps.
+- [x] 4.3 Implement conservative rollback for Alan-owned sudoers and Terminal Profile integration.
+- [x] 4.4 Gate account deletion and home-directory deletion behind separate explicit destructive confirmation if V1 includes deletion.
+- [x] 4.5 Add focused tests for ready, repairable, failed, rollback, and destructive-operation gating states.
+
+## 5. Terminal Profile Handoff
+
+- [x] 5.1 Connect successful Managed Terminal Account verification to creation or update of a matching `sudo_user` Terminal Profile.
+- [x] 5.2 Ensure failed or partial provisioning does not create a ready Terminal Profile.
+- [x] 5.3 Add optional current-Space binding after successful provisioning with explicit confirmation.
+- [x] 5.4 Add tests for profile creation, profile update, failed-provisioning suppression, and Space binding confirmation.
+
+## 6. Settings UI
+
+- [x] 6.1 Add Settings entry points for creating, previewing, applying, repairing, and rolling back Managed Terminal Accounts.
+- [x] 6.2 Use terminal-account wording and explicitly avoid GUI automatic-login wording.
+- [x] 6.3 Show privileged plan steps, readiness state, repairable state, rollback scope, and Terminal Profile linkage in compact shell-native UI.
+- [x] 6.4 Redact generated passwords, administrator credentials, raw privileged command payloads, and full sudoers text from normal Settings rows.
+- [x] 6.5 Add focused Settings/model tests for preview, confirmation, cancellation, ready state, repair state, rollback state, and redaction.
+
+## 7. Verification, Review, And Archive Readiness
+
+- [x] 7.1 Run focused provisioning planner, sudoers renderer, executor, verification, Terminal Profile handoff, and Settings tests.
+- [x] 7.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 7.3 Run a dev-channel manual smoke path that provisions or dry-runs a terminal account without touching stable-channel state.
+- [x] 7.4 Run `openspec validate provision-macos-terminal-accounts --strict`.
+- [x] 7.5 Review the diff for accidental GUI automatic-login behavior, admin-account defaults, password persistence, passwordless root grants, raw sudoers injection, and workspace-manifest leakage.
+- [x] 7.6 Prepare implementation PRs in dependency order: model/planner, sudoers/executor, verification/profile handoff, Settings UI.
+- [ ] 7.7 After implementation is merged, sync accepted spec deltas into `openspec/specs/` before archiving.


### PR DESCRIPTION
## Summary

- Adds machine-local macOS Terminal Profiles with structured launch modes, Space/tab/split profile inheritance, profile-aware restore metadata, Settings/sidebar affordances, and missing-profile fallback.
- Adds Managed Terminal Account provisioning models for terminal-only local accounts, previewable privileged plans, narrow sudoers rendering, readiness verification, rollback planning, and Terminal Profile handoff.
- Adds OpenSpec changes, completion audits, PR slice plans, and focused Apple shell smoke coverage for profile/account behavior.

## Test Plan

- [x] `openspec validate add-macos-terminal-profiles --strict`
- [x] `openspec validate provision-macos-terminal-accounts --strict`
- [x] `git diff --check HEAD`
- [x] `bash clients/apple/scripts/check-shell-contracts.sh`
- [x] `just apple-shell-focused-tests`
- [x] `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath /private/tmp/alan-derived-data-terminal-profiles-accounts-pr build`

## Notes

- The implementation branch was prepared in `/private/tmp/alan-terminal-profiles-accounts` from `origin/main` to avoid mixing in unrelated dirty `main` state from the primary checkout.
- OpenSpec archive sync tasks remain intentionally unchecked until the implementation is merged.
