### PR TITLE
Stabilize macOS Quick Terminal Peak

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -67,7 +67,7 @@ private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTermin
     private var pendingContentTask: Task<Void, Never>?
     private weak var presentedHost: ShellHostController?
     private var representedPaneID: String?
-    private var keyAttemptCount = 0
+    private var panelKeyRequestBudget = ShellQuickTerminalPanelKeyRequestBudget()
 
     var isVisible: Bool {
         panel?.isVisible == true
@@ -83,7 +83,7 @@ private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTermin
         pendingContentTask?.cancel()
         presentedHost = host
         representedPaneID = pane.paneID
-        keyAttemptCount = 0
+        panelKeyRequestBudget.reset()
 
         let loadingView = ShellQuickTerminalPeakView(
             host: host,
@@ -101,7 +101,7 @@ private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTermin
         panel.setFrame(placement.frame, display: true)
         panel.collectionBehavior = placement.windowCollectionBehavior
         panel.orderFrontRegardless()
-        requestPanelKeyIfPossible(panel)
+        requestPanelKeyIfAllowed(panel, for: .presentation)
         installTerminalContentAfterPanelPresentation(host: host, paneID: pane.paneID)
     }
 
@@ -120,7 +120,7 @@ private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTermin
     func focusTerminal(paneID: String) {
         guard representedPaneID == paneID else { return }
         if let panel, panel.isVisible {
-            requestPanelKeyIfPossible(panel)
+            requestPanelKeyIfAllowed(panel, for: .terminalFocus)
         }
         presentedHost?.terminalRuntimeRegistry.requestFocus(for: paneID, retryBudget: 3)
     }
@@ -195,15 +195,17 @@ private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTermin
                 return
             }
             if let panel {
-                requestPanelKeyIfPossible(panel)
+                requestPanelKeyIfAllowed(panel, for: .presentation)
             }
             host.terminalRuntimeRegistry.requestFocus(for: paneID, retryBudget: 3)
         }
     }
 
-    private func requestPanelKeyIfPossible(_ panel: NSPanel) {
-        guard keyAttemptCount < 2 else { return }
-        keyAttemptCount += 1
+    private func requestPanelKeyIfAllowed(
+        _ panel: NSPanel,
+        for purpose: ShellQuickTerminalPanelKeyRequestBudget.Purpose
+    ) {
+        guard panelKeyRequestBudget.shouldRequestKey(for: purpose) else { return }
         panel.makeKey()
     }
 }

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -10,6 +10,7 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
     let host: ShellHostController
     private let quickTerminalPeakPresenter: ShellQuickTerminalPeakPresenter
     private var quickTerminalPeakStateSubscription: AnyCancellable?
+    private var quickTerminalPeakFocusSubscription: AnyCancellable?
 
     init(fileManager: FileManager = .default) {
         let windowContext = ShellWindowContext.make(
@@ -40,6 +41,13 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
                 peakPresenter?.synchronize()
             }
         }
+        quickTerminalPeakFocusSubscription = resolvedHost.$quickTerminalFocusRequestID
+            .dropFirst()
+            .sink { [weak peakPresenter] _ in
+                Task { @MainActor in
+                    peakPresenter?.focusVisibleQuickTerminal()
+                }
+            }
         quickTerminalPeakPresenter.synchronize()
     }
 

--- a/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
+++ b/clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift
@@ -8,7 +8,6 @@ import AppKit
 @MainActor
 final class AlanMacPrimaryShellOwner: ObservableObject {
     let host: ShellHostController
-    private let quickTerminalPeakWindow: ShellQuickTerminalPeakPanelWindow
     private let quickTerminalPeakPresenter: ShellQuickTerminalPeakPresenter
     private var quickTerminalPeakStateSubscription: AnyCancellable?
 
@@ -22,10 +21,9 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
             windowContext: windowContext,
             startupMode: .workspaceManifest
         )
-        let peakWindow = ShellQuickTerminalPeakPanelWindow()
         let peakPresenter = ShellQuickTerminalPeakPresenter(
             host: resolvedHost,
-            window: peakWindow
+            window: QuickTerminalPeakWindowPresenter()
         )
         #if canImport(AppIntents)
         ShellAutomationEntityStore.install(snapshotProvider: { [weak resolvedHost] in
@@ -36,7 +34,6 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
         )
         #endif
         host = resolvedHost
-        quickTerminalPeakWindow = peakWindow
         quickTerminalPeakPresenter = peakPresenter
         quickTerminalPeakStateSubscription = resolvedHost.$shellState.sink { [weak peakPresenter] _ in
             Task { @MainActor in
@@ -55,10 +52,14 @@ final class AlanMacPrimaryShellOwner: ObservableObject {
 }
 
 @MainActor
-private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTerminalPeakWindowing, NSWindowDelegate {
+private final class QuickTerminalPeakWindowPresenter: NSObject, ShellQuickTerminalPeakWindowing, NSWindowDelegate {
     var onDismissRequest: (() -> Void)?
-    private var panel: NSPanel?
+    private var panel: QuickTerminalPeakPanel?
     private var hostingController: NSHostingController<ShellQuickTerminalPeakView>?
+    private var pendingContentTask: Task<Void, Never>?
+    private weak var presentedHost: ShellHostController?
+    private var representedPaneID: String?
+    private var keyAttemptCount = 0
 
     var isVisible: Bool {
         panel?.isVisible == true
@@ -66,37 +67,54 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
 
     func presentQuickTerminal(
         host: ShellHostController,
-        pane _: ShellPane,
+        pane: ShellPane,
         tab _: ShellTab,
         placement: ShellQuickTerminalPeakPlacement
     ) {
         let panel = ensurePanel()
+        pendingContentTask?.cancel()
+        presentedHost = host
+        representedPaneID = pane.paneID
+        keyAttemptCount = 0
+
+        let loadingView = ShellQuickTerminalPeakView(
+            host: host,
+            paneID: pane.paneID,
+            terminalContentEnabled: false
+        )
         if let hostingController {
-            hostingController.rootView = ShellQuickTerminalPeakView(host: host)
+            hostingController.rootView = loadingView
         } else {
-            let hostingController = NSHostingController(rootView: ShellQuickTerminalPeakView(host: host))
+            let hostingController = NSHostingController(rootView: loadingView)
             self.hostingController = hostingController
             panel.contentViewController = hostingController
         }
 
         panel.setFrame(placement.frame, display: true)
-        panel.collectionBehavior = collectionBehavior(for: placement)
-        orderFrontQuickTerminal(panel)
+        panel.collectionBehavior = placement.windowCollectionBehavior
+        panel.orderFrontRegardless()
+        requestPanelKeyIfPossible(panel)
+        installTerminalContentAfterPanelPresentation(host: host, paneID: pane.paneID)
     }
 
     func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason) {
+        pendingContentTask?.cancel()
+        pendingContentTask = nil
         panel?.orderOut(nil)
         if reason == .removed {
             panel?.contentViewController = nil
             hostingController = nil
+            presentedHost = nil
+            representedPaneID = nil
         }
     }
 
     func focusTerminal(paneID: String) {
-        guard let panel else {
-            return
+        guard representedPaneID == paneID else { return }
+        if let panel, panel.isVisible {
+            requestPanelKeyIfPossible(panel)
         }
-        orderFrontQuickTerminal(panel)
+        presentedHost?.terminalRuntimeRegistry.requestFocus(for: paneID, retryBudget: 3)
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
@@ -108,12 +126,12 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
         // Intentionally no-op. Focus loss must not hide the quick terminal Peak.
     }
 
-    private func ensurePanel() -> NSPanel {
+    private func ensurePanel() -> QuickTerminalPeakPanel {
         if let panel {
             return panel
         }
 
-        let panel = NSPanel(
+        let panel = QuickTerminalPeakPanel(
             contentRect: CGRect(x: 0, y: 0, width: 840, height: 360),
             styleMask: [.titled, .closable, .resizable, .fullSizeContentView, .nonactivatingPanel],
             backing: .buffered,
@@ -126,11 +144,9 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
         panel.hidesOnDeactivate = false
         panel.isFloatingPanel = true
         panel.level = .floating
-        panel.collectionBehavior = collectionBehavior(
-            for: ShellQuickTerminalPeakPlacement.defaultPlacement(
-                in: ShellQuickTerminalPeakPlacement.activeVisibleFrame()
-            )
-        )
+        panel.collectionBehavior = ShellQuickTerminalPeakPlacement.defaultPlacement(
+            in: ShellQuickTerminalPeakPlacement.activeVisibleFrame()
+        ).windowCollectionBehavior
         panel.backgroundColor = .clear
         panel.isOpaque = false
         panel.hasShadow = true
@@ -144,19 +160,48 @@ private final class ShellQuickTerminalPeakPanelWindow: NSObject, ShellQuickTermi
         return panel
     }
 
-    private func orderFrontQuickTerminal(_ panel: NSPanel) {
-        panel.orderFrontRegardless()
-        panel.makeKey()
+    private func installTerminalContentAfterPanelPresentation(
+        host: ShellHostController,
+        paneID: String
+    ) {
+        pendingContentTask = Task { @MainActor [weak self, weak host] in
+            await Task.yield()
+            guard let self,
+                  let host,
+                  !Task.isCancelled,
+                  representedPaneID == paneID,
+                  panel?.isVisible == true
+            else {
+                return
+            }
+            hostingController?.rootView = ShellQuickTerminalPeakView(
+                host: host,
+                paneID: paneID,
+                terminalContentEnabled: true
+            )
+            await Task.yield()
+            guard !Task.isCancelled,
+                  representedPaneID == paneID,
+                  panel?.isVisible == true
+            else {
+                return
+            }
+            if let panel {
+                requestPanelKeyIfPossible(panel)
+            }
+            host.terminalRuntimeRegistry.requestFocus(for: paneID, retryBudget: 3)
+        }
     }
 
-    private func collectionBehavior(
-        for placement: ShellQuickTerminalPeakPlacement
-    ) -> NSWindow.CollectionBehavior {
-        var behavior: NSWindow.CollectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
-        if placement.joinsAllSpaces {
-            behavior.insert(.canJoinAllSpaces)
-        }
-        return behavior
+    private func requestPanelKeyIfPossible(_ panel: NSPanel) {
+        guard keyAttemptCount < 2 else { return }
+        keyAttemptCount += 1
+        panel.makeKey()
     }
+}
+
+private final class QuickTerminalPeakPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
 }
 #endif

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -817,7 +817,9 @@ struct ShellWorkspaceMaterializer {
         )
         let slot = ShellQuickTerminalSlot(
             paneID: record.paneID,
-            presentation: record.presentation,
+            // The detached Peak panel is transient UI; restore its runtime and content
+            // without presenting the panel during app launch.
+            presentation: .hidden,
             lastWorkingDirectory: lastWorkingDirectory
         )
         return (slot, pane, content)

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -402,7 +402,7 @@ private extension AlanShellControlCommandKind {
         case .spaceCreate, .tabOpen, .tabPin, .tabReorder, .paneSplit,
             .paneMove, .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit,
             .paneEqualizeSplits, .paneZoom, .paneUnzoom, .terminalRenderMetrics,
-            .agentActivity:
+            .quickTerminalFocus, .agentActivity:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
+++ b/clients/apple/alan-macos/Services/Terminal/TerminalHostViewSupport.swift
@@ -11,6 +11,7 @@ struct TerminalHostView: NSViewRepresentable {
     let renderPriority: TerminalRuntimeRenderPriority
     let runtimeRegistry: TerminalRuntimeRegistry
     let activationDelegate: TerminalHostActivationDelegate?
+    var attachmentPolicy: TerminalHostAttachmentPolicy = .immediate
     let onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?
     let onCloseRequest: ((Bool) -> Void)?
     let onRuntimeUpdate: (TerminalHostRuntimeSnapshot) -> Void
@@ -24,6 +25,7 @@ struct TerminalHostView: NSViewRepresentable {
             isSelected: isSelected,
             renderPriority: renderPriority,
             activationDelegate: activationDelegate,
+            attachmentPolicy: attachmentPolicy,
             onShellAction: onShellAction,
             onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
@@ -40,6 +42,7 @@ struct TerminalHostView: NSViewRepresentable {
             isSelected: isSelected,
             renderPriority: renderPriority,
             activationDelegate: activationDelegate,
+            attachmentPolicy: attachmentPolicy,
             onShellAction: onShellAction,
             onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -133,6 +133,16 @@ struct ShellQuickTerminalPeakPlacement: Equatable {
     let joinsAllSpaces: Bool
     let requiresMainWindow: Bool
 
+    var windowCollectionBehavior: NSWindow.CollectionBehavior {
+        var behavior: NSWindow.CollectionBehavior = [.fullScreenAuxiliary]
+        if joinsAllSpaces {
+            behavior.insert(.canJoinAllSpaces)
+        } else if followsActiveSpace {
+            behavior.insert(.moveToActiveSpace)
+        }
+        return behavior
+    }
+
     static func defaultPlacement(in visibleFrame: CGRect) -> ShellQuickTerminalPeakPlacement {
         ShellQuickTerminalPeakPlacement(
             frame: defaultFrame(in: visibleFrame),
@@ -244,8 +254,8 @@ final class ShellQuickTerminalPeakPresenter {
 
         switch slot.presentation {
         case .visible:
-            let shouldActivate = !window.isVisible || lastPresentedPaneID != pane.paneID
-            if shouldActivate {
+            let shouldPresent = !window.isVisible || lastPresentedPaneID != pane.paneID
+            if shouldPresent {
                 let tab = ShellQuickTerminalPeakModel.tab(for: pane)
                 let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrameProvider())
                 window.presentQuickTerminal(
@@ -255,7 +265,6 @@ final class ShellQuickTerminalPeakPresenter {
                     placement: placement
                 )
                 window.focusTerminal(paneID: pane.paneID)
-                host.terminalRuntimeRegistry.requestFocus(for: pane.paneID)
             }
             lastPresentedPaneID = pane.paneID
         case .hidden:
@@ -956,7 +965,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             workingDirectory: focusedPaneWorkingDirectory()
         )
         applyMutationResult(result)
-        terminalRuntimeRegistry.requestFocus(for: result.paneID ?? ShellQuickTerminalSlot.globalPaneID)
         return result.paneID
     }
 
@@ -973,11 +981,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func focusQuickTerminal() -> String? {
-        let paneID = showQuickTerminal()
-        if let paneID {
-            terminalRuntimeRegistry.requestFocus(for: paneID)
-        }
-        return paneID
+        showQuickTerminal()
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -278,6 +278,21 @@ final class ShellQuickTerminalPeakPresenter {
     func windowDidResignKey() {
         // Terminal-first policy: focus loss is informational and never hides the Peak.
     }
+
+    func focusVisibleQuickTerminal() {
+        guard let slot = host.shellState.quickTerminal,
+              slot.presentation == .visible,
+              let pane = host.quickTerminalPane
+        else {
+            return
+        }
+        if !window.isVisible || lastPresentedPaneID != pane.paneID {
+            synchronize()
+            return
+        }
+        window.focusTerminal(paneID: pane.paneID)
+        lastPresentedPaneID = pane.paneID
+    }
 }
 
 @MainActor
@@ -388,6 +403,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     @Published private(set) var controlPlaneDiagnostics: [String] = []
     @Published private(set) var activityNotifications: [ShellActivityNotificationRoute] = []
     @Published private(set) var zoomedPaneIDByTabID: [String: String] = [:]
+    @Published private(set) var quickTerminalFocusRequestID: UInt64 = 0
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
     private let appIsActiveProvider: @MainActor () -> Bool
@@ -981,7 +997,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func focusQuickTerminal() -> String? {
-        showQuickTerminal()
+        let wasVisible = shellState.quickTerminal?.presentation == .visible
+        guard let paneID = showQuickTerminal() else { return nil }
+        if wasVisible {
+            quickTerminalFocusRequestID &+= 1
+        }
+        return paneID
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -184,6 +184,35 @@ struct ShellQuickTerminalPeakPlacement: Equatable {
     }
 }
 
+struct ShellQuickTerminalPanelKeyRequestBudget {
+    enum Purpose {
+        case presentation
+        case terminalFocus
+    }
+
+    private(set) var presentationAttemptCount = 0
+    let maximumPresentationAttempts: Int
+
+    init(maximumPresentationAttempts: Int = 2) {
+        self.maximumPresentationAttempts = max(0, maximumPresentationAttempts)
+    }
+
+    mutating func reset() {
+        presentationAttemptCount = 0
+    }
+
+    mutating func shouldRequestKey(for purpose: Purpose) -> Bool {
+        switch purpose {
+        case .presentation:
+            guard presentationAttemptCount < maximumPresentationAttempts else { return false }
+            presentationAttemptCount += 1
+            return true
+        case .terminalFocus:
+            return true
+        }
+    }
+}
+
 enum ShellQuickTerminalPeakDismissalReason: Equatable {
     case hidden
     case removed

--- a/clients/apple/alan-macos/TerminalHostView.swift
+++ b/clients/apple/alan-macos/TerminalHostView.swift
@@ -22,6 +22,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var terminalContentID: String?
     private var bootProfile: AlanShellBootProfile?
     private var isSelected = false
+    private var attachmentPolicy: TerminalHostAttachmentPolicy = .immediate
     private var renderPriority: TerminalRuntimeRenderPriority = .hiddenBackground
     private weak var activationDelegate: TerminalHostActivationDelegate?
     private var shellActionHandler: ((ShellActionID, ShellActionTarget) -> Void)?
@@ -39,6 +40,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     private var hasTornDownRuntime = false
     private var pendingFocusRequest = false
     private var needsWindowAttachmentFocus = false
+    private var needsDeferredSurfaceAttachment = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -94,6 +96,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         super.viewDidMoveToWindow()
         installWindowObservers()
         window?.acceptsMouseMovedEvents = true
+        if window != nil, needsDeferredSurfaceAttachment {
+            scheduleDeferredSurfaceAttachment()
+        } else if window == nil {
+            needsDeferredSurfaceAttachment = false
+        }
         if window != nil, needsWindowAttachmentFocus {
             needsWindowAttachmentFocus = false
             focusTerminalSoon()
@@ -143,6 +150,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         renderPriority: TerminalRuntimeRenderPriority,
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
+        attachmentPolicy: TerminalHostAttachmentPolicy,
         onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
@@ -156,6 +164,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
         self.terminalContentID = terminalContentID
         self.bootProfile = bootProfile
         self.isSelected = isSelected
+        self.attachmentPolicy = attachmentPolicy
         self.renderPriority = renderPriority
         surfaceController.bind(surfaceHandle: surfaceHandle, paneID: pane?.paneID)
         self.activationDelegate = activationDelegate
@@ -387,6 +396,11 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     private func synchronizeLiveHost() {
+        guard canSynchronizeLiveHost else {
+            needsDeferredSurfaceAttachment = true
+            publishRuntimeSnapshot()
+            return
+        }
 #if canImport(GhosttyKit)
         guard let canvasView = canvasView as? AlanGhosttyCanvasView else { return }
         surfaceController.attach(
@@ -416,6 +430,26 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
             }
         )
 #endif
+    }
+
+    private var canSynchronizeLiveHost: Bool {
+        attachmentPolicy == .immediate || window != nil
+    }
+
+    private func scheduleDeferredSurfaceAttachment() {
+        guard window != nil else {
+            needsDeferredSurfaceAttachment = true
+            return
+        }
+        needsDeferredSurfaceAttachment = false
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard window != nil else {
+                needsDeferredSurfaceAttachment = true
+                return
+            }
+            synchronizeLiveHost()
+        }
     }
 
     private func reportCloseRequest(requiresConfirmation: Bool) {
@@ -575,7 +609,7 @@ final class AlanTerminalHostNSView: NSView, NSTextInputClient, TerminalRuntimeHa
     }
 
     func focusTerminal() {
-        requestTerminalFocus()
+        focusTerminalSoon()
     }
 
     private func activateTerminalHostForMouseEvent() {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -381,26 +381,128 @@ struct TerminalPaneView: View {
 
 struct ShellQuickTerminalPeakView: View {
     @ObservedObject var host: ShellHostController
+    let paneID: String
+    let terminalContentEnabled: Bool
 
     var body: some View {
         ZStack {
             ShellMaterialBackgroundView(.windowBackdrop)
                 .ignoresSafeArea()
 
-            if let pane = host.quickTerminalPane {
-                TerminalPaneView(
+            if let pane = host.shellState.pane(paneID: paneID),
+               host.shellState.quickTerminal?.paneID == pane.paneID
+            {
+                QuickTerminalContentView(
                     host: host,
-                    tab: ShellQuickTerminalPeakModel.tab(for: pane),
-                    spaceID: ShellQuickTerminalSlot.globalSpaceID,
-                    selectedPaneID: pane.paneID,
-                    terminalSurfaceInsets: EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10),
-                    onClosePane: { _ in
-                        _ = host.requestCloseQuickTerminal()
-                    }
+                    pane: pane,
+                    terminalContentEnabled: terminalContentEnabled
                 )
+            } else {
+                Color.clear
             }
         }
         .frame(minWidth: 520, minHeight: 280)
+    }
+}
+
+private struct QuickTerminalContentView: View {
+    @ObservedObject var host: ShellHostController
+    let pane: ShellPane
+    let terminalContentEnabled: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            chrome
+            terminalSurface
+        }
+        .padding(10)
+    }
+
+    private var chrome: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(ShellPalette.ink)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 12)
+
+            Button {
+                promoteQuickTerminal()
+            } label: {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .help("Open in Space")
+            .disabled(promoteTargetSpaceID == nil)
+
+            Button {
+                _ = host.requestCloseQuickTerminal()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .help("Close Quick Terminal")
+        }
+        .padding(.horizontal, 2)
+        .frame(height: 30)
+    }
+
+    private var terminalSurface: some View {
+        ZStack {
+            ShellPalette.terminal
+
+            if terminalContentEnabled {
+                TerminalHostView(
+                    pane: pane,
+                    terminalContentMount: TerminalContentMount(pane: pane),
+                    bootProfile: host.bootProfile(for: pane),
+                    isSelected: true,
+                    renderPriority: host.terminalRenderPriority(for: pane),
+                    runtimeRegistry: host.terminalRuntimeRegistry,
+                    activationDelegate: host,
+                    attachmentPolicy: .deferUntilWindowAttached,
+                    onShellAction: { actionID, target in
+                        host.performShellAction(actionID, target: target, source: .terminalHost)
+                    },
+                    onCloseRequest: { requiresConfirmation in
+                        guard !requiresConfirmation else { return }
+                        _ = host.requestCloseQuickTerminal()
+                    },
+                    onRuntimeUpdate: host.updateTerminalRuntime,
+                    onMetadataUpdate: { metadata in
+                        host.updateTerminalMetadata(metadata, for: pane.paneID)
+                    }
+                )
+                .id(pane.paneID)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
+                .strokeBorder(ShellPalette.line.opacity(0.26), lineWidth: 0.8)
+        }
+    }
+
+    private var title: String {
+        pane.viewport?.title ?? "Quick Terminal"
+    }
+
+    private var promoteTargetSpaceID: String? {
+        host.selectedSpace?.spaceID
+            ?? host.shellState.focusedSpaceID
+            ?? host.shellState.spaces.first?.spaceID
+    }
+
+    private func promoteQuickTerminal() {
+        guard let targetSpaceID = promoteTargetSpaceID else { return }
+        _ = host.promoteQuickTerminal(to: targetSpaceID)
     }
 }
 

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -56,6 +56,11 @@ struct TerminalContentMount: Equatable {
     }
 }
 
+enum TerminalHostAttachmentPolicy: Equatable {
+    case immediate
+    case deferUntilWindowAttached
+}
+
 @MainActor
 final class TerminalRuntimeRegistry: ObservableObject {
     typealias MockDeliveryHandler = (String, String) -> TerminalRuntimeDeliveryResult
@@ -64,6 +69,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
     private var snapshotsByContentID: [String: TerminalHostRuntimeSnapshot] = [:]
     private var paneSlotIDByContentID: [String: String] = [:]
     private var contentIDByPaneSlotID: [String: String] = [:]
+    private var pendingFocusPaneSlotIDs: Set<String> = []
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
 
@@ -81,6 +87,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         isSelected: Bool,
         renderPriority: TerminalRuntimeRenderPriority = .foregroundInteractive,
         activationDelegate: TerminalHostActivationDelegate?,
+        attachmentPolicy: TerminalHostAttachmentPolicy = .immediate,
         onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
@@ -93,6 +100,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             isSelected: isSelected,
             renderPriority: renderPriority,
             activationDelegate: activationDelegate,
+            attachmentPolicy: attachmentPolicy,
             onShellAction: onShellAction,
             onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
@@ -107,6 +115,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         isSelected: Bool,
         renderPriority: TerminalRuntimeRenderPriority = .foregroundInteractive,
         activationDelegate: TerminalHostActivationDelegate?,
+        attachmentPolicy: TerminalHostAttachmentPolicy = .immediate,
         onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
@@ -123,6 +132,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             isSelected: isSelected,
             renderPriority: renderPriority,
             activationDelegate: activationDelegate,
+            attachmentPolicy: attachmentPolicy,
             onShellAction: onShellAction,
             onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
@@ -139,6 +149,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
         isSelected: Bool,
         renderPriority: TerminalRuntimeRenderPriority = .foregroundInteractive,
         activationDelegate: TerminalHostActivationDelegate?,
+        attachmentPolicy: TerminalHostAttachmentPolicy = .immediate,
         onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,
@@ -165,6 +176,7 @@ final class TerminalRuntimeRegistry: ObservableObject {
             renderPriority: renderPriority,
             surfaceHandle: surfaceHandle,
             activationDelegate: activationDelegate,
+            attachmentPolicy: attachmentPolicy,
             onShellAction: onShellAction,
             onCloseRequest: onCloseRequest,
             onRuntimeUpdate: onRuntimeUpdate,
@@ -393,8 +405,14 @@ final class TerminalRuntimeRegistry: ObservableObject {
             .dismissFindInteraction(refocusTerminal: refocusTerminal)
     }
 
-    func requestFocus(for paneID: String) {
-        hostViewsByContentID[terminalContentID(mountedAtPaneID: paneID)]?.focusTerminal()
+    func requestFocus(for paneID: String, retryBudget: Int = 0) {
+        let contentID = terminalContentID(mountedAtPaneID: paneID)
+        if let hostView = hostViewsByContentID[contentID] {
+            hostView.focusTerminal()
+            return
+        }
+        guard retryBudget > 0 else { return }
+        pendingFocusPaneSlotIDs.insert(paneID)
     }
 
     var registeredContentIDs: Set<String> {
@@ -442,6 +460,9 @@ final class TerminalRuntimeRegistry: ObservableObject {
         unregisterHostView(hostView, excludingContentID: contentID)
         recordMount(contentID: contentID, paneSlotID: paneSlotID)
         hostViewsByContentID[contentID] = hostView
+        if pendingFocusPaneSlotIDs.remove(paneSlotID) != nil {
+            hostView.focusTerminal()
+        }
     }
 
     private func unregisterHostView(

--- a/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata-host-stubs.swift
@@ -22,6 +22,7 @@ final class AlanTerminalHostNSView: NSView {
         renderPriority: TerminalRuntimeRenderPriority,
         surfaceHandle: AlanTerminalSurfaceHandle?,
         activationDelegate: TerminalHostActivationDelegate?,
+        attachmentPolicy: TerminalHostAttachmentPolicy,
         onShellAction: ((ShellActionID, ShellActionTarget) -> Void)?,
         onCloseRequest: ((Bool) -> Void)?,
         onRuntimeUpdate: @escaping (TerminalHostRuntimeSnapshot) -> Void,

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -53,6 +53,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalPeakPresenterReleasesPresentationAfterPromotion()
         verifiesQuickTerminalActiveCloseCancelPreservesRuntime()
         verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh()
+        verifiesQuickTerminalFocusRefocusesExistingVisiblePeak()
         verifiesQuickTerminalPeakCollectionBehaviorUsesAppKitValidFlags()
         verifiesQuickTerminalPeakAppKitHarnessCoversVisibilityAndFocusOrdering()
         verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
@@ -74,6 +75,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesAdvancedControlPlaneZoomFocusAndMovementResults()
         verifiesAdvancedControlPlaneRejectsUnknownUnzoomPane()
         verifiesPaneMoveSocketRequestsRequireHostMetadataHandler()
+        verifiesQuickTerminalFocusSocketRequestsRequireHostHandler()
         verifiesTerminalActivityProjectsByPaneID()
         verifiesProgressActivityFactoryUsesSourceFirstDisplay()
         verifiesCommandCompletionActivityFactory()
@@ -2355,6 +2357,46 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesQuickTerminalFocusRefocusesExistingVisiblePeak() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
+
+        _ = controller.showQuickTerminal()
+        presenter.synchronize()
+        let requestIDBefore = controller.quickTerminalFocusRequestID
+
+        _ = controller.focusQuickTerminal()
+        presenter.focusVisibleQuickTerminal()
+
+        expect(
+            controller.quickTerminalFocusRequestID == requestIDBefore &+ 1,
+            "explicit quick-terminal focus must emit a focus request when the Peak is already visible"
+        )
+        expect(
+            window.events == [
+                "present:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+            ],
+            "explicit quick-terminal focus must refocus the existing visible Peak"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "regular pane update", cwd: "/repo/app"),
+            for: "pane_1"
+        )
+        presenter.synchronize()
+        expect(
+            window.events == [
+                "present:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+            ],
+            "unrelated visible-state refresh must not refocus after explicit quick-terminal focus"
+        )
+    }
+
     private static func verifiesQuickTerminalPeakPlacementFitsActiveDisplay() {
         let visibleFrame = CGRect(x: 20, y: 40, width: 1_280, height: 760)
         let placement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrame)
@@ -3187,6 +3229,38 @@ private enum ShellRuntimeMetadataTests {
         )
 
         expect(localResponse == nil, "pane.move socket requests must be routed to the host handler")
+    }
+
+    private static func verifiesQuickTerminalFocusSocketRequestsRequireHostHandler() {
+        let controller = makeController()
+        let socketServer = AlanShellSocketServer(
+            socketURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("quick-terminal-focus-host-\(UUID().uuidString).sock"),
+            commandHandler: { controller.handleControlPlaneCommand($0) },
+            stateAdoptionHandler: { _ in
+                fail("quick_terminal.focus must not mutate through the local executor")
+            },
+            sideEffectHandler: { _ in
+                fail("quick_terminal.focus must not use local side effects")
+            }
+        )
+        _ = socketServer.mergePublishedState(controller.shellState)
+
+        let localResponse = socketServer.handleLocally(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "quick-terminal-focus-host-routing-1",
+                  "command": "quick_terminal.focus"
+                }
+                """
+            )
+        )
+
+        expect(
+            localResponse == nil,
+            "quick_terminal.focus socket requests must be routed to the host handler"
+        )
     }
 
     private static func verifiesTerminalActivityProjectsByPaneID() {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -3,6 +3,8 @@ import Darwin
 import Foundation
 
 #if os(macOS)
+import AppKit
+
 @main
 struct ShellRuntimeMetadataTestRunner {
     static func main() async {
@@ -27,6 +29,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesRuntimeRegistryPreservesInteractiveBehaviorAcrossPaneRemount()
         verifiesRuntimeRegistryCleanupUsesCurrentMountContentIDs()
         verifiesRuntimeRegistryRekeysHostViewAcrossContentReplacement()
+        verifiesRuntimeRegistryDeliversDeferredFocusAfterHostRegistration()
         verifiesTerminalLifecycleFinalizesClosedPaneAndPreservesSiblings()
         verifiesTerminalLifecycleFinalizesAllTabContentsOnce()
         verifiesTerminalLifecyclePreservesMovedAndLiftedRuntimes()
@@ -44,10 +47,14 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalTerminalCommandsStayRoutable()
         verifiesQuickTerminalPromotionMovesExistingPaneIntoSpace()
         verifiesQuickTerminalPeakPresenterShowsDetachedTerminalWindow()
+        verifiesQuickTerminalPeakPresenterOrdersPresentationBeforeFocus()
         verifiesQuickTerminalRuntimeFocusDoesNotCommitWorkspaceSelection()
         verifiesQuickTerminalPeakPresenterPreservesRuntimeOnExplicitHide()
+        verifiesQuickTerminalPeakPresenterReleasesPresentationAfterPromotion()
         verifiesQuickTerminalActiveCloseCancelPreservesRuntime()
         verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh()
+        verifiesQuickTerminalPeakCollectionBehaviorUsesAppKitValidFlags()
+        verifiesQuickTerminalPeakAppKitHarnessCoversVisibilityAndFocusOrdering()
         verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
         verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal()
         verifiesQuickTerminalRenderPriorityStaysDetachedFromMainWindowVisibility()
@@ -1047,6 +1054,54 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesRuntimeRegistryDeliversDeferredFocusAfterHostRegistration() {
+        let registry = TerminalRuntimeRegistry(runtimeService: FakeAlanTerminalRuntimeService())
+        let delayedMount = TerminalContentMount(
+            contentID: "content_delayed_focus",
+            paneSlotID: "pane_delayed_focus",
+            tabID: "tab_delayed_focus",
+            spaceID: "space_main"
+        )
+        let hostView = AlanTerminalHostNSView()
+
+        registry.requestFocus(for: "pane_delayed_focus", retryBudget: 3)
+        expect(hostView.focusCount == 0, "early focus must wait for host view registration")
+
+        registry.configureHostView(
+            hostView,
+            forTerminalContent: delayedMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+        expect(
+            hostView.focusCount == 1,
+            "pending focus must be delivered exactly once when the host view registers"
+        )
+
+        registry.configureHostView(
+            hostView,
+            forTerminalContent: delayedMount,
+            pane: nil,
+            bootProfile: nil,
+            isSelected: true,
+            activationDelegate: nil,
+            onShellAction: nil,
+            onCloseRequest: nil,
+            onRuntimeUpdate: { _ in },
+            onMetadataUpdate: { _ in }
+        )
+        expect(
+            hostView.focusCount == 1,
+            "deferred focus must not continuously refocus after registration"
+        )
+    }
+
     private static func verifiesTerminalLifecycleFinalizesClosedPaneAndPreservesSiblings() {
         let controller = makeController()
         _ = controller.splitPane(paneID: "pane_1", placement: .right)
@@ -1441,8 +1496,8 @@ private enum ShellRuntimeMetadataTests {
             "workspace manifest restore must recreate the quick terminal slot"
         )
         expect(
-            restoredState.quickTerminal?.presentation == .visible,
-            "workspace manifest restore must preserve quick terminal presentation"
+            restoredState.quickTerminal?.presentation == .hidden,
+            "workspace manifest restore must not auto-present the quick terminal peak"
         )
         expect(
             restoredState.pane(paneID: ShellQuickTerminalSlot.globalPaneID)?.cwd == "/repo/quick",
@@ -2059,6 +2114,36 @@ private enum ShellRuntimeMetadataTests {
         expect(controller.selectedTabID == selectedTabBefore, "peak presenter must not move the selected Alan tab")
     }
 
+    private static func verifiesQuickTerminalPeakPresenterOrdersPresentationBeforeFocus() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
+
+        _ = controller.showQuickTerminal()
+        presenter.synchronize()
+
+        expect(
+            window.events == [
+                "present:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+            ],
+            "Peak presenter must present the detached window before requesting terminal focus"
+        )
+
+        controller.updateTerminalMetadata(
+            metadata(title: "regular pane update", cwd: "/repo/app"),
+            for: "pane_1"
+        )
+        presenter.synchronize()
+        expect(
+            window.events == [
+                "present:\(ShellQuickTerminalSlot.globalPaneID)",
+                "focus:\(ShellQuickTerminalSlot.globalPaneID)",
+            ],
+            "visible Peak refresh must not continuously reorder or refocus"
+        )
+    }
+
     private static func verifiesQuickTerminalRuntimeFocusDoesNotCommitWorkspaceSelection() {
         let controller = makeController()
         let focusedSpaceBefore = controller.shellState.focusedSpaceID
@@ -2154,6 +2239,37 @@ private enum ShellRuntimeMetadataTests {
         expect(quickHandle.teardownCount == 1, "explicit close must release the quick-terminal runtime")
     }
 
+    private static func verifiesQuickTerminalPeakPresenterReleasesPresentationAfterPromotion() {
+        let controller = makeController()
+        let window = FakeQuickTerminalPeakWindow()
+        let presenter = ShellQuickTerminalPeakPresenter(host: controller, window: window)
+        _ = controller.createTerminalSpace(title: "Second", workingDirectory: "/tmp")
+
+        _ = controller.showQuickTerminal()
+        let quickHandle = fakeSurfaceHandle(
+            for: ShellQuickTerminalSlot.globalPaneID,
+            controller: controller
+        )
+        presenter.synchronize()
+
+        expect(controller.promoteQuickTerminal(to: "space_2"), "promotion must move the quick terminal")
+        presenter.synchronize()
+
+        expect(
+            window.dismissalReasons.last == .removed,
+            "promotion must release the detached Peak presentation after the slot clears"
+        )
+        expect(controller.quickTerminalPane == nil, "promotion must clear the quick-terminal slot")
+        expect(
+            quickHandle.teardownCount == 0,
+            "promotion must move the runtime without finalizing the terminal process"
+        )
+        expect(
+            controller.pane(paneID: ShellQuickTerminalSlot.globalPaneID)?.spaceID == "space_2",
+            "promotion must move the existing quick-terminal pane into the target Space"
+        )
+    }
+
     private static func verifiesQuickTerminalActiveCloseCancelPreservesRuntime() {
         let presenter = FakeShellCloseConfirmationPresenter(nextResponses: [false])
         let controller = makeController(closeConfirmationPresenter: presenter)
@@ -2247,6 +2363,87 @@ private enum ShellRuntimeMetadataTests {
         expect(placement.frame.width >= 720, "normal displays should get a usable terminal width")
         expect(placement.frame.height >= 320, "normal displays should get a usable terminal height")
         expect(placement.requiresMainWindow == false, "peak placement must be detached from the main window")
+    }
+
+    private static func verifiesQuickTerminalPeakCollectionBehaviorUsesAppKitValidFlags() {
+        let visibleFrame = CGRect(x: 20, y: 40, width: 1_280, height: 760)
+        let allSpacesPlacement = ShellQuickTerminalPeakPlacement.defaultPlacement(in: visibleFrame)
+        let allSpacesBehavior = allSpacesPlacement.windowCollectionBehavior
+
+        expect(
+            allSpacesBehavior.contains(.canJoinAllSpaces),
+            "all-spaces peak behavior must join Spaces"
+        )
+        expect(
+            !allSpacesBehavior.contains(.moveToActiveSpace),
+            "all-spaces peak behavior must not also move to the active Space"
+        )
+        verifyAppKitAcceptsPeakCollectionBehavior(
+            allSpacesBehavior,
+            "all-spaces peak behavior must be accepted by AppKit"
+        )
+
+        let activeSpacePlacement = ShellQuickTerminalPeakPlacement(
+            frame: allSpacesPlacement.frame,
+            followsActiveSpace: true,
+            joinsAllSpaces: false,
+            requiresMainWindow: false
+        )
+        let activeSpaceBehavior = activeSpacePlacement.windowCollectionBehavior
+        expect(
+            activeSpaceBehavior.contains(.moveToActiveSpace),
+            "active-space peak behavior must move to the active Space"
+        )
+        expect(
+            !activeSpaceBehavior.contains(.canJoinAllSpaces),
+            "active-space peak behavior must not join all Spaces"
+        )
+        verifyAppKitAcceptsPeakCollectionBehavior(
+            activeSpaceBehavior,
+            "active-space peak behavior must be accepted by AppKit"
+        )
+    }
+
+    private static func verifiesQuickTerminalPeakAppKitHarnessCoversVisibilityAndFocusOrdering() {
+        let behavior = ShellQuickTerminalPeakPlacement
+            .defaultPlacement(in: CGRect(x: 20, y: 40, width: 1_280, height: 760))
+            .windowCollectionBehavior
+        let panel = QuickTerminalPeakHarnessPanel(
+            contentRect: CGRect(x: -10_000, y: -10_000, width: 160, height: 100),
+            styleMask: [.titled, .closable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.collectionBehavior = behavior
+        panel.isReleasedWhenClosed = false
+        panel.orderFrontRegardless()
+        panel.makeKey()
+
+        expect(panel.isVisible, "AppKit Peak harness must make the panel visible after ordering")
+        expect(panel.collectionBehavior == behavior, "AppKit Peak harness must preserve valid collection behavior")
+        expect(
+            panel.events.prefix(2) == ["orderFrontRegardless", "makeKey"],
+            "AppKit Peak harness must order the panel before requesting key focus"
+        )
+
+        panel.orderOut(nil)
+        expect(!panel.isVisible, "AppKit Peak harness must hide the panel on orderOut")
+        panel.close()
+    }
+
+    private static func verifyAppKitAcceptsPeakCollectionBehavior(
+        _ behavior: NSWindow.CollectionBehavior,
+        _ message: String
+    ) {
+        let panel = NSPanel(
+            contentRect: CGRect(x: 0, y: 0, width: 160, height: 100),
+            styleMask: [.titled, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.collectionBehavior = behavior
+        expect(panel.collectionBehavior == behavior, message)
+        panel.close()
     }
 
     private static func verifiesQuickTerminalPeakEscapePolicyBelongsToTerminal() {
@@ -9575,6 +9772,7 @@ private enum ShellRuntimeMetadataTests {
         private(set) var dismissalReasons: [ShellQuickTerminalPeakDismissalReason] = []
         private(set) var lastPlacement: ShellQuickTerminalPeakPlacement?
         private(set) var lastTabID: String?
+        private(set) var events: [String] = []
         private(set) var isVisible = false
 
         func presentQuickTerminal(
@@ -9585,6 +9783,7 @@ private enum ShellRuntimeMetadataTests {
         ) {
             isVisible = true
             presentedPaneIDs.append(pane.paneID)
+            events.append("present:\(pane.paneID)")
             lastTabID = tab.tabID
             lastPlacement = placement
         }
@@ -9592,10 +9791,29 @@ private enum ShellRuntimeMetadataTests {
         func dismissQuickTerminalPeak(reason: ShellQuickTerminalPeakDismissalReason) {
             isVisible = false
             dismissalReasons.append(reason)
+            events.append("dismiss:\(reason)")
         }
 
         func focusTerminal(paneID: String) {
             focusedPaneIDs.append(paneID)
+            events.append("focus:\(paneID)")
+        }
+    }
+
+    private final class QuickTerminalPeakHarnessPanel: NSPanel {
+        private(set) var events: [String] = []
+
+        override var canBecomeKey: Bool { true }
+        override var canBecomeMain: Bool { false }
+
+        override func orderFrontRegardless() {
+            events.append("orderFrontRegardless")
+            super.orderFrontRegardless()
+        }
+
+        override func makeKey() {
+            events.append("makeKey")
+            super.makeKey()
         }
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -54,6 +54,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesQuickTerminalActiveCloseCancelPreservesRuntime()
         verifiesQuickTerminalPeakPresenterDoesNotRefocusOnVisibleRefresh()
         verifiesQuickTerminalFocusRefocusesExistingVisiblePeak()
+        verifiesQuickTerminalPanelKeyBudgetDoesNotBlockTerminalFocus()
         verifiesQuickTerminalPeakCollectionBehaviorUsesAppKitValidFlags()
         verifiesQuickTerminalPeakAppKitHarnessCoversVisibilityAndFocusOrdering()
         verifiesQuickTerminalPeakPlacementFitsActiveDisplay()
@@ -2394,6 +2395,42 @@ private enum ShellRuntimeMetadataTests {
                 "focus:\(ShellQuickTerminalSlot.globalPaneID)",
             ],
             "unrelated visible-state refresh must not refocus after explicit quick-terminal focus"
+        )
+    }
+
+    private static func verifiesQuickTerminalPanelKeyBudgetDoesNotBlockTerminalFocus() {
+        var budget = ShellQuickTerminalPanelKeyRequestBudget(maximumPresentationAttempts: 2)
+
+        expect(
+            budget.shouldRequestKey(for: .presentation),
+            "first presentation key request must be allowed"
+        )
+        expect(
+            budget.shouldRequestKey(for: .presentation),
+            "second presentation key request must be allowed"
+        )
+        expect(
+            !budget.shouldRequestKey(for: .presentation),
+            "presentation key requests must remain bounded"
+        )
+        expect(
+            budget.shouldRequestKey(for: .terminalFocus),
+            "terminal focus must still request panel key after presentation attempts are exhausted"
+        )
+        expect(
+            budget.shouldRequestKey(for: .terminalFocus),
+            "repeated terminal focus requests must not consume the presentation budget"
+        )
+        expect(
+            budget.presentationAttemptCount == 2,
+            "terminal focus requests must not advance the presentation attempt count"
+        )
+
+        budget.reset()
+        expect(budget.presentationAttemptCount == 0, "reset must clear presentation key attempts")
+        expect(
+            budget.shouldRequestKey(for: .presentation),
+            "a new presentation must get a fresh key request budget"
         )
     }
 

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/.openspec.yaml
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/design.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/design.md
@@ -1,0 +1,167 @@
+## Context
+
+The accepted Quick Terminal Peak contract deliberately chose one global
+quick-terminal runtime slot over per-Space or independent terminal runtimes.
+That contract preserves scrollback and process state across hide/show, supports
+`Open in Space` as a move rather than a copy, and keeps menu, shortcut,
+automation, and control-plane behavior aligned through shared shell commands.
+
+The problem is the implementation boundary. The current Peak is a detached
+`NSPanel`, but it is driven by the primary shell owner, observes the full
+`ShellHostController`, renders the general `TerminalPaneView`, and synchronously
+attaches a Ghostty-backed terminal surface during the panel presentation path.
+That means an ostensibly independent window still shares the main shell's
+SwiftUI state churn, focus race surface, and main-thread terminal attachment
+work.
+
+This change keeps the product semantics and refactors the boundary: Quick
+Terminal should behave like a dedicated macOS window/controller at the
+presentation layer while remaining the same Alan-owned global terminal runtime
+at the shell/runtime layer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve one global quick-terminal runtime slot and existing hide/show/close
+  semantics.
+- Preserve `Open in Space` as a move of the existing runtime into a normal Alan
+  tab.
+- Add a dedicated presentation controller and window presenter for Peak
+  lifecycle, frame, Space behavior, and focus timing.
+- Use a narrow Quick Terminal content view instead of the full workspace
+  `TerminalPaneView`.
+- Present the panel before terminal surface attachment and focus work, so slow
+  Ghostty setup cannot run in the same synchronous stack as shell-state mutation
+  and panel creation.
+- Restore quick-terminal content as hidden on app launch.
+- Avoid Alan Dev during verification; stable-channel verification is allowed.
+
+**Non-Goals:**
+
+- No independent quick-terminal runtime owner.
+- No change to the single global quick-terminal instance model.
+- No per-Alan-space or per-macOS-Space quick terminal instances.
+- No focus-loss auto-hide behavior.
+- No redesign of the normal terminal pane UI.
+- No requirement to complete the full behavior test suite in the first
+  implementation slice.
+
+## Decisions
+
+### 1. Keep runtime ownership in the shell model
+
+`ShellHostController` remains the owner of quick-terminal state mutations:
+show, hide, close, cwd selection, close guard routing, and promotion. The
+terminal runtime still belongs to the existing terminal runtime service and is
+keyed by the quick-terminal content identity.
+
+The new controller must not create a second terminal runtime and must not copy
+the process during promotion. Its job is to interpret shell state and drive
+presentation.
+
+### 2. Add a dedicated presentation state machine
+
+Introduce a `QuickTerminalController` that observes the quick-terminal slot and
+tracks presentation states such as:
+
+- `idle`: no visible Peak presentation.
+- `panelPreparing`: create or reuse the panel and install lightweight content.
+- `panelVisible`: the panel is ordered front and has a window.
+- `terminalAttaching`: terminal host attachment is allowed after the window is
+  visible or after a main-runloop deferral.
+- `terminalFocused`: focus was requested after the surface became attachable or
+  ready.
+- `hiding`: the panel is ordered out while runtime state remains live.
+- `closing`: shell close semantics are running and panel resources may be
+  released after the slot is cleared.
+
+The state machine is intentionally presentation-only. Shell mutations continue
+to flow through existing commands.
+
+### 3. Isolate `NSPanel` details in a window presenter
+
+Introduce a Quick Terminal window presenter that owns the `NSPanel`,
+`NSWindowDelegate`, collection behavior, frame, level, ordering, and key-window
+timing. It should make AppKit-valid Space behavior explicit and never combine
+mutually exclusive collection behaviors.
+
+Panel ordering and terminal focus should be separate operations. The presenter
+may order the panel front immediately, but terminal focus is best-effort and is
+scheduled after the panel is visible. Repeated focus attempts should be bounded
+and should not continuously call `makeKey`.
+
+### 4. Replace the Peak composition with a narrow content view
+
+The Peak should render a dedicated `QuickTerminalContentView` rather than the
+full `TerminalPaneView`. The content view should receive a narrow model with
+only the data and callbacks it needs:
+
+- quick-terminal pane/content mount.
+- boot profile.
+- runtime snapshot/render priority.
+- close request handler.
+- promote request handler.
+- runtime update and metadata callbacks.
+
+It should not include normal workspace sidebar, tab header, split controls,
+selection management, or general workspace decoration. This prevents ordinary
+workspace state updates from rebuilding the Peak more than necessary.
+
+### 5. Defer terminal surface attachment and focus
+
+Showing the Peak should not synchronously do every step. The flow should be:
+
+1. Apply shell mutation to mark the quick-terminal slot visible.
+2. Presentation controller creates/reuses and orders the panel.
+3. After the panel is attached/visible, install or update the narrow content
+   view.
+4. Attach the terminal surface on a deferred main-actor step.
+5. Request focus only after the terminal host is registered and window attached.
+
+This separates user-visible window presentation from Ghostty surface setup and
+reduces the chance that a slow terminal attachment makes the main window appear
+frozen.
+
+### 6. Restore hidden on launch
+
+Workspace manifest materialization may restore quick-terminal content and last
+working directory, but it must not auto-present the detached Peak on app launch.
+If a previous manifest records `visible`, materialization should produce a
+hidden presentation and wait for an explicit user show/toggle command.
+
+### 7. Stage verification
+
+The first implementation slice may focus on structure and stable-channel launch
+safety:
+
+- compile the Apple client target,
+- prove stable launch no longer traps on Peak collection behavior,
+- avoid Alan Dev entirely.
+
+A follow-up verification slice should add or extend:
+
+- presentation state-machine tests,
+- AppKit harness coverage for panel collection behavior, visibility, and focus
+  ordering,
+- runtime attach/focus sequencing tests,
+- stable-channel Quick Terminal behavior verification.
+
+## Error Handling
+
+- Panel creation failure should not clear the quick-terminal shell slot. It
+  should leave the runtime/content available and allow a later toggle to retry.
+- Terminal surface attach failure should be reported in the Peak content area or
+  diagnostic state without blocking the main workspace UI.
+- Focus failure is best-effort. The Peak may remain visible and accept a later
+  click/focus retry instead of repeatedly forcing key status.
+- Promotion clears the quick-terminal slot and releases the panel after shell
+  mutation succeeds. The presenter does not copy or finalize the runtime.
+- Close continues to use the existing close guard and runtime teardown path.
+
+## Migration
+
+Existing persisted quick-terminal slots remain compatible. The only launch-time
+behavioral migration is that visible persisted presentation restores as hidden.
+Normal panes, pinned tabs, and terminal transcript snapshots keep their existing
+restore behavior.

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/proposal.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Alan's Quick Terminal Peak is specified as a detached global terminal surface,
+but the current implementation couples Peak presentation to the main shell host,
+workspace view tree, and synchronous terminal surface attachment. This has
+already produced a stable-channel launch crash from invalid AppKit collection
+behavior, and the same coupling makes shortcut-triggered Peak presentation able
+to stall the main shell window before the Peak is visible.
+
+The product contract is still sound: one global quick-terminal runtime should
+survive hide/show and be promotable into a normal Alan tab. The fix is to move
+Peak presentation behind a dedicated controller/window boundary while preserving
+the existing runtime identity and shell command semantics.
+
+## What Changes
+
+- Add a dedicated Quick Terminal presentation controller that observes the
+  global quick-terminal slot and drives a small window/focus state machine.
+- Move `NSPanel` ownership, Space behavior, ordering, and focus timing into a
+  Quick Terminal window presenter instead of embedding those details in the
+  primary shell owner.
+- Replace the Peak's reuse of the full workspace `TerminalPaneView` with a
+  narrow Quick Terminal content view that renders only the terminal surface and
+  minimal Peak chrome.
+- Keep `ShellHostController` responsible for quick-terminal state mutations,
+  command routing, cwd selection, close guard semantics, and `Open in Space`
+  promotion.
+- Keep one global terminal runtime slot; hide/show preserves the runtime, close
+  tears it down, and promotion moves the existing runtime into a normal tab.
+- Restore persisted quick-terminal content as hidden on app launch so restart
+  never auto-presents the detached Peak.
+- Stage verification so the first implementation slice proves compilation and
+  stable-channel launch safety, while full state-machine, AppKit harness, and
+  Quick Terminal behavior tests may follow in a dedicated verification slice.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-quick-terminal-peak`: Tighten Peak ownership and lifecycle around a
+  dedicated presentation boundary while preserving global runtime identity.
+- `macos-shell-workspace-persistence`: Require persisted quick-terminal
+  presentation to restore hidden instead of auto-presenting the Peak at launch.
+- `macos-shell-build-test-contract`: Define the staged verification contract for
+  the refactor, including stable-channel launch safety and later AppKit harness
+  coverage.
+
+## Impact
+
+- `clients/apple/alan-macos/App/AlanMacPrimaryShellOwner.swift` should stop
+  owning detailed Quick Terminal panel behavior directly.
+- `clients/apple/alan-macos/ShellHostController.swift` should keep command and
+  shell-state ownership but delegate Peak presentation to the dedicated
+  controller.
+- `clients/apple/alan-macos/TerminalPaneView.swift` should no longer be the
+  Peak's primary composition surface; a focused Quick Terminal content view
+  should provide the minimal terminal-first UI.
+- `clients/apple/alan-macos/TerminalRuntimeRegistry.swift` and
+  `TerminalRuntimeService.swift` may need narrow attach/focus seams so the
+  presentation controller can defer terminal surface work until the Peak window
+  is visible.
+- Focused Apple scripts, an AppKit harness, and stable-channel verification
+  should be updated in the follow-up verification slice.

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-quick-terminal-peak/spec.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-quick-terminal-peak/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Quick Terminal Peak uses a dedicated presentation boundary
+Alan SHALL present the Quick Terminal Peak through a dedicated presentation
+controller and window presenter while preserving the existing global
+quick-terminal runtime identity.
+
+#### Scenario: Quick terminal show delegates presentation
+- **WHEN** the user invokes the quick-terminal show or toggle command
+- **THEN** Alan applies the quick-terminal shell mutation through the shared
+  shell command path
+- **AND** a dedicated Quick Terminal presentation controller observes the visible
+  slot and drives Peak window presentation
+- **AND** `ShellHostController` does not directly own detailed `NSPanel`
+  ordering, delegate, collection-behavior, or terminal-focus timing
+
+#### Scenario: Presentation does not create an independent runtime owner
+- **WHEN** the dedicated presentation controller shows the Peak
+- **THEN** it uses the existing quick-terminal content identity and terminal
+  runtime service
+- **AND** it does not create a second quick-terminal runtime owner
+
+### Requirement: Peak panel presentation precedes terminal surface attachment
+Alan SHALL separate user-visible Peak panel presentation from terminal surface
+attachment and focus so slow terminal renderer setup does not run in the same
+synchronous stack as shell-state mutation and panel creation.
+
+#### Scenario: Peak panel becomes visible before terminal attach
+- **WHEN** the quick-terminal slot becomes visible
+- **THEN** Alan creates or reuses the detached Peak panel and orders it visible
+- **AND** terminal surface attachment is deferred until the panel is attached or
+  visible on a later main-actor step
+
+#### Scenario: Terminal focus is best-effort after host registration
+- **WHEN** the Peak panel is visible and the terminal host view has been
+  registered for the quick-terminal content
+- **THEN** Alan requests terminal focus as a bounded best-effort action
+- **AND** repeated focus retries do not continuously force the panel key status
+
+#### Scenario: Terminal attach fails
+- **WHEN** Ghostty bootstrap or surface attachment fails for the Peak content
+- **THEN** Alan keeps the quick-terminal shell slot and runtime identity
+  recoverable
+- **AND** the main workspace window remains responsive
+
+### Requirement: Quick Terminal Peak uses narrow terminal-first content
+Alan SHALL render the Peak with a dedicated Quick Terminal content view that
+only depends on the quick-terminal pane/content model and minimal Peak commands.
+
+#### Scenario: Peak content excludes normal workspace chrome
+- **WHEN** Alan renders the Quick Terminal Peak
+- **THEN** the Peak content does not include the regular workspace sidebar,
+  normal tab header, general split controls, or workspace selection UI
+- **AND** the Peak remains terminal-first with minimal close and promotion
+  affordances
+
+#### Scenario: Ordinary workspace updates do not rebuild Peak composition
+- **WHEN** unrelated regular workspace state changes while the Peak is visible
+- **THEN** Alan avoids rebuilding Peak content from the full workspace
+  `TerminalPaneView` tree solely because normal tabs, spaces, or sidebar state
+  changed
+
+### Requirement: Quick Terminal promotion remains a runtime move
+Alan SHALL preserve `Open in Space` as a move of the existing quick-terminal
+runtime into a normal Alan tab.
+
+#### Scenario: Quick terminal is promoted after boundary refactor
+- **WHEN** the user promotes the quick terminal into a Space
+- **THEN** Alan moves the existing quick-terminal runtime identity into the
+  target Space as a normal tab
+- **AND** Alan clears the global quick-terminal slot and releases the Peak
+  presentation
+- **AND** Alan does not copy, link, or duplicate the terminal process

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Quick Terminal boundary refactor has staged verification
+The Apple client SHALL verify the Quick Terminal boundary refactor in stages so
+the implementation can first prove stable launch safety and compilation, then
+add focused behavior coverage.
+
+#### Scenario: First implementation slice is verified
+- **WHEN** the dedicated Quick Terminal presentation boundary is implemented
+- **THEN** verification includes the focused Apple build needed to prove the
+  refactor compiles
+- **AND** verification proves stable-channel launch does not trap on Quick
+  Terminal Peak setup
+- **AND** verification does not operate the Alan Dev app
+
+#### Scenario: Full behavior verification follows
+- **WHEN** the follow-up verification slice is performed
+- **THEN** tests cover Quick Terminal presentation state transitions for show,
+  hide, close, attach, focus, and promotion
+- **AND** an AppKit harness or equivalent focused test verifies panel collection
+  behavior, visibility, and focus ordering
+- **AND** runtime attach/focus sequencing tests prove early focus requests do
+  not race host view registration
+- **AND** stable-channel Quick Terminal behavior verification still avoids
+  touching Alan Dev

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Quick Terminal launch restore is presentation-hidden
+The macOS shell workspace manifest materializer SHALL restore quick-terminal
+content and last working directory without automatically presenting the detached
+Peak during app launch.
+
+#### Scenario: Manifest records visible quick terminal
+- **WHEN** Alan materializes shell state from a workspace manifest whose
+  quick-terminal record has visible presentation
+- **THEN** Alan restores the quick-terminal slot as hidden
+- **AND** Alan preserves the quick-terminal content identity and last working
+  directory when they are restorable
+- **AND** Alan waits for an explicit user show or toggle command before
+  presenting the Peak
+
+#### Scenario: Manifest records hidden quick terminal
+- **WHEN** Alan materializes shell state from a workspace manifest whose
+  quick-terminal record has hidden presentation
+- **THEN** Alan restores the quick-terminal slot as hidden
+- **AND** Alan does not create or show the Peak panel during launch solely
+  because a quick-terminal restore record exists

--- a/openspec/changes/stabilize-macos-quick-terminal-peak/tasks.md
+++ b/openspec/changes/stabilize-macos-quick-terminal-peak/tasks.md
@@ -1,0 +1,61 @@
+## 1. Presentation Boundary
+
+- [x] 1.1 Introduce a dedicated Quick Terminal presentation controller that
+  observes the quick-terminal slot and drives panel visibility without owning
+  shell mutations.
+- [x] 1.2 Move `NSPanel` ownership, delegate behavior, collection behavior,
+  ordering, and key/focus timing into a Quick Terminal window presenter.
+- [x] 1.3 Replace the Peak's full `TerminalPaneView` composition with a narrow
+  Quick Terminal content view and model.
+- [x] 1.4 Keep `ShellHostController` as the owner of show, hide, close, cwd,
+  close guard, and promotion semantics while delegating presentation.
+
+## 2. Runtime And Focus Sequencing
+
+- [x] 2.1 Split panel presentation from terminal surface attachment so the
+  panel can become visible before Ghostty surface setup runs.
+- [x] 2.2 Add or clarify runtime registry seams for quick-terminal
+  content-mount attach and focus after host view registration.
+- [x] 2.3 Bound focus retries and make terminal focus best-effort after window
+  visibility.
+- [x] 2.4 Preserve hidden runtime state across hide/show and preserve existing
+  close teardown behavior.
+
+## 3. Persistence And Promotion
+
+- [x] 3.1 Materialize persisted quick-terminal presentation as hidden during app
+  launch, including old manifests that recorded visible presentation.
+- [x] 3.2 Preserve `Open in Space` as a move of the existing runtime into a
+  normal Alan tab and clear the quick-terminal slot after promotion.
+- [x] 3.3 Ensure promotion releases the Peak presentation without copying,
+  linking, or finalizing the terminal process.
+
+## 4. First Implementation Verification
+
+- [x] 4.1 Run the focused Apple build needed to prove the refactor compiles.
+- [x] 4.2 Verify stable-channel launch safety without operating Alan Dev.
+- [x] 4.3 Confirm the stable launch path cannot trap on invalid Peak collection
+  behavior.
+- [x] 4.4 Document any deferred Quick Terminal behavior verification.
+
+Verification note: stable app launch and Quick Terminal show/hide behavior were
+verified against an isolated stable `Alan.app` bundle with a temporary
+Application Support directory and temporary shell-control namespace. Alan Dev
+was not operated.
+
+## 5. Follow-Up Verification Slice
+
+- [x] 5.1 Add presentation state-machine tests for show, hide, close, attach,
+  focus, and promotion transitions.
+- [x] 5.2 Add an AppKit harness covering Peak panel collection behavior,
+  visibility, and focus ordering.
+- [x] 5.3 Add runtime attach/focus sequencing tests that prove early focus
+  requests do not race host view registration.
+- [x] 5.4 Run stable-channel Quick Terminal behavior verification without
+  touching Alan Dev.
+
+## 6. OpenSpec Validation
+
+- [x] 6.1 Run `openspec validate stabilize-macos-quick-terminal-peak --type change --strict --json`.
+- [x] 6.2 Run `openspec validate --all --strict --json`.
+- [x] 6.3 Run `git diff --check`.


### PR DESCRIPTION
## Summary
- isolate Quick Terminal Peak behind a dedicated NSPanel presenter and narrow terminal-first content view
- defer terminal host attach/focus until the panel is visible and the host view is registered
- restore persisted quick-terminal presentation as hidden on launch and add OpenSpec/test coverage

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-pr-quick-terminal CODE_SIGNING_ALLOWED=NO build
- isolated LaunchServices stable Alan.app quick_terminal.show/hide: show applied, pane quick_terminal_pane, hide applied, final presentation hidden, surface_readiness ready; Alan Dev was not operated
- openspec validate stabilize-macos-quick-terminal-peak --type change --strict --json
- openspec validate --all --strict --json
- git diff --check