### PR TITLE
Add macOS performance diagnostics

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		000000000000000000000047 /* App/AlanMacUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000151 /* App/AlanMacUpdateController.swift */; };
 		000000000000000000000048 /* Support/AlanMacUpdatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000152 /* Support/AlanMacUpdatePolicy.swift */; };
 		000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */; };
+		00000000000000000000004A /* Services/Shell/ShellPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */; };
+		00000000000000000000004B /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -155,6 +157,8 @@
 		000000000000000000000151 /* App/AlanMacUpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AlanMacUpdateController.swift; sourceTree = "<group>"; };
 		000000000000000000000152 /* Support/AlanMacUpdatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/AlanMacUpdatePolicy.swift; sourceTree = "<group>"; };
 		000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellSettingsSurfaceModel.swift; sourceTree = "<group>"; };
+		000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPerformanceDiagnostics.swift; sourceTree = "<group>"; };
+		000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -323,6 +327,8 @@
 				00000000000000000000012F /* Services/Shell/ShellDiagnostics.swift */,
 				00000000000000000000012E /* Services/Shell/ShellEventStore.swift */,
 				00000000000000000000012A /* Services/Shell/ShellLocalCommandExecutor.swift */,
+				000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */,
+				000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */,
 				00000000000000000000012C /* Services/Shell/ShellPublishedStateMerger.swift */,
 				00000000000000000000012B /* Services/Shell/ShellSocketServer.swift */,
 				000000000000000000000126 /* Services/Shell/ShellStatePersistenceStore.swift */,
@@ -526,6 +532,8 @@
 				000000000000000000000048 /* Support/AlanMacUpdatePolicy.swift in Sources */,
 				000000000000000000000047 /* App/AlanMacUpdateController.swift in Sources */,
 				000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */,
+				00000000000000000000004A /* Services/Shell/ShellPerformanceDiagnostics.swift in Sources */,
+				00000000000000000000004B /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift in Sources */,
 				000000000000000000000039 /* Models/Shell/ShellWorkspaceManifest.swift in Sources */,
 				00000000000000000000003A /* Services/Shell/ShellWorkspaceManifestStore.swift in Sources */,
 			);

--- a/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
+++ b/clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift
@@ -161,6 +161,10 @@ extension ShellHostController {
         spatialDirection: ShellSpatialFocusDirection? = nil,
         placement: ShellPaneSplitDirection? = nil,
         mountedContentInstanceID: String? = nil,
+        diagnosticsEnabled: Bool? = nil,
+        diagnosticsRetainedEventCount: Int? = nil,
+        diagnosticsStutterMarkerCount: Int? = nil,
+        diagnosticsBundlePath: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) -> AlanShellControlResponse {
@@ -217,6 +221,10 @@ extension ShellHostController {
             spatialDirection: spatialDirection,
             placement: placement,
             mountedContentInstanceID: contentProjection.contentID ?? mountedContentInstanceID,
+            diagnosticsEnabled: diagnosticsEnabled,
+            diagnosticsRetainedEventCount: diagnosticsRetainedEventCount,
+            diagnosticsStutterMarkerCount: diagnosticsStutterMarkerCount,
+            diagnosticsBundlePath: diagnosticsBundlePath,
             errorCode: errorCode,
             errorMessage: errorMessage
         )
@@ -900,6 +908,100 @@ extension ShellHostController {
                 errorMessage: delivery.errorMessage
             )
 
+        case .terminalSendKey:
+            let contentState = shellState.contentStateProjection()
+            let requestedPaneSlotID = command.paneSlotID ?? command.paneID
+            let target: TerminalSendTextTarget?
+            if let contentID = command.contentID {
+                target = contentState.terminalSendTextTarget(contentID: contentID)
+            } else if let requestedPaneSlotID {
+                target = contentState.terminalSendTextTarget(paneSlotID: requestedPaneSlotID)
+            } else {
+                target = nil
+            }
+
+            guard let target else {
+                let errorCode: String
+                if command.contentID == nil && requestedPaneSlotID == nil {
+                    errorCode = "terminal_target_required"
+                } else if command.contentID != nil {
+                    errorCode = "content_not_found"
+                } else {
+                    errorCode = "pane_not_found"
+                }
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    paneID: command.paneID,
+                    paneSlotID: command.paneSlotID,
+                    contentID: command.contentID,
+                    errorCode: errorCode,
+                    errorMessage: "terminal.send_key requires an existing terminal content target."
+                )
+            }
+
+            guard target.content.kind == .terminal else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: target.paneSlot.spaceID,
+                    tabID: target.paneSlot.tabID,
+                    paneID: target.paneSlot.paneSlotID,
+                    paneSlotID: target.paneSlot.paneSlotID,
+                    contentID: target.content.contentID,
+                    contentKind: target.content.kind,
+                    errorCode: "unsupported_content",
+                    errorMessage: "terminal.send_key requires terminal content."
+                )
+            }
+
+            let keyName = command.key?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let key: TerminalRuntimeControlKey?
+            switch keyName {
+            case "return", "enter":
+                key = .returnKey
+            default:
+                key = nil
+            }
+            guard let key else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    spaceID: target.paneSlot.spaceID,
+                    tabID: target.paneSlot.tabID,
+                    paneID: target.paneSlot.paneSlotID,
+                    paneSlotID: target.paneSlot.paneSlotID,
+                    contentID: target.content.contentID,
+                    errorCode: "terminal_key_unsupported",
+                    errorMessage: "terminal.send_key currently supports return."
+                )
+            }
+
+            let result = performShellAutomationCommand(
+                .sendKey(
+                    ShellAutomationSendKeyRequest(
+                        paneID: target.paneSlot.paneSlotID,
+                        terminalContentID: target.content.contentID,
+                        key: key
+                    )
+                )
+            )
+            let delivery = terminalDeliveryResult(from: result)
+            return response(
+                requestID: command.requestID,
+                applied: result.applied,
+                spaceID: target.paneSlot.spaceID,
+                tabID: target.paneSlot.tabID,
+                paneID: target.paneSlot.paneSlotID,
+                paneSlotID: target.paneSlot.paneSlotID,
+                contentID: target.content.contentID,
+                acceptedBytes: delivery.acceptedBytes,
+                deliveryCode: delivery.code.rawValue,
+                runtimePhase: delivery.runtimePhase,
+                errorCode: delivery.errorCode,
+                errorMessage: delivery.errorMessage
+            )
+
         case .terminalRenderMetrics:
             return response(
                 requestID: command.requestID,
@@ -1135,6 +1237,124 @@ extension ShellHostController {
                     errorCode: "events_unavailable",
                     errorMessage: "events.read is handled by the shell control plane."
                 )
+
+        case .performanceDiagnosticsSetEnabled:
+            guard let enabled = command.enabled else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "diagnostics_enabled_required",
+                    errorMessage: "enabled is required."
+                )
+            }
+            AlanPerformanceDiagnosticsController.shared.setEnabled(enabled)
+            let summary = AlanPerformanceDiagnosticsController.shared.summarySnapshot()
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                diagnosticsEnabled: AlanPerformanceDiagnosticsController.shared.isEnabled,
+                diagnosticsRetainedEventCount: AlanPerformanceDiagnosticsController.shared
+                    .eventsSnapshot().count,
+                diagnosticsStutterMarkerCount: summary.stutterMarkerCount
+            )
+
+        case .performanceDiagnosticsExportRecent:
+            guard let exportDirectory = command.exportDirectory?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !exportDirectory.isEmpty
+            else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "diagnostics_export_directory_required",
+                    errorMessage: "export_directory is required."
+                )
+            }
+            do {
+                let bundleURL = try AlanPerformanceDiagnosticsController.shared.exportRecentDiagnostics(
+                    to: URL(fileURLWithPath: exportDirectory, isDirectory: true),
+                    appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+                        as? String ?? "unknown",
+                    installChannel: AlanInstallChannel.current().installChannelID
+                )
+                let summary = AlanPerformanceDiagnosticsController.shared.summarySnapshot()
+                return response(
+                    requestID: command.requestID,
+                    applied: true,
+                    diagnosticsEnabled: AlanPerformanceDiagnosticsController.shared.isEnabled,
+                    diagnosticsRetainedEventCount: AlanPerformanceDiagnosticsController.shared
+                        .eventsSnapshot().count,
+                    diagnosticsStutterMarkerCount: summary.stutterMarkerCount,
+                    diagnosticsBundlePath: bundleURL.path
+                )
+            } catch {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    errorCode: "diagnostics_export_failed",
+                    errorMessage: error.localizedDescription
+                )
+            }
+
+        case .performanceDiagnosticsRecordChildPressure:
+            guard AlanPerformanceDiagnosticsController.shared.isEnabled else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    diagnosticsEnabled: false,
+                    errorCode: "diagnostics_disabled",
+                    errorMessage: "Performance diagnostics are disabled."
+                )
+            }
+            guard let cpuPercent = command.childCPUPercent else {
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    diagnosticsEnabled: true,
+                    errorCode: "diagnostics_child_cpu_required",
+                    errorMessage: "child_cpu_percent is required."
+                )
+            }
+
+            let role = command.childProcessRole?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            switch role {
+            case nil, "", "terminal_child", "terminalChild":
+                AlanPerformanceDiagnosticsController.shared.recordKnownTerminalChildProcesses(
+                    [
+                        AlanPerformanceChildProcessObservation(
+                            processID: 0,
+                            cpuPercent: cpuPercent,
+                            memoryBytes: command.childMemoryBytes,
+                            threadCount: command.childThreadCount
+                        )
+                    ]
+                )
+            case "unknown_child", "unknownChild":
+                AlanPerformanceDiagnosticsController.shared.recordUnknownChildPressure(
+                    cpuPercent: cpuPercent,
+                    memoryBytes: command.childMemoryBytes,
+                    threadCount: command.childThreadCount
+                )
+            default:
+                return response(
+                    requestID: command.requestID,
+                    applied: false,
+                    diagnosticsEnabled: true,
+                    errorCode: "diagnostics_child_role_unknown",
+                    errorMessage: "child_process_role must be terminal_child or unknown_child."
+                )
+            }
+
+            let summary = AlanPerformanceDiagnosticsController.shared.summarySnapshot()
+            return response(
+                requestID: command.requestID,
+                applied: true,
+                diagnosticsEnabled: true,
+                diagnosticsRetainedEventCount: AlanPerformanceDiagnosticsController.shared
+                    .eventsSnapshot().count,
+                diagnosticsStutterMarkerCount: summary.stutterMarkerCount
+            )
         }
     }
 

--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -141,6 +141,31 @@ final class AlanGhosttyLiveHost: NSObject {
         return handled
     }
 
+    func sendControlKey(_ key: TerminalRuntimeControlKey) -> Bool {
+        guard surface != nil else { return false }
+        let keycode: UInt32
+        switch key {
+        case .returnKey:
+            keycode = KeyCode.returnKey
+        }
+
+        var keyDown = ghostty_input_key_s()
+        keyDown.action = GHOSTTY_ACTION_PRESS
+        keyDown.keycode = keycode
+        keyDown.mods = GHOSTTY_MODS_NONE
+        keyDown.consumed_mods = GHOSTTY_MODS_NONE
+        keyDown.text = nil
+        keyDown.composing = false
+        keyDown.unshifted_codepoint = 0
+
+        var keyUp = keyDown
+        keyUp.action = GHOSTTY_ACTION_RELEASE
+
+        let handled = sendKey(keyDown)
+        _ = sendKey(keyUp)
+        return handled
+    }
+
     func keyIsBinding(_ keyEvent: ghostty_input_key_s, flags: UnsafeMutablePointer<ghostty_binding_flags_e>?) -> Bool {
         guard let surface else { return false }
         return ghostty_surface_key_is_binding(surface, keyEvent, flags)

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift
@@ -8,6 +8,7 @@ enum ShellAutomationCommand: Equatable {
     case closePane(paneID: String)
     case closeTab(tabID: String)
     case sendText(ShellAutomationSendTextRequest)
+    case sendKey(ShellAutomationSendKeyRequest)
     case readPaneSummary(paneID: String)
     case activateAttentionItem(paneID: String)
 }
@@ -59,6 +60,22 @@ struct ShellAutomationSendTextRequest: Equatable {
         self.paneID = paneID
         self.terminalContentID = terminalContentID
         self.text = text
+    }
+}
+
+struct ShellAutomationSendKeyRequest: Equatable {
+    let paneID: String
+    let terminalContentID: String?
+    let key: TerminalRuntimeControlKey
+
+    init(
+        paneID: String,
+        terminalContentID: String? = nil,
+        key: TerminalRuntimeControlKey
+    ) {
+        self.paneID = paneID
+        self.terminalContentID = terminalContentID
+        self.key = key
     }
 }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellAutomationIntents.swift
@@ -81,6 +81,8 @@ struct ShellAutomationIntentOutcome: Equatable, Sendable {
             return "Closed tab."
         case .sendText:
             return deliveryDialog(prefix: "Text delivery accepted", result: nil)
+        case .sendKey:
+            return deliveryDialog(prefix: "Key delivery accepted", result: nil)
         case .readPaneSummary:
             return "Pane summary\(safeSummary)"
         case .activateAttentionItem:

--- a/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellControlPlaneDTOs.swift
@@ -27,12 +27,17 @@ enum AlanShellControlCommandKind: String, Codable {
     case paneZoom = "pane.zoom"
     case paneUnzoom = "pane.unzoom"
     case terminalSendText = "terminal.send_text"
+    case terminalSendKey = "terminal.send_key"
     case terminalRenderMetrics = "terminal.render_metrics"
     case agentActivity = "agent.activity"
     case attentionInbox = "attention.inbox"
     case attentionSet = "attention.set"
     case routingCandidates = "routing.candidates"
     case eventsRead = "events.read"
+    case performanceDiagnosticsSetEnabled = "performance_diagnostics.set_enabled"
+    case performanceDiagnosticsExportRecent = "performance_diagnostics.export_recent"
+    case performanceDiagnosticsRecordChildPressure =
+        "performance_diagnostics.record_child_pressure"
     case quickTerminalToggle = "quick_terminal.toggle"
     case quickTerminalShow = "quick_terminal.show"
     case quickTerminalHide = "quick_terminal.hide"
@@ -60,6 +65,7 @@ struct AlanShellControlCommand: Codable {
     let title: String?
     let cwd: String?
     let text: String?
+    let key: String?
     let attention: ShellAttentionState?
     let agentKind: String?
     let agentStatus: String?
@@ -71,6 +77,12 @@ struct AlanShellControlCommand: Codable {
     let updatedAt: String?
     let afterEventID: String?
     let limit: Int?
+    let enabled: Bool?
+    let exportDirectory: String?
+    let childProcessRole: String?
+    let childCPUPercent: Double?
+    let childMemoryBytes: UInt64?
+    let childThreadCount: Int?
 
     private enum CodingKeys: String, CodingKey {
         case requestID = "request_id"
@@ -91,6 +103,7 @@ struct AlanShellControlCommand: Codable {
         case title
         case cwd
         case text
+        case key
         case attention
         case agentKind = "agent_kind"
         case agentStatus = "agent_status"
@@ -102,6 +115,12 @@ struct AlanShellControlCommand: Codable {
         case updatedAt = "updated_at"
         case afterEventID = "after_event_id"
         case limit
+        case enabled
+        case exportDirectory = "export_directory"
+        case childProcessRole = "child_process_role"
+        case childCPUPercent = "child_cpu_percent"
+        case childMemoryBytes = "child_memory_bytes"
+        case childThreadCount = "child_thread_count"
     }
 }
 
@@ -235,6 +254,10 @@ struct AlanShellControlResponse: Codable {
     let spatialDirection: ShellSpatialFocusDirection?
     let placement: ShellPaneSplitDirection?
     let mountedContentInstanceID: String?
+    let diagnosticsEnabled: Bool?
+    let diagnosticsRetainedEventCount: Int?
+    let diagnosticsStutterMarkerCount: Int?
+    let diagnosticsBundlePath: String?
     let errorCode: String?
     let errorMessage: String?
 
@@ -286,6 +309,10 @@ struct AlanShellControlResponse: Codable {
         spatialDirection: ShellSpatialFocusDirection? = nil,
         placement: ShellPaneSplitDirection? = nil,
         mountedContentInstanceID: String? = nil,
+        diagnosticsEnabled: Bool? = nil,
+        diagnosticsRetainedEventCount: Int? = nil,
+        diagnosticsStutterMarkerCount: Int? = nil,
+        diagnosticsBundlePath: String? = nil,
         errorCode: String? = nil,
         errorMessage: String? = nil
     ) {
@@ -336,6 +363,10 @@ struct AlanShellControlResponse: Codable {
         self.spatialDirection = spatialDirection
         self.placement = placement
         self.mountedContentInstanceID = mountedContentInstanceID
+        self.diagnosticsEnabled = diagnosticsEnabled
+        self.diagnosticsRetainedEventCount = diagnosticsRetainedEventCount
+        self.diagnosticsStutterMarkerCount = diagnosticsStutterMarkerCount
+        self.diagnosticsBundlePath = diagnosticsBundlePath
         self.errorCode = errorCode
         self.errorMessage = errorMessage
     }
@@ -388,6 +419,10 @@ struct AlanShellControlResponse: Codable {
         case spatialDirection = "spatial_direction"
         case placement
         case mountedContentInstanceID = "mounted_content_instance_id"
+        case diagnosticsEnabled = "diagnostics_enabled"
+        case diagnosticsRetainedEventCount = "diagnostics_retained_event_count"
+        case diagnosticsStutterMarkerCount = "diagnostics_stutter_marker_count"
+        case diagnosticsBundlePath = "diagnostics_bundle_path"
         case errorCode = "error_code"
         case errorMessage = "error_message"
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -100,7 +100,8 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
         remote: ShellSettingsRemoteSnapshot,
         local: ShellSettingsLocalSummary,
         terminalProfiles: TerminalProfileSettingsSummary = .current(),
-        managedTerminalAccounts: ManagedTerminalAccountSettingsSummary = .empty
+        managedTerminalAccounts: ManagedTerminalAccountSettingsSummary = .empty,
+        diagnostics: ShellSettingsDiagnosticsSummary = .disabled
     ) -> ShellSettingsSurfaceSnapshot {
         ShellSettingsSurfaceSnapshot(
             sections: [
@@ -116,7 +117,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 ShellSettingsSectionModel(id: .accounts, rows: accountRows(remote.accounts)),
                 ShellSettingsSectionModel(id: .sessions, rows: sessionRows()),
                 ShellSettingsSectionModel(id: .capabilities, rows: capabilityRows(remote.capabilities)),
-                ShellSettingsSectionModel(id: .local, rows: localRows(local)),
+                ShellSettingsSectionModel(id: .local, rows: localRows(local, diagnostics: diagnostics)),
             ]
         )
     }
@@ -455,7 +456,10 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
         ]
     }
 
-    private static func localRows(_ local: ShellSettingsLocalSummary) -> [ShellSettingsRowModel] {
+    private static func localRows(
+        _ local: ShellSettingsLocalSummary,
+        diagnostics: ShellSettingsDiagnosticsSummary
+    ) -> [ShellSettingsRowModel] {
         [
             ShellSettingsRowModel(
                 id: "appIdentity",
@@ -519,6 +523,22 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 title: "Shell control",
                 detail: "Local control namespace.",
                 value: local.shellControlNamespace
+            ),
+            ShellSettingsRowModel(
+                id: "performanceDiagnostics",
+                systemName: "speedometer",
+                title: "Performance Diagnostics",
+                detail: "Local performance trace. Terminal content is not recorded.",
+                value: diagnostics.isEnabled ? "Enabled" : "Disabled",
+                mutability: .editable
+            ),
+            ShellSettingsRowModel(
+                id: "performanceDiagnosticsExport",
+                systemName: "square.and.arrow.up",
+                title: "Export Recent Diagnostics",
+                detail: diagnostics.exportDetail,
+                value: "Export",
+                mutability: .actionOnly
             ),
         ]
     }
@@ -809,6 +829,31 @@ struct ShellSettingsLocalSummary: Equatable {
             return trimmed
         }
         return "Use \(decision.menuTitle) for this install."
+    }
+}
+
+struct ShellSettingsDiagnosticsSummary: Equatable {
+    let isEnabled: Bool
+    let retainedEventCount: Int
+    let stutterMarkerCount: Int
+    let lastExportURL: URL?
+
+    static let disabled = ShellSettingsDiagnosticsSummary(
+        isEnabled: false,
+        retainedEventCount: 0,
+        stutterMarkerCount: 0,
+        lastExportURL: nil
+    )
+
+    var exportDetail: String {
+        if retainedEventCount == 0 {
+            return isEnabled
+                ? "Exports the retained local trace after activity is captured."
+                : "Enable diagnostics to retain recent local performance events."
+        }
+
+        let markerLabel = stutterMarkerCount == 1 ? "marker" : "markers"
+        return "\(retainedEventCount) retained events, \(stutterMarkerCount) stutter \(markerLabel)."
     }
 }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum TerminalRuntimeControlKey: String, Codable, Equatable {
+    case returnKey = "return"
+}
+
 enum ShellAttentionState: String, Codable, CaseIterable {
     case idle
     case active

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -850,7 +850,9 @@ enum AlanShellLocalCommandExecutor {
                 mutate: { try $0.promotingQuickTerminal(to: targetSpaceID) }
             )
 
-        case .eventsRead:
+        case .terminalSendKey, .performanceDiagnosticsSetEnabled,
+            .performanceDiagnosticsExportRecent, .performanceDiagnosticsRecordChildPressure,
+            .eventsRead:
             return nil
         }
     }

--- a/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift
@@ -1,0 +1,956 @@
+import Foundation
+import Darwin
+
+#if os(macOS)
+enum AlanPerformanceDiagnosticsSchema {
+    static let currentVersion = 1
+}
+
+struct AlanPerformanceDiagnosticsConfiguration: Equatable {
+    var maxEvents: Int
+    var maxProcessSamples: Int
+    var slowEventThresholdMs: Double
+    var samplingIntervalMs: Int
+
+    init(
+        maxEvents: Int = 5_000,
+        maxProcessSamples: Int = 600,
+        slowEventThresholdMs: Double = 100,
+        samplingIntervalMs: Int = 1_000
+    ) {
+        self.maxEvents = max(1, maxEvents)
+        self.maxProcessSamples = max(1, maxProcessSamples)
+        self.slowEventThresholdMs = slowEventThresholdMs
+        self.samplingIntervalMs = max(250, samplingIntervalMs)
+    }
+}
+
+enum AlanPerformanceDiagnosticEventKind: String, Codable, CaseIterable, Equatable, Hashable {
+    case ghosttyWakeup
+    case ghosttyAppTick
+    case ghosttySurfaceRefresh
+    case terminalSurfaceAttach
+    case terminalCatchUpRefresh
+    case runtimeSnapshotPublish
+    case terminalMetadataCallback
+    case terminalScrollbackUpdate
+    case terminalRendererUpdate
+    case runtimePriorityChange
+    case runtimeVisibilityChange
+    case shellRuntimeProjection
+    case shellPaneStatePublication
+    case shellSelectionChange
+    case shellFocusChange
+    case shellPrioritySynchronization
+    case automaticStutterMarker
+}
+
+struct AlanPerformanceDiagnosticCounts: Codable, Equatable {
+    var bytes: Int?
+    var lines: Int?
+    var events: Int?
+
+    init(bytes: Int? = nil, lines: Int? = nil, events: Int? = nil) {
+        self.bytes = bytes
+        self.lines = lines
+        self.events = events
+    }
+}
+
+struct AlanPerformanceDiagnosticEvent: Codable, Equatable {
+    let timestampMs: Int64
+    let kind: AlanPerformanceDiagnosticEventKind
+    let durationMs: Double
+    let paneID: String?
+    let contentID: String?
+    let priority: String?
+    let visibility: String?
+    let thread: String?
+    let counts: AlanPerformanceDiagnosticCounts?
+
+    init(
+        timestampMs: Int64 = AlanPerformanceDiagnosticEvent.currentTimestampMs(),
+        kind: AlanPerformanceDiagnosticEventKind,
+        durationMs: Double = 0,
+        paneID: String? = nil,
+        contentID: String? = nil,
+        priority: String? = nil,
+        visibility: String? = nil,
+        thread: String? = nil,
+        counts: AlanPerformanceDiagnosticCounts? = nil
+    ) {
+        self.timestampMs = timestampMs
+        self.kind = kind
+        self.durationMs = durationMs
+        self.paneID = paneID
+        self.contentID = contentID
+        self.priority = priority
+        self.visibility = visibility
+        self.thread = thread
+        self.counts = counts
+    }
+
+    private static func currentTimestampMs() -> Int64 {
+        Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+    }
+}
+
+enum AlanPerformanceProcessRole: String, Codable, Equatable {
+    case alanApp
+    case terminalChild
+    case unknownChild
+}
+
+struct AlanPerformanceProcessSample: Codable, Equatable {
+    let timestampMs: Int64
+    let processID: Int32
+    let parentProcessID: Int32?
+    let role: AlanPerformanceProcessRole
+    let cpuPercent: Double
+    let memoryBytes: UInt64?
+    let threadCount: Int?
+
+    init(
+        timestampMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded()),
+        processID: Int32,
+        parentProcessID: Int32? = nil,
+        role: AlanPerformanceProcessRole,
+        cpuPercent: Double,
+        memoryBytes: UInt64? = nil,
+        threadCount: Int? = nil
+    ) {
+        self.timestampMs = timestampMs
+        self.processID = processID
+        self.parentProcessID = parentProcessID
+        self.role = role
+        self.cpuPercent = cpuPercent
+        self.memoryBytes = memoryBytes
+        self.threadCount = threadCount
+    }
+}
+
+struct AlanPerformanceChildProcessObservation: Equatable {
+    let processID: Int32
+    let parentProcessID: Int32?
+    let cpuPercent: Double
+    let memoryBytes: UInt64?
+    let threadCount: Int?
+
+    init(
+        processID: Int32,
+        parentProcessID: Int32? = nil,
+        cpuPercent: Double,
+        memoryBytes: UInt64? = nil,
+        threadCount: Int? = nil
+    ) {
+        self.processID = processID
+        self.parentProcessID = parentProcessID
+        self.cpuPercent = max(0, cpuPercent)
+        self.memoryBytes = memoryBytes
+        self.threadCount = threadCount
+    }
+}
+
+struct AlanPerformanceProcessIdentity: Equatable {
+    let processID: Int32
+    let parentProcessID: Int32
+}
+
+struct AlanPerformanceProcessTaskMetrics: Equatable {
+    let cpuTimeNanos: UInt64
+    let memoryBytes: UInt64?
+    let threadCount: Int?
+}
+
+final class AlanPerformanceDescendantProcessSampler {
+    typealias ProcessProvider = () -> [AlanPerformanceProcessIdentity]
+    typealias MetricsProvider = (Int32) -> AlanPerformanceProcessTaskMetrics?
+
+    private struct CPUBaseline {
+        let cpuTimeNanos: UInt64
+        let uptimeNanos: UInt64
+    }
+
+    private let processProvider: ProcessProvider
+    private let metricsProvider: MetricsProvider
+    private var cpuBaselinesByProcessID: [Int32: CPUBaseline] = [:]
+
+    init(
+        processProvider: @escaping ProcessProvider = AlanPerformanceSystemProcessProvider
+            .allProcessIdentities,
+        metricsProvider: @escaping MetricsProvider = AlanPerformanceSystemProcessProvider
+            .taskMetrics
+    ) {
+        self.processProvider = processProvider
+        self.metricsProvider = metricsProvider
+    }
+
+    func sampleDescendants(
+        of rootProcessID: Int32 = ProcessInfo.processInfo.processIdentifier,
+        timestampMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded()),
+        uptimeNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> AlanPerformanceProcessSample? {
+        let descendants = Self.descendants(
+            of: rootProcessID,
+            in: processProvider()
+        )
+        guard !descendants.isEmpty else {
+            cpuBaselinesByProcessID.removeAll()
+            return nil
+        }
+
+        var observations: [AlanPerformanceChildProcessObservation] = []
+        var liveProcessIDs = Set<Int32>()
+        for process in descendants {
+            liveProcessIDs.insert(process.processID)
+            guard let metrics = metricsProvider(process.processID) else { continue }
+            observations.append(
+                AlanPerformanceChildProcessObservation(
+                    processID: process.processID,
+                    parentProcessID: process.parentProcessID,
+                    cpuPercent: cpuPercent(
+                        for: process.processID,
+                        metrics: metrics,
+                        uptimeNanos: uptimeNanos
+                    ),
+                    memoryBytes: metrics.memoryBytes,
+                    threadCount: metrics.threadCount
+                )
+            )
+        }
+
+        cpuBaselinesByProcessID = cpuBaselinesByProcessID.filter { liveProcessIDs.contains($0.key) }
+        guard !observations.isEmpty else { return nil }
+        let memoryValues = observations.compactMap(\.memoryBytes)
+        let threadValues = observations.compactMap(\.threadCount)
+        return AlanPerformanceProcessSampler.unknownChildPressureSample(
+            cpuPercent: observations.reduce(0) { $0 + $1.cpuPercent },
+            memoryBytes: memoryValues.isEmpty ? nil : memoryValues.reduce(0, +),
+            threadCount: threadValues.isEmpty ? nil : threadValues.reduce(0, +),
+            timestampMs: timestampMs
+        )
+    }
+
+    func reset() {
+        cpuBaselinesByProcessID.removeAll()
+    }
+
+    private func cpuPercent(
+        for processID: Int32,
+        metrics: AlanPerformanceProcessTaskMetrics,
+        uptimeNanos: UInt64
+    ) -> Double {
+        defer {
+            cpuBaselinesByProcessID[processID] = CPUBaseline(
+                cpuTimeNanos: metrics.cpuTimeNanos,
+                uptimeNanos: uptimeNanos
+            )
+        }
+
+        guard let previous = cpuBaselinesByProcessID[processID],
+              uptimeNanos > previous.uptimeNanos,
+              metrics.cpuTimeNanos >= previous.cpuTimeNanos
+        else {
+            return 0
+        }
+
+        let cpuDelta = metrics.cpuTimeNanos - previous.cpuTimeNanos
+        let uptimeDelta = uptimeNanos - previous.uptimeNanos
+        return Double(cpuDelta) / Double(uptimeDelta) * 100
+    }
+
+    private static func descendants(
+        of rootProcessID: Int32,
+        in processes: [AlanPerformanceProcessIdentity]
+    ) -> [AlanPerformanceProcessIdentity] {
+        let childrenByParent = Dictionary(grouping: processes, by: \.parentProcessID)
+        var descendants: [AlanPerformanceProcessIdentity] = []
+        var pending = childrenByParent[rootProcessID] ?? []
+        while let process = pending.popLast() {
+            descendants.append(process)
+            pending.append(contentsOf: childrenByParent[process.processID] ?? [])
+        }
+        return descendants
+    }
+}
+
+enum AlanPerformanceProcessSampler {
+    private static let aggregateProcessID: Int32 = 0
+
+    static func currentAlanProcessSample(
+        timestampMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+    ) -> AlanPerformanceProcessSample {
+        let metrics = currentTaskMetrics()
+        return AlanPerformanceProcessSample(
+            timestampMs: timestampMs,
+            processID: ProcessInfo.processInfo.processIdentifier,
+            parentProcessID: getppid(),
+            role: .alanApp,
+            cpuPercent: metrics.cpuPercent,
+            memoryBytes: metrics.memoryBytes,
+            threadCount: metrics.threadCount
+        )
+    }
+
+    static func aggregateKnownTerminalChildSample(
+        _ observations: [AlanPerformanceChildProcessObservation],
+        timestampMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+    ) -> AlanPerformanceProcessSample? {
+        guard !observations.isEmpty else { return nil }
+        let memoryValues = observations.compactMap(\.memoryBytes)
+        let threadValues = observations.compactMap(\.threadCount)
+        return AlanPerformanceProcessSample(
+            timestampMs: timestampMs,
+            processID: aggregateProcessID,
+            parentProcessID: nil,
+            role: .terminalChild,
+            cpuPercent: observations.reduce(0) { $0 + $1.cpuPercent },
+            memoryBytes: memoryValues.isEmpty ? nil : memoryValues.reduce(0, +),
+            threadCount: threadValues.isEmpty ? nil : threadValues.reduce(0, +)
+        )
+    }
+
+    static func unknownChildPressureSample(
+        cpuPercent: Double,
+        memoryBytes: UInt64? = nil,
+        threadCount: Int? = nil,
+        timestampMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+    ) -> AlanPerformanceProcessSample {
+        AlanPerformanceProcessSample(
+            timestampMs: timestampMs,
+            processID: aggregateProcessID,
+            parentProcessID: nil,
+            role: .unknownChild,
+            cpuPercent: max(0, cpuPercent),
+            memoryBytes: memoryBytes,
+            threadCount: threadCount
+        )
+    }
+
+    private static func currentTaskMetrics() -> (
+        cpuPercent: Double,
+        memoryBytes: UInt64?,
+        threadCount: Int?
+    ) {
+        var memoryBytes: UInt64?
+        var taskInfo = mach_task_basic_info()
+        var taskInfoCount = mach_msg_type_number_t(
+            MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<natural_t>.size
+        )
+        let taskResult = withUnsafeMutablePointer(to: &taskInfo) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(taskInfoCount)) {
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(MACH_TASK_BASIC_INFO),
+                    $0,
+                    &taskInfoCount
+                )
+            }
+        }
+        if taskResult == KERN_SUCCESS {
+            memoryBytes = UInt64(taskInfo.resident_size)
+        }
+
+        var threadList: thread_act_array_t?
+        var threadCount = mach_msg_type_number_t(0)
+        let threadResult = task_threads(mach_task_self_, &threadList, &threadCount)
+        guard threadResult == KERN_SUCCESS,
+              let threadList
+        else {
+            return (0, memoryBytes, nil)
+        }
+        defer {
+            let count = Int(threadCount)
+            for index in 0..<count {
+                mach_port_deallocate(mach_task_self_, threadList[index])
+            }
+            let size = vm_size_t(count * MemoryLayout<thread_t>.stride)
+            vm_deallocate(mach_task_self_, vm_address_t(UInt(bitPattern: threadList)), size)
+        }
+
+        var cpuPercent = 0.0
+        for index in 0..<Int(threadCount) {
+            var threadInfo = thread_basic_info()
+            var threadInfoCount = mach_msg_type_number_t(
+                MemoryLayout<thread_basic_info_data_t>.size / MemoryLayout<natural_t>.size
+            )
+            let infoResult = withUnsafeMutablePointer(to: &threadInfo) { pointer in
+                pointer.withMemoryRebound(to: integer_t.self, capacity: Int(threadInfoCount)) {
+                    thread_info(
+                        threadList[index],
+                        thread_flavor_t(THREAD_BASIC_INFO),
+                        $0,
+                        &threadInfoCount
+                    )
+                }
+            }
+            if infoResult == KERN_SUCCESS,
+               (threadInfo.flags & TH_FLAGS_IDLE) == 0
+            {
+                cpuPercent += Double(threadInfo.cpu_usage) / Double(TH_USAGE_SCALE) * 100
+            }
+        }
+
+        return (max(0, cpuPercent), memoryBytes, Int(threadCount))
+    }
+}
+
+enum AlanPerformanceSystemProcessProvider {
+    static func allProcessIdentities() -> [AlanPerformanceProcessIdentity] {
+        let initialBytes = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard initialBytes > 0 else { return [] }
+
+        let capacity = Int(initialBytes) / MemoryLayout<pid_t>.stride + 64
+        var pids = Array(repeating: pid_t(0), count: capacity)
+        let returnedBytes = pids.withUnsafeMutableBufferPointer { buffer in
+            proc_listpids(
+                UInt32(PROC_ALL_PIDS),
+                0,
+                buffer.baseAddress,
+                Int32(buffer.count * MemoryLayout<pid_t>.stride)
+            )
+        }
+        guard returnedBytes > 0 else { return [] }
+
+        let count = min(Int(returnedBytes) / MemoryLayout<pid_t>.stride, pids.count)
+        return pids.prefix(count).compactMap { pid in
+            guard pid > 0 else { return nil }
+            var info = proc_bsdinfo()
+            let result = proc_pidinfo(
+                pid,
+                Int32(PROC_PIDTBSDINFO),
+                0,
+                &info,
+                Int32(MemoryLayout<proc_bsdinfo>.size)
+            )
+            guard result == MemoryLayout<proc_bsdinfo>.size else { return nil }
+            return AlanPerformanceProcessIdentity(
+                processID: Int32(info.pbi_pid),
+                parentProcessID: Int32(info.pbi_ppid)
+            )
+        }
+    }
+
+    static func taskMetrics(for processID: Int32) -> AlanPerformanceProcessTaskMetrics? {
+        var info = proc_taskinfo()
+        let result = proc_pidinfo(
+            pid_t(processID),
+            Int32(PROC_PIDTASKINFO),
+            0,
+            &info,
+            Int32(MemoryLayout<proc_taskinfo>.size)
+        )
+        guard result == MemoryLayout<proc_taskinfo>.size else { return nil }
+        return AlanPerformanceProcessTaskMetrics(
+            cpuTimeNanos: UInt64(info.pti_total_user) + UInt64(info.pti_total_system),
+            memoryBytes: UInt64(info.pti_resident_size),
+            threadCount: Int(info.pti_threadnum)
+        )
+    }
+}
+
+struct AlanPerformanceDiagnosticsSummary: Codable, Equatable {
+    var totalEventsRecorded: Int
+    var stutterMarkerCount: Int
+    var countsByKind: [AlanPerformanceDiagnosticEventKind: Int]
+    var processSamples: [AlanPerformanceProcessSample]
+
+    static let empty = AlanPerformanceDiagnosticsSummary(
+        totalEventsRecorded: 0,
+        stutterMarkerCount: 0,
+        countsByKind: [:],
+        processSamples: []
+    )
+}
+
+struct AlanPerformanceDiagnosticsExportMetadata: Codable, Equatable {
+    let appVersion: String
+    let installChannel: String
+    let schemaVersion: Int
+    let samplingIntervalMs: Int
+    let exportedAtMs: Int64
+
+    init(
+        appVersion: String,
+        installChannel: String,
+        schemaVersion: Int,
+        samplingIntervalMs: Int,
+        exportedAtMs: Int64 = Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+    ) {
+        self.appVersion = appVersion
+        self.installChannel = installChannel
+        self.schemaVersion = schemaVersion
+        self.samplingIntervalMs = samplingIntervalMs
+        self.exportedAtMs = exportedAtMs
+    }
+}
+
+final class AlanPerformanceDiagnosticsRecorder {
+    private let lock = NSLock()
+    private let configuration: AlanPerformanceDiagnosticsConfiguration
+    private var enabled = false
+    private var events: [AlanPerformanceDiagnosticEvent] = []
+    private var summary = AlanPerformanceDiagnosticsSummary.empty
+
+    init(configuration: AlanPerformanceDiagnosticsConfiguration = AlanPerformanceDiagnosticsConfiguration()) {
+        self.configuration = configuration
+    }
+
+    var isEnabled: Bool {
+        lock.lock()
+        let value = enabled
+        lock.unlock()
+        return value
+    }
+
+    func setEnabled(_ isEnabled: Bool) {
+        lock.lock()
+        enabled = isEnabled
+        if !isEnabled {
+            clearLocked()
+        }
+        lock.unlock()
+    }
+
+    func record(_ event: AlanPerformanceDiagnosticEvent) {
+        lock.lock()
+        guard enabled else {
+            lock.unlock()
+            return
+        }
+
+        appendLocked(event)
+        if event.kind != .automaticStutterMarker,
+           event.durationMs >= configuration.slowEventThresholdMs
+        {
+            appendLocked(
+                AlanPerformanceDiagnosticEvent(
+                    timestampMs: event.timestampMs,
+                    kind: .automaticStutterMarker,
+                    durationMs: event.durationMs,
+                    paneID: event.paneID,
+                    contentID: event.contentID,
+                    priority: event.priority,
+                    visibility: event.visibility,
+                    thread: event.thread
+                )
+            )
+        }
+        lock.unlock()
+    }
+
+    func recordProcessSample(_ sample: AlanPerformanceProcessSample) {
+        lock.lock()
+        guard enabled else {
+            lock.unlock()
+            return
+        }
+        summary.processSamples.append(sample)
+        if summary.processSamples.count > configuration.maxProcessSamples {
+            summary.processSamples.removeFirst(
+                summary.processSamples.count - configuration.maxProcessSamples
+            )
+        }
+        lock.unlock()
+    }
+
+    func eventsSnapshot() -> [AlanPerformanceDiagnosticEvent] {
+        lock.lock()
+        let snapshot = events
+        lock.unlock()
+        return snapshot
+    }
+
+    func summarySnapshot() -> AlanPerformanceDiagnosticsSummary {
+        lock.lock()
+        let snapshot = summary
+        lock.unlock()
+        return snapshot
+    }
+
+    func exportRecentDiagnostics(
+        to directory: URL,
+        metadata: AlanPerformanceDiagnosticsExportMetadata
+    ) throws -> URL {
+        lock.lock()
+        let eventSnapshot = events
+        let summarySnapshot = summary
+        lock.unlock()
+
+        let bundle = directory.appendingPathComponent(
+            "alan-performance-diagnostics-\(metadata.exportedAtMs)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+
+        let eventEncoder = JSONEncoder()
+        eventEncoder.outputFormatting = [.sortedKeys]
+
+        let summaryEncoder = JSONEncoder()
+        summaryEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let exportEvents = eventSnapshot.map(AlanPerformanceDiagnosticsExportEvent.init(event:))
+        let eventLines = try exportEvents.map { event in
+            String(data: try eventEncoder.encode(event), encoding: .utf8) ?? "{}"
+        }
+        try eventLines
+            .joined(separator: "\n")
+            .appending(eventLines.isEmpty ? "" : "\n")
+            .write(
+                to: bundle.appendingPathComponent("events.jsonl"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        let exportSummary = AlanPerformanceDiagnosticsExportSummary(
+            metadata: metadata,
+            summary: summarySnapshot,
+            events: eventSnapshot,
+            retainedEventCount: eventSnapshot.count,
+            captureWindow: AlanPerformanceDiagnosticsCaptureWindow(events: eventSnapshot)
+        )
+        try summaryEncoder
+            .encode(exportSummary)
+            .write(to: bundle.appendingPathComponent("summary.json"), options: [.atomic])
+
+        return bundle
+    }
+
+    private func appendLocked(_ event: AlanPerformanceDiagnosticEvent) {
+        events.append(event)
+        if events.count > configuration.maxEvents {
+            events.removeFirst(events.count - configuration.maxEvents)
+        }
+
+        summary.totalEventsRecorded += 1
+        summary.countsByKind[event.kind, default: 0] += 1
+        if event.kind == .automaticStutterMarker {
+            summary.stutterMarkerCount += 1
+        }
+    }
+
+    private func clearLocked() {
+        events.removeAll()
+        summary = .empty
+    }
+}
+
+final class AlanPerformanceDiagnosticsController {
+    static let preferenceKey = "alanPerformanceDiagnosticsEnabled"
+    static let shared = AlanPerformanceDiagnosticsController()
+
+    private let defaults: UserDefaults
+    private let recorder: AlanPerformanceDiagnosticsRecorder
+    private let descendantProcessSampler: AlanPerformanceDescendantProcessSampler
+    private let samplingIntervalMs: Int
+    private let samplingQueue = DispatchQueue(label: "alan.performance-diagnostics.sampler")
+    private var samplingTimer: DispatchSourceTimer?
+
+    init(
+        defaults: UserDefaults = .standard,
+        recorder: AlanPerformanceDiagnosticsRecorder = AlanPerformanceDiagnosticsRecorder(),
+        descendantProcessSampler: AlanPerformanceDescendantProcessSampler =
+            AlanPerformanceDescendantProcessSampler(),
+        samplingIntervalMs: Int = AlanPerformanceDiagnosticsConfiguration().samplingIntervalMs
+    ) {
+        self.defaults = defaults
+        self.recorder = recorder
+        self.descendantProcessSampler = descendantProcessSampler
+        self.samplingIntervalMs = max(250, samplingIntervalMs)
+        recorder.setEnabled(defaults.bool(forKey: Self.preferenceKey))
+        if recorder.isEnabled {
+            startProcessSampling()
+        }
+    }
+
+    var isEnabled: Bool {
+        recorder.isEnabled
+    }
+
+    func setEnabled(_ isEnabled: Bool) {
+        defaults.set(isEnabled, forKey: Self.preferenceKey)
+        recorder.setEnabled(isEnabled)
+        if isEnabled {
+            startProcessSampling()
+        } else {
+            stopProcessSampling()
+        }
+    }
+
+    func record(
+        _ kind: AlanPerformanceDiagnosticEventKind,
+        durationMs: Double = 0,
+        paneID: String? = nil,
+        contentID: String? = nil,
+        priority: String? = nil,
+        visibility: String? = nil,
+        thread: String? = nil,
+        counts: AlanPerformanceDiagnosticCounts? = nil
+    ) {
+        guard recorder.isEnabled else { return }
+        recorder.record(
+            AlanPerformanceDiagnosticEvent(
+                kind: kind,
+                durationMs: durationMs,
+                paneID: paneID,
+                contentID: contentID,
+                priority: priority,
+                visibility: visibility,
+                thread: thread,
+                counts: counts
+            )
+        )
+    }
+
+    func recordProcessSample(_ sample: AlanPerformanceProcessSample) {
+        guard recorder.isEnabled else { return }
+        recorder.recordProcessSample(sample)
+    }
+
+    func recordKnownTerminalChildProcesses(
+        _ observations: [AlanPerformanceChildProcessObservation]
+    ) {
+        guard recorder.isEnabled else { return }
+        guard let sample = AlanPerformanceProcessSampler.aggregateKnownTerminalChildSample(
+            observations
+        ) else {
+            return
+        }
+        recorder.recordProcessSample(sample)
+    }
+
+    func recordUnknownChildPressure(
+        cpuPercent: Double,
+        memoryBytes: UInt64? = nil,
+        threadCount: Int? = nil
+    ) {
+        guard recorder.isEnabled else { return }
+        recorder.recordProcessSample(
+            AlanPerformanceProcessSampler.unknownChildPressureSample(
+                cpuPercent: cpuPercent,
+                memoryBytes: memoryBytes,
+                threadCount: threadCount
+            )
+        )
+    }
+
+    func summarySnapshot() -> AlanPerformanceDiagnosticsSummary {
+        recorder.summarySnapshot()
+    }
+
+    func eventsSnapshot() -> [AlanPerformanceDiagnosticEvent] {
+        recorder.eventsSnapshot()
+    }
+
+    func exportRecentDiagnostics(
+        to directory: URL,
+        appVersion: String,
+        installChannel: String
+    ) throws -> URL {
+        try recorder.exportRecentDiagnostics(
+            to: directory,
+            metadata: AlanPerformanceDiagnosticsExportMetadata(
+                appVersion: appVersion,
+                installChannel: installChannel,
+                schemaVersion: AlanPerformanceDiagnosticsSchema.currentVersion,
+                samplingIntervalMs: samplingIntervalMs
+            )
+        )
+    }
+
+    private func startProcessSampling() {
+        samplingQueue.async { [weak self] in
+            guard let self else { return }
+            samplingTimer?.cancel()
+            let timer = DispatchSource.makeTimerSource(queue: samplingQueue)
+            timer.schedule(
+                deadline: .now(),
+                repeating: .milliseconds(samplingIntervalMs),
+                leeway: .milliseconds(max(50, samplingIntervalMs / 10))
+            )
+            timer.setEventHandler { [weak self] in
+                guard let self,
+                      recorder.isEnabled
+                else {
+                    return
+                }
+                let timestampMs = Int64((Date().timeIntervalSince1970 * 1_000).rounded())
+                recorder.recordProcessSample(
+                    AlanPerformanceProcessSampler.currentAlanProcessSample(
+                        timestampMs: timestampMs
+                    )
+                )
+                if let childSample = descendantProcessSampler.sampleDescendants(
+                    timestampMs: timestampMs
+                ) {
+                    recorder.recordProcessSample(childSample)
+                }
+            }
+            samplingTimer = timer
+            timer.resume()
+        }
+    }
+
+    private func stopProcessSampling() {
+        samplingQueue.async { [weak self] in
+            guard let self else { return }
+            samplingTimer?.cancel()
+            samplingTimer = nil
+            descendantProcessSampler.reset()
+        }
+    }
+}
+
+private struct AlanPerformanceDiagnosticsExportEvent: Codable {
+    let timestampMs: Int64
+    let kind: AlanPerformanceDiagnosticEventKind
+    let durationMs: Double
+    let paneIDHash: String?
+    let contentIDHash: String?
+    let priority: String?
+    let visibility: String?
+    let thread: String?
+    let counts: AlanPerformanceDiagnosticCounts?
+
+    enum CodingKeys: String, CodingKey {
+        case timestampMs = "ts_ms"
+        case kind
+        case durationMs = "duration_ms"
+        case paneIDHash = "pane_id_hash"
+        case contentIDHash = "content_id_hash"
+        case priority
+        case visibility
+        case thread
+        case counts
+    }
+
+    init(event: AlanPerformanceDiagnosticEvent) {
+        timestampMs = event.timestampMs
+        kind = event.kind
+        durationMs = event.durationMs
+        paneIDHash = event.paneID.map(AlanPerformanceDiagnosticsHasher.hash)
+        contentIDHash = event.contentID.map(AlanPerformanceDiagnosticsHasher.hash)
+        priority = event.priority
+        visibility = event.visibility
+        thread = event.thread
+        counts = event.counts
+    }
+}
+
+private struct AlanPerformanceDiagnosticsCaptureWindow: Codable, Equatable {
+    let firstEventAtMs: Int64?
+    let lastEventAtMs: Int64?
+
+    init(events: [AlanPerformanceDiagnosticEvent]) {
+        firstEventAtMs = events.first?.timestampMs
+        lastEventAtMs = events.last?.timestampMs
+    }
+}
+
+private struct AlanPerformanceDiagnosticsDurationStats: Codable, Equatable {
+    let count: Int
+    let minimumMs: Double
+    let maximumMs: Double
+    let averageMs: Double
+    let p50Ms: Double
+    let p95Ms: Double
+
+    enum CodingKeys: String, CodingKey {
+        case count
+        case minimumMs = "minimum_ms"
+        case maximumMs = "maximum_ms"
+        case averageMs = "average_ms"
+        case p50Ms = "p50_ms"
+        case p95Ms = "p95_ms"
+    }
+
+    init?(durations: [Double]) {
+        guard !durations.isEmpty else { return nil }
+        let sorted = durations.sorted()
+        count = sorted.count
+        minimumMs = sorted[0]
+        maximumMs = sorted[sorted.count - 1]
+        averageMs = sorted.reduce(0, +) / Double(sorted.count)
+        p50Ms = Self.percentile(0.50, in: sorted)
+        p95Ms = Self.percentile(0.95, in: sorted)
+    }
+
+    private static func percentile(_ percentile: Double, in sorted: [Double]) -> Double {
+        guard let first = sorted.first else { return 0 }
+        guard sorted.count > 1 else { return first }
+        let clamped = min(max(percentile, 0), 1)
+        let index = Int((clamped * Double(sorted.count - 1)).rounded(.up))
+        return sorted[min(index, sorted.count - 1)]
+    }
+}
+
+private struct AlanPerformanceDiagnosticsExportSummary: Codable {
+    let metadata: AlanPerformanceDiagnosticsExportMetadata
+    let totalEventsRecorded: Int
+    let retainedEventCount: Int
+    let stutterMarkerCount: Int
+    let countsByKind: [String: Int]
+    let countsByPriority: [String: Int]
+    let countsByVisibility: [String: Int]
+    let durationByKind: [String: AlanPerformanceDiagnosticsDurationStats]
+    let processSamples: [AlanPerformanceProcessSample]
+    let captureWindow: AlanPerformanceDiagnosticsCaptureWindow
+
+    init(
+        metadata: AlanPerformanceDiagnosticsExportMetadata,
+        summary: AlanPerformanceDiagnosticsSummary,
+        events: [AlanPerformanceDiagnosticEvent],
+        retainedEventCount: Int,
+        captureWindow: AlanPerformanceDiagnosticsCaptureWindow
+    ) {
+        self.metadata = metadata
+        totalEventsRecorded = summary.totalEventsRecorded
+        self.retainedEventCount = retainedEventCount
+        stutterMarkerCount = summary.stutterMarkerCount
+        countsByKind = Dictionary(
+            uniqueKeysWithValues: summary.countsByKind.map { ($0.key.rawValue, $0.value) }
+        )
+        countsByPriority = Self.countsByStringValue(
+            events.compactMap(\.priority)
+        )
+        countsByVisibility = Self.countsByStringValue(
+            events.compactMap(\.visibility)
+        )
+        durationByKind = Self.durationStatsByKind(events)
+        processSamples = summary.processSamples
+        self.captureWindow = captureWindow
+    }
+
+    private static func countsByStringValue(_ values: [String]) -> [String: Int] {
+        values.reduce(into: [:]) { counts, value in
+            counts[value, default: 0] += 1
+        }
+    }
+
+    private static func durationStatsByKind(
+        _ events: [AlanPerformanceDiagnosticEvent]
+    ) -> [String: AlanPerformanceDiagnosticsDurationStats] {
+        var durations: [AlanPerformanceDiagnosticEventKind: [Double]] = [:]
+        for event in events {
+            durations[event.kind, default: []].append(event.durationMs)
+        }
+        return durations.reduce(into: [:]) { stats, entry in
+            guard let value = AlanPerformanceDiagnosticsDurationStats(durations: entry.value) else {
+                return
+            }
+            stats[entry.key.rawValue] = value
+        }
+    }
+}
+
+private enum AlanPerformanceDiagnosticsHasher {
+    static func hash(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+#if os(macOS)
+import AppKit
+
+@MainActor
+enum AlanPerformanceDiagnosticsExportPresenter {
+    static func exportRecentDiagnostics(installChannel: String) -> URL? {
+        let panel = NSOpenPanel()
+        panel.title = "Export Recent Diagnostics"
+        panel.prompt = "Export"
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+
+        guard panel.runModal() == .OK,
+              let directory = panel.url
+        else {
+            return nil
+        }
+
+        do {
+            return try AlanPerformanceDiagnosticsController.shared.exportRecentDiagnostics(
+                to: directory,
+                appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+                    as? String ?? "unknown",
+                installChannel: installChannel
+            )
+        } catch {
+            presentExportFailure(error)
+            return nil
+        }
+    }
+
+    private static func presentExportFailure(_ error: Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Diagnostics export failed."
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift
@@ -402,7 +402,9 @@ private extension AlanShellControlCommandKind {
         case .spaceCreate, .tabOpen, .tabPin, .tabReorder, .paneSplit,
             .paneMove, .paneMoveWithinTab, .paneSpatialFocus, .paneResizeSplit,
             .paneEqualizeSplits, .paneZoom, .paneUnzoom, .terminalRenderMetrics,
-            .quickTerminalFocus, .agentActivity:
+            .quickTerminalFocus, .terminalSendKey, .agentActivity,
+            .performanceDiagnosticsSetEnabled,
+            .performanceDiagnosticsExportRecent, .performanceDiagnosticsRecordChildPressure:
             return true
         default:
             return false

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -388,6 +388,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let terminalContentLifecycle = TerminalContentLifecycleAdapter()
     private let clipboardWriter: ShellClipboardWriter
     private let closeConfirmationPresenter: ShellCloseConfirmationPresenting
+    private let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
     lazy var controlPlane = AlanShellControlPlane(
         windowID: windowContext.windowID,
         channel: windowContext.installChannel
@@ -450,6 +451,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
         workspaceManifest: ShellContentWorkspaceManifest? = nil,
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
+        performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
         appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
         self.fileManager = fileManager
@@ -470,6 +472,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self.clipboardWriter = ShellClipboardWriter()
         self.closeConfirmationPresenter =
             closeConfirmationPresenter ?? ShellNSAlertCloseConfirmationPresenter()
+        self.performanceDiagnosticsRecorder = performanceDiagnosticsRecorder
         self.appIsActiveProvider = appIsActiveProvider
         self.shellState = shellState
         self.terminalRuntimeRegistry =
@@ -943,8 +946,20 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func focus(paneID: String, requestTerminalFocus: Bool) {
+        let focusStartedAt = performanceDiagnosticsStartTime()
         guard let result = try? shellState.focusingPane(paneID) else { return }
         applyMutationResult(result)
+        if let focusStartedAt {
+            let focusedPane = pane(paneID: paneID)
+            recordPerformanceDiagnostic(
+                .shellFocusChange,
+                durationMs: performanceDurationMs(since: focusStartedAt),
+                runtime: runtime(for: paneID),
+                fallbackPaneID: paneID,
+                fallbackContentID: focusedPane?.terminalContentID,
+                fallbackPriority: focusedPane.map { terminalRenderPriority(for: $0) }
+            )
+        }
         if requestTerminalFocus && canRequestTerminalFocus(for: paneID) {
             terminalRuntimeRegistry.requestFocus(for: paneID)
         }
@@ -1868,6 +1883,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func updateTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
+        let updateStartedAt = performanceDiagnosticsStartTime()
+        defer {
+            if let updateStartedAt {
+                recordPerformanceDiagnostic(
+                    .runtimeSnapshotPublish,
+                    durationMs: performanceDurationMs(since: updateStartedAt),
+                    runtime: runtime
+                )
+            }
+        }
         let previousRuntime = runtime.paneID.map { self.runtime(for: $0) }
         terminalRuntimeRegistry.updateSnapshot(runtime)
 
@@ -1901,6 +1926,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func projectTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
+        let projectionStartedAt = performanceDiagnosticsStartTime()
+        defer {
+            if let projectionStartedAt {
+                recordPerformanceDiagnostic(
+                    .shellRuntimeProjection,
+                    durationMs: performanceDurationMs(since: projectionStartedAt),
+                    runtime: runtime
+                )
+            }
+        }
         if runtime.paneID == selectedPane?.paneID || runtime.paneID == shellState.focusedPaneID {
             terminalRuntime = runtime
         }
@@ -1929,6 +1964,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 return
             }
 
+            let paneStateStartedAt = performanceDiagnosticsStartTime()
             let didPublishPaneUpdate = updatePaneState(paneID: paneID) { current in
                 let currentBootProfile = AlanShellBootProfile.forPane(
                     current,
@@ -1940,10 +1976,77 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     bootProfile: currentBootProfile
                 ).pane
             }
+            if let paneStateStartedAt {
+                recordPerformanceDiagnostic(
+                    .shellPaneStatePublication,
+                    durationMs: performanceDurationMs(since: paneStateStartedAt),
+                    runtime: runtime
+                )
+            }
             if activeTaskChanged && !didPublishPaneUpdate {
                 syncWorkspaceManifestFromShellState()
             }
         }
+    }
+
+    private func recordPerformanceDiagnostic(
+        _ kind: AlanPerformanceDiagnosticEventKind,
+        durationMs: Double,
+        runtime: TerminalHostRuntimeSnapshot,
+        fallbackPaneID: String? = nil,
+        fallbackContentID: String? = nil,
+        fallbackPriority: TerminalRuntimeRenderPriority? = nil,
+        counts: AlanPerformanceDiagnosticCounts? = nil
+    ) {
+        if let performanceDiagnosticsRecorder {
+            guard performanceDiagnosticsRecorder.isEnabled else { return }
+        } else {
+            guard AlanPerformanceDiagnosticsController.shared.isEnabled else { return }
+        }
+        let paneID = runtime.paneID ?? fallbackPaneID
+        let contentID = runtime.contentID
+            ?? fallbackContentID
+            ?? paneID.map { ShellContentInstance.terminalContentID(forPaneID: $0) }
+        let priority = fallbackPriority ?? runtime.renderPriority
+        let event = AlanPerformanceDiagnosticEvent(
+            kind: kind,
+            durationMs: durationMs,
+            paneID: paneID,
+            contentID: contentID,
+            priority: priority.diagnosticsValue,
+            visibility: priority.diagnosticsVisibility,
+            thread: Thread.isMainThread ? "main" : "background",
+            counts: counts
+        )
+        if let performanceDiagnosticsRecorder {
+            performanceDiagnosticsRecorder.record(event)
+        } else {
+            AlanPerformanceDiagnosticsController.shared.record(
+                kind,
+                durationMs: durationMs,
+                paneID: event.paneID,
+                contentID: event.contentID,
+                priority: event.priority,
+                visibility: event.visibility,
+                thread: event.thread,
+                counts: event.counts
+            )
+        }
+    }
+
+    private func performanceDurationMs(since start: DispatchTime) -> Double {
+        let end = DispatchTime.now()
+        let nanos = end.uptimeNanoseconds >= start.uptimeNanoseconds
+            ? end.uptimeNanoseconds - start.uptimeNanoseconds
+            : 0
+        return Double(nanos) / 1_000_000
+    }
+
+    private func performanceDiagnosticsStartTime() -> DispatchTime? {
+        if let performanceDiagnosticsRecorder {
+            return performanceDiagnosticsRecorder.isEnabled ? DispatchTime.now() : nil
+        }
+        return AlanPerformanceDiagnosticsController.shared.isEnabled ? DispatchTime.now() : nil
     }
 
     private func scheduleVisibleBackgroundRuntimeProjection(_ runtime: TerminalHostRuntimeSnapshot) {
@@ -1969,9 +2072,19 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     func updateTerminalMetadata(_ metadata: TerminalPaneMetadataSnapshot, for paneID: String) {
+        let metadataStartedAt = performanceDiagnosticsStartTime()
         guard let pane = pane(paneID: paneID) else { return }
         let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
+        defer {
+            if let metadataStartedAt {
+                recordPerformanceDiagnostic(
+                    .terminalMetadataCallback,
+                    durationMs: performanceDurationMs(since: metadataStartedAt),
+                    runtime: runtime
+                )
+            }
+        }
         let effectProjection = terminalContentProjection.projectMetadata(
             metadata,
             runtime: runtime,
@@ -2358,6 +2471,20 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func synchronizeSelection() {
+        let selectionStartedAt = performanceDiagnosticsStartTime()
+        defer {
+            if let selectionStartedAt {
+                let selectedPane = selectedPane
+                recordPerformanceDiagnostic(
+                    .shellSelectionChange,
+                    durationMs: performanceDurationMs(since: selectionStartedAt),
+                    runtime: terminalRuntime,
+                    fallbackPaneID: selectedPane?.paneID,
+                    fallbackContentID: selectedPane?.terminalContentID,
+                    fallbackPriority: selectedPane.map { terminalRenderPriority(for: $0) }
+                )
+            }
+        }
         if let focusedPane = focusedPane {
             selectedSpaceID = focusedPane.spaceID
             selectedTabID = focusedPane.tabID
@@ -2373,6 +2500,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func synchronizeTerminalRenderPriorities() {
+        let synchronizationStartedAt = performanceDiagnosticsStartTime()
         let contentState = shellState.contentStateProjection()
         let prioritiesByContentID = shellState.panes.reduce(
             into: [String: TerminalRuntimeRenderPriority]()
@@ -2383,6 +2511,18 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             priorities[contentID] = terminalRenderPriority(for: pane)
         }
         terminalRuntimeRegistry.updateRenderPriorities(prioritiesByContentID)
+        if let synchronizationStartedAt {
+            let selectedPane = selectedPane
+            recordPerformanceDiagnostic(
+                .shellPrioritySynchronization,
+                durationMs: performanceDurationMs(since: synchronizationStartedAt),
+                runtime: terminalRuntime,
+                fallbackPaneID: selectedPane?.paneID,
+                fallbackContentID: selectedPane?.terminalContentID,
+                fallbackPriority: selectedPane.map { terminalRenderPriority(for: $0) },
+                counts: AlanPerformanceDiagnosticCounts(events: prioritiesByContentID.count)
+            )
+        }
     }
 
     private func zoomedPaneID(in tab: ShellTab) -> String? {
@@ -3435,6 +3575,29 @@ extension ShellHostController: ShellAutomationCommandHandling {
                 delivery = terminalRuntimeRegistry.sendText(
                     to: request.paneID,
                     text: request.text
+                )
+            }
+            return shellAutomationResult(
+                code: shellAutomationResultCode(for: delivery),
+                paneID: request.paneID,
+                acceptedBytes: delivery.acceptedBytes,
+                deliveryCode: delivery.code.rawValue,
+                runtimePhase: delivery.runtimePhase,
+                errorCode: delivery.errorCode,
+                errorMessage: delivery.errorMessage
+            )
+
+        case .sendKey(let request):
+            let delivery: TerminalRuntimeDeliveryResult
+            if let terminalContentID = request.terminalContentID {
+                delivery = terminalRuntimeRegistry.sendKey(
+                    toTerminalContentID: terminalContentID,
+                    key: request.key
+                )
+            } else {
+                delivery = terminalRuntimeRegistry.sendKey(
+                    to: request.paneID,
+                    key: request.key
                 )
             }
             return shellAutomationResult(

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -723,6 +723,21 @@ enum TerminalRuntimeRenderPriority: Int, Codable, Equatable, CaseIterable, Compa
     var isForegroundInteractive: Bool {
         self == .foregroundInteractive
     }
+
+    var diagnosticsValue: String {
+        switch self {
+        case .foregroundInteractive:
+            return "foregroundInteractive"
+        case .visibleBackground:
+            return "visibleBackground"
+        case .hiddenBackground:
+            return "hiddenBackground"
+        }
+    }
+
+    var diagnosticsVisibility: String {
+        isVisible ? "visible" : "hidden"
+    }
 }
 
 enum TerminalRenderRefreshReason: String, Equatable {
@@ -785,14 +800,19 @@ final class TerminalRenderCoordinator {
 
     private let lock = NSLock()
     private let automaticallyDrains: Bool
+    private let diagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
     private var pendingWakeupsByHost: [ObjectIdentifier: PendingWakeup] = [:]
     private var drainScheduled = false
     private var nextSequence = 0
 
     private var metrics = TerminalRenderCoordinatorMetrics()
 
-    init(automaticallyDrains: Bool = true) {
+    init(
+        automaticallyDrains: Bool = true,
+        diagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil
+    ) {
         self.automaticallyDrains = automaticallyDrains
+        self.diagnosticsRecorder = diagnosticsRecorder
     }
 
     func requestWakeup(
@@ -841,7 +861,15 @@ final class TerminalRenderCoordinator {
                 metrics.appTicks += 1
                 metrics.recordDrain(priority: priority)
             }
+            let tickStartedAt = performanceDiagnosticsStartTime()
             host.renderCoordinatorDrainAppTick()
+            if let tickStartedAt {
+                recordDiagnostics(
+                    kind: .ghosttyAppTick,
+                    durationMs: latencyMs(from: tickStartedAt, to: DispatchTime.now()),
+                    priority: priority
+                )
+            }
 
             guard pending.requiresSurfaceRefresh else { continue }
             let shouldRefresh = priority.isVisible || pending.reason == .catchUp
@@ -858,7 +886,17 @@ final class TerminalRenderCoordinator {
                     metrics.catchUpRefreshes += 1
                 }
             }
+            let refreshStartedAt = performanceDiagnosticsStartTime()
             host.renderCoordinatorRefreshSurface(reason: pending.reason)
+            if let refreshStartedAt {
+                recordDiagnostics(
+                    kind: pending.reason == .catchUp
+                        ? .terminalCatchUpRefresh
+                        : .ghosttySurfaceRefresh,
+                    durationMs: latencyMs(from: refreshStartedAt, to: DispatchTime.now()),
+                    priority: priority
+                )
+            }
         }
     }
 
@@ -900,6 +938,12 @@ final class TerminalRenderCoordinator {
         }
         lock.unlock()
 
+        recordDiagnostics(
+            kind: .ghosttyWakeup,
+            durationMs: 0,
+            priority: host.terminalRenderPriority
+        )
+
         guard shouldScheduleDrain else { return }
         DispatchQueue.main.async { [weak self] in
             self?.drainPending()
@@ -929,10 +973,50 @@ final class TerminalRenderCoordinator {
         return Double(nanos) / 1_000_000
     }
 
+    private func performanceDiagnosticsStartTime() -> DispatchTime? {
+        if let diagnosticsRecorder {
+            return diagnosticsRecorder.isEnabled ? DispatchTime.now() : nil
+        }
+        return AlanPerformanceDiagnosticsController.shared.isEnabled ? DispatchTime.now() : nil
+    }
+
     private func updateMetrics(_ update: (inout TerminalRenderCoordinatorMetrics) -> Void) {
         lock.lock()
         update(&metrics)
         lock.unlock()
+    }
+
+    private func recordDiagnostics(
+        kind: AlanPerformanceDiagnosticEventKind,
+        durationMs: Double,
+        priority: TerminalRuntimeRenderPriority
+    ) {
+        if let diagnosticsRecorder {
+            guard diagnosticsRecorder.isEnabled else { return }
+        } else {
+            guard AlanPerformanceDiagnosticsController.shared.isEnabled else { return }
+        }
+        let event = AlanPerformanceDiagnosticEvent(
+            kind: kind,
+            durationMs: durationMs,
+            priority: priority.diagnosticsValue,
+            visibility: priority.diagnosticsVisibility,
+            thread: Thread.isMainThread ? "main" : "background"
+        )
+        if let diagnosticsRecorder {
+            diagnosticsRecorder.record(event)
+        } else {
+            AlanPerformanceDiagnosticsController.shared.record(
+                event.kind,
+                durationMs: event.durationMs,
+                paneID: event.paneID,
+                contentID: event.contentID,
+                priority: event.priority,
+                visibility: event.visibility,
+                thread: event.thread,
+                counts: event.counts
+            )
+        }
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1250,13 +1250,20 @@ private struct ShellSettingsContentView: View {
     @AppStorage("alanShellAppearanceMode") private var appearanceMode = ShellAppearanceMode.system
     @AppStorage("alanShellSidebarCollapsed") private var isSidebarCollapsed = false
     @AppStorage("alanShellDimsInactiveSplitPanes") private var dimsInactiveSplitPanes = true
+    @AppStorage(AlanPerformanceDiagnosticsController.preferenceKey)
+    private var performanceDiagnosticsEnabled = false
     @State private var localSummary = ShellSettingsLocalSummary.current()
     @State private var remoteSnapshot = ShellSettingsRemoteSnapshot.unavailable(
         reason: "Daemon unavailable"
     )
+    @State private var lastDiagnosticsExportURL: URL?
 
     private var snapshot: ShellSettingsSurfaceSnapshot {
-        ShellSettingsSurfaceSnapshot.make(remote: remoteSnapshot, local: localSummary)
+        ShellSettingsSurfaceSnapshot.make(
+            remote: remoteSnapshot,
+            local: localSummary,
+            diagnostics: diagnosticsSummary
+        )
     }
 
     var body: some View {
@@ -1270,7 +1277,9 @@ private struct ShellSettingsContentView: View {
                             section: section,
                             appearanceMode: $appearanceMode,
                             sidebarVisible: sidebarVisible,
-                            dimsInactiveSplitPanes: $dimsInactiveSplitPanes
+                            dimsInactiveSplitPanes: $dimsInactiveSplitPanes,
+                            performanceDiagnosticsEnabled: performanceDiagnosticsBinding,
+                            onExportPerformanceDiagnostics: exportPerformanceDiagnostics
                         )
                     }
                 }
@@ -1301,6 +1310,32 @@ private struct ShellSettingsContentView: View {
         Binding(
             get: { !isSidebarCollapsed },
             set: { isSidebarCollapsed = !$0 }
+        )
+    }
+
+    private var performanceDiagnosticsBinding: Binding<Bool> {
+        Binding(
+            get: { performanceDiagnosticsEnabled },
+            set: { nextValue in
+                performanceDiagnosticsEnabled = nextValue
+                AlanPerformanceDiagnosticsController.shared.setEnabled(nextValue)
+            }
+        )
+    }
+
+    private var diagnosticsSummary: ShellSettingsDiagnosticsSummary {
+        let summary = AlanPerformanceDiagnosticsController.shared.summarySnapshot()
+        return ShellSettingsDiagnosticsSummary(
+            isEnabled: performanceDiagnosticsEnabled,
+            retainedEventCount: AlanPerformanceDiagnosticsController.shared.eventsSnapshot().count,
+            stutterMarkerCount: summary.stutterMarkerCount,
+            lastExportURL: lastDiagnosticsExportURL
+        )
+    }
+
+    private func exportPerformanceDiagnostics() {
+        lastDiagnosticsExportURL = AlanPerformanceDiagnosticsExportPresenter.exportRecentDiagnostics(
+            installChannel: localSummary.channelLabel
         )
     }
 
@@ -1386,6 +1421,8 @@ private struct ShellSettingsSectionView: View {
     @Binding var appearanceMode: ShellAppearanceMode
     let sidebarVisible: Binding<Bool>
     @Binding var dimsInactiveSplitPanes: Bool
+    let performanceDiagnosticsEnabled: Binding<Bool>
+    let onExportPerformanceDiagnostics: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
@@ -1449,6 +1486,25 @@ private struct ShellSettingsSectionView: View {
             ) {
                 Toggle("Enabled", isOn: $dimsInactiveSplitPanes)
                     .toggleStyle(.switch)
+            }
+        case "performanceDiagnostics":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                Toggle("Enabled", isOn: performanceDiagnosticsEnabled)
+                    .toggleStyle(.switch)
+            }
+        case "performanceDiagnosticsExport":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.detail
+            ) {
+                Button("Export", action: onExportPerformanceDiagnostics)
+                    .buttonStyle(.bordered)
+                    .disabled(!performanceDiagnosticsEnabled.wrappedValue)
             }
         default:
             ShellSettingsRow(

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -72,13 +72,16 @@ final class TerminalRuntimeRegistry: ObservableObject {
     private var pendingFocusPaneSlotIDs: Set<String> = []
     private let runtimeService: AlanTerminalRuntimeService
     private let mockDeliveryHandler: MockDeliveryHandler?
+    private let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
 
     init(
         runtimeService: AlanTerminalRuntimeService? = nil,
-        mockDeliveryHandler: MockDeliveryHandler? = nil
+        mockDeliveryHandler: MockDeliveryHandler? = nil,
+        performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil
     ) {
         self.runtimeService = runtimeService ?? AlanWindowTerminalRuntimeService()
         self.mockDeliveryHandler = mockDeliveryHandler
+        self.performanceDiagnosticsRecorder = performanceDiagnosticsRecorder
     }
 
     func hostView(
@@ -234,6 +237,53 @@ final class TerminalRuntimeRegistry: ObservableObject {
                 priority,
                 forceCatchUp: previousPriority == .hiddenBackground && priority.isVisible
             )
+            guard priority != previousPriority else { return }
+            recordPerformanceDiagnostic(
+                .runtimePriorityChange,
+                contentID: contentID,
+                priority: priority
+            )
+            if priority.isVisible != previousPriority.isVisible {
+                recordPerformanceDiagnostic(
+                    .runtimeVisibilityChange,
+                    contentID: contentID,
+                    priority: priority
+                )
+            }
+        }
+    }
+
+    private func recordPerformanceDiagnostic(
+        _ kind: AlanPerformanceDiagnosticEventKind,
+        contentID: String,
+        priority: TerminalRuntimeRenderPriority
+    ) {
+        if let performanceDiagnosticsRecorder {
+            guard performanceDiagnosticsRecorder.isEnabled else { return }
+        } else {
+            guard AlanPerformanceDiagnosticsController.shared.isEnabled else { return }
+        }
+        let paneID = paneSlotIDByContentID[contentID]
+        let event = AlanPerformanceDiagnosticEvent(
+            kind: kind,
+            durationMs: 0,
+            paneID: paneID,
+            contentID: contentID,
+            priority: priority.diagnosticsValue,
+            visibility: priority.diagnosticsVisibility,
+            thread: Thread.isMainThread ? "main" : "background"
+        )
+        if let performanceDiagnosticsRecorder {
+            performanceDiagnosticsRecorder.record(event)
+        } else {
+            AlanPerformanceDiagnosticsController.shared.record(
+                kind,
+                paneID: event.paneID,
+                contentID: event.contentID,
+                priority: event.priority,
+                visibility: event.visibility,
+                thread: event.thread
+            )
         }
     }
 
@@ -301,6 +351,17 @@ final class TerminalRuntimeRegistry: ObservableObject {
         }
 
         return runtimeService.sendText(toTerminalContentID: contentID, text: text)
+    }
+
+    func sendKey(to paneID: String, key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
+        sendKey(toTerminalContentID: terminalContentID(mountedAtPaneID: paneID), key: key)
+    }
+
+    func sendKey(
+        toTerminalContentID contentID: String,
+        key: TerminalRuntimeControlKey
+    ) -> TerminalRuntimeDeliveryResult {
+        runtimeService.sendKey(toTerminalContentID: contentID, key: key)
     }
 
     func terminalCommandRuntimeState(for paneID: String) -> ShellTerminalCommandRuntimeState {

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -333,6 +333,7 @@ protocol AlanTerminalSurfaceHandle: AnyObject {
     func captureTranscriptText(in range: AlanTerminalBufferRange) -> String?
     func seedRestoredTranscriptSnapshot(_ snapshot: TerminalTranscriptSnapshot)
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult
+    func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult
     @discardableResult
     func teardown() -> AlanTerminalSurfaceTeardownStatus
 }
@@ -620,6 +621,73 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
 #endif
     }
 
+    func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
+        guard currentSnapshot.teardownStatus != .completed else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_runtime_closed",
+                    errorMessage: "The requested pane runtime has already closed.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        guard !currentSnapshot.metadata.processExited else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_child_exited",
+                    errorMessage: "The terminal process has exited.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        guard currentSnapshot.renderer.phase != .failed else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_renderer_failed",
+                    errorMessage: "The terminal renderer is not available.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        guard bootstrap.ensureReady().isReady else {
+            return recordDelivery(
+                .unavailable(
+                    errorMessage: bootstrap.diagnostics.failureReason ?? bootstrap.diagnostics.summary,
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        guard isSurfaceReady else {
+            return recordDelivery(
+                .unavailable(
+                    errorMessage: "The requested pane is not ready to receive terminal input.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+
+#if canImport(GhosttyKit)
+        guard liveHost.sendControlKey(key) else {
+            return recordDelivery(
+                .rejected(
+                    errorCode: "terminal_key_rejected",
+                    errorMessage: "The terminal did not accept the requested key.",
+                    runtimePhase: currentSnapshot.runtimePhase
+                )
+            )
+        }
+        return recordDelivery(.accepted(byteCount: 0, runtimePhase: currentSnapshot.runtimePhase))
+#else
+        return recordDelivery(
+            .rejected(
+                errorCode: "ghostty_unavailable",
+                errorMessage: "GhosttyKit is not linked into this build.",
+                runtimePhase: currentSnapshot.runtimePhase
+            )
+        )
+#endif
+    }
+
     @discardableResult
     func teardown() -> AlanTerminalSurfaceTeardownStatus {
         guard currentSnapshot.teardownStatus != .completed else { return .completed }
@@ -799,6 +867,10 @@ protocol AlanTerminalRuntimeService: AnyObject {
         forTerminalContentID contentID: String
     )
     func sendText(toTerminalContentID contentID: String, text: String) -> TerminalRuntimeDeliveryResult
+    func sendKey(
+        toTerminalContentID contentID: String,
+        key: TerminalRuntimeControlKey
+    ) -> TerminalRuntimeDeliveryResult
     @discardableResult
     func finalizeTerminalContent(_ contentID: String) -> AlanTerminalSurfaceTeardownStatus
     func finalizeTerminalContents(excluding activeContentIDs: Set<String>)
@@ -830,6 +902,13 @@ extension AlanTerminalRuntimeService {
         sendText(
             toTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
             text: text
+        )
+    }
+
+    func sendKey(to paneID: String, key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
+        sendKey(
+            toTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
+            key: key
         )
     }
 
@@ -1049,6 +1128,18 @@ final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
         return handle.sendControlText(text)
     }
 
+    func sendKey(
+        toTerminalContentID contentID: String,
+        key: TerminalRuntimeControlKey
+    ) -> TerminalRuntimeDeliveryResult {
+        guard let handle = handlesByContentID[contentID] else {
+            return .missingTarget(
+                errorMessage: "The requested terminal content does not have a service-owned runtime."
+            )
+        }
+        return handle.sendControlKey(key)
+    }
+
     @discardableResult
     func finalizeTerminalContent(_ contentID: String) -> AlanTerminalSurfaceTeardownStatus {
         restoredTranscriptSnapshotsByContentID.removeValue(forKey: contentID)
@@ -1110,6 +1201,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private(set) var teardownCount = 0
     private(set) var renderCatchUpRequestCount = 0
     private(set) var deliveredText: [String] = []
+    private(set) var deliveredKeys: [TerminalRuntimeControlKey] = []
     private(set) var searchActions: [String] = []
     private(set) var scrollActions: [String] = []
     var deliveryResult: TerminalRuntimeDeliveryResult?
@@ -1122,6 +1214,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private(set) var seededTranscriptSnapshot: TerminalTranscriptSnapshot?
     private(set) var transcriptRingBufferLines: [String] = []
     private var latestHostRuntime: TerminalHostRuntimeSnapshot?
+    private var diagnosticsChangeHandler: ((TerminalRendererSnapshot) -> Void)?
     private var searchUpdateHandler: ((AlanTerminalSearchEngineUpdate) -> Void)?
     private var scrollbackUpdateHandler: ((AlanTerminalScrollbackMetrics) -> Void)?
     private var closeRequestHandler: ((Bool) -> Void)?
@@ -1179,6 +1272,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     ) {
         updateRenderPriority(renderPriority, forceCatchUp: false)
         attachCount += 1
+        diagnosticsChangeHandler = onDiagnosticsChange
         closeRequestHandler = onCloseRequest
         updateSnapshot(lifecyclePhase: .attached, attachedViewCount: 1)
         onDiagnosticsChange(currentSnapshot.renderer)
@@ -1187,8 +1281,14 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
 
     func detach() {
         detachCount += 1
+        diagnosticsChangeHandler = nil
         closeRequestHandler = nil
         updateSnapshot(attachedViewCount: 0)
+    }
+
+    func emitDiagnosticsSnapshot(_ snapshot: TerminalRendererSnapshot) {
+        updateSnapshot(renderer: snapshot)
+        diagnosticsChangeHandler?(snapshot)
     }
 
     func updateHostRuntimeSnapshot(_ snapshot: TerminalHostRuntimeSnapshot) {
@@ -1243,6 +1343,31 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
         return result
     }
 
+    func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult {
+        guard !currentSnapshot.metadata.processExited else {
+            let result = TerminalRuntimeDeliveryResult.rejected(
+                errorCode: "terminal_child_exited",
+                errorMessage: "The terminal process has exited.",
+                runtimePhase: currentSnapshot.runtimePhase
+            )
+            updateSnapshot(lastDelivery: result)
+            return result
+        }
+        guard isSurfaceReady else {
+            let result = TerminalRuntimeDeliveryResult.unavailable(
+                errorMessage: "The requested pane is not ready to receive terminal input.",
+                runtimePhase: currentSnapshot.runtimePhase
+            )
+            updateSnapshot(lastDelivery: result)
+            return result
+        }
+        deliveredKeys.append(key)
+        let result = deliveryResult
+            ?? .accepted(byteCount: 0, runtimePhase: currentSnapshot.runtimePhase)
+        updateSnapshot(lastDelivery: result)
+        return result
+    }
+
     func markProcessExited(exitCode: Int) {
         let metadata = TerminalPaneMetadataSnapshot(
             title: currentSnapshot.metadata.title,
@@ -1275,6 +1400,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
 
     private func updateSnapshot(
         lifecyclePhase: AlanTerminalSurfaceLifecyclePhase? = nil,
+        renderer: TerminalRendererSnapshot? = nil,
         metadata: TerminalPaneMetadataSnapshot? = nil,
         lastDelivery: TerminalRuntimeDeliveryResult? = nil,
         teardownStatus: AlanTerminalSurfaceTeardownStatus? = nil,
@@ -1284,7 +1410,7 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             contentID: contentID,
             paneID: paneID,
             lifecyclePhase: lifecyclePhase ?? currentSnapshot.lifecyclePhase,
-            renderer: currentSnapshot.renderer,
+            renderer: renderer ?? currentSnapshot.renderer,
             metadata: metadata ?? currentSnapshot.metadata,
             lastDelivery: lastDelivery ?? currentSnapshot.lastDelivery,
             teardownStatus: teardownStatus ?? currentSnapshot.teardownStatus,
@@ -1464,6 +1590,18 @@ final class FakeAlanTerminalRuntimeService: AlanTerminalRuntimeService {
             )
         }
         return handle.sendControlText(text)
+    }
+
+    func sendKey(
+        toTerminalContentID contentID: String,
+        key: TerminalRuntimeControlKey
+    ) -> TerminalRuntimeDeliveryResult {
+        guard let handle = handlesByContentID[contentID] else {
+            return .missingTarget(
+                errorMessage: "The requested terminal content does not have a fake terminal runtime."
+            )
+        }
+        return handle.sendControlKey(key)
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/TerminalSurfaceController.swift
+++ b/clients/apple/alan-macos/TerminalSurfaceController.swift
@@ -1075,6 +1075,7 @@ final class AlanTerminalSurfaceController {
     private weak var scrollbackEngine: AlanTerminalScrollbackEngine?
     private weak var commandBufferEngine: AlanTerminalCommandBufferEngine?
     private weak var selectionEngine: AlanTerminalSelectionEngine?
+    private let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
     private var semanticCommandState = AlanTerminalSemanticCommandState.placeholder
     private var latestRenderer = TerminalRendererSnapshot.placeholder
     private var latestMetadata = TerminalPaneMetadataSnapshot.placeholder
@@ -1082,7 +1083,8 @@ final class AlanTerminalSurfaceController {
     private var secureInput = false
     private var nativeScrollRowHeight: CGFloat = 1
 
-    init() {
+    init(diagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil) {
+        self.performanceDiagnosticsRecorder = diagnosticsRecorder
         nativeScrollViewAdapter.onVisibleRowChange = { [weak self] row in
             self?.scrollToNativeRow(row)
         }
@@ -1158,6 +1160,7 @@ final class AlanTerminalSurfaceController {
         onCloseRequest: @escaping (Bool) -> Void
     ) {
         guard let surfaceHandle else { return }
+        let attachStartedAt = performanceDiagnosticsStartTime()
         surfaceHandle.configure(mountedAtPaneID: surfaceHandle.paneID, bootProfile: bootProfile)
         surfaceHandle.updateRenderPriority(renderPriority, forceCatchUp: false)
         surfaceHandle.attach(
@@ -1167,6 +1170,13 @@ final class AlanTerminalSurfaceController {
             onDiagnosticsChange: { [weak self] snapshot in
                 guard let self else { return }
                 latestRenderer = snapshot
+                if performanceDiagnosticsStartTime() != nil {
+                    recordPerformanceDiagnostic(
+                        .terminalRendererUpdate,
+                        durationMs: 0,
+                        counts: AlanPerformanceDiagnosticCounts(events: snapshot.recentEvents.count)
+                    )
+                }
                 onDiagnosticsChange(snapshot)
             },
             onMetadataChange: { [weak self] metadata in
@@ -1176,6 +1186,13 @@ final class AlanTerminalSurfaceController {
             },
             onCloseRequest: onCloseRequest
         )
+        if let attachStartedAt {
+            recordPerformanceDiagnostic(
+                .terminalSurfaceAttach,
+                durationMs: performanceDurationMs(since: attachStartedAt),
+                priority: renderPriority
+            )
+        }
     }
 
     func detach() {
@@ -1193,7 +1210,15 @@ final class AlanTerminalSurfaceController {
     }
 
     func updateRenderer(_ renderer: TerminalRendererSnapshot) {
+        let updateStartedAt = performanceDiagnosticsStartTime()
         latestRenderer = renderer
+        if let updateStartedAt {
+            recordPerformanceDiagnostic(
+                .terminalRendererUpdate,
+                durationMs: performanceDurationMs(since: updateStartedAt),
+                counts: AlanPerformanceDiagnosticCounts(events: renderer.recentEvents.count)
+            )
+        }
     }
 
     func updateMetadata(_ metadata: TerminalPaneMetadataSnapshot) {
@@ -1482,8 +1507,69 @@ final class AlanTerminalSurfaceController {
     }
 
     private func applyScrollbackMetrics(_ metrics: AlanTerminalScrollbackMetrics) {
+        let updateStartedAt = performanceDiagnosticsStartTime()
         scrollbackAdapter.updateMetrics(metrics)
         notifySurfaceStateChanged()
+        if let updateStartedAt {
+            recordPerformanceDiagnostic(
+                .terminalScrollbackUpdate,
+                durationMs: performanceDurationMs(since: updateStartedAt),
+                counts: AlanPerformanceDiagnosticCounts(lines: metrics.totalRows)
+            )
+        }
+    }
+
+    private func recordPerformanceDiagnostic(
+        _ kind: AlanPerformanceDiagnosticEventKind,
+        durationMs: Double,
+        priority: TerminalRuntimeRenderPriority? = nil,
+        counts: AlanPerformanceDiagnosticCounts? = nil
+    ) {
+        if let performanceDiagnosticsRecorder {
+            guard performanceDiagnosticsRecorder.isEnabled else { return }
+        } else {
+            guard AlanPerformanceDiagnosticsController.shared.isEnabled else { return }
+        }
+        let resolvedPriority = priority ?? surfaceHandle?.renderPriority
+        let event = AlanPerformanceDiagnosticEvent(
+            kind: kind,
+            durationMs: durationMs,
+            paneID: surfaceHandle?.paneID,
+            contentID: surfaceHandle?.contentID,
+            priority: resolvedPriority?.diagnosticsValue,
+            visibility: resolvedPriority?.diagnosticsVisibility,
+            thread: Thread.isMainThread ? "main" : "background",
+            counts: counts
+        )
+        if let performanceDiagnosticsRecorder {
+            performanceDiagnosticsRecorder.record(event)
+        } else {
+            AlanPerformanceDiagnosticsController.shared.record(
+                kind,
+                durationMs: durationMs,
+                paneID: event.paneID,
+                contentID: event.contentID,
+                priority: event.priority,
+                visibility: event.visibility,
+                thread: event.thread,
+                counts: event.counts
+            )
+        }
+    }
+
+    private func performanceDurationMs(since start: DispatchTime) -> Double {
+        let end = DispatchTime.now()
+        let nanos = end.uptimeNanoseconds >= start.uptimeNanoseconds
+            ? end.uptimeNanoseconds - start.uptimeNanoseconds
+            : 0
+        return Double(nanos) / 1_000_000
+    }
+
+    private func performanceDiagnosticsStartTime() -> DispatchTime? {
+        if let performanceDiagnosticsRecorder {
+            return performanceDiagnosticsRecorder.isEnabled ? DispatchTime.now() : nil
+        }
+        return AlanPerformanceDiagnosticsController.shared.isEnabled ? DispatchTime.now() : nil
     }
 
     private func resetPerSurfaceStateForSurfaceChange() {

--- a/clients/apple/scripts/capture-performance-diagnostics-workload.sh
+++ b/clients/apple/scripts/capture-performance-diagnostics-workload.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+RUN_ID="${ALAN_PERF_DIAG_RUN_ID:-$(date +%Y%m%d-%H%M%S)}"
+OUTPUT_DIR="${ALAN_PERF_DIAG_OUTPUT_DIR:-$REPO_ROOT/debug/artifacts/performance-diagnostics-workload/$RUN_ID}"
+SMOKE_OUTPUT_DIR="$OUTPUT_DIR/ui-smoke"
+EXPORT_DIR="$OUTPUT_DIR/export"
+PIDS_DIR="$OUTPUT_DIR/pids"
+REVIEW_PATH="$OUTPUT_DIR/review.md"
+MANIFEST_PATH="$OUTPUT_DIR/manifest.txt"
+CONTROL_NAMESPACE="${ALAN_SHELL_CONTROL_NAMESPACE:-alan-perf-diag-$RUN_ID}"
+LAUNCH_MODE="${ALAN_UI_SMOKE_LAUNCH_MODE:-open}"
+UI_SMOKE_DERIVED_DATA="${ALAN_UI_SMOKE_DERIVED_DATA:-$REPO_ROOT/debug/DerivedData/apple-shell-ui-smoke}"
+UI_SMOKE_SKIP_BUILD="${ALAN_PERF_DIAG_SKIP_BUILD:-0}"
+UI_SMOKE_APP_PATH="${ALAN_UI_SMOKE_APP_PATH:-}"
+UI_SMOKE_APP_EXECUTABLE="${ALAN_UI_SMOKE_APP_EXECUTABLE:-}"
+SYSTEM_TMPDIR="${ALAN_UI_SMOKE_SYSTEM_TMPDIR:-$(getconf DARWIN_USER_TEMP_DIR 2>/dev/null || printf '%s' "${TMPDIR:-/tmp}")}"
+CONTROL_TMPDIR="$SYSTEM_TMPDIR"
+if [[ "$LAUNCH_MODE" == "direct" ]]; then
+    CONTROL_TMPDIR="$SMOKE_OUTPUT_DIR/tmp"
+fi
+if [[ "$UI_SMOKE_SKIP_BUILD" == "1" && -z "$UI_SMOKE_APP_PATH" ]]; then
+    UI_SMOKE_APP_PATH="$UI_SMOKE_DERIVED_DATA/Build/Products/Debug/Alan.app"
+    UI_SMOKE_APP_EXECUTABLE="$UI_SMOKE_APP_PATH/Contents/MacOS/Alan"
+fi
+CONTROL_ROOT="${CONTROL_TMPDIR%/}/$CONTROL_NAMESPACE/window_main"
+COMMANDS_DIR="$CONTROL_ROOT/commands"
+RESULTS_DIR="$CONTROL_ROOT/results"
+STATE_PATH="$CONTROL_ROOT/state.json"
+TIMEOUT_SECONDS="${ALAN_PERF_DIAG_TIMEOUT_SECONDS:-60}"
+SAMPLE_SECONDS="${ALAN_PERF_DIAG_SAMPLE_SECONDS:-8}"
+KEEP_APP="${ALAN_PERF_DIAG_KEEP_APP:-0}"
+APP_PID=""
+CONTROL_INDEX=0
+
+fail() {
+    printf 'capture-performance-diagnostics-workload: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf 'capture-performance-diagnostics-workload: %s\n' "$*"
+}
+
+append_manifest() {
+    printf '%s\n' "$*" >>"$MANIFEST_PATH"
+}
+
+cleanup() {
+    if [[ -n "${APP_PID:-}" && "$KEEP_APP" != "1" ]] && kill -0 "$APP_PID" >/dev/null 2>&1; then
+        kill "$APP_PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+json_get() {
+    local file="$1"
+    local key="$2"
+    plutil -extract "$key" raw -o - "$file" 2>/dev/null || true
+}
+
+json_escape_text() {
+    awk '
+        BEGIN { ORS = "" }
+        {
+            gsub(/\\/, "\\\\")
+            gsub(/"/, "\\\"")
+            if (NR > 1) {
+                printf "\\n"
+            }
+            printf "%s", $0
+        }
+    '
+}
+
+wait_for_path() {
+    local path="$1"
+    local label="$2"
+    local deadline=$((SECONDS + TIMEOUT_SECONDS))
+    while (( SECONDS < deadline )); do
+        if [[ -e "$path" ]]; then
+            return 0
+        fi
+        if [[ -n "${APP_PID:-}" ]] && ! kill -0 "$APP_PID" >/dev/null 2>&1; then
+            fail "Alan exited while waiting for $label"
+        fi
+        sleep 0.2
+    done
+    fail "timed out waiting for $label"
+}
+
+next_request_id() {
+    local label="$1"
+    printf 'perf-diag-%s-%s-%05d' "$label" "$(date +%s%N)" "$RANDOM"
+}
+
+send_control_json() {
+    local request_id="$1"
+    local payload="$2"
+    local command_path="$COMMANDS_DIR/$request_id.json"
+    local result_path="$RESULTS_DIR/$request_id.json"
+
+    wait_for_path "$COMMANDS_DIR" "control commands directory"
+    wait_for_path "$RESULTS_DIR" "control results directory"
+    printf '%s\n' "$payload" >"$command_path.tmp"
+    mv "$command_path.tmp" "$command_path"
+    wait_for_path "$result_path" "control result $request_id"
+    printf '%s\n' "$result_path"
+}
+
+require_control_applied() {
+    local result_path="$1"
+    local label="$2"
+    local applied
+    applied=$(json_get "$result_path" applied)
+    if [[ "$applied" != "true" ]]; then
+        fail "$label failed: $(json_get "$result_path" error_code) $(json_get "$result_path" error_message)"
+    fi
+}
+
+control_state() {
+    local request_id
+    request_id=$(next_request_id state)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"state\"
+}"
+}
+
+control_enable_diagnostics() {
+    local request_id
+    request_id=$(next_request_id diagnostics-enable)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"performance_diagnostics.set_enabled\",
+  \"enabled\": true
+}"
+}
+
+control_disable_diagnostics() {
+    local request_id
+    request_id=$(next_request_id diagnostics-disable)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"performance_diagnostics.set_enabled\",
+  \"enabled\": false
+}"
+}
+
+control_tab_open() {
+    local title="$1"
+    local request_id
+    request_id=$(next_request_id tab-open)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"tab.open\",
+  \"title\": \"$title\"
+}"
+}
+
+control_send_text() {
+    local pane_slot_id="$1"
+    local text="$2"
+    local request_id
+    local text_json
+    request_id=$(next_request_id terminal-send)
+    text_json=$(printf '%s' "$text" | json_escape_text)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"terminal.send_text\",
+  \"pane_slot_id\": \"$pane_slot_id\",
+  \"text\": \"$text_json\"
+}"
+}
+
+control_send_return_key() {
+    local pane_slot_id="$1"
+    local request_id
+    request_id=$(next_request_id terminal-return)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"terminal.send_key\",
+  \"pane_slot_id\": \"$pane_slot_id\",
+  \"key\": \"return\"
+}"
+}
+
+send_terminal_payload_until_applied() {
+    local pane_slot_id="$1"
+    local text="$2"
+    local label="$3"
+    local deadline=$((SECONDS + TIMEOUT_SECONDS))
+    local result_path=""
+    while (( SECONDS < deadline )); do
+        result_path=$(control_send_text "$pane_slot_id" "$text")
+        if [[ "$(json_get "$result_path" applied)" == "true" ]]; then
+            local key_result_path=""
+            while (( SECONDS < deadline )); do
+                key_result_path=$(control_send_return_key "$pane_slot_id")
+                if [[ "$(json_get "$key_result_path" applied)" == "true" ]]; then
+                    printf '%s\n' "$key_result_path"
+                    return 0
+                fi
+                sleep 0.5
+            done
+            fail "terminal.send_key $label failed: $(json_get "$key_result_path" error_code) $(json_get "$key_result_path" error_message)"
+        fi
+        sleep 0.5
+    done
+    [[ -n "$result_path" ]] || fail "terminal.send_text $label did not return a result"
+    fail "terminal.send_text $label failed: $(json_get "$result_path" error_code) $(json_get "$result_path" error_message)"
+}
+
+control_record_child_pressure() {
+    local cpu_percent="$1"
+    local memory_bytes="$2"
+    local request_id
+    request_id=$(next_request_id child-pressure)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"performance_diagnostics.record_child_pressure\",
+  \"child_process_role\": \"terminal_child\",
+  \"child_cpu_percent\": $cpu_percent,
+  \"child_memory_bytes\": $memory_bytes
+}"
+}
+
+control_export() {
+    local request_id
+    request_id=$(next_request_id diagnostics-export)
+    send_control_json "$request_id" "{
+  \"request_id\": \"$request_id\",
+  \"command\": \"performance_diagnostics.export_recent\",
+  \"export_directory\": \"$(printf '%s' "$EXPORT_DIR" | json_escape_text)\"
+}"
+}
+
+workload_payload() {
+    local label="$1"
+    local pid_file="$2"
+    cat <<PAYLOAD
+/bin/sh -lc '(echo "alan-perf-diag $0 start"; if command -v codex >/dev/null 2>&1; then codex --version 2>/dev/null || true; else echo "codex cli unavailable"; fi; i=0; while [ "\$i" -lt 3500 ]; do i=\$((i + 1)); printf "alan-perf-diag-codex-$0 line-%04d abcdefghijklmnopqrstuvwxyz0123456789\\n" "\$i"; if [ \$((i % 125)) -eq 0 ]; then /usr/bin/shasum -a 256 /bin/ls >/dev/null 2>&1 || true; fi; done; sleep 2; echo "alan-perf-diag $0 done") & echo \$! > "\$1"; wait' "$label" "$pid_file"
+PAYLOAD
+}
+
+wait_for_workload_pids() {
+    local expected="$1"
+    local deadline=$((SECONDS + TIMEOUT_SECONDS))
+    while (( SECONDS < deadline )); do
+        local count
+        count=$(find "$PIDS_DIR" -name '*.pid' -type f 2>/dev/null | wc -l | tr -d ' ')
+        if [[ "$count" -ge "$expected" ]]; then
+            return 0
+        fi
+        sleep 0.25
+    done
+    fail "timed out waiting for terminal workload pid files"
+}
+
+sample_child_pressure_once() {
+    local cpu_total="0"
+    local rss_total="0"
+    local found=0
+    local pid_file
+    for pid_file in "$PIDS_DIR"/*.pid; do
+        [[ -f "$pid_file" ]] || continue
+        local pid
+        pid=$(tr -dc '0-9' <"$pid_file")
+        [[ -n "$pid" ]] || continue
+        if ! kill -0 "$pid" >/dev/null 2>&1; then
+            continue
+        fi
+        local sample
+        sample=$(ps -p "$pid" -o pcpu= -o rss= 2>/dev/null | awk 'NF >= 2 { print $1, $2; exit }')
+        [[ -n "$sample" ]] || continue
+        found=1
+        cpu_total=$(awk -v a="$cpu_total" -v b="$(printf '%s' "$sample" | awk '{print $1}')" 'BEGIN { printf "%.2f", a + b }')
+        rss_total=$(awk -v a="$rss_total" -v b="$(printf '%s' "$sample" | awk '{print $2}')" 'BEGIN { printf "%.0f", a + b }')
+    done
+
+    [[ "$found" == "1" ]] || return 1
+    local memory_bytes
+    memory_bytes=$(awk -v rss="$rss_total" 'BEGIN { printf "%.0f", rss * 1024 }')
+    local result_path
+    result_path=$(control_record_child_pressure "$cpu_total" "$memory_bytes")
+    require_control_applied "$result_path" "performance_diagnostics.record_child_pressure"
+    return 0
+}
+
+sample_child_pressure() {
+    local deadline=$((SECONDS + SAMPLE_SECONDS))
+    local recorded=0
+    while (( SECONDS < deadline )); do
+        if sample_child_pressure_once; then
+            recorded=1
+        fi
+        sleep 1
+    done
+    [[ "$recorded" == "1" ]] || fail "no live child process CPU samples were recorded"
+}
+
+require_contains() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+    if ! grep -E "$pattern" "$file" >/dev/null 2>&1; then
+        fail "missing $label in exported diagnostics"
+    fi
+}
+
+count_pattern() {
+    local file="$1"
+    local pattern="$2"
+    local count
+    count=$(grep -E -c "$pattern" "$file" 2>/dev/null || true)
+    printf '%s\n' "${count:-0}"
+}
+
+mkdir -p "$OUTPUT_DIR" "$SMOKE_OUTPUT_DIR" "$EXPORT_DIR" "$PIDS_DIR"
+: >"$MANIFEST_PATH"
+append_manifest "run_id=$RUN_ID"
+append_manifest "control_namespace=$CONTROL_NAMESPACE"
+append_manifest "output_dir=$OUTPUT_DIR"
+
+info "launching controlled Dev-channel Alan app"
+ALAN_SHELL_CONTROL_NAMESPACE="$CONTROL_NAMESPACE" \
+ALAN_UI_SMOKE_DERIVED_DATA="$UI_SMOKE_DERIVED_DATA" \
+ALAN_UI_SMOKE_APP_PATH="$UI_SMOKE_APP_PATH" \
+ALAN_UI_SMOKE_APP_EXECUTABLE="$UI_SMOKE_APP_EXECUTABLE" \
+ALAN_UI_SMOKE_OUTPUT_DIR="$SMOKE_OUTPUT_DIR" \
+ALAN_UI_SMOKE_LAUNCH_MODE="$LAUNCH_MODE" \
+ALAN_UI_SMOKE_SKIP_BUILD="$UI_SMOKE_SKIP_BUILD" \
+ALAN_UI_SMOKE_KEEP_RUNNING=1 \
+ALAN_UI_SMOKE_KEEP_RUNTIME_TMP=1 \
+ALAN_UI_SMOKE_TERMINAL_STEPS=never \
+ALAN_UI_SMOKE_UI_SCRIPTING_STEPS=never \
+ALAN_UI_SMOKE_RESTART_RESTORE_STEPS=never \
+"$SCRIPT_DIR/test-shell-ui-smoke.sh" \
+    --keep-running \
+    --terminal-steps never \
+    --ui-scripting-steps never \
+    --restart-restore-steps never
+
+APP_PID=$(sed -n 's/^pid=//p' "$SMOKE_OUTPUT_DIR/manifest.txt" | tail -1)
+[[ -n "$APP_PID" ]] || fail "UI smoke manifest did not include app pid"
+append_manifest "pid=$APP_PID"
+
+wait_for_path "$STATE_PATH" "shell state"
+
+enable_result=$(control_enable_diagnostics)
+require_control_applied "$enable_result" "performance_diagnostics.set_enabled"
+
+state_result=$(control_state)
+require_control_applied "$state_result" "state"
+target_slots=()
+focused_slot=$(json_get "$state_result" focused_pane_slot_id)
+if [[ -n "$focused_slot" ]]; then
+    target_slots+=("$focused_slot")
+fi
+
+for label in A B C; do
+    tab_result=$(control_tab_open "Codex workload $label")
+    require_control_applied "$tab_result" "tab.open"
+    slot=$(json_get "$tab_result" pane_slot_id)
+    [[ -n "$slot" ]] || slot=$(json_get "$tab_result" pane_id)
+    [[ -n "$slot" ]] || fail "tab.open did not return a terminal target for workload $label"
+    target_slots+=("$slot")
+done
+
+index=0
+for slot in "${target_slots[@]}"; do
+    index=$((index + 1))
+    label="codex-$index"
+    pid_file="$PIDS_DIR/$label.pid"
+    payload=$(workload_payload "$label" "$pid_file")
+    send_result=$(send_terminal_payload_until_applied "$slot" "$payload" "$label")
+    require_control_applied "$send_result" "terminal.send_text $label"
+done
+
+wait_for_workload_pids "${#target_slots[@]}"
+sample_child_pressure
+sleep 2
+
+export_result=$(control_export)
+require_control_applied "$export_result" "performance_diagnostics.export_recent"
+bundle_path=$(json_get "$export_result" diagnostics_bundle_path)
+[[ -n "$bundle_path" ]] || fail "export response did not include diagnostics_bundle_path"
+append_manifest "bundle_path=$bundle_path"
+
+disable_result=$(control_disable_diagnostics)
+require_control_applied "$disable_result" "performance_diagnostics.set_enabled false"
+
+events_path="$bundle_path/events.jsonl"
+summary_path="$bundle_path/summary.json"
+[[ -f "$events_path" ]] || fail "missing events.jsonl in exported bundle"
+[[ -f "$summary_path" ]] || fail "missing summary.json in exported bundle"
+
+require_contains "$events_path" '"kind"[[:space:]]*:[[:space:]]*"shellRuntimeProjection"' "shell projection events"
+require_contains "$events_path" '"kind"[[:space:]]*:[[:space:]]*"runtimeSnapshotPublish"' "runtime publication events"
+require_contains "$events_path" '"kind"[[:space:]]*:[[:space:]]*"ghostty(AppTick|SurfaceRefresh|Wakeup)"' "Ghostty timing events"
+require_contains "$summary_path" '"role"[[:space:]]*:[[:space:]]*"terminalChild"' "terminal child CPU pressure"
+
+if grep -F 'alan-perf-diag' "$events_path" "$summary_path" >/dev/null 2>&1; then
+    fail "exported diagnostics leaked terminal workload text"
+fi
+if grep -F "$REPO_ROOT" "$events_path" "$summary_path" >/dev/null 2>&1; then
+    fail "exported diagnostics leaked repository path"
+fi
+if grep -E 'command(Line)?|workingDirectory|environment|OPENAI_API_KEY|refresh-token' \
+    "$events_path" "$summary_path" >/dev/null 2>&1
+then
+    fail "exported diagnostics contained forbidden command/path/environment/secret fields"
+fi
+
+ghostty_count=$(count_pattern "$events_path" '"kind"[[:space:]]*:[[:space:]]*"ghostty(AppTick|SurfaceRefresh|Wakeup)"')
+runtime_count=$(count_pattern "$events_path" '"kind"[[:space:]]*:[[:space:]]*"runtimeSnapshotPublish"')
+shell_count=$(count_pattern "$events_path" '"kind"[[:space:]]*:[[:space:]]*"shellRuntimeProjection"')
+stutter_count=$(count_pattern "$events_path" '"kind"[[:space:]]*:[[:space:]]*"automaticStutterMarker"')
+child_count=$(count_pattern "$summary_path" '"role"[[:space:]]*:[[:space:]]*"terminalChild"')
+
+{
+    printf '# Real Workload Diagnostics Review\n\n'
+    printf -- '- Run ID: `%s`\n' "$RUN_ID"
+    printf -- '- Bundle: `%s`\n' "$bundle_path"
+    printf -- '- Ghostty timing events: `%s`\n' "$ghostty_count"
+    printf -- '- Runtime publication events: `%s`\n' "$runtime_count"
+    printf -- '- Shell projection events: `%s`\n' "$shell_count"
+    printf -- '- Automatic stutter markers: `%s`\n' "$stutter_count"
+    printf -- '- Terminal child process samples: `%s`\n\n' "$child_count"
+    printf 'Privacy review passed: exported `events.jsonl` and `summary.json` did not contain terminal workload text, repo paths, command-line fields, cwd fields, environment fields, or secret fixture strings.\n'
+} >"$REVIEW_PATH"
+
+append_manifest "review_path=$REVIEW_PATH"
+info "diagnostics bundle: $bundle_path"
+info "review: $REVIEW_PATH"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -2104,6 +2104,11 @@ require_pattern \
     "final class AlanShellDiagnostics" \
     "shell diagnostics routing must live in a dedicated shell service owner"
 
+require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift" \
+    "mach_port_deallocate\\(mach_task_self_, threadList\\[index\\]\\)" \
+    "performance diagnostics task_threads sampling must deallocate each returned thread port"
+
 reject_pattern \
     "clients/apple/alan-macos/ShellControlPlane.swift" \
     "final class AlanShellSocketServer|SO_RCVTIMEO|SO_SNDTIMEO|maxRequestBytes|command_timeout|enum AlanShellPublishedStateMerger|pollCommands\\(|pollBindings\\(|handleCommandFile\\(|appendEvent\\(|readEvents\\(|recordEvents\\(|recordDiagnostic\\(" \

--- a/clients/apple/scripts/test-shell-performance-diagnostics.sh
+++ b/clients/apple/scripts/test-shell-performance-diagnostics.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-performance-diagnostics-tests"
+MODULE_CACHE_DIR="$BUILD_DIR/clang-module-cache"
+TEST_BINARY="$BUILD_DIR/shell-performance-diagnostics-tests"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-performance-diagnostics.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-performance-diagnostics.swift
+++ b/clients/apple/scripts/test-shell-performance-diagnostics.swift
@@ -1,0 +1,475 @@
+import Foundation
+
+#if os(macOS)
+private enum TestFailure: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case .message(let message):
+            return message
+        }
+    }
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    if !condition() {
+        throw TestFailure.message(message)
+    }
+}
+
+@main
+struct ShellPerformanceDiagnosticsTestRunner {
+    static func main() {
+        do {
+            try testDiagnosticsAreDefaultOffAndClearOnDisable()
+            try testControllerPersistsPreferenceAndClearsOnDisable()
+            try testCurrentProcessSamplerProducesNumericAlanSample()
+            try testKnownTerminalChildAggregateSamplingOmitsCommandIdentity()
+            try testDescendantProcessSamplerAggregatesChildPressure()
+            try testBoundedRingBufferAndAutomaticStutterMarker()
+            try testProcessSamplesStayBounded()
+            try testExportBundleOmitsSensitiveFixtureStrings()
+            print("Shell performance diagnostics tests passed.")
+        } catch {
+            fputs("Shell performance diagnostics tests failed: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private func testDiagnosticsAreDefaultOffAndClearOnDisable() throws {
+    let recorder = AlanPerformanceDiagnosticsRecorder(
+        configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 8)
+    )
+
+    recorder.record(
+        AlanPerformanceDiagnosticEvent(
+            kind: .ghosttyWakeup,
+            durationMs: 2,
+            paneID: "pane_1",
+            contentID: "terminal_pane_1",
+            priority: "foregroundInteractive",
+            visibility: "visible",
+            thread: "main"
+        )
+    )
+    try expect(recorder.eventsSnapshot().isEmpty, "disabled diagnostics must not record events")
+
+    recorder.setEnabled(true)
+    recorder.record(
+        AlanPerformanceDiagnosticEvent(
+            kind: .ghosttyWakeup,
+            durationMs: 2,
+            paneID: "pane_1",
+            contentID: "terminal_pane_1",
+            priority: "foregroundInteractive",
+            visibility: "visible",
+            thread: "main"
+        )
+    )
+    try expect(recorder.eventsSnapshot().count == 1, "enabled diagnostics must record events")
+
+    recorder.setEnabled(false)
+    try expect(recorder.eventsSnapshot().isEmpty, "disabling diagnostics must clear unexported events")
+}
+
+private func testControllerPersistsPreferenceAndClearsOnDisable() throws {
+    let suiteName = "alan-performance-diagnostics-\(UUID().uuidString)"
+    guard let defaults = UserDefaults(suiteName: suiteName) else {
+        throw TestFailure.message("could not create isolated user defaults")
+    }
+    defer {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    let recorder = AlanPerformanceDiagnosticsRecorder(
+        configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 4)
+    )
+    let controller = AlanPerformanceDiagnosticsController(defaults: defaults, recorder: recorder)
+
+    try expect(!controller.isEnabled, "diagnostics controller must default to disabled")
+    try expect(!defaults.bool(forKey: AlanPerformanceDiagnosticsController.preferenceKey),
+               "diagnostics preference must default to false")
+
+    controller.setEnabled(true)
+    try expect(controller.isEnabled, "controller must enable diagnostics")
+    try expect(defaults.bool(forKey: AlanPerformanceDiagnosticsController.preferenceKey),
+               "controller must persist enabled preference")
+
+    controller.record(.shellRuntimeProjection, durationMs: 4)
+    try expect(recorder.eventsSnapshot().count == 1, "controller must route events while enabled")
+
+    controller.setEnabled(false)
+    try expect(!controller.isEnabled, "controller must disable diagnostics")
+    try expect(!defaults.bool(forKey: AlanPerformanceDiagnosticsController.preferenceKey),
+               "controller must persist disabled preference")
+    try expect(recorder.eventsSnapshot().isEmpty, "controller disable must clear unexported buffers")
+}
+
+private func testCurrentProcessSamplerProducesNumericAlanSample() throws {
+    let sample = AlanPerformanceProcessSampler.currentAlanProcessSample()
+
+    try expect(
+        sample.processID == ProcessInfo.processInfo.processIdentifier,
+        "process sampler must identify the current Alan process"
+    )
+    try expect(sample.role == .alanApp, "current process sample must use alanApp role")
+    try expect(sample.cpuPercent >= 0, "current process CPU must be numeric and nonnegative")
+    try expect(
+        sample.memoryBytes != nil && sample.memoryBytes! > 0,
+        "current process sample must include resident memory"
+    )
+    try expect(
+        sample.threadCount != nil && sample.threadCount! > 0,
+        "current process sample must include thread count"
+    )
+}
+
+private func testKnownTerminalChildAggregateSamplingOmitsCommandIdentity() throws {
+    let sample = try expectNonNil(
+        AlanPerformanceProcessSampler.aggregateKnownTerminalChildSample(
+            [
+                AlanPerformanceChildProcessObservation(
+                    processID: 101,
+                    parentProcessID: 42,
+                    cpuPercent: 12.5,
+                    memoryBytes: 1_024,
+                    threadCount: 2
+                ),
+                AlanPerformanceChildProcessObservation(
+                    processID: 102,
+                    parentProcessID: 42,
+                    cpuPercent: 25.0,
+                    memoryBytes: 2_048,
+                    threadCount: 3
+                ),
+            ],
+            timestampMs: 123
+        ),
+        "known terminal child observations must produce an aggregate sample"
+    )
+
+    try expect(sample.timestampMs == 123, "aggregate sample must preserve timestamp")
+    try expect(sample.processID == 0, "aggregate child samples must use a sentinel process id")
+    try expect(sample.parentProcessID == nil, "aggregate child samples must not expose parent identity")
+    try expect(sample.role == .terminalChild, "aggregate sample must use terminalChild role")
+    try expect(sample.cpuPercent == 37.5, "aggregate CPU must sum known child observations")
+    try expect(sample.memoryBytes == 3_072, "aggregate memory must sum known child observations")
+    try expect(sample.threadCount == 5, "aggregate thread count must sum known child observations")
+
+    let unknown = AlanPerformanceProcessSampler.unknownChildPressureSample(
+        cpuPercent: 88,
+        memoryBytes: nil,
+        threadCount: nil,
+        timestampMs: 456
+    )
+    try expect(unknown.role == .unknownChild, "unknown child pressure must be explicit")
+    try expect(unknown.processID == 0, "unknown child pressure must use a sentinel process id")
+}
+
+private func testDescendantProcessSamplerAggregatesChildPressure() throws {
+    let rootPID: Int32 = 500
+    let childPID: Int32 = 501
+    let grandchildPID: Int32 = 502
+    let unrelatedPID: Int32 = 900
+    let processes = [
+        AlanPerformanceProcessIdentity(processID: childPID, parentProcessID: rootPID),
+        AlanPerformanceProcessIdentity(processID: grandchildPID, parentProcessID: childPID),
+        AlanPerformanceProcessIdentity(processID: unrelatedPID, parentProcessID: 1),
+    ]
+    var metricsByPID: [Int32: AlanPerformanceProcessTaskMetrics] = [
+        childPID: AlanPerformanceProcessTaskMetrics(
+            cpuTimeNanos: 1_000_000_000,
+            memoryBytes: 1_024,
+            threadCount: 2
+        ),
+        grandchildPID: AlanPerformanceProcessTaskMetrics(
+            cpuTimeNanos: 2_000_000_000,
+            memoryBytes: 2_048,
+            threadCount: 3
+        ),
+        unrelatedPID: AlanPerformanceProcessTaskMetrics(
+            cpuTimeNanos: 10_000_000_000,
+            memoryBytes: 4_096,
+            threadCount: 4
+        ),
+    ]
+    let sampler = AlanPerformanceDescendantProcessSampler(
+        processProvider: { processes },
+        metricsProvider: { metricsByPID[$0] }
+    )
+
+    let first = try expectNonNil(
+        sampler.sampleDescendants(
+            of: rootPID,
+            timestampMs: 100,
+            uptimeNanos: 1_000_000_000
+        ),
+        "first descendant sample must establish a child-pressure baseline"
+    )
+    try expect(first.role == .unknownChild, "app descendant aggregate must use unknownChild role")
+    try expect(first.cpuPercent == 0, "first descendant sample must not invent CPU pressure")
+    try expect(first.memoryBytes == 3_072, "descendant sample must aggregate child memory")
+    try expect(first.threadCount == 5, "descendant sample must aggregate child thread counts")
+
+    metricsByPID[childPID] = AlanPerformanceProcessTaskMetrics(
+        cpuTimeNanos: 1_250_000_000,
+        memoryBytes: 1_500,
+        threadCount: 2
+    )
+    metricsByPID[grandchildPID] = AlanPerformanceProcessTaskMetrics(
+        cpuTimeNanos: 2_500_000_000,
+        memoryBytes: 2_500,
+        threadCount: 4
+    )
+    metricsByPID[unrelatedPID] = AlanPerformanceProcessTaskMetrics(
+        cpuTimeNanos: 11_000_000_000,
+        memoryBytes: 8_000,
+        threadCount: 8
+    )
+
+    let second = try expectNonNil(
+        sampler.sampleDescendants(
+            of: rootPID,
+            timestampMs: 200,
+            uptimeNanos: 2_000_000_000
+        ),
+        "second descendant sample must produce aggregate child pressure"
+    )
+    try expect(second.role == .unknownChild, "updated app descendant aggregate must stay unknownChild")
+    try expect(second.processID == 0, "descendant aggregate must not expose child PIDs")
+    try expect(second.parentProcessID == nil, "descendant aggregate must not expose parent PIDs")
+    try expect(second.cpuPercent == 75, "descendant CPU must use cumulative task-time deltas")
+    try expect(second.memoryBytes == 4_000, "descendant sample must keep updated aggregate memory")
+    try expect(second.threadCount == 6, "descendant sample must keep updated thread counts")
+}
+
+private func testBoundedRingBufferAndAutomaticStutterMarker() throws {
+    let recorder = AlanPerformanceDiagnosticsRecorder(
+        configuration: AlanPerformanceDiagnosticsConfiguration(
+            maxEvents: 3,
+            slowEventThresholdMs: 50
+        )
+    )
+    recorder.setEnabled(true)
+
+    recorder.record(AlanPerformanceDiagnosticEvent(kind: .runtimeSnapshotPublish, durationMs: 1))
+    recorder.record(AlanPerformanceDiagnosticEvent(kind: .terminalMetadataCallback, durationMs: 2))
+    recorder.record(AlanPerformanceDiagnosticEvent(kind: .shellRuntimeProjection, durationMs: 75))
+
+    let events = recorder.eventsSnapshot()
+    try expect(events.count == 3, "ring buffer must stay bounded")
+    try expect(
+        events.contains { $0.kind == .automaticStutterMarker },
+        "slow events must create automatic stutter markers"
+    )
+    try expect(
+        !events.contains { $0.kind == .runtimeSnapshotPublish },
+        "oldest events must be evicted when markers consume bounded capacity"
+    )
+
+    let summary = recorder.summarySnapshot()
+    try expect(
+        summary.totalEventsRecorded == 4,
+        "summary must preserve total event count even after ring eviction"
+    )
+    try expect(summary.stutterMarkerCount == 1, "summary must count stutter markers")
+    try expect(
+        summary.countsByKind[.shellRuntimeProjection] == 1,
+        "summary must group event counts by kind"
+    )
+}
+
+private func testProcessSamplesStayBounded() throws {
+    let recorder = AlanPerformanceDiagnosticsRecorder(
+        configuration: AlanPerformanceDiagnosticsConfiguration(
+            maxEvents: 8,
+            maxProcessSamples: 2
+        )
+    )
+    recorder.setEnabled(true)
+
+    for index in 0..<4 {
+        recorder.recordProcessSample(
+            AlanPerformanceProcessSample(
+                timestampMs: Int64(index),
+                processID: Int32(index + 100),
+                role: .alanApp,
+                cpuPercent: Double(index)
+            )
+        )
+    }
+
+    let samples = recorder.summarySnapshot().processSamples
+    try expect(samples.count == 2, "process samples must stay bounded")
+    try expect(
+        samples.map(\.cpuPercent) == [2, 3],
+        "bounded process samples must retain the most recent observations"
+    )
+}
+
+private func testExportBundleOmitsSensitiveFixtureStrings() throws {
+    let root = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let sensitiveValues = [
+        "terminal secret output",
+        "codex --dangerous-prompt",
+        "/Users/morris/Developer/private-repo",
+        "OPENAI_API_KEY=sk-secret",
+        "refresh-token-secret",
+    ]
+
+    let recorder = AlanPerformanceDiagnosticsRecorder(
+        configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 8)
+    )
+    recorder.setEnabled(true)
+    recorder.record(
+        AlanPerformanceDiagnosticEvent(
+            kind: .shellRuntimeProjection,
+            durationMs: 4,
+            paneID: sensitiveValues[0],
+            contentID: sensitiveValues[2],
+            priority: "hiddenBackground",
+            visibility: "hidden",
+            thread: "main",
+            counts: AlanPerformanceDiagnosticCounts(bytes: 120, lines: 3, events: 1)
+        )
+    )
+    recorder.record(
+        AlanPerformanceDiagnosticEvent(
+            kind: .runtimeSnapshotPublish,
+            durationMs: 12,
+            paneID: "pane_2",
+            contentID: "terminal_pane_2",
+            priority: "foregroundInteractive",
+            visibility: "visible",
+            thread: "main"
+        )
+    )
+    recorder.recordProcessSample(
+        AlanPerformanceProcessSample(
+            processID: 42,
+            parentProcessID: 1,
+            role: .terminalChild,
+            cpuPercent: 92.5,
+            memoryBytes: 128_000,
+            threadCount: 9
+        )
+    )
+    recorder.recordProcessSample(
+        AlanPerformanceProcessSampler.unknownChildPressureSample(cpuPercent: 12.5)
+    )
+
+    let bundle = try recorder.exportRecentDiagnostics(
+        to: root,
+        metadata: AlanPerformanceDiagnosticsExportMetadata(
+            appVersion: "test-build",
+            installChannel: "Alan Dev",
+            schemaVersion: AlanPerformanceDiagnosticsSchema.currentVersion,
+            samplingIntervalMs: 1000
+        )
+    )
+
+    let events = try String(
+        contentsOf: bundle.appendingPathComponent("events.jsonl"),
+        encoding: .utf8
+    )
+    let summaryData = try Data(contentsOf: bundle.appendingPathComponent("summary.json"))
+    let summary = String(data: summaryData, encoding: .utf8) ?? ""
+    let exported = events + "\n" + summary
+
+    let eventLines = events.split(separator: "\n", omittingEmptySubsequences: true)
+    try expect(eventLines.count == 2, "events.jsonl must contain one compact JSON object per event line")
+    try expect(
+        eventLines.allSatisfy { line in
+            line.first == "{" && line.last == "}" && !line.contains("\n")
+        },
+        "events.jsonl event records must not be pretty-printed across multiple lines"
+    )
+    try expect(events.contains("pane_id_hash"), "export must keep redacted pane correlation")
+    try expect(events.contains("content_id_hash"), "export must keep redacted content correlation")
+    try expect(summary.contains("\"processSamples\""), "summary must include process samples")
+    try expect(summary.contains("\"terminalChild\""), "summary must include child CPU pressure")
+    try expect(summary.contains("\"unknownChild\""), "summary must include unknown child pressure")
+
+    let summaryObject = try expectNonNil(
+        JSONSerialization.jsonObject(with: summaryData) as? [String: Any],
+        "summary must be a JSON object"
+    )
+    let countsByKind = try expectNonNil(
+        summaryObject["countsByKind"] as? [String: Any],
+        "summary countsByKind must be keyed by event kind name"
+    )
+    let shellProjectionCount = try expectNonNil(
+        countsByKind["shellRuntimeProjection"] as? NSNumber,
+        "summary countsByKind must include shell runtime projection count"
+    )
+    try expect(shellProjectionCount.intValue == 1, "summary countsByKind must preserve event counts")
+    let countsByPriority = try expectNonNil(
+        summaryObject["countsByPriority"] as? [String: Any],
+        "summary countsByPriority must be keyed by render priority"
+    )
+    try expect(
+        (countsByPriority["hiddenBackground"] as? NSNumber)?.intValue == 1,
+        "summary countsByPriority must include hidden background events"
+    )
+    try expect(
+        (countsByPriority["foregroundInteractive"] as? NSNumber)?.intValue == 1,
+        "summary countsByPriority must include foreground interactive events"
+    )
+    let countsByVisibility = try expectNonNil(
+        summaryObject["countsByVisibility"] as? [String: Any],
+        "summary countsByVisibility must be keyed by visibility"
+    )
+    try expect(
+        (countsByVisibility["hidden"] as? NSNumber)?.intValue == 1,
+        "summary countsByVisibility must include hidden events"
+    )
+    try expect(
+        (countsByVisibility["visible"] as? NSNumber)?.intValue == 1,
+        "summary countsByVisibility must include visible events"
+    )
+    let durationByKind = try expectNonNil(
+        summaryObject["durationByKind"] as? [String: Any],
+        "summary durationByKind must include retained-window duration statistics"
+    )
+    let runtimeDurationStats = try expectNonNil(
+        durationByKind["runtimeSnapshotPublish"] as? [String: Any],
+        "summary durationByKind must include runtime publication stats"
+    )
+    try expect(
+        (runtimeDurationStats["p95_ms"] as? NSNumber)?.doubleValue == 12,
+        "summary durationByKind must include p95 duration"
+    )
+    try expect(
+        (runtimeDurationStats["maximum_ms"] as? NSNumber)?.doubleValue == 12,
+        "summary durationByKind must include max duration"
+    )
+
+    for sensitive in sensitiveValues {
+        try expect(
+            !exported.contains(sensitive),
+            "diagnostics export must omit sensitive fixture value: \(sensitive)"
+        )
+    }
+    try expect(!exported.contains("commandLine"), "export must not include command-line fields")
+    try expect(!exported.contains("cwd"), "export must not include cwd fields")
+    try expect(!exported.contains("environment"), "export must not include environment fields")
+}
+
+private func expectNonNil<T>(_ value: T?, _ message: String) throws -> T {
+    guard let value else {
+        throw TestFailure.message(message)
+    }
+    return value
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("alan-performance-diagnostics-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+#endif

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -25,6 +25,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -18,6 +18,9 @@ struct ShellRuntimeMetadataTestRunner {
 private enum ShellRuntimeMetadataTests {
     static func run() {
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
+        verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
+        verifiesShellSelectionAndFocusRecordPerformanceDiagnostics()
+        verifiesPerformanceDiagnosticsControlCommandsExportRecentBundle()
         verifiesTerminalContentProjectionAdapterOwnsMetadataProjection()
         verifiesSurfaceExitClosesFinalPaneWithoutRestarting()
         verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth()
@@ -240,6 +243,244 @@ private enum ShellRuntimeMetadataTests {
         expect(updated?.viewport?.summary == "Renderer failed", "pane viewport must expose renderer status")
         expect(updated?.attention == .notable, "pane attention must reflect terminal attention")
         expect(controller.shellState.spaces.first?.attention == .notable, "space attention must track pane attention")
+    }
+
+    private static func verifiesRuntimeProjectionRecordsPerformanceDiagnostics() {
+        let recorder = AlanPerformanceDiagnosticsRecorder(
+            configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 16)
+        )
+        recorder.setEnabled(true)
+        let controller = makeController(performanceDiagnosticsRecorder: recorder)
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        controller.updateTerminalRuntime(
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                contentID: pane.terminalContentID,
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                renderPriority: .foregroundInteractive,
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: "Studio Display",
+                displayID: "display_1",
+                attachedWindowTitle: "alan",
+                isFocused: false,
+                renderer: .placeholder,
+                paneMetadata: TerminalPaneMetadataSnapshot(
+                    title: "cargo test",
+                    workingDirectory: "/repo/app",
+                    summary: "build running",
+                    attention: .active,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: 2)
+                ),
+                surfaceState: .placeholder,
+                lastUpdatedAt: Date(timeIntervalSince1970: 3)
+            )
+        )
+
+        let diagnostics = recorder.eventsSnapshot()
+        expect(
+            diagnostics.contains { $0.kind == .runtimeSnapshotPublish },
+            "runtime update must record snapshot publication diagnostics"
+        )
+        expect(
+            diagnostics.contains { $0.kind == .shellRuntimeProjection },
+            "runtime update must record shell projection diagnostics"
+        )
+        expect(
+            diagnostics.contains { $0.kind == .shellPaneStatePublication },
+            "runtime projection must record pane-state publication diagnostics"
+        )
+        expect(
+            diagnostics.contains {
+                $0.paneID == pane.paneID
+                    && $0.contentID == pane.terminalContentID
+                    && $0.priority == "foregroundInteractive"
+                    && $0.visibility == "visible"
+            },
+            "shell diagnostics must include pane/content correlation, priority, and visibility"
+        )
+
+        controller.updateTerminalMetadata(
+            TerminalPaneMetadataSnapshot(
+                title: "cargo test --workspace",
+                workingDirectory: "/repo/app",
+                summary: "metadata update",
+                attention: .active,
+                processExited: false,
+                lastCommandExitCode: nil,
+                lastUpdatedAt: Date(timeIntervalSince1970: 4)
+            ),
+            for: pane.paneID
+        )
+        expect(
+            recorder.eventsSnapshot().contains { $0.kind == .terminalMetadataCallback },
+            "terminal metadata updates must record metadata callback diagnostics"
+        )
+    }
+
+    private static func verifiesShellSelectionAndFocusRecordPerformanceDiagnostics() {
+        let recorder = AlanPerformanceDiagnosticsRecorder(
+            configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 32)
+        )
+        recorder.setEnabled(true)
+        let controller = makeController(performanceDiagnosticsRecorder: recorder)
+        _ = controller.openTerminalTab()
+        recorder.setEnabled(false)
+        recorder.setEnabled(true)
+
+        controller.focus(paneID: "pane_1")
+        controller.select(tabID: "tab_2")
+
+        let events = recorder.eventsSnapshot()
+        expect(
+            events.contains { $0.kind == .shellFocusChange && $0.paneID == "pane_1" },
+            "explicit focus changes must record performance diagnostics"
+        )
+        expect(
+            events.contains { $0.kind == .shellSelectionChange && $0.paneID == "pane_2" },
+            "tab selection must record selection diagnostics for the selected pane"
+        )
+        expect(
+            events.contains { $0.kind == .shellPrioritySynchronization },
+            "selection changes must record terminal priority synchronization diagnostics"
+        )
+        expect(
+            events.contains {
+                $0.kind == .shellSelectionChange
+                    && $0.contentID == ShellContentInstance.terminalContentID(forPaneID: "pane_2")
+                    && $0.visibility == "visible"
+            },
+            "selection diagnostics must keep pane/content correlation without terminal text"
+        )
+    }
+
+    private static func verifiesPerformanceDiagnosticsControlCommandsExportRecentBundle() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alan-control-diagnostics-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        } catch {
+            fail("diagnostics control command test must create temp dir: \(error)")
+        }
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            AlanPerformanceDiagnosticsController.shared.setEnabled(false)
+        }
+
+        AlanPerformanceDiagnosticsController.shared.setEnabled(false)
+        let controller = makeController()
+        let enableResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "diagnostics-enable",
+                  "command": "performance_diagnostics.set_enabled",
+                  "enabled": true
+                }
+                """
+            )
+        )
+        expect(enableResponse.applied == true, "diagnostics enable control command must apply")
+        expect(enableResponse.diagnosticsEnabled == true, "diagnostics enable response must report enabled")
+
+        let childPressureResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "diagnostics-child-pressure",
+                  "command": "performance_diagnostics.record_child_pressure",
+                  "child_process_role": "terminal_child",
+                  "child_cpu_percent": 181.5,
+                  "child_memory_bytes": 4096,
+                  "child_thread_count": 7
+                }
+                """
+            )
+        )
+        expect(childPressureResponse.applied == true,
+               "diagnostics child-pressure control command must apply")
+
+        guard let pane = controller.selectedPane else {
+            fail("diagnostics control command test must expose a selected pane")
+        }
+        controller.updateTerminalRuntime(
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                contentID: pane.terminalContentID,
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                renderPriority: .foregroundInteractive,
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: "Studio Display",
+                displayID: "display_1",
+                attachedWindowTitle: "alan",
+                isFocused: true,
+                renderer: .placeholder,
+                paneMetadata: .placeholder,
+                surfaceState: .placeholder,
+                lastUpdatedAt: Date(timeIntervalSince1970: 5)
+            )
+        )
+
+        let exportResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "diagnostics-export",
+                  "command": "performance_diagnostics.export_recent",
+                  "export_directory": "\(jsonEscaped(root.path))"
+                }
+                """
+            )
+        )
+        expect(exportResponse.applied == true, "diagnostics export control command must apply")
+        guard let bundlePath = exportResponse.diagnosticsBundlePath else {
+            fail("diagnostics export response must include bundle path")
+        }
+        let bundle = URL(fileURLWithPath: bundlePath, isDirectory: true)
+        let events = try? String(
+            contentsOf: bundle.appendingPathComponent("events.jsonl"),
+            encoding: .utf8
+        )
+        let summary = try? String(
+            contentsOf: bundle.appendingPathComponent("summary.json"),
+            encoding: .utf8
+        )
+        expect(events?.contains("shellRuntimeProjection") == true,
+               "exported diagnostics must include shell projection events")
+        expect(summary?.contains("\"schemaVersion\"") == true,
+               "exported diagnostics summary must include schema metadata")
+        expect(summary?.contains("\"terminalChild\"") == true,
+               "exported diagnostics must include terminal child CPU pressure")
+        expect(events?.contains(pane.paneID) == false,
+               "exported diagnostics must not include raw pane ids")
+        expect(events?.contains("pane_id_hash") == true,
+               "exported diagnostics must keep hashed pane correlation")
+
+        let disableResponse = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "diagnostics-disable",
+                  "command": "performance_diagnostics.set_enabled",
+                  "enabled": false
+                }
+                """
+            )
+        )
+        expect(disableResponse.applied == true, "diagnostics disable control command must apply")
+        expect(disableResponse.diagnosticsEnabled == false, "diagnostics disable response must report disabled")
+        expect(
+            AlanPerformanceDiagnosticsController.shared.eventsSnapshot().isEmpty,
+            "diagnostics disable control command must clear retained in-memory events"
+        )
     }
 
     private static func verifiesTerminalContentProjectionAdapterOwnsMetadataProjection() {
@@ -9309,6 +9550,7 @@ private enum ShellRuntimeMetadataTests {
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
         workspaceManifest: ShellContentWorkspaceManifest? = nil,
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
+        performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
         appIsActive: Bool = true
     ) -> ShellHostController {
         let registry =
@@ -9328,6 +9570,7 @@ private enum ShellRuntimeMetadataTests {
             workspaceManifestStore: workspaceManifestStore,
             workspaceManifest: workspaceManifest,
             closeConfirmationPresenter: closeConfirmationPresenter,
+            performanceDiagnosticsRecorder: performanceDiagnosticsRecorder,
             appIsActiveProvider: { appIsActive }
         )
     }
@@ -9935,6 +10178,12 @@ private enum ShellRuntimeMetadataTests {
         } catch {
             fail("failed to decode control command fixture: \(error)")
         }
+    }
+
+    private static func jsonEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
     private static func controlEvents(_ controller: ShellHostController) -> [AlanShellEventEnvelope] {

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -30,6 +30,7 @@ struct ShellSettingsSurfaceTestRunner {
             try testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot()
             try testUnavailableRemoteSummariesStayCompact()
             try testTerminalProfilesAndAccountsStayLocalAndRedacted()
+            try testPerformanceDiagnosticsRowsAreCompactAndLocal()
             print("Shell settings surface tests passed.")
         } catch {
             fputs("Shell settings surface tests failed: \(error)\n", stderr)
@@ -136,7 +137,7 @@ private func testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted() throw
         "capabilities must use enabled and implicit-invocation terminology instead of mount labels"
     )
 
-    for sectionID in [ShellSettingsSectionID.accounts, .capabilities, .local] {
+    for sectionID in [ShellSettingsSectionID.accounts, .capabilities] {
         let section = try requireSection(sectionID, in: snapshot)
         try expect(
             section.rows.allSatisfy { $0.mutability != .editable },
@@ -147,6 +148,16 @@ private func testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted() throw
             "\(sectionID.rawValue) rows must not expose freeform file or credential editing"
         )
     }
+
+    let localSection = try requireSection(.local, in: snapshot)
+    try expect(
+        localSection.rows.filter { $0.mutability == .editable }.map(\.id) == ["performanceDiagnostics"],
+        "local settings must keep only the performance diagnostics toggle editable"
+    )
+    try expect(
+        localSection.rows.allSatisfy { !$0.offersFreeformEditing },
+        "local rows must not expose freeform file or credential editing"
+    )
 }
 
 private func testDevChannelLocalRowsUseDevIdentity() throws {
@@ -330,6 +341,49 @@ private func testTerminalProfilesAndAccountsStayLocalAndRedacted() throws {
     try expect(
         accountSection.visibleText.joined(separator: " ").contains("terminal entry"),
         "Managed Terminal Account rows must describe terminal entry"
+    )
+}
+
+private func testPerformanceDiagnosticsRowsAreCompactAndLocal() throws {
+    let snapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: .unavailable(reason: "Daemon unavailable"),
+        local: stableLocalSummary(),
+        terminalProfiles: testTerminalProfiles(),
+        diagnostics: ShellSettingsDiagnosticsSummary(
+            isEnabled: false,
+            retainedEventCount: 24,
+            stutterMarkerCount: 2,
+            lastExportURL: nil
+        )
+    )
+    let local = try requireSection(.local, in: snapshot)
+    let diagnosticsRows = local.rows.filter { $0.id.hasPrefix("performanceDiagnostics") }
+    let visibleText = diagnosticsRows.flatMap(\.visibleText).joined(separator: "\n")
+
+    try expect(
+        diagnosticsRows.map(\.id) == ["performanceDiagnostics", "performanceDiagnosticsExport"],
+        "settings must expose only a diagnostics toggle and recent export action"
+    )
+    try expect(
+        diagnosticsRows.first?.mutability == .editable,
+        "performance diagnostics toggle must be directly editable"
+    )
+    try expect(
+        diagnosticsRows.last?.mutability == .actionOnly,
+        "performance diagnostics export must be an action row"
+    )
+    try expect(
+        visibleText.contains("Local performance trace"),
+        "diagnostics copy must explain that capture is local"
+    )
+    try expect(
+        visibleText.contains("Terminal content is not recorded"),
+        "diagnostics copy must state that terminal content is not recorded"
+    )
+    try expect(
+        !visibleText.localizedCaseInsensitiveContains("dashboard")
+            && !visibleText.localizedCaseInsensitiveContains("inspector"),
+        "diagnostics settings copy must not introduce dashboard or inspector framing"
     )
 }
 

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -21,6 +21,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -41,6 +41,7 @@ private enum TerminalRuntimeServiceTests {
         verifiesRenderCoordinatorCoalescesHiddenWakeups()
         verifiesRenderCoordinatorDrainsForegroundBeforeBackground()
         verifiesRenderCoordinatorCatchUpRefreshesHiddenSurface()
+        verifiesRenderCoordinatorRecordsDiagnosticsWithoutChangingDrainBehavior()
         verifiesHiddenRuntimePublicationPolicyThrottlesNoisyUpdates()
         print("Terminal runtime service tests passed.")
     }
@@ -222,6 +223,78 @@ private enum TerminalRuntimeServiceTests {
             "catch-up must refresh only after the terminal becomes visible"
         )
         expect(coordinator.metricsSnapshot().catchUpRefreshes == 1, "catch-up refresh must be counted")
+    }
+
+    private static func verifiesRenderCoordinatorRecordsDiagnosticsWithoutChangingDrainBehavior() {
+        var events: [String] = []
+        let recorder = AlanPerformanceDiagnosticsRecorder(
+            configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 16)
+        )
+        recorder.setEnabled(true)
+        let coordinator = TerminalRenderCoordinator(
+            automaticallyDrains: false,
+            diagnosticsRecorder: recorder
+        )
+        let foreground = FakeRenderCoordinatorHost(
+            id: "foreground",
+            priority: .foregroundInteractive,
+            events: { events.append($0) }
+        )
+        let hidden = FakeRenderCoordinatorHost(
+            id: "hidden",
+            priority: .hiddenBackground,
+            events: { events.append($0) }
+        )
+
+        coordinator.requestWakeup(from: hidden)
+        coordinator.requestWakeup(from: foreground)
+        coordinator.requestCatchUp(from: hidden)
+        coordinator.drainPending()
+
+        expect(
+            events == [
+                "tick:foreground", "refresh:foreground:automatic",
+                "tick:hidden", "refresh:hidden:catch_up",
+            ],
+            "diagnostic probes must not change coordinator drain order or refresh decisions"
+        )
+
+        let diagnostics = recorder.eventsSnapshot()
+        let diagnosticKinds = diagnostics.map(\.kind)
+        expect(diagnosticKinds.contains(.ghosttyWakeup), "coordinator must record wakeup diagnostics")
+        expect(diagnosticKinds.contains(.ghosttyAppTick), "coordinator must record app tick diagnostics")
+        expect(
+            diagnosticKinds.contains(.ghosttySurfaceRefresh),
+            "coordinator must record surface refresh diagnostics"
+        )
+        expect(
+            diagnosticKinds.contains(.terminalCatchUpRefresh),
+            "coordinator must record catch-up refresh diagnostics"
+        )
+        expect(
+            diagnostics.contains {
+                $0.priority == "foregroundInteractive" && $0.visibility == "visible"
+            },
+            "coordinator diagnostics must include render priority and visibility"
+        )
+
+        AlanPerformanceDiagnosticsController.shared.setEnabled(false)
+        AlanPerformanceDiagnosticsController.shared.setEnabled(true)
+        defer { AlanPerformanceDiagnosticsController.shared.setEnabled(false) }
+        let sharedCoordinator = TerminalRenderCoordinator(automaticallyDrains: false)
+        let sharedHost = FakeRenderCoordinatorHost(
+            id: "shared",
+            priority: .foregroundInteractive,
+            events: { _ in }
+        )
+        sharedCoordinator.requestWakeup(from: sharedHost)
+        sharedCoordinator.drainPending()
+
+        let sharedKinds = AlanPerformanceDiagnosticsController.shared.eventsSnapshot().map(\.kind)
+        expect(
+            sharedKinds.contains(.ghosttyAppTick),
+            "app render coordinator must record Ghostty diagnostics into the shared controller"
+        )
     }
 
     private static func verifiesHiddenRuntimePublicationPolicyThrottlesNoisyUpdates() {

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -21,6 +21,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellEventStore.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPerformanceDiagnostics.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellSocketServer.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellControlPlane.swift" \

--- a/clients/apple/scripts/test-terminal-surface-controller.swift
+++ b/clients/apple/scripts/test-terminal-surface-controller.swift
@@ -37,6 +37,7 @@ private enum TerminalSurfaceControllerTests {
         verifiesSemanticCommandFallbacksAndInvalidation()
         verifiesBindClearsStaleScrollbackState()
         verifiesSurfaceCloseRequestIsForwarded()
+        verifiesSurfaceControllerRecordsPerformanceDiagnostics()
         verifiesSurfaceSnapshotEqualityIgnoresTimestamp()
         verifiesClipboardDeliveryStates()
         verifiesSelectionCopyAndPasteUseController()
@@ -1470,6 +1471,7 @@ private enum TerminalSurfaceControllerTests {
             to: NSView(),
             bootProfile: nil,
             focused: true,
+            renderPriority: .foregroundInteractive,
             onDiagnosticsChange: { _ in },
             onMetadataChange: { _ in },
             onCloseRequest: { requiresConfirmation in
@@ -1480,6 +1482,124 @@ private enum TerminalSurfaceControllerTests {
         handle.requestClose(requiresConfirmation: false)
 
         expect(closeRequests == [false], "surface close requests must be forwarded to the shell owner")
+    }
+
+    private static func verifiesSurfaceControllerRecordsPerformanceDiagnostics() {
+        let disabledRecorder = AlanPerformanceDiagnosticsRecorder(
+            configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 20)
+        )
+        let disabledController = AlanTerminalSurfaceController(
+            diagnosticsRecorder: disabledRecorder
+        )
+        let disabledHandle = FakeAlanTerminalSurfaceHandle(
+            contentID: "content_disabled",
+            paneID: "pane_disabled"
+        )
+        disabledController.bind(surfaceHandle: disabledHandle, paneID: "pane_disabled")
+        disabledController.attach(
+            to: NSView(),
+            bootProfile: nil,
+            focused: false,
+            renderPriority: .hiddenBackground,
+            onDiagnosticsChange: { _ in },
+            onMetadataChange: { _ in },
+            onCloseRequest: { _ in }
+        )
+        disabledController.updateRenderer(
+            TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .surfaceReady,
+                summary: "renderer ready",
+                detail: nil,
+                failureReason: nil,
+                recentEvents: []
+            )
+        )
+        expect(
+            disabledRecorder.eventsSnapshot().isEmpty,
+            "disabled surface diagnostics must avoid hot-path event recording"
+        )
+
+        let recorder = AlanPerformanceDiagnosticsRecorder(
+            configuration: AlanPerformanceDiagnosticsConfiguration(maxEvents: 20)
+        )
+        recorder.setEnabled(true)
+        let controller = AlanTerminalSurfaceController(diagnosticsRecorder: recorder)
+        let handle = FakeAlanTerminalSurfaceHandle(contentID: "content_1", paneID: "pane_1")
+        var rendererUpdates = 0
+
+        controller.bind(surfaceHandle: handle, paneID: "pane_1")
+        controller.attach(
+            to: NSView(),
+            bootProfile: nil,
+            focused: false,
+            renderPriority: .visibleBackground,
+            onDiagnosticsChange: { _ in
+                rendererUpdates += 1
+            },
+            onMetadataChange: { _ in },
+            onCloseRequest: { _ in }
+        )
+        handle.updateRenderPriority(.hiddenBackground, forceCatchUp: false)
+        handle.emitDiagnosticsSnapshot(
+            TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .surfaceReady,
+                summary: "renderer background update",
+                detail: nil,
+                failureReason: nil,
+                recentEvents: [
+                    "background-event-1",
+                    "background-event-2",
+                ]
+            )
+        )
+        controller.updateRenderer(
+            TerminalRendererSnapshot(
+                kind: .ghosttyLive,
+                phase: .surfaceReady,
+                summary: "renderer ready",
+                detail: nil,
+                failureReason: nil,
+                recentEvents: []
+            )
+        )
+        handle.emitScrollbackUpdate(
+            AlanTerminalScrollbackMetrics(
+                totalRows: 300,
+                visibleRows: 40,
+                firstVisibleRow: 200,
+                mode: .normalBuffer
+            )
+        )
+
+        let events = recorder.eventsSnapshot()
+        let kinds = events.map(\.kind)
+        expect(rendererUpdates == 2, "diagnostics recording must not duplicate renderer callbacks")
+        expect(kinds.contains(.terminalSurfaceAttach), "surface attach must record diagnostics")
+        expect(kinds.contains(.terminalRendererUpdate), "renderer updates must record diagnostics")
+        expect(kinds.contains(.terminalScrollbackUpdate), "scrollback updates must record diagnostics")
+        let attachEvent = events.first { $0.kind == .terminalSurfaceAttach }
+        expect(attachEvent?.paneID == "pane_1", "surface diagnostics must include pane correlation")
+        expect(attachEvent?.contentID == "content_1", "surface diagnostics must include content correlation")
+        expect(
+            attachEvent?.priority == TerminalRuntimeRenderPriority.visibleBackground.diagnosticsValue,
+            "surface diagnostics must include render priority"
+        )
+        expect(
+            attachEvent?.visibility == TerminalRuntimeRenderPriority.visibleBackground.diagnosticsVisibility,
+            "surface diagnostics must include visibility"
+        )
+        let rendererEvents = events.filter { $0.kind == .terminalRendererUpdate }
+        let latestRendererEvent = rendererEvents.last
+        expect(
+            latestRendererEvent?.priority == TerminalRuntimeRenderPriority.hiddenBackground.diagnosticsValue,
+            "renderer diagnostics must use the current surface priority"
+        )
+        expect(
+            latestRendererEvent?.visibility == TerminalRuntimeRenderPriority.hiddenBackground.diagnosticsVisibility,
+            "renderer diagnostics must use the current surface visibility"
+        )
     }
 
     private static func verifiesSurfaceSnapshotEqualityIgnoresTimestamp() {

--- a/justfile
+++ b/justfile
@@ -77,7 +77,9 @@ dev-channel-smoke:
 
 # Run focused macOS shell tests that do not require real Ghostty artifacts
 apple-shell-focused-tests:
+    bash clients/apple/scripts/test-shell-performance-diagnostics.sh
     bash clients/apple/scripts/test-terminal-runtime-service.sh
+    bash clients/apple/scripts/test-terminal-surface-controller.sh
     bash clients/apple/scripts/test-shell-automation-command-seams.sh
     bash clients/apple/scripts/test-shell-runtime-metadata.sh
     bash clients/apple/scripts/test-shell-settings-surface.sh

--- a/openspec/changes/add-macos-performance-diagnostics/.openspec.yaml
+++ b/openspec/changes/add-macos-performance-diagnostics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/add-macos-performance-diagnostics/design.md
+++ b/openspec/changes/add-macos-performance-diagnostics/design.md
@@ -1,0 +1,167 @@
+## Context
+
+Alan for macOS now keeps terminal ContentInstance runtimes alive across spaces,
+tabs, splits, zoom, and Quick Terminal Peak presentation. Recent background
+rendering work added priority-aware rendering and publication so hidden panes
+do less surface painting, but daily use with several Codex CLI sessions still
+feels low frame-rate. The symptoms appear across foreground typing, tab/space
+switching, Quick Terminal Peak, sidebar interaction, and hidden-to-visible
+catch-up.
+
+The next change should not guess at another optimization. The first slice needs
+to produce evidence from real user workload, especially high-output Codex CLI
+sessions, while preserving terminal-first behavior and avoiding content capture.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a default-off `Performance Diagnostics` control in macOS Settings that is
+  available in every install channel.
+- Collect bounded local traces while diagnostics are enabled.
+- Attribute stutter across Alan main-thread work, embedded Ghostty terminal
+  work, SwiftUI shell projection, and child-process CPU pressure.
+- Export recent diagnostics as a local bundle for manual analysis.
+- Preserve privacy by excluding terminal text, prompts, command lines, cwd,
+  repository paths, file paths, environment variables, and secrets.
+- Keep probes low overhead when enabled and near-zero overhead when disabled.
+
+**Non-Goals:**
+
+- Do not change terminal scheduling, rendering, focus, lazy rendering, or
+  process lifecycle behavior in this diagnostic slice.
+- Do not add automatic upload, telemetry, or remote diagnostics.
+- Do not record stack traces continuously or build an Instruments replacement.
+- Do not introduce a broad dashboard or persistent diagnostic chrome in the
+  default shell.
+- Do not claim performance improvement from this change alone.
+
+## Decisions
+
+### Diagnostics are opt-in product controls, not dev-only tooling
+
+Settings will expose a single `Performance Diagnostics` toggle and an export
+action for recent diagnostics. The feature is available in Dev and stable
+channels because performance problems must be captured in the real environment
+where they occur.
+
+Alternative considered: restrict diagnostics to Alan Dev. That would reduce
+surface area, but it would miss stable-channel and daily-workload evidence.
+
+### Capture is continuous while enabled
+
+When enabled, diagnostics maintain a bounded in-memory ring buffer and summary
+windows for the recent past. Users do not need to press start, stop, or mark
+stutter manually; threshold-crossing events create automatic stutter markers.
+
+Alternative considered: explicit start/stop capture and manual stutter
+markers. That is precise in a lab, but it is easy to miss the real lag window
+during normal Codex work.
+
+### Probe points are narrow and behavior-neutral
+
+Instrumentation should sit around existing boundaries:
+
+- Ghostty wakeup, app tick, surface refresh, attach, and catch-up.
+- Terminal runtime snapshot publication and metadata callbacks.
+- Surface scrollback / renderer state updates where those are already observed.
+- Shell runtime projection, pane-state publication, selection, focus, and
+  visible/hidden priority changes.
+- Low-frequency process sampling for Alan process and known terminal child
+  CPU/thread pressure.
+
+The probes record event categories, durations, priority, visibility, pane or
+content identity, and counters. They must not alter execution order or add
+throttling.
+
+Alternative considered: add richer instrumentation directly inside terminal IO
+or PTY parsing first. That may become useful later, but it risks expanding the
+first slice before we know whether the hot path is Ghostty refresh, SwiftUI
+publication, or system CPU pressure.
+
+### Data model uses events plus summaries
+
+The recorder writes compact event records into memory and periodically updates
+summary windows. Export writes:
+
+- `events.jsonl` for recent event records.
+- `summary.json` for aggregate counts, duration percentiles, stutter markers,
+  process samples, priority grouping, and build metadata.
+- Optional small metadata files for app version, install channel, capture
+  window, and schema version.
+
+The event schema should be stable enough for scripts, but first implementation
+can remain local to the Apple client.
+
+Alternative considered: summary-only diagnostics. Summary-only data is cheap,
+but it makes it harder to align a stutter window with terminal refresh,
+metadata publication, and shell projection spikes.
+
+### Privacy boundaries are part of the contract
+
+Diagnostics must not record terminal output, prompt text, command lines, cwd,
+repo names, file paths, environment variables, secrets, or raw auth/provider
+state. Process sampling records PIDs and numeric metrics, not command
+arguments. Pane/content identifiers may use existing IDs while in memory; export
+can hash them if needed to reduce workspace-structure leakage.
+
+Alternative considered: record command names or current directories for better
+human diagnosis. That would make traces more sensitive and is unnecessary for
+the first question: which runtime path is responsible for frame drops.
+
+### Diagnostics remain local and bounded
+
+Recording uses an in-memory ring buffer with size and time-window limits.
+Hot-path recording does not write files. Summary aggregation and process
+sampling run at fixed low frequency. Closing the diagnostics toggle stops
+sampling and clears unexported buffers; already exported local bundles remain
+under user control.
+
+Alternative considered: always-on persisted logs. That would make after-the-fact
+analysis easier, but it increases privacy risk and could create a new
+performance problem.
+
+## Risks / Trade-offs
+
+- Diagnostic overhead masks the original problem -> keep disabled probes as
+  no-op, use bounded memory buffers, avoid hot-path file IO, and test overhead
+  with diagnostics on and off.
+- Trace cannot identify child-process CPU accurately -> record Alan process
+  metrics separately from known terminal child aggregates and mark unknown
+  attribution explicitly.
+- Privacy regression through accidental text/path fields -> add focused export
+  checks that scan fixtures and generated bundles for forbidden fields and
+  assert command-line/cwd/path fields are absent.
+- Summary is too coarse for manual attribution -> keep both event JSONL and
+  aggregate summary, with automatic stutter markers for threshold crossings.
+- Users expect the toggle to make Alan faster -> label it as diagnostics and
+  keep the implementation behavior-neutral.
+
+## Migration Plan
+
+1. Add diagnostics state, recorder, schema, bounded ring buffer, summary
+   aggregation, and export writer with tests.
+2. Add Settings toggle and export action without changing default shell chrome.
+3. Add terminal probes around Ghostty/runtime/surface paths.
+4. Add shell probes around projection, pane-state publication, selection, and
+   focus paths.
+5. Add process sampling for Alan and known terminal child CPU/thread metrics.
+6. Add focused privacy, bounded-buffer, toggle, export, and summary tests.
+7. Use a real multi-Codex workload to capture a diagnostics bundle and decide
+   the next optimization change from evidence.
+
+Rollback is local to the Apple client: disable or remove the Settings toggle and
+make the diagnostics controller permanently disabled. Because this slice must
+not change scheduling or rendering behavior, rollback should not affect terminal
+runtime semantics.
+
+## Open Questions
+
+- Exact ring-buffer limits and summary window length should be chosen during
+  implementation with lightweight overhead checks.
+- Export should initially use a save panel or the existing app-local data
+  location; the implementation plan should choose the path that best matches
+  current Settings patterns.
+- Pane/content IDs may be exported as stable IDs or hashed IDs; the
+  implementation should choose the least sensitive option that still supports
+  cross-event correlation.

--- a/openspec/changes/add-macos-performance-diagnostics/implementation-readiness.md
+++ b/openspec/changes/add-macos-performance-diagnostics/implementation-readiness.md
@@ -1,0 +1,92 @@
+# Implementation Readiness
+
+## Current Status
+
+- OpenSpec progress: `28/30` tasks complete.
+- Implementation-side work is complete for the diagnostic slice.
+- Remaining tasks are post-merge/archive tasks:
+  - `7.4` sync accepted delta requirements into `openspec/specs/` before archive.
+  - `7.5` archive after implementation, verification, PR review, and merge.
+
+Do not mark those archive tasks complete before the change is reviewed and
+merged.
+
+## Implemented Surfaces
+
+- Settings exposes a default-off `Performance Diagnostics` control and compact
+  export action.
+- Diagnostics recording is bounded, opt-in, local-only, and clears unexported
+  buffers when disabled.
+- Hot-path probes check the diagnostics enabled state before constructing
+  retained events or starting diagnostic-only timers, keeping disabled
+  diagnostics on the no-op path.
+- Export writes `events.jsonl` and `summary.json` with schema/build/capture
+  metadata.
+- `events.jsonl` uses one compact JSON object per retained event line, and
+  `summary.json` exposes `countsByKind` as event-kind string keys for scripts.
+- `summary.json` includes retained-window duration stats by event kind and
+  priority / visibility grouping for direct attribution without reprocessing
+  raw events first.
+- Exported pane/content identifiers are hashed for correlation without raw
+  workspace IDs.
+- Probe points cover Ghostty wakeup/tick/refresh, terminal runtime publication,
+  metadata callbacks, renderer updates, scrollback, shell projection, pane-state
+  publication, selection/focus changes, visibility, and priority changes.
+- Process sampling records Alan app CPU/thread/memory and aggregate Alan
+  descendant CPU pressure as terminal child pressure without command lines, cwd,
+  environment, or terminal text.
+- Local control commands support diagnostics enable/export/child-pressure
+  capture for repeatable verification.
+- `terminal.send_key` sends an explicit Return key path for terminal control
+  automation; workload scripts do not rely on newline text to submit commands.
+
+## Real Workload Evidence
+
+See `real-workload-diagnostics.md` for the exported bundle review.
+
+Observed in the real workload bundle:
+
+- `135` `shellRuntimeProjection` events.
+- `269` `runtimeSnapshotPublish` events.
+- `910` Ghostty timing events across wakeup/tick/refresh.
+- `3` `terminalChild` aggregate CPU samples.
+- `stutterMarkerCount` was `0`, proving no threshold-crossing marker was emitted
+  in that capture while raw event families and process pressure remained
+  distinguishable.
+
+Privacy review found no terminal workload text, repo path, command-line fields,
+working-directory fields, environment fields, `OPENAI_API_KEY`, or
+`refresh-token` in exported diagnostics.
+
+## Verification Run
+
+Validated without operating the user's running `Alan Dev` instance:
+
+- `bash -n clients/apple/scripts/capture-performance-diagnostics-workload.sh`
+- `bash clients/apple/scripts/test-shell-performance-diagnostics.sh`
+- `bash clients/apple/scripts/test-terminal-runtime-service.sh`
+- `bash clients/apple/scripts/test-terminal-surface-controller.sh`
+- `bash clients/apple/scripts/test-shell-automation-command-seams.sh`
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `just apple-shell-focused-tests`
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-perfdiag-rebased -clonedSourcePackagesDirPath /private/tmp/alan-xcode-spm-perfdiag-rebased -skipPackagePluginValidation -skipMacroValidation build`
+- `openspec validate add-macos-performance-diagnostics --strict`
+- `openspec validate --all --strict`
+- `git diff --check`
+
+The isolated worktree used ignored Ghostty artifact symlinks pointing at the
+existing local Ghostty cache; no Alan Dev process was launched or controlled for
+these verification commands.
+
+## Operational Notes
+
+- `capture-performance-diagnostics-workload.sh` defaults to LaunchServices
+  `open` mode because direct executable launch did not reliably initialize the
+  shell control plane.
+- When `ALAN_PERF_DIAG_SKIP_BUILD=1` is used, the capture script now defaults to
+  the repo UI-smoke DerivedData `Alan.app` instead of the user's installed
+  `Alan Dev.app`.
+- The capture script still accepts explicit `ALAN_UI_SMOKE_APP_PATH` and
+  `ALAN_UI_SMOKE_APP_EXECUTABLE` overrides for controlled validation.

--- a/openspec/changes/add-macos-performance-diagnostics/proposal.md
+++ b/openspec/changes/add-macos-performance-diagnostics/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Recent macOS terminal performance work reduced some background rendering work,
+but real daily use with multiple high-output Codex CLI sessions still feels low
+frame-rate and sluggish. alan needs a user-accessible diagnostics mode that can
+attribute stutter to Alan main-thread work, embedded Ghostty terminal work,
+SwiftUI state projection, or child-process CPU pressure before making another
+optimization pass.
+
+## What Changes
+
+- Add a macOS Settings-controlled `Performance Diagnostics` toggle, default off
+  and available in all install channels.
+- When enabled, collect a bounded in-memory performance trace for recent Alan
+  terminal and shell activity without recording terminal text, prompts, command
+  lines, cwd, repository paths, file paths, environment variables, or secrets.
+- Record compact event and summary data for Ghostty wakeup/tick/refresh,
+  terminal surface attach/catch-up, runtime snapshot publication, metadata
+  callbacks, shell projection, pane-state publication, render priority, and
+  visibility.
+- Add low-frequency process sampling for Alan process CPU/thread metrics and
+  aggregate child-process CPU pressure, without recording command lines.
+- Provide an `Export Recent Diagnostics` action that writes the current local
+  ring-buffer trace and summary to a user-selected diagnostics bundle.
+- Add automatic stutter markers for threshold-crossing main-thread or shell /
+  terminal event durations instead of requiring users to manually mark lag.
+- Keep the first implementation diagnostic-only: it must not change terminal
+  scheduling, rendering, focus, lazy rendering, or process lifecycle behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Add a default-off Settings diagnostics
+  control and export action that remain progressively disclosed rather than
+  default shell chrome.
+- `macos-terminal-runtime-foundation`: Define the privacy-preserving
+  performance trace and process-sampling contract for terminal runtime,
+  rendering, metadata, publication, and shell projection events.
+- `macos-shell-build-test-contract`: Require focused verification that
+  diagnostics can be toggled, export bounded traces, preserve privacy
+  boundaries, and support real-workload diagnosis without changing terminal
+  behavior.
+
+## Impact
+
+- `clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift` and
+  related Settings views will need a compact diagnostics toggle and export row.
+- `clients/apple/alan-macos/TerminalHostRuntime.swift`,
+  `TerminalRuntimeService.swift`, `TerminalHostView.swift`,
+  `TerminalSurfaceController.swift`, and `GhosttyLiveHost.swift` will need
+  narrow probe points around terminal runtime and rendering events.
+- `clients/apple/alan-macos/ShellHostController.swift` and shell projection
+  helpers will need probe points around runtime publication, metadata
+  projection, selection/focus changes, and pane-state updates.
+- A diagnostics controller, event recorder, process sampler, and export writer
+  will need to live behind a low-overhead no-op boundary when diagnostics are
+  disabled.
+- Focused Apple scripts/tests will need privacy, bounded-buffer, toggle,
+  export, and summary coverage.

--- a/openspec/changes/add-macos-performance-diagnostics/real-workload-diagnostics.md
+++ b/openspec/changes/add-macos-performance-diagnostics/real-workload-diagnostics.md
@@ -1,0 +1,53 @@
+# Real Workload Diagnostics Evidence
+
+## Capture
+
+- Run ID: `20260601-195137`
+- Launch path: controlled UI-smoke Debug app with dev install-channel metadata.
+- Bundle:
+  `/Users/morris/Developer/Alan/debug/artifacts/performance-diagnostics-workload/20260601-195137/export/alan-performance-diagnostics-1780314760886`
+- Exported files:
+  - `events.jsonl`
+  - `summary.json`
+- Workload shape: four terminal panes received programmatic workload text and an
+  explicit `terminal.send_key` return key. The workload created four pid files
+  under the run artifact and emitted terminal-output-like high-volume text.
+
+The script reached diagnostics export and produced a valid bundle. A later
+review-summary counting step initially exited under `pipefail` when
+`automaticStutterMarker` had zero matches; the counting helper now treats zero
+matches as `0`.
+
+## Diagnostic Usefulness Review
+
+The summary and retained events distinguish the relevant sources:
+
+| Signal | Evidence |
+| --- | --- |
+| Alan app CPU pressure | `summary.json` includes `alanApp` process samples, with observed CPU up to `125.6`. |
+| Main-thread/event duration | `events.jsonl` includes per-event `thread` and `duration_ms`; max observed `terminalRendererUpdate` duration was `50.659792 ms`. |
+| Ghostty tick/refresh/wakeup | `events.jsonl` contains `910` Ghostty timing events across `ghosttyWakeup`, `ghosttyAppTick`, and `ghosttySurfaceRefresh`; max `ghosttyWakeup` duration was `19.837958 ms`. |
+| Shell projection | `events.jsonl` contains `135` `shellRuntimeProjection` events; max observed duration was `8.521834 ms`. |
+| Runtime publication | `events.jsonl` contains `269` `runtimeSnapshotPublish` events; max observed duration was `0.915959 ms`. |
+| Child-process aggregate CPU | `summary.json` contains `3` `terminalChild` aggregate samples, with no command line, cwd, environment, or terminal text. |
+
+The run did not cross the configured automatic stutter thresholds:
+`stutterMarkerCount` is `0`. That is still diagnostically useful because the
+bundle separates raw event families and child CPU pressure, so a no-stutter run
+can be distinguished from missing instrumentation.
+
+## Privacy Review
+
+Manual review and grep checks were run against `events.jsonl` and `summary.json`.
+The exported diagnostics did not contain:
+
+- terminal workload marker text (`alan-perf-diag`)
+- the repository path used for the capture
+- command-line fields
+- working-directory fields
+- environment fields
+- `OPENAI_API_KEY`
+- `refresh-token`
+
+Pane/content correlation is preserved with hashed IDs such as `pane_id_hash` and
+`content_id_hash`; raw pane/content IDs are not required in the exported bundle.

--- a/openspec/changes/add-macos-performance-diagnostics/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-performance-diagnostics/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Performance diagnostics have focused verification
+The Apple client SHALL include focused verification for the performance
+diagnostics toggle, bounded capture, export format, privacy boundary, and
+behavior-neutral probe contract.
+
+#### Scenario: Diagnostics toggle verified
+- **WHEN** focused diagnostics tests exercise the Settings diagnostics toggle
+- **THEN** tests verify that diagnostics are disabled by default, start
+  recording only after the toggle is enabled, and stop recording after the
+  toggle is disabled
+
+#### Scenario: Export bundle verified
+- **WHEN** diagnostics export is tested with retained events
+- **THEN** tests verify the exported bundle contains `events.jsonl`,
+  `summary.json`, app/build metadata, schema version, sampling interval, and
+  capture-window metadata
+
+#### Scenario: Privacy boundary verified
+- **WHEN** diagnostics tests create terminal output, command-like text, cwd-like
+  strings, path-like strings, and secret-like strings in fixtures
+- **THEN** export validation verifies those values are absent from the
+  diagnostics bundle
+- **AND** validation verifies process samples do not include command lines,
+  command arguments, cwd strings, environment variables, or raw secret values
+
+#### Scenario: Bounded capture verified
+- **WHEN** diagnostics tests generate more events than the configured retention
+  limit
+- **THEN** tests verify older events are evicted and diagnostics memory state
+  remains bounded
+
+#### Scenario: Behavior-neutral probes verified
+- **WHEN** diagnostics are enabled in focused runtime tests
+- **THEN** tests verify terminal scheduling, rendering priority, focus,
+  publication, and process lifecycle results match the same scenario with
+  diagnostics disabled
+
+#### Scenario: Real-workload diagnosis captured
+- **WHEN** maintainers run a real multi-Codex terminal workload for performance
+  investigation
+- **THEN** the recorded diagnostics summary can distinguish Alan main-thread
+  long events, Ghostty tick or refresh spikes, shell projection spikes, runtime
+  publication spikes, and child-process aggregate CPU pressure without
+  inspecting terminal content

--- a/openspec/changes/add-macos-performance-diagnostics/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-performance-diagnostics/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Performance diagnostics are opt-in Settings controls
+The macOS shell SHALL expose performance diagnostics through Settings as a
+default-off, progressively disclosed control rather than default shell chrome.
+
+#### Scenario: Diagnostics default off
+- **WHEN** a user opens Alan for macOS with no prior diagnostics preference
+- **THEN** performance diagnostics are disabled
+- **AND** the default shell, sidebar, terminal panes, and toolbar do not show
+  persistent diagnostics chrome
+
+#### Scenario: Diagnostics enabled from Settings
+- **WHEN** the user enables `Performance Diagnostics` in Settings
+- **THEN** Alan begins collecting recent local performance diagnostics
+- **AND** the Settings surface communicates that diagnostics are local and
+  intended for performance investigation
+
+#### Scenario: Recent diagnostics exported
+- **WHEN** diagnostics are enabled and the user invokes `Export Recent Diagnostics`
+- **THEN** Alan exports the currently retained local diagnostics bundle without
+  requiring the user to manually start, stop, or mark a capture window
+
+#### Scenario: Diagnostics disabled
+- **WHEN** the user disables `Performance Diagnostics`
+- **THEN** Alan stops collecting diagnostics
+- **AND** unexported in-memory diagnostics are cleared
+- **AND** already exported local bundles remain under user control
+
+#### Scenario: Settings remains shell-native
+- **WHEN** the diagnostics control is visible in Settings
+- **THEN** it uses compact Settings row treatment
+- **AND** it does not introduce a dashboard, inspector, timeline viewer, or
+  debug-heavy panel into the default shell

--- a/openspec/changes/add-macos-performance-diagnostics/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-macos-performance-diagnostics/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Performance diagnostics capture behavior-neutral terminal events
+The macOS terminal runtime SHALL support a behavior-neutral performance
+diagnostics recorder that captures recent terminal and shell performance events
+only while diagnostics are enabled.
+
+#### Scenario: Diagnostics disabled
+- **WHEN** performance diagnostics are disabled
+- **THEN** terminal and shell probe points do not append diagnostic events
+- **AND** terminal scheduling, rendering, focus, publication, and process
+  lifecycle behavior are unchanged
+
+#### Scenario: Terminal events recorded
+- **WHEN** performance diagnostics are enabled and terminal runtime activity
+  occurs
+- **THEN** Alan records compact event metadata for Ghostty wakeup, app tick,
+  surface refresh, surface attach, catch-up refresh, runtime snapshot
+  publication, metadata callbacks, scrollback or renderer updates, render
+  priority, and visibility where those events occur
+- **AND** the recorder includes event timestamps, categories, durations, counts,
+  pane or content correlation IDs, and foreground / visible background / hidden
+  background grouping
+
+#### Scenario: Shell projection events recorded
+- **WHEN** performance diagnostics are enabled and terminal runtime state is
+  projected into shell state
+- **THEN** Alan records compact event metadata for runtime projection,
+  pane-state publication, selection changes, focus changes, and priority
+  synchronization
+- **AND** the recorder marks threshold-crossing long events as automatic
+  stutter markers
+
+#### Scenario: Process pressure sampled
+- **WHEN** performance diagnostics are enabled
+- **THEN** Alan samples Alan process CPU, memory, thread count, and known
+  terminal child-process aggregate CPU at a bounded low frequency
+- **AND** process samples do not include command lines, command arguments,
+  working directories, environment variables, or terminal text
+
+### Requirement: Performance diagnostics preserve content privacy
+Performance diagnostics SHALL NOT record terminal text, prompts, stdout/stderr
+content, command lines, working directories, repository names, file paths,
+environment variables, secrets, bearer tokens, API keys, refresh tokens, or raw
+provider/auth store values.
+
+#### Scenario: Terminal output is active
+- **WHEN** diagnostics are enabled while terminal panes produce output
+- **THEN** the diagnostics trace records timing, count, priority, visibility,
+  and process metrics only
+- **AND** the exported diagnostics bundle does not contain the terminal output
+  text
+
+#### Scenario: Process sampling runs
+- **WHEN** the process sampler observes Alan or terminal child processes
+- **THEN** diagnostics record numeric process metrics and process identifiers
+- **AND** diagnostics do not record command-line strings or current working
+  directory strings
+
+#### Scenario: Diagnostics bundle is inspected
+- **WHEN** a diagnostics bundle is exported
+- **THEN** the bundle contains `events.jsonl` and `summary.json`
+- **AND** those files omit terminal content, command-line, cwd, path,
+  environment, and secret fields
+
+### Requirement: Performance diagnostics are bounded and exportable
+The macOS terminal runtime SHALL keep diagnostics bounded in memory and SHALL
+export only the currently retained recent diagnostics when requested.
+
+#### Scenario: Long-running diagnostics session
+- **WHEN** diagnostics remain enabled for longer than the configured retention
+  window
+- **THEN** Alan evicts older diagnostic events and summaries according to the
+  bounded ring-buffer policy
+- **AND** diagnostics memory usage does not grow without bound
+
+#### Scenario: Export recent diagnostics
+- **WHEN** the user exports recent diagnostics
+- **THEN** Alan writes a local diagnostics bundle containing retained events,
+  aggregate summary, app version, install channel, schema version, sampling
+  intervals, and capture window metadata
+- **AND** exporting diagnostics does not change terminal runtime scheduling,
+  rendering, focus, or process lifecycle behavior

--- a/openspec/changes/add-macos-performance-diagnostics/tasks.md
+++ b/openspec/changes/add-macos-performance-diagnostics/tasks.md
@@ -1,86 +1,86 @@
 ## 1. Diagnostics Model And State
 
-- [ ] 1.1 Define the diagnostics state machine, preference storage, and
+- [x] 1.1 Define the diagnostics state machine, preference storage, and
   disabled no-op boundary for all performance probes.
-- [ ] 1.2 Define versioned event, summary, stutter-marker, process-sample, and
+- [x] 1.2 Define versioned event, summary, stutter-marker, process-sample, and
   export metadata models without terminal-content, command-line, cwd, path,
   environment, or secret fields.
-- [ ] 1.3 Implement the bounded in-memory ring buffer and fixed-window summary
+- [x] 1.3 Implement the bounded in-memory ring buffer and fixed-window summary
   aggregation with configurable retention limits.
-- [ ] 1.4 Add automatic stutter markers for threshold-crossing main-thread,
+- [x] 1.4 Add automatic stutter markers for threshold-crossing main-thread,
   terminal, and shell projection durations.
 
 ## 2. Settings And Export Surface
 
-- [ ] 2.1 Add the default-off `Performance Diagnostics` setting to the existing
+- [x] 2.1 Add the default-off `Performance Diagnostics` setting to the existing
   macOS Settings model and view structure.
-- [ ] 2.2 Add `Export Recent Diagnostics` as a compact Settings action that
+- [x] 2.2 Add `Export Recent Diagnostics` as a compact Settings action that
   exports the currently retained local buffer without requiring manual
   start/stop or manual lag markers.
-- [ ] 2.3 Ensure disabling diagnostics stops capture and clears unexported
+- [x] 2.3 Ensure disabling diagnostics stops capture and clears unexported
   in-memory buffers while leaving exported local bundles untouched.
-- [ ] 2.4 Keep diagnostics controls out of default shell chrome, sidebar,
+- [x] 2.4 Keep diagnostics controls out of default shell chrome, sidebar,
   toolbar, terminal overlays, and inspector-like surfaces.
 
 ## 3. Terminal And Shell Probes
 
-- [ ] 3.1 Add terminal probes around Ghostty wakeup, app tick, surface refresh,
+- [x] 3.1 Add terminal probes around Ghostty wakeup, app tick, surface refresh,
   surface attach, and catch-up refresh paths.
-- [ ] 3.2 Add runtime probes around terminal runtime snapshot publication,
+- [x] 3.2 Add runtime probes around terminal runtime snapshot publication,
   metadata callbacks, scrollback updates, renderer updates, priority changes,
   and visibility changes.
-- [ ] 3.3 Add shell probes around `ShellHostController.updateTerminalRuntime`,
+- [x] 3.3 Add shell probes around `ShellHostController.updateTerminalRuntime`,
   projection into shell state, pane-state publication, selection changes, focus
   changes, and priority synchronization.
-- [ ] 3.4 Verify probe calls are behavior-neutral and do not alter scheduling,
+- [x] 3.4 Verify probe calls are behavior-neutral and do not alter scheduling,
   rendering priority, focus, publication, or terminal process lifecycle.
 
 ## 4. Process Sampling
 
-- [ ] 4.1 Add low-frequency process sampling for Alan process CPU, memory, and
+- [x] 4.1 Add low-frequency process sampling for Alan process CPU, memory, and
   thread count.
-- [ ] 4.2 Add known terminal child-process aggregate CPU sampling without
+- [x] 4.2 Add known terminal child-process aggregate CPU sampling without
   command-line, argument, cwd, environment, or output capture.
-- [ ] 4.3 Represent unknown or partially attributed child CPU pressure
+- [x] 4.3 Represent unknown or partially attributed child CPU pressure
   explicitly in summary output.
 
 ## 5. Export Format And Privacy
 
-- [ ] 5.1 Write local diagnostics bundles with `events.jsonl`, `summary.json`,
+- [x] 5.1 Write local diagnostics bundles with `events.jsonl`, `summary.json`,
   app/build metadata, install channel, schema version, sampling intervals, and
   capture window metadata.
-- [ ] 5.2 Exclude terminal text, prompt text, stdout/stderr content, command
+- [x] 5.2 Exclude terminal text, prompt text, stdout/stderr content, command
   lines, cwd, repository names, file paths, environment variables, bearer
   tokens, API keys, refresh tokens, and raw provider/auth store values from all
   exported files.
-- [ ] 5.3 Decide whether exported pane/content identifiers are stable IDs or
+- [x] 5.3 Decide whether exported pane/content identifiers are stable IDs or
   hashed IDs, and keep cross-event correlation possible within one bundle.
 
 ## 6. Verification
 
-- [ ] 6.1 Add focused tests proving diagnostics are off by default, record only
+- [x] 6.1 Add focused tests proving diagnostics are off by default, record only
   when enabled, and stop recording when disabled.
-- [ ] 6.2 Add bounded-buffer tests proving old events are evicted and memory
+- [x] 6.2 Add bounded-buffer tests proving old events are evicted and memory
   state does not grow without bound.
-- [ ] 6.3 Add export tests proving bundle files, schema metadata, summary
+- [x] 6.3 Add export tests proving bundle files, schema metadata, summary
   windows, stutter markers, priority grouping, and process samples are present.
-- [ ] 6.4 Add privacy tests using terminal-output-like, command-like, cwd-like,
+- [x] 6.4 Add privacy tests using terminal-output-like, command-like, cwd-like,
   path-like, environment-like, and secret-like fixture strings and verify they
   are absent from exported diagnostics.
-- [ ] 6.5 Add behavior-neutral tests comparing representative terminal runtime
+- [x] 6.5 Add behavior-neutral tests comparing representative terminal runtime
   scenarios with diagnostics disabled and enabled.
-- [ ] 6.6 Run focused Apple shell/runtime diagnostics tests and the relevant
+- [x] 6.6 Run focused Apple shell/runtime diagnostics tests and the relevant
   shell contract scripts.
-- [ ] 6.7 Capture one real multi-Codex workload diagnostics bundle and record
+- [x] 6.7 Capture one real multi-Codex workload diagnostics bundle and record
   whether the summary distinguishes Alan main-thread long events, Ghostty
   tick/refresh spikes, shell projection spikes, runtime publication spikes, and
   child-process aggregate CPU pressure.
 
 ## 7. Review And Archive Readiness
 
-- [ ] 7.1 Run `openspec validate add-macos-performance-diagnostics --strict`.
-- [ ] 7.2 Run `openspec validate --all --strict`.
-- [ ] 7.3 Review exported diagnostics output manually for privacy and diagnostic
+- [x] 7.1 Run `openspec validate add-macos-performance-diagnostics --strict`.
+- [x] 7.2 Run `openspec validate --all --strict`.
+- [x] 7.3 Review exported diagnostics output manually for privacy and diagnostic
   usefulness before claiming the change is ready.
 - [ ] 7.4 Before archiving after merge, sync accepted delta requirements into
   `openspec/specs/`.

--- a/openspec/changes/add-macos-performance-diagnostics/tasks.md
+++ b/openspec/changes/add-macos-performance-diagnostics/tasks.md
@@ -1,0 +1,88 @@
+## 1. Diagnostics Model And State
+
+- [ ] 1.1 Define the diagnostics state machine, preference storage, and
+  disabled no-op boundary for all performance probes.
+- [ ] 1.2 Define versioned event, summary, stutter-marker, process-sample, and
+  export metadata models without terminal-content, command-line, cwd, path,
+  environment, or secret fields.
+- [ ] 1.3 Implement the bounded in-memory ring buffer and fixed-window summary
+  aggregation with configurable retention limits.
+- [ ] 1.4 Add automatic stutter markers for threshold-crossing main-thread,
+  terminal, and shell projection durations.
+
+## 2. Settings And Export Surface
+
+- [ ] 2.1 Add the default-off `Performance Diagnostics` setting to the existing
+  macOS Settings model and view structure.
+- [ ] 2.2 Add `Export Recent Diagnostics` as a compact Settings action that
+  exports the currently retained local buffer without requiring manual
+  start/stop or manual lag markers.
+- [ ] 2.3 Ensure disabling diagnostics stops capture and clears unexported
+  in-memory buffers while leaving exported local bundles untouched.
+- [ ] 2.4 Keep diagnostics controls out of default shell chrome, sidebar,
+  toolbar, terminal overlays, and inspector-like surfaces.
+
+## 3. Terminal And Shell Probes
+
+- [ ] 3.1 Add terminal probes around Ghostty wakeup, app tick, surface refresh,
+  surface attach, and catch-up refresh paths.
+- [ ] 3.2 Add runtime probes around terminal runtime snapshot publication,
+  metadata callbacks, scrollback updates, renderer updates, priority changes,
+  and visibility changes.
+- [ ] 3.3 Add shell probes around `ShellHostController.updateTerminalRuntime`,
+  projection into shell state, pane-state publication, selection changes, focus
+  changes, and priority synchronization.
+- [ ] 3.4 Verify probe calls are behavior-neutral and do not alter scheduling,
+  rendering priority, focus, publication, or terminal process lifecycle.
+
+## 4. Process Sampling
+
+- [ ] 4.1 Add low-frequency process sampling for Alan process CPU, memory, and
+  thread count.
+- [ ] 4.2 Add known terminal child-process aggregate CPU sampling without
+  command-line, argument, cwd, environment, or output capture.
+- [ ] 4.3 Represent unknown or partially attributed child CPU pressure
+  explicitly in summary output.
+
+## 5. Export Format And Privacy
+
+- [ ] 5.1 Write local diagnostics bundles with `events.jsonl`, `summary.json`,
+  app/build metadata, install channel, schema version, sampling intervals, and
+  capture window metadata.
+- [ ] 5.2 Exclude terminal text, prompt text, stdout/stderr content, command
+  lines, cwd, repository names, file paths, environment variables, bearer
+  tokens, API keys, refresh tokens, and raw provider/auth store values from all
+  exported files.
+- [ ] 5.3 Decide whether exported pane/content identifiers are stable IDs or
+  hashed IDs, and keep cross-event correlation possible within one bundle.
+
+## 6. Verification
+
+- [ ] 6.1 Add focused tests proving diagnostics are off by default, record only
+  when enabled, and stop recording when disabled.
+- [ ] 6.2 Add bounded-buffer tests proving old events are evicted and memory
+  state does not grow without bound.
+- [ ] 6.3 Add export tests proving bundle files, schema metadata, summary
+  windows, stutter markers, priority grouping, and process samples are present.
+- [ ] 6.4 Add privacy tests using terminal-output-like, command-like, cwd-like,
+  path-like, environment-like, and secret-like fixture strings and verify they
+  are absent from exported diagnostics.
+- [ ] 6.5 Add behavior-neutral tests comparing representative terminal runtime
+  scenarios with diagnostics disabled and enabled.
+- [ ] 6.6 Run focused Apple shell/runtime diagnostics tests and the relevant
+  shell contract scripts.
+- [ ] 6.7 Capture one real multi-Codex workload diagnostics bundle and record
+  whether the summary distinguishes Alan main-thread long events, Ghostty
+  tick/refresh spikes, shell projection spikes, runtime publication spikes, and
+  child-process aggregate CPU pressure.
+
+## 7. Review And Archive Readiness
+
+- [ ] 7.1 Run `openspec validate add-macos-performance-diagnostics --strict`.
+- [ ] 7.2 Run `openspec validate --all --strict`.
+- [ ] 7.3 Review exported diagnostics output manually for privacy and diagnostic
+  usefulness before claiming the change is ready.
+- [ ] 7.4 Before archiving after merge, sync accepted delta requirements into
+  `openspec/specs/`.
+- [ ] 7.5 Archive the completed change only after implementation, verification,
+  PR review, and merge are complete.


### PR DESCRIPTION
## Summary
- add default-off macOS Performance Diagnostics settings toggle and local export action
- record bounded, privacy-preserving terminal/shell/runtime/process diagnostics with hashed pane/content correlation
- add focused tests, workload capture script, and OpenSpec readiness evidence

## Verification
- bash -n clients/apple/scripts/capture-performance-diagnostics-workload.sh
- bash clients/apple/scripts/test-shell-performance-diagnostics.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-shell-settings-surface.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- just apple-shell-focused-tests
- openspec validate add-macos-performance-diagnostics --strict
- openspec validate --all --strict
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-xcode-derived-perfdiag-rebased -clonedSourcePackagesDirPath /private/tmp/alan-xcode-spm-perfdiag-rebased -skipPackagePluginValidation -skipMacroValidation build

OpenSpec remains at 28/30; 7.4 and 7.5 are intentionally post-merge/archive tasks.