### PR TITLE
Polish macOS sidebar space slider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,6 +399,13 @@ placement contract at
 choose inline unit tests, extracted white-box tests, or crate-level integration
 tests deliberately.
 
+### Specification Workflow
+
+Use OpenSpec for all Alan change proposals, design docs, task lists, and spec
+deltas. Do not create Superpowers spec files under `docs/superpowers/specs/`
+for this repository. When a change needs a written design or implementation
+plan, create or update an `openspec/changes/<change-id>/` change instead.
+
 ---
 
 ## Configuration

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -448,6 +448,8 @@ struct MacShellRootView: View {
                 ShellSidebarNewSpaceControl {
                     _ = host.createTerminalSpace()
                 }
+                .disabled(!canCreateTerminalSpace)
+                .opacity(canCreateTerminalSpace ? 1 : 0.38)
                 .contentShape(Rectangle())
                 .onHover(perform: handleCollapsedSidebarToolbarHover)
             }
@@ -460,6 +462,10 @@ struct MacShellRootView: View {
         }
         .ignoresSafeArea(edges: .top)
         .zIndex(30)
+    }
+
+    private var canCreateTerminalSpace: Bool {
+        host.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces
     }
 }
 

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -432,27 +432,30 @@ struct MacShellRootView: View {
 
     private var sidebarChromeControls: some View {
         GeometryReader { _ in
-            HStack(spacing: ShellSidebarMetrics.titlebarToolSpacing) {
-                ShellSidebarCollapseControl(isCollapsed: isSidebarCollapsed) {
-                    updateSidebarCollapsed(!isSidebarCollapsed)
-                }
+            HStack(spacing: 0) {
+                HStack(spacing: ShellSidebarMetrics.titlebarToolSpacing) {
+                    ShellSidebarCollapseControl(isCollapsed: isSidebarCollapsed) {
+                        updateSidebarCollapsed(!isSidebarCollapsed)
+                    }
 
-                ShellAppearanceModeControl(mode: $appearanceMode)
+                    ShellAppearanceModeControl(mode: $appearanceMode)
+                }
+                .contentShape(Rectangle())
+                .onHover(perform: handleCollapsedSidebarToolbarHover)
+
+                Spacer(minLength: ShellSidebarMetrics.titlebarToolSpacing)
+
+                ShellSidebarNewSpaceControl {
+                    _ = host.createTerminalSpace()
+                }
+                .contentShape(Rectangle())
+                .onHover(perform: handleCollapsedSidebarToolbarHover)
             }
-            .padding(
-                .leading,
-                windowChromeMetrics.titlebarToolLeadingInset
-            )
-            .padding(
-                .top,
-                windowChromeMetrics.titlebarToolTopInset
-            )
-            .offset(
-                x: sidebarChromeSurfaceOrigin.x,
-                y: sidebarChromeSurfaceOrigin.y
-            )
-            .contentShape(Rectangle())
-            .onHover(perform: handleCollapsedSidebarToolbarHover)
+            .padding(.leading, windowChromeMetrics.titlebarToolLeadingInset)
+            .padding(.trailing, ShellSidebarMetrics.edgeInset)
+            .padding(.top, windowChromeMetrics.titlebarToolTopInset)
+            .frame(width: sidebarPresentation.surfaceWidth, alignment: .topLeading)
+            .offset(x: sidebarChromeSurfaceOrigin.x, y: sidebarChromeSurfaceOrigin.y)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .ignoresSafeArea(edges: .top)
@@ -552,6 +555,19 @@ private struct ShellAppearanceModeControl: View {
         ) {
             mode = mode.next
         }
+    }
+}
+
+private struct ShellSidebarNewSpaceControl: View {
+    let action: () -> Void
+
+    var body: some View {
+        ShellGhostChromeButton(
+            systemName: "plus",
+            help: "Create Space",
+            accessibilityLabel: "Create Space",
+            action: action
+        )
     }
 }
 

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -50,6 +50,19 @@ enum AlanShellLocalCommandExecutor {
             )
 
         case .spaceCreate:
+            guard state.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
+                return AlanShellLocalCommandResult(
+                    response: response(
+                        for: command,
+                        state: state,
+                        applied: false,
+                        errorCode: "space_create_failed",
+                        errorMessage: "Failed to create a new shell space."
+                    ),
+                    updatedState: nil,
+                    sideEffect: nil
+                )
+            }
             let resolvedTerminalProfileID = command.terminalProfileID
                 ?? terminalProfileIDForGlobalDefaultPaneCapture()
             let result = state.creatingSpace(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1137,6 +1137,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
+        guard shellState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
+            return nil
+        }
         let resolvedTerminalProfileID = terminalProfileID
             ?? globalDefaultTerminalProfileIDForPaneCapture()
         let result = shellState.creatingSpace(
@@ -1156,9 +1159,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        guard shellState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
-            return nil
-        }
         return createSpace(
             launchTarget: .shell,
             title: title,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1156,7 +1156,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        createSpace(
+        guard shellState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
+            return nil
+        }
+        return createSpace(
             launchTarget: .shell,
             title: title,
             workingDirectory: workingDirectory,

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum ShellSidebarSpaceSliderPolicy {
+    static let maximumVisibleSpaces = 8
+}
+
 struct ShellSidebarTabProjection: Equatable {
     let title: String
     let secondaryLine: String

--- a/clients/apple/alan-macos/Support/ShellDesignTokens.swift
+++ b/clients/apple/alan-macos/Support/ShellDesignTokens.swift
@@ -263,10 +263,6 @@ enum ShellSidebarMetrics {
     static let rowInset: CGFloat = 10
     static let iconColumnWidth: CGFloat = 16
     static let iconPointSize: CGFloat = 12
-    static let spaceDockInternalVerticalPadding: CGFloat = 2
-    static var spaceDockOuterBottomInset: CGFloat {
-        max(edgeInset - spaceDockInternalVerticalPadding, 0)
-    }
     static let trafficLightLeadingInset: CGFloat = 14
     static let trafficLightTopInset: CGFloat = 16
     static let trafficLightFallbackGroupWidth: CGFloat = 58

--- a/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
+++ b/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
@@ -323,8 +323,14 @@ enum ShellWindowDoubleClickZoomHitTesting {
             windowSize: windowSize,
             chromeSurface: chromeSurface
         )
+        let hitsTrailingTitlebarControl =
+            chromeSurface.width.map {
+                sidebarTrailingTitlebarToolControlFrame(surfaceWidth: $0).contains(localPoint)
+            } ?? false
+
         return standardTrafficLightControlFrames.contains { $0.contains(localPoint) }
-            || sidebarTitlebarToolControlFrame.contains(localPoint)
+            || sidebarLeadingTitlebarToolControlFrame.contains(localPoint)
+            || hitsTrailingTitlebarControl
     }
 
     private static var standardTrafficLightGroupFrame: CGRect {
@@ -351,7 +357,7 @@ enum ShellWindowDoubleClickZoomHitTesting {
         }
     }
 
-    private static var sidebarTitlebarToolControlFrame: CGRect {
+    private static var sidebarLeadingTitlebarToolControlFrame: CGRect {
         let trafficLights = standardTrafficLightGroupFrame
         let firstButtonX = trafficLights.maxX + ShellSidebarMetrics.titlebarToolGapAfterTrafficLights
         let buttonCount: CGFloat = 2
@@ -365,6 +371,22 @@ enum ShellWindowDoubleClickZoomHitTesting {
             width: totalButtonWidth,
             height: ShellSidebarMetrics.titlebarToolHeight
         )
+    }
+
+    private static func sidebarTrailingTitlebarToolControlFrame(surfaceWidth: CGFloat) -> CGRect {
+        CGRect(
+            x: surfaceWidth
+                - ShellSidebarMetrics.edgeInset
+                - ShellSidebarMetrics.titlebarToolWidth,
+            y: titlebarToolY,
+            width: ShellSidebarMetrics.titlebarToolWidth,
+            height: ShellSidebarMetrics.titlebarToolHeight
+        )
+    }
+
+    private static var titlebarToolY: CGFloat {
+        let trafficLights = standardTrafficLightGroupFrame
+        return max(0, trafficLights.midY - (ShellSidebarMetrics.titlebarToolHeight / 2))
     }
 
     private static func localTopLeadingPoint(

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 #if os(macOS)
+enum ShellSidebarSpaceSliderPolicy {
+    static let maximumVisibleSpaces = 8
+}
+
 struct ShellSidebarView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var host: ShellHostController
@@ -66,7 +70,8 @@ struct ShellSidebarView: View {
         ShellSidebarSpaceSlider(
             host: host,
             displaySpaceID: sourceSpaceID,
-            previewedSpaceID: previewedSpaceID
+            previewedSpaceID: previewedSpaceID,
+            activityFreshnessNow: activityFreshnessNow
         )
         .frame(maxWidth: .infinity)
         .frame(height: 30)
@@ -915,16 +920,16 @@ private struct ShellSidebarScrollBoundary: View {
 }
 
 private struct ShellSidebarSpaceSlider: View {
-    private static let maximumVisibleSpaces = 8
     @ObservedObject var host: ShellHostController
     let displaySpaceID: String?
     let previewedSpaceID: String?
+    let activityFreshnessNow: Date
     @State private var hoveredSpaceID: String?
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 7) {
-                ForEach(Array(host.spaces.prefix(Self.maximumVisibleSpaces))) { space in
+                ForEach(Array(host.spaces.prefix(ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces))) { space in
                     if isDisplaySpace(space) {
                         selectedTitle(for: space)
                     } else {
@@ -1029,7 +1034,7 @@ private struct ShellSidebarSpaceSlider: View {
     private func strongestAttention(for space: ShellSpace) -> ShellAttentionState {
         host.shellState.panes
             .filter { $0.spaceID == space.spaceID }
-            .map { shellEffectiveAttention(for: $0) }
+            .map { shellEffectiveAttention(for: $0, now: activityFreshnessNow) }
             .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
             ?? .idle
     }

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -2,10 +2,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 #if os(macOS)
-enum ShellSidebarSpaceSliderPolicy {
-    static let maximumVisibleSpaces = 8
-}
-
 struct ShellSidebarView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var host: ShellHostController

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -12,7 +12,6 @@ struct ShellSidebarView: View {
     @State private var spacePagerToken = 0
     @State private var spacePagerPageWidth: CGFloat = 1
     @State private var hoveredTabID: String?
-    @State private var hoveredSpaceID: String?
     @State private var tabListScrollOffsetY: CGFloat = 0
     @State private var activityFreshnessNow = Date()
     @State private var activeTabDrag: ShellSidebarTabDragState?
@@ -54,14 +53,23 @@ struct ShellSidebarView: View {
 
     private var sidebarContent: some View {
         VStack(alignment: .leading, spacing: 0) {
+            fixedSpaceSlider
+                .padding(.bottom, 2)
             spaceContentPager
-            spaceDock
-                .padding(.horizontal, ShellSidebarMetrics.edgeInset)
-                .padding(.top, 10)
         }
         .padding(.top, chromeMetrics.commandLauncherTopInset)
-        .padding(.bottom, ShellSidebarMetrics.spaceDockOuterBottomInset)
+        .padding(.bottom, ShellSidebarMetrics.edgeInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var fixedSpaceSlider: some View {
+        ShellSidebarSpaceSlider(
+            host: host,
+            displaySpaceID: sourceSpaceID,
+            previewedSpaceID: previewedSpaceID
+        )
+        .frame(maxWidth: .infinity)
+        .frame(height: 30)
     }
 
     private var spaceContentPager: some View {
@@ -69,11 +77,7 @@ struct ShellSidebarView: View {
             let pageWidth = max(proxy.size.width, 1)
             ZStack(alignment: .leading) {
                 ForEach(spacePageIndices, id: \.self) { index in
-                    VStack(alignment: .leading, spacing: 0) {
-                        spaceLabelRow(for: spaceID(forSpaceAt: index))
-                            .padding(.bottom, 2)
-                        tabSection(for: spaceID(forSpaceAt: index))
-                    }
+                    tabSection(for: spaceID(forSpaceAt: index))
                     .frame(width: pageWidth, height: proxy.size.height, alignment: .topLeading)
                     .offset(x: spacePageOffset(for: index, pageWidth: pageWidth))
                     .allowsHitTesting(spacePager == nil && index == selectedSpaceIndex)
@@ -88,15 +92,6 @@ struct ShellSidebarView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private func spaceLabelRow(for spaceID: String?) -> some View {
-        ShellSidebarSpaceHeader(
-            host: host,
-            spaceID: spaceID
-        )
-        .frame(maxWidth: .infinity)
-        .frame(height: 28)
     }
 
     private func tabSection(for spaceID: String?) -> some View {
@@ -125,17 +120,6 @@ struct ShellSidebarView: View {
             VStack(alignment: .leading, spacing: 0) {
                 if let space = space(for: spaceID) {
                     tabOrganizationSections(for: space)
-                    ShellCompactEmptyAction(
-                        title: "New Tab",
-                        systemImage: "plus",
-                        action: {
-                            host.performShellAction(
-                                .newTerminalTab,
-                                target: .contextSpace(space.spaceID)
-                            )
-                        }
-                    )
-                    .help("Create a tab in this space")
                 } else {
                     ShellCompactEmptyAction(
                         title: "New Space",
@@ -169,18 +153,31 @@ struct ShellSidebarView: View {
                 in: space,
                 section: .pinned
             )
-        }
-
-        if !pinnedTabs.isEmpty && !unpinnedTabs.isEmpty {
             ShellSidebarTabSectionDivider()
                 .padding(.vertical, 4)
         }
+
+        newTabRow(for: space)
 
         tabRows(
             unpinnedTabs,
             in: space,
             section: .unpinned
         )
+    }
+
+    private func newTabRow(for space: ShellSpace) -> some View {
+        ShellCompactEmptyAction(
+            title: "New Tab",
+            systemImage: "plus",
+            action: {
+                host.performShellAction(
+                    .newTerminalTab,
+                    target: .contextSpace(space.spaceID)
+                )
+            }
+        )
+        .help("Create a tab in this space")
     }
 
     @ViewBuilder
@@ -233,60 +230,6 @@ struct ShellSidebarView: View {
         ShellSidebarTabInsertionLine(
             isVisible: tabInsertionPreview == target
         )
-    }
-
-    private var spaceDock: some View {
-        HStack(spacing: 8) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 4) {
-                    ForEach(host.spaces) { space in
-                        Button {
-                            host.select(spaceID: space.spaceID)
-                        } label: {
-                            ShellSpaceSwitcherItem(
-                                title: space.title,
-                                symbolName: spaceSymbol(for: space),
-                                attention: strongestAttention(for: space),
-                                tabCount: space.tabs.count,
-                                isSelected: host.selectedSpace?.spaceID == space.spaceID,
-                                isPreviewed: previewedSpaceID == space.spaceID,
-                                isHovered: hoveredSpaceID == space.spaceID
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { isHovering in
-                            hoveredSpaceID = isHovering ? space.spaceID : nil
-                        }
-                    }
-                }
-                .padding(.vertical, ShellSidebarMetrics.spaceDockInternalVerticalPadding)
-            }
-
-            Button(action: createSpaceFromDock) {
-                Image(systemName: "plus")
-                    .font(.system(size: 12.5, weight: .semibold))
-                    .foregroundStyle(ShellPalette.sidebarInk.opacity(0.76))
-                    .frame(width: 30, height: 30)
-                    .background {
-                        if hoveredSpaceID == "__new_space__" {
-                            ShellMaterialShape(
-                                role: .controlGlassHover,
-                                shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                            )
-                        }
-                    }
-            }
-            .buttonStyle(.plain)
-            .help("Create a new space")
-            .accessibilityLabel("Create space")
-            .onHover { isHovering in
-                hoveredSpaceID = isHovering ? "__new_space__" : nil
-            }
-        }
-    }
-
-    private func createSpaceFromDock() {
-        _ = host.createTerminalSpace()
     }
 
     private func handleSpaceSwipe(_ update: ShellSidebarSwipeUpdate) {
@@ -784,27 +727,6 @@ struct ShellSidebarView: View {
             .first(where: { $0 != .idle })
     }
 
-    private func strongestAttention(for space: ShellSpace) -> ShellAttentionState {
-        host.shellState.panes
-            .filter { $0.spaceID == space.spaceID }
-            .map { shellEffectiveAttention(for: $0, now: activityFreshnessNow) }
-            .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
-            ?? .idle
-    }
-
-    private func spaceSymbol(for space: ShellSpace) -> String {
-        if space.tabs.count > 1 {
-            return "square.stack.3d.up"
-        }
-
-        let contentState = host.shellState.contentStateProjection()
-        if let content = space.tabs.lazy.compactMap({ contentState.primaryContent(in: $0.tabID) }).first {
-            return contentIconName(for: content)
-        }
-
-        return "terminal"
-    }
-
     private func showsAlanMarker(for tab: ShellTab, activity: TerminalActivitySnapshot?) -> Bool {
         false
     }
@@ -945,7 +867,7 @@ private struct ShellSidebarTabDropDelegate: DropDelegate {
 private struct ShellSidebarTabSectionDivider: View {
     var body: some View {
         Rectangle()
-            .fill(ShellPalette.line.opacity(0.18))
+            .fill(ShellPalette.line.opacity(0.30))
             .frame(height: 0.5)
             .padding(.horizontal, ShellSidebarMetrics.rowInset + 4)
             .allowsHitTesting(false)
@@ -992,103 +914,106 @@ private struct ShellSidebarScrollBoundary: View {
     }
 }
 
-private struct ShellSidebarSpaceHeader: View {
+private struct ShellSidebarSpaceSlider: View {
+    private static let maximumVisibleSpaces = 8
     @ObservedObject var host: ShellHostController
-    let spaceID: String?
+    let displaySpaceID: String?
+    let previewedSpaceID: String?
+    @State private var hoveredSpaceID: String?
 
     var body: some View {
-        headerPage(for: spaceID)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 26)
-    }
-
-    private func headerPage(for spaceID: String?) -> some View {
-        let space = space(for: spaceID)
-        return HStack(spacing: 10) {
-            Image(systemName: symbolName(for: space))
-                .font(.system(size: ShellSidebarMetrics.iconPointSize, weight: .semibold))
-                .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.78))
-                .frame(width: ShellSidebarMetrics.iconColumnWidth)
-
-            Text(space?.title ?? "Space")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.82))
-                .lineLimit(1)
-
-            Spacer(minLength: 4)
-
-            if let space {
-                terminalProfileMenu(for: space)
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 7) {
+                ForEach(Array(host.spaces.prefix(Self.maximumVisibleSpaces))) { space in
+                    if isDisplaySpace(space) {
+                        selectedTitle(for: space)
+                    } else {
+                        spaceDotButton(for: space)
+                    }
+                }
             }
+            .padding(.horizontal, ShellSidebarMetrics.edgeInset)
+            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, ShellSidebarMetrics.rowInset)
-        .padding(.vertical, 5)
-        .padding(.leading, ShellSidebarMetrics.edgeInset)
-        .padding(.trailing, ShellSidebarMetrics.edgeInset)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func space(for spaceID: String?) -> ShellSpace? {
-        guard let spaceID else { return host.selectedSpace }
-        return host.spaces.first { $0.spaceID == spaceID }
-    }
-
-    private func symbolName(for space: ShellSpace?) -> String {
-        guard let space else { return "terminal" }
-        if space.tabs.count > 1 {
-            return "square.stack.3d.up"
-        }
-
-        let contentState = host.shellState.contentStateProjection()
-        if let content = space.tabs.lazy.compactMap({ contentState.primaryContent(in: $0.tabID) }).first {
-            return contentIconName(for: content)
-        }
-
-        return "terminal"
-    }
-
-    private func terminalProfileMenu(for space: ShellSpace) -> some View {
-        let profiles = TerminalProfileStore.defaultStore().load().profiles
-        let current = profiles.first { $0.id == space.terminalProfileID }
-        return Menu {
-            Button("Default") {
-                _ = host.setTerminalProfile(nil, forSpaceID: space.spaceID)
-            }
-
-            ForEach(profiles, id: \.id) { profile in
-                Button(profileMenuTitle(profile)) {
-                    _ = host.setTerminalProfile(profile.id, forSpaceID: space.spaceID)
-                }
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: currentProfileSymbol(space: space, profile: current))
-                    .font(.system(size: 10, weight: .semibold))
-                if let current {
-                    Text(current.title)
-                        .font(.system(size: 10, weight: .medium))
-                        .lineLimit(1)
-                }
-            }
-            .foregroundStyle(profileForegroundStyle(space: space, profile: current))
-            .frame(maxWidth: 96, alignment: .trailing)
+    private func selectedTitle(for space: ShellSpace) -> some View {
+        Text(space.title)
+            .font(.system(size: 12.5, weight: .semibold))
+            .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.86))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 2)
+            .frame(minHeight: 22, alignment: .center)
             .contentShape(Rectangle())
+            .contextMenu {
+                spaceContextMenu(for: space)
+            }
+            .help(space.title)
+            .accessibilityLabel(spaceAccessibilityLabel(for: space, isSelected: true))
+    }
+
+    private func spaceDotButton(for space: ShellSpace) -> some View {
+        Button {
+            host.select(spaceID: space.spaceID)
+        } label: {
+            ShellSidebarSpaceDot(
+                attention: strongestAttention(for: space),
+                isHovered: hoveredSpaceID == space.spaceID,
+                isPreviewed: previewedSpaceID == space.spaceID
+            )
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .contextMenu {
+            spaceContextMenu(for: space)
+        }
+        .help(space.title)
+        .accessibilityLabel(spaceAccessibilityLabel(for: space, isSelected: false))
+        .onHover { isHovering in
+            hoveredSpaceID = isHovering ? space.spaceID : nil
+        }
+    }
+
+    @ViewBuilder
+    private func spaceContextMenu(for space: ShellSpace) -> some View {
+        Menu("Terminal Profile") {
+            Button {
+                _ = host.setTerminalProfile(nil, forSpaceID: space.spaceID)
+            } label: {
+                Label("Default", systemImage: space.terminalProfileID == nil ? "checkmark" : "terminal")
+            }
+
+            ForEach(TerminalProfileStore.defaultStore().load().profiles, id: \.id) { profile in
+                Button {
+                    _ = host.setTerminalProfile(profile.id, forSpaceID: space.spaceID)
+                } label: {
+                    Label(
+                        profileMenuTitle(profile),
+                        systemImage: profile.id == space.terminalProfileID
+                            ? "checkmark"
+                            : profileSymbol(for: profile)
+                    )
+                }
+            }
+        }
+    }
+
+    private func isDisplaySpace(_ space: ShellSpace) -> Bool {
+        space.spaceID == resolvedDisplaySpaceID
+    }
+
+    private var resolvedDisplaySpaceID: String? {
+        displaySpaceID ?? host.selectedSpace?.spaceID
     }
 
     private func profileMenuTitle(_ profile: TerminalProfileDefinition) -> String {
         "\(profile.title) · \(profile.launch.kind.rawValue)"
     }
 
-    private func currentProfileSymbol(
-        space: ShellSpace,
-        profile: TerminalProfileDefinition?
-    ) -> String {
-        guard let profile else {
-            return space.terminalProfileID == nil ? "terminal" : "questionmark.circle"
-        }
+    private func profileSymbol(for profile: TerminalProfileDefinition) -> String {
         switch profile.launch {
         case .loginShell:
             return "terminal"
@@ -1101,81 +1026,88 @@ private struct ShellSidebarSpaceHeader: View {
         }
     }
 
-    private func profileForegroundStyle(
-        space: ShellSpace,
-        profile: TerminalProfileDefinition?
-    ) -> Color {
-        if space.terminalProfileID != nil, profile == nil {
-            return .orange
-        }
-        if profile?.launch == .sudoRoot {
-            return .red
-        }
-        return ShellPalette.sidebarMutedInk.opacity(0.72)
+    private func strongestAttention(for space: ShellSpace) -> ShellAttentionState {
+        host.shellState.panes
+            .filter { $0.spaceID == space.spaceID }
+            .map { shellEffectiveAttention(for: $0) }
+            .max(by: { attentionRank(for: $0) < attentionRank(for: $1) })
+            ?? .idle
     }
 
-    private func contentIconName(for content: ShellContentInstance) -> String {
-        if let iconName = content.iconName?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !iconName.isEmpty
-        {
-            return iconName
-        }
-
-        switch content.kind {
-        case .terminal:
-            return "terminal"
-        case .markdown:
-            return "doc.text"
-        case .settings:
-            return "gearshape"
+    private func attentionRank(for attention: ShellAttentionState) -> Int {
+        switch attention {
+        case .awaitingUser:
+            return 3
+        case .notable:
+            return 2
+        case .active:
+            return 1
+        case .idle:
+            return 0
         }
     }
-}
 
-private struct ShellSpaceSwitcherItem: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let title: String
-    let symbolName: String
-    let attention: ShellAttentionState
-    let tabCount: Int
-    let isSelected: Bool
-    let isPreviewed: Bool
-    let isHovered: Bool
-
-    var body: some View {
-        ZStack {
-            if isSelected || isHovered || isPreviewed {
-                ShellMaterialShape(
-                    role: isSelected ? .controlGlassSelected : .controlGlassHover,
-                    shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                )
-            }
-            Image(systemName: symbolName)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(isSelected || isPreviewed ? ShellPalette.accent : ShellPalette.sidebarInk.opacity(0.74))
-        }
-        .frame(width: 30, height: 30)
-        .scaleEffect(isSelected ? 1 : (isHovered || isPreviewed ? 1.015 : 1))
-        .shellShadow(isSelected || isPreviewed ? ShellShadows.navigationSelection : ShellShadows.none)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isHovered)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isSelected)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: isPreviewed)
-        .help(title)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private var accessibilityLabel: String {
-        var parts = [title, tabCount == 1 ? "1 tab" : "\(tabCount) tabs"]
+    private func spaceAccessibilityLabel(for space: ShellSpace, isSelected: Bool) -> String {
+        var parts = [space.title, space.tabs.count == 1 ? "1 tab" : "\(space.tabs.count) tabs"]
         if isSelected {
             parts.append("selected")
         }
-        if isPreviewed {
+        if previewedSpaceID == space.spaceID {
             parts.append("preview")
         }
-        if attention != .idle {
+        if strongestAttention(for: space) != .idle {
             parts.append("needs attention")
         }
         return parts.joined(separator: ", ")
+    }
+}
+
+private struct ShellSidebarSpaceDot: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let attention: ShellAttentionState
+    let isHovered: Bool
+    let isPreviewed: Bool
+
+    var body: some View {
+        ZStack {
+            if isHovered || isPreviewed {
+                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                    .fill(ShellPalette.sidebarHover)
+            }
+
+            Circle()
+                .fill(dotFill)
+                .frame(width: dotSize, height: dotSize)
+                .overlay {
+                    Circle()
+                        .stroke(dotStroke, lineWidth: 0.6)
+                }
+        }
+        .frame(width: 18, height: 22)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovered)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isPreviewed)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: attention)
+    }
+
+    private var dotSize: CGFloat {
+        isHovered || isPreviewed || attention != .idle ? 6.5 : 5.2
+    }
+
+    private var dotFill: Color {
+        if isPreviewed {
+            return ShellPalette.accent.opacity(0.82)
+        }
+        if attention != .idle {
+            return ShellPalette.attention.opacity(0.82)
+        }
+        return ShellPalette.sidebarMutedInk.opacity(isHovered ? 0.72 : 0.46)
+    }
+
+    private var dotStroke: Color {
+        if isPreviewed {
+            return ShellPalette.accent.opacity(0.34)
+        }
+        return ShellPalette.line.opacity(isHovered ? 0.24 : 0.12)
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -36,7 +36,14 @@ struct ShellSpaceKeyboardShortcuts: View {
             }
             .shellActionKeyboardShortcut(host.shellActionShortcut(.spaceSelectNext))
 
-            ForEach(Array(host.spaces.prefix(9).enumerated()), id: \.element.spaceID) { index, _ in
+            ForEach(
+                Array(
+                    host.spaces
+                        .prefix(ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces)
+                        .enumerated()
+                ),
+                id: \.element.spaceID
+            ) { index, _ in
                 let target = ShellActionTarget.spaceIndex(index)
                 Button("") {
                     host.performShellAction(.spaceSelectByIndex, target: target)

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -461,6 +461,21 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "maximumVisibleSpaces = 8" \
+    "first-pass Space slider must keep its eight-Space visible cap explicit"
+
+require_pattern \
+    "clients/apple/alan-macos/ShellHostController.swift" \
+    "shellState\\.spaces\\.count < ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces" \
+    "Space creation must share the first-pass slider visible cap"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "\\.disabled\\(!canCreateTerminalSpace\\)" \
+    "titlebar New Space must disable when the first-pass slider cap is reached"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "spaceContextMenu\\(" \
     "Space profile selection must be exposed through the Space context menu"
 
@@ -1308,6 +1323,11 @@ require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "task\\(id: activityFreshnessRefreshID\\)" \
     "sidebar activity freshness must schedule refreshes for stale/expires deadlines"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "shellEffectiveAttention\\(for: .*now: activityFreshnessNow\\)" \
+    "Space slider attention must use the state-driven freshness clock"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -460,14 +460,24 @@ require_pattern \
     "sidebar Space navigation must render through the top Space slider"
 
 require_pattern \
-    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "clients/apple/alan-macos/ShellModel.swift" \
     "maximumVisibleSpaces = 8" \
     "first-pass Space slider must keep its eight-Space visible cap explicit"
 
 require_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
     "shellState\\.spaces\\.count < ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces" \
-    "Space creation must share the first-pass slider visible cap"
+    "host Space creation must share the first-pass slider visible cap"
+
+require_pattern \
+    "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
+    "state\\.spaces\\.count < ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces" \
+    "local space.create must share the first-pass slider visible cap"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
+    "prefix\\(ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces\\)" \
+    "hidden Space index shortcuts must share the first-pass slider visible cap"
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
@@ -538,6 +548,11 @@ require_pattern \
     "clients/apple/scripts/test-shell-runtime-metadata.swift" \
     "verifiesTerminalStatusSummaryPrioritizesExitAndRendererHealth" \
     "shell runtime tests must prove sidebar status prioritizes exit and renderer health"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-runtime-metadata.swift" \
+    "verifiesSpaceCreateCapAppliesToControlCommandPaths" \
+    "shell runtime tests must prove space.create shares the sidebar Space cap"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -455,29 +455,44 @@ reject_pattern \
     "Find UI must render through ShellFindBarView instead of the passive terminal overlay card"
 
 require_pattern \
-    "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
-    "spaceDockOuterBottomInset" \
-    "bottom space dock must use a tokenized outer inset to align with the sidebar edge"
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "ShellSidebarSpaceSlider" \
+    "sidebar Space navigation must render through the top Space slider"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
-    "padding\\(\\.bottom, ShellSidebarMetrics\\.spaceDockOuterBottomInset\\)" \
-    "bottom space dock must align its visible controls to the sidebar bottom edge inset"
+    "spaceContextMenu\\(" \
+    "Space profile selection must be exposed through the Space context menu"
+
+reject_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "spaceDock|createSpaceFromDock|ShellSidebarSpaceHeader" \
+    "default sidebar must not keep the old bottom Space dock or header profile surface"
 
 require_pattern \
-    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
-    "padding\\(\\.vertical, ShellSidebarMetrics\\.spaceDockInternalVerticalPadding\\)" \
-    "space dock internal vertical padding must stay paired with its bottom alignment token"
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "ShellSidebarNewSpaceControl" \
+    "New Space must live in the sidebar titlebar tool group"
 
 require_pattern \
-    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
-    "Button\\(action: createSpaceFromDock\\)" \
-    "bottom space dock add control must be a direct button, not a variant menu"
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "Spacer\\(minLength: ShellSidebarMetrics\\.titlebarToolSpacing\\)" \
+    "New Space must be separated from leading titlebar tools and right-aligned"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "\\.padding\\(\\.trailing, ShellSidebarMetrics\\.edgeInset\\)" \
+    "right-aligned titlebar New Space must keep the sidebar trailing inset"
+
+require_pattern \
+    "clients/apple/alan-macos/MacShellRootView.swift" \
+    "\\.frame\\(width: sidebarPresentation\\.surfaceWidth, alignment: \\.topLeading\\)" \
+    "sidebar titlebar controls must align within the sidebar surface width"
 
 reject_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "New Space with alan|createAlanSpace|menuIndicator\\(\\.hidden\\)" \
-    "bottom space dock add control must not expose the removed New Space with alan menu path"
+    "Space creation must not expose the removed New Space with alan menu path"
 
 require_pattern \
     "clients/apple/scripts/test-terminal-surface-controller.swift" \
@@ -1086,8 +1101,13 @@ require_pattern \
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
-    "spaceDock" \
-    "sidebar-local pager motion must keep the bottom space dock owned by the sidebar"
+    "fixedSpaceSlider" \
+    "sidebar-local pager motion must keep Space identity and switching as a fixed sidebar control"
+
+reject_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "spaceSlider\\(for: spaceID\\(forSpaceAt:|ShellSidebarSpaceSlider\\([^)]*spaceID\\(forSpaceAt:" \
+    "Space slider must not be rendered inside per-Space pager pages"
 
 reject_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
@@ -1558,6 +1578,16 @@ require_pattern \
     "clients/apple/scripts/test-shell-window-placement.swift" \
     "verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit" \
     "shell window placement tests must prove blank sidebar chrome remains a double-click zoom target"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-window-placement.swift" \
+    "verifiesSidebarSpaceSliderDoesNotTriggerWindowDrag" \
+    "shell window placement tests must prove Space slider controls are not intercepted by zoom overlay"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
+    "sidebarTrailingTitlebarToolControlFrame" \
+    "hidden-titlebar hit testing must model the right-aligned New Space button separately"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -41,6 +41,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalLifecycleShutdownFinalizesAllRuntimes()
         verifiesShellHostControllerRoutesSharedAutomationCommands()
         verifiesControlPlaneRoutesSharedAutomationCommandSemantics()
+        verifiesSpaceCreateCapAppliesToControlCommandPaths()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -2111,6 +2112,67 @@ private enum ShellRuntimeMetadataTests {
             handle.deliveredText == ["pwd\n"],
             "control-plane send_text must route through the shared runtime command path"
         )
+    }
+
+    private static func verifiesSpaceCreateCapAppliesToControlCommandPaths() {
+        var cappedState = ShellStateSnapshot.bootstrapDefault(windowID: "space_cap_control")
+        while cappedState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces {
+            cappedState = cappedState.creatingTerminalSpace(
+                title: nil,
+                workingDirectory: nil
+            ).state
+        }
+
+        let controller = makeController(
+            windowID: "space_cap_control",
+            shellState: cappedState
+        )
+        let directSpaceID = controller.createSpace()
+        expect(directSpaceID == nil, "direct createSpace must reject the capped Space count")
+        expect(
+            controller.shellState.spaces.count
+                == ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces,
+            "direct createSpace must leave the capped Space count unchanged"
+        )
+
+        let controlPlaneCreate = controller.handleControlPlaneCommand(
+            decodeControlCommand(
+                """
+                {
+                  "request_id": "space-cap-control-plane",
+                  "command": "space.create"
+                }
+                """
+            )
+        )
+        expect(
+            controlPlaneCreate.applied == false
+                && controlPlaneCreate.errorCode == "space_create_failed",
+            "control-plane space.create must reject the capped Space count"
+        )
+        expect(
+            controller.shellState.spaces.count
+                == ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces,
+            "control-plane space.create must leave the capped Space count unchanged"
+        )
+
+        let localCreate = AlanShellLocalCommandExecutor.execute(
+            command: decodeControlCommand(
+                """
+                {
+                  "request_id": "space-cap-local",
+                  "command": "space.create"
+                }
+                """
+            ),
+            state: cappedState
+        )
+        expect(
+            localCreate?.response.applied == false
+                && localCreate?.response.errorCode == "space_create_failed",
+            "local space.create must reject the capped Space count"
+        )
+        expect(localCreate?.updatedState == nil, "local space.create must not mutate capped state")
     }
 
     private static func verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd() {

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -33,7 +33,7 @@ private enum ShellWindowPlacementTests {
         try verifiesTrafficLightGapsCanTriggerDoubleClickZoom()
         try verifiesSidebarChromeBlankAreaCanTriggerDoubleClickZoom()
         try verifiesSidebarTabListDoesNotTriggerWindowDrag()
-        try verifiesSidebarSpaceDockDoesNotTriggerWindowDrag()
+        try verifiesSidebarSpaceSliderDoesNotTriggerWindowDrag()
         try verifiesSidebarToolbarButtonsDoNotTriggerDoubleClickZoom()
         try verifiesTitlebarOverlayAcceptsTopBlankHit()
         try verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit()
@@ -470,7 +470,7 @@ private enum ShellWindowPlacementTests {
         )
     }
 
-    private static func verifiesSidebarSpaceDockDoesNotTriggerWindowDrag() throws {
+    private static func verifiesSidebarSpaceSliderDoesNotTriggerWindowDrag() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -487,7 +487,7 @@ private enum ShellWindowPlacementTests {
                 in: window,
                 chromeSurface: chromeSurface
             ),
-            "sidebar space switcher rows must not be treated as window drag or zoom candidates"
+            "sidebar Space slider controls must not be treated as window drag or zoom candidates"
         )
     }
 
@@ -499,17 +499,26 @@ private enum ShellWindowPlacementTests {
             defer: false
         )
         let chromeSurface = ShellWindowChromeSurface(width: 264)
+        let controlY = window.frame.height - 20
 
-        let location = CGPoint(x: 98, y: window.frame.height - 20)
-
-        expect(
-            !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
-                locationInWindow: location,
-                in: window,
-                chromeSurface: chromeSurface
-            ),
-            "sidebar titlebar toolbar buttons must receive clicks instead of the window zoom overlay"
+        let leadingControlLocation = CGPoint(x: 98, y: controlY)
+        let newSpaceControlLocation = CGPoint(
+            x: 264
+                - ShellSidebarMetrics.edgeInset
+                - (ShellSidebarMetrics.titlebarToolWidth / 2),
+            y: controlY
         )
+
+        for location in [leadingControlLocation, newSpaceControlLocation] {
+            expect(
+                !ShellWindowDoubleClickZoomHitTesting.isWindowTopChromeZoomCandidate(
+                    locationInWindow: location,
+                    in: window,
+                    chromeSurface: chromeSurface
+                ),
+                "sidebar titlebar toolbar buttons must receive clicks instead of the window zoom overlay"
+            )
+        }
     }
 
     private static func verifiesTitlebarOverlayAcceptsTopBlankHit() throws {

--- a/openspec/changes/polish-macos-sidebar-space-slider/.openspec.yaml
+++ b/openspec/changes/polish-macos-sidebar-space-slider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/polish-macos-sidebar-space-slider/design.md
+++ b/openspec/changes/polish-macos-sidebar-space-slider/design.md
@@ -1,0 +1,134 @@
+## Context
+
+The current macOS shell sidebar uses three separate areas for related Space and
+Tab actions:
+
+- The top Space header shows the selected Space title, icon, and terminal
+  profile menu.
+- The bottom Space dock switches Spaces and creates new Spaces.
+- The tab list places New Tab after the tab sections.
+
+This layout works functionally, but it spreads the Space workflow across the
+sidebar and creates extra controls in the default shell. The product direction
+calls for a calmer, Arc-like material sidebar where Spaces and tabs remain
+scannable and terminal content stays dominant.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Merge Space identity and Space switching into a compact top Space slider.
+- Remove the bottom Space dock from the default sidebar layout.
+- Move New Space into the existing sidebar titlebar control group.
+- Move terminal profile selection from an always-visible header menu into the
+  Space context menu.
+- Place New Tab between pinned and unpinned tabs, with a divider only after
+  pinned tabs exist.
+- Keep interaction surfaces stable for collapsed-sidebar reveal, window dragging,
+  keyboard focus, reduced motion, and accessibility.
+
+**Non-Goals:**
+
+- Redesign the entire sidebar visual system.
+- Add complex Space overflow behavior beyond the current 8-Space cap.
+- Introduce new daemon/runtime APIs or persistence formats.
+- Add new Space management actions such as rename/delete unless already
+  available locally.
+- Replace the custom shell sidebar with `NavigationSplitView`.
+
+## Decisions
+
+### Decision: Replace Space header and dock with a top Space slider
+
+The selected Space displays its title; non-selected Spaces display dots. Left
+clicking a dot switches to that Space. Right clicking either the selected title
+or a dot opens the corresponding Space context menu. Hovering a dot exposes the
+Space title through help/tooltip text.
+
+This keeps the default surface compact while preserving named Spaces. It also
+removes the need for a persistent Space icon because the selected title becomes
+the context anchor.
+
+Alternative considered: keep the bottom Space dock and only restyle it into dot
+mode. That preserves the current structure but does not solve the split between
+Space identity, switching, and creation.
+
+The Space slider is fixed at the sidebar level rather than rendered inside each
+Space page. During a Space paging gesture, only the tab content moves underneath
+it; the slider remains the stable global navigation control and may indicate the
+target Space through dot preview state.
+
+### Decision: Keep New Space in titlebar chrome, not the Space slider row
+
+The New Space button joins the existing sidebar pin/unpin and appearance
+controls in `MacShellRootView`. It stays icon-only and follows the same compact
+chrome treatment as the adjacent controls. Pin/unpin and appearance stay on the
+leading side of the sidebar titlebar, while New Space is right-aligned to the
+sidebar surface with the standard trailing edge inset.
+
+This keeps creation discoverable without turning the Space slider into a row of
+mixed navigation and creation affordances. It also removes the bottom-right dock
+button, which currently competes with tab-list actions.
+
+Alternative considered: place New Space at the end of the Space slider. That is
+visually compact but makes the slider handle both switching and creation,
+increasing hit-test and overflow complexity.
+
+### Decision: Move terminal profile selection to a Space context menu
+
+The always-visible terminal profile menu is removed from the Space header. The
+same profile choices move into a `Terminal Profile` submenu on the Space context
+menu.
+
+Profile selection is important but infrequent. Moving it behind right click keeps
+the default sidebar focused on navigation while preserving per-Space profile
+control.
+
+Alternative considered: keep a tiny profile glyph beside the selected Space
+title. That saves one click but keeps a secondary configuration control visible
+in the highest-priority navigation row.
+
+### Decision: Treat New Tab as the first unpinned-tab action
+
+The tab list becomes pinned tabs, divider when pinned tabs exist, New Tab, then
+unpinned tabs. New Tab visually behaves like a normal sidebar row with lighter
+foreground treatment and creates a normal unpinned terminal tab in the current
+Space.
+
+This makes pinned tabs read as fixed entry points while New Tab remains attached
+to the ordinary tab flow. There is no divider between New Tab and unpinned tabs.
+
+Alternative considered: keep New Tab after all tabs. That is lower risk but
+keeps creation far from the section it affects.
+
+### Decision: Keep implementation scoped to existing sidebar components
+
+The change should stay local to `ShellSidebarView`, `MacShellRootView`, shared
+sidebar metrics/tokens, and focused sidebar tests. The existing sidebar paging,
+collapsed floating panel, and tab drag/drop models remain in place.
+
+This avoids broad architecture churn while allowing focused extraction of a
+Space slider component and a reusable Space context menu builder.
+
+## Risks / Trade-offs
+
+- [Risk] Dots can become ambiguous when users have many named Spaces.
+  -> Mitigation: keep the current 8-Space cap, provide help/tooltip labels, and
+  preserve accessibility labels with Space title and tab count.
+
+- [Risk] Moving New Space into the titlebar controls can interfere with hidden
+  titlebar drag and double-click zoom behavior.
+  -> Mitigation: extend focused window-placement checks so the right-aligned
+  New Space control is an explicit interaction surface, while the spacer between
+  leading controls and New Space remains blank chrome.
+
+- [Risk] Removing the bottom Space dock changes muscle memory.
+  -> Mitigation: keep the selected Space title at the top, preserve one-click dot
+  switching, and maintain compact hover/selection feedback.
+
+- [Risk] Profile selection becomes less visible.
+  -> Mitigation: keep it in the Space context menu and use clear submenu labels.
+
+- [Risk] New Tab placement can affect drag/drop insertion previews.
+  -> Mitigation: keep New Tab out of drop targets and preserve insertion targets
+  inside pinned and unpinned tab sections only.

--- a/openspec/changes/polish-macos-sidebar-space-slider/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-space-slider/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The macOS sidebar currently separates Space identity, Space switching, Space
+creation, and tab creation across the top header, bottom dock, and tab list.
+This adds visual weight and makes related navigation controls feel farther apart
+than they should in the Arc-like, terminal-first shell.
+
+## What Changes
+
+- Replace the current Space header and bottom Space dock with a compact top
+  Space slider.
+- Show the selected Space as text and non-selected Spaces as dots, with the
+  current Space count capped at 8.
+- Move New Space from the bottom dock into the right-aligned action slot of the
+  sidebar titlebar, with pin/unpin and appearance controls kept leading.
+- Remove the always-visible terminal profile selector from the Space header and
+  expose profile selection from the Space context menu.
+- Reorder the tab list so pinned tabs appear first, then a divider when pinned
+  tabs exist, then the New Tab row, then unpinned tabs.
+- Keep New Tab visually consistent with ordinary sidebar rows while creating a
+  normal unpinned terminal tab in the current Space.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Updates the default sidebar layout contract
+  for Space navigation, Space creation, profile disclosure, and New Tab
+  placement.
+- `macos-shell-build-test-contract`: Adds focused verification expectations for
+  the new sidebar layout ordering, interaction surfaces, and visual review.
+
+## Impact
+
+- Affected code is expected in the Apple client sidebar and shell root views,
+  especially `ShellSidebarView.swift`, `MacShellRootView.swift`,
+  `ShellDesignTokens.swift`, and focused sidebar/window placement scripts.
+- No daemon, runtime, protocol, or provider API changes are expected.
+- No dependency changes are expected.

--- a/openspec/changes/polish-macos-sidebar-space-slider/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-sidebar-space-slider/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Sidebar Space slider layout has focused verification
+The Apple client SHALL include focused automated or documented verification for
+the top Space slider layout, titlebar New Space control, Space context menu
+profile disclosure, and New Tab placement when the sidebar layout changes.
+
+#### Scenario: Sidebar layout ordering is verified
+- **WHEN** the sidebar Space slider layout is implemented
+- **THEN** focused checks verify that the default sidebar orders controls as
+  titlebar controls, top Space slider, pinned tabs, pinned-tab divider when
+  pinned tabs exist, New Tab row, and unpinned tabs
+- **AND** focused checks verify that titlebar New Space is right-aligned within
+  the sidebar titlebar while pin/unpin and appearance controls remain leading
+- **AND** focused checks verify that the bottom Space dock and always-visible
+  Space profile selector are absent from the default sidebar
+- **AND** focused checks verify that the Space slider is fixed outside the
+  per-Space content pager instead of being rendered inside each Space page
+
+#### Scenario: Sidebar interaction surfaces are verified
+- **WHEN** Space slider title or dot controls, the titlebar New Space button,
+  the New Tab row, or tab rows are changed
+- **THEN** focused window-placement checks verify those controls remain
+  interaction surfaces rather than hidden-titlebar window-drag surfaces
+- **AND** existing empty chrome double-click zoom behavior remains covered for
+  non-control titlebar/sidebar chrome
+
+#### Scenario: Visual evidence captures the new sidebar hierarchy
+- **WHEN** sidebar Space slider polish is marked complete
+- **THEN** maintainers can inspect running-app screenshots or manual notes from
+  a fresh Alan Dev launch showing the light-mode pinned sidebar with the top
+  Space slider, titlebar New Space control, pinned-tab divider behavior, New Tab
+  row, unpinned tabs, and no bottom Space dock
+- **AND** if collapsed-sidebar rendering is affected, visual evidence also
+  covers the collapsed floating sidebar reveal

--- a/openspec/changes/polish-macos-sidebar-space-slider/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-space-slider/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Visual system follows native material guidance
+The default macOS shell SHALL use a light-mode-first native material visual
+system that feels calm, precise, and terminal-oriented. It SHALL avoid
+card-heavy dashboard composition, decorative gradients, hard-coded dominant
+theme panels, and ornamental controls.
+
+#### Scenario: Material sidebar
+- **WHEN** the app window is visible in the default light appearance
+- **THEN** the unified sidebar column, top Space slider, active-Space tab list,
+  and compact sidebar controls use material-backed surfaces, subtle separators
+  where useful, and restrained selection states rather than an opaque themed
+  sidebar panel, separate Space rail, or bottom Space switcher
+
+#### Scenario: Stable compact controls
+- **WHEN** the user hovers, selects, inserts, closes, creates, or switches tabs
+  and Spaces
+- **THEN** rows, icon controls, dots, counters, and status marks keep stable
+  dimensions and do not resize the sidebar or terminal content
+- **AND** the top Space slider aligns its visible controls to the sidebar edge
+  inset so the title, dots, and tab rows share one optical column
+- **AND** the titlebar New Space button directly creates a standard new Space
+  instead of opening a menu of Space variants
+- **AND** the titlebar New Space button is right-aligned within the sidebar
+  titlebar instead of sitting immediately after the pin/unpin and appearance
+  controls
+
+#### Scenario: Space slider replaces header and dock
+- **WHEN** the default sidebar displays Space navigation
+- **THEN** the selected Space is represented by its title in the top Space
+  slider, non-selected Spaces are represented by dots, and no Space icon is
+  shown in the slider
+- **AND** alan does not show a separate bottom Space dock in the default sidebar
+- **AND** the top Space slider remains a fixed sidebar-level control while
+  Space tab content pages move beneath it during Space paging gestures
+
+#### Scenario: Space profile uses context menu disclosure
+- **WHEN** the default sidebar displays the selected Space
+- **THEN** alan does not show an always-visible terminal profile selector in the
+  Space header or Space slider
+- **AND WHEN** the user opens a Space context menu from the selected Space title
+  or a non-selected Space dot
+- **THEN** terminal profile selection is available as a Space-level context menu
+  action
+
+#### Scenario: New Tab belongs to ordinary tab flow
+- **WHEN** the active Space contains pinned tabs
+- **THEN** alan shows pinned tabs first, then a subtle divider, then the New Tab
+  row, then unpinned tabs
+- **AND WHEN** the active Space contains no pinned tabs
+- **THEN** alan shows the New Tab row before unpinned tabs without a pinned-tab
+  divider
+- **AND** the New Tab row creates a normal unpinned terminal tab in the current
+  Space

--- a/openspec/changes/polish-macos-sidebar-space-slider/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-space-slider/tasks.md
@@ -1,0 +1,49 @@
+## 1. Sidebar Layout Implementation
+
+- [x] 1.1 Replace the existing Space header in `ShellSidebarView` with a top Space slider that shows the selected Space title and non-selected Space dots.
+- [x] 1.2 Remove the bottom Space dock from the default sidebar layout and preserve stable bottom padding.
+- [x] 1.3 Add an icon-only New Space control to the sidebar titlebar tool group in `MacShellRootView`.
+- [x] 1.4 Move terminal profile selection from the visible Space header into a Space context menu available from the selected title and non-selected dots.
+- [x] 1.5 Reorder the tab list so pinned tabs render first, then a divider only when pinned tabs exist, then New Tab, then unpinned tabs.
+- [x] 1.6 Keep New Tab as a compact sidebar row that creates a normal unpinned terminal tab in the current Space and is not a drag/drop insertion target.
+
+## 2. Interaction And Accessibility
+
+- [x] 2.1 Verify selected Space title left click is a no-op and right click opens the selected Space context menu.
+- [x] 2.2 Verify non-selected Space dots left click switch Spaces, hover exposes the Space title, and right click opens the target Space context menu.
+- [x] 2.3 Preserve accessibility labels for selected Space, non-selected Space dots, New Space, New Tab, and Space profile actions.
+- [x] 2.4 Preserve reduced-motion, reduced-transparency, increased-contrast, hover, selection, and keyboard-focus behavior for the new sidebar controls.
+
+## 3. Focused Tests
+
+- [x] 3.1 Add or update focused Swift sidebar tests for layout ordering, bottom Space dock removal, titlebar New Space placement, and profile menu disclosure.
+- [x] 3.2 Update window-placement or sidebar interaction tests so the Space slider, dots, titlebar New Space button, and New Tab row are not treated as hidden-titlebar window-drag surfaces.
+- [x] 3.3 Run the focused sidebar/window-placement test scripts that cover the changed layout and hit-test behavior.
+- [x] 3.4 Run `openspec validate polish-macos-sidebar-space-slider --strict`.
+
+## 4. Visual Verification
+
+- [x] 4.1 Freshly relaunch Alan Dev before visual verification.
+- [x] 4.2 Capture or document a light-mode pinned-sidebar screenshot showing the Space slider, titlebar New Space control, pinned divider behavior, New Tab row, unpinned tabs, and no bottom Space dock.
+- [x] 4.3 If collapsed-sidebar rendering changes, capture or document the collapsed floating sidebar reveal.
+
+Note: visual verification used a freshly launched isolated `app.alanworks.macos.ui-smoke`
+build of the current app because the installed Alan Dev path is blocked by the
+local install/signing environment. Evidence:
+`debug/artifacts/sidebar-space-slider-ui-smoke-fixed/00-launch.png` covers the
+default Space slider, titlebar New Space button, New Tab row, selected unpinned
+tab, and no bottom Space dock. `debug/artifacts/sidebar-space-slider-pinned-fixture/output/00-launch.png`
+covers pinned tab, pinned/New Tab divider placement, New Tab, unpinned tab, and
+no bottom Space dock. The collapsed-sidebar wrapper was not changed, so no
+separate collapsed reveal capture was required.
+
+## 5. Review And Archive Readiness
+
+- [x] 5.1 Confirm the implementation diff is limited to the sidebar layout, focused tests, and this OpenSpec change.
+- [ ] 5.2 Sync accepted delta specs into `openspec/specs/` after implementation is merged.
+- [ ] 5.3 Archive the completed OpenSpec change after synced specs validate.
+
+Note: `git diff --name-only` is limited to the sidebar/root view, shell design
+tokens, focused shell scripts, and the user-requested `AGENTS.md` OpenSpec
+workflow rule. The unrelated untracked
+`openspec/changes/add-macos-alan-owned-pty-runtime/` change remains untouched.


### PR DESCRIPTION
## Summary
- replace the old sidebar Space header/bottom dock with a fixed top Space slider
- move New Space into the sidebar titlebar and keep it right-aligned
- place New Tab between pinned and unpinned tabs, with the pinned divider only after pinned tabs
- move Space profile selection into the Space context menu and document the OpenSpec workflow rule in AGENTS.md

## Verification
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-window-placement.sh
- openspec validate polish-macos-sidebar-space-slider --strict
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -derivedDataPath debug/xcode-derived/sidebar-space-slider-clean-build build