### PR TITLE
Polish macOS adaptive space slider scrub

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */; };
 		00000000000000000000004A /* Services/Shell/ShellPerformanceDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */; };
 		00000000000000000000004B /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */; };
+		00000000000000000000004C /* Support/ShellSidebarSpaceSliderLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000156 /* Support/ShellSidebarSpaceSliderLayout.swift */; };
+		00000000000000000000004D /* Support/ShellSidebarSpaceSliderWheelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000157 /* Support/ShellSidebarSpaceSliderWheelMonitor.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -159,6 +161,8 @@
 		000000000000000000000153 /* Models/Shell/ShellSettingsSurfaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Shell/ShellSettingsSurfaceModel.swift; sourceTree = "<group>"; };
 		000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPerformanceDiagnostics.swift; sourceTree = "<group>"; };
 		000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift; sourceTree = "<group>"; };
+		000000000000000000000156 /* Support/ShellSidebarSpaceSliderLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceSliderLayout.swift; sourceTree = "<group>"; };
+		000000000000000000000157 /* Support/ShellSidebarSpaceSliderWheelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceSliderWheelMonitor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,6 +254,8 @@
 				000000000000000000000138 /* Support/ShellSidebarSwipeMonitor.swift */,
 				00000000000000000000013D /* Support/ShellSidebarPresentation.swift */,
 				00000000000000000000013B /* Support/ShellSidebarSpaceContentPager.swift */,
+				000000000000000000000156 /* Support/ShellSidebarSpaceSliderLayout.swift */,
+				000000000000000000000157 /* Support/ShellSidebarSpaceSliderWheelMonitor.swift */,
 				000000000000000000000119 /* Support/ShellWindowPlacement.swift */,
 				00000000000000000000011D /* Support/ShellVoiceCommandController.swift */,
 			);
@@ -528,6 +534,8 @@
 				000000000000000000000038 /* Support/ShellSidebarSwipeMonitor.swift in Sources */,
 				00000000000000000000003D /* Support/ShellSidebarPresentation.swift in Sources */,
 				00000000000000000000003B /* Support/ShellSidebarSpaceContentPager.swift in Sources */,
+				00000000000000000000004C /* Support/ShellSidebarSpaceSliderLayout.swift in Sources */,
+				00000000000000000000004D /* Support/ShellSidebarSpaceSliderWheelMonitor.swift in Sources */,
 				00000000000000000000003C /* Support/AlanCommandLineToolInstaller.swift in Sources */,
 				000000000000000000000048 /* Support/AlanMacUpdatePolicy.swift in Sources */,
 				000000000000000000000047 /* App/AlanMacUpdateController.swift in Sources */,

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -64,6 +64,10 @@ struct MacShellRootView: View {
         sidebarPresentation.surfaceOrigin
     }
 
+    private var canCreateTerminalSpace: Bool {
+        host.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces
+    }
+
     private var sidebarPresentationConfiguration: ShellSidebarPresentationConfiguration {
         ShellSidebarPresentationConfiguration(
             sidebarWidth: sidebarWidth,
@@ -449,7 +453,7 @@ struct MacShellRootView: View {
                     _ = host.createTerminalSpace()
                 }
                 .disabled(!canCreateTerminalSpace)
-                .opacity(canCreateTerminalSpace ? 1 : 0.38)
+                .opacity(canCreateTerminalSpace ? 1 : 0.45)
                 .contentShape(Rectangle())
                 .onHover(perform: handleCollapsedSidebarToolbarHover)
             }
@@ -464,9 +468,6 @@ struct MacShellRootView: View {
         .zIndex(30)
     }
 
-    private var canCreateTerminalSpace: Bool {
-        host.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces
-    }
 }
 
 private struct ShellWindowPlacementAnimationSyncView: View, Animatable {

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -50,7 +50,7 @@ enum AlanShellLocalCommandExecutor {
             )
 
         case .spaceCreate:
-            guard state.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
+            guard state.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces else {
                 return AlanShellLocalCommandResult(
                     response: response(
                         for: command,

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -1137,7 +1137,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        guard shellState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces else {
+        guard shellState.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces else {
             return nil
         }
         let resolvedTerminalProfileID = terminalProfileID

--- a/clients/apple/alan-macos/ShellModel.swift
+++ b/clients/apple/alan-macos/ShellModel.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-enum ShellSidebarSpaceSliderPolicy {
-    static let maximumVisibleSpaces = 8
-}
-
 struct ShellSidebarTabProjection: Equatable {
     let title: String
     let secondaryLine: String

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
@@ -363,7 +363,7 @@ struct ShellSidebarSpaceSliderWheelIntentState: Equatable {
             if abs(accumulatedY) >= Self.intentLockDistance,
                abs(accumulatedY) >= abs(accumulatedX) * Self.verticalIntentBias
             {
-                reset()
+                intent = .vertical
                 return .passThrough
             }
 

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
@@ -1,0 +1,399 @@
+import CoreGraphics
+import Foundation
+
+#if os(macOS)
+struct ShellSidebarSpaceSliderLayout: Equatable {
+    static let maximumVisibleSpaces = 9
+    static let spacing: CGFloat = 7
+    static let minimumItemWidth: CGFloat = 8
+
+    enum Density: Equatable {
+        case low
+        case medium
+        case high
+    }
+
+    enum DisplayMode: Equatable {
+        case fullTitle
+        case shortTitle
+        case indicator
+    }
+
+    struct Item: Equatable {
+        let index: Int
+        let mode: DisplayMode
+        let width: CGFloat
+        let visualScale: CGFloat
+        let opacity: CGFloat
+        let isSelected: Bool
+        let isFocused: Bool
+    }
+
+    let density: Density
+    let items: [Item]
+    let contentWidth: CGFloat
+
+    static func make(
+        spaceCount rawSpaceCount: Int,
+        selectedIndex rawSelectedIndex: Int?,
+        hoveredIndex rawHoveredIndex: Int? = nil,
+        scrubFocusIndex rawScrubFocusIndex: Int? = nil,
+        availableWidth: CGFloat,
+        reduceMotion: Bool
+    ) -> ShellSidebarSpaceSliderLayout {
+        let spaceCount = min(max(rawSpaceCount, 0), maximumVisibleSpaces)
+        let density = density(for: spaceCount)
+        guard spaceCount > 0 else {
+            return ShellSidebarSpaceSliderLayout(density: density, items: [], contentWidth: 0)
+        }
+
+        let selectedIndex = clamped(rawSelectedIndex, count: spaceCount)
+        let hoveredIndex = clamped(rawHoveredIndex, count: spaceCount)
+        let scrubFocusIndex = clamped(rawScrubFocusIndex, count: spaceCount)
+        let focusIndex = scrubFocusIndex ?? hoveredIndex
+        let width = max(availableWidth, 0)
+        let spacingWidth = CGFloat(max(spaceCount - 1, 0)) * spacing
+        let itemBudget = max(width - spacingWidth, CGFloat(spaceCount) * minimumItemWidth)
+        let modes = displayModes(
+            density: density,
+            spaceCount: spaceCount,
+            selectedIndex: selectedIndex,
+            hoveredIndex: hoveredIndex,
+            scrubFocusIndex: scrubFocusIndex
+        )
+        let itemWidths = widths(
+            modes: modes,
+            selectedIndex: selectedIndex,
+            focusIndex: focusIndex,
+            itemBudget: itemBudget
+        )
+
+        let items = modes.enumerated().map { index, mode in
+            let isFocused = focusIndex == index
+            let distance = focusIndex.map { abs($0 - index) } ?? 0
+            return Item(
+                index: index,
+                mode: mode,
+                width: itemWidths[index],
+                visualScale: visualScale(
+                    distanceFromFocus: distance,
+                    isFocused: isFocused,
+                    hasFocus: focusIndex != nil,
+                    reduceMotion: reduceMotion
+                ),
+                opacity: opacity(
+                    distanceFromFocus: distance,
+                    hasFocus: focusIndex != nil
+                ),
+                isSelected: selectedIndex == index,
+                isFocused: isFocused
+            )
+        }
+
+        let contentWidth = itemWidths.reduce(0, +) + spacingWidth
+        return ShellSidebarSpaceSliderLayout(density: density, items: items, contentWidth: contentWidth)
+    }
+
+    static func density(for spaceCount: Int) -> Density {
+        switch min(max(spaceCount, 0), maximumVisibleSpaces) {
+        case 0...3:
+            return .low
+        case 4...6:
+            return .medium
+        default:
+            return .high
+        }
+    }
+
+    private static func displayModes(
+        density: Density,
+        spaceCount: Int,
+        selectedIndex: Int?,
+        hoveredIndex: Int?,
+        scrubFocusIndex: Int?
+    ) -> [DisplayMode] {
+        (0..<spaceCount).map { index in
+            switch density {
+            case .low:
+                return .fullTitle
+            case .medium:
+                return selectedIndex == index ? .fullTitle : .shortTitle
+            case .high:
+                if selectedIndex == index || scrubFocusIndex == index {
+                    return .fullTitle
+                }
+                if hoveredIndex == index {
+                    return .shortTitle
+                }
+                return .indicator
+            }
+        }
+    }
+
+    private static func widths(
+        modes: [DisplayMode],
+        selectedIndex: Int?,
+        focusIndex: Int?,
+        itemBudget: CGFloat
+    ) -> [CGFloat] {
+        let weights = modes.enumerated().map { index, mode -> CGFloat in
+            switch mode {
+            case .fullTitle:
+                if selectedIndex == index {
+                    return 3.4
+                }
+                if focusIndex == index {
+                    return 3.1
+                }
+                return 2.6
+            case .shortTitle:
+                return focusIndex == index ? 2.1 : 1.65
+            case .indicator:
+                return focusIndex == index ? 1.0 : 0.72
+            }
+        }
+        let totalWeight = max(weights.reduce(0, +), 1)
+        return weights.map { max(minimumItemWidth, itemBudget * ($0 / totalWeight)) }
+    }
+
+    private static func visualScale(
+        distanceFromFocus distance: Int,
+        isFocused: Bool,
+        hasFocus: Bool,
+        reduceMotion: Bool
+    ) -> CGFloat {
+        guard hasFocus, !reduceMotion else { return 1 }
+        if isFocused {
+            return 1.035
+        }
+        if distance == 1 {
+            return 1.012
+        }
+        return 1
+    }
+
+    private static func opacity(distanceFromFocus distance: Int, hasFocus: Bool) -> CGFloat {
+        guard hasFocus else { return 1 }
+        if distance <= 1 {
+            return 1
+        }
+        if distance == 2 {
+            return 0.82
+        }
+        return 0.68
+    }
+
+    private static func clamped(_ index: Int?, count: Int) -> Int? {
+        guard let index, count > 0 else { return nil }
+        return min(max(index, 0), count - 1)
+    }
+
+    func frame(for index: Int) -> CGRect? {
+        var cursor: CGFloat = 0
+        for item in items {
+            let frame = CGRect(x: cursor, y: 0, width: item.width, height: 22)
+            if item.index == index {
+                return frame
+            }
+            cursor += item.width + Self.spacing
+        }
+        return nil
+    }
+
+    func midpoint(for index: Int) -> CGFloat? {
+        frame(for: index).map(\.midX)
+    }
+
+    func targetIndex(at locationX: CGFloat) -> Int? {
+        guard !items.isEmpty else { return nil }
+        var cursor: CGFloat = 0
+        for item in items {
+            let minimumX = cursor - (Self.spacing * 0.5)
+            let maximumX = cursor + item.width + (Self.spacing * 0.5)
+            if locationX >= minimumX && locationX <= maximumX {
+                return item.index
+            }
+            cursor += item.width + Self.spacing
+        }
+        return nil
+    }
+
+    func clampedTargetIndex(at locationX: CGFloat) -> Int? {
+        guard let first = items.first?.index,
+              let last = items.last?.index
+        else {
+            return nil
+        }
+        if let target = targetIndex(at: locationX) {
+            return target
+        }
+        return locationX < 0 ? first : last
+    }
+}
+
+enum ShellSidebarSpaceSliderScrubSource: Equatable {
+    case drag
+    case wheel
+    case keyboard
+}
+
+struct ShellSidebarSpaceSliderScrubState: Equatable {
+    static let dragThreshold: CGFloat = 8
+    static let wheelStepWidth: CGFloat = 24
+    static let edgeResistanceLimit: CGFloat = 7
+    static let wheelCommitDelay: TimeInterval = 0.16
+
+    let source: ShellSidebarSpaceSliderScrubSource
+    let sourceIndex: Int
+    var focusIndex: Int
+    var accumulatedWheelDeltaX: CGFloat = 0
+    var edgeResistanceOffset: CGFloat = 0
+
+    init?(source: ShellSidebarSpaceSliderScrubSource, selectedIndex: Int?, spaceCount: Int) {
+        guard let selectedIndex,
+              spaceCount > 0
+        else {
+            return nil
+        }
+        let clampedIndex = Self.clampedIndex(selectedIndex, spaceCount: spaceCount)
+        self.source = source
+        sourceIndex = clampedIndex
+        focusIndex = clampedIndex
+    }
+
+    var hasPreviewTarget: Bool {
+        focusIndex != sourceIndex
+    }
+
+    var commitIndex: Int {
+        focusIndex
+    }
+
+    var cancelIndex: Int {
+        sourceIndex
+    }
+
+    mutating func updateDrag(
+        locationX: CGFloat,
+        translationX: CGFloat,
+        layout: ShellSidebarSpaceSliderLayout
+    ) {
+        guard abs(translationX) >= Self.dragThreshold,
+              let targetIndex = layout.clampedTargetIndex(at: locationX)
+        else {
+            focusIndex = sourceIndex
+            edgeResistanceOffset = 0
+            return
+        }
+
+        focusIndex = targetIndex
+        edgeResistanceOffset = Self.edgeResistanceOffset(
+            locationX: locationX,
+            contentWidth: layout.contentWidth
+        )
+    }
+
+    mutating func updateWheel(deltaX: CGFloat, itemSpan: CGFloat, spaceCount: Int) {
+        accumulatedWheelDeltaX += deltaX
+        let stepWidth = max(itemSpan, Self.wheelStepWidth)
+        let rawStep = Int((accumulatedWheelDeltaX / stepWidth).rounded(.towardZero))
+        let nextIndex = Self.clampedIndex(sourceIndex + rawStep, spaceCount: spaceCount)
+        focusIndex = nextIndex
+        edgeResistanceOffset = nextIndex == sourceIndex + rawStep ? 0 : Self.edgeResistanceLimit * CGFloat(rawStep.signum())
+    }
+
+    mutating func moveFocus(by delta: Int, spaceCount: Int) {
+        focusIndex = Self.clampedIndex(focusIndex + delta, spaceCount: spaceCount)
+        edgeResistanceOffset = 0
+    }
+
+    private static func edgeResistanceOffset(locationX: CGFloat, contentWidth: CGFloat) -> CGFloat {
+        if locationX < 0 {
+            let distance = abs(locationX)
+            return -edgeResistanceLimit * distance / (distance + edgeResistanceLimit)
+        }
+        if locationX > contentWidth {
+            let distance = locationX - contentWidth
+            return edgeResistanceLimit * distance / (distance + edgeResistanceLimit)
+        }
+        return 0
+    }
+
+    private static func clampedIndex(_ index: Int, spaceCount: Int) -> Int {
+        min(max(index, 0), max(spaceCount - 1, 0))
+    }
+}
+
+struct ShellSidebarSpaceSliderWheelIntentState: Equatable {
+    enum Route: Equatable {
+        case passThrough
+        case scrub(deltaX: CGFloat)
+    }
+
+    private enum Intent: Equatable {
+        case undecided
+        case horizontal
+        case vertical
+    }
+
+    static let intentLockDistance: CGFloat = 5
+    static let horizontalIntentBias: CGFloat = 1.18
+    static let verticalIntentBias: CGFloat = 1.12
+
+    private var accumulatedX: CGFloat = 0
+    private var accumulatedY: CGFloat = 0
+    private var intent = Intent.undecided
+
+    mutating func route(deltaX: CGFloat, deltaY: CGFloat) -> Route {
+        guard abs(deltaX) > 0 || abs(deltaY) > 0 else {
+            return .passThrough
+        }
+
+        switch intent {
+        case .horizontal:
+            accumulatedX += deltaX
+            accumulatedY += deltaY
+            return .scrub(deltaX: deltaX)
+        case .vertical:
+            return .passThrough
+        case .undecided:
+            accumulatedX += deltaX
+            accumulatedY += deltaY
+
+            if abs(accumulatedY) >= Self.intentLockDistance,
+               abs(accumulatedY) >= abs(accumulatedX) * Self.verticalIntentBias
+            {
+                reset()
+                return .passThrough
+            }
+
+            guard abs(accumulatedX) >= Self.intentLockDistance,
+                  abs(accumulatedX) > abs(accumulatedY) * Self.horizontalIntentBias
+            else {
+                return .passThrough
+            }
+
+            intent = .horizontal
+            return .scrub(deltaX: accumulatedX)
+        }
+    }
+
+    mutating func reset() {
+        accumulatedX = 0
+        accumulatedY = 0
+        intent = .undecided
+    }
+}
+
+enum ShellSidebarSpaceSliderClickSelection {
+    static func targetIndex(selectedIndex: Int?, clickedIndex: Int, spaceCount: Int) -> Int? {
+        guard clickedIndex >= 0,
+              clickedIndex < spaceCount,
+              clickedIndex != selectedIndex
+        else {
+            return nil
+        }
+        return clickedIndex
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
@@ -3,6 +3,46 @@ import SwiftUI
 #if os(macOS)
 import AppKit
 
+final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
+    static let resetDelay: TimeInterval = 0.14
+
+    private let onReset: () -> Void
+    private let scheduleWorkItem: (DispatchWorkItem, TimeInterval) -> Void
+    private var workItem: DispatchWorkItem?
+
+    init(
+        onReset: @escaping () -> Void,
+        scheduleWorkItem: @escaping (DispatchWorkItem, TimeInterval) -> Void = { workItem, delay in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
+    ) {
+        self.onReset = onReset
+        self.scheduleWorkItem = scheduleWorkItem
+    }
+
+    func scheduleResetAfterIdle() {
+        cancel()
+        var nextWorkItem: DispatchWorkItem!
+        nextWorkItem = DispatchWorkItem { [weak self] in
+            guard let self, !nextWorkItem.isCancelled else { return }
+            self.workItem = nil
+            self.onReset()
+        }
+        workItem = nextWorkItem
+        scheduleWorkItem(nextWorkItem, Self.resetDelay)
+    }
+
+    func resetNow() {
+        cancel()
+        onReset()
+    }
+
+    func cancel() {
+        workItem?.cancel()
+        workItem = nil
+    }
+}
+
 struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
     let onScroll: (CGFloat, CGFloat) -> Bool
     let onReset: () -> Void
@@ -54,6 +94,10 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
         var onContextMenuIntent: () -> Void
         private weak var view: NSView?
         private var monitor: Any?
+        private lazy var phaseLessResetScheduler =
+            ShellSidebarSpaceSliderWheelPhaseLessResetScheduler { [weak self] in
+                self?.onReset()
+            }
 
         init(
             onScroll: @escaping (CGFloat, CGFloat) -> Bool,
@@ -77,6 +121,7 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
         }
 
         func uninstall() {
+            phaseLessResetScheduler.cancel()
             if let monitor {
                 NSEvent.removeMonitor(monitor)
             }
@@ -107,7 +152,7 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
             }
 
             if event.phase.contains(.began) || event.momentumPhase.contains(.began) {
-                onReset()
+                phaseLessResetScheduler.resetNow()
             }
 
             let consumed = onScroll(scrollDeltaX(from: event), scrollDeltaY(from: event))
@@ -117,7 +162,9 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
                 || event.momentumPhase.contains(.ended)
                 || event.momentumPhase.contains(.cancelled)
             {
-                onReset()
+                phaseLessResetScheduler.resetNow()
+            } else if event.phase.isEmpty, event.momentumPhase.isEmpty {
+                phaseLessResetScheduler.scheduleResetAfterIdle()
             }
 
             return consumed ? nil : event

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
+    let onScroll: (CGFloat, CGFloat) -> Bool
+    let onReset: () -> Void
+    let onContextMenuIntent: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            onScroll: onScroll,
+            onReset: onReset,
+            onContextMenuIntent: onContextMenuIntent
+        )
+    }
+
+    func makeNSView(context: Context) -> MonitorView {
+        let view = MonitorView()
+        view.coordinator = context.coordinator
+        context.coordinator.install(for: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: MonitorView, context: Context) {
+        context.coordinator.onScroll = onScroll
+        context.coordinator.onReset = onReset
+        context.coordinator.onContextMenuIntent = onContextMenuIntent
+        nsView.coordinator = context.coordinator
+        context.coordinator.install(for: nsView)
+    }
+
+    final class MonitorView: NSView {
+        var coordinator: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            coordinator?.install(for: self)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
+        deinit {
+            coordinator?.uninstall()
+        }
+    }
+
+    final class Coordinator {
+        var onScroll: (CGFloat, CGFloat) -> Bool
+        var onReset: () -> Void
+        var onContextMenuIntent: () -> Void
+        private weak var view: NSView?
+        private var monitor: Any?
+
+        init(
+            onScroll: @escaping (CGFloat, CGFloat) -> Bool,
+            onReset: @escaping () -> Void,
+            onContextMenuIntent: @escaping () -> Void
+        ) {
+            self.onScroll = onScroll
+            self.onReset = onReset
+            self.onContextMenuIntent = onContextMenuIntent
+        }
+
+        func install(for view: NSView) {
+            self.view = view
+            guard monitor == nil else { return }
+
+            monitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.scrollWheel, .rightMouseDown, .leftMouseDown]
+            ) { [weak self] event in
+                self?.handle(event) ?? event
+            }
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+        }
+
+        private func handle(_ event: NSEvent) -> NSEvent? {
+            guard let view,
+                  view.window === event.window
+            else {
+                return event
+            }
+
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) else {
+                return event
+            }
+
+            if event.type == .rightMouseDown
+                || (event.type == .leftMouseDown && event.modifierFlags.contains(.control))
+            {
+                onContextMenuIntent()
+                return event
+            }
+
+            guard event.type == .scrollWheel else {
+                return event
+            }
+
+            if event.phase.contains(.began) || event.momentumPhase.contains(.began) {
+                onReset()
+            }
+
+            let consumed = onScroll(scrollDeltaX(from: event), scrollDeltaY(from: event))
+
+            if event.phase.contains(.ended)
+                || event.phase.contains(.cancelled)
+                || event.momentumPhase.contains(.ended)
+                || event.momentumPhase.contains(.cancelled)
+            {
+                onReset()
+            }
+
+            return consumed ? nil : event
+        }
+
+        private func scrollDeltaX(from event: NSEvent) -> CGFloat {
+            if event.hasPreciseScrollingDeltas {
+                return event.scrollingDeltaX
+            }
+            return event.deltaX * 10
+        }
+
+        private func scrollDeltaY(from event: NSEvent) -> CGFloat {
+            if event.hasPreciseScrollingDeltas {
+                return event.scrollingDeltaY
+            }
+            return event.deltaY * 10
+        }
+    }
+}
+#endif

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
@@ -3,6 +3,8 @@ import SwiftUI
 #if os(macOS)
 import AppKit
 
+typealias ShellSidebarSpaceSliderWheelEvent = NSEvent
+
 final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
     static let resetDelay: TimeInterval = 0.14
 
@@ -44,7 +46,7 @@ final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
 }
 
 struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
-    let onScroll: (CGFloat, CGFloat) -> Bool
+    let onScroll: (NSEvent, CGFloat, CGFloat) -> Bool
     let onReset: () -> Void
     let onContextMenuIntent: () -> Void
 
@@ -89,7 +91,7 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
     }
 
     final class Coordinator {
-        var onScroll: (CGFloat, CGFloat) -> Bool
+        var onScroll: (NSEvent, CGFloat, CGFloat) -> Bool
         var onReset: () -> Void
         var onContextMenuIntent: () -> Void
         private weak var view: NSView?
@@ -100,7 +102,7 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
             }
 
         init(
-            onScroll: @escaping (CGFloat, CGFloat) -> Bool,
+            onScroll: @escaping (NSEvent, CGFloat, CGFloat) -> Bool,
             onReset: @escaping () -> Void,
             onContextMenuIntent: @escaping () -> Void
         ) {
@@ -155,7 +157,11 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
                 phaseLessResetScheduler.resetNow()
             }
 
-            let consumed = onScroll(scrollDeltaX(from: event), scrollDeltaY(from: event))
+            let consumed = onScroll(
+                event,
+                scrollDeltaX(from: event),
+                scrollDeltaY(from: event)
+            )
 
             if event.phase.contains(.ended)
                 || event.phase.contains(.cancelled)
@@ -182,6 +188,106 @@ struct ShellSidebarSpaceSliderWheelMonitor: NSViewRepresentable {
                 return event.scrollingDeltaY
             }
             return event.deltaY * 10
+        }
+    }
+}
+
+enum ShellSidebarSpaceSliderWheelForwarding {
+    static func shouldForwardPassThroughToTabList(deltaX _: CGFloat, deltaY: CGFloat) -> Bool {
+        abs(deltaY) > 0
+    }
+}
+
+final class ShellSidebarTabListWheelRouter: ObservableObject {
+    private weak var scrollView: NSScrollView?
+
+    func setActiveScrollView(_ scrollView: NSScrollView?) {
+        self.scrollView = scrollView
+    }
+
+    func clearActiveScrollView(_ scrollView: NSScrollView?) {
+        guard scrollView == nil || self.scrollView === scrollView else { return }
+        self.scrollView = nil
+    }
+
+    func forward(_ event: NSEvent) -> Bool {
+        guard let scrollView,
+              scrollView.window === event.window
+        else {
+            return false
+        }
+
+        scrollView.scrollWheel(with: event)
+        return true
+    }
+}
+
+struct ShellSidebarTabListWheelForwardingAnchor: NSViewRepresentable {
+    let router: ShellSidebarTabListWheelRouter
+
+    func makeNSView(context _: Context) -> AnchorView {
+        let view = AnchorView()
+        view.router = router
+        return view
+    }
+
+    func updateNSView(_ nsView: AnchorView, context _: Context) {
+        nsView.router = router
+        nsView.registerWhenReady()
+    }
+
+    static func dismantleNSView(_ nsView: AnchorView, coordinator _: ()) {
+        nsView.unregister()
+    }
+
+    final class AnchorView: NSView {
+        weak var router: ShellSidebarTabListWheelRouter?
+        private weak var registeredScrollView: NSScrollView?
+
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            registerWhenReady()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            registerWhenReady()
+        }
+
+        func registerWhenReady() {
+            guard window != nil else { return }
+
+            if let scrollView = enclosingScrollView() {
+                registeredScrollView = scrollView
+                router?.setActiveScrollView(scrollView)
+                return
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                self?.registerIfPossible()
+            }
+        }
+
+        func unregister() {
+            router?.clearActiveScrollView(registeredScrollView)
+            registeredScrollView = nil
+        }
+
+        private func registerIfPossible() {
+            guard let scrollView = enclosingScrollView() else { return }
+            registeredScrollView = scrollView
+            router?.setActiveScrollView(scrollView)
+        }
+
+        private func enclosingScrollView() -> NSScrollView? {
+            var view = superview
+            while let current = view {
+                if let scrollView = current as? NSScrollView {
+                    return scrollView
+                }
+                view = current.superview
+            }
+            return nil
         }
     }
 }

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift
@@ -11,6 +11,7 @@ final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
     private let onReset: () -> Void
     private let scheduleWorkItem: (DispatchWorkItem, TimeInterval) -> Void
     private var workItem: DispatchWorkItem?
+    private var resetGeneration = 0
 
     init(
         onReset: @escaping () -> Void,
@@ -24,9 +25,14 @@ final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
 
     func scheduleResetAfterIdle() {
         cancel()
-        var nextWorkItem: DispatchWorkItem!
-        nextWorkItem = DispatchWorkItem { [weak self] in
-            guard let self, !nextWorkItem.isCancelled else { return }
+        resetGeneration += 1
+        let generation = resetGeneration
+        let nextWorkItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.resetGeneration == generation
+            else {
+                return
+            }
             self.workItem = nil
             self.onReset()
         }
@@ -40,6 +46,7 @@ final class ShellSidebarSpaceSliderWheelPhaseLessResetScheduler {
     }
 
     func cancel() {
+        resetGeneration += 1
         workItem?.cancel()
         workItem = nil
     }

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -37,11 +37,6 @@ struct ShellSidebarView: View {
 
     var body: some View {
         sidebarContent
-        .background {
-            if isSwipeEnabled {
-                ShellSidebarSwipeMonitor(onUpdate: handleSpaceSwipe)
-            }
-        }
         .scrollDisabled(isTabListScrollDisabled)
         .onChange(of: sourceSpaceID) { _, _ in
             tabListScrollOffsetY = 0
@@ -93,6 +88,11 @@ struct ShellSidebarView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background {
+            if isSwipeEnabled {
+                ShellSidebarSwipeMonitor(onUpdate: handleSpaceSwipe)
+            }
+        }
     }
 
     private func tabSection(for spaceID: String?) -> some View {
@@ -916,72 +916,140 @@ private struct ShellSidebarScrollBoundary: View {
 }
 
 private struct ShellSidebarSpaceSlider: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var host: ShellHostController
     let displaySpaceID: String?
     let previewedSpaceID: String?
     let activityFreshnessNow: Date
+    @FocusState private var isKeyboardFocused: Bool
     @State private var hoveredSpaceID: String?
+    @State private var scrubState: ShellSidebarSpaceSliderScrubState?
+    @State private var wheelIntentState = ShellSidebarSpaceSliderWheelIntentState()
+    @State private var wheelCommitToken = 0
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 7) {
-                ForEach(Array(host.spaces.prefix(ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces))) { space in
-                    if isDisplaySpace(space) {
-                        selectedTitle(for: space)
-                    } else {
-                        spaceDotButton(for: space)
+        GeometryReader { proxy in
+            let spaces = visibleSpaces
+            let layout = sliderLayout(availableWidth: proxy.size.width)
+
+            HStack(spacing: ShellSidebarSpaceSliderLayout.spacing) {
+                ForEach(Array(spaces.enumerated()), id: \.element.spaceID) { index, space in
+                    if let item = layout.items.first(where: { $0.index == index }) {
+                        spaceControl(for: space, item: item)
                     }
                 }
             }
             .padding(.horizontal, ShellSidebarMetrics.edgeInset)
             .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .offset(x: reduceMotion ? 0 : scrubState?.edgeResistanceOffset ?? 0)
+            .contentShape(Rectangle())
+            .simultaneousGesture(dragScrubGesture(layout: layout))
+            .background {
+                ShellSidebarSpaceSliderWheelMonitor(
+                    onScroll: { deltaX, deltaY in
+                        handleWheel(deltaX: deltaX, deltaY: deltaY, availableWidth: proxy.size.width)
+                    },
+                    onReset: resetWheelIntent,
+                    onContextMenuIntent: cancelScrubPreview
+                )
+            }
+            .focusable()
+            .focused($isKeyboardFocused)
+            .focusEffectDisabled()
+            .onMoveCommand(perform: handleMoveCommand)
+            .onExitCommand {
+                cancelScrubPreview()
+            }
+            .onKeyPress(.return) {
+                commitKeyboardScrub()
+                return .handled
+            }
+            .onKeyPress(.space) {
+                commitKeyboardScrub()
+                return .handled
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onChange(of: visibleSpaceIDs) { _, _ in
+            cancelInvalidScrubIfNeeded()
+        }
+        .onChange(of: resolvedDisplaySpaceID) { _, _ in
+            cancelScrubPreview()
+        }
     }
 
-    private func selectedTitle(for space: ShellSpace) -> some View {
-        Text(space.title)
-            .font(.system(size: 12.5, weight: .semibold))
-            .foregroundStyle(ShellPalette.sidebarMutedInk.opacity(0.86))
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .padding(.horizontal, 2)
-            .frame(minHeight: 22, alignment: .center)
-            .contentShape(Rectangle())
-            .contextMenu {
-                spaceContextMenu(for: space)
-            }
-            .help(space.title)
-            .accessibilityLabel(spaceAccessibilityLabel(for: space, isSelected: true))
+    private var visibleSpaces: [ShellSpace] {
+        Array(host.spaces.prefix(ShellSidebarSpaceSliderLayout.maximumVisibleSpaces))
     }
 
-    private func spaceDotButton(for space: ShellSpace) -> some View {
+    private func sliderLayout(availableWidth: CGFloat) -> ShellSidebarSpaceSliderLayout {
+        let selectedIndex = visibleSpaces.firstIndex { $0.spaceID == resolvedDisplaySpaceID }
+        let hoveredIndex = scrubState == nil
+            ? visibleSpaces.firstIndex { $0.spaceID == hoveredSpaceID }
+            : nil
+        let previewedIndex = visibleSpaces.firstIndex { $0.spaceID == scrubFocusSpaceID }
+        return ShellSidebarSpaceSliderLayout.make(
+            spaceCount: visibleSpaces.count,
+            selectedIndex: selectedIndex,
+            hoveredIndex: hoveredIndex,
+            scrubFocusIndex: previewedIndex,
+            availableWidth: availableWidth - (ShellSidebarMetrics.edgeInset * 2),
+            reduceMotion: reduceMotion
+        )
+    }
+
+    private func spaceControl(for space: ShellSpace, item: ShellSidebarSpaceSliderLayout.Item) -> some View {
         Button {
-            host.select(spaceID: space.spaceID)
+            guard let targetIndex = ShellSidebarSpaceSliderClickSelection.targetIndex(
+                selectedIndex: selectedSpaceIndex,
+                clickedIndex: item.index,
+                spaceCount: visibleSpaces.count
+            ) else {
+                return
+            }
+            cancelScrubPreview()
+            host.select(spaceID: visibleSpaces[targetIndex].spaceID)
         } label: {
-            ShellSidebarSpaceDot(
-                attention: strongestAttention(for: space),
-                isHovered: hoveredSpaceID == space.spaceID,
-                isPreviewed: previewedSpaceID == space.spaceID
-            )
+            switch item.mode {
+            case .fullTitle, .shortTitle:
+                ShellSidebarSpaceTitlePill(
+                    title: space.title,
+                    mode: item.mode,
+                    attention: strongestAttention(for: space),
+                    isSelected: item.isSelected,
+                    isFocused: item.isFocused
+                )
+            case .indicator:
+                ShellSidebarSpaceDot(
+                    attention: strongestAttention(for: space),
+                    isHovered: hoveredSpaceID == space.spaceID,
+                    isPreviewed: item.isFocused
+                )
+            }
         }
         .buttonStyle(.plain)
+        .frame(width: item.width, height: 22)
+        .scaleEffect(item.visualScale)
+        .opacity(Double(item.opacity))
         .contentShape(Rectangle())
         .contextMenu {
             spaceContextMenu(for: space)
         }
         .help(space.title)
-        .accessibilityLabel(spaceAccessibilityLabel(for: space, isSelected: false))
+        .accessibilityLabel(spaceAccessibilityLabel(for: space, isSelected: item.isSelected))
+        .accessibilityAddTraits(item.isSelected ? .isSelected : [])
         .onHover { isHovering in
             hoveredSpaceID = isHovering ? space.spaceID : nil
         }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: item)
     }
 
     @ViewBuilder
     private func spaceContextMenu(for space: ShellSpace) -> some View {
         Menu("Terminal Profile") {
             Button {
+                cancelScrubPreview()
                 _ = host.setTerminalProfile(nil, forSpaceID: space.spaceID)
             } label: {
                 Label("Default", systemImage: space.terminalProfileID == nil ? "checkmark" : "terminal")
@@ -989,6 +1057,7 @@ private struct ShellSidebarSpaceSlider: View {
 
             ForEach(TerminalProfileStore.defaultStore().load().profiles, id: \.id) { profile in
                 Button {
+                    cancelScrubPreview()
                     _ = host.setTerminalProfile(profile.id, forSpaceID: space.spaceID)
                 } label: {
                     Label(
@@ -1002,12 +1071,167 @@ private struct ShellSidebarSpaceSlider: View {
         }
     }
 
-    private func isDisplaySpace(_ space: ShellSpace) -> Bool {
-        space.spaceID == resolvedDisplaySpaceID
-    }
-
     private var resolvedDisplaySpaceID: String? {
         displaySpaceID ?? host.selectedSpace?.spaceID
+    }
+
+    private var selectedSpaceIndex: Int? {
+        visibleSpaces.firstIndex { $0.spaceID == resolvedDisplaySpaceID }
+    }
+
+    private var scrubFocusSpaceID: String? {
+        if let scrubState,
+           visibleSpaces.indices.contains(scrubState.focusIndex)
+        {
+            return visibleSpaces[scrubState.focusIndex].spaceID
+        }
+        return previewedSpaceID
+    }
+
+    private var visibleSpaceIDs: [String] {
+        visibleSpaces.map(\.spaceID)
+    }
+
+    private func dragScrubGesture(layout: ShellSidebarSpaceSliderLayout) -> some Gesture {
+        DragGesture(
+            minimumDistance: ShellSidebarSpaceSliderScrubState.dragThreshold,
+            coordinateSpace: .local
+        )
+        .onChanged { value in
+            updateDragScrub(value, layout: layout)
+        }
+        .onEnded { value in
+            updateDragScrub(value, layout: layout)
+            commitScrubSelection()
+        }
+    }
+
+    private func updateDragScrub(
+        _ value: DragGesture.Value,
+        layout: ShellSidebarSpaceSliderLayout
+    ) {
+        guard var nextState = scrubStateForUpdating(source: .drag) else { return }
+        nextState.updateDrag(
+            locationX: value.location.x - ShellSidebarMetrics.edgeInset,
+            translationX: value.translation.width,
+            layout: layout
+        )
+        scrubState = nextState
+    }
+
+    private func handleWheel(deltaX: CGFloat, deltaY: CGFloat, availableWidth: CGFloat) -> Bool {
+        var nextIntent = wheelIntentState
+        let route = nextIntent.route(deltaX: deltaX, deltaY: deltaY)
+        wheelIntentState = nextIntent
+
+        switch route {
+        case .passThrough:
+            return false
+        case .scrub(let routedDeltaX):
+            updateWheelScrub(deltaX: routedDeltaX, availableWidth: availableWidth)
+            scheduleWheelCommit()
+            return true
+        }
+    }
+
+    private func updateWheelScrub(deltaX: CGFloat, availableWidth: CGFloat) {
+        guard var nextState = scrubStateForUpdating(source: .wheel) else { return }
+        let itemSpan = max(
+            (availableWidth - ShellSidebarMetrics.edgeInset * 2)
+                / CGFloat(max(visibleSpaces.count, 1)),
+            ShellSidebarSpaceSliderScrubState.wheelStepWidth
+        )
+        nextState.updateWheel(
+            deltaX: deltaX,
+            itemSpan: itemSpan,
+            spaceCount: visibleSpaces.count
+        )
+        scrubState = nextState
+    }
+
+    private func handleMoveCommand(_ direction: MoveCommandDirection) {
+        let delta: Int
+        switch direction {
+        case .left:
+            delta = -1
+        case .right:
+            delta = 1
+        default:
+            return
+        }
+
+        guard var nextState = scrubStateForUpdating(source: .keyboard) else { return }
+        nextState.moveFocus(by: delta, spaceCount: visibleSpaces.count)
+        scrubState = nextState
+    }
+
+    private func scrubStateForUpdating(
+        source: ShellSidebarSpaceSliderScrubSource
+    ) -> ShellSidebarSpaceSliderScrubState? {
+        if let scrubState, scrubState.source == source {
+            return scrubState
+        }
+        return ShellSidebarSpaceSliderScrubState(
+            source: source,
+            selectedIndex: selectedSpaceIndex,
+            spaceCount: visibleSpaces.count
+        )
+    }
+
+    private func scheduleWheelCommit() {
+        wheelCommitToken += 1
+        let token = wheelCommitToken
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + ShellSidebarSpaceSliderScrubState.wheelCommitDelay
+        ) {
+            guard wheelCommitToken == token,
+                  scrubState?.source == .wheel
+            else {
+                return
+            }
+            commitScrubSelection()
+            resetWheelIntent()
+        }
+    }
+
+    private func commitKeyboardScrub() {
+        guard scrubState?.source == .keyboard else { return }
+        commitScrubSelection()
+    }
+
+    private func commitScrubSelection() {
+        guard let scrubState,
+              visibleSpaces.indices.contains(scrubState.commitIndex)
+        else {
+            cancelScrubPreview()
+            return
+        }
+
+        let targetSpace = visibleSpaces[scrubState.commitIndex]
+        cancelScrubPreview()
+        if targetSpace.spaceID != resolvedDisplaySpaceID {
+            host.select(spaceID: targetSpace.spaceID)
+        }
+    }
+
+    private func cancelScrubPreview() {
+        scrubState = nil
+        wheelCommitToken += 1
+        resetWheelIntent()
+    }
+
+    private func resetWheelIntent() {
+        wheelIntentState.reset()
+    }
+
+    private func cancelInvalidScrubIfNeeded() {
+        guard let scrubState else { return }
+        guard visibleSpaces.indices.contains(scrubState.focusIndex),
+              visibleSpaces.indices.contains(scrubState.sourceIndex)
+        else {
+            cancelScrubPreview()
+            return
+        }
     }
 
     private func profileMenuTitle(_ profile: TerminalProfileDefinition) -> String {
@@ -1060,6 +1284,80 @@ private struct ShellSidebarSpaceSlider: View {
             parts.append("needs attention")
         }
         return parts.joined(separator: ", ")
+    }
+}
+
+private struct ShellSidebarSpaceTitlePill: View {
+    let title: String
+    let mode: ShellSidebarSpaceSliderLayout.DisplayMode
+    let attention: ShellAttentionState
+    let isSelected: Bool
+    let isFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if attention != .idle {
+                Circle()
+                    .fill(ShellPalette.attention.opacity(0.82))
+                    .frame(width: 4.5, height: 4.5)
+            }
+
+            Text(title)
+                .font(font)
+                .foregroundStyle(foreground)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, horizontalPadding)
+        .frame(maxWidth: .infinity, minHeight: 22, alignment: .center)
+        .background {
+            if showsBackground {
+                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                    .fill(background)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                            .stroke(ShellPalette.line.opacity(isSelected ? 0.18 : 0.12), lineWidth: 0.6)
+                    }
+            }
+        }
+        .shellShadow(isSelected ? ShellShadows.navigationSelection : ShellShadows.none)
+    }
+
+    private var font: Font {
+        switch mode {
+        case .fullTitle:
+            return .system(size: 12.2, weight: isSelected ? .semibold : .medium)
+        case .shortTitle:
+            return .system(size: 11.4, weight: isFocused ? .semibold : .medium)
+        case .indicator:
+            return .system(size: 11.4, weight: .medium)
+        }
+    }
+
+    private var horizontalPadding: CGFloat {
+        mode == .fullTitle ? 8 : 6
+    }
+
+    private var showsBackground: Bool {
+        isSelected || isFocused || mode == .fullTitle
+    }
+
+    private var background: Color {
+        if isSelected {
+            return ShellPalette.sidebarSelection
+        }
+        if isFocused {
+            return ShellPalette.sidebarHover
+        }
+        return ShellPalette.materialTopWash.opacity(0.7)
+    }
+
+    private var foreground: Color {
+        if isSelected || isFocused {
+            return ShellPalette.sidebarInk.opacity(0.88)
+        }
+        return ShellPalette.sidebarMutedInk.opacity(0.72)
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -16,6 +16,7 @@ struct ShellSidebarView: View {
     @State private var activityFreshnessNow = Date()
     @State private var activeTabDrag: ShellSidebarTabDragState?
     @State private var tabInsertionPreview: ShellSidebarTabInsertionTarget?
+    @StateObject private var tabListWheelRouter = ShellSidebarTabListWheelRouter()
 
     init(
         host: ShellHostController,
@@ -62,7 +63,8 @@ struct ShellSidebarView: View {
             host: host,
             displaySpaceID: sourceSpaceID,
             previewedSpaceID: previewedSpaceID,
-            activityFreshnessNow: activityFreshnessNow
+            activityFreshnessNow: activityFreshnessNow,
+            onForwardVerticalWheel: tabListWheelRouter.forward
         )
         .frame(maxWidth: .infinity)
         .frame(height: 30)
@@ -110,6 +112,12 @@ struct ShellSidebarView: View {
 
     private func tabListPage(for spaceID: String?) -> some View {
         ScrollView(.vertical, showsIndicators: false) {
+            if spaceID == sourceSpaceID {
+                ShellSidebarTabListWheelForwardingAnchor(router: tabListWheelRouter)
+                    .frame(width: 0, height: 0)
+                    .accessibilityHidden(true)
+            }
+
             GeometryReader { proxy in
                 Color.clear.preference(
                     key: ShellSidebarTabListOffsetPreferenceKey.self,
@@ -921,6 +929,7 @@ private struct ShellSidebarSpaceSlider: View {
     let displaySpaceID: String?
     let previewedSpaceID: String?
     let activityFreshnessNow: Date
+    let onForwardVerticalWheel: (ShellSidebarSpaceSliderWheelEvent) -> Bool
     @FocusState private var isKeyboardFocused: Bool
     @State private var hoveredSpaceID: String?
     @State private var scrubState: ShellSidebarSpaceSliderScrubState?
@@ -947,8 +956,13 @@ private struct ShellSidebarSpaceSlider: View {
             .simultaneousGesture(dragScrubGesture(layout: layout))
             .background {
                 ShellSidebarSpaceSliderWheelMonitor(
-                    onScroll: { deltaX, deltaY in
-                        handleWheel(deltaX: deltaX, deltaY: deltaY, availableWidth: proxy.size.width)
+                    onScroll: { event, deltaX, deltaY in
+                        handleWheel(
+                            event: event,
+                            deltaX: deltaX,
+                            deltaY: deltaY,
+                            availableWidth: proxy.size.width
+                        )
                     },
                     onReset: resetWheelIntent,
                     onContextMenuIntent: cancelScrubPreview
@@ -1119,14 +1133,25 @@ private struct ShellSidebarSpaceSlider: View {
         scrubState = nextState
     }
 
-    private func handleWheel(deltaX: CGFloat, deltaY: CGFloat, availableWidth: CGFloat) -> Bool {
+    private func handleWheel(
+        event: ShellSidebarSpaceSliderWheelEvent,
+        deltaX: CGFloat,
+        deltaY: CGFloat,
+        availableWidth: CGFloat
+    ) -> Bool {
         var nextIntent = wheelIntentState
         let route = nextIntent.route(deltaX: deltaX, deltaY: deltaY)
         wheelIntentState = nextIntent
 
         switch route {
         case .passThrough:
-            return false
+            guard ShellSidebarSpaceSliderWheelForwarding.shouldForwardPassThroughToTabList(
+                deltaX: deltaX,
+                deltaY: deltaY
+            ) else {
+                return false
+            }
+            return onForwardVerticalWheel(event)
         case .scrub(let routedDeltaX):
             updateWheelScrub(deltaX: routedDeltaX, availableWidth: availableWidth)
             scheduleWheelCommit()

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -39,7 +39,7 @@ struct ShellSpaceKeyboardShortcuts: View {
             ForEach(
                 Array(
                     host.spaces
-                        .prefix(ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces)
+                        .prefix(ShellSidebarSpaceSliderLayout.maximumVisibleSpaces)
                         .enumerated()
                 ),
                 id: \.element.spaceID

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -525,6 +525,16 @@ require_pattern \
     "Space slider layout tests must cover phase-less wheel intent reset"
 
 require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift" \
+    "ShellSidebarTabListWheelForwardingAnchor" \
+    "Space slider vertical pass-through wheel input must be forwarded to the active tab list"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesPassThroughWheelForwardingDecision" \
+    "Space slider layout tests must cover pass-through wheel forwarding to the tab list"
+
+require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "onMoveCommand|onKeyPress\\(\\.return\\)|onExitCommand" \
     "Space slider must preserve keyboard preview, commit, and Escape cancel entry points"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -515,6 +515,16 @@ require_pattern \
     "Space slider context-menu intent must detect right-click and Control-click without stealing the event"
 
 require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift" \
+    "ShellSidebarSpaceSliderWheelPhaseLessResetScheduler" \
+    "Space slider wheel monitor must reset phase-less wheel intent after idle"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesPhaseLessWheelResetSchedulerResetsAfterIdle" \
+    "Space slider layout tests must cover phase-less wheel intent reset"
+
+require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "onMoveCommand|onKeyPress\\(\\.return\\)|onExitCommand" \
     "Space slider must preserve keyboard preview, commit, and Escape cancel entry points"

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -460,34 +460,64 @@ require_pattern \
     "sidebar Space navigation must render through the top Space slider"
 
 require_pattern \
-    "clients/apple/alan-macos/ShellModel.swift" \
-    "maximumVisibleSpaces = 8" \
-    "first-pass Space slider must keep its eight-Space visible cap explicit"
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "maximumVisibleSpaces = 9" \
+    "adaptive Space slider must cap the default sidebar at 9 visible Spaces"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "case low|case medium|case high" \
+    "adaptive Space slider must define low, medium, and high density tiers"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "ShellSidebarSpaceSliderWheelIntentState" \
+    "adaptive Space slider must route wheel input through a focused horizontal-intent model"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "dragThreshold" \
+    "adaptive Space slider must keep press-drag scrub behind an explicit horizontal threshold"
 
 require_pattern \
     "clients/apple/alan-macos/ShellHostController.swift" \
-    "shellState\\.spaces\\.count < ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces" \
-    "host Space creation must share the first-pass slider visible cap"
+    "ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces" \
+    "host Space creation must share the 9-Space slider cap"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
-    "state\\.spaces\\.count < ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces" \
-    "local space.create must share the first-pass slider visible cap"
+    "ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces" \
+    "local space.create must share the 9-Space slider cap"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "prefix\\(ShellSidebarSpaceSliderPolicy\\.maximumVisibleSpaces\\)" \
-    "hidden Space index shortcuts must share the first-pass slider visible cap"
+    "prefix\\(ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces\\)" \
+    "hidden Space index shortcuts must share the 9-Space slider cap"
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
     "\\.disabled\\(!canCreateTerminalSpace\\)" \
-    "titlebar New Space must disable when the first-pass slider cap is reached"
+    "titlebar New Space must disable when the adaptive slider cap is reached"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "spaceContextMenu\\(" \
     "Space profile selection must be exposed through the Space context menu"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "onContextMenuIntent: cancelScrubPreview" \
+    "Space context-menu opening must cancel active scrub preview before settings actions"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift" \
+    "rightMouseDown|modifierFlags\\.contains\\(\\.control\\)" \
+    "Space slider context-menu intent must detect right-click and Control-click without stealing the event"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "onMoveCommand|onKeyPress\\(\\.return\\)|onExitCommand" \
+    "Space slider must preserve keyboard preview, commit, and Escape cancel entry points"
 
 reject_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
@@ -1618,6 +1648,21 @@ require_pattern \
     "clients/apple/scripts/test-shell-window-placement.swift" \
     "verifiesSidebarSpaceSliderDoesNotTriggerWindowDrag" \
     "shell window placement tests must prove Space slider controls are not intercepted by zoom overlay"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesDensityTiers" \
+    "shell sidebar Space slider tests must verify adaptive density tiers"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesWheelIntentRoutingProtectsVerticalScroll" \
+    "shell sidebar Space slider tests must verify horizontal wheel scrub and vertical scroll protection"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesScrubCancelRestoresTheSelectedSource" \
+    "shell sidebar Space slider tests must verify scrub cancel restores the selected Space"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.sh
+++ b/clients/apple/scripts/test-shell-runtime-metadata.sh
@@ -18,6 +18,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellAutomationCommand.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellClipboardWriter.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -2116,7 +2116,7 @@ private enum ShellRuntimeMetadataTests {
 
     private static func verifiesSpaceCreateCapAppliesToControlCommandPaths() {
         var cappedState = ShellStateSnapshot.bootstrapDefault(windowID: "space_cap_control")
-        while cappedState.spaces.count < ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces {
+        while cappedState.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces {
             cappedState = cappedState.creatingTerminalSpace(
                 title: nil,
                 workingDirectory: nil
@@ -2131,7 +2131,7 @@ private enum ShellRuntimeMetadataTests {
         expect(directSpaceID == nil, "direct createSpace must reject the capped Space count")
         expect(
             controller.shellState.spaces.count
-                == ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces,
+                == ShellSidebarSpaceSliderLayout.maximumVisibleSpaces,
             "direct createSpace must leave the capped Space count unchanged"
         )
 
@@ -2152,7 +2152,7 @@ private enum ShellRuntimeMetadataTests {
         )
         expect(
             controller.shellState.spaces.count
-                == ShellSidebarSpaceSliderPolicy.maximumVisibleSpaces,
+                == ShellSidebarSpaceSliderLayout.maximumVisibleSpaces,
             "control-plane space.create must leave the capped Space count unchanged"
         )
 

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh
@@ -11,6 +11,7 @@ mkdir -p "$MODULE_CACHE_DIR"
 
 CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderWheelMonitor.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
     -o "$TEST_BINARY"
 

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/alan-shell-sidebar-space-slider-layout-tests"
+MODULE_CACHE_DIR="${BUILD_DIR}/clang-module-cache"
+TEST_BINARY="${BUILD_DIR}/shell-sidebar-space-slider-layout-tests"
+
+mkdir -p "$MODULE_CACHE_DIR"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "$REPO_ROOT/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    -o "$TEST_BINARY"
+
+"$TEST_BINARY"

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
@@ -207,6 +207,18 @@ private enum ShellSidebarSpaceSliderLayoutTests {
             verticalRoute == .passThrough,
             "vertical wheel input over the slider must pass through to tab-list scrolling"
         )
+        let verticalJitterRoute = verticalState.route(deltaX: 12, deltaY: 1)
+        expect(
+            verticalJitterRoute == .passThrough,
+            "vertical wheel intent must stay pass-through for the rest of the gesture"
+        )
+
+        verticalState.reset()
+        let postResetHorizontalRoute = verticalState.route(deltaX: 8, deltaY: 1)
+        expect(
+            postResetHorizontalRoute == .scrub(deltaX: 8),
+            "wheel intent reset must allow a later horizontal gesture to scrub Spaces"
+        )
 
         var ambiguousState = ShellSidebarSpaceSliderWheelIntentState()
         let ambiguousRoute = ambiguousState.route(deltaX: 4, deltaY: 4)

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
@@ -1,0 +1,277 @@
+import CoreGraphics
+import Foundation
+
+@main
+struct ShellSidebarSpaceSliderLayoutTestRunner {
+    static func main() throws {
+        try ShellSidebarSpaceSliderLayoutTests.run()
+    }
+}
+
+private enum ShellSidebarSpaceSliderLayoutTests {
+    static func run() throws {
+        try verifiesDensityTiers()
+        try verifiesLowDensityUsesFullTitles()
+        try verifiesMediumDensityUsesSelectedFullTitleAndShortTitles()
+        try verifiesHighDensityUsesSelectedTitleAndIndicators()
+        try verifiesHighDensityHoverExpandsTheHoveredIndicator()
+        try verifiesScrubFocusIsDistinctFromSelectedSpace()
+        try verifiesMaximumVisibleSpaceCap()
+        try verifiesReducedMotionRemovesScaleEmphasis()
+        try verifiesClickSelectionRules()
+        try verifiesDragScrubPreviewAndCommitTarget()
+        try verifiesDragScrubUsesEdgeResistanceAtBounds()
+        try verifiesWheelScrubPreviewAndCommitTarget()
+        try verifiesScrubCancelRestoresTheSelectedSource()
+        try verifiesWheelIntentRoutingProtectsVerticalScroll()
+        print("Shell sidebar Space slider layout tests passed.")
+    }
+
+    private static func verifiesDensityTiers() throws {
+        expect(ShellSidebarSpaceSliderLayout.density(for: 1) == .low, "1 Space must be low density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 3) == .low, "3 Spaces must be low density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 4) == .medium, "4 Spaces must be medium density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 6) == .medium, "6 Spaces must be medium density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 7) == .high, "7 Spaces must be high density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 9) == .high, "9 Spaces must be high density")
+        expect(ShellSidebarSpaceSliderLayout.density(for: 12) == .high, "Space count must cap into high density")
+    }
+
+    private static func verifiesLowDensityUsesFullTitles() throws {
+        let layout = make(spaceCount: 3, selectedIndex: 1)
+
+        expect(layout.density == .low, "3 Spaces must use low density")
+        expect(
+            layout.items.map(\.mode) == [.fullTitle, .fullTitle, .fullTitle],
+            "low density must render every Space as a full title"
+        )
+        expect(layout.items[1].isSelected, "selected item must be preserved")
+    }
+
+    private static func verifiesMediumDensityUsesSelectedFullTitleAndShortTitles() throws {
+        let layout = make(spaceCount: 6, selectedIndex: 2)
+
+        expect(layout.density == .medium, "6 Spaces must use medium density")
+        expect(layout.items[2].mode == .fullTitle, "selected medium-density Space must be full title")
+        expect(
+            layout.items.enumerated().allSatisfy { index, item in
+                index == 2 || item.mode == .shortTitle
+            },
+            "inactive medium-density Spaces must be short titles"
+        )
+    }
+
+    private static func verifiesHighDensityUsesSelectedTitleAndIndicators() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 4)
+
+        expect(layout.density == .high, "9 Spaces must use high density")
+        expect(layout.items[4].mode == .fullTitle, "selected high-density Space must be full title")
+        expect(
+            layout.items.enumerated().allSatisfy { index, item in
+                index == 4 || item.mode == .indicator
+            },
+            "inactive high-density Spaces must be indicators"
+        )
+    }
+
+    private static func verifiesHighDensityHoverExpandsTheHoveredIndicator() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 0, hoveredIndex: 5)
+
+        expect(layout.items[5].mode == .shortTitle, "hovered high-density indicator must expand to a short title")
+        expect(layout.items[5].isFocused, "hovered item must become focused for local preview")
+        expect(layout.items[4].visualScale >= 1, "neighboring items must remain visually stable")
+    }
+
+    private static func verifiesScrubFocusIsDistinctFromSelectedSpace() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 0, scrubFocusIndex: 6)
+
+        expect(layout.items[0].isSelected, "selected Space marker must remain on the active Space")
+        expect(layout.items[6].isFocused, "scrub focus must mark the preview Space")
+        expect(layout.items[6].mode == .fullTitle, "scrub-focused high-density Space must become a title")
+    }
+
+    private static func verifiesMaximumVisibleSpaceCap() throws {
+        let layout = make(spaceCount: 12, selectedIndex: 10)
+
+        expect(
+            ShellSidebarSpaceSliderLayout.maximumVisibleSpaces == 9,
+            "maximum visible Space count must be 9"
+        )
+        expect(layout.items.count == 9, "layout must cap rendered Spaces at 9")
+        expect(layout.items[8].isSelected, "selected index must clamp into the visible range")
+    }
+
+    private static func verifiesReducedMotionRemovesScaleEmphasis() throws {
+        let layout = ShellSidebarSpaceSliderLayout.make(
+            spaceCount: 9,
+            selectedIndex: 0,
+            scrubFocusIndex: 4,
+            availableWidth: 240,
+            reduceMotion: true
+        )
+
+        expect(
+            layout.items.allSatisfy { $0.visualScale == 1 },
+            "reduced motion must disable scale emphasis"
+        )
+    }
+
+    private static func verifiesClickSelectionRules() throws {
+        expect(
+            ShellSidebarSpaceSliderClickSelection.targetIndex(
+                selectedIndex: 2,
+                clickedIndex: 2,
+                spaceCount: 6
+            ) == nil,
+            "clicking the selected Space must leave selection unchanged"
+        )
+        expect(
+            ShellSidebarSpaceSliderClickSelection.targetIndex(
+                selectedIndex: 2,
+                clickedIndex: 4,
+                spaceCount: 6
+            ) == 4,
+            "clicking a non-selected Space must produce an immediate switch target"
+        )
+        expect(
+            ShellSidebarSpaceSliderClickSelection.targetIndex(
+                selectedIndex: 2,
+                clickedIndex: 9,
+                spaceCount: 6
+            ) == nil,
+            "clicking outside visible Space bounds must not select"
+        )
+    }
+
+    private static func verifiesDragScrubPreviewAndCommitTarget() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 2)
+        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 9)
+        let targetX = try expectValue(layout.midpoint(for: 6), "target midpoint must exist")
+
+        scrub.updateDrag(locationX: targetX, translationX: 3, layout: layout)
+        expect(scrub.focusIndex == 2, "drag below threshold must not move preview focus")
+
+        scrub.updateDrag(locationX: targetX, translationX: 48, layout: layout)
+        expect(scrub.focusIndex == 6, "drag scrub must preview the target under the pointer")
+        expect(scrub.hasPreviewTarget, "drag scrub must distinguish preview from selected Space")
+        expect(scrub.commitIndex == 6, "drag release must commit the focused Space")
+    }
+
+    private static func verifiesDragScrubUsesEdgeResistanceAtBounds() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 4)
+        var leadingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 9)
+        var trailingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 9)
+
+        leadingScrub.updateDrag(locationX: -40, translationX: -80, layout: layout)
+        trailingScrub.updateDrag(locationX: layout.contentWidth + 40, translationX: 80, layout: layout)
+
+        expect(leadingScrub.focusIndex == 0, "leading edge drag must clamp to the first Space")
+        expect(
+            leadingScrub.edgeResistanceOffset < 0,
+            "leading edge drag must expose a resisted offset"
+        )
+        expect(trailingScrub.focusIndex == 8, "trailing edge drag must clamp to the last Space")
+        expect(
+            trailingScrub.edgeResistanceOffset > 0,
+            "trailing edge drag must expose a resisted offset"
+        )
+    }
+
+    private static func verifiesWheelScrubPreviewAndCommitTarget() throws {
+        var scrub = try makeScrub(source: .wheel, selectedIndex: 3, spaceCount: 9)
+
+        scrub.updateWheel(deltaX: 10, itemSpan: 24, spaceCount: 9)
+        expect(scrub.focusIndex == 3, "small wheel scrub must enter preview without moving focus")
+
+        scrub.updateWheel(deltaX: 58, itemSpan: 24, spaceCount: 9)
+        expect(scrub.focusIndex == 5, "wheel scrub must move preview focus after enough horizontal input")
+        expect(scrub.hasPreviewTarget, "wheel scrub must preview before commit")
+        expect(scrub.commitIndex == 5, "wheel dwell must commit the focused Space")
+    }
+
+    private static func verifiesScrubCancelRestoresTheSelectedSource() throws {
+        let layout = make(spaceCount: 9, selectedIndex: 2)
+        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 9)
+        let targetX = try expectValue(layout.midpoint(for: 6), "target midpoint must exist")
+
+        scrub.updateDrag(locationX: targetX, translationX: 48, layout: layout)
+
+        expect(scrub.focusIndex == 6, "scrub preview must move before cancel")
+        expect(scrub.cancelIndex == 2, "scrub cancel must restore the selected source Space")
+    }
+
+    private static func verifiesWheelIntentRoutingProtectsVerticalScroll() throws {
+        var verticalState = ShellSidebarSpaceSliderWheelIntentState()
+        let verticalRoute = verticalState.route(deltaX: 1, deltaY: 8)
+        expect(
+            verticalRoute == .passThrough,
+            "vertical wheel input over the slider must pass through to tab-list scrolling"
+        )
+
+        var ambiguousState = ShellSidebarSpaceSliderWheelIntentState()
+        let ambiguousRoute = ambiguousState.route(deltaX: 4, deltaY: 4)
+        expect(
+            ambiguousRoute == .passThrough,
+            "ambiguous wheel input over the slider must not enter Space scrub"
+        )
+
+        var horizontalState = ShellSidebarSpaceSliderWheelIntentState()
+        let horizontalRoute = horizontalState.route(deltaX: 8, deltaY: 1)
+        expect(
+            horizontalRoute == .scrub(deltaX: 8),
+            "clear horizontal wheel input over the slider must enter Space scrub"
+        )
+    }
+
+    private static func make(
+        spaceCount: Int,
+        selectedIndex: Int?,
+        hoveredIndex: Int? = nil,
+        scrubFocusIndex: Int? = nil
+    ) -> ShellSidebarSpaceSliderLayout {
+        ShellSidebarSpaceSliderLayout.make(
+            spaceCount: spaceCount,
+            selectedIndex: selectedIndex,
+            hoveredIndex: hoveredIndex,
+            scrubFocusIndex: scrubFocusIndex,
+            availableWidth: 240,
+            reduceMotion: false
+        )
+    }
+
+    private static func makeScrub(
+        source: ShellSidebarSpaceSliderScrubSource,
+        selectedIndex: Int?,
+        spaceCount: Int
+    ) throws -> ShellSidebarSpaceSliderScrubState {
+        try expectValue(
+            ShellSidebarSpaceSliderScrubState(
+                source: source,
+                selectedIndex: selectedIndex,
+                spaceCount: spaceCount
+            ),
+            "scrub state must be created"
+        )
+    }
+
+    private static func expectValue<T>(_ value: T?, _ message: String) throws -> T {
+        guard let value else {
+            throw TestFailure(message)
+        }
+        return value
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fatalError(message)
+        }
+    }
+
+    private struct TestFailure: Error {
+        let message: String
+
+        init(_ message: String) {
+            self.message = message
+        }
+    }
+}

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
@@ -24,6 +24,7 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         try verifiesWheelScrubPreviewAndCommitTarget()
         try verifiesScrubCancelRestoresTheSelectedSource()
         try verifiesWheelIntentRoutingProtectsVerticalScroll()
+        try verifiesPhaseLessWheelResetSchedulerResetsAfterIdle()
         print("Shell sidebar Space slider layout tests passed.")
     }
 
@@ -233,6 +234,42 @@ private enum ShellSidebarSpaceSliderLayoutTests {
             horizontalRoute == .scrub(deltaX: 8),
             "clear horizontal wheel input over the slider must enter Space scrub"
         )
+    }
+
+    private static func verifiesPhaseLessWheelResetSchedulerResetsAfterIdle() throws {
+        var resetCount = 0
+        var scheduledWorkItems: [DispatchWorkItem] = []
+        var scheduledDelays: [TimeInterval] = []
+        let scheduler = ShellSidebarSpaceSliderWheelPhaseLessResetScheduler(
+            onReset: {
+                resetCount += 1
+            },
+            scheduleWorkItem: { workItem, delay in
+                scheduledWorkItems.append(workItem)
+                scheduledDelays.append(delay)
+            }
+        )
+
+        scheduler.scheduleResetAfterIdle()
+        expect(scheduledWorkItems.count == 1, "phase-less wheel input must schedule an idle reset")
+        expect(
+            scheduledDelays == [ShellSidebarSpaceSliderWheelPhaseLessResetScheduler.resetDelay],
+            "phase-less wheel reset must use the shared idle delay"
+        )
+
+        let firstWorkItem = scheduledWorkItems[0]
+        scheduler.scheduleResetAfterIdle()
+        firstWorkItem.perform()
+        expect(resetCount == 0, "a later phase-less event must cancel the prior idle reset")
+
+        scheduledWorkItems[1].perform()
+        expect(resetCount == 1, "phase-less idle reset must fire after the final scheduled event")
+
+        scheduler.scheduleResetAfterIdle()
+        let pendingWorkItem = scheduledWorkItems[2]
+        scheduler.resetNow()
+        pendingWorkItem.perform()
+        expect(resetCount == 2, "explicit wheel boundaries must cancel pending phase-less reset")
     }
 
     private static func make(

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
@@ -24,6 +24,7 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         try verifiesWheelScrubPreviewAndCommitTarget()
         try verifiesScrubCancelRestoresTheSelectedSource()
         try verifiesWheelIntentRoutingProtectsVerticalScroll()
+        try verifiesPassThroughWheelForwardingDecision()
         try verifiesPhaseLessWheelResetSchedulerResetsAfterIdle()
         print("Shell sidebar Space slider layout tests passed.")
     }
@@ -233,6 +234,24 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         expect(
             horizontalRoute == .scrub(deltaX: 8),
             "clear horizontal wheel input over the slider must enter Space scrub"
+        )
+    }
+
+    private static func verifiesPassThroughWheelForwardingDecision() throws {
+        expect(
+            ShellSidebarSpaceSliderWheelForwarding
+                .shouldForwardPassThroughToTabList(deltaX: 1, deltaY: 8),
+            "vertical pass-through wheel input over the fixed slider must be forwarded to the tab list"
+        )
+        expect(
+            ShellSidebarSpaceSliderWheelForwarding
+                .shouldForwardPassThroughToTabList(deltaX: 4, deltaY: 4),
+            "ambiguous pass-through wheel input with vertical delta must still reach tab-list scrolling"
+        )
+        expect(
+            !ShellSidebarSpaceSliderWheelForwarding
+                .shouldForwardPassThroughToTabList(deltaX: 8, deltaY: 0),
+            "horizontal-only pass-through wheel input must not be forwarded as vertical tab-list scrolling"
         )
     }
 

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/.openspec.yaml
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/design.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/design.md
@@ -1,0 +1,156 @@
+## Context
+
+The active `polish-macos-sidebar-space-slider` change moves Space navigation
+into a fixed top slider, removes the bottom Space dock, moves New Space into the
+sidebar titlebar, and places New Tab between pinned and unpinned tabs. That
+first pass solves layout structure, but the slider still needs a more polished
+visual and motion model.
+
+The target interaction should feel closer to native Safari tab density at low
+Space counts and closer to Arc-like compact navigation at high Space counts.
+It must also support fast Space selection without making the default sidebar
+visually noisy or causing the tab pager to switch repeatedly during rapid input.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support up to 9 Spaces in the default sidebar.
+- Use three density tiers for the Space slider: `1-3`, `4-6`, and `7-9`.
+- Keep low Space counts readable with named tab-like controls.
+- Keep high Space counts quiet with active-title plus indicator controls.
+- Add hover preview that locally expands or highlights the target Space without
+  switching.
+- Add scrub preview through both horizontal wheel/trackpad input and press-drag
+  input.
+- Commit scrub selection after release or a short focus dwell so the tab pager
+  does not churn during fast scrubbing.
+- Preserve Space context menus, click-to-switch behavior, hidden-titlebar
+  hit-testing, keyboard access, reduced motion, and VoiceOver semantics.
+
+**Non-Goals:**
+
+- Add Space overflow beyond 9 Spaces.
+- Add 3D transforms, perspective, or large cover-flow surfaces.
+- Move New Space back into the slider row.
+- Change tab organization, pinned tab semantics, terminal profile storage, or
+  daemon/runtime APIs.
+- Introduce a generalized carousel component outside the shell sidebar.
+
+## Decisions
+
+### Decision: Use adaptive density tiers instead of one fixed slider layout
+
+The Space slider uses three fixed tiers:
+
+- `1-3`: all Spaces show full titles in quiet Safari-like tab/pill controls.
+- `4-6`: active Space shows its full title; inactive Spaces show short,
+  single-line truncated titles in narrower tab/pill controls.
+- `7-9`: active Space shows its title; inactive Spaces show compact indicator
+  dots that can expand while hovered or scrub-focused.
+
+This makes the control useful when only a few Spaces exist while keeping the
+full 9-Space state calm and scannable.
+
+Alternative considered: always render active title plus dots. That is compact,
+but wastes available space and hides useful names when users only have a few
+Spaces. Another alternative was to keep Safari-like tabs at all counts, but
+that becomes crowded and visually heavy in the sidebar at 7-9 Spaces.
+
+### Decision: Keep static layout stable and bounded
+
+The slider stays inside the sidebar edge insets, remains single-line, and does
+not resize the sidebar or push titlebar controls. Long titles truncate before
+they cause layout growth. The active Space receives the most readable width;
+inactive titles truncate earlier.
+
+The active item is not forcibly centered in static mode. This avoids large
+position shifts when clicking nearby Spaces and keeps the top of the sidebar
+quiet during ordinary tab work.
+
+### Decision: Separate hover preview from selection
+
+Hovering a Space target only changes local presentation:
+
+- In `1-3`, the hovered inactive tab becomes slightly brighter and text
+  strengthens.
+- In `4-6`, the hovered inactive tab can widen modestly to show more title.
+- In `7-9`, the hovered indicator expands into a short-title pill, with nearby
+  indicators subtly emphasizing proximity.
+
+Hover never changes the active Space or moves the tab pager. This keeps pointer
+exploration cheap and avoids surprising workspace changes.
+
+### Decision: Use scrub preview with delayed commit
+
+The slider supports two scrub inputs:
+
+- Horizontal wheel or trackpad movement while the pointer is over the slider.
+- Press-drag movement that crosses a horizontal threshold.
+
+Entering scrub mode creates a temporary preview focus. The focused Space becomes
+the largest title pill in a lightweight cover-flow-like rail; neighboring Spaces
+scale and fade by distance. The currently active Space keeps a selected marker
+when it differs from the scrub focus, so preview and selection remain distinct.
+
+Scrub does not immediately switch the tab pager. Selection commits when the user
+releases the drag or when wheel/trackpad focus dwells for roughly `120-180ms`.
+After commit, the existing tab pager transition handles the content switch and
+the slider springs back to its static tier layout.
+
+Alternative considered: immediate switching while scrubbing. That feels direct
+but can churn the sidebar content and make the terminal workflow feel unstable
+with fast trackpad input.
+
+### Decision: Protect vertical scrolling and hidden-titlebar behavior
+
+Wheel/trackpad input only enters scrub when horizontal intent is clear. Vertical
+or ambiguous scroll input continues to the tab list and must not be captured by
+the slider.
+
+The slider must continue to participate in the hidden-titlebar hit-test model as
+an explicit control region, while blank sidebar chrome remains available for
+double-click zoom. Scrub hit areas should be broad enough for usability without
+turning the whole titlebar or spacer region into a control.
+
+### Decision: Keep accessibility and reduced motion first-class
+
+Each Space remains an individual accessibility button with label data for title,
+selected state, and tab count. Keyboard focus enters the slider as a group;
+left/right arrows move preview focus, Enter commits, and Escape cancels preview.
+
+When reduced motion is enabled, scrub avoids cover-flow scale and springy
+movement. It keeps the same state model using highlight, opacity, and bounded
+width changes.
+
+## Risks / Trade-offs
+
+- [Risk] The scrub interaction can steal vertical tab-list scrolling.
+  -> Mitigation: require clear horizontal intent before entering scrub and keep
+  ambiguous wheel input pass-through.
+
+- [Risk] Cover-flow motion can feel decorative or distracting in a terminal
+  product.
+  -> Mitigation: make the effect lightweight, sidebar-local, and only active
+  during deliberate scrub input.
+
+- [Risk] Multiple density tiers can make tests and layout math brittle.
+  -> Mitigation: extract a small layout model with deterministic inputs for
+  Space count, selected index, hovered index, scrub focus, available width, and
+  reduced-motion state.
+
+- [Risk] Hover expansion can cause distracting row shifts.
+  -> Mitigation: keep expansion bounded within the slider width, avoid changing
+  slider height, and use predictable truncation.
+
+- [Risk] The 9-Space cap changes previous assumptions from the first-pass
+  slider work.
+  -> Mitigation: update UI contracts, shell contract checks, and creation guard
+  tests in the same change.
+
+## Migration Plan
+
+Implement after `polish-macos-sidebar-space-slider` is merged or otherwise
+stabilized, because this change assumes the fixed top slider and removed bottom
+Space dock from that baseline. If the scrub polish is reverted, alan can fall
+back to the first-pass static slider without affecting persisted workspace data.

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/proposal.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The first-pass macOS Space slider removes the old header and bottom dock, but
+its static active-title-and-dot layout still feels under-polished compared with
+native tab bars. The next iteration should make Space navigation scale cleanly
+from a few named Spaces to a full set while adding a deliberate, fast scrub
+interaction for switching without making the default sidebar busy.
+
+## What Changes
+
+- Add an adaptive Space slider density model:
+  - `1-3` Spaces render as quiet Safari-like named tabs.
+  - `4-6` Spaces render active Space as a full title and inactive Spaces as
+    compact short-title tabs.
+  - `7-9` Spaces render active Space as a title and inactive Spaces as compact
+    indicators that can expand on hover or scrub focus.
+- Increase the default Space cap from 8 to 9.
+- Add hover preview behavior that locally expands or highlights the hovered
+  Space without switching the active Space.
+- Add scrub preview behavior for horizontal trackpad/wheel input and press-drag
+  input on the slider.
+- Commit scrub selection only after release or a short focus dwell so the tab
+  pager does not churn during fast scrubbing.
+- Preserve Space context menus, click-to-switch behavior, reduced-motion
+  behavior, keyboard access, VoiceOver labels, and hidden-titlebar hit testing.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Defines adaptive Space slider density,
+  hover preview, scrub preview/commit behavior, the 9-Space cap, accessibility,
+  reduced-motion, and scroll-input protection.
+- `macos-shell-build-test-contract`: Adds focused verification expectations for
+  adaptive density tiers, slider input states, scrub preview/commit behavior,
+  and titlebar/window hit-test preservation.
+
+## Impact
+
+- Expected Apple client changes are local to the sidebar Space slider and
+  related shell input/hit-test checks, especially `ShellSidebarView.swift`,
+  shared shell design tokens, and focused Apple shell scripts.
+- No daemon, runtime, protocol, provider, persistence, or dependency changes are
+  expected.
+- Visual verification will need a fresh Alan Dev launch when implementation
+  reaches review.

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Adaptive Space slider polish has focused verification
+The Apple client SHALL include focused automated checks or documented visual
+verification for adaptive Space slider density, hover preview, scrub
+preview/commit behavior, input protection, accessibility, and hit-test
+preservation.
+
+#### Scenario: Density tiers are verified
+- **WHEN** the adaptive Space slider is implemented
+- **THEN** focused checks verify the 1-3, 4-6, and 7-9 Space density tiers
+- **AND** focused checks verify that the Space cap is 9 and creation affordances
+  do not expose a tenth default-sidebar Space
+
+#### Scenario: Static layout stability is verified
+- **WHEN** Space titles are long, localized, or mixed with different Space counts
+- **THEN** focused checks or documented review verify that the slider remains
+  single-line, does not resize the sidebar, keeps the fixed top slider position,
+  and truncates inactive titles before text overlaps adjacent controls
+
+#### Scenario: Hover and click behavior is verified
+- **WHEN** Space slider hover or click behavior changes
+- **THEN** focused checks verify hover preview does not switch Spaces
+- **AND** focused checks verify clicking a non-selected Space switches
+  immediately while clicking the selected Space leaves selection unchanged
+
+#### Scenario: Scrub preview and commit are verified
+- **WHEN** Space slider scrub behavior is implemented
+- **THEN** focused checks verify press-drag scrub moves preview focus before
+  commit
+- **AND** focused checks verify horizontal wheel or trackpad scrub commits only
+  after release or dwell timing rather than switching on every delta
+- **AND** focused checks verify canceling scrub restores the previous selected
+  Space when no commit occurred
+
+#### Scenario: Scroll input protection is verified
+- **WHEN** wheel or trackpad routing for the Space slider changes
+- **THEN** focused checks verify clear horizontal input can enter scrub
+- **AND** vertical or ambiguous input does not prevent the tab list from
+  scrolling vertically
+
+#### Scenario: Accessibility and reduced motion are verified
+- **WHEN** adaptive Space slider polish is marked complete
+- **THEN** focused checks or documented review verify VoiceOver labels,
+  selected-state announcements, keyboard preview/commit/cancel behavior, and
+  reduced-motion scrub behavior
+
+#### Scenario: Hidden-titlebar hit testing remains verified
+- **WHEN** slider hit areas, hover expansion, or scrub controls are changed
+- **THEN** focused window-placement checks verify Space slider controls are not
+  treated as blank double-click zoom chrome
+- **AND** blank sidebar chrome outside actual controls remains available for
+  hidden-titlebar double-click zoom
+
+#### Scenario: Visual evidence captures all density tiers
+- **WHEN** adaptive Space slider implementation is ready for review
+- **THEN** maintainers can inspect running-app screenshots or notes from a fresh
+  Alan Dev launch showing the light-mode sidebar at representative 1-3, 4-6,
+  and 7-9 Space counts
+- **AND** visual evidence covers hover expansion, scrub preview focus,
+  post-commit selected state, and the absence of the removed bottom Space dock

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Space slider supports adaptive density and scrub navigation
+The default macOS shell Space slider SHALL adapt its visual density to the
+number of Spaces and SHALL support deliberate preview-first scrub navigation
+without making the default sidebar visually noisy or unstable.
+
+#### Scenario: Low-density Space slider shows full titles
+- **WHEN** the default sidebar has 1 to 3 Spaces
+- **THEN** the Space slider shows every Space as a named, single-line
+  Safari-like tab or pill control
+- **AND** the selected Space has the strongest material and text treatment
+- **AND** inactive Spaces remain readable without using Space icons
+
+#### Scenario: Mid-density Space slider shows active and short titles
+- **WHEN** the default sidebar has 4 to 6 Spaces
+- **THEN** the Space slider shows the selected Space with its full title
+- **AND** every inactive Space remains visible as a compact short-title control
+- **AND** inactive Space titles truncate on one line before they resize the
+  sidebar, wrap text, or overlap adjacent controls
+
+#### Scenario: High-density Space slider uses active title and indicators
+- **WHEN** the default sidebar has 7 to 9 Spaces
+- **THEN** the Space slider shows the selected Space as a title control
+- **AND** inactive Spaces render as compact indicators in the default idle state
+- **AND** hovered or scrub-focused inactive indicators can expand into short
+  title controls without changing slider height or sidebar width
+
+#### Scenario: Space count is capped at nine
+- **WHEN** the user attempts to create Spaces from the default macOS shell
+- **THEN** alan allows at most 9 Spaces in the Space slider model
+- **AND** creation affordances do not produce a tenth visible Space in the
+  default sidebar
+
+#### Scenario: Hover previews without switching
+- **WHEN** the pointer hovers a non-selected Space in the slider
+- **THEN** alan locally highlights or expands that Space according to the active
+  density tier
+- **AND** alan does not switch the selected Space, move the tab pager, or change
+  focused terminal content merely because of hover
+
+#### Scenario: Click switching remains immediate
+- **WHEN** the user clicks a non-selected Space in the slider
+- **THEN** alan immediately selects that Space
+- **AND WHEN** the user clicks the selected Space
+- **THEN** alan keeps the current selection unchanged
+
+#### Scenario: Scrub previews before commit
+- **WHEN** the user press-drags horizontally on the Space slider or sends clear
+  horizontal wheel or trackpad input while hovering the slider
+- **THEN** alan enters a scrub preview state with a focused target Space
+- **AND** alan distinguishes the scrub focus from the currently selected Space
+  when they differ
+- **AND** alan does not commit Space selection until drag release or a short
+  dwell after wheel or trackpad input stops
+
+#### Scenario: Scrub uses lightweight cover-flow motion
+- **WHEN** reduced motion is disabled and Space scrub is active
+- **THEN** the scrub-focused Space is emphasized as the largest title control
+- **AND** nearby Spaces scale or fade by distance to communicate direction
+- **AND** the effect remains bounded inside the sidebar Space slider rather than
+  introducing a large carousel or decorative overlay
+
+#### Scenario: Vertical scrolling is preserved
+- **WHEN** wheel or trackpad input over the Space slider is vertical or
+  ambiguous between horizontal and vertical intent
+- **THEN** alan does not enter Space scrub
+- **AND** the tab list can continue receiving vertical scrolling behavior
+
+#### Scenario: Space context menus remain available
+- **WHEN** the user right-clicks or opens the context menu for a selected,
+  hovered, or scrub-focused Space target
+- **THEN** alan opens the context menu for that Space
+- **AND** any active scrub preview is canceled before the context menu action
+  changes Space-level settings
+
+#### Scenario: Reduced motion preserves the state model
+- **WHEN** reduced motion is enabled
+- **THEN** hover and scrub use bounded highlight, opacity, and width changes
+  instead of cover-flow scale, springy movement, or perspective-like motion
+- **AND** click, hover, scrub preview, commit, cancel, and keyboard behavior
+  remain equivalent
+
+#### Scenario: Keyboard and accessibility navigation remain explicit
+- **WHEN** keyboard focus or VoiceOver reaches the Space slider
+- **THEN** each Space is exposed as a distinct actionable target with its title,
+  selected state, and tab count
+- **AND** left and right keyboard navigation can move preview focus without
+  immediately switching Spaces
+- **AND** Enter commits the focused Space and Escape cancels preview focus

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/tasks.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/tasks.md
@@ -1,0 +1,48 @@
+## 1. Baseline And Model
+
+- [x] 1.1 Confirm `polish-macos-sidebar-space-slider` is merged, archived, or explicitly selected as the implementation baseline.
+- [x] 1.2 Raise the default macOS Space creation cap from 8 to 9 and update related creation guardrails.
+- [x] 1.3 Extract or add a deterministic Space slider layout model for Space count, selected index, hovered index, scrub focus, available width, and reduced-motion state.
+- [x] 1.4 Define layout output for the `1-3`, `4-6`, and `7-9` density tiers, including title truncation and indicator hit areas.
+
+## 2. Static Slider Layout
+
+- [x] 2.1 Render the `1-3` tier as full-title Safari-like tab or pill controls without Space icons.
+- [x] 2.2 Render the `4-6` tier with selected full title and inactive compact short-title controls.
+- [x] 2.3 Render the `7-9` tier with selected title and inactive compact indicators.
+- [x] 2.4 Preserve single-line height, sidebar edge insets, fixed top slider placement, and no bottom Space dock.
+
+## 3. Hover And Scrub Interaction
+
+- [x] 3.1 Add hover preview state that locally highlights or expands Space targets without selecting them.
+- [x] 3.2 Add press-drag scrub input with a horizontal threshold and edge resistance at first/last Space.
+- [x] 3.3 Add horizontal wheel or trackpad scrub input with clear horizontal-intent gating.
+- [x] 3.4 Add scrub preview state that distinguishes focus Space from the currently selected Space.
+- [x] 3.5 Commit scrub selection on drag release or after the wheel/trackpad focus dwell window.
+- [x] 3.6 Cancel scrub preview for Escape, context menu open, invalid target, or selected Space deletion.
+
+## 4. Motion, Accessibility, And Hit Testing
+
+- [x] 4.1 Add lightweight cover-flow-style scrub emphasis for the focused Space and neighboring Spaces.
+- [x] 4.2 Add reduced-motion behavior that preserves the state model without scale-heavy or springy motion.
+- [x] 4.3 Preserve Space context menus for selected, hovered, and scrub-focused Space targets.
+- [x] 4.4 Preserve VoiceOver labels, selected-state announcement, tab count, keyboard preview, Enter commit, and Escape cancel.
+- [x] 4.5 Preserve hidden-titlebar hit testing so slider controls are clickable and blank sidebar chrome remains a double-click zoom target.
+
+## 5. Focused Verification
+
+- [x] 5.1 Add focused layout-model tests for the `1-3`, `4-6`, and `7-9` density tiers and 9-Space cap.
+- [x] 5.2 Add focused interaction tests for hover preview, click immediate switch, drag scrub preview/commit, wheel scrub preview/commit, and cancel behavior.
+- [x] 5.3 Add focused scroll-routing tests proving vertical or ambiguous wheel input does not steal tab-list scrolling.
+- [x] 5.4 Update shell contract checks for adaptive slider tiers, 9-Space cap, removed bottom Space dock, and hit-test preservation.
+- [x] 5.5 Run focused shell/sidebar/window-placement scripts that cover the changed layout and input behavior.
+- [x] 5.6 Run `openspec validate polish-macos-space-slider-adaptive-scrub --strict`.
+
+## 6. Visual Review And Archive Readiness
+
+- [x] 6.1 Freshly relaunch Alan Dev before visual verification.
+- [x] 6.2 Capture or document light-mode sidebar evidence for representative `1-3`, `4-6`, and `7-9` Space counts.
+- [x] 6.3 Capture or document hover expansion, scrub preview focus, and post-commit selected state.
+- [x] 6.4 Confirm the implementation diff is limited to sidebar Space slider polish, focused tests, and this OpenSpec change.
+- [ ] 6.5 Sync accepted delta specs into `openspec/specs/` after implementation is merged.
+- [ ] 6.6 Archive the completed OpenSpec change after synced specs validate.

--- a/openspec/changes/polish-macos-space-slider-adaptive-scrub/visual-review.md
+++ b/openspec/changes/polish-macos-space-slider-adaptive-scrub/visual-review.md
@@ -1,0 +1,57 @@
+## Visual Review
+
+Run: `space-slider-adaptive-open-fresh`
+
+Fresh launch evidence:
+
+- Built app: `debug/DerivedData/apple-shell-ui-smoke/Build/Products/Debug/Alan.app`
+- Executable confirmed by `lsof -p 50789`:
+  `/private/tmp/alan-space-slider-adaptive-scrub/debug/DerivedData/apple-shell-ui-smoke/Build/Products/Debug/Alan.app/Contents/MacOS/Alan`
+- Bundle id: `app.alanworks.macos.space-slider-adaptive`
+- Smoke manifest: `debug/artifacts/space-slider-adaptive-open-fresh/manifest.txt`
+- Capturable window: `capture-alan-window.sh --pid 50789 --list` returned window `23016`.
+
+Light-mode density screenshots:
+
+- `debug/artifacts/space-slider-adaptive-open-fresh/01-space-create.png`
+  shows the 3-Space low-density state with all Space targets rendered as named,
+  single-line controls.
+- `debug/artifacts/space-slider-adaptive-open-fresh/04-six-spaces.png`
+  shows the 6-Space medium-density state with a selected title control and
+  compact inactive short-title controls.
+- `debug/artifacts/space-slider-adaptive-open-fresh/05-nine-spaces.png`
+  shows the 9-Space high-density state with compact inactive indicators and a
+  selected title control. The New Space affordance is visually disabled at cap.
+
+Interaction evidence:
+
+- `debug/artifacts/space-slider-adaptive-open-fresh/06-hover-indicator.png`
+  records a cursor-warp hover attempt over the high-density slider. SwiftUI hover
+  expansion did not visibly trigger from this non-Accessibility path, so this is
+  not treated as proof of hover expansion.
+- Local Accessibility scripting was unavailable:
+  `osascript -e 'tell application "System Events" to count of processes'`
+  returned error `-10827`, and the smoke manifest recorded
+  `skipped_ui_scripting_steps=Accessibility permission was unavailable or disabled`.
+- Hover expansion, scrub preview focus, drag/wheel commit, cancel behavior,
+  reduced motion, and vertical-scroll protection are covered by
+  `clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh`, including:
+  `verifiesHighDensityHoverExpandsTheHoveredIndicator`,
+  `verifiesScrubFocusIsDistinctFromSelectedSpace`,
+  `verifiesDragScrubPreviewAndCommitTarget`,
+  `verifiesWheelScrubPreviewAndCommitTarget`,
+  `verifiesScrubCancelRestoresTheSelectedSource`, and
+  `verifiesWheelIntentRoutingProtectsVerticalScroll`.
+
+Post-commit selected state:
+
+- The 3-, 6-, and 9-Space screenshots were captured after successful
+  `space.create` control-plane commands. Each command returned `applied=true`,
+  and the captured slider selected the newly created Space after the state
+  mutation committed.
+
+Scope check:
+
+- The implementation diff is limited to the macOS sidebar Space slider polish,
+  the Space creation cap guard, focused shell contract checks/tests, and this
+  OpenSpec change.


### PR DESCRIPTION
## Summary
- add the adaptive 1-3 / 4-6 / 7-9 Space slider layout model with a 9-Space cap
- render static low, medium, and high density slider states and preserve fixed top placement
- add hover preview, drag scrub, horizontal wheel scrub, reduced-motion, accessibility, and context-menu handling
- add focused layout/interaction tests, contract checks, and OpenSpec visual-review notes

## Verification
- bash clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh
- bash clients/apple/scripts/test-shell-sidebar-swipe-monitor.sh
- bash clients/apple/scripts/test-shell-window-placement.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- openspec validate polish-macos-space-slider-adaptive-scrub --strict
- git diff --check
- xcodebuild via fresh UI smoke build
- visual evidence: debug/artifacts/space-slider-adaptive-open-fresh/01-space-create.png, 04-six-spaces.png, 05-nine-spaces.png

Stacked on #532 / codex/polish-macos-sidebar-space-slider.