### PR TITLE
Retire stale sidebar title pager spec wording

### DIFF
--- a/openspec/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/specs/macos-shell-build-test-contract/spec.md
@@ -271,11 +271,11 @@ navigation.
 - **WHEN** tab or space row secondary actions are progressively disclosed
 - **THEN** verification covers default, hover, selected, no-notification-dot, and empty states without row resizing or layout shifts
 - **AND** verification covers the tab row hierarchy where normal rows are containerless, hover/focus rows are subtle, selected rows are strongest, and creation rows stay muted until interaction
-- **AND** verification covers the space-title/tab-list scroll boundary where the divider and shadow appear only as tab rows scroll underneath the fixed space title region
+- **AND** verification covers the Space slider/tab-list scroll boundary where the divider and shadow appear only as tab rows scroll underneath the fixed top Space slider region
 
 #### Scenario: Sidebar space swipe is reviewed
 - **WHEN** horizontal space switching is implemented in the sidebar
-- **THEN** verification covers gesture-tracked left and right sidebar previews, translation-first drag mapping, fast horizontal flick commit, full-width space-title and tab-list motion, stationary hold, zero-delta release, horizontal/vertical axis lock, later vertical movement during a horizontal swipe, no static side padding gaps during page motion, a stable workspace during drag, commit, cancel, edge resistance, and confirms vertical tab-list scrolling still works
+- **THEN** verification covers gesture-tracked left and right sidebar previews, translation-first drag mapping, fast horizontal flick commit, full-width per-Space tab content motion beneath the fixed top Space slider, stationary hold, zero-delta release, horizontal/vertical axis lock, later vertical movement during a horizontal swipe, no static side padding gaps during page motion, a stable workspace during drag, commit, cancel, edge resistance, and confirms vertical tab-list scrolling still works
 
 #### Scenario: Split tab indicator is reviewed
 - **WHEN** split-aware tab row implementation is marked complete

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -582,9 +582,9 @@ accessibility labels rather than persistent instructional copy.
 - **AND** trailing close affordances appear for selected, hover, or focus states without resizing the row or shifting neighboring rows
 - **AND** compact creation rows remain muted by default and gain a subtle backing only on hover or focus
 
-#### Scenario: Space title scroll boundary
+#### Scenario: Space slider scroll boundary
 - **WHEN** the active-space tab list is at its resting top position
-- **THEN** the active-space title appears as a quiet grayscale label without a persistent pill or control background
+- **THEN** the selected Space title appears inside the top Space slider as a quiet label without a persistent pill or control background
 - **AND** the area between the top Space slider and the first tab row keeps a compact quiet material gap without a persistent divider
 - **WHEN** the user scrolls the active-space tab list upward so tab rows move underneath the fixed top Space slider region
 - **THEN** alan gradually reveals a subtle divider and downward shadow at the slider/list boundary
@@ -592,7 +592,7 @@ accessibility labels rather than persistent instructional copy.
 
 #### Scenario: Visible copy is minimized
 - **WHEN** the default sidebar has at least one space and one tab
-- **THEN** the sidebar does not rely on persistent explanatory paragraphs, product slogans, keyboard-shortcut labels, redundant `Tabs` and `Spaces` headings, or always-visible creation icons in the space-title row to explain normal operation
+- **THEN** the sidebar does not rely on persistent explanatory paragraphs, product slogans, keyboard-shortcut labels, redundant `Tabs` and `Spaces` headings, or always-visible creation icons in the Space slider to explain normal operation
 
 #### Scenario: Accessibility remains explicit
 - **WHEN** visible explanatory copy is removed from the sidebar


### PR DESCRIPTION
## Summary

- retire stale build-test wording that still required full-width Space title/header pager motion
- align sidebar scroll-boundary wording with the fixed top Space slider contract
- sweep canonical specs for stale space-title/header-pager terms

## Verification

- `openspec validate --all --strict`
- `git diff --check`
- `rg -n "space-title|space title|fixed space title|active-space title|space-title row|full-width space-title|active-space header|space header|title pager|header pager|bottom space switcher|bottom Space switcher|bottom switcher|command input remains fixed" openspec/specs`
