### PR TITLE
Preserve terminal transcript output during graceful close

### DIFF
--- a/clients/apple/alan-macos/GhosttyLiveHost.swift
+++ b/clients/apple/alan-macos/GhosttyLiveHost.swift
@@ -38,6 +38,8 @@ final class AlanGhosttyLiveHost: NSObject {
     private var queuedForegroundCommandSubmissions = 0
 
     private enum KeyCode {
+        static let d: UInt32 = 2
+        static let c: UInt32 = 8
         static let returnKey: UInt32 = 36
         static let keypadEnter: UInt32 = 76
     }
@@ -144,15 +146,23 @@ final class AlanGhosttyLiveHost: NSObject {
     func sendControlKey(_ key: TerminalRuntimeControlKey) -> Bool {
         guard surface != nil else { return false }
         let keycode: UInt32
+        let mods: ghostty_input_mods_e
         switch key {
+        case .interrupt:
+            keycode = KeyCode.c
+            mods = GHOSTTY_MODS_CTRL
+        case .endOfTransmission:
+            keycode = KeyCode.d
+            mods = GHOSTTY_MODS_CTRL
         case .returnKey:
             keycode = KeyCode.returnKey
+            mods = GHOSTTY_MODS_NONE
         }
 
         var keyDown = ghostty_input_key_s()
         keyDown.action = GHOSTTY_ACTION_PRESS
         keyDown.keycode = keycode
-        keyDown.mods = GHOSTTY_MODS_NONE
+        keyDown.mods = mods
         keyDown.consumed_mods = GHOSTTY_MODS_NONE
         keyDown.text = nil
         keyDown.composing = false

--- a/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum TerminalRuntimeControlKey: String, Codable, Equatable {
+    case interrupt
+    case endOfTransmission = "end_of_transmission"
     case returnKey = "return"
 }
 

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -384,6 +384,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let workspaceManifestStore: ShellWorkspaceManifestStore?
     private var workspaceManifest: ShellContentWorkspaceManifest?
     private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
+    private var terminalContentIDsSuppressingAutoClose: Set<String> = []
     private let paneProjection: ShellPaneProjectionService
     private let terminalContentProjection: TerminalContentProjectionAdapter
     private let terminalContentLifecycle = TerminalContentLifecycleAdapter()
@@ -3149,6 +3150,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
     @discardableResult
     func closePaneAfterTerminalRuntimeExit(paneID: String) -> Bool {
+        guard !terminalAutoCloseIsSuppressed(paneID: paneID) else { return false }
         if shellState.quickTerminal?.paneID == paneID {
             return closeQuickTerminalAfterTerminalRuntimeExit()
         }
@@ -3159,10 +3161,25 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard closeConfirmationPresenter.confirmClose(impact: impact) else {
             return false
         }
-        let gracefullyRequestedContentIDs = requestGracefulShutdownForConfirmedClose(impact)
-        waitForGracefulShutdownDrain(contentIDs: gracefullyRequestedContentIDs)
-        let capturedTranscripts = captureTerminalTranscriptSnapshots(for: impact)
-        return applyConfirmedClose(impact, transcriptSnapshotOverrides: capturedTranscripts)
+        return withTerminalAutoCloseSuppressed(for: impact.affectedTerminalContentIDs) {
+            let gracefullyRequestedContentIDs = requestGracefulShutdownForConfirmedClose(impact)
+            waitForGracefulShutdownDrain(contentIDs: gracefullyRequestedContentIDs)
+            let capturedTranscripts = captureTerminalTranscriptSnapshots(for: impact)
+            return applyConfirmedClose(impact, transcriptSnapshotOverrides: capturedTranscripts)
+        }
+    }
+
+    private func withTerminalAutoCloseSuppressed<T>(
+        for contentIDs: [String],
+        operation: () -> T
+    ) -> T {
+        guard !contentIDs.isEmpty else { return operation() }
+        let previous = terminalContentIDsSuppressingAutoClose
+        terminalContentIDsSuppressingAutoClose.formUnion(contentIDs)
+        defer {
+            terminalContentIDsSuppressingAutoClose = previous
+        }
+        return operation()
     }
 
     @discardableResult
@@ -3466,7 +3483,18 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     ) -> Bool {
         guard processExited else { return false }
         guard pane(paneID: paneID) != nil else { return false }
+        guard !terminalAutoCloseIsSuppressed(paneID: paneID) else { return false }
         return applyClosePaneMutation(paneID: paneID) == .closed
+    }
+
+    private func terminalAutoCloseIsSuppressed(paneID: String) -> Bool {
+        let contentState = shellState.contentStateProjection()
+        let contentID = terminalContentIDForCloseGuard(
+            paneID: paneID,
+            contentState: contentState
+        ) ?? pane(paneID: paneID)?.terminalContentID
+        guard let contentID else { return false }
+        return terminalContentIDsSuppressingAutoClose.contains(contentID)
     }
 
     func movePane(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -375,6 +375,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private static let unpinnedTabRetentionTTL: TimeInterval = 12 * 60 * 60
+    private static let gracefulShutdownPollInterval: TimeInterval = 0.05
     private static let iso8601Formatter = ISO8601DateFormatter()
     private let fileManager: FileManager
     private let windowContext: ShellWindowContext
@@ -388,6 +389,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let terminalContentLifecycle = TerminalContentLifecycleAdapter()
     private let clipboardWriter: ShellClipboardWriter
     private let closeConfirmationPresenter: ShellCloseConfirmationPresenting
+    private let gracefulShutdownTimeout: TimeInterval
     private let performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder?
     lazy var controlPlane = AlanShellControlPlane(
         windowID: windowContext.windowID,
@@ -451,6 +453,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
         workspaceManifest: ShellContentWorkspaceManifest? = nil,
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
+        gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
         appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
@@ -472,6 +475,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self.clipboardWriter = ShellClipboardWriter()
         self.closeConfirmationPresenter =
             closeConfirmationPresenter ?? ShellNSAlertCloseConfirmationPresenter()
+        self.gracefulShutdownTimeout = gracefulShutdownTimeout
         self.performanceDiagnosticsRecorder = performanceDiagnosticsRecorder
         self.appIsActiveProvider = appIsActiveProvider
         self.shellState = shellState
@@ -3155,8 +3159,89 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard closeConfirmationPresenter.confirmClose(impact: impact) else {
             return false
         }
+        let gracefullyRequestedContentIDs = requestGracefulShutdownForConfirmedClose(impact)
+        waitForGracefulShutdownDrain(contentIDs: gracefullyRequestedContentIDs)
         let capturedTranscripts = captureTerminalTranscriptSnapshots(for: impact)
         return applyConfirmedClose(impact, transcriptSnapshotOverrides: capturedTranscripts)
+    }
+
+    @discardableResult
+    private func requestGracefulShutdownForConfirmedClose(
+        _ impact: ShellCloseGuardImpact
+    ) -> [String] {
+        let reason = gracefulShutdownReason(for: impact.scope)
+        var requestedContentIDs: [String] = []
+        var seenContentIDs: Set<String> = []
+        for contentID in impact.activeTerminalContentIDs
+            where seenContentIDs.insert(contentID).inserted
+        {
+            let result = terminalRuntimeRegistry.requestGracefulShutdown(
+                forTerminalContentID: contentID,
+                reason: reason
+            )
+            if result.wasRequested {
+                requestedContentIDs.append(contentID)
+            } else if result.code != .alreadyExited {
+                recordControlPlaneDiagnostic(
+                    "terminal graceful shutdown request \(result.code.rawValue) for \(contentID)"
+                )
+            }
+        }
+        return requestedContentIDs
+    }
+
+    private func waitForGracefulShutdownDrain(contentIDs: [String]) {
+        guard gracefulShutdownTimeout > 0, !contentIDs.isEmpty else { return }
+        let deadline = Date().addingTimeInterval(gracefulShutdownTimeout)
+        while Date() < deadline {
+            if contentIDs.allSatisfy({ terminalGracefulShutdownSettled(contentID: $0) }) {
+                return
+            }
+            let remaining = max(0, deadline.timeIntervalSinceNow)
+            _ = RunLoop.current.run(
+                mode: .default,
+                before: Date().addingTimeInterval(
+                    min(Self.gracefulShutdownPollInterval, remaining)
+                )
+            )
+        }
+
+        let timedOutContentIDs = contentIDs.filter {
+            !terminalGracefulShutdownSettled(contentID: $0)
+        }
+        guard !timedOutContentIDs.isEmpty else { return }
+        recordControlPlaneDiagnostic(
+            "terminal graceful shutdown timed out for \(timedOutContentIDs.joined(separator: ","))"
+        )
+    }
+
+    private func terminalGracefulShutdownSettled(contentID: String) -> Bool {
+        let runtime = terminalRuntimeRegistry.snapshot(forTerminalContentID: contentID)
+        let metadata = runtime.paneMetadata
+        if metadata.processExited {
+            return true
+        }
+        if let activeTaskState = metadata.activeTaskState {
+            return !activeTaskState.protectsFromPruning
+        }
+        return !terminalRuntimeRegistry.registeredContentIDs.contains(contentID)
+    }
+
+    private func gracefulShutdownReason(
+        for scope: ShellCloseGuardScope
+    ) -> TerminalRuntimeGracefulShutdownReason {
+        switch scope {
+        case .paneSlot:
+            return .paneClose
+        case .tab:
+            return .tabClose
+        case .quickTerminal:
+            return .quickTerminalClose
+        case .window:
+            return .windowClose
+        case .app:
+            return .appQuit
+        }
     }
 
     @discardableResult

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -736,6 +736,15 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         return AlanShellBootProfile.forPane(pane, shellState: shellState)
     }
 
+    func restoredTranscriptSnapshot(for pane: ShellPane?) -> TerminalTranscriptSnapshot? {
+        guard let pane,
+              let content = terminalContentInstance(mountedIn: pane)
+        else {
+            return nil
+        }
+        return content.payload.terminal?.transcriptSnapshot?.boundedForManifest()
+    }
+
     private func seedRestoredTranscriptSnapshotIfNeeded(for pane: ShellPane) {
         guard let content = terminalContentInstance(mountedIn: pane),
               let transcriptSnapshot = content.payload.terminal?.transcriptSnapshot

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -458,29 +458,35 @@ private struct QuickTerminalContentView: View {
             ShellPalette.terminal
 
             if terminalContentEnabled {
-                TerminalHostView(
-                    pane: pane,
-                    terminalContentMount: TerminalContentMount(pane: pane),
-                    bootProfile: host.bootProfile(for: pane),
-                    isSelected: true,
-                    renderPriority: host.terminalRenderPriority(for: pane),
-                    runtimeRegistry: host.terminalRuntimeRegistry,
-                    activationDelegate: host,
-                    attachmentPolicy: .deferUntilWindowAttached,
-                    onShellAction: { actionID, target in
-                        host.performShellAction(actionID, target: target, source: .terminalHost)
-                    },
-                    onCloseRequest: { requiresConfirmation in
-                        guard !requiresConfirmation else { return }
-                        _ = host.closeQuickTerminalAfterTerminalRuntimeExit()
-                    },
-                    onRuntimeUpdate: host.updateTerminalRuntime,
-                    onMetadataUpdate: { metadata in
-                        host.updateTerminalMetadata(metadata, for: pane.paneID)
+                VStack(spacing: 0) {
+                    if let snapshot = host.restoredTranscriptSnapshot(for: pane) {
+                        RestoredTerminalTranscriptView(snapshot: snapshot)
                     }
-                )
-                .id(pane.paneID)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                    TerminalHostView(
+                        pane: pane,
+                        terminalContentMount: TerminalContentMount(pane: pane),
+                        bootProfile: host.bootProfile(for: pane),
+                        isSelected: true,
+                        renderPriority: host.terminalRenderPriority(for: pane),
+                        runtimeRegistry: host.terminalRuntimeRegistry,
+                        activationDelegate: host,
+                        attachmentPolicy: .deferUntilWindowAttached,
+                        onShellAction: { actionID, target in
+                            host.performShellAction(actionID, target: target, source: .terminalHost)
+                        },
+                        onCloseRequest: { requiresConfirmation in
+                            guard !requiresConfirmation else { return }
+                            _ = host.closeQuickTerminalAfterTerminalRuntimeExit()
+                        },
+                        onRuntimeUpdate: host.updateTerminalRuntime,
+                        onMetadataUpdate: { metadata in
+                            host.updateTerminalMetadata(metadata, for: pane.paneID)
+                        }
+                    )
+                    .id(pane.paneID)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous))
@@ -607,6 +613,7 @@ private struct ShellPaneTreeLayoutView: View {
         ShellTerminalLeafView(
             pane: pane,
             bootProfile: host.bootProfile(for: pane),
+            restoredTranscriptSnapshot: host.restoredTranscriptSnapshot(for: pane),
             isSelected: selectedPaneID == pane.paneID,
             renderPriority: host.terminalRenderPriority(for: pane),
             isZoomed: host.isPaneZoomed(pane.paneID),
@@ -899,6 +906,7 @@ private struct ShellTerminalLeafView: View {
 
     let pane: ShellPane
     let bootProfile: AlanShellBootProfile?
+    let restoredTranscriptSnapshot: TerminalTranscriptSnapshot?
     let isSelected: Bool
     let renderPriority: TerminalRuntimeRenderPriority
     let isZoomed: Bool
@@ -944,24 +952,30 @@ private struct ShellTerminalLeafView: View {
             )
 
             ZStack(alignment: .topTrailing) {
-                TerminalHostView(
-                    pane: pane,
-                    terminalContentMount: TerminalContentMount(pane: pane),
-                    bootProfile: bootProfile,
-                    isSelected: isSelected,
-                    renderPriority: renderPriority,
-                    runtimeRegistry: runtimeRegistry,
-                    activationDelegate: activationDelegate,
-                    onShellAction: onShellAction,
-                    onCloseRequest: { requiresConfirmation in
-                        guard !requiresConfirmation else { return }
-                        onTerminalRuntimeExit()
-                    },
-                    onRuntimeUpdate: onRuntimeUpdate,
-                    onMetadataUpdate: onMetadataUpdate
-                )
-                .id(pane.paneID)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                VStack(spacing: 0) {
+                    if let restoredTranscriptSnapshot {
+                        RestoredTerminalTranscriptView(snapshot: restoredTranscriptSnapshot)
+                    }
+
+                    TerminalHostView(
+                        pane: pane,
+                        terminalContentMount: TerminalContentMount(pane: pane),
+                        bootProfile: bootProfile,
+                        isSelected: isSelected,
+                        renderPriority: renderPriority,
+                        runtimeRegistry: runtimeRegistry,
+                        activationDelegate: activationDelegate,
+                        onShellAction: onShellAction,
+                        onCloseRequest: { requiresConfirmation in
+                            guard !requiresConfirmation else { return }
+                            onTerminalRuntimeExit()
+                        },
+                        onRuntimeUpdate: onRuntimeUpdate,
+                        onMetadataUpdate: onMetadataUpdate
+                    )
+                    .id(pane.paneID)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
                 .background(ShellPalette.terminal)
                 .overlay {
                     ShellInactivePaneDim(
@@ -992,6 +1006,52 @@ private struct ShellTerminalLeafView: View {
                     .padding(10)
                 }
             }
+        }
+    }
+}
+
+private struct RestoredTerminalTranscriptView: View {
+    let snapshot: TerminalTranscriptSnapshot
+
+    private var lines: [String] {
+        let boundedLines = snapshot.boundedForManifest().transcriptLines
+        guard boundedLines.contains(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+        else {
+            return []
+        }
+        return boundedLines
+    }
+
+    private var transcriptText: String {
+        lines.joined(separator: "\n")
+    }
+
+    private var height: CGFloat {
+        let visibleRows = max(1, min(lines.count, 12))
+        return CGFloat(visibleRows) * 17 + 20
+    }
+
+    var body: some View {
+        if !lines.isEmpty {
+            ScrollView([.vertical, .horizontal]) {
+                Text(transcriptText)
+                    .font(.system(size: 12, weight: .regular, design: .monospaced))
+                    .lineSpacing(2)
+                    .foregroundStyle(Color.white.opacity(0.68))
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+            }
+            .frame(maxWidth: .infinity, minHeight: height, maxHeight: height, alignment: .topLeading)
+            .background(ShellPalette.terminal)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(ShellPalette.line.opacity(0.20))
+                    .frame(height: 0.6)
+            }
+            .accessibilityIdentifier("restored-terminal-transcript")
         }
     }
 }

--- a/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeRegistry.swift
@@ -304,6 +304,16 @@ final class TerminalRuntimeRegistry: ObservableObject {
         runtimeService.captureTranscriptSnapshot(forTerminalContentID: contentID)
     }
 
+    func requestGracefulShutdown(
+        forTerminalContentID contentID: String,
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        runtimeService.requestGracefulShutdown(
+            forTerminalContentID: contentID,
+            reason: reason
+        )
+    }
+
     func seedRestoredTranscriptSnapshot(
         _ snapshot: TerminalTranscriptSnapshot,
         forTerminalContentID contentID: String

--- a/clients/apple/alan-macos/TerminalRuntimeService.swift
+++ b/clients/apple/alan-macos/TerminalRuntimeService.swift
@@ -122,6 +122,34 @@ enum TerminalTranscriptCaptureResult: Equatable {
     case failed(TerminalTranscriptCaptureFailure)
 }
 
+enum TerminalRuntimeGracefulShutdownReason: String, Codable, Equatable {
+    case paneClose = "pane_close"
+    case tabClose = "tab_close"
+    case quickTerminalClose = "quick_terminal_close"
+    case windowClose = "window_close"
+    case appQuit = "app_quit"
+}
+
+enum TerminalRuntimeGracefulShutdownRequestCode: String, Codable, Equatable {
+    case requested
+    case alreadyExited = "already_exited"
+    case missingRuntime = "missing_runtime"
+    case unavailable
+    case rejected
+}
+
+struct TerminalRuntimeGracefulShutdownRequestResult: Codable, Equatable {
+    let contentID: String
+    let reason: TerminalRuntimeGracefulShutdownReason
+    let code: TerminalRuntimeGracefulShutdownRequestCode
+    let delivery: TerminalRuntimeDeliveryResult?
+    let message: String?
+
+    var wasRequested: Bool {
+        code == .requested
+    }
+}
+
 enum AlanGhosttyBootstrapPhase: String, Equatable {
     case pending
     case ready
@@ -334,6 +362,9 @@ protocol AlanTerminalSurfaceHandle: AnyObject {
     func seedRestoredTranscriptSnapshot(_ snapshot: TerminalTranscriptSnapshot)
     func sendControlText(_ text: String) -> TerminalRuntimeDeliveryResult
     func sendControlKey(_ key: TerminalRuntimeControlKey) -> TerminalRuntimeDeliveryResult
+    func requestGracefulShutdown(
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult
     @discardableResult
     func teardown() -> AlanTerminalSurfaceTeardownStatus
 }
@@ -688,6 +719,49 @@ final class AlanGhosttySurfaceHandle: AlanTerminalSurfaceHandle {
 #endif
     }
 
+    func requestGracefulShutdown(
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        if currentSnapshot.metadata.processExited {
+            return TerminalRuntimeGracefulShutdownRequestResult(
+                contentID: contentID,
+                reason: reason,
+                code: .alreadyExited,
+                delivery: nil,
+                message: "The terminal process has already exited."
+            )
+        }
+        if currentSnapshot.teardownStatus == .completed {
+            return TerminalRuntimeGracefulShutdownRequestResult(
+                contentID: contentID,
+                reason: reason,
+                code: .unavailable,
+                delivery: nil,
+                message: "The terminal runtime has already closed."
+            )
+        }
+
+        let delivery = sendControlKey(.interrupt)
+        let code: TerminalRuntimeGracefulShutdownRequestCode
+        switch delivery.code {
+        case .accepted, .queued:
+            code = .requested
+        case .missingTarget:
+            code = .missingRuntime
+        case .unavailableRuntime, .timeout:
+            code = .unavailable
+        case .rejected:
+            code = .rejected
+        }
+        return TerminalRuntimeGracefulShutdownRequestResult(
+            contentID: contentID,
+            reason: reason,
+            code: code,
+            delivery: delivery,
+            message: delivery.errorMessage
+        )
+    }
+
     @discardableResult
     func teardown() -> AlanTerminalSurfaceTeardownStatus {
         guard currentSnapshot.teardownStatus != .completed else { return .completed }
@@ -862,6 +936,10 @@ protocol AlanTerminalRuntimeService: AnyObject {
     func existingSurfaceHandle(forTerminalContentID contentID: String) -> AlanTerminalSurfaceHandle?
     func snapshot(forTerminalContentID contentID: String) -> AlanTerminalSurfaceSnapshot?
     func captureTranscriptSnapshot(forTerminalContentID contentID: String) -> TerminalTranscriptCaptureResult
+    func requestGracefulShutdown(
+        forTerminalContentID contentID: String,
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult
     func seedRestoredTranscriptSnapshot(
         _ snapshot: TerminalTranscriptSnapshot,
         forTerminalContentID contentID: String
@@ -909,6 +987,16 @@ extension AlanTerminalRuntimeService {
         sendKey(
             toTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
             key: key
+        )
+    }
+
+    func requestGracefulShutdown(
+        for paneID: String,
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        requestGracefulShutdown(
+            forTerminalContentID: ShellContentInstance.terminalContentID(forPaneID: paneID),
+            reason: reason
         )
     }
 
@@ -1110,6 +1198,22 @@ final class AlanWindowTerminalRuntimeService: AlanTerminalRuntimeService {
         return buildTerminalTranscriptCapture(for: handle)
     }
 
+    func requestGracefulShutdown(
+        forTerminalContentID contentID: String,
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        guard let handle = handlesByContentID[contentID] else {
+            return TerminalRuntimeGracefulShutdownRequestResult(
+                contentID: contentID,
+                reason: reason,
+                code: .missingRuntime,
+                delivery: nil,
+                message: "No service-owned terminal runtime is registered for this content."
+            )
+        }
+        return handle.requestGracefulShutdown(reason: reason)
+    }
+
     func seedRestoredTranscriptSnapshot(
         _ snapshot: TerminalTranscriptSnapshot,
         forTerminalContentID contentID: String
@@ -1202,9 +1306,11 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
     private(set) var renderCatchUpRequestCount = 0
     private(set) var deliveredText: [String] = []
     private(set) var deliveredKeys: [TerminalRuntimeControlKey] = []
+    private(set) var gracefulShutdownRequests: [TerminalRuntimeGracefulShutdownReason] = []
     private(set) var searchActions: [String] = []
     private(set) var scrollActions: [String] = []
     var deliveryResult: TerminalRuntimeDeliveryResult?
+    var onGracefulShutdownRequest: ((TerminalRuntimeGracefulShutdownReason) -> Void)?
     var searchActionsShouldSucceed = true
     var scrollActionsShouldSucceed = true
     var commandOutputTextByRange: [AlanTerminalBufferRange: String] = [:]
@@ -1366,6 +1472,56 @@ final class FakeAlanTerminalSurfaceHandle: AlanTerminalSurfaceHandle {
             ?? .accepted(byteCount: 0, runtimePhase: currentSnapshot.runtimePhase)
         updateSnapshot(lastDelivery: result)
         return result
+    }
+
+    func requestGracefulShutdown(
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        if currentSnapshot.metadata.processExited {
+            return TerminalRuntimeGracefulShutdownRequestResult(
+                contentID: contentID,
+                reason: reason,
+                code: .alreadyExited,
+                delivery: nil,
+                message: "The terminal process has already exited."
+            )
+        }
+
+        gracefulShutdownRequests.append(reason)
+        let delivery = sendControlKey(.interrupt)
+        let code: TerminalRuntimeGracefulShutdownRequestCode
+        switch delivery.code {
+        case .accepted, .queued:
+            code = .requested
+            onGracefulShutdownRequest?(reason)
+        case .missingTarget:
+            code = .missingRuntime
+        case .unavailableRuntime, .timeout:
+            code = .unavailable
+        case .rejected:
+            code = .rejected
+        }
+        return TerminalRuntimeGracefulShutdownRequestResult(
+            contentID: contentID,
+            reason: reason,
+            code: code,
+            delivery: delivery,
+            message: delivery.errorMessage
+        )
+    }
+
+    func markActiveTaskState(_ activeTaskState: ShellTabActiveTaskState?) {
+        let metadata = TerminalPaneMetadataSnapshot(
+            title: currentSnapshot.metadata.title,
+            workingDirectory: currentSnapshot.metadata.workingDirectory,
+            summary: currentSnapshot.metadata.summary,
+            attention: activeTaskState?.protectsFromPruning == true ? .active : .idle,
+            processExited: currentSnapshot.metadata.processExited,
+            lastCommandExitCode: currentSnapshot.metadata.lastCommandExitCode,
+            lastUpdatedAt: .now,
+            activeTaskState: activeTaskState
+        )
+        updateSnapshot(metadata: metadata)
     }
 
     func markProcessExited(exitCode: Int) {
@@ -1572,6 +1728,22 @@ final class FakeAlanTerminalRuntimeService: AlanTerminalRuntimeService {
             )
         }
         return buildTerminalTranscriptCapture(for: handle)
+    }
+
+    func requestGracefulShutdown(
+        forTerminalContentID contentID: String,
+        reason: TerminalRuntimeGracefulShutdownReason
+    ) -> TerminalRuntimeGracefulShutdownRequestResult {
+        guard let handle = handlesByContentID[contentID] else {
+            return TerminalRuntimeGracefulShutdownRequestResult(
+                contentID: contentID,
+                reason: reason,
+                code: .missingRuntime,
+                delivery: nil,
+                message: "No fake terminal runtime is registered for this content."
+            )
+        }
+        return handle.requestGracefulShutdown(reason: reason)
     }
 
     func seedRestoredTranscriptSnapshot(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -130,6 +130,8 @@ private enum ShellRuntimeMetadataTests {
         verifiesActiveTabCloseRequiresOneConfirmationForMultiplePanes()
         verifiesInteractivePaneCloseCancelLeavesStateManifestAndRuntimeUnchanged()
         verifiesInteractiveConfirmedPaneCloseCapturesSnapshotBeforeFinalization()
+        verifiesConfirmedAppCloseRequestsGracefulShutdownBeforeTranscriptCapture()
+        verifiesConfirmedAppCloseCapturesLatestTranscriptAfterGracefulTimeout()
         verifiesWindowAndAppCloseCancelRequireOneConfirmationWithoutMutation()
         verifiesWindowAndAppCloseIncludeActiveQuickTerminal()
         verifiesConfirmedAppClosePersistsAndRestoresQuickTerminalTranscript()
@@ -1497,7 +1499,8 @@ private enum ShellRuntimeMetadataTests {
         let registry = TerminalRuntimeRegistry(runtimeService: service)
         let controller = makeController(
             terminalRuntimeRegistry: registry,
-            closeConfirmationPresenter: presenter
+            closeConfirmationPresenter: presenter,
+            gracefulShutdownTimeout: 0
         )
         let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
         let range = AlanTerminalBufferRange(lowerBound: 0, upperBound: 1)
@@ -1557,6 +1560,120 @@ private enum ShellRuntimeMetadataTests {
         )
         expect(handle.teardownCount == 1, "confirmed close must finalize the terminal runtime")
         expect(controller.pane(paneID: "pane_1") == nil, "confirmed close must remove the pane")
+    }
+
+    private static func verifiesConfirmedAppCloseRequestsGracefulShutdownBeforeTranscriptCapture() {
+        let windowID = "graceful_app_close_\(UUID().uuidString)"
+        let manifestURL = manifestURL("graceful_app_close")
+        let service = FakeAlanTerminalRuntimeService()
+        let registry = TerminalRuntimeRegistry(runtimeService: service)
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let presenter = FakeShellCloseConfirmationPresenter(nextResponses: [true])
+        let controller = makeController(
+            windowID: windowID,
+            terminalRuntimeRegistry: registry,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/repo/app",
+                now: Date(timeIntervalSince1970: 82)
+            ),
+            closeConfirmationPresenter: presenter,
+            gracefulShutdownTimeout: 0
+        )
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        handle.recordTranscriptOutput("codex running")
+        handle.markActiveTaskState(.foregroundCommand)
+        handle.onGracefulShutdownRequest = { reason in
+            expect(reason == .appQuit, "app quit must request app-quit graceful shutdown")
+            handle.recordTranscriptOutput("codex resume previous-session-id")
+            handle.markActiveTaskState(.inactive)
+        }
+        controller.updateTerminalMetadata(
+            metadata(title: "codex", cwd: "/repo/app", activeTaskState: .foregroundCommand),
+            for: "pane_1"
+        )
+
+        expect(controller.requestTerminateApp(), "confirmed app quit must apply after graceful request")
+        expect(
+            handle.gracefulShutdownRequests == [.appQuit],
+            "confirmed app quit must request graceful shutdown for active terminal content"
+        )
+        expect(
+            handle.deliveredKeys == [.interrupt],
+            "graceful shutdown must send terminal interrupt before finalization"
+        )
+
+        guard let savedManifest = decodeManifest(at: manifestURL),
+              let liveSnapshot = savedManifest.spaces.first?.tabs.first?.liveSnapshot,
+              let payload = terminalPayload(in: liveSnapshot, paneSlotID: "pane_1"),
+              let transcript = payload.transcriptSnapshot
+        else {
+            fail("confirmed app quit must persist a transcript snapshot")
+        }
+        expect(
+            transcript.transcriptLines == [
+                "codex running",
+                "codex resume previous-session-id",
+            ],
+            "transcript capture must include output printed during graceful shutdown"
+        )
+        expect(handle.teardownCount == 1, "confirmed app quit must still finalize the runtime")
+    }
+
+    private static func verifiesConfirmedAppCloseCapturesLatestTranscriptAfterGracefulTimeout() {
+        let windowID = "graceful_timeout_\(UUID().uuidString)"
+        let manifestURL = manifestURL("graceful_timeout")
+        let service = FakeAlanTerminalRuntimeService()
+        let registry = TerminalRuntimeRegistry(runtimeService: service)
+        let store = ShellWorkspaceManifestStore(manifestURL: manifestURL)
+        let presenter = FakeShellCloseConfirmationPresenter(nextResponses: [true])
+        let controller = makeController(
+            windowID: windowID,
+            terminalRuntimeRegistry: registry,
+            workspaceManifestStore: store,
+            workspaceManifest: ShellContentWorkspaceManifest.defaultManifest(
+                windowID: windowID,
+                defaultWorkingDirectory: "/repo/app",
+                now: Date(timeIntervalSince1970: 83)
+            ),
+            closeConfirmationPresenter: presenter,
+            gracefulShutdownTimeout: 0.001
+        )
+        let handle = fakeSurfaceHandle(for: "pane_1", controller: controller)
+        handle.recordTranscriptOutput("long command still running")
+        handle.markActiveTaskState(.foregroundCommand)
+        controller.updateTerminalMetadata(
+            metadata(title: "cargo test", cwd: "/repo/app", activeTaskState: .foregroundCommand),
+            for: "pane_1"
+        )
+
+        expect(controller.requestTerminateApp(), "confirmed app quit must not block forever on graceful timeout")
+        expect(
+            handle.deliveredKeys == [.interrupt],
+            "timeout path must still request graceful shutdown once"
+        )
+        expect(handle.teardownCount == 1, "timeout path must force-finalize the runtime")
+        expect(
+            controller.controlPlaneDiagnostics.contains {
+                $0.contains("terminal graceful shutdown timed out")
+            },
+            "timeout path must record a graceful shutdown diagnostic"
+        )
+
+        guard let savedManifest = decodeManifest(at: manifestURL),
+              let liveSnapshot = savedManifest.spaces.first?.tabs.first?.liveSnapshot,
+              let transcript = terminalPayload(
+                in: liveSnapshot,
+                paneSlotID: "pane_1"
+              )?.transcriptSnapshot
+        else {
+            fail("timeout path must still persist latest transcript tail")
+        }
+        expect(
+            transcript.transcriptLines == ["long command still running"],
+            "timeout path must capture the latest available transcript tail"
+        )
     }
 
     private static func verifiesWindowAndAppCloseCancelRequireOneConfirmationWithoutMutation() {
@@ -1652,7 +1769,8 @@ private enum ShellRuntimeMetadataTests {
                 defaultWorkingDirectory: "/repo/app",
                 now: Date(timeIntervalSince1970: 94)
             ),
-            closeConfirmationPresenter: presenter
+            closeConfirmationPresenter: presenter,
+            gracefulShutdownTimeout: 0
         )
         _ = controller.showQuickTerminal()
         let quickHandle = fakeSurfaceHandle(
@@ -9776,6 +9894,7 @@ private enum ShellRuntimeMetadataTests {
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
         workspaceManifest: ShellContentWorkspaceManifest? = nil,
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
+        gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
         appIsActive: Bool = true
     ) -> ShellHostController {
@@ -9796,6 +9915,7 @@ private enum ShellRuntimeMetadataTests {
             workspaceManifestStore: workspaceManifestStore,
             workspaceManifest: workspaceManifest,
             closeConfirmationPresenter: closeConfirmationPresenter,
+            gracefulShutdownTimeout: gracefulShutdownTimeout,
             performanceDiagnosticsRecorder: performanceDiagnosticsRecorder,
             appIsActiveProvider: { appIsActive }
         )

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -7281,6 +7281,7 @@ private enum ShellRuntimeMetadataTests {
         )
 
         guard let pane = controller.pane(paneID: "pane_1"),
+              let visibleTranscript = controller.restoredTranscriptSnapshot(for: pane),
               let bootProfile = controller.bootProfile(for: pane),
               let handle = registry.surfaceHandle(
                 for: pane,
@@ -7290,6 +7291,10 @@ private enum ShellRuntimeMetadataTests {
             fail("workspace manifest restore must create a terminal runtime handle")
         }
 
+        expect(
+            visibleTranscript.transcriptLines == ["server ready", "listening on 3000"],
+            "restored terminal transcript must be available to the terminal leaf as visible history"
+        )
         expect(
             bootProfile.workingDirectory == "/repo/app",
             "restored terminal runtime must start a fresh shell in the restored cwd"

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -1588,6 +1588,23 @@ private enum ShellRuntimeMetadataTests {
             expect(reason == .appQuit, "app quit must request app-quit graceful shutdown")
             handle.recordTranscriptOutput("codex resume previous-session-id")
             handle.markActiveTaskState(.inactive)
+            expect(
+                !controller.closePaneAfterTerminalRuntimeExit(paneID: "pane_1"),
+                "confirmed graceful close must suppress runtime-exit auto-close before transcript capture"
+            )
+            controller.updateTerminalMetadata(
+                metadata(
+                    title: "codex",
+                    cwd: "/repo/app",
+                    processExited: true,
+                    activeTaskState: .inactive
+                ),
+                for: "pane_1"
+            )
+            expect(
+                controller.pane(paneID: "pane_1") != nil,
+                "confirmed graceful close must keep the pane available until transcript capture"
+            )
         }
         controller.updateTerminalMetadata(
             metadata(title: "codex", cwd: "/repo/app", activeTaskState: .foregroundCommand),

--- a/clients/apple/scripts/test-terminal-runtime-service.sh
+++ b/clients/apple/scripts/test-terminal-runtime-service.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \

--- a/clients/apple/scripts/test-terminal-runtime-service.swift
+++ b/clients/apple/scripts/test-terminal-runtime-service.swift
@@ -444,9 +444,10 @@ private enum TerminalRuntimeServiceTests {
     }
 
     private static func verifiesDevChannelPropagatesInstallChannelEnvironment() {
+        let previousInstallChannel = ProcessInfo.processInfo.environment["ALAN_INSTALL_CHANNEL"]
         setenv("ALAN_INSTALL_CHANNEL", "dev", 1)
         defer {
-            unsetenv("ALAN_INSTALL_CHANNEL")
+            restoreEnvironmentValue(previousInstallChannel, forKey: "ALAN_INSTALL_CHANNEL")
         }
 
         let state = ShellStateSnapshot.bootstrapDefault()
@@ -460,6 +461,12 @@ private enum TerminalRuntimeServiceTests {
     }
 
     private static func verifiesChannelScopedShellControlPaths() {
+        let previousNamespace = ProcessInfo.processInfo.environment["ALAN_SHELL_CONTROL_NAMESPACE"]
+        unsetenv("ALAN_SHELL_CONTROL_NAMESPACE")
+        defer {
+            restoreEnvironmentValue(previousNamespace, forKey: "ALAN_SHELL_CONTROL_NAMESPACE")
+        }
+
         let stableRoot = alanShellControlPlaneRootURL(
             windowID: "window_main",
             channel: .stable
@@ -501,9 +508,13 @@ private enum TerminalRuntimeServiceTests {
     }
 
     private static func verifiesDevBootProfileUsesDevShellControlNamespace() {
+        let previousInstallChannel = ProcessInfo.processInfo.environment["ALAN_INSTALL_CHANNEL"]
+        let previousNamespace = ProcessInfo.processInfo.environment["ALAN_SHELL_CONTROL_NAMESPACE"]
         setenv("ALAN_INSTALL_CHANNEL", "dev", 1)
+        unsetenv("ALAN_SHELL_CONTROL_NAMESPACE")
         defer {
-            unsetenv("ALAN_INSTALL_CHANNEL")
+            restoreEnvironmentValue(previousInstallChannel, forKey: "ALAN_INSTALL_CHANNEL")
+            restoreEnvironmentValue(previousNamespace, forKey: "ALAN_SHELL_CONTROL_NAMESPACE")
         }
 
         let state = ShellStateSnapshot.bootstrapDefault()
@@ -1112,6 +1123,14 @@ private enum TerminalRuntimeServiceTests {
     private static func fail(_ message: String) -> Never {
         fputs("error: \(message)\n", stderr)
         exit(1)
+    }
+
+    private static func restoreEnvironmentValue(_ value: String?, forKey key: String) {
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
     }
 }
 

--- a/clients/apple/scripts/test-terminal-surface-controller.sh
+++ b/clients/apple/scripts/test-terminal-surface-controller.sh
@@ -16,6 +16,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellTreeMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/ShellModel.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellControlFilePoller.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellDiagnostics.swift" \

--- a/openspec/changes/persist-macos-terminal-session-snapshots/design.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/design.md
@@ -30,8 +30,10 @@ block model.
 - Prevent destructive pane, tab, window, app, and Quick Terminal close paths
   from silently killing active terminal work.
 - Keep the default idle-shell close path fast and confirmation-free.
-- Persist a bounded terminal transcript snapshot before confirmed close or app
-  teardown.
+- Give active terminal work a bounded graceful shutdown window after confirmed
+  close and before forced runtime finalization.
+- Persist a bounded terminal transcript snapshot after the graceful shutdown
+  window has drained, or at timeout, before confirmed close or app teardown.
 - Restore terminal panes after app restart with their prior visible transcript,
   scrollback tail, title, cwd, layout, and focus context.
 - Start a new shell in the restored cwd after restart so the pane remains usable.
@@ -72,13 +74,35 @@ keyboard, sidebar, pane title-bar, quick terminal, and automation paths.
 ### Interactive close confirms once per requested scope
 
 For interactive close, Alan presents one confirmation sheet for the requested
-scope. Cancelling the sheet leaves shell state, workspace manifest, and terminal
-runtimes unchanged. Confirming runs snapshot capture first, then applies the
-existing close mutation and runtime finalization.
+scope. Cancelling the sheet leaves shell state, workspace manifest, terminal
+runtimes, and terminal input untouched. Confirming asks affected active terminal
+runtimes to perform a bounded graceful shutdown, waits briefly for foreground
+work to exit or return to the prompt, captures transcript snapshots after that
+drain point, then applies the existing close mutation and runtime finalization.
 
 Alternative considered: confirm per terminal pane. That gives more detail but is
 annoying for split tabs and app quit, and it makes app termination harder to
 reason about.
+
+### Graceful shutdown is best-effort and bounded
+
+Alan will add a terminal-runtime-owned graceful shutdown seam before confirmed
+close finalization. In the current Ghostty-backed runtime, that seam can request
+terminal-level interruption/EOF-style graceful input and observe whether the
+surface returns to inactive foreground-work state. Alan then captures the latest
+transcript tail, including any resume/session hints printed during shutdown,
+before force-finalizing remaining runtimes.
+
+The first implementation intentionally does not claim process-group signal
+ownership. Sending `SIGTERM` or `SIGHUP` to the foreground process group requires
+GhosttyKit to expose a process-control seam or Alan to own the PTY/process tree.
+That remains future work; the current guarantee is a bounded best-effort
+graceful request, post-drain transcript capture, and forced finalization on
+timeout.
+
+Alternative considered: immediately free the Ghostty surface after confirmation.
+That matches typical terminal behavior but loses the final output from tools
+such as Codex that print resume/session information while exiting.
 
 ### Automation close is non-destructive by default
 
@@ -106,10 +130,12 @@ renderer-version incompatibility, and still cannot restore dead child processes.
 ### Runtime service owns capture and replay seams
 
 The terminal runtime service will expose a snapshot capture API for live
-ContentInstance handles and a restore API for startup. Capture first asks the
-live terminal surface for a text/scrollback range. If that is unavailable, Alan
-can use a lightweight transcript ring buffer maintained by the runtime handle.
-App/window teardown performs a best-effort flush before finalization.
+ContentInstance handles, a confirmed-close graceful shutdown request API, and a
+restore API for startup. Capture first asks the live terminal surface for a
+text/scrollback range. If that is unavailable, Alan can use a lightweight
+transcript ring buffer maintained by the runtime handle. App/window teardown
+requests graceful shutdown for active work, performs a best-effort flush, and
+captures after the drain window before finalization.
 
 On restart, materialization passes the saved snapshot to runtime creation. The
 new runtime presents the restored transcript as initial terminal history and
@@ -155,6 +181,9 @@ and conflicts with explicit user confirmation.
   restore instead of claiming live app recovery.
 - Snapshot capture during app quit can race late output -> flush runtime state
   before capture and accept best-effort tail fidelity.
+- Graceful shutdown may not stop arbitrary foreground programs without a real
+  process-group signal seam -> keep the close path bounded and force finalize on
+  timeout, while documenting true signal delivery as future work.
 - Large scrollback can make manifest writes slow or huge -> cap row count and
   encoded bytes, prefer tail content, and record truncation metadata.
 - Pinned live transcript overlay can be confusing if the pin template no longer

--- a/openspec/changes/persist-macos-terminal-session-snapshots/proposal.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/proposal.md
@@ -17,8 +17,9 @@ a fresh shell with no visible session history.
 - Require automation/control-plane close paths to report `requires_confirmation`
   instead of silently killing active terminal work unless a future explicit force
   mechanism is added.
-- Persist bounded terminal transcript snapshots in the workspace manifest before
-  confirmed close, app quit, or lifecycle teardown.
+- After interactive confirmation, request a bounded graceful shutdown window for
+  active terminal runtimes, then persist bounded terminal transcript snapshots
+  before forced finalization, app quit, or lifecycle teardown.
 - Restore terminal panes after app restart with the saved transcript, cwd, title,
   layout, focus, and shell metadata, then start a new shell in the restored cwd
   without presenting extra user-facing "restored session" chrome.
@@ -58,11 +59,12 @@ a fresh shell with no visible session history.
   payload with bounded size and old-manifest compatibility.
 - `clients/apple/alan-macos/TerminalRuntimeService.swift`,
   `TerminalRuntimeRegistry.swift`, `GhosttyLiveHost.swift`, and terminal surface
-  adapters need a snapshot extraction seam and a restored-transcript startup
-  path.
+  adapters need a snapshot extraction seam, a confirmed-close graceful shutdown
+  request seam, and a restored-transcript startup path.
 - `clients/apple/alan-macos/Controllers/Shell/ShellHostControlCommandHandling.swift`
   and shell control DTOs need a stable confirmation-required response for
   guarded close commands.
 - Focused Apple scripts and UI smoke coverage need scenarios for active close
-  confirmation, idle close bypass, manifest snapshot round trip, restart with
-  restored terminal output, and continued input in the new shell.
+  confirmation, graceful shutdown before capture, idle close bypass, manifest
+  snapshot round trip, restart with restored terminal output, and continued
+  input in the new shell.

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-shell-terminal-lifecycle/spec.md
@@ -31,12 +31,24 @@ terminal ContentInstance runtimes.
 ### Requirement: Confirmed close captures terminal session snapshots
 The macOS shell host SHALL attempt to capture bounded terminal transcript
 snapshots for affected live terminal ContentInstances after a destructive
-terminal close request is confirmed and before finalizing their runtimes.
+terminal close request is confirmed, after a bounded graceful shutdown attempt
+for active terminal work, and before finalizing their runtimes.
 
 #### Scenario: Confirmed pane close captures a snapshot
 - **WHEN** the user confirms closing a terminal PaneSlot with restorable terminal history
-- **THEN** Alan captures a bounded transcript snapshot for the mounted terminal ContentInstance before invoking runtime finalization
+- **THEN** Alan first requests graceful shutdown for active foreground terminal work when applicable
+- **AND** Alan captures a bounded transcript snapshot for the mounted terminal ContentInstance before invoking runtime finalization
 - **AND** the snapshot is associated with the terminal ContentInstance identity and close reason
+
+#### Scenario: Graceful shutdown output is captured
+- **WHEN** a confirmed close affects terminal work that can print final session or resume metadata while shutting down
+- **THEN** Alan gives the runtime a bounded graceful shutdown window before forced finalization
+- **AND** Alan captures transcript history after the graceful window drains or times out so final output can be restored after restart
+
+#### Scenario: Graceful shutdown times out
+- **WHEN** the affected terminal work does not exit or return to an idle prompt within the bounded graceful shutdown window
+- **THEN** Alan captures the latest available transcript tail
+- **AND** Alan may force-finalize the runtime after the timeout instead of blocking app quit or close indefinitely
 
 #### Scenario: Snapshot capture fails after confirmation
 - **WHEN** the user has confirmed a destructive close and snapshot capture or persistence fails

--- a/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/specs/macos-terminal-runtime-foundation/spec.md
@@ -19,6 +19,27 @@ state without exposing durable manifests to Ghostty renderer internals.
 - **WHEN** a terminal transcript snapshot is produced
 - **THEN** it does not include PTY file descriptors, child process handles, Ghostty surface pointers, renderer objects, delivery queues, or unbounded scrollback
 
+### Requirement: Terminal runtime service supports bounded graceful shutdown requests
+The terminal runtime service SHALL expose a service-owned graceful shutdown
+request path for live terminal ContentInstances so confirmed close can give
+foreground work a chance to exit and print final transcript output before forced
+runtime finalization.
+
+#### Scenario: Graceful shutdown is requested for active terminal work
+- **WHEN** the shell host has received user confirmation for closing active terminal work
+- **THEN** the runtime service requests a graceful shutdown for the corresponding terminal ContentInstance without exposing PTY handles or Ghostty surface pointers to the shell host
+- **AND** the shell host can observe whether the terminal returned to inactive foreground-work state or exited before the bounded wait expires
+
+#### Scenario: Graceful shutdown cannot be requested
+- **WHEN** the runtime surface is missing, failed, exited, or unable to receive the graceful shutdown request
+- **THEN** the runtime service returns an explicit request result
+- **AND** confirmed close may continue to capture the latest available transcript and force-finalize the runtime
+
+#### Scenario: Process-group signal delivery is unavailable
+- **WHEN** the current Ghostty-backed runtime does not expose a foreground process-group signal seam
+- **THEN** Alan treats graceful shutdown as best-effort terminal-level shutdown input and bounded observation
+- **AND** Alan does not claim true PTY/process survival or guaranteed `SIGTERM` delivery
+
 ### Requirement: Restored transcript history seeds newly created terminal runtimes
 The terminal runtime service SHALL seed newly created terminal runtimes with
 restored transcript history when a terminal ContentInstance is materialized from

--- a/openspec/changes/persist-macos-terminal-session-snapshots/tasks.md
+++ b/openspec/changes/persist-macos-terminal-session-snapshots/tasks.md
@@ -51,3 +51,10 @@
 - [x] 7.1 Document that true PTY/process survival and daemon-backed terminal attach remain future work.
 - [x] 7.2 Prepare PR review notes covering close guard scope, transcript bounds, old-manifest compatibility, and restart smoke evidence.
 - [ ] 7.3 After implementation is merged, sync accepted spec deltas into `openspec/specs/` before archiving the change.
+
+## 8. Graceful Confirmed Close
+
+- [x] 8.1 Add a terminal runtime graceful shutdown request API and control-key support.
+- [x] 8.2 Request graceful shutdown after interactive close confirmation and wait a bounded window before transcript capture.
+- [x] 8.3 Capture post-shutdown transcript output before forced runtime finalization.
+- [x] 8.4 Add focused tests for graceful shutdown request, timeout, and post-shutdown transcript capture.


### PR DESCRIPTION
## Summary
- restore transcript snapshots into terminal runtimes without visible restored-session chrome
- request bounded graceful shutdown before confirmed close capture so final session output can persist
- keep focused terminal Swift test scripts resilient to space slider dependencies and Alan shell env overrides

## OpenSpec
- persist-macos-terminal-session-snapshots implementation follow-up
- archive task remains deferred until after merge

## Verification
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/test-terminal-runtime-service.sh
- bash clients/apple/scripts/test-terminal-surface-controller.sh
- ALAN_GHOSTTY_CACHE_DIR=/private/tmp/alan-ghostty-cache bash clients/apple/scripts/setup-local-ghosttykit.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate persist-macos-terminal-session-snapshots --strict
- openspec validate --all --strict