### PR TITLE
Recover macOS Settings native polish

### DIFF
--- a/clients/apple/alan-macos.xcodeproj/project.pbxproj
+++ b/clients/apple/alan-macos.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		00000000000000000000004B /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */; };
 		00000000000000000000004C /* Support/ShellSidebarSpaceSliderLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000156 /* Support/ShellSidebarSpaceSliderLayout.swift */; };
 		00000000000000000000004D /* Support/ShellSidebarSpaceSliderWheelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000157 /* Support/ShellSidebarSpaceSliderWheelMonitor.swift */; };
+		00000000000000000000004E /* Services/Shell/ShellLocalFolderOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000158 /* Services/Shell/ShellLocalFolderOpener.swift */; };
 		000000000000000000000034 /* Controllers/Console/AlanConsoleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000134 /* Controllers/Console/AlanConsoleViewModel.swift */; };
 		000000000000000000000035 /* Views/Console/ConsoleSupportViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000135 /* Views/Console/ConsoleSupportViews.swift */; };
 		000000000000000000000036 /* Support/ConsoleAdaptiveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000136 /* Support/ConsoleAdaptiveColor.swift */; };
@@ -163,6 +164,7 @@
 		000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift; sourceTree = "<group>"; };
 		000000000000000000000156 /* Support/ShellSidebarSpaceSliderLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceSliderLayout.swift; sourceTree = "<group>"; };
 		000000000000000000000157 /* Support/ShellSidebarSpaceSliderWheelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Support/ShellSidebarSpaceSliderWheelMonitor.swift; sourceTree = "<group>"; };
+		000000000000000000000158 /* Services/Shell/ShellLocalFolderOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/Shell/ShellLocalFolderOpener.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -333,6 +335,7 @@
 				00000000000000000000012F /* Services/Shell/ShellDiagnostics.swift */,
 				00000000000000000000012E /* Services/Shell/ShellEventStore.swift */,
 				00000000000000000000012A /* Services/Shell/ShellLocalCommandExecutor.swift */,
+				000000000000000000000158 /* Services/Shell/ShellLocalFolderOpener.swift */,
 				000000000000000000000154 /* Services/Shell/ShellPerformanceDiagnostics.swift */,
 				000000000000000000000155 /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift */,
 				00000000000000000000012C /* Services/Shell/ShellPublishedStateMerger.swift */,
@@ -542,6 +545,7 @@
 				000000000000000000000049 /* Models/Shell/ShellSettingsSurfaceModel.swift in Sources */,
 				00000000000000000000004A /* Services/Shell/ShellPerformanceDiagnostics.swift in Sources */,
 				00000000000000000000004B /* Services/Shell/ShellPerformanceDiagnosticsExportPresenter.swift in Sources */,
+				00000000000000000000004E /* Services/Shell/ShellLocalFolderOpener.swift in Sources */,
 				000000000000000000000039 /* Models/Shell/ShellWorkspaceManifest.swift in Sources */,
 				00000000000000000000003A /* Services/Shell/ShellWorkspaceManifestStore.swift in Sources */,
 			);

--- a/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift
@@ -106,23 +106,23 @@ enum ShellSettingsGroupSectionID: String, Equatable, Identifiable {
         case .profiles:
             return "Profiles"
         case .localIdentity:
-            return "Local Identity"
+            return "Identity"
         case .agent:
             return "Agent"
         case .connection:
             return "Connection"
         case .runtimeDefaults:
-            return "Runtime Defaults"
+            return "Runtime"
         case .skills:
             return "Skills"
         case .skillSources:
-            return "Skill Sources"
+            return "Sources"
         case .entryPoints:
-            return "Entry Points"
+            return "Entry points"
         case .app:
-            return "App"
+            return "Application"
         case .localRuntime:
-            return "Local Runtime"
+            return "Runtime"
         case .storage:
             return "Storage"
         case .diagnostics:
@@ -302,36 +302,27 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 ),
             ].compactMap { $0 }
         case .agent:
-            return [
-                ShellSettingsGroupSectionModel(id: .agent, rows: [Self.agentSelectorRow()]),
-                section(
-                    .connection,
-                    rowIDs: [
-                        "accountsUnavailable",
-                        "selectedProfile",
-                        "provider",
-                        "model",
-                        "credential",
-                        "accountActions",
-                    ],
+            let agentRows = [Self.agentSelectorRow()]
+                + rows(
+                    rowIDs: ["accountsUnavailable", "selectedProfile"],
                     rowsByID: rowLookup
-                ),
+                )
+            let skillRows = rows(
+                rowIDs: [
+                    "capabilitiesUnavailable",
+                    "capabilitiesAvailable",
+                    "publicSkills",
+                ],
+                rowsByID: rowLookup
+            )
+            return [
+                section(.agent, rows: agentRows),
                 section(
                     .runtimeDefaults,
                     rowIDs: ["governance", "reasoningEffort", "streamingMode", "recoveryMode"],
                     rowsByID: rowLookup
                 ),
-                section(
-                    .skills,
-                    rowIDs: [
-                        "capabilitiesUnavailable",
-                        "enabledSkills",
-                        "implicitInvocation",
-                        "unavailableSkills",
-                    ],
-                    rowsByID: rowLookup
-                ),
-                section(.skillSources, rowIDs: ["publicSkills"], rowsByID: rowLookup),
+                section(.skills, rows: skillRows),
                 section(.entryPoints, rowIDs: ["cliTool"], rowsByID: rowLookup),
             ].compactMap { $0 }
         case .system:
@@ -370,6 +361,13 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
 
     private func rows(
         rowIDs: [String],
+        rowsByID: [String: ShellSettingsRowModel]
+    ) -> [ShellSettingsRowModel] {
+        rowIDs.compactMap { rowsByID[$0] }
+    }
+
+    private func rows(
+        rowIDs: [String],
         matchingPrefix prefix: String,
         rowsByID: [String: ShellSettingsRowModel]
     ) -> [ShellSettingsRowModel] {
@@ -383,7 +381,6 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             id: "agentSelector",
             systemName: "sparkles",
             title: "Agent",
-            detail: "Alan is the currently configurable agent.",
             value: "Alan"
         )
     }
@@ -394,21 +391,21 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 id: "appearance",
                 systemName: "circle.lefthalf.filled",
                 title: "Appearance",
-                detail: "Follow the system appearance or pin Alan to light or dark.",
+                detail: "Use system appearance or choose a fixed theme.",
                 mutability: .editable
             ),
             ShellSettingsRowModel(
                 id: "sidebar",
                 systemName: "sidebar.left",
                 title: "Sidebar",
-                detail: "Show the workspace sidebar in shell windows.",
+                detail: "Show workspace sidebar in terminal windows.",
                 mutability: .editable
             ),
             ShellSettingsRowModel(
                 id: "inactiveSplitDimming",
                 systemName: "rectangle.split.2x1",
                 title: "Inactive split dimming",
-                detail: "Dim inactive terminal splits so the focused pane stays prominent.",
+                detail: "Dim inactive terminal panes.",
                 mutability: .editable
             ),
         ]
@@ -421,17 +418,17 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             ShellSettingsRowModel(
                 id: "terminalProfilesDefault",
                 systemName: "terminal",
-                title: "Default Terminal Profile",
-                detail: "Local startup identity for new terminal content.",
+                title: "Default profile",
+                detail: "Used for new terminals.",
                 value: summary.defaultProfileTitle ?? "Login shell",
                 mutability: .editable
             ),
             ShellSettingsRowModel(
                 id: "terminalProfilesCreate",
                 systemName: "plus.circle",
-                title: "New Terminal Profile",
-                detail: "Structured launch mode with local validation.",
-                value: "Create",
+                title: "New profile",
+                detail: "Create a local startup profile.",
+                value: "Create…",
                 mutability: .actionOnly
             )
         ]
@@ -454,7 +451,10 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                     id: "terminalProfile.\(profile.id)",
                     systemName: terminalProfileSystemName(profile),
                     title: profile.title,
-                    detail: profile.redactedDisplayDetail,
+                    detail: Self.nonRepeatingDetail(
+                        profile.redactedDisplayDetail,
+                        title: profile.title
+                    ),
                     value: profile.id == summary.defaultProfileID ? "Default" : profile.launch.kind.rawValue,
                     mutability: .editable
                 )
@@ -482,7 +482,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                     systemName: "person.crop.circle.badge.plus",
                     title: "Managed terminal account",
                     detail: "Create a terminal-only local user for passwordless terminal entry.",
-                    value: "Preview plan",
+                    value: "Preview…",
                     mutability: .actionOnly
                 ),
                 ShellSettingsRowModel(
@@ -505,6 +505,20 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 mutability: .actionOnly
             )
         }
+    }
+
+    private static func nonRepeatingDetail(_ detail: String?, title: String) -> String? {
+        let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedDetail = detail?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let normalizedDetail,
+              !normalizedDetail.isEmpty,
+              normalizedDetail.localizedCaseInsensitiveCompare(normalizedTitle) != .orderedSame
+        else {
+            return nil
+        }
+
+        return normalizedDetail
     }
 
     private static func terminalProfileSystemName(_ profile: TerminalProfileDefinition) -> String {
@@ -573,13 +587,12 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
     private static func accountRows(
         _ summary: ShellSettingsAccountsSummary
     ) -> [ShellSettingsRowModel] {
-        if let reason = summary.compactUnavailableReason {
+        if summary.compactUnavailableReason != nil {
             return [
                 unavailableRow(
                     id: "accountsUnavailable",
                     systemName: "person.crop.circle.badge.exclamationmark",
-                    title: "Connection profile",
-                    reason: reason
+                    title: "Connection profile"
                 ),
             ]
         }
@@ -589,58 +602,19 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 ShellSettingsRowModel(
                     id: "selectedProfile",
                     systemName: "person.crop.circle",
-                    title: "Selected profile",
-                    detail: "Add one with alan connection add.",
+                    title: "Connection profile",
                     value: "Not configured"
-                ),
-                ShellSettingsRowModel(
-                    id: "accountActions",
-                    systemName: "arrowshape.turn.up.right",
-                    title: "Account actions",
-                    detail: "Login, key entry, and connection tests run through alan connection.",
-                    value: "Command line"
-                ),
+                )
             ]
         }
 
-        let provider = summary.provider(for: profile.provider)
         return [
             ShellSettingsRowModel(
                 id: "selectedProfile",
                 systemName: "person.crop.circle",
-                title: "Selected profile",
-                detail: "Profile ID: \(profile.profileID)",
+                title: "Connection profile",
                 value: profile.displayName
-            ),
-            ShellSettingsRowModel(
-                id: "provider",
-                systemName: "network",
-                title: "Provider",
-                detail: profile.provider,
-                value: provider?.displayName ?? displayProviderName(profile.provider)
-            ),
-            ShellSettingsRowModel(
-                id: "model",
-                systemName: "cpu",
-                title: "Model",
-                detail: "Resolved by the connection profile.",
-                value: profile.modelDisplayValue
-            ),
-            ShellSettingsRowModel(
-                id: "credential",
-                systemName: "key",
-                title: "Credential",
-                detail: "Secret values stay in the host credential store.",
-                value: displayCredentialStatus(profile.credentialStatus)
-            ),
-            ShellSettingsRowModel(
-                id: "accountActions",
-                systemName: "arrowshape.turn.up.right",
-                title: "Account actions",
-                detail: "Login, key entry, and connection tests run through alan connection.",
-                value: provider?.supportedActionLabel ?? "Command line",
-                mutability: .actionOnly
-            ),
+            )
         ]
     }
 
@@ -650,14 +624,14 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 id: "governance",
                 systemName: "checkmark.shield",
                 title: "Governance",
-                detail: "Default new-session policy.",
+                detail: "Default policy for new sessions.",
                 value: "Conservative"
             ),
             ShellSettingsRowModel(
                 id: "reasoningEffort",
                 systemName: "brain.head.profile",
                 title: "Reasoning effort",
-                detail: "Uses model defaults when no session override is selected.",
+                detail: "Uses the model default unless a session overrides it.",
                 value: "Model default"
             ),
             ShellSettingsRowModel(
@@ -671,7 +645,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
                 id: "recoveryMode",
                 systemName: "arrow.clockwise",
                 title: "Stream recovery",
-                detail: "Partial stream recovery continues once by default.",
+                detail: "Retry a partial stream once by default.",
                 value: "Continue once"
             ),
         ]
@@ -680,43 +654,25 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
     private static func capabilityRows(
         _ summary: ShellSettingsCapabilitiesSummary
     ) -> [ShellSettingsRowModel] {
-        if let reason = summary.compactUnavailableReason {
+        if summary.compactUnavailableReason != nil {
             return [
                 unavailableRow(
                     id: "capabilitiesUnavailable",
                     systemName: "puzzlepiece.extension",
-                    title: "Skill catalog",
-                    reason: reason
+                    title: "Skill catalog"
                 ),
             ]
         }
 
         let total = summary.skills.count
         let enabled = summary.skills.filter(\.enabled).count
-        let implicit = summary.skills.filter(\.allowImplicitInvocation).count
-        let unavailable = summary.skills.filter { !$0.available }.count
 
         return [
             ShellSettingsRowModel(
-                id: "enabledSkills",
+                id: "capabilitiesAvailable",
                 systemName: "puzzlepiece.extension",
-                title: "Enabled skills",
-                detail: "Resolved from the skill catalog.",
+                title: "Skill catalog",
                 value: total == 0 ? "No skills" : "\(enabled) of \(total)"
-            ),
-            ShellSettingsRowModel(
-                id: "implicitInvocation",
-                systemName: "sparkle.magnifyingglass",
-                title: "Implicit invocation",
-                detail: "Shows how many skills may be invoked without an explicit mention.",
-                value: "\(implicit) allowed"
-            ),
-            ShellSettingsRowModel(
-                id: "unavailableSkills",
-                systemName: "exclamationmark.triangle",
-                title: "Unavailable skills",
-                detail: "Unavailable packages stay visible without blocking Settings.",
-                value: unavailable == 0 ? "None" : "\(unavailable)"
             ),
         ]
     }
@@ -729,70 +685,61 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             ShellSettingsRowModel(
                 id: "appIdentity",
                 systemName: "app",
-                title: "App",
-                detail: local.bundleIdentifier,
-                value: local.appDisplayName
+                title: "Bundle ID",
+                value: local.bundleIdentifier
             ),
             ShellSettingsRowModel(
                 id: "installChannel",
                 systemName: "shippingbox",
-                title: "Install channel",
-                detail: local.appBundleName,
+                title: "Channel",
                 value: local.channelLabel
             ),
             ShellSettingsRowModel(
                 id: "cliTool",
                 systemName: "terminal",
                 title: "Command line tool",
-                detail: "Installed into /usr/local/bin when requested.",
                 value: local.cliToolName
             ),
             ShellSettingsRowModel(
                 id: "daemonEndpoint",
                 systemName: "server.rack",
                 title: "Daemon endpoint",
-                detail: "Bind \(local.daemonBindAddress)",
                 value: local.daemonURL
             ),
             ShellSettingsRowModel(
                 id: "updates",
                 systemName: "arrow.down.circle",
                 title: "Updates",
-                detail: local.updateDetail,
                 value: local.updateSummary
             ),
             ShellSettingsRowModel(
                 id: "dataRoot",
                 systemName: "folder",
                 title: "Alan home",
-                detail: "Credentials and auth are stored separately; values are not shown.",
                 value: local.alanHomeDisplayPath
             ),
             ShellSettingsRowModel(
                 id: "publicSkills",
                 systemName: "folder.badge.gearshape",
-                title: "Skill package path",
-                detail: "Package install root for this channel.",
+                title: "Skill packages",
                 value: local.globalSkillsDisplayPath
             ),
             ShellSettingsRowModel(
                 id: "applicationSupport",
                 systemName: "externaldrive",
                 title: "Shell state",
-                detail: "Workspace manifests and local shell state.",
                 value: local.applicationSupportDisplayPath
             ),
             ShellSettingsRowModel(
                 id: "shellControl",
                 systemName: "point.3.connected.trianglepath.dotted",
-                title: "Shell control",
-                detail: "Local control namespace.",
+                title: "Control namespace",
                 value: local.shellControlNamespace
             ),
             ShellSettingsRowModel(
                 id: "performanceDiagnostics",
                 systemName: "speedometer",
-                title: "Performance Diagnostics",
+                title: "Performance Trace",
                 detail: "Local performance trace. Terminal content is not recorded.",
                 value: diagnostics.isEnabled ? "Enabled" : "Disabled",
                 mutability: .editable
@@ -800,7 +747,7 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
             ShellSettingsRowModel(
                 id: "performanceDiagnosticsExport",
                 systemName: "square.and.arrow.up",
-                title: "Export Recent Diagnostics",
+                title: "Export Diagnostics",
                 detail: diagnostics.exportDetail,
                 value: "Export",
                 mutability: .actionOnly
@@ -811,27 +758,14 @@ struct ShellSettingsSurfaceSnapshot: Equatable {
     private static func unavailableRow(
         id: String,
         systemName: String,
-        title: String,
-        reason: String
+        title: String
     ) -> ShellSettingsRowModel {
         ShellSettingsRowModel(
             id: id,
             systemName: systemName,
             title: title,
-            detail: sanitizedUnavailableReason(reason),
             value: "Unavailable"
         )
-    }
-
-    private static func sanitizedUnavailableReason(_ reason: String) -> String {
-        let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return "The daemon did not return this summary."
-        }
-        if trimmed.contains("\n") || trimmed.contains("{") || trimmed.contains("}") {
-            return "The daemon did not return this summary."
-        }
-        return trimmed
     }
 
     private static func displayCredentialStatus(_ status: String) -> String {

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift
@@ -2,12 +2,12 @@
 import AppKit
 import Foundation
 
-@MainActor
 enum ShellLocalFolderOpener {
     static func canOpenFolder(displayPath: String?) -> Bool {
         folderURL(displayPath: displayPath) != nil
     }
 
+    @MainActor
     static func openFolder(displayPath: String?) {
         guard let url = folderURL(displayPath: displayPath) else {
             return
@@ -24,6 +24,13 @@ enum ShellLocalFolderOpener {
 
         let expandedPath = NSString(string: displayPath).expandingTildeInPath
         guard expandedPath.hasPrefix("/") else {
+            return nil
+        }
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: expandedPath, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
             return nil
         }
         return URL(fileURLWithPath: expandedPath, isDirectory: true)

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift
@@ -1,0 +1,32 @@
+#if os(macOS)
+import AppKit
+import Foundation
+
+@MainActor
+enum ShellLocalFolderOpener {
+    static func canOpenFolder(displayPath: String?) -> Bool {
+        folderURL(displayPath: displayPath) != nil
+    }
+
+    static func openFolder(displayPath: String?) {
+        guard let url = folderURL(displayPath: displayPath) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    private static func folderURL(displayPath: String?) -> URL? {
+        guard let displayPath = displayPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !displayPath.isEmpty
+        else {
+            return nil
+        }
+
+        let expandedPath = NSString(string: displayPath).expandingTildeInPath
+        guard expandedPath.hasPrefix("/") else {
+            return nil
+        }
+        return URL(fileURLWithPath: expandedPath, isDirectory: true)
+    }
+}
+#endif

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -1362,28 +1362,22 @@ private struct ShellSettingsContentView: View {
                 ZStack(alignment: .topLeading) {
                     ShellSettingsDetailBackground()
 
-                    ShellSettingsPageSheet {
-                        ScrollView {
-                            ShellSettingsGroupView(
-                                group: selectedGroupModel,
-                                appearanceMode: $appearanceMode,
-                                sidebarVisible: sidebarVisible,
-                                dimsInactiveSplitPanes: $dimsInactiveSplitPanes,
-                                performanceDiagnosticsEnabled: performanceDiagnosticsBinding,
-                                onExportPerformanceDiagnostics: exportPerformanceDiagnostics
-                            )
-                            .frame(maxWidth: ShellSettingsMetrics.contentWidth, alignment: .leading)
-                            .padding(.horizontal, ShellSettingsMetrics.pageContentHorizontalPadding)
-                            .padding(.top, ShellSettingsMetrics.pageContentTopPadding)
-                            .padding(.bottom, ShellSettingsMetrics.pageContentBottomPadding)
-                            .frame(maxWidth: .infinity, alignment: .topLeading)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    ScrollView {
+                        ShellSettingsGroupView(
+                            group: selectedGroupModel,
+                            appearanceMode: $appearanceMode,
+                            sidebarVisible: sidebarVisible,
+                            dimsInactiveSplitPanes: $dimsInactiveSplitPanes,
+                            performanceDiagnosticsEnabled: performanceDiagnosticsBinding,
+                            onExportPerformanceDiagnostics: exportPerformanceDiagnostics
+                        )
+                        .frame(maxWidth: ShellSettingsMetrics.contentWidth, alignment: .leading)
+                        .padding(.leading, ShellSettingsMetrics.detailContentLeadingPadding)
+                        .padding(.trailing, ShellSettingsMetrics.detailContentTrailingPadding)
+                        .padding(.top, ShellSettingsMetrics.detailContentTopPadding)
+                        .padding(.bottom, ShellSettingsMetrics.detailContentBottomPadding)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
                     }
-                    .padding(.leading, ShellSettingsMetrics.pageSheetOuterLeadingInset)
-                    .padding(.top, ShellSettingsMetrics.pageSheetOuterTopInset)
-                    .padding(.trailing, ShellSettingsMetrics.pageSheetOuterTrailingInset)
-                    .padding(.bottom, ShellSettingsMetrics.pageSheetOuterBottomInset)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -1592,8 +1586,8 @@ private struct ShellSettingsNavigationView: View {
 
     private func iconStyle(for group: ShellSettingsNavigationGroupModel) -> some ShapeStyle {
         group.id == selectedGroup
-            ? AnyShapeStyle(ShellPalette.accent.opacity(0.94))
-            : AnyShapeStyle(ShellPalette.settingsSecondaryInk.opacity(0.82))
+            ? AnyShapeStyle(ShellPalette.settingsPrimaryInk)
+            : AnyShapeStyle(ShellPalette.settingsSecondaryInk)
     }
 
     private func textStyle(for group: ShellSettingsNavigationGroupModel) -> some ShapeStyle {
@@ -1640,44 +1634,28 @@ private enum ShellSettingsNavigationRowVisualState: Equatable {
         case .hover:
             return ShellPalette.line.opacity(0.07)
         case .selected:
-            return ShellPalette.line.opacity(0.12)
+            return ShellPalette.line.opacity(0.08)
         }
     }
 }
 
 private struct ShellSettingsNavigationRowBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     let state: ShellSettingsNavigationRowVisualState
 
     var body: some View {
-        if let fill = state.fill {
-            let shape = RoundedRectangle(
-                cornerRadius: ShellSettingsMetrics.navigationSelectionCornerRadius,
-                style: .continuous
-            )
-            shape
-                .fill(fill)
-                .overlay {
-                    shape.stroke(state.stroke, lineWidth: 0.5)
-                }
-                .overlay {
-                    if colorScheme == .light && state == .selected {
-                        shape
-                            .stroke(Color.white.opacity(0.30), lineWidth: 0.55)
-                            .mask {
-                                shape.fill(
-                                    LinearGradient(
-                                        colors: [
-                                            Color.white,
-                                            Color.white.opacity(0),
-                                        ],
-                                        startPoint: .top,
-                                        endPoint: .bottom
-                                    )
-                                )
-                            }
+        let shape = RoundedRectangle(
+            cornerRadius: ShellSettingsMetrics.navigationSelectionCornerRadius,
+            style: .continuous
+        )
+
+        ZStack(alignment: .leading) {
+            if let fill = state.fill {
+                shape
+                    .fill(fill)
+                    .overlay {
+                        shape.stroke(state.stroke, lineWidth: 0.5)
                     }
-                }
+            }
         }
     }
 }
@@ -1691,12 +1669,12 @@ private struct ShellSettingsGroupView: View {
     let onExportPerformanceDiagnostics: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: ShellSettingsMetrics.pageTitleToSectionsSpacing) {
             Text(group.title)
                 .font(ShellSettingsTypography.pageTitle)
                 .foregroundStyle(ShellPalette.settingsPrimaryInk)
 
-            VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: ShellSettingsMetrics.sectionSpacing) {
                 ForEach(group.sections) { section in
                     ShellSettingsSectionView(
                         section: section,
@@ -1729,11 +1707,19 @@ private struct ShellSettingsSectionView: View {
     let onExportPerformanceDiagnostics: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(section.title)
-                .font(ShellSettingsTypography.sectionLabel)
-                .foregroundStyle(ShellPalette.settingsTertiaryInk)
-                .textCase(.uppercase)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 14) {
+                Text(section.title.uppercased())
+                    .font(ShellSettingsTypography.sectionTitle)
+                    .foregroundStyle(ShellPalette.settingsSecondaryInk)
+                    .tracking(0.4)
+                    .lineLimit(1)
+
+                Rectangle()
+                    .fill(ShellPalette.line.opacity(0.20))
+                    .frame(height: 0.8)
+            }
+            .padding(.bottom, ShellSettingsMetrics.sectionTitleBottomPadding)
 
             VStack(spacing: 0) {
                 ForEach(Array(section.rows.enumerated()), id: \.element.id) { index, row in
@@ -1764,7 +1750,7 @@ private struct ShellSettingsSectionView: View {
                 .labelsHidden()
                 .pickerStyle(.segmented)
                 .controlSize(.small)
-                .frame(width: 186)
+                .frame(width: ShellSettingsMetrics.segmentedControlWidth)
             }
         case "sidebar":
             ShellSettingsRow(
@@ -1809,36 +1795,93 @@ private struct ShellSettingsSectionView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .disabled(!performanceDiagnosticsEnabled.wrappedValue)
+                    .opacity(
+                        performanceDiagnosticsEnabled.wrappedValue
+                            ? 1
+                            : ShellSettingsMetrics.disabledButtonOpacity
+                    )
             }
         case "agentSelector":
+            ShellSettingsAgentSummaryRow()
+        case "daemonEndpoint":
             ShellSettingsRow(
                 systemName: row.systemName,
                 title: row.title,
-                detail: row.detail
+                detail: row.value
             ) {
-                ShellSettingsAgentSelector()
+                ShellSettingsInlineValueAction(
+                    isEnabled: row.value != nil,
+                    buttonSystemName: "doc.on.doc",
+                    buttonHelp: "Copy daemon endpoint"
+                ) {
+                    shellSettingsCopyToPasteboard(row.value)
+                }
+            }
+        case "applicationSupport", "dataRoot", "publicSkills":
+            ShellSettingsRow(
+                systemName: row.systemName,
+                title: row.title,
+                detail: row.value
+            ) {
+                ShellSettingsPathAction(value: row.value)
             }
         default:
-            ShellSettingsRow(
-                systemName: row.systemName,
-                title: row.title,
-                detail: row.detail
-            ) {
-                ShellSettingsValueLabel(value: row.value, mutability: row.mutability)
+            if let detail = row.detail, row.value != nil {
+                ShellSettingsRow(
+                    systemName: row.systemName,
+                    title: row.title,
+                    detail: detail
+                ) {
+                    ShellSettingsValueLabel(
+                        value: row.value,
+                        mutability: row.mutability
+                    )
+                }
+            } else {
+                ShellSettingsRow(
+                    systemName: row.systemName,
+                    title: row.title,
+                    detail: row.detail ?? row.value
+                )
             }
         }
     }
 }
 
+private struct ShellSettingsRowHoveredKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+private extension EnvironmentValues {
+    var shellSettingsRowHovered: Bool {
+        get { self[ShellSettingsRowHoveredKey.self] }
+        set { self[ShellSettingsRowHoveredKey.self] = newValue }
+    }
+}
+
 private struct ShellSettingsRow<Accessory: View>: View {
+    @State private var isHovered = false
+
     let systemName: String
     let title: String
     let detail: String?
     @ViewBuilder let accessory: () -> Accessory
 
+    init(
+        systemName: String,
+        title: String,
+        detail: String?,
+        @ViewBuilder accessory: @escaping () -> Accessory
+    ) {
+        self.systemName = systemName
+        self.title = title
+        self.detail = detail
+        self.accessory = accessory
+    }
+
     var body: some View {
-        HStack(alignment: .center, spacing: 0) {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(alignment: .center, spacing: ShellSettingsMetrics.rowColumnSpacing) {
+            VStack(alignment: .leading, spacing: ShellSettingsMetrics.rowTextSpacing) {
                 Text(title)
                     .font(ShellSettingsTypography.rowTitle)
                     .foregroundStyle(ShellPalette.settingsPrimaryInk)
@@ -1855,35 +1898,76 @@ private struct ShellSettingsRow<Accessory: View>: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .layoutPriority(1)
 
-            Spacer(minLength: 16)
-
-            accessory()
-                .font(ShellSettingsTypography.accessory)
-                .frame(width: ShellSettingsMetrics.accessoryColumnWidth, alignment: .trailing)
+            accessoryView
+                .environment(\.shellSettingsRowHovered, isHovered)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, ShellSettingsMetrics.rowVerticalPadding)
-        .frame(minHeight: ShellSettingsMetrics.rowMinHeight)
+        .frame(minHeight: rowMinHeight)
+        .onHover { isHovered = $0 }
+    }
+
+    private var rowMinHeight: CGFloat {
+        let hasDetail = detail?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        return hasDetail ? ShellSettingsMetrics.rowMinHeightWithDetail : ShellSettingsMetrics.rowMinHeight
+    }
+
+    @ViewBuilder
+    private var accessoryView: some View {
+        accessory()
+            .font(ShellSettingsTypography.accessory)
+            .frame(width: ShellSettingsMetrics.accessoryColumnWidth, alignment: .trailing)
     }
 }
 
-private struct ShellSettingsAgentSelector: View {
+private extension ShellSettingsRow where Accessory == EmptyView {
+    init(
+        systemName: String,
+        title: String,
+        detail: String?
+    ) {
+        self.systemName = systemName
+        self.title = title
+        self.detail = detail
+        self.accessory = { EmptyView() }
+    }
+}
+
+private struct ShellSettingsAgentSummaryRow: View {
     var body: some View {
-        Text("Alan")
-            .font(ShellSettingsTypography.value)
-            .foregroundStyle(ShellPalette.settingsValueInk)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                    .fill(ShellPalette.panel.opacity(0.86))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                    .stroke(ShellPalette.line.opacity(0.24), lineWidth: 0.8)
-            )
-            .accessibilityLabel(Text("Alan"))
+        HStack(alignment: .center, spacing: ShellSettingsMetrics.rowColumnSpacing) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Alan")
+                    .font(ShellSettingsTypography.agentName)
+                    .foregroundStyle(ShellPalette.settingsPrimaryInk)
+
+                Text("Current agent")
+                    .font(ShellSettingsTypography.rowDetail)
+                    .foregroundStyle(ShellPalette.settingsSecondaryInk)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("Configurable")
+                .font(ShellSettingsTypography.badge)
+                .foregroundStyle(ShellPalette.settingsValueInk)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                        .fill(ShellPalette.panel.opacity(0.56))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                        .stroke(ShellPalette.line.opacity(0.18), lineWidth: 0.7)
+                )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, ShellSettingsMetrics.rowVerticalPadding)
+        .frame(minHeight: ShellSettingsMetrics.agentSummaryRowMinHeight)
+        .accessibilityLabel(Text("Alan, current configurable agent"))
     }
 }
 
@@ -1893,12 +1977,6 @@ private struct ShellSettingsValueLabel: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if mutability == .actionOnly {
-                Image(systemName: "arrow.up.right")
-                    .font(ShellSettingsTypography.valueActionIcon)
-                    .foregroundStyle(ShellPalette.settingsTertiaryInk)
-            }
-
             Text(value ?? "Unavailable")
                 .font(ShellSettingsTypography.value)
                 .foregroundStyle(valueStyle)
@@ -1915,127 +1993,123 @@ private struct ShellSettingsValueLabel: View {
         if value == "Unavailable" {
             return AnyShapeStyle(ShellPalette.settingsDisabledInk)
         }
+        if mutability == .actionOnly {
+            return AnyShapeStyle(ShellPalette.settingsValueInk)
+        }
         return AnyShapeStyle(ShellPalette.settingsValueInk)
     }
 }
 
+private struct ShellSettingsInlineValueAction: View {
+    @Environment(\.shellSettingsRowHovered) private var isRowHovered
+
+    let isEnabled: Bool
+    let buttonSystemName: String
+    let buttonHelp: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label("Copy", systemImage: buttonSystemName)
+                .labelStyle(.titleAndIcon)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!isEnabled)
+        .opacity(isRowHovered || isEnabled ? 1 : ShellSettingsMetrics.disabledButtonOpacity)
+        .help(buttonHelp)
+    }
+}
+
+private struct ShellSettingsPathAction: View {
+    let value: String?
+
+    var body: some View {
+        Button("Show…") {
+            shellSettingsOpenFolder(value)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(!ShellLocalFolderOpener.canOpenFolder(displayPath: value))
+        .help(value ?? "Folder unavailable")
+    }
+}
+
+@MainActor
+private func shellSettingsCopyToPasteboard(_ value: String?) {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !value.isEmpty
+    else {
+        return
+    }
+    ShellClipboardWriter().writeString(value)
+}
+
+@MainActor
+private func shellSettingsOpenFolder(_ value: String?) {
+    ShellLocalFolderOpener.openFolder(displayPath: value)
+}
+
 private struct ShellSettingsDivider: View {
     var body: some View {
-        Rectangle()
-            .fill(ShellPalette.line.opacity(0.14))
-            .frame(height: 0.8)
+        Divider()
+            .opacity(0.45)
             .padding(.leading, ShellSettingsMetrics.rowDividerLeadingPadding)
     }
 }
 
 private enum ShellSettingsMetrics {
-    static let navigationWidth: CGFloat = 156
-    static let navigationLeadingPadding: CGFloat = 8
+    static let navigationWidth: CGFloat = 188
+    static let navigationLeadingPadding: CGFloat = 12
     static let navigationTrailingPadding: CGFloat = 8
-    static let navigationTopPadding: CGFloat = 2
-    static let navigationRowHeight: CGFloat = 28
+    static let navigationTopPadding: CGFloat = 24
+    static let navigationRowHeight: CGFloat = 30
     static let navigationRowSpacing: CGFloat = 2
     static let navigationRowHorizontalPadding: CGFloat = 8
     static let navigationRowContentSpacing: CGFloat = 12
-    static let navigationIconSlotWidth: CGFloat = 17
-    static let navigationSelectionCornerRadius: CGFloat = 8
-    static let contentWidth: CGFloat = 640
-    static let pageSheetOuterLeadingInset: CGFloat = 4
-    static let pageSheetOuterTopInset: CGFloat = 0
-    static let pageSheetOuterTrailingInset: CGFloat = 8
-    static let pageSheetOuterBottomInset: CGFloat = 8
-    static let pageSheetCornerRadius: CGFloat = 8
-    static let pageContentHorizontalPadding: CGFloat = 32
-    static let pageContentTopPadding: CGFloat = 30
-    static let pageContentBottomPadding: CGFloat = 30
-    static let rowVerticalPadding: CGFloat = 10
-    static let rowMinHeight: CGFloat = 56
+    static let navigationIconSlotWidth: CGFloat = 18
+    static let navigationSelectionCornerRadius: CGFloat = 7
+    static let contentWidth: CGFloat = 760
+    static let detailContentLeadingPadding: CGFloat = 48
+    static let detailContentTrailingPadding: CGFloat = 48
+    static let detailContentTopPadding: CGFloat = 42
+    static let detailContentBottomPadding: CGFloat = 40
+    static let pageTitleToSectionsSpacing: CGFloat = 26
+    static let sectionSpacing: CGFloat = 28
+    static let sectionTitleBottomPadding: CGFloat = 10
+    static let rowVerticalPadding: CGFloat = 8
+    static let rowMinHeight: CGFloat = 48
+    static let rowMinHeightWithDetail: CGFloat = 56
+    static let agentSummaryRowMinHeight: CGFloat = 58
+    static let rowTextSpacing: CGFloat = 1
+    static let rowColumnSpacing: CGFloat = 20
     static let rowDividerLeadingPadding: CGFloat = 0
-    static let accessoryColumnWidth: CGFloat = 224
-    static let valueColumnWidth: CGFloat = 216
+    static let accessoryColumnWidth: CGFloat = 188
+    static let valueColumnWidth: CGFloat = 220
+    static let inlineActionSpacing: CGFloat = 8
+    static let inlineIconButtonSize: CGFloat = 22
+    static let segmentedControlWidth: CGFloat = 196
+    static let disabledButtonOpacity: CGFloat = 0.55
 }
 
 private enum ShellSettingsTypography {
-    static let navigationIcon = Font.system(size: 12, weight: .medium)
+    static let navigationIcon = Font.system(size: 13, weight: .regular)
 
     static func navigationLabel(selected: Bool) -> Font {
-        .system(size: 12.75, weight: selected ? .medium : .regular)
+        .system(size: 13, weight: selected ? .semibold : .regular)
     }
 
-    static let pageTitle = Font.system(size: 21.5, weight: .semibold)
-    static let sectionLabel = Font.system(size: 11, weight: .semibold)
-    static let rowTitle = Font.system(size: 13, weight: .medium)
-    static let rowDetail = Font.system(size: 12.25, weight: .regular)
-    static let accessory = Font.system(size: 12.5, weight: .medium)
-    static let value = Font.system(size: 12.5, weight: .medium)
+    static let pageTitle = Font.system(size: 22, weight: .semibold)
+    static let sectionTitle = Font.system(size: 11, weight: .semibold)
+    static let rowTitle = Font.system(size: 13, weight: .semibold)
+    static let rowDetail = Font.system(size: 12, weight: .regular)
+    static let accessory = Font.system(size: 13, weight: .regular)
+    static let value = Font.system(size: 13, weight: .medium)
+    static let agentName = Font.system(size: 15, weight: .semibold)
+    static let badge = Font.system(size: 11.5, weight: .medium)
     static let valueActionIcon = Font.system(size: 9.5, weight: .semibold)
-}
-
-private struct ShellSettingsPageSheet<Content: View>: View {
-    @ViewBuilder let content: () -> Content
-    private let shape = RoundedRectangle(
-        cornerRadius: ShellSettingsMetrics.pageSheetCornerRadius,
-        style: .continuous
-    )
-
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            ShellSettingsPageSheetBackground()
-            content()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .clipShape(shape)
-    }
-}
-
-private struct ShellSettingsPageSheetBackground: View {
-    private let shape = RoundedRectangle(
-        cornerRadius: ShellSettingsMetrics.pageSheetCornerRadius,
-        style: .continuous
-    )
-
-    var body: some View {
-        shape
-            .fill(ShellPalette.settingsSheet)
-            .overlay {
-                shape
-                    .strokeBorder(ShellPalette.line.opacity(0.24), lineWidth: 0.6)
-            }
-            .overlay {
-                shape
-                    .inset(by: 0.7)
-                    .strokeBorder(
-                        LinearGradient(
-                            stops: [
-                                .init(color: Color.black.opacity(0.050), location: 0.00),
-                                .init(color: Color.black.opacity(0.020), location: 0.12),
-                                .init(color: Color.clear, location: 0.22),
-                                .init(color: Color.clear, location: 1.00),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: 0.8
-                    )
-            }
-            .overlay {
-                shape
-                    .inset(by: 1.3)
-                    .strokeBorder(
-                        LinearGradient(
-                            stops: [
-                                .init(color: Color.white.opacity(0.58), location: 0.00),
-                                .init(color: Color.white.opacity(0.18), location: 0.14),
-                                .init(color: Color.clear, location: 0.24),
-                                .init(color: Color.clear, location: 1.00),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: 0.45
-                    )
-            }
-    }
+    static let inlineActionIcon = Font.system(size: 10.5, weight: .medium)
+    static let actionButton = Font.system(size: 12.3, weight: .medium)
 }
 
 private struct ShellContentPaneTitleBarView: View {

--- a/clients/apple/scripts/test-shell-settings-surface.sh
+++ b/clients/apple/scripts/test-shell-settings-surface.sh
@@ -15,6 +15,7 @@ CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR" swiftc \
     "$REPO_ROOT/clients/apple/alan-macos/Support/AlanMacUpdatePolicy.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift" \
     "$REPO_ROOT/clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift" \
+    "$REPO_ROOT/clients/apple/alan-macos/Services/Shell/ShellLocalFolderOpener.swift" \
     "$REPO_ROOT/clients/apple/scripts/test-shell-settings-surface.swift" \
     -o "$TEST_BINARY"
 

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -26,6 +26,7 @@ struct ShellSettingsSurfaceTestRunner {
             try testAccountsCapabilitiesAndLocalRowsStayReadOnlyAndRedacted()
             try testDevChannelLocalRowsUseDevIdentity()
             try testLocalSummaryReadsHostConfigForDaemonEndpoint()
+            try testLocalFolderOpenerRequiresExistingDirectory()
             try testWorkspaceContextUsesRegistryForWorkspaceScopedRequests()
             try testWorkspaceContextFallsBackToDiscoveredWorkspaceRoot()
             try testUnavailableRemoteSummariesStayCompact()
@@ -225,6 +226,38 @@ private func testLocalSummaryReadsHostConfigForDaemonEndpoint() throws {
     try expect(
         summary.daemonURL == "http://127.0.0.1:9123",
         "settings must query the daemon URL derived from host.toml"
+    )
+}
+
+private func testLocalFolderOpenerRequiresExistingDirectory() throws {
+    let homeDirectory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: homeDirectory) }
+
+    let existingDirectory = homeDirectory.appendingPathComponent("skills", isDirectory: true)
+    try FileManager.default.createDirectory(at: existingDirectory, withIntermediateDirectories: true)
+    let existingFile = homeDirectory.appendingPathComponent("not-a-folder")
+    try Data("not a directory".utf8).write(to: existingFile)
+    let missingDirectory = homeDirectory.appendingPathComponent("missing", isDirectory: true)
+
+    try expect(
+        ShellLocalFolderOpener.canOpenFolder(displayPath: existingDirectory.path),
+        "folder opener must enable existing absolute directories"
+    )
+    try expect(
+        !ShellLocalFolderOpener.canOpenFolder(displayPath: missingDirectory.path),
+        "folder opener must disable missing absolute directories"
+    )
+    try expect(
+        !ShellLocalFolderOpener.canOpenFolder(displayPath: existingFile.path),
+        "folder opener must disable regular files"
+    )
+    try expect(
+        !ShellLocalFolderOpener.canOpenFolder(displayPath: "relative/folder"),
+        "folder opener must disable relative paths"
+    )
+    try expect(
+        !ShellLocalFolderOpener.canOpenFolder(displayPath: "  "),
+        "folder opener must disable blank paths"
     )
 }
 

--- a/clients/apple/scripts/test-shell-settings-surface.swift
+++ b/clients/apple/scripts/test-shell-settings-surface.swift
@@ -180,7 +180,10 @@ private func testDevChannelLocalRowsUseDevIdentity() throws {
     )
     let localText = try requireSection(.local, in: snapshot).visibleText.joined(separator: "\n")
 
-    try expect(localText.contains("Alan Dev"), "dev settings must identify the Alan Dev app")
+    try expect(
+        localText.contains("app.alanworks.macos.dev"),
+        "dev settings must show the Alan Dev bundle identifier"
+    )
     try expect(localText.contains("alan-dev"), "dev settings must show the alan-dev CLI tool")
     try expect(localText.contains("~/.alan-dev"), "dev settings must show the dev alan home")
     try expect(
@@ -427,6 +430,22 @@ private func testNavigationGroupsMapTaskOrientedRows() throws {
         terminal.sections.map(\.id) == [.profiles, .localIdentity],
         "Terminal must group terminal profiles and local terminal identity"
     )
+    let terminalRowsByID = Dictionary(uniqueKeysWithValues: terminal.rows.map { ($0.id, $0) })
+    try expect(
+        terminalRowsByID["terminalProfilesDefault"]?.title == "Default profile"
+            && terminalRowsByID["terminalProfilesDefault"]?.detail == "Used for new terminals.",
+        "Terminal default profile row must use the shared setting label/detail/value template"
+    )
+    try expect(
+        terminalRowsByID["terminalProfilesCreate"]?.title == "New profile"
+            && terminalRowsByID["terminalProfilesCreate"]?.value == "Create…"
+            && terminalRowsByID["terminalProfilesCreate"]?.detail == "Create a local startup profile.",
+        "Terminal create row must use native ellipsis action copy with concise detail"
+    )
+    try expect(
+        terminalRowsByID["terminalProfile.login_shell"]?.detail == nil,
+        "Terminal login shell row must not repeat its title as secondary copy"
+    )
 }
 
 private func testNavigationGroupsKeepTerminalIdentityOutOfAgent() throws {
@@ -499,18 +518,100 @@ private func testNavigationGroupsPlaceAgentAndSystemRows() throws {
         "Agent must contain compact skill catalog unavailable state"
     )
     try expect(
-        agent.rows.contains { $0.id == "publicSkills" && $0.title == "Skill package path" },
+        agent.rows.contains { $0.id == "publicSkills" && $0.title == "Skill packages" },
         "Agent must contain the renamed skill package path row"
+    )
+    try expect(
+        agent.sections.map(\.id) == [.agent, .runtimeDefaults, .skills, .entryPoints],
+        "Agent must merge connection and skill source details into task-oriented sections"
     )
     try expect(
         agent.rows.map(\.id).contains("cliTool"),
         "Agent must contain the command line tool entry point"
     )
 
+    let connectedSnapshot = ShellSettingsSurfaceSnapshot.make(
+        remote: ShellSettingsRemoteSnapshot(
+            accounts: ShellSettingsAccountsSummary(
+                current: ShellSettingsConnectionSelection(
+                    defaultProfile: "chatgpt-main",
+                    effectiveProfile: "chatgpt-main",
+                    effectiveSource: "global"
+                ),
+                profiles: [
+                    ShellSettingsConnectionProfile(
+                        profileID: "chatgpt-main",
+                        label: "ChatGPT",
+                        provider: "chatgpt",
+                        credentialStatus: "available",
+                        settings: [:],
+                        isDefault: true
+                    )
+                ],
+                providers: [],
+                unavailableReason: nil
+            ),
+            capabilities: ShellSettingsCapabilitiesSummary(
+                skills: [
+                    ShellSettingsSkillSummary(
+                        id: "memory",
+                        name: "Memory",
+                        enabled: true,
+                        allowImplicitInvocation: false,
+                        available: true
+                    ),
+                    ShellSettingsSkillSummary(
+                        id: "plan",
+                        name: "Plan",
+                        enabled: false,
+                        allowImplicitInvocation: false,
+                        available: true
+                    ),
+                ],
+                unavailableReason: nil
+            )
+        ),
+        local: devLocalSummary()
+    )
+    let connectedAgent = try requireNavigationGroup(.agent, in: connectedSnapshot)
+    let connectedRowIDs = connectedAgent.rows.map { $0.id }
+    let connectionRow = connectedAgent.rows.first { $0.id == "selectedProfile" }
+    let skillCatalogRow = connectedAgent.rows.first { $0.id == "capabilitiesAvailable" }
+    try expect(
+        connectionRow?.title == "Connection profile" && connectionRow?.detail == nil,
+        "Agent connection row must stay compact when profile metadata is available"
+    )
+    try expect(
+        skillCatalogRow?.title == "Skill catalog" && skillCatalogRow?.detail == nil,
+        "Agent skill catalog row must stay compact when capability metadata is available"
+    )
+    try expect(
+        !connectedRowIDs.contains("enabledSkills")
+            && !connectedRowIDs.contains("implicitInvocation")
+            && !connectedRowIDs.contains("unavailableSkills"),
+        "Agent must not expand skill catalog into debug-count rows"
+    )
+
     try expect(
         ["appIdentity", "installChannel", "updates", "daemonEndpoint", "dataRoot",
          "applicationSupport", "shellControl"].allSatisfy(system.rows.map(\.id).contains),
         "System must contain app, runtime, storage, and shell control rows"
+    )
+    let rowsByID = Dictionary(uniqueKeysWithValues: system.rows.map { ($0.id, $0) })
+    try expect(
+        rowsByID["updates"]?.detail == nil,
+        "System Updates must not show dev/update explanation as always-visible copy"
+    )
+    try expect(
+        rowsByID["daemonEndpoint"]?.detail == nil,
+        "System Daemon Endpoint must render as a compact inspector value row"
+    )
+    try expect(
+        rowsByID["daemonEndpoint"]?.title == "Daemon endpoint"
+            && rowsByID["dataRoot"]?.title == "Alan home"
+            && rowsByID["applicationSupport"]?.title == "Shell state"
+            && rowsByID["shellControl"]?.title == "Control namespace",
+        "System path rows must use control-panel labels"
     )
     try expect(
         system.rows.filter { $0.id.hasPrefix("performanceDiagnostics") }.map(\.id)

--- a/openspec/changes/add-macos-settings-navigation/design.md
+++ b/openspec/changes/add-macos-settings-navigation/design.md
@@ -90,7 +90,7 @@ window.
 5. **Rename ambiguous skill path copy.**
 
    The old Local row title `Public skills` is unclear. In the revised Agent
-   group it should be named `Skill package path` and placed under a Skill
+   group it should be named `Skill Packages` and placed under a Skill
    Sources section. This distinguishes current agent skill availability from
    the filesystem package source that feeds the skill catalog.
 

--- a/openspec/changes/add-macos-settings-navigation/implementation-plan.md
+++ b/openspec/changes/add-macos-settings-navigation/implementation-plan.md
@@ -15,7 +15,7 @@
 - Modify `clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift`
   - Replace six navigation groups with General, Terminal, Agent, System.
   - Add group-section models and row-ID based grouping.
-  - Rename `Public skills` row to `Skill package path`.
+  - Rename `Public skills` row to `Skill Packages`.
   - Add an Alan-only agent selector row or model affordance.
 - Modify `clients/apple/alan-macos/TerminalPaneView.swift`
   - Render group sections from the new model.
@@ -256,7 +256,7 @@ System:
 
 - [ ] **Step 5: Rename row title**
 
-Change the `publicSkills` row title from `Public skills` to `Skill package path`.
+Change the `publicSkills` row title from `Public skills` to `Skill Packages`.
 
 - [ ] **Step 6: Run model tests**
 

--- a/openspec/changes/add-macos-settings-navigation/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/add-macos-settings-navigation/specs/macos-shell-ui-ux-conformance/spec.md
@@ -62,7 +62,7 @@ The default Settings navigation order SHALL be:
 
 #### Scenario: Skill package source copy is explicit
 - **WHEN** Settings renders the Agent skill source row
-- **THEN** alan labels the filesystem package source as Skill package path
+- **THEN** alan labels the filesystem package source as Skill Packages
 - **AND** alan does not label that path as Public skills
 
 #### Scenario: Navigation stays visually subordinate

--- a/openspec/changes/add-macos-settings-navigation/tasks.md
+++ b/openspec/changes/add-macos-settings-navigation/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.3 Ensure Terminal contains Terminal Profiles, Managed Terminal Account, Mac login session, and sudo behavior rows.
 - [x] 1.4 Ensure Agent contains Alan selector, provider connection, model, credential, account action, runtime default, skill status, skill package source, and command line tool rows.
 - [x] 1.5 Ensure System contains app identity, install channel, daemon endpoint, updates, Alan home, shell state, shell control, and diagnostics rows.
-- [x] 1.6 Rename the old `Public skills` row to `Skill package path`.
+- [x] 1.6 Rename the old `Public skills` row to `Skill Packages`.
 
 ## 2. Settings Layout
 

--- a/openspec/changes/add-macos-settings-navigation/tasks.md
+++ b/openspec/changes/add-macos-settings-navigation/tasks.md
@@ -32,10 +32,10 @@
 - [x] 4.2 Run `bash clients/apple/scripts/test-shell-runtime-metadata.sh`.
 - [x] 4.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [x] 4.4 Run `openspec validate add-macos-settings-navigation --strict`.
-- [ ] 4.5 Build and relaunch Alan Dev fresh, then verify Settings in light mode for default General selection, Agent/System group switching, long Agent/System content, and row control layout.
+- [x] 4.5 Build and relaunch Alan Dev fresh, then verify Settings in light mode for default General selection, Agent/System group switching, long Agent/System content, and row control layout.
 
 ## 5. Review And Archive Readiness
 
-- [ ] 5.1 Review the implementation against `openspec/specs/macos-shell-ui-ux-conformance/spec.md` and this change's delta spec for duplicate or conflicting Settings requirements.
+- [x] 5.1 Review the implementation against `openspec/specs/macos-shell-ui-ux-conformance/spec.md` and this change's delta spec for duplicate or conflicting Settings requirements.
 - [ ] 5.2 Before archiving after merge, sync the accepted delta requirements into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
 - [ ] 5.3 Archive the completed change only after implementation, verification, PR review, and merge are complete.

--- a/openspec/changes/polish-macos-settings-native-surface/design.md
+++ b/openspec/changes/polish-macos-settings-native-surface/design.md
@@ -2,18 +2,18 @@
 
 `add-macos-settings-navigation` gives Settings a clearer information
 architecture with General, Terminal, Agent, and System groups. The latest visual
-review shows that the hierarchy is still not enough: the surface reads as a web
-admin page because it uses a pale inner sidebar, a large white detail canvas,
-and isolated card-like settings groups.
+review shows that the hierarchy is still not enough: the surface reads either
+as a web admin page or as an Apple System Settings clone because it relies on a
+large white sheet, low information density, and weak preference-list rhythm.
 
 Alan's design context calls for a calm, precise, native macOS shell inspired by
 Arc's material sidebar and terminal-first organization. Settings should support
 that shell rather than becoming a dashboard, website page, or separate
 preferences app. The visual reference for this pass is:
 
-- Apple Settings for the native source-list plus grouped-form pattern.
 - Linear for dense alignment, controlled row rhythm, and precise status columns.
-- Notion only for concise secondary copy where a row needs context.
+- Raycast and Warp for developer-tool settings that scan like a control panel.
+- Apple Pro Apps for native control-panel discipline without heavy cards.
 
 ## Goals / Non-Goals
 
@@ -21,23 +21,20 @@ preferences app. The visual reference for this pass is:
 
 - Make Settings feel native inside a macOS app rather than web-like.
 - Preserve the current Settings group IA and row semantics.
-- Turn the right detail area into a compact grouped settings form with clear
-  content width, row rhythm, control alignment, and descriptions.
+- Turn the right detail area into a compact preference list with clear content
+  width, row rhythm, control alignment, and descriptions.
 - Make the internal Settings navigation read as a subordinate macOS source list,
   not as a second application sidebar or button stack.
-- Make the selected Settings group live in a stable white page sheet whose
-  top border meets the pane title bar, and whose right and bottom edges stay
-  8px from the pane edge, without an outer shadow.
-- Keep the navigation-to-sheet seam tighter than the outer sheet margins so the
-  source list and selected page feel connected inside one Settings surface.
+- Remove the stable white page sheet as the main visual device; use the shared
+  pane plane plus direct section dividers so Settings reads as a control panel
+  rather than a document page.
+- Keep the navigation-to-detail seam tight so the source list and selected group
+  feel connected inside one Settings surface.
 - Keep the internal Settings source list close to the pane edges with compact
   leading, trailing, and top insets so the navigation reads as native chrome
   rather than a padded web sidebar.
-- Align the first source-list row's visible top edge optically with the white
-  page sheet's top edge, allowing a small compensation for rounded-corner
-  antialiasing.
-- Match the selected source-list row's visible corner treatment to the page
-  sheet so the aligned top edges do not appear offset by antialiasing.
+- Align the first source-list row's visible top edge optically with the detail
+  content start, allowing a small compensation for rounded-corner antialiasing.
 - Reduce excessive white space, heavy card affordances, and accent-color
   dominance.
 - Add verification tasks that require a fresh Alan Dev visual check.
@@ -54,49 +51,51 @@ preferences app. The visual reference for this pass is:
 
 ## Decisions
 
-1. **Use Apple Settings as the primary structural pattern.**
+1. **Use a developer control-panel pattern, not Apple System Settings.**
 
-   Settings should render as a source-list navigation plus an inset grouped
-   form. The source list owns selection, and the detail side owns grouped rows.
-   This is preferable to a web-dashboard layout because Settings is a
-   configuration surface, not a page with cards.
+   Settings should render as source-list navigation plus a dense preference
+   list. The source list owns selection, and the detail side owns sectioned
+   label/value rows. This is preferable to a web-dashboard layout or Apple
+   System Settings clone because Alan is a developer tool, and Settings should
+   behave like a control panel for fast scanning and modification.
 
    Alternative considered: keep the current two-column layout and only tune
    colors. That would leave the same web-like composition and would not fix the
    large white canvas or card-page reading.
 
-2. **Use a stable page sheet with compact left-anchored content.**
+2. **Use direct sections inside a stable 760pt content column.**
 
-   The selected group should render inside a white page sheet that is fixed to
-   the detail pane with its top border flush against the pane title bar and 8px
-   right and bottom insets. The sheet should avoid outer drop shadows and may
-   use only a thin border plus focused inner edge treatment to focus the surface.
-   The leading seam between the source list and sheet should be tighter than
-   the right and bottom sheet margins, avoiding a visible dead gutter.
-   Inside that sheet, rows keep a fixed maximum content width instead of
-   stretching across the window. The form content sits near the upper-left with
-   native preference spacing, so extra sheet space feels intentional rather than
-   like an empty web canvas.
+   The selected group should render directly on the detail pane with a stable
+   maximum content width of roughly 760pt, left-anchored placement within the
+   detail pane, and section dividers. Removing the white sheet avoids the document-page
+   feeling and lets hierarchy come from typography, separators, and row
+   alignment instead of container chrome. Rows should not stretch across the
+   full window, but the content width should be broad enough for paths,
+   endpoints, and metadata to scan quickly. The detail content should use a
+   predictable top offset and balanced horizontal padding so wide windows do
+   not make the content drift right.
 
    Alternative considered: center the form in the available content area. That
    makes Settings feel like a web page and weakens alignment with the shell and
    source list.
 
-3. **Replace card groups with inset grouped rows.**
+3. **Replace card groups with section dividers and compact rows.**
 
-   Section surfaces should use subtle grouped-list treatment: quiet fill,
-   restrained stroke, row dividers aligned from the text column, and stable
-   trailing controls. A settings group is not a dashboard card; it is a compact
-   form section.
+   Section surfaces should use a readable title, a quiet horizontal divider,
+   row dividers aligned from the text column, and stable trailing controls. A
+   settings group is not a dashboard card; it is a compact preference section.
 
    Alternative considered: keep card containers and add shadows or stronger
    borders. That increases web chrome and fights the native material direction.
 
-4. **Use Linear-like density and alignment, not Linear's product styling.**
+4. **Use one native setting-row template, not a database table.**
 
-   Rows should have fixed icon, text, value, and control columns. Labels,
-   descriptions, values, toggles, and segmented controls should align across
-   sections. The UI should become more precise through spacing, not through more
+   Rows should share one structure: setting title, optional secondary detail,
+   and an optional native trailing control. Read-only System metadata with no
+   control should render the value as secondary text below the label, not as a
+   far-right table cell. Rows with controls, such as toggles, segmented controls,
+   Copy, Show..., and Export, should align to a bounded trailing control column.
+   The UI should become more precise through spacing, not through more
    decoration.
 
    Typography should use native macOS system text roles rather than page-like
@@ -104,29 +103,52 @@ preferences app. The visual reference for this pass is:
    and trailing values should each have distinct size, weight, and blue-gray ink
    roles. Row values should read as metadata, not competing primary labels, and
    descriptions should be clearly secondary without becoming low-contrast.
-   Row labels should favor medium weight over semibold so the form feels like a
-   settings surface rather than a table of headings. Long trailing values such
-   as paths should keep the row rhythm by truncating in the middle on one line
-   while preserving the full value through native help.
+   Row labels should use restrained native weight so the form feels like a
+   settings surface rather than a table of headings. Long metadata values such
+   as paths should stay subordinate as secondary text while preserving the full
+   value through native help or a real action.
 
    Alternative considered: make rows larger and add more explanatory copy. That
    would make the surface feel heavier and less like a native developer tool.
 
-5. **Treat the source list as pane chrome, not a page section.**
+5. **Make System rows behave like a control panel.**
 
-   The source list should use small edge insets and compact rows. The selected
-   state may be visible, but the row should not look like a large floating
-   card or app-level tab. It should use a quieter second-level source-list fill,
-   subtle stroke, and no button-like drop shadow. Tight left, right, and top
-   spacing keeps the navigation visually attached to the Settings pane title and
-   page sheet. The first source-list row should optically align with the page
-   sheet's top edge instead of floating lower in the rail; a small top
-   compensation is acceptable when rounded-corner antialiasing makes strict
-   geometric alignment look off. Its selected background should use compatible
-   corner geometry with the page sheet so the visible antialiased edges read as
-   aligned.
+   System should not read like an About page or `select * from settings`.
+   Read-only install facts such as Bundle ID, Channel, and Updates remain direct
+   title/value rows, with the value below the label. Rows with obvious local
+   actions should expose compact native affordances: Daemon Endpoint can be
+   copied, Shell state and Alan home can be shown in Finder, and Diagnostics
+   remains a toggle plus export action. Update explanations and path
+   implementation details should move out of always-visible copy unless they
+   are needed for current user action.
 
-6. **Use Notion-like secondary copy only where it clarifies scope.**
+   Alternative considered: make Channel a disabled dropdown to add visual
+   activity. That would create a fake control and reduce trust.
+
+6. **Treat the source list as pane chrome, not a page section.**
+
+   The source list should contain only the four navigation rows, without an
+   internal `Settings` title. The pane titlebar and selected detail page already
+   name the surface, so another title in the navigation rail creates duplicate
+   hierarchy. The selected state should use a macOS-style rounded capsule fill
+   with darker active text and icon treatment, without a blue accent bar. The
+   navigation list should start 24pt below the Settings content top, with 12pt
+   leading inset and 8pt trailing inset so the rail has enough air without
+   becoming a second sidebar.
+
+   Source-list labels should stay lighter than the outer application sidebar:
+   icons around 13pt, labels around 13pt, and selected emphasis expressed
+   through primary text color rather than blue labels.
+
+7. **Use native action language.**
+
+   Action labels should read like a macOS app. Folder actions should use a
+   compact native button labeled `Show...`; deferred commands should use an
+   ellipsis, such as `Create...` or `Preview...`; external-link arrows should
+   not appear in native Settings rows. The daemon endpoint should use a real
+   `Copy` control rather than blue link styling.
+
+8. **Use secondary copy only where it clarifies scope.**
 
    Short descriptions should explain what a preference affects, for example
    Sidebar or Inactive split dimming. Descriptions must be one concise line when
@@ -136,7 +158,7 @@ preferences app. The visual reference for this pass is:
    screenshots show that this makes sparse groups feel empty and lowers
    confidence in what each setting controls.
 
-7. **Tone down accent color dominance.**
+9. **Tone down accent color dominance.**
 
    Accent blue should identify selected controls and active state, not define
    the whole page. Native controls should be preferred over custom bright pills
@@ -147,7 +169,7 @@ preferences app. The visual reference for this pass is:
    That solves the wrong problem; the current surface needs hierarchy and native
    rhythm, not stronger color.
 
-8. **Verify with a fresh Alan Dev launch and screenshot review.**
+10. **Verify with a fresh Alan Dev launch and screenshot review.**
 
    Unit tests can prove row membership and bindings, but they cannot prove that
    Settings no longer looks like a web app. This change requires a fresh Alan
@@ -159,14 +181,14 @@ preferences app. The visual reference for this pass is:
 
 ## Risks / Trade-offs
 
-- [Risk] Native grouped forms become too similar to Apple System Settings. ->
-  Keep Alan-specific shell context, compact row density, and Arc-like material
-  continuity with the outer sidebar.
+- [Risk] Preference lists become too plain. -> Keep Alan-specific shell context,
+  precise typography, compact row density, and subtle pane material continuity
+  instead of adding cards or large sheets.
 - [Risk] More row descriptions reduce density. -> Keep descriptions short and
   optional; use them where a setting name alone is ambiguous.
 - [Risk] Tightening width makes long Agent or System values truncate. -> Use
-  stable trailing value behavior, tooltips or reveal actions for paths, and
-  existing unavailable/detail rows instead of stretching the full page.
+  stable value behavior, native help, and explicit copy/open actions for
+  endpoints and paths instead of stretching the full page.
 - [Risk] Visual polish touches shared row components and regresses behavior. ->
   Preserve the settings surface model and keep focused tests for bindings,
   navigation, redaction, and unavailable states.
@@ -182,11 +204,16 @@ preferences app. The visual reference for this pass is:
 2. Refactor presentation tokens for Settings-specific surfaces, typography,
    row dimensions, and separators without changing row data semantics.
 3. Update the internal navigation to a native source-list treatment.
-4. Update the selected group detail pane to an inset grouped-form layout.
-5. Add or adjust concise row descriptions for ambiguous General rows first, then
+4. Update the selected group detail pane to a direct sectioned preference-list
+   layout.
+5. Collapse row presentation into one title/detail/control template, keeping
+   read-only values subordinate and controls bounded on the trailing edge.
+6. Add compact copy/open/export affordances for System rows that already have a
+   natural local action, without implying read-only install facts are editable.
+7. Add or adjust concise row descriptions for ambiguous General rows first, then
    extend only where Terminal, Agent, or System rows need scope clarity.
-6. Run focused Swift/script tests and a macOS build from repo-local DerivedData.
-7. Launch a fresh Alan Dev build and verify Settings visually in light mode.
+8. Run focused Swift/script tests and a macOS build from repo-local DerivedData.
+9. Launch a fresh Alan Dev build and verify Settings visually in light mode.
 
 Rollback: revert the visual component changes while keeping the existing
 Settings navigation model and row data intact. The IA change remains valid even

--- a/openspec/changes/polish-macos-settings-native-surface/proposal.md
+++ b/openspec/changes/polish-macos-settings-native-surface/proposal.md
@@ -1,22 +1,32 @@
 ## Why
 
 Alan's macOS Settings surface now has the right high-level information
-architecture, but the visual execution still reads as a web app: a pale sidebar,
-a large white canvas, and dashboard-like row cards. This change makes Settings
-feel like a native macOS preference surface that belongs inside Alan's calm,
-terminal-first shell.
+architecture, but the visual execution drifted toward an Apple System Settings
+clone: a large white sheet, low information density, and weak preference-list
+rhythm. This change moves Settings toward a Linear/Raycast-style control panel
+that belongs inside Alan's calm, terminal-first shell.
 
 ## What Changes
 
 - Polish the shell-hosted Settings layout into a native-feeling source-list plus
-  inset grouped form instead of a web-style sidebar and card page.
+  dense preference list instead of an Apple Settings sheet or web-style card
+  page.
 - Preserve the accepted Settings navigation hierarchy from
   `add-macos-settings-navigation`: General, Terminal, Agent, and System.
 - Tighten layout density, content width, row rhythm, typography, icon sizing,
-  dividers, and trailing control alignment so Settings feels precise rather than
-  sparse.
-- Replace heavy card affordances with macOS-style grouped rows, restrained
-  separators, subtle material depth, and purpose-built row descriptions.
+  section dividers, and a shared title/detail/control row template so Settings
+  feels precise rather than sparse.
+- Use a native capsule selected state in the Settings source list, with darker
+  selected text instead of blue accent bars.
+- Keep the detail content in a left-anchored 760pt maximum-width column so wide
+  windows do not stretch Settings into an empty page.
+- Replace sheet/card affordances with direct section headings, horizontal
+  separators, compact label/value rows, and concise row descriptions.
+- Turn local System metadata rows that have obvious actions into control-panel
+  affordances, for example copy daemon endpoint and open local folders, while
+  avoiding fake edit controls for read-only install facts.
+- Use native action copy such as Show..., Create..., and Preview... instead of
+  web-style external-link arrows or blue text links.
 - Reduce unnecessary accent-color dominance while keeping native controls and
   existing preference behavior.
 - Verify the polish in Alan Dev with a fresh relaunch and screenshot review
@@ -31,8 +41,9 @@ terminal-first shell.
 ### Modified Capabilities
 
 - `macos-shell-ui-ux-conformance`: Settings shall use a native macOS visual
-  hierarchy with source-list navigation, grouped settings rows, disciplined
-  typography, subtle surface depth, and screenshot-verifiable polish.
+  hierarchy with source-list navigation, dense preference-list rows,
+  disciplined typography, subtle surface depth, and screenshot-verifiable
+  polish.
 
 ## Impact
 

--- a/openspec/changes/polish-macos-settings-native-surface/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-settings-native-surface/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,46 +1,56 @@
 ## ADDED Requirements
 
-### Requirement: Settings Uses Native Source List And Grouped Detail
+### Requirement: Settings Uses Native Source List And Preference Detail
 Alan macOS Settings SHALL present its internal navigation as a compact native
-source list and SHALL present the selected group as a compact grouped settings
-form inside the existing shell content area.
+source list and SHALL present the selected group as a compact sectioned
+preference list inside the existing shell content area.
 
 #### Scenario: Settings opens with native hierarchy
 - **WHEN** the user opens the Settings content tab in light mode
 - **THEN** alan shows the existing Settings groups in a compact source-list navigation
 - **AND** the Settings pane title, navigation rail, and page backdrop share a shallow native gray plane
-- **AND** the selected group renders inside a stable white page sheet rather than a web-style card page
+- **AND** the selected group renders as direct preference sections rather than a stable white page sheet or web-style card page
 - **AND** the Settings surface remains inside the shell content area without creating a separate preferences window or dashboard shell
 
-#### Scenario: Selected group uses stable sheet geometry
+#### Scenario: Selected group uses direct preference geometry
 - **WHEN** the Settings window is wider than the selected group's content
-- **THEN** alan aligns the white Settings page sheet's top border with the bottom edge of the pane title bar
-- **AND** alan keeps the white Settings page sheet inset from the detail pane's right edge by 8px
-- **AND** alan keeps the white Settings page sheet inset from the detail pane's bottom edge by 8px
-- **AND** alan uses no outer drop shadow on the white Settings page sheet
-- **AND** alan may use only a thin border and focused inner edge treatment to focus the sheet
-- **AND** alan keeps the selected group's row content column left anchored with a stable maximum width inside the sheet
-- **AND** alan does not stretch sparse settings rows across the full sheet
+- **THEN** alan keeps the selected group's row content column left anchored with a stable maximum width
+- **AND** alan gives the content enough width for developer metadata such as paths, endpoints, and namespaces
+- **AND** alan uses section titles and horizontal dividers to create hierarchy instead of container cards or a page sheet
+- **AND** alan does not stretch sparse settings rows across the full detail pane
+- **AND** alan does not compensate for sparse settings with large blank card surfaces
 
 #### Scenario: Navigation remains subordinate
 - **WHEN** Settings renders the internal navigation
 - **THEN** the navigation uses source-list row selection, restrained icon and label sizing, and subtle material depth
-- **AND** the navigation keeps compact leading, trailing, and top insets relative to the Settings pane
-- **AND** the first source-list row's visible top edge optically aligns with the white Settings page sheet's top edge
-- **AND** the selected source-list row uses compatible corner geometry so its visible top edge optically aligns with the sheet
-- **AND** the selected source-list row remains quieter than an app-level sidebar tab and avoids button-like drop shadow
+- **AND** the navigation rail contains only General, Terminal, Agent, and System, without a duplicate internal Settings title
+- **AND** the navigation list starts 24pt below the Settings content top with 12pt leading inset and 8pt trailing inset
+- **AND** each navigation row uses 30pt row height with approximately 13pt icon and 13pt label sizing
+- **AND** the selected source-list row uses a macOS-style capsule fill with active text/icon state and no blue accent bar
+- **AND** selected navigation text and icons become primary rather than blue-emphasized
 - **AND** alan does not present the internal Settings navigation as a second app-level sidebar, large tab bar, or stack of web buttons
 
 ### Requirement: Settings Rows Use Precise Native Form Rhythm
 Alan macOS Settings rows SHALL use disciplined app-UI typography, stable columns,
-and restrained dividers so settings can be scanned like a native form rather
-than a dashboard card.
+and restrained dividers so settings can be scanned like a developer control
+panel rather than a dashboard card.
 
 #### Scenario: Row columns align
 - **WHEN** a selected Settings group renders multiple rows
-- **THEN** icon, label, description, value, action, toggle, and segmented-control positions align consistently across rows in that group
-- **AND** trailing controls share a stable right edge
-- **AND** long trailing metadata values stay on one line with middle truncation and expose the full value through native help
+- **THEN** label, description, value, action, toggle, and segmented-control positions align consistently across rows in that group
+- **AND** rows use one native setting template: title, optional secondary text, and optional trailing control
+- **AND** read-only System metadata values render as secondary text below the label rather than as a far-right table column
+- **AND** toggles, segmented controls, and button actions share a bounded trailing control column instead of hugging the full 760pt content edge
+- **AND** long metadata values expose the full value through native help or an explicit Copy/Show action
+
+#### Scenario: System rows expose real actions
+- **WHEN** the System group presents local endpoint, path, and diagnostics rows
+- **THEN** alan exposes compact actions for rows with natural local operations, such as copying the daemon endpoint and opening local folders
+- **AND** daemon endpoint uses a native Copy button rather than blue link styling
+- **AND** local folder actions use native wording such as Show... rather than web-style external-link arrows
+- **AND** diagnostics remains a real toggle plus export action
+- **AND** install facts such as Channel and Updates remain honest read-only values rather than disabled or fake edit controls
+- **AND** update explanations and implementation details do not appear as always-visible copy when the label/value pair is already clear
 
 #### Scenario: Row descriptions clarify scope
 - **WHEN** a row label is ambiguous without context, such as Sidebar or Inactive split dimming
@@ -57,6 +67,7 @@ than a dashboard card.
 #### Scenario: Dense row rhythm is preserved
 - **WHEN** a selected Settings group contains only a small number of rows
 - **THEN** alan keeps row height, section spacing, and typography compact enough that the surface feels intentional instead of empty
+- **AND** section spacing stays close to a control-panel rhythm rather than leaving large About-page gaps between sections
 - **AND** alan does not compensate for sparse content with oversized headers, hero spacing, or large decorative panels
 
 ### Requirement: Settings Surface Depth Avoids Web Dashboard Chrome
@@ -66,7 +77,7 @@ admin page.
 
 #### Scenario: Surface layers are distinguishable
 - **WHEN** Settings is visible in the default light appearance
-- **THEN** the window/titlebar, Settings source list, detail pane, grouped rows, and controls are distinguishable through subtle material, tint, separators, and fill differences
+- **THEN** the window/titlebar, Settings source list, detail pane, preference rows, and controls are distinguishable through subtle material, tint, separators, and fill differences
 - **AND** the surface does not collapse into one flat white or pale-gray plane
 
 #### Scenario: Accent color is controlled
@@ -84,9 +95,9 @@ the implementation tasks are marked complete.
 
 #### Scenario: Fresh Alan Dev screenshot review
 - **WHEN** Settings native-polish implementation is ready for review
-- **THEN** maintainers can inspect a fresh Alan Dev light-mode screenshot showing source-list navigation, the selected General group, grouped rows, aligned trailing controls, and restrained accent color
+- **THEN** maintainers can inspect a fresh Alan Dev light-mode screenshot showing capsule source-list navigation, section dividers, unified title/detail/control rows, aligned trailing controls, real System actions, and restrained accent color
 - **AND** the screenshot is captured after relaunching Alan Dev rather than reusing a stale running window
 
 #### Scenario: Visual review checks native criteria
 - **WHEN** the screenshot is reviewed
-- **THEN** maintainers compare it against this change's native-surface criteria: compact source list, stable white page sheet geometry, left-anchored grouped form content, stable row columns, subtle surface depth, no card-heavy dashboard chrome, and no oversized web-page spacing
+- **THEN** maintainers compare it against this change's native-surface criteria: compact capsule source-list selection, direct sectioned preference layout, left-anchored 760pt maximum-width content, unified setting rows, subordinate read-only metadata values, bounded trailing controls, subtle surface depth, no card-heavy dashboard chrome, and no oversized web-page spacing

--- a/openspec/changes/polish-macos-settings-native-surface/tasks.md
+++ b/openspec/changes/polish-macos-settings-native-surface/tasks.md
@@ -58,7 +58,7 @@
 - [x] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [x] 5.4 Run `git diff --check`.
 - [x] 5.5 Run a macOS app build from a writable DerivedData path.
-- [ ] 5.6 Assemble or launch a fresh Alan Dev build, open Settings in light
+- [x] 5.6 Assemble or launch a fresh Alan Dev build, open Settings in light
   mode, and capture/review a screenshot against the native-surface checklist.
 - [x] 5.7 Run `openspec validate polish-macos-settings-native-surface --strict`.
 
@@ -95,7 +95,7 @@
   so wide windows do not create a sparse full-width reading path.
 - [x] 7.8 Re-run focused Settings tests, shell contract checks, diff checks, and
   OpenSpec validation after the direction pivot.
-- [ ] 7.9 Relaunch Alan Dev fresh and review a light-mode screenshot against the
+- [x] 7.9 Relaunch Alan Dev fresh and review a light-mode screenshot against the
   Linear/Raycast-style control-panel criteria.
 
 ## 8. Native Capsule And Typography Pass
@@ -111,5 +111,5 @@
   Skill packages inside Skills and without a separate Sources section.
 - [x] 8.4 Re-run focused Settings tests, shell contract checks, diff checks, and
   OpenSpec validation after the native capsule pass.
-- [ ] 8.5 Relaunch Alan Dev fresh and review a light-mode screenshot against the
+- [x] 8.5 Relaunch Alan Dev fresh and review a light-mode screenshot against the
   "navigation Apple, content Linear, controls native" target.

--- a/openspec/changes/polish-macos-settings-native-surface/tasks.md
+++ b/openspec/changes/polish-macos-settings-native-surface/tasks.md
@@ -4,8 +4,8 @@
   `TerminalPaneView.swift` to identify the source-list, detail pane, section,
   row, value, and control components that need visual polish.
 - [x] 1.2 Translate the spec scenarios into a short implementation checklist:
-  compact source list, inset grouped detail form, stable row columns, subtle
-  surface depth, controlled accent color, and no dashboard/card-page chrome.
+  compact source list, direct sectioned preference list, unified setting rows,
+  subtle surface depth, controlled accent color, and no dashboard/card-page chrome.
 - [x] 1.3 Confirm the existing General, Terminal, Agent, and System group
   membership from `ShellSettingsSurfaceModel.swift` remains unchanged for this
   polish slice.
@@ -18,10 +18,10 @@
 - [x] 2.2 Rework the selected-group detail pane into a left-anchored compact
   content column with a stable maximum width instead of full-window stretched
   settings rows.
-- [x] 2.3 Replace card-like section treatment with inset grouped settings rows
-  using quiet fill, subtle stroke, native separators, and dividers aligned from
+- [x] 2.3 Replace card-like section treatment with direct preference sections
+  using readable section titles, native separators, and dividers aligned from
   the text column.
-- [x] 2.4 Tune window/titlebar, Settings source list, detail pane, grouped rows,
+- [x] 2.4 Tune window/titlebar, Settings source list, detail pane, preference rows,
   and controls so the layers remain distinguishable without decorative
   gradients or dashboard shadows.
 
@@ -29,8 +29,9 @@
 
 - [x] 3.1 Establish Settings-specific typography roles for pane title, source
   list item, section label, row label, row description, and trailing value.
-- [x] 3.2 Align icon, label, description, value, action, toggle, and segmented
-  control columns across rows, with a stable trailing control edge.
+- [x] 3.2 Align label, description, value, action, toggle, and segmented control
+  positions across rows with one title/detail/control template and a bounded
+  trailing control edge.
 - [x] 3.3 Add concise secondary copy for ambiguous General rows such as Sidebar
   and Inactive split dimming while keeping descriptions visually subordinate.
 - [x] 3.4 Reduce accent-color dominance by using native control styling and
@@ -56,8 +57,8 @@
 - [x] 5.2 Run `bash clients/apple/scripts/test-shell-runtime-metadata.sh`.
 - [x] 5.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [x] 5.4 Run `git diff --check`.
-- [x] 5.5 Run a macOS app build from a repo-local DerivedData path.
-- [x] 5.6 Assemble or launch a fresh Alan Dev build, open Settings in light
+- [x] 5.5 Run a macOS app build from a writable DerivedData path.
+- [ ] 5.6 Assemble or launch a fresh Alan Dev build, open Settings in light
   mode, and capture/review a screenshot against the native-surface checklist.
 - [x] 5.7 Run `openspec validate polish-macos-settings-native-surface --strict`.
 
@@ -67,9 +68,48 @@
   existing `macos-shell-ui-ux-conformance` contract for duplicate or conflicting
   Settings requirements.
 - [x] 6.2 Document the final visual verification result, including whether the
-  screenshot passes compact source list, inset grouped form, row alignment,
+  screenshot passes compact source list, direct sectioned preference layout, row alignment,
   surface depth, controlled accent color, and no dashboard chrome.
 - [ ] 6.3 Before archiving after merge, sync accepted delta requirements into
   `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
 - [ ] 6.4 Archive the completed change only after implementation, verification,
   and PR merge are complete.
+
+## 7. Control-Panel Direction Pivot
+
+- [x] 7.1 Remove the stable white page sheet as the primary Settings detail
+  container.
+- [x] 7.2 Replace uppercase section labels and sheet/card hierarchy with
+  section titles, horizontal dividers, and compact preference rows.
+- [x] 7.3 Simplify System metadata copy into direct control-panel labels such as
+  Bundle ID, Channel, Daemon endpoint, Alan home, Skill packages, and Control
+  namespace.
+- [x] 7.4 Change read-only metadata rows to the shared title/detail template so
+  System values sit below their labels instead of forming a database-like table.
+- [x] 7.5 Add compact System control affordances for natural local actions such
+  as copying the daemon endpoint and opening local folders, without adding fake
+  edit controls for read-only install facts.
+- [x] 7.6 Simplify Settings source-list selection to a native capsule fill with
+  primary selected text and no blue accent bar.
+- [x] 7.7 Keep the detail content in a left-anchored 760pt maximum-width column
+  so wide windows do not create a sparse full-width reading path.
+- [x] 7.8 Re-run focused Settings tests, shell contract checks, diff checks, and
+  OpenSpec validation after the direction pivot.
+- [ ] 7.9 Relaunch Alan Dev fresh and review a light-mode screenshot against the
+  Linear/Raycast-style control-panel criteria.
+
+## 8. Native Capsule And Typography Pass
+
+- [x] 8.1 Apply the final source-list capsule selection, 188pt navigation width,
+  24pt navigation top inset, 12/8pt navigation side insets, 30pt navigation row
+  height, 760pt content width, 48pt detail padding, 48/56pt row heights,
+  unified setting rows, bounded 188pt control column, and lighter section/row
+  typography.
+- [x] 8.2 Replace web-style action language with native Settings copy, including
+  Show..., Create..., Preview..., and a real daemon endpoint Copy button.
+- [x] 8.3 Reorganize Agent into Agent, Runtime, Skills, and Entry Points, with
+  Skill packages inside Skills and without a separate Sources section.
+- [x] 8.4 Re-run focused Settings tests, shell contract checks, diff checks, and
+  OpenSpec validation after the native capsule pass.
+- [ ] 8.5 Relaunch Alan Dev fresh and review a light-mode screenshot against the
+  "navigation Apple, content Linear, controls native" target.

--- a/openspec/changes/polish-macos-settings-native-surface/verification.md
+++ b/openspec/changes/polish-macos-settings-native-surface/verification.md
@@ -44,14 +44,26 @@ contract, OpenSpec, and build levels:
 
 ## Visual Verification Status
 
-The current sandbox prevented completing a fresh capturable Alan Dev launch for
-visual review. Release Alan Dev assembly was blocked when Xcode package
-resolution attempted to write user cache files under `~/Library/Caches` and
-`~/.cache`, and the network proxy could not re-clone Sparkle into a new
-DerivedData directory. A direct arm64 Debug Alan Dev bundle did build under
-`/tmp/alan-xcode-derived-settings-polish`, but LaunchServices returned
-`kLSNoExecutableErr` for `open`, direct executable launch did not produce an
-observable Alan Dev process/window, and process inspection is unavailable in
-this sandbox. Stable Alan was not quit. Because there was no fresh, capturable
-Alan Dev Settings window, the final light-mode screenshot review remains
-pending rather than marked complete.
+Fresh Alan Dev visual verification now passes.
+
+- Built `/tmp/alan-xcode-derived-settings-polish/Build/Products/Debug/Alan Dev.app`
+  with `PRODUCT_BUNDLE_IDENTIFIER=app.alanworks.macos.dev`.
+- Launched that fresh Alan Dev bundle without quitting the stable Alan app.
+- Opened Settings through `Cmd+,` in light mode.
+- Captured and reviewed the General, Agent, and System Settings states with
+  `screencapture -l` after the repository capture helper stalled in
+  ScreenCapture handoff.
+
+Observed results:
+
+- General opens by default and shows compact capsule source-list navigation,
+  direct section dividers, unified title/detail/control rows, aligned toggles,
+  and no dashboard cards.
+- Agent switching works and shows the long Agent, Runtime, Skills, and Entry
+  Points content with compact row rhythm, bounded trailing controls, and
+  subordinate values.
+- System switching works and shows Bundle ID, Channel, Updates, daemon endpoint
+  Copy, Shell state Show..., Alan home Show..., and diagnostics toggle rows with
+  native action copy and controlled accent use.
+- The Settings surface remains inside the shell content area and avoids
+  web-style cards, marketing panels, and oversized page spacing.

--- a/openspec/changes/polish-macos-settings-native-surface/verification.md
+++ b/openspec/changes/polish-macos-settings-native-surface/verification.md
@@ -1,27 +1,57 @@
-## Visual Verification
+## Automated Verification
 
-- Fresh Alan Dev build launched:
-  `debug/DerivedData/install-dev-polish-settings-native-arm64/Build/Products/Release/Alan Dev.app`
-- Captured screenshot:
-  `debug/alan-dev-settings-fixed-sheet-polish.png`
-- Reviewed state:
-  Settings in light mode, General selected, Alan Dev only.
+- `bash clients/apple/scripts/test-shell-settings-surface.sh`
+- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
+- `bash clients/apple/scripts/check-shell-contracts.sh`
+- `openspec validate polish-macos-settings-native-surface --strict`
+- `openspec validate add-macos-settings-navigation --strict`
+- `git diff --check`
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos
+  -configuration Debug -destination generic/platform=macOS -derivedDataPath
+  /tmp/alan-xcode-derived-settings-polish build`
+- `xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos
+  -configuration Debug -destination generic/platform=macOS -derivedDataPath
+  /tmp/alan-xcode-derived-settings-polish ARCHS=arm64
+  PRODUCT_BUNDLE_IDENTIFIER=app.alanworks.macos.dev PRODUCT_NAME="Alan Dev"
+  INFOPLIST_KEY_CFBundleDisplayName="Alan Dev" CODE_SIGNING_ALLOWED=NO build`
 
 ## Result
 
-The screenshot passes the updated native-surface checklist:
+The implementation passes the updated control-panel checklist at the model,
+contract, OpenSpec, and build levels:
 
-- Settings title, navigation rail, and pane backdrop share a shallow gray plane.
-- The selected group sits in a wider white page sheet.
-- The white sheet's top border meets the pane title bar bottom edge.
-- The white sheet keeps stable 8px right and bottom insets from the Settings pane.
-- The white sheet uses a restrained 8pt corner radius so the sheet edge does not fight the pane edge.
-- The white sheet has no outer drop shadow.
-- The sheet uses a thin border and focused inner edge treatment for focus.
-- General row content remains left anchored inside the sheet and does not stretch across the full sheet.
-- Row labels, descriptions, segmented control, and toggles keep stable alignment.
-- The surface avoids dashboard cards, decorative gradients, and web-page hero spacing.
+- Settings title, source list, and detail area share one shallow native pane plane.
+- The selected source-list row uses compact macOS capsule chrome with primary
+  selected text and no blue accent bar.
+- The detail area renders as direct sections with quiet dividers, not as a white
+  page sheet or card stack.
+- System metadata rows use the shared title/detail template so values sit under
+  labels instead of forming a database-like table.
+- Rows with controls use a bounded trailing accessory column so toggles,
+  segmented controls, Copy, Show..., and Export buttons do not hug the far right
+  edge.
+- Daemon endpoint exposes a native Copy button; Shell state, Alan home, and
+  Skill packages use Show... buttons without web-style external link arrows.
+- Agent is grouped into Agent, Runtime, Skills, and Entry Points, with Skill
+  packages inside Skills and no separate Sources section.
+- Terminal rows use compact native copy such as Default profile, New profile,
+  Create..., and Preview..., and the Login shell row no longer repeats its title
+  as secondary copy.
+- Diagnostics remains a real toggle plus export action, preserving Settings as
+  a control panel rather than an About page.
+- The surface avoids dashboard cards, decorative gradients, web-page hero
+  spacing, and Apple System Settings-style card groups.
 
-The visual pass focused on the sheet geometry and surface hierarchy using the
-General group. Script tests cover the other Settings groups' row membership and
-model semantics.
+## Visual Verification Status
+
+The current sandbox prevented completing a fresh capturable Alan Dev launch for
+visual review. Release Alan Dev assembly was blocked when Xcode package
+resolution attempted to write user cache files under `~/Library/Caches` and
+`~/.cache`, and the network proxy could not re-clone Sparkle into a new
+DerivedData directory. A direct arm64 Debug Alan Dev bundle did build under
+`/tmp/alan-xcode-derived-settings-polish`, but LaunchServices returned
+`kLSNoExecutableErr` for `open`, direct executable launch did not produce an
+observable Alan Dev process/window, and process inspection is unavailable in
+this sandbox. Stable Alan was not quit. Because there was no fresh, capturable
+Alan Dev Settings window, the final light-mode screenshot review remains
+pending rather than marked complete.


### PR DESCRIPTION
## Summary
- recover the local macOS Settings polish implementation onto latest main
- keep Settings inside the shell content area with compact source-list navigation and direct preference rows
- add local folder actions for System rows and update focused Settings/OpenSpec evidence

## OpenSpec
- add-macos-settings-navigation: implementation verified; merge-after spec sync/archive tasks remain deferred
- polish-macos-settings-native-surface: implementation verified; merge-after spec sync/archive tasks remain deferred

## Visual Verification
- built fresh Alan Dev bundle at /tmp/alan-xcode-derived-settings-polish/Build/Products/Debug/Alan Dev.app
- launched app.alanworks.macos.dev without quitting stable Alan
- opened Settings in light mode with Cmd+,
- captured/reviewed General, Agent, and System via screencapture -l

## Verification
- bash clients/apple/scripts/test-shell-settings-surface.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- bash clients/apple/scripts/check-shell-contracts.sh
- git diff --check
- openspec validate polish-macos-settings-native-surface --strict
- openspec validate add-macos-settings-navigation --strict
- openspec validate --all --strict
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /tmp/alan-xcode-derived-settings-polish build
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /tmp/alan-xcode-derived-settings-polish ARCHS=arm64 PRODUCT_BUNDLE_IDENTIFIER=app.alanworks.macos.dev PRODUCT_NAME="Alan Dev" INFOPLIST_KEY_CFBundleDisplayName="Alan Dev" CODE_SIGNING_ALLOWED=NO build