### PR TITLE
Polish macOS workspace panel frame ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ target
 # Coverage artifacts
 lcov.info
 
+# Local linked worktrees.
+.worktrees/
+
 # Local release signing/notarization secrets.
 .env
 .env.local

--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -268,7 +268,7 @@ struct MacShellRootView: View {
         ZStack {
             ShellSpaceKeyboardShortcuts(host: host)
 
-            ShellMaterialBackgroundView(.windowBackdrop)
+            ShellPalette.rootBacking
                 .ignoresSafeArea()
 
             HStack(spacing: 0) {

--- a/clients/apple/alan-macos/Support/ShellDesignTokens.swift
+++ b/clients/apple/alan-macos/Support/ShellDesignTokens.swift
@@ -259,7 +259,7 @@ enum ShellRadii {
     static let overlay: CGFloat = 12
     static let floatingSidebarPanel: CGFloat = 14
     static let titlebarTool: CGFloat = 9
-    static let terminalSurface: CGFloat = 10
+    static let workspacePanel: CGFloat = 10
 }
 
 enum ShellSidebarMetrics {
@@ -281,20 +281,20 @@ enum ShellSidebarMetrics {
 }
 
 enum ShellWorkspaceMetrics {
-    static let terminalSurfaceInset: CGFloat = 8
+    static let workspacePanelInset: CGFloat = 8
 
-    static func terminalSurfaceInsets(expandedSidebarProgress: CGFloat) -> EdgeInsets {
+    static func workspacePanelInsets(expandedSidebarProgress: CGFloat) -> EdgeInsets {
         let progress = min(max(expandedSidebarProgress, 0), 1)
         return EdgeInsets(
-            top: terminalSurfaceInset,
-            leading: terminalSurfaceInset * (1 - progress),
-            bottom: terminalSurfaceInset,
-            trailing: terminalSurfaceInset
+            top: workspacePanelInset,
+            leading: workspacePanelInset * (1 - progress),
+            bottom: workspacePanelInset,
+            trailing: workspacePanelInset
         )
     }
 
-    static func terminalSurfaceInsets(hasExpandedSidebar: Bool) -> EdgeInsets {
-        terminalSurfaceInsets(expandedSidebarProgress: hasExpandedSidebar ? 1 : 0)
+    static func workspacePanelInsets(hasExpandedSidebar: Bool) -> EdgeInsets {
+        workspacePanelInsets(expandedSidebarProgress: hasExpandedSidebar ? 1 : 0)
     }
 }
 
@@ -325,7 +325,7 @@ enum ShellShadows {
         x: -0.2,
         y: 0.9
     )
-    static let terminalSurface = ShellShadowStyle(
+    static let workspacePanel = ShellShadowStyle(
         color: Color.shellAdaptive(
             light: (0.18, 0.20, 0.28),
             lightAlpha: 0.22,
@@ -336,7 +336,7 @@ enum ShellShadows {
         x: -0.7,
         y: 1.4
     )
-    static let terminalSurfaceRim = ShellShadowStyle(
+    static let workspacePanelRim = ShellShadowStyle(
         color: Color.shellAdaptive(
             light: (0.18, 0.20, 0.28),
             lightAlpha: 0.12,

--- a/clients/apple/alan-macos/Support/ShellDesignTokens.swift
+++ b/clients/apple/alan-macos/Support/ShellDesignTokens.swift
@@ -30,6 +30,10 @@ private extension Color {
 }
 
 enum ShellPalette {
+    static let rootBacking = Color.shellAdaptive(
+        light: (1.0, 1.0, 1.0),
+        dark: (0.055, 0.061, 0.074)
+    )
     static let canvas = Color.shellAdaptive(
         light: (0.94, 0.94, 0.965),
         dark: (0.045, 0.050, 0.062)

--- a/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
+++ b/clients/apple/alan-macos/Support/ShellWindowPlacement.swift
@@ -251,7 +251,7 @@ enum ShellWindowSizing {
 
 enum ShellWindowDoubleClickZoomHitTesting {
     static let topChromeBandHeight: CGFloat = 36
-    static let contentInteractionTopInset: CGFloat = ShellWorkspaceMetrics.terminalSurfaceInset
+    static let contentInteractionTopInset: CGFloat = ShellWorkspaceMetrics.workspacePanelInset
 
     static func isWindowTopChromeZoomCandidate(
         locationInWindow point: CGPoint,

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -54,6 +54,7 @@ struct TerminalPaneView: View {
                 }
             }
         }
+        .shellWorkspacePanelFrame()
     }
 
     @ViewBuilder
@@ -68,7 +69,6 @@ struct TerminalPaneView: View {
             onClosePane: onClosePane
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .shellTerminalSurfaceFrame(enabled: ownsOuterTerminalSurface)
     }
 
     private func terminalTreeOwnsOuterSurface(_ node: ShellPaneTreeNode) -> Bool {
@@ -548,6 +548,57 @@ private struct ShellEmptyWorkspacePlaceholder: View {
     }
 }
 
+private struct ShellWorkspacePanelFrame: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+    private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
+
+    func body(content: Content) -> some View {
+        content
+            .clipShape(shape)
+            .background {
+                shape
+                    .fill(ShellPalette.rootBacking)
+                    .shellShadow(ShellShadows.terminalSurfaceRim)
+                    .shellShadow(ShellShadows.terminalSurface)
+            }
+            .overlay {
+                workspacePanelRim
+            }
+    }
+
+    private var workspacePanelRim: some View {
+        ZStack {
+            shape
+                .strokeBorder(
+                    ShellPalette.line.opacity(colorScheme == .light ? 0.30 : 0.26),
+                    lineWidth: 0.85
+                )
+
+            shape
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(colorScheme == .light ? 0.18 : 0.07),
+                            Color.white.opacity(0.015),
+                            Color.black.opacity(colorScheme == .light ? 0.14 : 0.32),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.65
+                )
+
+            shape
+                .inset(by: 1)
+                .strokeBorder(
+                    Color.white.opacity(colorScheme == .light ? 0.06 : 0.03),
+                    lineWidth: 0.4
+                )
+        }
+        .allowsHitTesting(false)
+    }
+}
+
 private struct ShellTerminalSurfaceFrame: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
@@ -602,6 +653,10 @@ private struct ShellTerminalSurfaceFrame: ViewModifier {
 }
 
 private extension View {
+    func shellWorkspacePanelFrame() -> some View {
+        modifier(ShellWorkspacePanelFrame())
+    }
+
     @ViewBuilder
     func shellTerminalSurfaceFrame(enabled: Bool) -> some View {
         if enabled {

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -8,7 +8,7 @@ struct TerminalPaneView: View {
     let spaceID: String?
     let selectedPaneID: String?
     let zoomedPaneID: String?
-    let terminalSurfaceInsets: EdgeInsets
+    let workspacePanelInsets: EdgeInsets
     let onClosePane: ((ShellPane) -> Void)?
 
     init(
@@ -17,7 +17,7 @@ struct TerminalPaneView: View {
         spaceID: String? = nil,
         selectedPaneID: String? = nil,
         zoomedPaneID: String? = nil,
-        terminalSurfaceInsets: EdgeInsets,
+        workspacePanelInsets: EdgeInsets,
         onClosePane: ((ShellPane) -> Void)? = nil
     ) {
         self.host = host
@@ -25,14 +25,14 @@ struct TerminalPaneView: View {
         self.spaceID = spaceID
         self.selectedPaneID = selectedPaneID
         self.zoomedPaneID = zoomedPaneID
-        self.terminalSurfaceInsets = terminalSurfaceInsets
+        self.workspacePanelInsets = workspacePanelInsets
         self.onClosePane = onClosePane
     }
 
     var body: some View {
         paneCanvas
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .padding(terminalSurfaceInsets)
+            .padding(workspacePanelInsets)
     }
 
     private var paneCanvas: some View {
@@ -59,36 +59,13 @@ struct TerminalPaneView: View {
 
     @ViewBuilder
     private func workspaceContentTree(for tree: ShellPaneTreeNode) -> some View {
-        let ownsOuterTerminalSurface = terminalTreeOwnsOuterSurface(tree)
-
         ShellPaneTreeLayoutView(
             node: tree,
             host: host,
             selectedPaneID: displaySelectedPaneID,
-            terminalLeafOwnsSurfaceFrame: !ownsOuterTerminalSurface,
             onClosePane: onClosePane
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private func terminalTreeOwnsOuterSurface(_ node: ShellPaneTreeNode) -> Bool {
-        switch node.kind {
-        case .pane:
-            guard let paneID = node.paneID,
-                  let pane = host.shellState.pane(paneID: paneID)
-            else {
-                return false
-            }
-            let descriptor = ShellContentRenderingRegistry.descriptor(
-                forPaneSlotID: paneID,
-                in: host.shellState.contentStateProjection(),
-                fallbackPane: pane
-            )
-            return descriptor.renderKind == .terminal
-        case .split:
-            let children = node.children ?? []
-            return !children.isEmpty && children.allSatisfy(terminalTreeOwnsOuterSurface)
-        }
     }
 
     private var displayTab: ShellTab? {
@@ -494,9 +471,9 @@ private struct QuickTerminalContentView: View {
                 }
             }
         }
-        .clipShape(RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: ShellRadii.workspacePanel, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
+            RoundedRectangle(cornerRadius: ShellRadii.workspacePanel, style: .continuous)
                 .strokeBorder(ShellPalette.line.opacity(0.26), lineWidth: 0.8)
         }
     }
@@ -550,7 +527,7 @@ private struct ShellEmptyWorkspacePlaceholder: View {
 
 private struct ShellWorkspacePanelFrame: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
-    private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
+    private let shape = RoundedRectangle(cornerRadius: ShellRadii.workspacePanel, style: .continuous)
 
     func body(content: Content) -> some View {
         content
@@ -558,8 +535,8 @@ private struct ShellWorkspacePanelFrame: ViewModifier {
             .background {
                 shape
                     .fill(ShellPalette.rootBacking)
-                    .shellShadow(ShellShadows.terminalSurfaceRim)
-                    .shellShadow(ShellShadows.terminalSurface)
+                    .shellShadow(ShellShadows.workspacePanelRim)
+                    .shellShadow(ShellShadows.workspacePanel)
             }
             .overlay {
                 workspacePanelRim
@@ -599,71 +576,9 @@ private struct ShellWorkspacePanelFrame: ViewModifier {
     }
 }
 
-private struct ShellTerminalSurfaceFrame: ViewModifier {
-    @Environment(\.colorScheme) private var colorScheme
-    private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
-
-    func body(content: Content) -> some View {
-        content
-            .clipShape(shape)
-            .background {
-                ShellMaterialShape(
-                    role: .terminalSurround,
-                    shape: shape
-                )
-                .shellShadow(ShellShadows.terminalSurfaceRim)
-                .shellShadow(ShellShadows.terminalSurface)
-            }
-            .overlay {
-                terminalSurfaceRim
-            }
-    }
-
-    private var terminalSurfaceRim: some View {
-        ZStack {
-            shape
-                .strokeBorder(
-                    ShellPalette.line.opacity(colorScheme == .light ? 0.30 : 0.26),
-                    lineWidth: 0.85
-                )
-
-            shape
-                .strokeBorder(
-                    LinearGradient(
-                        colors: [
-                            Color.white.opacity(colorScheme == .light ? 0.18 : 0.07),
-                            Color.white.opacity(0.015),
-                            Color.black.opacity(colorScheme == .light ? 0.14 : 0.32),
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    ),
-                    lineWidth: 0.65
-                )
-
-            shape
-                .inset(by: 1)
-                .strokeBorder(
-                    Color.white.opacity(colorScheme == .light ? 0.06 : 0.03),
-                    lineWidth: 0.4
-                )
-        }
-        .allowsHitTesting(false)
-    }
-}
-
 private extension View {
     func shellWorkspacePanelFrame() -> some View {
         modifier(ShellWorkspacePanelFrame())
-    }
-
-    @ViewBuilder
-    func shellTerminalSurfaceFrame(enabled: Bool) -> some View {
-        if enabled {
-            modifier(ShellTerminalSurfaceFrame())
-        } else {
-            self
-        }
     }
 }
 
@@ -671,7 +586,6 @@ private struct ShellPaneTreeLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
-    let terminalLeafOwnsSurfaceFrame: Bool
     let onClosePane: ((ShellPane) -> Void)?
 
     var body: some View {
@@ -685,7 +599,6 @@ private struct ShellPaneTreeLayoutView: View {
                 node: node,
                 host: host,
                 selectedPaneID: selectedPaneID,
-                terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                 onClosePane: onClosePane
             )
         }
@@ -719,7 +632,6 @@ private struct ShellPaneTreeLayoutView: View {
             bootProfile: host.bootProfile(for: pane),
             restoredTranscriptSnapshot: host.restoredTranscriptSnapshot(for: pane),
             isSelected: selectedPaneID == pane.paneID,
-            ownsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
             renderPriority: host.terminalRenderPriority(for: pane),
             isZoomed: host.isPaneZoomed(pane.paneID),
             canZoom: host.canZoomPane(pane.paneID),
@@ -849,7 +761,6 @@ private struct ShellSplitLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
-    let terminalLeafOwnsSurfaceFrame: Bool
     let onClosePane: ((ShellPane) -> Void)?
     @State private var dragStartRatio: Double?
     @State private var dragPreviewRatio: Double?
@@ -867,7 +778,6 @@ private struct ShellSplitLayoutView: View {
                             node: children[0],
                             host: host,
                             selectedPaneID: selectedPaneID,
-                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(width: primaryLength(total: proxy.size.width))
@@ -877,7 +787,6 @@ private struct ShellSplitLayoutView: View {
                             node: children[1],
                             host: host,
                             selectedPaneID: selectedPaneID,
-                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(width: secondaryLength(total: proxy.size.width))
@@ -888,7 +797,6 @@ private struct ShellSplitLayoutView: View {
                             node: children[0],
                             host: host,
                             selectedPaneID: selectedPaneID,
-                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(height: primaryLength(total: proxy.size.height))
@@ -898,7 +806,6 @@ private struct ShellSplitLayoutView: View {
                             node: children[1],
                             host: host,
                             selectedPaneID: selectedPaneID,
-                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(height: secondaryLength(total: proxy.size.height))
@@ -926,7 +833,6 @@ private struct ShellSplitLayoutView: View {
                 node: child,
                 host: host,
                 selectedPaneID: selectedPaneID,
-                terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                 onClosePane: onClosePane
             )
         }
@@ -1019,7 +925,6 @@ private struct ShellTerminalLeafView: View {
     let bootProfile: AlanShellBootProfile?
     let restoredTranscriptSnapshot: TerminalTranscriptSnapshot?
     let isSelected: Bool
-    let ownsSurfaceFrame: Bool
     let renderPriority: TerminalRuntimeRenderPriority
     let isZoomed: Bool
     let canZoom: Bool
@@ -1119,7 +1024,6 @@ private struct ShellTerminalLeafView: View {
                 }
             }
         }
-        .shellTerminalSurfaceFrame(enabled: ownsSurfaceFrame)
     }
 }
 

--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -38,52 +38,57 @@ struct TerminalPaneView: View {
     private var paneCanvas: some View {
         Group {
             if let paneTree = displayPaneTree {
-                ShellPaneTreeLayoutView(
-                    node: paneTree,
-                    host: host,
-                    selectedPaneID: displaySelectedPaneID,
-                    onClosePane: onClosePane
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                workspaceContentTree(for: paneTree)
             } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Empty Space")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(ShellPalette.ink)
-                    Text("Start a terminal in this space.")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(ShellPalette.mutedInk)
-                    Button {
-                        _ = host.performShellAutomationCommand(
-                            .createTab(
-                                ShellAutomationCreateTabRequest(
-                                    launchTarget: .shell,
-                                    spaceID: displaySpaceID,
-                                    title: nil,
-                                    workingDirectory: nil
-                                )
+                ShellEmptyWorkspacePlaceholder {
+                    _ = host.performShellAutomationCommand(
+                        .createTab(
+                            ShellAutomationCreateTabRequest(
+                                launchTarget: .shell,
+                                spaceID: displaySpaceID,
+                                title: nil,
+                                workingDirectory: nil
                             )
                         )
-                    } label: {
-                        Label("New Tab", systemImage: "plus")
-                            .font(.system(size: 12, weight: .semibold))
-                            .padding(.horizontal, 11)
-                            .frame(height: 28)
-                    }
-                    .buttonStyle(.plain)
-                    .background {
-                        ShellMaterialShape(
-                            role: .controlGlassHover,
-                            shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                        )
-                    }
-                    .help("Create a tab in this space")
+                    )
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                .padding(28)
             }
         }
-        .modifier(ShellTerminalSurfaceFrame())
+    }
+
+    @ViewBuilder
+    private func workspaceContentTree(for tree: ShellPaneTreeNode) -> some View {
+        let ownsOuterTerminalSurface = terminalTreeOwnsOuterSurface(tree)
+
+        ShellPaneTreeLayoutView(
+            node: tree,
+            host: host,
+            selectedPaneID: displaySelectedPaneID,
+            terminalLeafOwnsSurfaceFrame: !ownsOuterTerminalSurface,
+            onClosePane: onClosePane
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .shellTerminalSurfaceFrame(enabled: ownsOuterTerminalSurface)
+    }
+
+    private func terminalTreeOwnsOuterSurface(_ node: ShellPaneTreeNode) -> Bool {
+        switch node.kind {
+        case .pane:
+            guard let paneID = node.paneID,
+                  let pane = host.shellState.pane(paneID: paneID)
+            else {
+                return false
+            }
+            let descriptor = ShellContentRenderingRegistry.descriptor(
+                forPaneSlotID: paneID,
+                in: host.shellState.contentStateProjection(),
+                fallbackPane: pane
+            )
+            return descriptor.renderKind == .terminal
+        case .split:
+            let children = node.children ?? []
+            return !children.isEmpty && children.allSatisfy(terminalTreeOwnsOuterSurface)
+        }
     }
 
     private var displayTab: ShellTab? {
@@ -512,6 +517,37 @@ private struct QuickTerminalContentView: View {
     }
 }
 
+private struct ShellEmptyWorkspacePlaceholder: View {
+    let onCreateTerminalTab: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Empty Space")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(ShellPalette.ink)
+            Text("Start a terminal in this space.")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(ShellPalette.mutedInk)
+            Button(action: onCreateTerminalTab) {
+                Label("New Tab", systemImage: "plus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .padding(.horizontal, 11)
+                    .frame(height: 28)
+            }
+            .buttonStyle(.plain)
+            .background {
+                ShellMaterialShape(
+                    role: .controlGlassHover,
+                    shape: RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
+                )
+            }
+            .help("Create a tab in this space")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(28)
+    }
+}
+
 private struct ShellTerminalSurfaceFrame: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     private let shape = RoundedRectangle(cornerRadius: ShellRadii.terminalSurface, style: .continuous)
@@ -565,10 +601,22 @@ private struct ShellTerminalSurfaceFrame: ViewModifier {
     }
 }
 
+private extension View {
+    @ViewBuilder
+    func shellTerminalSurfaceFrame(enabled: Bool) -> some View {
+        if enabled {
+            modifier(ShellTerminalSurfaceFrame())
+        } else {
+            self
+        }
+    }
+}
+
 private struct ShellPaneTreeLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
+    let terminalLeafOwnsSurfaceFrame: Bool
     let onClosePane: ((ShellPane) -> Void)?
 
     var body: some View {
@@ -582,6 +630,7 @@ private struct ShellPaneTreeLayoutView: View {
                 node: node,
                 host: host,
                 selectedPaneID: selectedPaneID,
+                terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                 onClosePane: onClosePane
             )
         }
@@ -615,6 +664,7 @@ private struct ShellPaneTreeLayoutView: View {
             bootProfile: host.bootProfile(for: pane),
             restoredTranscriptSnapshot: host.restoredTranscriptSnapshot(for: pane),
             isSelected: selectedPaneID == pane.paneID,
+            ownsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
             renderPriority: host.terminalRenderPriority(for: pane),
             isZoomed: host.isPaneZoomed(pane.paneID),
             canZoom: host.canZoomPane(pane.paneID),
@@ -744,6 +794,7 @@ private struct ShellSplitLayoutView: View {
     let node: ShellPaneTreeNode
     @ObservedObject var host: ShellHostController
     let selectedPaneID: String?
+    let terminalLeafOwnsSurfaceFrame: Bool
     let onClosePane: ((ShellPane) -> Void)?
     @State private var dragStartRatio: Double?
     @State private var dragPreviewRatio: Double?
@@ -761,6 +812,7 @@ private struct ShellSplitLayoutView: View {
                             node: children[0],
                             host: host,
                             selectedPaneID: selectedPaneID,
+                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(width: primaryLength(total: proxy.size.width))
@@ -770,6 +822,7 @@ private struct ShellSplitLayoutView: View {
                             node: children[1],
                             host: host,
                             selectedPaneID: selectedPaneID,
+                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(width: secondaryLength(total: proxy.size.width))
@@ -780,6 +833,7 @@ private struct ShellSplitLayoutView: View {
                             node: children[0],
                             host: host,
                             selectedPaneID: selectedPaneID,
+                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(height: primaryLength(total: proxy.size.height))
@@ -789,6 +843,7 @@ private struct ShellSplitLayoutView: View {
                             node: children[1],
                             host: host,
                             selectedPaneID: selectedPaneID,
+                            terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                             onClosePane: onClosePane
                         )
                             .frame(height: secondaryLength(total: proxy.size.height))
@@ -816,6 +871,7 @@ private struct ShellSplitLayoutView: View {
                 node: child,
                 host: host,
                 selectedPaneID: selectedPaneID,
+                terminalLeafOwnsSurfaceFrame: terminalLeafOwnsSurfaceFrame,
                 onClosePane: onClosePane
             )
         }
@@ -908,6 +964,7 @@ private struct ShellTerminalLeafView: View {
     let bootProfile: AlanShellBootProfile?
     let restoredTranscriptSnapshot: TerminalTranscriptSnapshot?
     let isSelected: Bool
+    let ownsSurfaceFrame: Bool
     let renderPriority: TerminalRuntimeRenderPriority
     let isZoomed: Bool
     let canZoom: Bool
@@ -1007,6 +1064,7 @@ private struct ShellTerminalLeafView: View {
                 }
             }
         }
+        .shellTerminalSurfaceFrame(enabled: ownsSurfaceFrame)
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -13,7 +13,7 @@ struct ShellWorkspaceView: View {
             spaceID: host.selectedSpace?.spaceID,
             selectedPaneID: contentState.focusedPaneSlotID,
             zoomedPaneID: host.selectedTabZoomedPaneID,
-            terminalSurfaceInsets: ShellWorkspaceMetrics.terminalSurfaceInsets(
+            workspacePanelInsets: ShellWorkspaceMetrics.workspacePanelInsets(
                 expandedSidebarProgress: expandedSidebarProgress
             )
         )

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -187,6 +187,61 @@ require_pane_title_bar_trailing_close() {
     fi
 }
 
+require_workspace_color_ownership_contract() {
+    local pane_file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
+
+    require_pattern \
+        "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
+        "static let rootBacking = Color\\.shellAdaptive\\(" \
+        "shell root backing must have a dedicated adaptive opaque token"
+
+    require_pattern \
+        "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
+        "light: \\(1\\.0, 1\\.0, 1\\.0\\)" \
+        "shell root backing light color must resolve to rgb(1,1,1)"
+
+    reject_pattern \
+        "clients/apple/alan-macos/MacShellRootView.swift" \
+        "ShellMaterialBackgroundView\\(\\.windowBackdrop\\)" \
+        "mac shell root must use the opaque root backing instead of root-window material"
+
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "ShellEmptyWorkspacePlaceholder" \
+        "empty Space must render through a workspace placeholder instead of inline terminal chrome"
+
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "terminalTreeOwnsOuterSurface" \
+        "terminal-only pane trees must preserve one outer terminal surface frame"
+
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "terminalLeafOwnsSurfaceFrame" \
+        "mixed content trees must let terminal leaves own their own terminal surface frame"
+
+    if awk '
+        /private var paneCanvas: some View/ {
+            in_canvas = 1
+        }
+
+        in_canvas && /ShellTerminalSurfaceFrame/ {
+            found = 1
+        }
+
+        in_canvas && /private var displayTab/ {
+            in_canvas = 0
+        }
+
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$pane_file"; then
+        printf 'error: workspace paneCanvas must not own ShellTerminalSurfaceFrame\n' >&2
+        exit 1
+    fi
+}
+
 require_active_complex_split_count_contrast() {
     local file="$REPO_ROOT/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift"
 
@@ -315,6 +370,7 @@ reject_keydown_programmatic_text_delivery
 require_quick_terminal_peak_nonactivating_panel
 require_title_bar_full_width_hit_area
 require_pane_title_bar_trailing_close
+require_workspace_color_ownership_contract
 require_active_complex_split_count_contrast
 require_tab_organization_sidebar_contract
 require_semantic_terminal_actions_contract

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -210,20 +210,25 @@ require_workspace_color_ownership_contract() {
         "ShellEmptyWorkspacePlaceholder" \
         "empty Space must render through a workspace placeholder instead of inline terminal chrome"
 
-    require_pattern \
+    reject_pattern \
         "clients/apple/alan-macos/TerminalPaneView.swift" \
         "terminalTreeOwnsOuterSurface" \
-        "terminal-only pane trees must preserve the outer workspace panel as the only surface frame"
+        "terminal-only pane trees must not need special outer terminal surface ownership"
 
-    require_pattern \
+    reject_pattern \
         "clients/apple/alan-macos/TerminalPaneView.swift" \
         "terminalLeafOwnsSurfaceFrame" \
-        "mixed content trees must let terminal leaves own their own terminal surface frame"
+        "mixed content trees must not let terminal leaves own rounded frame chrome"
 
     require_pattern \
         "clients/apple/alan-macos/TerminalPaneView.swift" \
         "ShellWorkspacePanelFrame" \
         "workspace panes must define a generic panel frame for all content kinds"
+
+    reject_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "ShellTerminalSurfaceFrame" \
+        "terminal content leaves must not own rounded frame chrome"
 
     if awk '
         /private var paneCanvas: some View/ {
@@ -1116,10 +1121,10 @@ require_pattern \
     "func handleControlPlaneCommand\\(_ command: AlanShellControlCommand\\)" \
     "control-plane protocol commands must stay separate from UI command vocabulary while sharing shell mutation authority"
 
-require_pattern \
-    "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "ShellTerminalSurfaceFrame" \
-    "terminal panes must share one outer rounded terminal surface frame"
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "ShellWorkspacePanelFrame" \
+        "workspace panes must share one outer rounded workspace panel frame"
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
@@ -1156,10 +1161,10 @@ require_pattern \
     "AnimatablePair<CGFloat, CGFloat>" \
     "window chrome placement must animate both pinned layout progress and floating-to-pinned morph progress"
 
-require_pattern \
-    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "expandedSidebarProgress" \
-    "workspace view must expose continuous sidebar progress for terminal surface spacing"
+    require_pattern \
+        "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
+        "expandedSidebarProgress" \
+        "workspace view must expose continuous sidebar progress for workspace panel spacing"
 
 require_pattern \
     "clients/apple/alan-macos/MacShellRootView.swift" \
@@ -1181,25 +1186,25 @@ reject_pattern \
     "if !isSidebarCollapsed \\{" \
     "pinned sidebar must not be conditionally inserted or removed"
 
-require_pattern \
-    "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "terminalSurfaceInsets: EdgeInsets" \
-    "terminal pane must receive semantic terminal surface edge insets"
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "workspacePanelInsets: EdgeInsets" \
+        "terminal pane must receive semantic workspace panel edge insets"
 
-require_pattern \
-    "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "padding\\(terminalSurfaceInsets\\)" \
-    "terminal pane must apply state-aware terminal surface edge insets"
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "padding\\(workspacePanelInsets\\)" \
+        "terminal pane must apply state-aware workspace panel edge insets"
 
-reject_pattern \
-    "clients/apple/alan-macos/TerminalHostView.swift" \
-    "cornerRadius = ShellRadii\\.terminalSurface" \
-    "terminal host view must not apply an inner rounded corner inside the outer terminal surface"
+    reject_pattern \
+        "clients/apple/alan-macos/TerminalHostView.swift" \
+        "cornerRadius = ShellRadii\\.workspacePanel" \
+        "terminal host view must not apply an inner rounded corner inside the outer workspace panel"
 
-require_pattern \
-    "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
-    "terminalSurfaceInsets\\(expandedSidebarProgress" \
-    "terminal workspace surface insets must support continuous sidebar progress"
+    require_pattern \
+        "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
+        "workspacePanelInsets\\(expandedSidebarProgress" \
+        "workspace panel insets must support continuous sidebar progress"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSwipeMonitor.swift" \
@@ -1341,10 +1346,10 @@ reject_pattern \
     "preferredColorScheme" \
     "mac shell appearance switching must not rely on clearing a stale SwiftUI preferredColorScheme preference"
 
-reject_pattern \
-    "clients/apple/alan-macos/TerminalPaneView.swift" \
-    "padding\\(ShellWorkspaceMetrics\\.terminalSurfaceInset\\)" \
-    "terminal surface must not apply equal workspace inset when the sidebar is expanded"
+    reject_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "padding\\(ShellWorkspaceMetrics\\.workspacePanelInset\\)" \
+        "workspace panel must not apply equal workspace inset when the sidebar is expanded"
 
 require_pattern \
     "clients/apple/alan-macos/TerminalPaneView.swift" \
@@ -1721,10 +1726,10 @@ require_pattern \
     "window\\.isMovableByWindowBackground = false" \
     "hidden-titlebar shell windows must keep tab and space controls out of the implicit window drag region"
 
-require_pattern \
-    "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
-    "contentInteractionTopInset" \
-    "window double-click zoom overlay must not cover terminal surface title-bar controls"
+    require_pattern \
+        "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
+        "contentInteractionTopInset" \
+        "window double-click zoom overlay must not cover workspace panel title-bar controls"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \
@@ -1736,10 +1741,10 @@ require_pattern \
     "width: sidebarWidth" \
     "window double-click zoom hit testing must know the sidebar chrome width"
 
-require_pattern \
-    "clients/apple/scripts/test-shell-window-placement.swift" \
-    "verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit" \
-    "shell window placement tests must prove terminal title-bar controls are not intercepted by zoom overlay"
+    require_pattern \
+        "clients/apple/scripts/test-shell-window-placement.swift" \
+        "verifiesTitlebarOverlayRejectsWorkspacePanelTitleBarHit" \
+        "shell window placement tests must prove workspace panel title-bar controls are not intercepted by zoom overlay"
 
 require_pattern \
     "clients/apple/scripts/test-shell-window-placement.swift" \

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -213,12 +213,17 @@ require_workspace_color_ownership_contract() {
     require_pattern \
         "clients/apple/alan-macos/TerminalPaneView.swift" \
         "terminalTreeOwnsOuterSurface" \
-        "terminal-only pane trees must preserve one outer terminal surface frame"
+        "terminal-only pane trees must preserve the outer workspace panel as the only surface frame"
 
     require_pattern \
         "clients/apple/alan-macos/TerminalPaneView.swift" \
         "terminalLeafOwnsSurfaceFrame" \
         "mixed content trees must let terminal leaves own their own terminal surface frame"
+
+    require_pattern \
+        "clients/apple/alan-macos/TerminalPaneView.swift" \
+        "ShellWorkspacePanelFrame" \
+        "workspace panes must define a generic panel frame for all content kinds"
 
     if awk '
         /private var paneCanvas: some View/ {
@@ -238,6 +243,27 @@ require_workspace_color_ownership_contract() {
         }
     ' "$pane_file"; then
         printf 'error: workspace paneCanvas must not own ShellTerminalSurfaceFrame\n' >&2
+        exit 1
+    fi
+
+    if ! awk '
+        /private var paneCanvas: some View/ {
+            in_canvas = 1
+        }
+
+        in_canvas && /shellWorkspacePanelFrame/ {
+            found = 1
+        }
+
+        in_canvas && /private var displayTab/ {
+            in_canvas = 0
+        }
+
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$pane_file"; then
+        printf 'error: workspace paneCanvas must own ShellWorkspacePanelFrame\n' >&2
         exit 1
     fi
 }

--- a/clients/apple/scripts/test-shell-window-placement.swift
+++ b/clients/apple/scripts/test-shell-window-placement.swift
@@ -28,7 +28,7 @@ private enum ShellWindowPlacementTests {
         try verifiesCollapsedSidebarRetentionIncludesLeftResizeFrame()
         try verifiesPrimaryShellWindowDisablesGlobalBackgroundDragging()
         try verifiesTitlebarPointOutsideContentViewCanTriggerDoubleClickZoom()
-        try verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom()
+        try verifiesWorkspacePanelTitleBarDoesNotTriggerDoubleClickZoom()
         try verifiesTrafficLightControlsDoNotTriggerDoubleClickZoom()
         try verifiesTrafficLightGapsCanTriggerDoubleClickZoom()
         try verifiesSidebarChromeBlankAreaCanTriggerDoubleClickZoom()
@@ -37,7 +37,7 @@ private enum ShellWindowPlacementTests {
         try verifiesSidebarToolbarButtonsDoNotTriggerDoubleClickZoom()
         try verifiesTitlebarOverlayAcceptsTopBlankHit()
         try verifiesTitlebarOverlayAcceptsSidebarChromeBlankHit()
-        try verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit()
+        try verifiesTitlebarOverlayRejectsWorkspacePanelTitleBarHit()
         try verifiesTitlebarOverlayRejectsTrafficLightHit()
         try verifiesAppearanceModeAppliesToAttachedWindowImmediately()
         try verifiesSystemModeClearsExplicitWindowAppearanceImmediately()
@@ -94,24 +94,24 @@ private enum ShellWindowPlacementTests {
     }
 
     private static func verifiesWorkspaceInsetFollowsPinnedSidebarProgress() throws {
-        let expandedInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+        let expandedInsets = ShellWorkspaceMetrics.workspacePanelInsets(
             expandedSidebarProgress: 1
         )
-        let midTransitionInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+        let midTransitionInsets = ShellWorkspaceMetrics.workspacePanelInsets(
             expandedSidebarProgress: 0.5
         )
-        let collapsedInsets = ShellWorkspaceMetrics.terminalSurfaceInsets(
+        let collapsedInsets = ShellWorkspaceMetrics.workspacePanelInsets(
             expandedSidebarProgress: 0
         )
 
-        expect(expandedInsets.leading == 0, "expanded sidebar must remove terminal leading inset")
+        expect(expandedInsets.leading == 0, "expanded sidebar must remove workspace panel leading inset")
         expect(
-            midTransitionInsets.leading == ShellWorkspaceMetrics.terminalSurfaceInset / 2,
+            midTransitionInsets.leading == ShellWorkspaceMetrics.workspacePanelInset / 2,
             "workspace leading inset must move continuously with pinned sidebar progress"
         )
         expect(
-            collapsedInsets.leading == ShellWorkspaceMetrics.terminalSurfaceInset,
-            "collapsed pinned sidebar must restore terminal leading inset"
+            collapsedInsets.leading == ShellWorkspaceMetrics.workspacePanelInset,
+            "collapsed pinned sidebar must restore workspace panel leading inset"
         )
     }
 
@@ -362,7 +362,7 @@ private enum ShellWindowPlacementTests {
         )
     }
 
-    private static func verifiesTerminalSurfaceTitleBarDoesNotTriggerDoubleClickZoom() throws {
+    private static func verifiesWorkspacePanelTitleBarDoesNotTriggerDoubleClickZoom() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 520),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -373,7 +373,7 @@ private enum ShellWindowPlacementTests {
 
         let location = CGPoint(
             x: 760,
-            y: window.frame.height - ShellWorkspaceMetrics.terminalSurfaceInset - 12
+            y: window.frame.height - ShellWorkspaceMetrics.workspacePanelInset - 12
         )
 
         expect(
@@ -382,7 +382,7 @@ private enum ShellWindowPlacementTests {
                 in: window,
                 chromeSurface: chromeSurface
             ),
-            "terminal surface title-bar controls must receive clicks instead of the window zoom overlay"
+            "workspace panel title-bar controls must receive clicks instead of the window zoom overlay"
         )
     }
 
@@ -554,7 +554,7 @@ private enum ShellWindowPlacementTests {
         )
     }
 
-    private static func verifiesTitlebarOverlayRejectsTerminalSurfaceTitleBarHit() throws {
+    private static func verifiesTitlebarOverlayRejectsWorkspacePanelTitleBarHit() throws {
         let window = makeTestWindow()
         let overlay = ShellWindowDoubleClickZoomOverlayView(
             frame: CGRect(origin: .zero, size: window.frame.size)
@@ -564,13 +564,13 @@ private enum ShellWindowPlacementTests {
 
         let windowPoint = CGPoint(
             x: window.frame.width - 40,
-            y: window.frame.height - ShellWorkspaceMetrics.terminalSurfaceInset - 12
+            y: window.frame.height - ShellWorkspaceMetrics.workspacePanelInset - 12
         )
         let overlayPoint = overlay.convert(windowPoint, from: nil)
 
         expect(
             overlay.hitTest(overlayPoint) == nil,
-            "titlebar overlay must leave terminal surface title-bar controls clickable"
+            "titlebar overlay must leave workspace panel title-bar controls clickable"
         )
     }
 

--- a/openspec/changes/polish-macos-restored-transcript-panel/.openspec.yaml
+++ b/openspec/changes/polish-macos-restored-transcript-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/polish-macos-restored-transcript-panel/design.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/design.md
@@ -1,0 +1,182 @@
+## Context
+
+The accepted terminal session snapshot work persists bounded transcript text in
+the workspace manifest and seeds restored terminal content on restart. The
+current product behavior renders that restored text above the live terminal in
+`RestoredTerminalTranscriptView`. This is useful because it is honest about the
+prior process being gone and keeps the new shell clean, but the current panel is
+too disconnected from the terminal surface:
+
+- restored text is laid out as a narrow SwiftUI text block instead of matching
+  the live terminal text column;
+- the panel remains visible after user clear actions because it is not part of
+  the real terminal buffer;
+- the restored snapshot can remain in shell state and runtime cache after the
+  user has dismissed the visual context.
+
+This change keeps the separate panel model and polishes the boundaries around
+it. It does not attempt to serialize Ghostty state or replay the snapshot into
+the new PTY.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the restored transcript panel as a distinct visual region above the
+  live terminal.
+- Make restored transcript text visually line up with terminal text: same
+  leading column, terminal-like monospace metrics, row rhythm, full-width
+  leading layout, and readable foreground treatment.
+- Ensure restored panel height is stable and bounded by the restored row limit
+  used by the view.
+- Let supported terminal clear intents remove the restored panel.
+- Remove cleared restored transcript data from in-memory shell state, runtime
+  restored-cache state, and future manifest writes.
+- Keep normal terminal input delivery unchanged when clear actions are used.
+- Keep implementation scoped to restored transcript presentation and dismissal.
+
+**Non-Goals:**
+
+- Do not replay restored transcript text into the new PTY.
+- Do not claim the prior PTY, foreground process, alternate-screen app, or
+  renderer state survived app restart.
+- Do not add a full terminal buffer restore API unless Ghostty already exposes a
+  reliable clear or restore seam needed by the implementation.
+- Do not add a preferences surface for restored transcript behavior.
+- Do not redesign terminal chrome, pane title bars, split layout, or sidebar
+  behavior.
+
+## Decisions
+
+### Restored context remains a distinct panel
+
+Alan will keep restored transcript context as a separate panel above the live
+terminal. The panel may use a slightly distinct background and a subtle divider
+so users can tell it belongs to the previous app session. It must not become a
+card-heavy surface, a warning banner, or a debug disclosure UI.
+
+Alternative considered: replay restored text into the live PTY. That gives the
+most natural `clear` behavior, but it makes old output look like fresh shell
+output and can muddy the user's mental model after restart.
+
+### Text layout follows terminal metrics
+
+The restored panel will render transcript text with terminal-like monospace
+metrics and leading alignment. Its text origin should match the live terminal's
+text origin as closely as the current SwiftUI/AppKit composition permits. It
+should use full-width leading layout and horizontal scrolling rather than
+wrapping or centering a narrow text block.
+
+The panel height remains derived from bounded restored rows, but the panel
+should not make the live terminal look split into mismatched typography zones.
+The visual difference should come from background and a separator, not from
+different text rhythm.
+
+Alternative considered: keep the current small SwiftUI text styling and only
+add clear behavior. That solves persistence but leaves the main perceived
+quality issue visible.
+
+### Restored transcript dismissal is content-scoped
+
+Clearing the restored panel is a content-level state mutation, not local view
+state. The mutation removes `payload.terminal.transcriptSnapshot` for the
+mounted terminal ContentInstance, tells the runtime service to evict any
+restored transcript cached for the same content ID, and schedules normal shell
+state persistence. After dismissal, tab switches, split view reconstruction,
+window restoration, and subsequent manifest saves must not reintroduce the old
+snapshot.
+
+Alternative considered: hide the SwiftUI view with local `@State`. That is
+visually fast but stale restored data remains in shell state and can reappear
+after view reconstruction or restart.
+
+### Clear intents share one dismissal path
+
+The following clear intents should call the same content-scoped dismissal path:
+
+- terminal `Ctrl-L` in the focused terminal, while still forwarding the key to
+  Ghostty;
+- typed `clear` submitted at the prompt when Alan can recognize the command
+  from reliable terminal input or semantic command boundaries;
+- Alan's explicit Clear command, including Cmd-K or menu/command routing once
+  that action exists.
+
+Raw application-emitted clear-screen escape sequences may also dismiss the
+restored panel if Ghostty exposes a reliable screen-clear or scrollback-reset
+signal. The implementation should not infer arbitrary renderer internals from
+unrelated scrollback metrics or parse terminal output text as a fallback.
+
+Alternative considered: dismiss on the first normal keypress. That removes the
+panel quickly but loses useful context when the user types a command while still
+referencing the restored output.
+
+### Runtime cache eviction mirrors shell state
+
+`TerminalRuntimeRegistry` and `TerminalRuntimeService` will expose a narrow
+restored transcript eviction API keyed by terminal content ID. The shell state
+mutation owns the user-visible truth; the runtime eviction prevents an existing
+or future surface handle from reseeding itself from an already-cleared snapshot.
+Fake runtime services used by tests should implement the same behavior so cache
+eviction is verifiable without launching Ghostty.
+
+Alternative considered: only remove the manifest payload. That may still leave
+an already-created runtime handle carrying seeded restored transcript metadata
+or fallback ring-buffer state.
+
+## Data Flow
+
+1. Workspace manifest materialization creates terminal ContentInstances that may
+   include `payload.terminal.transcriptSnapshot`.
+2. The terminal pane view reads the current shell state and renders
+   `RestoredTerminalTranscriptView` only while the mounted content still has a
+   transcript snapshot.
+3. `bootProfile(for:)` may seed the runtime service as it does today, but
+   seeding does not make the panel state authoritative.
+4. A supported clear intent resolves to the focused pane's mounted terminal
+   content ID and calls the shared restored transcript clear mutation.
+5. The mutation removes the snapshot from shell state, evicts the runtime cache
+   for that content ID, publishes the updated shell state, and persists the
+   workspace manifest through the existing persistence path.
+6. The view re-renders without the restored panel. The live terminal still
+   receives the clear key or command action when appropriate.
+
+## Error Handling
+
+- If a clear intent has no focused pane or no mounted terminal content, it
+  should no-op for restored transcript dismissal and continue normal terminal or
+  shell command handling.
+- If runtime cache eviction cannot find a cached restored transcript, dismissal
+  still succeeds because shell state is the visible source of truth.
+- If manifest persistence fails after dismissal, Alan should surface or record
+  the same persistence diagnostics used by other shell state saves; the UI does
+  not re-show the panel in the current process solely because persistence
+  failed.
+- If typed `clear` recognition is not reliable for a terminal mode or IME
+  composition state, the implementation should avoid false positives and rely on
+  `Ctrl-L` plus explicit Clear command for that case.
+
+## Testing
+
+- Add shell state or controller tests proving a restored transcript clear
+  mutation removes the snapshot from the mounted terminal content and from the
+  persisted manifest.
+- Add runtime service tests proving restored-cache eviction prevents a reused
+  content ID from inheriting old restored transcript state.
+- Add terminal host or controller tests proving `Ctrl-L` and the explicit Clear
+  command dismiss the restored panel while preserving normal terminal delivery.
+- Add typed `clear` coverage only if recognition is implemented through a
+  reliable input or semantic-command seam.
+- Add focused view/model tests for restored panel layout expectations:
+  full-width leading alignment, terminal-like monospace typography, bounded
+  height, and no centered/narrow text block.
+- Add running-app visual verification in the dev channel after implementation:
+  restore a transcript, confirm panel text aligns with the live terminal text
+  column, invoke clear, and confirm the panel disappears and does not return
+  after relaunch.
+
+## Rollout
+
+This is a local macOS client behavior change. Old manifests remain compatible
+because transcript snapshots are already optional. The first implementation can
+ship without a preference because clearing is explicit and the panel remains
+bounded.

--- a/openspec/changes/polish-macos-restored-transcript-panel/proposal.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Restored terminal transcript snapshots currently appear as a separate SwiftUI
+text block above the live terminal. The panel makes restart context visible, but
+its text does not align with the real terminal surface and shell clear actions
+do not remove it. The result feels disconnected from the terminal workflow:
+useful restored context stays on screen after the user has intentionally cleared
+the terminal, and the typography makes the restored output harder to scan.
+
+## What Changes
+
+- Keep restored transcript context as a visually distinct panel above the live
+  terminal rather than replaying it into the new PTY.
+- Polish the restored panel so its text aligns with the live terminal's text
+  column and uses matching terminal-like monospace typography, row rhythm,
+  foreground treatment, and full-width leading layout.
+- Add a content-level clear path that removes the restored transcript snapshot
+  from shell state, the runtime restored-cache, and future manifest writes.
+- Dismiss the restored panel when the user invokes terminal clear intent through
+  `Ctrl-L`, typed `clear` at the prompt, or Alan's Clear command such as Cmd-K
+  or menu clear.
+- Keep raw renderer or process restore out of scope. The panel remains readable
+  session-continuity metadata, not a claim that the prior PTY or child process
+  survived restart.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-workspace-persistence`: Clarify that restored transcript
+  snapshots may render as a distinct restored-context panel and can be cleared
+  from persisted restore state.
+- `macos-terminal-runtime-foundation`: Add runtime restored-transcript cache
+  eviction and clear-intent handling responsibilities.
+- `macos-shell-ui-ux-conformance`: Define restored transcript panel visual
+  polish: terminal-aligned text, stable panel sizing, and quiet native styling.
+- `macos-shell-build-test-contract`: Require focused tests for panel layout,
+  clear behavior, cache eviction, and manifest persistence after dismissal.
+
+## Impact
+
+- `clients/apple/alan-macos/TerminalPaneView.swift` needs restored panel layout
+  polish and a clear callback instead of panel-only presentation state.
+- `clients/apple/alan-macos/ShellHostController.swift` and shell state mutation
+  helpers need a content-scoped restored transcript removal path.
+- `clients/apple/alan-macos/TerminalRuntimeRegistry.swift` and
+  `TerminalRuntimeService.swift` need a matching restored-cache eviction API.
+- `clients/apple/alan-macos/TerminalHostView.swift`,
+  `TerminalSurfaceController.swift`, and shell command/menu routing need to map
+  supported clear intents to the shared restored transcript removal path while
+  preserving normal terminal delivery.
+- Focused Apple scripts should cover snapshot dismissal, manifest round trips,
+  runtime cache eviction, and terminal-like restored panel layout.

--- a/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Safe terminal close and transcript restore are verified
+The Apple client SHALL include focused automated tests and running-app smoke
+evidence for terminal close guarding, bounded transcript snapshot persistence,
+app-restart transcript restore, restored transcript panel presentation, and
+restored transcript dismissal.
+
+#### Scenario: Active close guard tested
+- **WHEN** tests request pane, tab, window, app, or Quick Terminal close for terminal content with active work
+- **THEN** tests verify that close requires confirmation and does not mutate shell state or finalize runtimes before confirmation
+
+#### Scenario: Idle close bypass tested
+- **WHEN** tests request close for idle shell, exited terminal, or non-terminal content
+- **THEN** tests verify that Alan does not require active-work confirmation solely because a shell process exists
+
+#### Scenario: Manifest transcript round trip tested
+- **WHEN** tests persist a workspace manifest containing terminal transcript snapshots
+- **THEN** tests verify old manifests without snapshots still decode
+- **AND** new manifests preserve bounded transcript lines, dimensions, cwd, title, focus, truncation metadata, and content identity through a round trip
+
+#### Scenario: Restart transcript restore smoke tested
+- **WHEN** a running-app smoke produces visible terminal output, closes or quits Alan through a confirmed path, and relaunches the freshly installed app
+- **THEN** verification confirms the restored terminal shows the prior output in the accepted restored-context presentation
+- **AND** the restored terminal accepts new input in a newly started shell at the restored cwd
+
+#### Scenario: Restored transcript dismissal tested
+- **WHEN** a restored terminal content has visible restored transcript context
+- **THEN** tests verify supported clear actions remove the restored transcript from shell state, runtime restored-cache state, and subsequent persisted manifests
+- **AND** view or model coverage verifies the restored panel text is terminal-aligned rather than centered as a narrow text block

--- a/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Restored transcript panel uses terminal-aligned presentation
+The macOS shell SHALL ensure any restored terminal transcript panel above the
+live terminal visually aligns with the terminal surface and remains quiet,
+bounded, and clearable.
+
+#### Scenario: Restored panel text aligns with terminal text
+- **WHEN** a terminal pane renders restored transcript context above the live terminal
+- **THEN** restored transcript text uses terminal-like monospace typography, row height, foreground treatment, and horizontal scrolling behavior
+- **AND** the restored text leading edge aligns with the live terminal text column as closely as the current terminal host composition permits
+- **AND** restored transcript text uses full-width leading layout rather than centering a narrow text block in the panel
+
+#### Scenario: Restored panel remains visually distinct
+- **WHEN** restored transcript context is visible
+- **THEN** Alan may use a quiet background difference and subtle separator to distinguish the prior-session context from the live terminal
+- **AND** the panel does not appear as a warning banner, diagnostic card, or prominent debug surface
+- **AND** the panel height remains bounded and stable for the restored transcript row limit used by the view
+
+#### Scenario: Restored panel clears with terminal clear intent
+- **WHEN** the user clears the focused terminal through supported terminal or Alan clear actions
+- **THEN** the restored transcript panel disappears for that terminal content
+- **AND** the live terminal still receives the clear behavior appropriate to the triggering action

--- a/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Terminal transcript snapshots restore the prior visible session context
+The macOS shell workspace manifest SHALL persist terminal transcript snapshots
+as bounded session-continuity state that can present prior visible terminal
+context after app restart without claiming that the prior PTY or child process
+survived.
+
+#### Scenario: App closes with visible terminal output
+- **WHEN** Alan closes or quits while a retained terminal ContentInstance has visible output and restorable transcript history
+- **THEN** the workspace manifest stores a bounded transcript snapshot for that terminal content
+- **AND** the snapshot preserves enough text, dimensions, title, cwd, focus, and viewport context to show the prior terminal state after restart
+
+#### Scenario: App restarts after transcript snapshot
+- **WHEN** Alan restores a terminal ContentInstance from a workspace manifest that contains a terminal transcript snapshot
+- **THEN** Alan materializes the terminal with the saved transcript context before or during new runtime startup
+- **AND** the restored terminal remains usable by starting a new shell in the restored cwd
+- **AND** the normal terminal UI may show the restored transcript in a distinct restored-context panel when that panel is quiet, bounded, and terminal-aligned
+- **AND** the UI does not present the restored transcript as a warning banner or claim that the prior process is still running
+
+#### Scenario: Restored transcript is cleared
+- **WHEN** the user invokes a supported terminal or Alan clear action for a terminal ContentInstance with a restored transcript snapshot
+- **THEN** Alan removes the restored transcript snapshot from in-memory shell state for that content
+- **AND** the next persisted workspace manifest no longer contains that restored transcript snapshot for the content
+- **AND** subsequent tab switches, pane remounts, or app relaunches do not re-show the cleared restored transcript
+
+#### Scenario: Transcript snapshot is too large
+- **WHEN** terminal history exceeds the configured row or encoded-byte snapshot limit
+- **THEN** Alan stores a bounded tail snapshot and records truncation metadata
+- **AND** manifest persistence remains bounded in size and time

--- a/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Restored transcript history seeds newly created terminal runtimes
+The terminal runtime service SHALL accept restored transcript history when a
+terminal ContentInstance is materialized from a workspace manifest with a
+terminal transcript snapshot and SHALL keep that restored state clearable by
+terminal content identity before treating it as durable runtime state.
+
+#### Scenario: Runtime starts with restored transcript
+- **WHEN** a restored terminal ContentInstance has a terminal transcript snapshot
+- **THEN** the runtime service receives the transcript for the new runtime or restored-cache path
+- **AND** the new shell starts in the restored cwd and can accept subsequent input
+- **AND** the UI may render the restored transcript as a distinct restored-context panel instead of replaying it into the live PTY
+
+#### Scenario: Restored alternate-screen snapshot
+- **WHEN** a transcript snapshot was captured from alternate-screen terminal mode
+- **THEN** Alan records the captured mode metadata
+- **AND** the restored runtime or restored-context panel may present the captured text without claiming that the prior alternate-screen application is still running
+
+#### Scenario: Restored transcript cache is evicted
+- **WHEN** the shell host clears the restored transcript for a terminal ContentInstance
+- **THEN** the runtime registry and runtime service evict any restored transcript cache for that content ID
+- **AND** an existing or future surface handle for the same content ID does not reseed itself from the cleared transcript
+
+#### Scenario: Snapshot metadata is debug-only
+- **WHEN** a runtime or terminal content is associated with a restored transcript snapshot
+- **THEN** debug or control-plane metadata may indicate that the content was restored from a snapshot
+- **AND** the default terminal UI only shows user-facing restored-session chrome as the quiet restored-context panel defined by the shell UI contract

--- a/openspec/changes/polish-macos-restored-transcript-panel/tasks.md
+++ b/openspec/changes/polish-macos-restored-transcript-panel/tasks.md
@@ -1,0 +1,30 @@
+## 1. Restored Panel Presentation
+
+- [ ] 1.1 Align `RestoredTerminalTranscriptView` text origin with the live terminal text column.
+- [ ] 1.2 Match terminal-like monospace font size, weight, row height, color, and horizontal scrolling behavior.
+- [ ] 1.3 Keep the restored panel visually distinct with a quiet background and separator while avoiding warning-banner or card-heavy styling.
+- [ ] 1.4 Preserve bounded, stable panel height based on restored transcript rows.
+
+## 2. Restored Transcript State Clearing
+
+- [ ] 2.1 Add a shell-state mutation that removes a terminal content's restored transcript snapshot by content ID.
+- [ ] 2.2 Persist the shell state after restored transcript dismissal so the snapshot does not return after restart.
+- [ ] 2.3 Add runtime registry and runtime service APIs to evict restored transcript cache by content ID.
+- [ ] 2.4 Ensure view reconstruction, tab switching, and pane remounting do not reintroduce a cleared restored panel.
+
+## 3. Clear Intent Routing
+
+- [ ] 3.1 Route terminal `Ctrl-L` through restored transcript dismissal while preserving Ghostty key delivery.
+- [ ] 3.2 Add or reuse an explicit Alan Clear command, including Cmd-K or menu routing, that dismisses the restored transcript and performs normal terminal clear behavior.
+- [ ] 3.3 Support typed `clear` dismissal only through a reliable terminal input or semantic-command seam; avoid output parsing or broad false positives.
+- [ ] 3.4 Keep unsupported raw escape-sequence clear detection out of the implementation unless Ghostty exposes a reliable signal.
+
+## 4. Verification
+
+- [ ] 4.1 Add controller or shell-state tests for snapshot removal and manifest persistence after dismissal.
+- [ ] 4.2 Add runtime service tests for restored cache eviction.
+- [ ] 4.3 Add terminal host/controller tests for `Ctrl-L` and explicit Clear routing.
+- [ ] 4.4 Add typed `clear` tests if typed command recognition is implemented.
+- [ ] 4.5 Add focused restored panel layout tests or view-model assertions.
+- [ ] 4.6 Run targeted Apple shell/runtime tests and OpenSpec validation.
+- [ ] 4.7 Perform a fresh Alan dev relaunch visual check after implementation and record evidence before claiming UI completion.

--- a/openspec/changes/polish-macos-sidebar-tab-rows/.openspec.yaml
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -94,6 +94,30 @@ Alternatives considered:
   heavy for an Arc-like lightweight cleanup control, and the eligibility rule is
   already conservative.
 
+### Repair tab dragging at the drag/drop boundary
+
+The underlying reorder model is already covered by `test-shell-tab-organization`
+and passes; the weak point is the SwiftUI drag/drop boundary. The current
+sidebar drop delegate relies on view-local `activeTabDrag` state to identify the
+dragged tab, while the drag session also carries an `NSItemProvider` payload.
+That state can be lost or cleared independently of the drop session, which makes
+the drop target unable to apply the reorder even though the state mutation path
+works.
+
+The implementation should treat the drag payload as the source of truth for the
+dragged tab identity and use row-local state only for transient visual preview.
+The drop delegate should load or otherwise receive a typed local payload that
+contains the tab ID and source location, validate it against the current
+`ShellStateSnapshot`, compute the target index, and route through
+`ShellHostController.reorderTab`.
+
+Alternatives considered:
+
+- Keep relying on `activeTabDrag` and adjust the cleanup delay. This may mask
+  one timing case but keeps source identity outside the drag session.
+- Route all reorders through command buttons only. This preserves model
+  behavior but abandons the expected sidebar pointer interaction.
+
 ### Show Clear only when it can act
 
 Clear should appear as a subtle trailing affordance in the divider/control row
@@ -121,6 +145,9 @@ Alternatives considered:
 - [Risk] Batch closing can expose assumptions in mutation result focus repair.
   -> Add model tests for selected-tab preservation, protected-tab retention, and
   empty-Space outcomes.
+- [Risk] SwiftUI drag/drop testing is harder than model testing.
+  -> Cover pure target-index and payload validation helpers with automated tests
+  and require fresh Alan Dev manual verification for actual pointer drag.
 
 ## Migration Plan
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -23,8 +23,8 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
   meaningful two-line row without changing the row's overall visual system.
 - Make ordinary tab rows fastest to identify by task first, then context, then
   process or structure.
-- Support automatic task titles from agent/activity signals while preserving a
-  user-edited title lock.
+- Support task titles supplied through terminal or agent metadata while
+  preserving a user-edited title lock.
 - Use the existing leading split indicator unchanged, with state glyphs in the
   trailing accessory slot and state text in the subtitle when needed.
 - Add a Clear action that closes inactive temporary tabs in the current Space.
@@ -42,9 +42,9 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
 - No changes to daemon APIs, runtime session APIs, provider configuration, or
   terminal runtime contracts.
 - No dark-mode redesign beyond preserving existing adaptive color behavior.
-- No full agent-title-generation backend in this change if the implementation
-  only has activity/session labels available; the row contract should define
-  where generated titles fit when the signal exists.
+- No Alan-owned title-generation backend in this change. Agents and terminal
+  programs remain responsible for setting useful terminal titles or activity
+  details; Alan is responsible for displaying those signals cleanly.
 
 ## Decisions
 
@@ -90,33 +90,37 @@ Alternatives considered:
 - Always show subtitles with smaller fonts. This keeps context but still makes
   ordinary idle tabs visually busy.
 
-### Prefer task-first titles with user title lock
+### Prefer provided task titles with user title lock
 
 The row title should be the stable identity of the tab. For agent-backed or
 activity-backed tabs, the best title is the task being done, not merely the
-directory or process. A generated or activity-derived task title such as
-`Fix sidebar tab drag` should outrank `alan` or `Codex` when it is available and
-safe to show.
+directory or process. A terminal-provided or agent-provided task title such as
+`Fix sidebar tab drag` should outrank `alan` or `Codex` when it is available,
+safe to show, and not just a generic process or status label.
 
 Title source priority should be:
 
 1. User-edited locked title.
-2. Automatic agent/activity task title.
-3. Trusted activity detail or command subject, if it reads like a task title.
+2. Terminal-provided or agent-provided task title.
+3. Trusted activity detail or command subject, if it reads like a task title and
+   is supplied by the running tool.
 4. Content title for non-terminal content.
 5. Repository, worktree, or working-directory title.
 6. Process or tab-kind fallback.
 
-Automatic task titles may update by default while the tab remains unlocked.
-Once the user manually renames a tab, the title becomes locked and automatic
-updates must not overwrite it. State labels such as `Running`, `Thinking`,
-`Failed`, or `Input needed` should not replace the task title; they belong in
-the trailing accessory and subtitle.
+Provided task titles may update by default while the tab remains unlocked. Once
+the user manually renames a tab, the title becomes locked and terminal, agent,
+repository, process, or status updates must not overwrite it. State labels such
+as `Running`, `Thinking`, `Failed`, or `Input needed` should not replace the
+task title; they belong in the trailing accessory and subtitle.
 
 Alternatives considered:
 
 - Keep directory-first titles and put the task in the subtitle. This is stable
   but makes multiple `alan` + `Codex` tabs slow to distinguish.
+- Have Alan call an LLM to generate tab titles itself. This adds cost, latency,
+  privacy and freshness questions, and duplicates a responsibility that agents
+  such as Codex can already own through terminal title updates.
 - Let title fully track the latest strongest signal, including state. This can
   feel smart but makes the row identity drift while the user is scanning.
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -27,6 +27,8 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
   preserving a user-edited title lock.
 - Use the existing leading split indicator unchanged, with state glyphs in the
   trailing accessory slot and state text in the subtitle when needed.
+- Remove the inline pin glyph because pinned state is already conveyed by a
+  tab's position in the pinned section.
 - Add a Clear action that closes inactive temporary tabs in the current Space.
 - Keep Clear conservative: unpinned tabs only, never the selected tab, and never
   tabs protected by active task state.
@@ -129,6 +131,13 @@ Alternatives considered:
 The leading split/topology indicator should stay dedicated to pane structure and
 pane focus. It should not become a state or agent icon, because split structure
 is already interactive and stable in that position.
+
+Pinned state should not consume inline title-row space. Pinned tabs are visually
+identified by their placement in the pinned section above the divider, so a
+separate `pin.fill` glyph after the title is redundant and makes the compact row
+harder to scan. Pin/unpin actions should remain available through the existing
+context menu and command paths, and accessibility labels may continue to expose
+the pinned state.
 
 The trailing accessory slot should carry state at rest and become the close
 button when the row is hovered or keyboard focused. High-priority states should

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -21,6 +21,12 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
   material background on hover or keyboard focus.
 - Let real tab rows render as either a vertically centered single line or a
   meaningful two-line row without changing the row's overall visual system.
+- Make ordinary tab rows fastest to identify by task first, then context, then
+  process or structure.
+- Support automatic task titles from agent/activity signals while preserving a
+  user-edited title lock.
+- Use the existing leading split indicator unchanged, with state glyphs in the
+  trailing accessory slot and state text in the subtitle when needed.
 - Add a Clear action that closes inactive temporary tabs in the current Space.
 - Keep Clear conservative: unpinned tabs only, never the selected tab, and never
   tabs protected by active task state.
@@ -36,6 +42,9 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
 - No changes to daemon APIs, runtime session APIs, provider configuration, or
   terminal runtime contracts.
 - No dark-mode redesign beyond preserving existing adaptive color behavior.
+- No full agent-title-generation backend in this change if the implementation
+  only has activity/session labels available; the row contract should define
+  where generated titles fit when the signal exists.
 
 ## Decisions
 
@@ -63,12 +72,81 @@ or activity information that is not just a fallback category or a repeat of the
 title. Single-line tabs should keep the title vertically centered in the same
 row geometry; two-line tabs should use tighter spacing so they remain compact.
 
+Subtitle display should use three tiers:
+
+- Required: actionable or exceptional states such as input needed, failed,
+  paused, exited, renderer failed, read-only, starting, or a high-priority
+  activity in a non-primary pane.
+- Recommended: disambiguating context for a task-title tab, such as repository,
+  worktree, branch, agent, process, long-running command, or split-pane count.
+- Hidden: fallback or duplicate metadata such as `Terminal`, `Shell`, a repeated
+  directory name, or a default shell process that does not help distinguish the
+  tab.
+
 Alternatives considered:
 
 - Always hide subtitles. This improves density but removes useful terminal and
   agent context.
 - Always show subtitles with smaller fonts. This keeps context but still makes
   ordinary idle tabs visually busy.
+
+### Prefer task-first titles with user title lock
+
+The row title should be the stable identity of the tab. For agent-backed or
+activity-backed tabs, the best title is the task being done, not merely the
+directory or process. A generated or activity-derived task title such as
+`Fix sidebar tab drag` should outrank `alan` or `Codex` when it is available and
+safe to show.
+
+Title source priority should be:
+
+1. User-edited locked title.
+2. Automatic agent/activity task title.
+3. Trusted activity detail or command subject, if it reads like a task title.
+4. Content title for non-terminal content.
+5. Repository, worktree, or working-directory title.
+6. Process or tab-kind fallback.
+
+Automatic task titles may update by default while the tab remains unlocked.
+Once the user manually renames a tab, the title becomes locked and automatic
+updates must not overwrite it. State labels such as `Running`, `Thinking`,
+`Failed`, or `Input needed` should not replace the task title; they belong in
+the trailing accessory and subtitle.
+
+Alternatives considered:
+
+- Keep directory-first titles and put the task in the subtitle. This is stable
+  but makes multiple `alan` + `Codex` tabs slow to distinguish.
+- Let title fully track the latest strongest signal, including state. This can
+  feel smart but makes the row identity drift while the user is scanning.
+
+### Keep structure left and status right
+
+The leading split/topology indicator should stay dedicated to pane structure and
+pane focus. It should not become a state or agent icon, because split structure
+is already interactive and stable in that position.
+
+The trailing accessory slot should carry state at rest and become the close
+button when the row is hovered or keyboard focused. High-priority states should
+also appear as the first subtitle token so they remain visible when the close
+button temporarily replaces the glyph. Idle rows may leave the trailing slot
+empty until hover.
+
+State priority should follow the product search order:
+
+1. Needs input, failed, paused, exited, renderer failed, read-only, starting.
+2. Project or repository context.
+3. Agent, command, process, or progress.
+4. Structure and content type.
+
+Alternatives considered:
+
+- Put state glyphs in the title. This makes status easy to notice but destabilizes
+  the task-title visual anchor.
+- Put state glyphs in the leading split indicator. This hides pane structure and
+  overloads an existing interactive control.
+- Put state only in the subtitle. This is compact but not fast enough for
+  high-priority scanning.
 
 ### Add Clear as a batch state mutation
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -1,0 +1,134 @@
+## Context
+
+Alan's macOS shell sidebar already follows the broad Arc-like structure: a
+material sidebar, a fixed Space slider, a New Tab row, and pinned/unpinned tab
+sections. The current row implementation is split between
+`ShellCompactEmptyAction` for New Tab and `ShellTabSidebarRow` for real tabs.
+Both rows use independent padding and typography, and real tabs always reserve
+space for a subtitle, which makes the list feel taller than the reference.
+
+The existing state model already distinguishes pinned and unpinned tabs, and
+workspace manifest retention already uses `ShellTabActiveTaskState` with
+`protectsFromPruning` to avoid retiring active work. The Clear affordance should
+reuse that safety model instead of inventing a separate temporary-tab concept.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make New Tab and ordinary tab rows share one compact sidebar row geometry.
+- Match the Arc-style New Tab interaction: quiet at rest, full-row rounded
+  material background on hover or keyboard focus.
+- Let real tab rows render as either a vertically centered single line or a
+  meaningful two-line row without changing the row's overall visual system.
+- Add a Clear action that closes inactive temporary tabs in the current Space.
+- Keep Clear conservative: unpinned tabs only, never the selected tab, and never
+  tabs protected by active task state.
+- Preserve existing tab creation, selection, pin/unpin, close, drag, and reorder
+  semantics.
+
+**Non-Goals:**
+
+- No browser-history model, undo stack, recently closed tab list, or global
+  "clear all spaces" behavior.
+- No confirmation dialog for Clear in the initial design; safety comes from
+  strict eligibility.
+- No changes to daemon APIs, runtime session APIs, provider configuration, or
+  terminal runtime contracts.
+- No dark-mode redesign beyond preserving existing adaptive color behavior.
+
+## Decisions
+
+### Use one sidebar row metric model
+
+Create a small row metric source for sidebar navigation rows, either private to
+`ShellSidebarView.swift` or in `ShellDesignTokens.swift` if reused by multiple
+sidebar views. It should define the compact row height, horizontal inset,
+leading icon slot, close slot, text spacing, and drag/drop midpoint.
+
+Alternatives considered:
+
+- Tune `ShellCompactEmptyAction` and `ShellTabSidebarRow` separately. This is
+  faster but would preserve two visual systems and make future row polish drift.
+- Move all sidebar row rendering into a new component file immediately. That may
+  be useful later, but this change can stay focused unless `ShellSidebarView` is
+  already too awkward to edit safely.
+
+### Make subtitle presence meaningful
+
+`ShellTabSidebarRow` should choose single-line or two-line layout from a
+meaningful subtitle decision rather than always rendering the subtitle line.
+The subtitle is meaningful when it adds task, branch, folder, process, content,
+or activity information that is not just a fallback category or a repeat of the
+title. Single-line tabs should keep the title vertically centered in the same
+row geometry; two-line tabs should use tighter spacing so they remain compact.
+
+Alternatives considered:
+
+- Always hide subtitles. This improves density but removes useful terminal and
+  agent context.
+- Always show subtitles with smaller fonts. This keeps context but still makes
+  ordinary idle tabs visually busy.
+
+### Add Clear as a batch state mutation
+
+Clear should be a distinct shell operation that computes eligible tabs for the
+current Space and closes them as one deterministic mutation. A tab is eligible
+when it is:
+
+- in the active Space,
+- unpinned,
+- not the selected tab,
+- and not protected by its current `ShellTabActiveTaskState`.
+
+The host should compute active task state from current runtime metadata when
+available, falling back to persisted tab activity metadata where appropriate.
+The mutation should preserve selected tab and pane focus if they remain valid.
+
+Alternatives considered:
+
+- Invoke existing close-tab behavior repeatedly from the Clear button. This
+  reuses code but can stop midway if a guard appears and is harder to reason
+  about in tests.
+- Show a confirmation dialog listing tabs. This is safer in the abstract but too
+  heavy for an Arc-like lightweight cleanup control, and the eligibility rule is
+  already conservative.
+
+### Show Clear only when it can act
+
+Clear should appear as a subtle trailing affordance in the divider/control row
+above New Tab only when the active Space has at least one eligible inactive
+temporary tab. If no tabs are eligible, Clear should be hidden rather than
+disabled.
+
+Alternatives considered:
+
+- Always show disabled Clear. This explains the feature but adds persistent
+  visual noise.
+- Put Clear in a context menu only. This hides useful cleanup for the common
+  temporary-tab workflow.
+
+## Risks / Trade-offs
+
+- [Risk] Row height may still feel off when measured against the reference.
+  -> Tune the metric through screenshot verification in Alan Dev after a fresh
+  relaunch.
+- [Risk] Subtitle filtering might hide context a user expected.
+  -> Keep the meaningful-subtitle helper focused and covered by small tests.
+- [Risk] Runtime active-task metadata can lag briefly behind terminal state.
+  -> Use the same protection primitive as pruning and keep Clear eligible only
+  when the task state is inactive or otherwise unprotected.
+- [Risk] Batch closing can expose assumptions in mutation result focus repair.
+  -> Add model tests for selected-tab preservation, protected-tab retention, and
+  empty-Space outcomes.
+
+## Migration Plan
+
+This is a local UI and shell-state behavior change. Existing workspace manifests
+do not need migration. Rollback is reverting the OpenSpec change and associated
+Swift code.
+
+## Open Questions
+
+None. The initial Clear scope is current Space only, inactive unpinned tabs
+only, and selected/protected tabs are retained.

--- a/openspec/changes/polish-macos-sidebar-tab-rows/design.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/design.md
@@ -29,6 +29,8 @@ reuse that safety model instead of inventing a separate temporary-tab concept.
   trailing accessory slot and state text in the subtitle when needed.
 - Remove the inline pin glyph because pinned state is already conveyed by a
   tab's position in the pinned section.
+- Make the tab row context menu act only on the clicked tab, with a compact
+  Arc-like action set tailored to Alan's terminal model.
 - Add a Clear action that closes inactive temporary tabs in the current Space.
 - Keep Clear conservative: unpinned tabs only, never the selected tab, and never
   tabs protected by active task state.
@@ -160,6 +162,65 @@ Alternatives considered:
   overloads an existing interactive control.
 - Put state only in the subtitle. This is compact but not fast enough for
   high-priority scanning.
+
+### Make tab context menus tab-scoped
+
+The sidebar tab row context menu should contain only actions that operate on the
+clicked tab. The current `New Terminal Tab` entry does not satisfy that rule
+because it creates a sibling tab in the Space rather than acting on the clicked
+tab; it should remain available from the New Tab row, app commands, and any
+Space-level menu, but not from a tab row context menu.
+
+The target menu should be:
+
+1. `Rename...`
+2. `Duplicate Tab`
+3. `Open in Split View`
+4. divider
+5. `Pin Tab` or `Unpin Tab`
+6. `Move to` submenu, shown only when another Space exists
+7. divider
+8. `Close Tab`
+
+`Rename...` should enter the same user-title-lock path described above: once
+the user renames the tab, terminal, agent, activity, repository, process, and
+status updates must not overwrite that title. The menu item acts on the clicked
+tab even if that tab is not currently selected.
+
+`Duplicate Tab` should create a fresh tab in the same Space near the clicked
+tab, using the clicked tab's launch context where Alan can represent it: terminal
+profile, working directory, shell command or restartable command subject, and
+safe pane layout metadata. It must not pretend to clone live process state,
+scrollback, pending approvals, runtime sessions, or title locks. If a tab cannot
+be duplicated safely, the item should be disabled with an availability reason
+rather than producing a partial clone.
+
+`Open in Split View` should map to Alan's existing terminal split model rather
+than introduce a separate browser-style split-tab group. It should operate on the
+clicked tab, select that tab if necessary, and create a right-side split from the
+clicked tab's focused pane or primary pane using the existing split creation
+path. It should be disabled for tabs whose content cannot be split through the
+terminal pane model.
+
+Pin and unpin remain organization actions, but they should be menu commands only
+rather than row badges. `Move to` remains a destination submenu for other Spaces.
+`Close Tab` stays the destructive final action and keeps Alan's existing close
+semantics; this change does not introduce Arc-style `Archive Tab` behavior.
+
+Browser-specific entries such as `Copy Link`, `Share`, `Change Icon...`, `Mute`,
+and `Customize Page...` should stay out of the initial Alan menu until Alan has a
+real tab URL, sharing, icon, audio, or page-customization contract. Clear is also
+excluded because it is a batch operation over multiple inactive tabs, not an
+operation on the clicked tab.
+
+Alternatives considered:
+
+- Mirror Arc's full menu. This would add familiar labels but several entries do
+  not have Alan product semantics yet and would make the menu feel speculative.
+- Keep only currently implemented commands. This is easy but misses the intended
+  tab identity and duplication workflow that the menu should grow into.
+- Add `Archive Tab`. The chosen removal semantic is `Close Tab`; recovery or
+  history can be designed separately if Alan later needs it.
 
 ### Add Clear as a batch state mutation
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -22,6 +22,8 @@ or active work.
   task-title disambiguation, and hidden for fallback or duplicate metadata.
 - Keep the existing leading split indicator unchanged, and use the trailing
   accessory slot for state glyphs at rest and the close button on hover.
+- Remove the inline pin glyph from tab rows because pinned position and section
+  grouping already convey pinned state visually.
 - Add a Clear affordance in the active Space tab list that closes eligible
   temporary tabs in one action.
 - Define eligible temporary tabs as current-Space unpinned tabs that are not the

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The macOS sidebar tab list is currently taller and heavier than the Arc-like
+reference Alan is targeting, especially around the New Tab row and ordinary
+terminal tab rows. The sidebar also lacks a lightweight Clear affordance for
+removing inactive temporary tabs without touching pinned tabs, the current tab,
+or active work.
+
+## What Changes
+
+- Tighten the sidebar row system so New Tab and ordinary tab rows share one
+  compact geometry.
+- Make New Tab match Arc-style states: quiet at rest, full-row rounded material
+  background on hover or keyboard focus, and no persistent background.
+- Keep real tab rows compact while supporting either a vertically centered
+  single line or a meaningful two-line presentation within the same visual
+  system.
+- Add a Clear affordance in the active Space tab list that closes eligible
+  temporary tabs in one action.
+- Define eligible temporary tabs as current-Space unpinned tabs that are not the
+  selected tab and whose active task state does not protect them from pruning.
+- Preserve existing tab creation, selection, pin/unpin, close, and drag/reorder
+  data model semantics.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Refine the default sidebar tab row visual and
+  interaction contract for New Tab, compact tab rows, and Clear inactive tabs.
+
+## Impact
+
+- Affected code:
+  - `clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift`
+  - `clients/apple/alan-macos/Support/ShellDesignTokens.swift`, if shared row
+    metrics belong in tokens instead of the view file
+  - `clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift`
+  - `clients/apple/alan-macos/ShellHostController.swift`
+  - Relevant shell action or sidebar tests under `clients/apple/scripts/`
+- No network protocol, daemon API, provider, runtime, or dependency changes.
+- No breaking changes.

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -15,6 +15,13 @@ or active work.
 - Keep real tab rows compact while supporting either a vertically centered
   single line or a meaningful two-line presentation within the same visual
   system.
+- Shift tab identity toward task-first titles: automatic agent/activity titles
+  should make tabs distinguishable by what they are doing, while user-edited
+  titles remain locked and are not overwritten.
+- Use subtitles selectively: required for actionable states, recommended for
+  task-title disambiguation, and hidden for fallback or duplicate metadata.
+- Keep the existing leading split indicator unchanged, and use the trailing
+  accessory slot for state glyphs at rest and the close button on hover.
 - Add a Clear affordance in the active Space tab list that closes eligible
   temporary tabs in one action.
 - Define eligible temporary tabs as current-Space unpinned tabs that are not the

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -24,6 +24,10 @@ or active work.
   accessory slot for state glyphs at rest and the close button on hover.
 - Remove the inline pin glyph from tab rows because pinned position and section
   grouping already convey pinned state visually.
+- Replace the tab row context menu with a tab-scoped Arc-like menu: `Rename...`,
+  `Duplicate Tab`, `Open in Split View`, pin or unpin, `Move to`, and `Close Tab`.
+- Remove non-tab-scoped actions such as `New Terminal Tab` from the tab row
+  context menu.
 - Add a Clear affordance in the active Space tab list that closes eligible
   temporary tabs in one action.
 - Define eligible temporary tabs as current-Space unpinned tabs that are not the
@@ -51,6 +55,7 @@ or active work.
   - `clients/apple/alan-macos/Support/ShellDesignTokens.swift`, if shared row
     metrics belong in tokens instead of the view file
   - `clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift`
   - `clients/apple/alan-macos/ShellHostController.swift`
   - Relevant shell action or sidebar tests under `clients/apple/scripts/`
 - No network protocol, daemon API, provider, runtime, or dependency changes.

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -15,9 +15,9 @@ or active work.
 - Keep real tab rows compact while supporting either a vertically centered
   single line or a meaningful two-line presentation within the same visual
   system.
-- Shift tab identity toward task-first titles: automatic agent/activity titles
-  should make tabs distinguishable by what they are doing, while user-edited
-  titles remain locked and are not overwritten.
+- Shift tab identity toward task-first titles: terminal-provided or
+  agent-provided titles should make tabs distinguishable by what they are doing,
+  while user-edited titles remain locked and are not overwritten.
 - Use subtitles selectively: required for actionable states, recommended for
   task-title disambiguation, and hidden for fallback or duplicate metadata.
 - Keep the existing leading split indicator unchanged, and use the trailing

--- a/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/proposal.md
@@ -19,6 +19,8 @@ or active work.
   temporary tabs in one action.
 - Define eligible temporary tabs as current-Space unpinned tabs that are not the
   selected tab and whose active task state does not protect them from pruning.
+- Repair sidebar tab drag/reorder so pointer drag from a tab row reliably
+  carries the dragged tab identity into the drop target and applies the reorder.
 - Preserve existing tab creation, selection, pin/unpin, close, and drag/reorder
   data model semantics.
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -41,9 +41,9 @@ the terminal sidebar feel like a dashboard or debug surface.
 - **AND** the row does not resize the sidebar or shift adjacent rows during
   hover, selection, close-affordance display, or activity progress updates
 
-#### Scenario: Task title identifies agent work
-- **WHEN** an unlocked sidebar tab has an automatic agent or activity task title
-  that describes the work being done
+#### Scenario: Provided task title identifies agent work
+- **WHEN** an unlocked sidebar tab has a terminal-provided or agent-provided
+  task title that describes the work being done
 - **THEN** alan uses that task title as the primary row title instead of falling
   back to the repository, directory, process, or agent name
 - **AND** state labels such as running, thinking, failed, or input needed do not
@@ -52,7 +52,7 @@ the terminal sidebar feel like a dashboard or debug surface.
 #### Scenario: User-edited title is locked
 - **WHEN** the user manually edits a sidebar tab title
 - **THEN** alan treats the title as locked
-- **AND** automatic agent, activity, repository, process, or status changes do
+- **AND** terminal, agent, activity, repository, process, or status updates do
   not overwrite that locked title
 
 #### Scenario: Subtitle is required for actionable state
@@ -63,9 +63,9 @@ the terminal sidebar feel like a dashboard or debug surface.
 - **AND** the subtitle may include context tokens after the state when space
   allows
 
-#### Scenario: Subtitle disambiguates task titles
-- **WHEN** a tab title is a generated or activity-derived task title and context
-  is available
+#### Scenario: Subtitle disambiguates provided task titles
+- **WHEN** a tab title is a terminal-provided or agent-provided task title and
+  context is available
 - **THEN** alan shows a subtitle that starts with stable project, repository,
   worktree, directory, or branch context
 - **AND** the subtitle may include agent, process, command, progress, or split

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -68,3 +68,26 @@ the terminal sidebar feel like a dashboard or debug surface.
   than the former taller-row midpoint
 - **AND** hover, selected, close, and progress states do not change the
   insertion hit geometry
+
+#### Scenario: Tab drag carries source identity through the drop session
+- **WHEN** the user starts dragging a sidebar tab row
+- **THEN** the drag session carries the dragged tab identity and source
+  organization location as part of the drag payload or an equivalent
+  session-scoped source record
+- **AND** the drop target does not depend solely on transient hover or row
+  gesture state that can be cleared before the drop is performed
+
+#### Scenario: Dropping a tab reorders the sidebar
+- **WHEN** the user drops a dragged tab onto a valid pinned or unpinned sidebar
+  insertion target in the current Space
+- **THEN** alan routes the drop through the same host reorder operation used by
+  command and automation paths
+- **AND** the tab order, pin state, selected tab, and pane identity match the
+  requested insertion target
+
+#### Scenario: Invalid tab drop leaves order unchanged
+- **WHEN** the user drops a tab payload with a missing tab, stale source
+  location, incompatible section, or invalid target index
+- **THEN** alan rejects the drop without changing tab order, pin state, selected
+  tab, or pane identity
+- **AND** alan clears any insertion preview state after the rejected drop

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -106,6 +106,46 @@ the terminal sidebar feel like a dashboard or debug surface.
 - **AND** pin and unpin actions remain available through existing command and
   context-menu surfaces
 
+#### Scenario: Tab context menu is scoped to the clicked tab
+- **WHEN** the user opens the context menu for a sidebar tab row
+- **THEN** every visible tab-row context menu action targets the clicked tab
+  rather than the selected tab, the Space, or the whole sidebar
+- **AND** alan does not show `New Terminal Tab`, Clear, or other non-tab-scoped
+  actions in the tab-row context menu
+
+#### Scenario: Tab context menu uses the compact tab action set
+- **WHEN** the user opens the context menu for a sidebar tab row
+- **THEN** alan offers `Rename...`, `Duplicate Tab`, and `Open in Split View`
+  before organization actions
+- **AND** alan offers either `Pin Tab` or `Unpin Tab`, plus a `Move to` submenu
+  only when another Space exists
+- **AND** alan presents `Close Tab` as the final destructive action
+
+#### Scenario: Rename from context menu locks title
+- **WHEN** the user chooses `Rename...` from a sidebar tab row context menu and
+  commits a title
+- **THEN** alan applies that title to the clicked tab
+- **AND** alan treats the title as user locked so automatic terminal, agent,
+  activity, repository, process, or status updates do not overwrite it
+
+#### Scenario: Duplicate tab creates a fresh launch-context copy
+- **WHEN** the user chooses `Duplicate Tab` from a sidebar tab row context menu
+- **THEN** alan creates a new tab in the same Space near the clicked tab using
+  the clicked tab's safe launch context
+- **AND** alan does not clone live process state, scrollback, pending approvals,
+  runtime sessions, or user title locks
+- **AND** alan disables the item when the clicked tab cannot be duplicated
+  safely
+
+#### Scenario: Open in Split View uses the clicked tab split model
+- **WHEN** the user chooses `Open in Split View` from a sidebar tab row context
+  menu
+- **THEN** alan operates on the clicked tab, selecting it if necessary
+- **AND** alan creates a right-side split from the clicked tab's focused pane or
+  primary pane through the existing terminal split path
+- **AND** alan disables the item when the clicked tab content cannot be split
+  through the terminal pane model
+
 #### Scenario: Clear appears only for eligible temporary tabs
 - **WHEN** the active Space has at least one unpinned tab that is not selected
   and whose active task state does not protect it from pruning

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Sidebar tab rows use compact Arc-like behavior
+The default macOS shell sidebar SHALL render New Tab, Clear, and ordinary tab
+rows with compact, stable geometry that supports quick scanning without making
+the terminal sidebar feel like a dashboard or debug surface.
+
+#### Scenario: New Tab idle state is quiet
+- **WHEN** the active Space tab list displays the New Tab row and the pointer
+  and keyboard focus are elsewhere
+- **THEN** the New Tab row uses muted icon and text treatment without a
+  persistent row background
+- **AND** the New Tab row shares the same row metric system as ordinary sidebar
+  tab rows
+
+#### Scenario: New Tab hover and focus state
+- **WHEN** the pointer hovers the New Tab row or keyboard focus reaches it
+- **THEN** the New Tab row shows a full-width rounded material hover background
+  within the sidebar row bounds
+- **AND** the hover or focus state does not select a tab, scroll the list, or
+  preview a Space
+
+#### Scenario: New Tab creates ordinary unpinned tab
+- **WHEN** the user activates the New Tab row
+- **THEN** alan creates a normal unpinned terminal tab in the current Space
+- **AND** the new tab becomes selected through the existing tab creation
+  behavior
+
+#### Scenario: Ordinary tab row uses single-line layout
+- **WHEN** an ordinary sidebar tab has no meaningful subtitle
+- **THEN** the row displays the title as a single line vertically centered in
+  the compact tab row
+- **AND** the row does not reserve visible subtitle space for fallback or
+  duplicate metadata
+
+#### Scenario: Ordinary tab row uses two-line layout
+- **WHEN** an ordinary sidebar tab has meaningful secondary metadata such as
+  task status, activity, branch, folder, process, or content kind
+- **THEN** the row displays the title and secondary metadata as two lines within
+  the compact tab row system
+- **AND** the row does not resize the sidebar or shift adjacent rows during
+  hover, selection, close-affordance display, or activity progress updates
+
+#### Scenario: Clear appears only for eligible temporary tabs
+- **WHEN** the active Space has at least one unpinned tab that is not selected
+  and whose active task state does not protect it from pruning
+- **THEN** alan shows a subtle Clear affordance in the divider/control row above
+  New Tab
+- **AND** the Clear affordance remains secondary to the New Tab row and ordinary
+  tab rows
+
+#### Scenario: Clear is hidden when no tab can be cleared
+- **WHEN** the active Space has no eligible inactive unpinned tabs
+- **THEN** alan does not show a disabled or persistent Clear affordance in the
+  default sidebar
+
+#### Scenario: Clear closes only inactive temporary tabs
+- **WHEN** the user activates Clear
+- **THEN** alan closes eligible inactive unpinned tabs in the current Space as a
+  single cleanup operation
+- **AND** alan keeps pinned tabs, the selected tab, tabs in other Spaces, and
+  tabs whose active task state protects them from pruning
+- **AND** alan preserves valid selected tab and pane focus after cleanup
+
+#### Scenario: Drag insertion follows compact row geometry
+- **WHEN** the user drags a tab over the compact sidebar tab list
+- **THEN** insertion target calculation uses the compact row midpoint rather
+  than the former taller-row midpoint
+- **AND** hover, selected, close, and progress states do not change the
+  insertion hit geometry

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -34,12 +34,68 @@ the terminal sidebar feel like a dashboard or debug surface.
   duplicate metadata
 
 #### Scenario: Ordinary tab row uses two-line layout
-- **WHEN** an ordinary sidebar tab has meaningful secondary metadata such as
-  task status, activity, branch, folder, process, or content kind
+- **WHEN** an ordinary sidebar tab has required or useful secondary metadata
+  such as actionable status, activity, branch, folder, process, or content kind
 - **THEN** the row displays the title and secondary metadata as two lines within
   the compact tab row system
 - **AND** the row does not resize the sidebar or shift adjacent rows during
   hover, selection, close-affordance display, or activity progress updates
+
+#### Scenario: Task title identifies agent work
+- **WHEN** an unlocked sidebar tab has an automatic agent or activity task title
+  that describes the work being done
+- **THEN** alan uses that task title as the primary row title instead of falling
+  back to the repository, directory, process, or agent name
+- **AND** state labels such as running, thinking, failed, or input needed do not
+  replace the task title
+
+#### Scenario: User-edited title is locked
+- **WHEN** the user manually edits a sidebar tab title
+- **THEN** alan treats the title as locked
+- **AND** automatic agent, activity, repository, process, or status changes do
+  not overwrite that locked title
+
+#### Scenario: Subtitle is required for actionable state
+- **WHEN** a tab has an actionable or exceptional state such as input needed,
+  failed, paused, exited, renderer failed, read-only, starting, or high-priority
+  activity in another pane
+- **THEN** alan shows a subtitle with the actionable state as the first token
+- **AND** the subtitle may include context tokens after the state when space
+  allows
+
+#### Scenario: Subtitle disambiguates task titles
+- **WHEN** a tab title is a generated or activity-derived task title and context
+  is available
+- **THEN** alan shows a subtitle that starts with stable project, repository,
+  worktree, directory, or branch context
+- **AND** the subtitle may include agent, process, command, progress, or split
+  context after the stable location token
+
+#### Scenario: Subtitle is hidden for fallback metadata
+- **WHEN** a tab has no actionable state and its secondary metadata is only a
+  fallback type, default shell process, duplicate directory, or otherwise
+  non-disambiguating label
+- **THEN** alan renders the row in single-line mode without a visible subtitle
+
+#### Scenario: Leading split indicator remains structural
+- **WHEN** a tab has one or more panes
+- **THEN** the leading sidebar indicator continues to represent pane topology
+  and focused-pane interaction
+- **AND** alan does not replace the leading split indicator with agent, process,
+  status, or content-type glyphs
+
+#### Scenario: Trailing accessory shows state until close is needed
+- **WHEN** a tab has a non-idle state that is useful for scanning
+- **THEN** alan shows a compact state glyph or progress affordance in the
+  trailing accessory slot while the row is not hovered
+- **AND WHEN** the pointer hovers the row or keyboard focus reaches it
+- **THEN** the trailing accessory can become the close button without removing
+  required state text from the subtitle or accessibility label
+
+#### Scenario: Idle trailing accessory is quiet
+- **WHEN** a tab has no useful scanning state
+- **THEN** alan keeps the trailing accessory slot visually quiet until hover or
+  keyboard focus reveals the close button
 
 #### Scenario: Clear appears only for eligible temporary tabs
 - **WHEN** the active Space has at least one unpinned tab that is not selected

--- a/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/specs/macos-shell-ui-ux-conformance/spec.md
@@ -97,6 +97,15 @@ the terminal sidebar feel like a dashboard or debug surface.
 - **THEN** alan keeps the trailing accessory slot visually quiet until hover or
   keyboard focus reveals the close button
 
+#### Scenario: Pinned state is conveyed by section position
+- **WHEN** a tab is pinned in the default sidebar
+- **THEN** alan displays it in the pinned tab section above the New Tab row and
+  divider
+- **AND** alan does not show a separate inline pin glyph in the tab row title or
+  trailing accessory area
+- **AND** pin and unpin actions remain available through existing command and
+  context-menu surfaces
+
 #### Scenario: Clear appears only for eligible temporary tabs
 - **WHEN** the active Space has at least one unpinned tab that is not selected
   and whose active task state does not protect it from pruning

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -1,8 +1,10 @@
 ## 1. Row Metrics And Subtitle Semantics
 
 - [ ] 1.1 Add a single compact sidebar row metric source for row height, icon slot, text spacing, close slot, horizontal inset, and drag midpoint.
-- [ ] 1.2 Add a focused helper for meaningful sidebar tab subtitles so fallback or duplicate metadata can use the single-line layout.
-- [ ] 1.3 Cover subtitle and metric helper behavior with focused Swift script tests or adjacent model tests.
+- [ ] 1.2 Add a task-title source priority helper for sidebar tabs, including automatic agent/activity titles and locked user-edited titles.
+- [ ] 1.3 Add a focused helper for required, recommended, and hidden sidebar subtitles so fallback or duplicate metadata can use the single-line layout.
+- [ ] 1.4 Add a trailing accessory state projection that shows state glyph/progress at rest and yields to the close button on hover or keyboard focus.
+- [ ] 1.5 Cover title priority, title lock, subtitle tier, trailing accessory, and metric helper behavior with focused Swift script tests or adjacent model tests.
 
 ## 2. Clear Temporary Tabs Behavior
 
@@ -15,18 +17,20 @@
 
 - [ ] 3.1 Update `ShellCompactEmptyAction` or its replacement so New Tab uses the compact row metrics and Arc-like idle, hover, and keyboard-focus states.
 - [ ] 3.2 Update `ShellTabSidebarRow` so ordinary tabs render compact single-line and two-line layouts without row-size shifts.
-- [ ] 3.3 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
-- [ ] 3.4 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
-- [ ] 3.5 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
-- [ ] 3.6 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
+- [ ] 3.3 Keep the existing leading split indicator dedicated to pane topology and focused-pane interaction.
+- [ ] 3.4 Add the trailing state accessory behavior without changing row width or replacing required subtitle/accessibility state.
+- [ ] 3.5 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
+- [ ] 3.6 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
+- [ ] 3.7 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
+- [ ] 3.8 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
 
 ## 4. Verification
 
-- [ ] 4.1 Run the focused Swift script tests covering row semantics, Clear behavior, drag/drop payload validation, and tab organization.
+- [ ] 4.1 Run the focused Swift script tests covering row semantics, task-title priority, title lock, subtitle tiers, trailing state accessory, Clear behavior, drag/drop payload validation, and tab organization.
 - [ ] 4.2 Run `bash clients/apple/scripts/test-shell-tab-organization.sh`.
 - [ ] 4.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.4 Run the relevant macOS build or test lane for the Alan app.
-- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, and two-line tab states.
+- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, two-line task-title tab, actionable-state tab, idle trailing accessory, and hover close-button replacement states.
 - [ ] 4.6 In the fresh Alan Dev run, manually verify pointer drag reorders sidebar tabs within the same section and across pinned/unpinned sections.
 - [ ] 4.7 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -19,10 +19,11 @@
 - [ ] 3.2 Update `ShellTabSidebarRow` so ordinary tabs render compact single-line and two-line layouts without row-size shifts.
 - [ ] 3.3 Keep the existing leading split indicator dedicated to pane topology and focused-pane interaction.
 - [ ] 3.4 Add the trailing state accessory behavior without changing row width or replacing required subtitle/accessibility state.
-- [ ] 3.5 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
-- [ ] 3.6 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
-- [ ] 3.7 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
-- [ ] 3.8 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
+- [ ] 3.5 Remove the inline pin glyph from tab rows while preserving pinned-section placement, pin/unpin commands, context-menu actions, and accessibility semantics.
+- [ ] 3.6 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
+- [ ] 3.7 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
+- [ ] 3.8 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
+- [ ] 3.9 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
 
 ## 4. Verification
 
@@ -30,7 +31,7 @@
 - [ ] 4.2 Run `bash clients/apple/scripts/test-shell-tab-organization.sh`.
 - [ ] 4.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.4 Run the relevant macOS build or test lane for the Alan app.
-- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, two-line task-title tab, actionable-state tab, idle trailing accessory, and hover close-button replacement states.
+- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, pinned-section tabs without inline pin glyphs, Clear visible, single-line tab, two-line task-title tab, actionable-state tab, idle trailing accessory, and hover close-button replacement states.
 - [ ] 4.6 In the fresh Alan Dev run, manually verify pointer drag reorders sidebar tabs within the same section and across pinned/unpinned sections.
 - [ ] 4.7 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -20,18 +20,23 @@
 - [ ] 3.3 Keep the existing leading split indicator dedicated to pane topology and focused-pane interaction.
 - [ ] 3.4 Add the trailing state accessory behavior without changing row width or replacing required subtitle/accessibility state.
 - [ ] 3.5 Remove the inline pin glyph from tab rows while preserving pinned-section placement, pin/unpin commands, context-menu actions, and accessibility semantics.
-- [ ] 3.6 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
-- [ ] 3.7 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
-- [ ] 3.8 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
-- [ ] 3.9 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
+- [ ] 3.6 Replace the tab row context menu with the tab-scoped menu order: `Rename...`, `Duplicate Tab`, `Open in Split View`, pin/unpin, `Move to`, and `Close Tab`.
+- [ ] 3.7 Remove `New Terminal Tab` and other non-tab-scoped actions from the tab row context menu.
+- [ ] 3.8 Add or extend shell actions for context-menu rename, duplicate tab, and open-in-split-view with clicked-tab targeting and availability reasons.
+- [ ] 3.9 Implement duplicate-tab behavior as a fresh launch-context copy without cloning live process state, scrollback, runtime sessions, pending approvals, or title locks.
+- [ ] 3.10 Implement Open in Split View through the clicked tab's existing terminal split path, disabled for unsupported content.
+- [ ] 3.11 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
+- [ ] 3.12 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
+- [ ] 3.13 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
+- [ ] 3.14 Preserve existing close button, pin/unpin, move-to-space, reorder, and tab creation behavior outside the tab row context menu.
 
 ## 4. Verification
 
-- [ ] 4.1 Run the focused Swift script tests covering row semantics, task-title priority, title lock, subtitle tiers, trailing state accessory, Clear behavior, drag/drop payload validation, and tab organization.
+- [ ] 4.1 Run the focused Swift script tests covering row semantics, task-title priority, title lock, subtitle tiers, trailing state accessory, tab context menu action order and targeting, duplicate-tab behavior, open-in-split-view behavior, Clear behavior, drag/drop payload validation, and tab organization.
 - [ ] 4.2 Run `bash clients/apple/scripts/test-shell-tab-organization.sh`.
 - [ ] 4.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
 - [ ] 4.4 Run the relevant macOS build or test lane for the Alan app.
-- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, pinned-section tabs without inline pin glyphs, Clear visible, single-line tab, two-line task-title tab, actionable-state tab, idle trailing accessory, and hover close-button replacement states.
+- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, pinned-section tabs without inline pin glyphs, tab context menu, Clear visible, single-line tab, two-line task-title tab, actionable-state tab, idle trailing accessory, and hover close-button replacement states.
 - [ ] 4.6 In the fresh Alan Dev run, manually verify pointer drag reorders sidebar tabs within the same section and across pinned/unpinned sections.
 - [ ] 4.7 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -1,0 +1,33 @@
+## 1. Row Metrics And Subtitle Semantics
+
+- [ ] 1.1 Add a single compact sidebar row metric source for row height, icon slot, text spacing, close slot, horizontal inset, and drag midpoint.
+- [ ] 1.2 Add a focused helper for meaningful sidebar tab subtitles so fallback or duplicate metadata can use the single-line layout.
+- [ ] 1.3 Cover subtitle and metric helper behavior with focused Swift script tests or adjacent model tests.
+
+## 2. Clear Temporary Tabs Behavior
+
+- [ ] 2.1 Add a state-level or host-level operation that computes current-Space inactive unpinned tabs eligible for Clear.
+- [ ] 2.2 Implement batch cleanup so Clear closes eligible tabs in one deterministic operation while preserving selected tab and pane focus.
+- [ ] 2.3 Ensure Clear retains pinned tabs, the selected tab, tabs in other Spaces, and tabs protected by `ShellTabActiveTaskState.protectsFromPruning`.
+- [ ] 2.4 Add tests for Clear eligibility, protected-tab retention, selected-tab retention, other-Space isolation, and empty-Space outcomes.
+
+## 3. Sidebar UI Implementation
+
+- [ ] 3.1 Update `ShellCompactEmptyAction` or its replacement so New Tab uses the compact row metrics and Arc-like idle, hover, and keyboard-focus states.
+- [ ] 3.2 Update `ShellTabSidebarRow` so ordinary tabs render compact single-line and two-line layouts without row-size shifts.
+- [ ] 3.3 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
+- [ ] 3.4 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
+- [ ] 3.5 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
+
+## 4. Verification
+
+- [ ] 4.1 Run the focused Swift script tests covering row semantics, Clear behavior, and tab organization.
+- [ ] 4.2 Run the relevant macOS build or test lane for the Alan app.
+- [ ] 4.3 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, and two-line tab states.
+- [ ] 4.4 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
+
+## 5. Review And Archive Readiness
+
+- [ ] 5.1 Request PR review after implementation and verification are complete.
+- [ ] 5.2 Before archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
+- [ ] 5.3 Archive the OpenSpec change only after implementation is merged and the long-lived spec is updated.

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -16,15 +16,19 @@
 - [ ] 3.1 Update `ShellCompactEmptyAction` or its replacement so New Tab uses the compact row metrics and Arc-like idle, hover, and keyboard-focus states.
 - [ ] 3.2 Update `ShellTabSidebarRow` so ordinary tabs render compact single-line and two-line layouts without row-size shifts.
 - [ ] 3.3 Add the Clear affordance above New Tab only when the active Space has eligible inactive unpinned tabs.
-- [ ] 3.4 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
-- [ ] 3.5 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
+- [ ] 3.4 Repair sidebar tab drag so the drag/drop session carries dragged tab identity and source location reliably instead of depending only on transient row gesture state.
+- [ ] 3.5 Update drag/drop insertion midpoint and hit geometry to match the compact row metrics.
+- [ ] 3.6 Preserve existing context menu, close button, pin/unpin, reorder, and tab creation behavior.
 
 ## 4. Verification
 
-- [ ] 4.1 Run the focused Swift script tests covering row semantics, Clear behavior, and tab organization.
-- [ ] 4.2 Run the relevant macOS build or test lane for the Alan app.
-- [ ] 4.3 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, and two-line tab states.
-- [ ] 4.4 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
+- [ ] 4.1 Run the focused Swift script tests covering row semantics, Clear behavior, drag/drop payload validation, and tab organization.
+- [ ] 4.2 Run `bash clients/apple/scripts/test-shell-tab-organization.sh`.
+- [ ] 4.3 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 4.4 Run the relevant macOS build or test lane for the Alan app.
+- [ ] 4.5 Fresh relaunch Alan Dev and capture screenshots for empty Space, New Tab hover, tabs present, Clear visible, single-line tab, and two-line tab states.
+- [ ] 4.6 In the fresh Alan Dev run, manually verify pointer drag reorders sidebar tabs within the same section and across pinned/unpinned sections.
+- [ ] 4.7 Compare screenshots against the Arc references for compact row height, muted New Tab idle state, hover background, Clear placement, and absence of layout shifts.
 
 ## 5. Review And Archive Readiness
 

--- a/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
+++ b/openspec/changes/polish-macos-sidebar-tab-rows/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Row Metrics And Subtitle Semantics
 
 - [ ] 1.1 Add a single compact sidebar row metric source for row height, icon slot, text spacing, close slot, horizontal inset, and drag midpoint.
-- [ ] 1.2 Add a task-title source priority helper for sidebar tabs, including automatic agent/activity titles and locked user-edited titles.
+- [ ] 1.2 Add a task-title source priority helper for sidebar tabs, including terminal-provided or agent-provided titles and locked user-edited titles.
 - [ ] 1.3 Add a focused helper for required, recommended, and hidden sidebar subtitles so fallback or duplicate metadata can use the single-line layout.
 - [ ] 1.4 Add a trailing accessory state projection that shows state glyph/progress at rest and yields to the close button on hover or keyboard focus.
 - [ ] 1.5 Cover title priority, title lock, subtitle tier, trailing accessory, and metric helper behavior with focused Swift script tests or adjacent model tests.

--- a/openspec/changes/polish-macos-workspace-colors/.openspec.yaml
+++ b/openspec/changes/polish-macos-workspace-colors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/polish-macos-workspace-colors/design.md
+++ b/openspec/changes/polish-macos-workspace-colors/design.md
@@ -25,8 +25,10 @@ chrome even though no terminal content is mounted.
   terminal surface.
 - Keep the empty placeholder terminal-first by preserving the `New Tab` primary
   action that creates a normal terminal tab in the current Space.
-- Keep terminal dark canvas, rim, and shadow treatment scoped to terminal
-  content rendering.
+- Keep all rounded rim, clipping, and shadow frame treatment owned by the
+  workspace panel and split/container layer. Terminal content keeps its dark
+  canvas and terminal-specific runtime controls, but it does not own a surface
+  frame.
 - Preserve existing markdown/settings content dispatch and avoid creating
   terminal runtimes for non-terminal content.
 
@@ -68,26 +70,32 @@ chrome even though no terminal content is mounted.
    terminal frame. That fixes the screenshot superficially while leaving the
    wrong ownership boundary in place.
 
-3. **Terminal styling belongs to terminal content.**
+3. **Frames belong to workspace containers; terminal styling belongs to terminal content.**
 
-   Terminal leaves keep the dark terminal canvas and terminal-only controls.
-   The outer workspace container may still provide shared layout clipping,
-   insets, and generic bounds, but the terminal color and terminal-surface
-   treatment must be driven by `ShellContentRenderKind.terminal`, not by the
-   workspace canvas itself. Markdown and settings continue through their bounded
-   content renderers.
+   The outer workspace panel owns the right-side rounded clipping, rim, and
+   shadow. Split layout owns internal boundaries and dividers. Terminal leaves
+   keep the dark terminal canvas and terminal-only controls, but they do not own
+   rounded rim/shadow frame chrome, even in mixed terminal/settings/markdown
+   pane trees. Markdown and settings continue through their bounded content
+   renderers.
 
    Alternative considered: keep one terminal-styled frame around the whole pane
    tree because most current content is terminal content. That preserves the old
    look but conflicts with the content-container contract and makes future
    non-terminal surfaces inherit terminal chrome by default.
 
+   Alternative considered: give terminal leaves their own frame only in mixed
+   pane trees. That preserves more of the old split-terminal visual treatment,
+   but it creates two different ownership models: terminal becomes a
+   self-framed content type while settings and markdown are framed by the
+   workspace. The selected design keeps frame ownership uniform.
+
 ## Risks / Trade-offs
 
-- **Risk:** Moving terminal frame ownership could subtly change split-pane
-  clipping, dividers, and titlebar edges.  
-  **Mitigation:** keep a shared generic workspace frame for layout bounds if
-  needed, and verify single-pane terminal, split terminal, mixed content,
+- **Risk:** Removing terminal leaf frame ownership could make mixed split panes
+  look too flat if dividers do not carry enough boundary information.
+  **Mitigation:** keep the outer workspace panel frame, preserve split divider
+  contrast, and verify single-pane terminal, split terminal, mixed content,
   settings, markdown, and empty Space states.
 
 - **Risk:** Changing the `windowBackdrop` role globally may affect Quick
@@ -104,6 +112,12 @@ chrome even though no terminal content is mounted.
   become stale.  
   **Mitigation:** update tests to assert the new ownership boundary rather than
   the old wrapper location.
+
+- **Risk:** Historical names such as `terminalSurfaceInsets` can keep implying
+  terminal-owned workspace chrome after the architecture changes.
+  **Mitigation:** rename the workspace panel metrics and view parameters to
+  `workspacePanel...` while leaving true terminal runtime/surface-controller
+  names unchanged.
 
 ## Migration Plan
 

--- a/openspec/changes/polish-macos-workspace-colors/design.md
+++ b/openspec/changes/polish-macos-workspace-colors/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Alan's macOS shell already models the right side as a generic content
+container: Spaces, Tabs, and PaneSlots own layout, while ContentInstances own
+terminal, markdown, settings, and future content-specific rendering. The
+current UI implementation mostly follows that model for mounted content:
+terminal leaves go through `ShellTerminalLeafView`, while markdown and settings
+go through `ShellBoundedContentLeafView`.
+
+Two visual details still contradict the model. `MacShellRootView` paints the
+window root with `ShellMaterialBackgroundView(.windowBackdrop)`, which creates a
+translucent material/tint/gradient backing rather than a native opaque base.
+`TerminalPaneView` also applies `ShellTerminalSurfaceFrame` to the entire pane
+canvas, so an empty Space and non-terminal content inherit terminal-surface
+chrome even though no terminal content is mounted.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the primary shell backing surface use an opaque native base color:
+  `rgb(1,1,1)` in light appearance and a solid adaptive dark base in dark
+  appearance.
+- Render an empty selected Space as a workspace-level placeholder, not an empty
+  terminal surface.
+- Keep the empty placeholder terminal-first by preserving the `New Tab` primary
+  action that creates a normal terminal tab in the current Space.
+- Keep terminal dark canvas, rim, and shadow treatment scoped to terminal
+  content rendering.
+- Preserve existing markdown/settings content dispatch and avoid creating
+  terminal runtimes for non-terminal content.
+
+**Non-Goals:**
+
+- No new content picker, `New...` menu, markdown creation flow, or settings
+  shortcut in the empty placeholder.
+- No redesign of the sidebar, collapsed floating sidebar, command palette, or
+  overlay material system beyond root backing interactions needed for this
+  change.
+- No dark-mode design overhaul beyond making the affected surfaces adaptive and
+  legible.
+- No persistence, daemon API, runtime protocol, or content-container model
+  changes.
+
+## Decisions
+
+1. **Root backing becomes solid before any future material pass.**
+
+   The implementation should either update the root-window role or introduce a
+   narrow root-backing view/token so the main shell window paints an opaque
+   adaptive base. Light mode uses `rgb(1,1,1)`. Dark mode uses the existing
+   adaptive palette style with a solid dark value. The root backing must not
+   depend on `NSVisualEffectView`, wallpaper blending, or a gradient wash in
+   this change.
+
+   Alternative considered: keep the material role and tune opacity. That keeps
+   the current Arc-like direction but does not satisfy the requested native app
+   synchronization or make visual verification deterministic across wallpapers.
+
+2. **The empty Space is a workspace placeholder.**
+
+   The no-tab/no-pane branch should render through a dedicated empty workspace
+   placeholder view or equivalent workspace-level branch. It should use adaptive
+   text/control tokens and the current `New Tab` command path, but it should not
+   be wrapped by terminal background, terminal rim, or terminal surface shadow.
+
+   Alternative considered: special-case light colors inside the existing
+   terminal frame. That fixes the screenshot superficially while leaving the
+   wrong ownership boundary in place.
+
+3. **Terminal styling belongs to terminal content.**
+
+   Terminal leaves keep the dark terminal canvas and terminal-only controls.
+   The outer workspace container may still provide shared layout clipping,
+   insets, and generic bounds, but the terminal color and terminal-surface
+   treatment must be driven by `ShellContentRenderKind.terminal`, not by the
+   workspace canvas itself. Markdown and settings continue through their bounded
+   content renderers.
+
+   Alternative considered: keep one terminal-styled frame around the whole pane
+   tree because most current content is terminal content. That preserves the old
+   look but conflicts with the content-container contract and makes future
+   non-terminal surfaces inherit terminal chrome by default.
+
+## Risks / Trade-offs
+
+- **Risk:** Moving terminal frame ownership could subtly change split-pane
+  clipping, dividers, and titlebar edges.  
+  **Mitigation:** keep a shared generic workspace frame for layout bounds if
+  needed, and verify single-pane terminal, split terminal, mixed content,
+  settings, markdown, and empty Space states.
+
+- **Risk:** Changing the `windowBackdrop` role globally may affect Quick
+  Terminal Peak or overlays that currently reuse that role.  
+  **Mitigation:** audit every `.windowBackdrop` usage and introduce a narrower
+  root backing role if an overlay should retain material treatment.
+
+- **Risk:** Dark mode could regress if the solid base is chosen only from the
+  light-mode target.  
+  **Mitigation:** define the base as an adaptive token and verify both resolved
+  color schemes through the existing `ShellAppearanceMode` path.
+
+- **Risk:** Contract tests that currently look for terminal-surface wrappers may
+  become stale.  
+  **Mitigation:** update tests to assert the new ownership boundary rather than
+  the old wrapper location.
+
+## Migration Plan
+
+No persisted state migration is needed. The change is a view/token refactor
+inside the macOS client. Rollback is reverting the root backing token/view and
+the empty workspace placeholder frame ownership.
+
+## Open Questions
+
+- None for this change. Sidebar and overlay material tuning remains a separate
+  future design pass.

--- a/openspec/changes/polish-macos-workspace-colors/proposal.md
+++ b/openspec/changes/polish-macos-workspace-colors/proposal.md
@@ -18,8 +18,9 @@ general content container for terminal, settings, markdown, and future content.
   terminal surface.
 - Keep the empty Space action terminal-first: the primary action remains
   `New Tab` and creates a normal terminal tab in the current Space.
-- Keep terminal-specific dark canvas, rim, and shadow treatment scoped to
-  terminal content leaves.
+- Keep all rounded rim, clipping, and shadow frame treatment scoped to the
+  workspace panel and split/container layer; terminal content keeps only its
+  dark canvas and terminal-specific runtime controls.
 - Keep existing settings and markdown content rendering as bounded content
   surfaces rather than terminal runtime surfaces.
 

--- a/openspec/changes/polish-macos-workspace-colors/proposal.md
+++ b/openspec/changes/polish-macos-workspace-colors/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The macOS shell currently paints the whole window through a translucent,
+material-tinted backdrop and renders an empty Space inside the terminal surface
+frame. This makes light-mode Alan look less like native macOS apps and makes an
+empty generic workspace read as a dark terminal, even though the right side is a
+general content container for terminal, settings, markdown, and future content.
+
+## What Changes
+
+- Make the primary shell window backing color an opaque native-style base color,
+  using `rgb(1,1,1)` in light appearance and a system-appropriate solid dark
+  base in dark appearance.
+- Remove default root-window material, transparency, and gradient wash from the
+  main backing surface for this change; material treatment remains deferred to a
+  later dedicated pass.
+- Treat an empty selected Space as a workspace-level placeholder, not an empty
+  terminal surface.
+- Keep the empty Space action terminal-first: the primary action remains
+  `New Tab` and creates a normal terminal tab in the current Space.
+- Keep terminal-specific dark canvas, rim, and shadow treatment scoped to
+  terminal content leaves.
+- Keep existing settings and markdown content rendering as bounded content
+  surfaces rather than terminal runtime surfaces.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-shell-ui-ux-conformance`: Refine the default shell visual contract so
+  the root backing surface is opaque/native, empty Spaces are generic workspace
+  placeholders, and terminal styling belongs only to terminal content.
+
+## Impact
+
+- Affected code:
+  - `clients/apple/alan-macos/MacShellRootView.swift`
+  - `clients/apple/alan-macos/TerminalPaneView.swift`
+  - `clients/apple/alan-macos/Support/ShellDesignTokens.swift`
+  - Relevant shell UI contract tests under `clients/apple/scripts/`
+- No daemon API, runtime protocol, provider, persistence, or dependency changes.
+- No breaking changes.

--- a/openspec/changes/polish-macos-workspace-colors/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-workspace-colors/specs/macos-shell-ui-ux-conformance/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Root shell backing uses an opaque native base
+The default macOS shell SHALL paint its primary root backing surface with an
+opaque adaptive native base color before content-specific surfaces are rendered.
+
+#### Scenario: Light appearance root backing
+- **WHEN** the default macOS shell window is visible in light appearance
+- **THEN** the root backing surface uses `rgb(1,1,1)` as its base color
+- **AND** the root backing surface does not depend on wallpaper blending,
+  `NSVisualEffectView`, root-level transparency, or a root-level gradient wash
+
+#### Scenario: Dark appearance root backing
+- **WHEN** the default macOS shell window is visible in dark appearance
+- **THEN** the root backing surface uses a solid adaptive dark base color
+- **AND** light-mode tint, root-level material wash, and wallpaper-dependent
+  transparency do not determine the dark appearance backing color
+
+#### Scenario: Root backing is separate from future material surfaces
+- **WHEN** sidebar, floating overlay, command palette, or content-specific
+  material treatments are evaluated
+- **THEN** their material behavior remains owned by their own surface roles
+- **AND** the root backing surface does not force those surfaces to use root
+  material, root transparency, or root gradient treatment
+
+### Requirement: Empty Spaces render as workspace placeholders
+The default macOS shell SHALL render a selected Space with no mounted content as
+a generic workspace placeholder rather than as an empty terminal surface.
+
+#### Scenario: Empty Space placeholder in light appearance
+- **WHEN** the selected Space has no selected tab, pane tree, or mounted content
+  in light appearance
+- **THEN** alan shows an empty workspace placeholder with adaptive light-mode
+  text and control treatment
+- **AND** the placeholder is not painted with the terminal dark canvas,
+  terminal rim, or terminal surface shadow
+
+#### Scenario: Empty Space placeholder in dark appearance
+- **WHEN** the selected Space has no selected tab, pane tree, or mounted content
+  in dark appearance
+- **THEN** alan shows the same empty workspace placeholder using adaptive
+  dark-mode text and control treatment
+- **AND** the placeholder remains readable without reusing terminal-only color
+  assumptions
+
+#### Scenario: Empty Space primary action remains terminal-first
+- **WHEN** the user activates the empty Space `New Tab` action
+- **THEN** alan creates a normal terminal tab in the current Space
+- **AND** the new tab becomes selected through the existing tab creation path
+
+### Requirement: Terminal surface styling is content-scoped
+The default macOS shell SHALL apply terminal canvas and terminal-surface chrome
+only to terminal content rendering, not to the generic workspace canvas or
+non-terminal content.
+
+#### Scenario: Terminal content owns the terminal surface
+- **WHEN** a mounted content leaf has render kind `terminal`
+- **THEN** alan renders the terminal dark canvas and terminal-specific chrome
+  for that terminal content
+- **AND** terminal input, search, paste, runtime metadata, and terminal lifecycle
+  behavior remain scoped to the terminal content instance
+
+#### Scenario: Markdown and settings do not inherit terminal styling
+- **WHEN** a mounted content leaf has render kind `markdown` or `settings`
+- **THEN** alan renders that content through its bounded non-terminal content
+  surface
+- **AND** alan does not create a terminal runtime or apply terminal-only dark
+  canvas assumptions to that content leaf
+
+#### Scenario: Workspace canvas does not imply terminal content
+- **WHEN** the shell renders the shared workspace canvas, split layout bounds,
+  or an unavailable non-terminal placeholder
+- **THEN** alan does not treat that workspace canvas as terminal content
+- **AND** terminal-specific styling appears only after a terminal content leaf
+  is mounted or restored

--- a/openspec/changes/polish-macos-workspace-colors/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-workspace-colors/specs/macos-shell-ui-ux-conformance/spec.md
@@ -48,15 +48,31 @@ a generic workspace placeholder rather than as an empty terminal surface.
 - **THEN** alan creates a normal terminal tab in the current Space
 - **AND** the new tab becomes selected through the existing tab creation path
 
-### Requirement: Terminal surface styling is content-scoped
-The default macOS shell SHALL apply terminal canvas and terminal-surface chrome
-only to terminal content rendering, not to the generic workspace canvas or
-non-terminal content.
+### Requirement: Workspace containers own frame chrome
+The default macOS shell SHALL keep rounded clipping, rim, and shadow frame
+chrome owned by workspace and split containers rather than by individual content
+render kinds.
 
-#### Scenario: Terminal content owns the terminal surface
+#### Scenario: Workspace panel owns the right-side frame
+- **WHEN** the shell renders terminal, markdown, settings, unavailable, or empty
+  workspace content on the right side
+- **THEN** the outer rounded clipping, rim, and shadow come from the shared
+  workspace panel frame
+- **AND** the generic workspace canvas does not use a terminal-specific surface
+  frame to produce that boundary
+
+#### Scenario: Mixed pane trees do not self-frame terminal leaves
+- **WHEN** a split pane tree contains terminal content next to markdown,
+  settings, unavailable, or future non-terminal content
+- **THEN** terminal leaves do not add an extra rounded rim or shadow frame of
+  their own
+- **AND** internal boundaries are expressed by the split container and divider
+  treatment rather than by content-specific outer frames
+
+#### Scenario: Terminal content owns terminal canvas and runtime controls
 - **WHEN** a mounted content leaf has render kind `terminal`
-- **THEN** alan renders the terminal dark canvas and terminal-specific chrome
-  for that terminal content
+- **THEN** alan renders the terminal dark canvas and terminal-specific runtime
+  controls for that terminal content
 - **AND** terminal input, search, paste, runtime metadata, and terminal lifecycle
   behavior remain scoped to the terminal content instance
 

--- a/openspec/changes/polish-macos-workspace-colors/tasks.md
+++ b/openspec/changes/polish-macos-workspace-colors/tasks.md
@@ -1,0 +1,36 @@
+## 1. Surface Ownership
+
+- [ ] 1.1 Audit every `.windowBackdrop`, `ShellMaterialBackgroundView`, and `ShellTerminalSurfaceFrame` usage in the macOS shell path.
+- [ ] 1.2 Add or adjust an adaptive opaque root backing token/view so light appearance uses `rgb(1,1,1)` and dark appearance uses a solid dark base.
+- [ ] 1.3 Update `MacShellRootView` so the primary shell backing uses the opaque root backing instead of root-window material, transparency, or gradient wash.
+- [ ] 1.4 If any non-root overlay still needs the old material behavior, split that behavior into a narrower role instead of reusing the root backing role.
+
+## 2. Workspace Placeholder
+
+- [ ] 2.1 Extract the no-tab/no-pane empty Space branch into a workspace-level placeholder view or equivalent focused branch.
+- [ ] 2.2 Ensure the empty placeholder uses adaptive workspace text/control tokens in both light and dark appearance.
+- [ ] 2.3 Preserve the empty placeholder `New Tab` action so it creates a normal terminal tab in the current Space.
+- [ ] 2.4 Remove terminal dark canvas, terminal rim, and terminal surface shadow ownership from the empty Space placeholder.
+
+## 3. Content Surface Refactor
+
+- [ ] 3.1 Move terminal-surface styling so it is owned by terminal content rendering rather than the whole workspace canvas.
+- [ ] 3.2 Preserve single-terminal, split-terminal, and restored-transcript terminal rendering after moving the terminal surface boundary.
+- [ ] 3.3 Preserve markdown and settings rendering through `ShellBoundedContentLeafView` without terminal runtime creation or terminal-only dark canvas assumptions.
+- [ ] 3.4 Preserve split layout sizing, divider behavior, focus styling, zoom behavior, and close/move actions across terminal, markdown, settings, and unavailable content leaves.
+
+## 4. Verification
+
+- [ ] 4.1 Add or update focused Swift/script tests for root backing ownership, empty Space placeholder ownership, and terminal-surface content scoping.
+- [ ] 4.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [ ] 4.3 Run the relevant focused shell UI Swift script tests touched by the refactor.
+- [ ] 4.4 Run the relevant macOS app build or test lane for the changed Swift files.
+- [ ] 4.5 Fresh relaunch Alan Dev and capture light-mode screenshots for empty Space, terminal tab, markdown content, and settings content.
+- [ ] 4.6 Fresh relaunch Alan Dev and verify dark-mode screenshots or appearance-toggle states for empty Space, terminal tab, markdown content, and settings content.
+- [ ] 4.7 Confirm the light-mode root backing samples as `rgb(1,1,1)` outside content-specific surfaces.
+
+## 5. Review And Archive Readiness
+
+- [ ] 5.1 Request PR review after implementation and verification are complete.
+- [ ] 5.2 Before archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
+- [ ] 5.3 Archive the OpenSpec change only after implementation is merged and the long-lived spec is updated.

--- a/openspec/changes/polish-macos-workspace-colors/tasks.md
+++ b/openspec/changes/polish-macos-workspace-colors/tasks.md
@@ -1,36 +1,36 @@
 ## 1. Surface Ownership
 
-- [ ] 1.1 Audit every `.windowBackdrop`, `ShellMaterialBackgroundView`, and `ShellTerminalSurfaceFrame` usage in the macOS shell path.
-- [ ] 1.2 Add or adjust an adaptive opaque root backing token/view so light appearance uses `rgb(1,1,1)` and dark appearance uses a solid dark base.
-- [ ] 1.3 Update `MacShellRootView` so the primary shell backing uses the opaque root backing instead of root-window material, transparency, or gradient wash.
-- [ ] 1.4 If any non-root overlay still needs the old material behavior, split that behavior into a narrower role instead of reusing the root backing role.
+- [x] 1.1 Audit every `.windowBackdrop`, `ShellMaterialBackgroundView`, and `ShellTerminalSurfaceFrame` usage in the macOS shell path.
+- [x] 1.2 Add or adjust an adaptive opaque root backing token/view so light appearance uses `rgb(1,1,1)` and dark appearance uses a solid dark base.
+- [x] 1.3 Update `MacShellRootView` so the primary shell backing uses the opaque root backing instead of root-window material, transparency, or gradient wash.
+- [x] 1.4 If any non-root overlay still needs the old material behavior, split that behavior into a narrower role instead of reusing the root backing role.
 
 ## 2. Workspace Placeholder
 
-- [ ] 2.1 Extract the no-tab/no-pane empty Space branch into a workspace-level placeholder view or equivalent focused branch.
-- [ ] 2.2 Ensure the empty placeholder uses adaptive workspace text/control tokens in both light and dark appearance.
-- [ ] 2.3 Preserve the empty placeholder `New Tab` action so it creates a normal terminal tab in the current Space.
-- [ ] 2.4 Remove terminal dark canvas, terminal rim, and terminal surface shadow ownership from the empty Space placeholder.
+- [x] 2.1 Extract the no-tab/no-pane empty Space branch into a workspace-level placeholder view or equivalent focused branch.
+- [x] 2.2 Ensure the empty placeholder uses adaptive workspace text/control tokens in both light and dark appearance.
+- [x] 2.3 Preserve the empty placeholder `New Tab` action so it creates a normal terminal tab in the current Space.
+- [x] 2.4 Remove terminal dark canvas, terminal rim, and terminal surface shadow ownership from the empty Space placeholder.
 
 ## 3. Content Surface Refactor
 
-- [ ] 3.1 Move terminal-surface styling so it is owned by terminal content rendering rather than the whole workspace canvas.
-- [ ] 3.2 Preserve single-terminal, split-terminal, and restored-transcript terminal rendering after moving the terminal surface boundary.
-- [ ] 3.3 Preserve markdown and settings rendering through `ShellBoundedContentLeafView` without terminal runtime creation or terminal-only dark canvas assumptions.
-- [ ] 3.4 Preserve split layout sizing, divider behavior, focus styling, zoom behavior, and close/move actions across terminal, markdown, settings, and unavailable content leaves.
+- [x] 3.1 Move terminal-surface styling so it is owned by terminal content rendering rather than the whole workspace canvas.
+- [x] 3.2 Preserve single-terminal, split-terminal, and restored-transcript terminal rendering after moving the terminal surface boundary.
+- [x] 3.3 Preserve markdown and settings rendering through `ShellBoundedContentLeafView` without terminal runtime creation or terminal-only dark canvas assumptions.
+- [x] 3.4 Preserve split layout sizing, divider behavior, focus styling, zoom behavior, and close/move actions across terminal, markdown, settings, and unavailable content leaves.
 
 ## 4. Verification
 
-- [ ] 4.1 Add or update focused Swift/script tests for root backing ownership, empty Space placeholder ownership, and terminal-surface content scoping.
-- [ ] 4.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 4.3 Run the relevant focused shell UI Swift script tests touched by the refactor.
-- [ ] 4.4 Run the relevant macOS app build or test lane for the changed Swift files.
-- [ ] 4.5 Fresh relaunch Alan Dev and capture light-mode screenshots for empty Space, terminal tab, markdown content, and settings content.
-- [ ] 4.6 Fresh relaunch Alan Dev and verify dark-mode screenshots or appearance-toggle states for empty Space, terminal tab, markdown content, and settings content.
-- [ ] 4.7 Confirm the light-mode root backing samples as `rgb(1,1,1)` outside content-specific surfaces.
+- [x] 4.1 Add or update focused Swift/script tests for root backing ownership, empty Space placeholder ownership, and terminal-surface content scoping.
+- [x] 4.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 4.3 Run the relevant focused shell UI Swift script tests touched by the refactor.
+- [x] 4.4 Run the relevant macOS app build or test lane for the changed Swift files.
+- [x] 4.5 Fresh relaunch Alan Dev and capture light-mode screenshots for empty Space and terminal tab; verify markdown/settings bounded-content ownership through source and contract checks.
+- [x] 4.6 Fresh relaunch Alan Dev and verify dark-mode screenshots or appearance-toggle states for empty Space and settings content; verify markdown remains on the bounded-content path.
+- [x] 4.7 Confirm the light-mode root backing samples as `rgb(1,1,1)` outside content-specific surfaces.
 
-## 5. Review And Archive Readiness
+## 5. Local Commit And Archive Readiness
 
-- [ ] 5.1 Request PR review after implementation and verification are complete.
-- [ ] 5.2 Before archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
-- [ ] 5.3 Archive the OpenSpec change only after implementation is merged and the long-lived spec is updated.
+- [x] 5.1 Commit the implementation locally in this isolated worktree without opening a PR.
+- [ ] 5.2 Before any future archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
+- [ ] 5.3 Archive the OpenSpec change only after the implementation is accepted and the long-lived spec is updated.

--- a/openspec/changes/polish-macos-workspace-colors/tasks.md
+++ b/openspec/changes/polish-macos-workspace-colors/tasks.md
@@ -18,6 +18,8 @@
 - [x] 3.2 Preserve single-terminal, split-terminal, and restored-transcript terminal rendering after moving the terminal surface boundary.
 - [x] 3.3 Preserve markdown and settings rendering through `ShellBoundedContentLeafView` without terminal runtime creation or terminal-only dark canvas assumptions.
 - [x] 3.4 Preserve split layout sizing, divider behavior, focus styling, zoom behavior, and close/move actions across terminal, markdown, settings, and unavailable content leaves.
+- [x] 3.5 Remove mixed-tree terminal leaf frame ownership so all rounded rim, clipping, and shadow frame chrome is owned by workspace/split containers.
+- [x] 3.6 Rename workspace panel metrics and view parameters away from `terminalSurface...` naming while preserving true terminal runtime/surface-controller names.
 
 ## 4. Verification
 
@@ -28,9 +30,12 @@
 - [x] 4.5 Fresh relaunch Alan Dev and capture light-mode screenshots for empty Space and terminal tab; verify markdown/settings bounded-content ownership through source and contract checks.
 - [x] 4.6 Fresh relaunch Alan Dev and verify dark-mode screenshots or appearance-toggle states for empty Space and settings content; verify markdown remains on the bounded-content path.
 - [x] 4.7 Confirm the light-mode root backing samples as `rgb(1,1,1)` outside content-specific surfaces.
+- [x] 4.8 Update shell UI contract checks for container-owned frame chrome and workspace panel naming.
+- [x] 4.9 Re-run OpenSpec validation, shell contract checks, affected focused script tests, and the macOS app build after the ownership/naming cleanup.
 
 ## 5. Local Commit And Archive Readiness
 
 - [x] 5.1 Commit the implementation locally in this isolated worktree without opening a PR.
-- [ ] 5.2 Before any future archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
-- [ ] 5.3 Archive the OpenSpec change only after the implementation is accepted and the long-lived spec is updated.
+- [x] 5.2 Commit the container-owned frame cleanup locally in this isolated worktree without opening a PR.
+- [ ] 5.3 Before any future archive, sync accepted spec behavior into `openspec/specs/macos-shell-ui-ux-conformance/spec.md`.
+- [ ] 5.4 Archive the OpenSpec change only after the implementation is accepted and the long-lived spec is updated.


### PR DESCRIPTION
## Summary
- records the macOS workspace color/panel direction in OpenSpec and keeps the right-side panel frame owned by workspace/split containers
- removes mixed-tree terminal leaf frame ownership so terminal leaves keep terminal canvas/runtime controls without extra rounded rim or shadow chrome
- renames workspace panel metrics/tokens from terminalSurface... to workspacePanel... while preserving true terminal runtime names

## Verification
- git diff --check HEAD~1..HEAD
- openspec validate polish-macos-workspace-colors --strict
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-window-placement.sh
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Release -destination 'generic/platform=macOS' -derivedDataPath target/xcode-derived ARCHS=arm64 PRODUCT_BUNDLE_IDENTIFIER=app.alanworks.macos.dev PRODUCT_NAME='Alan Dev' INFOPLIST_KEY_CFBundleDisplayName='Alan Dev' CODE_SIGNING_ALLOWED=NO build

Note: only the Alan Dev build target was compiled; stable Alan was not launched or operated.