### PR TITLE
Add Emacs TUI profile OpenSpec

### DIFF
--- a/openspec/changes/add-macos-emacs-tui-profile/.openspec.yaml
+++ b/openspec/changes/add-macos-emacs-tui-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/add-macos-emacs-tui-profile/design.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Alan's macOS shell already has the right primitive for terminal Emacs: a
+Terminal Profile can bind a pane to a resolved launch command, working
+directory, and non-secret terminal environment while the pane remains ordinary
+Ghostty-backed terminal content. The product direction is terminal-first, so
+Emacs should enter through this terminal profile boundary rather than through a
+new editor renderer, a GUI Emacs embed, or a new shell content kind.
+
+The near-term user need is simple: open a reliable Emacs TUI tab from Alan and
+let Emacs own editing, keybindings, buffers, org-mode, and process state. Later
+Alan-native org previews can build on explicit Emacs-to-Alan bridge messages,
+but that is not part of this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a first-party Emacs TUI Terminal Profile preset with a stable profile
+  id and title.
+- Add a direct shell action for opening a new Emacs tab without manual profile
+  setup.
+- Keep Emacs panes as normal terminal content so tabs, splits, restore,
+  metadata, close guards, and automation stay within existing shell contracts.
+- Preserve Emacs TUI input fidelity for Control, Meta, Escape, paste,
+  alternate-screen, and terminal mouse workflows.
+- Leave environment metadata sufficient for a later explicit Emacs Lisp bridge.
+
+**Non-Goals:**
+
+- Embed GUI Emacs, use Emacs.app as the renderer, or add native buffer editing.
+- Add org-mode rich preview panes, media rendering, or automatic org parsing.
+- Add a new `ShellTabKind`, `ShellLaunchTarget`, content payload, daemon API, or
+  runtime provider capability.
+- Automatically inspect arbitrary Emacs buffers or send buffer contents to Alan.
+
+## Decisions
+
+1. Treat Emacs as a managed Terminal Profile preset.
+
+   The Emacs entry point should be a stable local Terminal Profile with id
+   `emacs_tui`, title `Emacs`, presentation icon `rectangle.and.pencil.and.ellipsis`,
+   and a `custom_command` launch. This uses the existing terminal profile
+   resolution path, including Space defaults, explicit tab creation, workspace
+   restore, and environment projection.
+
+   Alternative considered: add `ShellLaunchTarget.emacs`. That would make Emacs
+   a separate launch mode and force new restore/control-plane cases for behavior
+   that is already covered by Terminal Profiles.
+
+2. Launch through a small shell command, not a new binary dependency.
+
+   The preset command should prefer `emacsclient -nw -a ""`, fall back to
+   `emacs -nw`, and if neither command exists, print a short actionable message
+   before returning to the user's login shell. The Terminal Profile validator
+   should continue validating the `/bin/zsh` command runner rather than failing
+   the profile solely because Emacs is not currently installed or not on PATH.
+
+   Alternative considered: require an absolute Emacs path in settings. That is
+   less useful across Homebrew, MacPorts, Nix, and custom installs, and it makes
+   the first-run path heavier than needed.
+
+3. Add a workspace action instead of a new tab type.
+
+   "New Emacs Tab" should route through the same command handling as "New
+   Terminal Tab", passing `terminal_profile_id = emacs_tui`. Sidebar rows,
+   pane titles, process metadata, and close behavior should come from the
+   terminal runtime and profile presentation rather than from an Emacs-specific
+   shell model branch.
+
+   Alternative considered: show Emacs as a separate sidebar content kind. That
+   would make later GUI preview work harder to separate from the terminal editor
+   and would blur the terminal-first product boundary.
+
+4. Keep future Alan/Emacs communication explicit.
+
+   The Emacs TUI process should receive the existing `ALAN_SHELL_*` and
+   `ALAN_TERMINAL_PROFILE_*` variables. A later Emacs Lisp package can use
+   those variables plus the shell control plane to ask Alan for previews or
+   context transfer, but this change does not create that protocol.
+
+   Alternative considered: infer Emacs state from terminal screen output. That
+   is fragile and would create accidental context capture.
+
+## Risks / Trade-offs
+
+- Emacs Meta behavior can conflict with macOS Option handling -> Verify the
+  terminal input adapter supports the expected Option-as-Meta behavior and
+  document any existing limitation before marking the task complete.
+- `emacsclient -nw -a ""` behavior varies with user Emacs installs -> Keep the
+  fallback command self-contained and verify both daemon-present and no-server
+  cases when possible.
+- Long-running Emacs sessions look like foreground commands -> Ensure close
+  guards treat Emacs panes as active terminal work and do not silently close
+  them.
+- A managed preset could be mistaken for provider/account config -> Keep it
+  strictly channel-local Terminal Profile state and never write workspace,
+  connection, credential, or agent definition files.
+- Future org preview work could expand scope -> Leave it as a follow-up change
+  with explicit bridge requirements.
+
+## Migration Plan
+
+1. Add the Emacs TUI preset to the active channel's Terminal Profile surfaces
+   without changing the user's default profile.
+2. Add the "New Emacs Tab" action and route it through existing terminal tab
+   creation with explicit `terminal_profile_id`.
+3. Verify restore and close behavior using existing terminal lifecycle paths.
+4. If a problem is found, rollback is removing the managed preset/action while
+   leaving existing user Terminal Profiles and terminal restore data untouched.
+
+## Open Questions
+
+- Should the first UI entry point live only in the command/menu surface, or also
+  appear as a compact sidebar/profile menu item?
+- Should a future setting let users override the Emacs launch command while
+  keeping the managed profile id?

--- a/openspec/changes/add-macos-emacs-tui-profile/proposal.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Alan for macOS is terminal-first, but users who live in Emacs need a reliable
+way to launch terminal Emacs as a first-class workspace surface instead of
+manually configuring a generic custom command each time. Supporting Emacs TUI as
+a built-in terminal workflow keeps editing inside the existing Ghostty-backed
+terminal model while creating a stable foundation for later Alan-native previews.
+
+## What Changes
+
+- Add a first-party Emacs TUI Terminal Profile preset that launches terminal
+  Emacs through `emacsclient -nw -a ""` with a safe fallback to `emacs -nw`.
+- Add an explicit "New Emacs Tab" workspace action that creates an ordinary
+  terminal tab bound to the Emacs TUI profile.
+- Preserve existing terminal content, Space, split, restore, and close semantics;
+  Emacs does not become a new `ShellTabKind` or separate renderer.
+- Project non-secret Emacs profile metadata to the terminal environment so a
+  future Emacs Lisp bridge can discover the Alan pane/window context explicitly.
+- Add focused verification for Emacs-class TUI keyboard behavior, including
+  Control/Meta/Escape sequences, alternate screen, paste, and process-exit
+  state.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `macos-terminal-profiles`: Terminal Profiles gain a managed Emacs TUI preset
+  with deterministic launch, validation, and local storage behavior.
+- `macos-shell-workspace-interactions`: The shell workspace gains an explicit
+  command/menu action for creating an Emacs TUI terminal tab.
+- `macos-shell-terminal-lifecycle`: Terminal startup and restore behavior must
+  treat Emacs TUI as normal terminal content using the resolved profile.
+- `macos-shell-build-test-contract`: Verification must cover Emacs-class TUI
+  input and lifecycle behavior.
+
+## Impact
+
+- Apple client shell model, action registry, command handling, sidebar/menu
+  surfaces, Terminal Profile store/defaults, and Terminal Profile resolution.
+- Ghostty-backed terminal boot profile metadata and environment projection.
+- Focused Swift/script tests for Terminal Profile presets, shell actions, and
+  TUI input behavior.
+- No daemon API, Rust runtime, provider connection, credential, or GUI Emacs
+  integration changes.

--- a/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Emacs TUI Profile Has Focused Verification
+The Apple client SHALL verify the managed Emacs TUI Terminal Profile and New
+Emacs Tab workflow through focused automated tests, script-level checks, or
+documented manual notes where live TUI behavior cannot be fully automated.
+
+#### Scenario: Emacs profile preset verification
+- **WHEN** the Terminal Profile store is loaded in a focused test
+- **THEN** verification confirms the Emacs TUI preset is present with stable id
+  `emacs_tui`, title `Emacs`, and custom-command launch semantics
+
+#### Scenario: New Emacs tab state verification
+- **WHEN** the New Emacs Tab command is executed against a shell model or
+  control-plane test host
+- **THEN** verification confirms the created terminal content stores
+  `terminal_profile_id` `emacs_tui`
+- **AND** focused Space, tab, pane, cwd, and terminal content identity are
+  updated through the normal terminal tab path
+
+#### Scenario: Emacs keyboard verification
+- **WHEN** an Emacs TUI pane is focused in a running app verification pass
+- **THEN** verification covers printable input, Escape, Tab, Backspace,
+  Control-key sequences such as `C-x` and `C-c`, Meta input, paste, terminal
+  mouse mode, and alternate-screen behavior
+- **AND** alan does not consume those keys as shell workspace commands unless an
+  explicit app-reserved `Command` shortcut owns the key
+
+#### Scenario: Emacs lifecycle verification
+- **WHEN** an Emacs TUI pane exits, is split, moves to the background, restores
+  after restart, or is closed with active work
+- **THEN** verification confirms alan reports terminal lifecycle state
+  truthfully and preserves normal terminal ContentInstance ownership

--- a/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Emacs TUI Uses Normal Terminal Lifecycle
+The macOS terminal lifecycle SHALL run Emacs TUI panes through the same
+Ghostty-backed terminal ContentInstance lifecycle used by other Terminal
+Profile-backed panes.
+
+#### Scenario: Emacs terminal starts through resolved profile
+- **WHEN** terminal content is created with `terminal_profile_id` `emacs_tui`
+- **THEN** alan resolves the managed Emacs TUI Terminal Profile
+- **AND** Ghostty surface creation receives the resolved command, working
+  directory, and environment through the existing terminal boot profile
+
+#### Scenario: Emacs process stays bound to terminal content identity
+- **WHEN** an Emacs TUI pane enters alternate-screen mode, updates its terminal
+  title, or receives terminal runtime metadata
+- **THEN** alan keeps runtime handle, scrollback, metadata, pending delivery,
+  and teardown state bound to the same terminal ContentInstance id
+- **AND** alan does not remount the pane as GUI editor content
+
+#### Scenario: Restored Emacs tab relaunches as terminal Emacs
+- **WHEN** alan restores terminal content from a workspace manifest with
+  `terminal_profile_id` `emacs_tui`
+- **THEN** alan relaunches the pane using the current managed Emacs TUI profile
+  definition
+- **AND** alan does not claim continuity with the previous app instance's Emacs
+  process or PTY
+
+#### Scenario: Closing Emacs follows terminal close guard
+- **WHEN** the user closes an Emacs TUI pane whose process is still active
+- **THEN** alan applies the same destructive terminal close guard used for other
+  active terminal work
+- **AND** confirmed close finalizes the terminal ContentInstance through the
+  existing terminal lifecycle boundary

--- a/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-workspace-interactions/spec.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/specs/macos-shell-workspace-interactions/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Workspace Creates Emacs TUI Terminal Tabs
+The macOS shell workspace SHALL expose an explicit command for creating a new
+Emacs TUI tab. The command SHALL create ordinary terminal content using the
+managed Emacs TUI Terminal Profile rather than introducing an Emacs-specific tab
+kind or content renderer.
+
+#### Scenario: New Emacs tab command
+- **WHEN** the user invokes the New Emacs Tab command from the shell workspace
+- **THEN** alan creates a new terminal tab in the selected Space
+- **AND** the tab's terminal content stores `terminal_profile_id` `emacs_tui`
+- **AND** the tab participates in normal terminal tab selection, focus, split,
+  movement, and close behavior
+
+#### Scenario: Emacs tab uses current working directory
+- **WHEN** the focused terminal pane has runtime cwd metadata `/repo/app`
+- **AND** the user invokes the New Emacs Tab command without an explicit cwd
+- **THEN** alan creates the Emacs terminal tab with working directory
+  `/repo/app`
+
+#### Scenario: Emacs tab remains terminal content
+- **WHEN** an Emacs TUI tab is shown in the sidebar, command surface, or control
+  plane
+- **THEN** alan identifies it as terminal content with Terminal Profile metadata
+- **AND** alan does not require a new `ShellTabKind`, non-terminal content
+  payload, or GUI Emacs renderer to represent the tab
+
+#### Scenario: Space default can use Emacs profile
+- **WHEN** the user binds a Space to Terminal Profile `emacs_tui`
+- **AND** the user creates a new terminal tab in that Space without an explicit
+  profile override
+- **THEN** alan creates the new terminal content with `terminal_profile_id`
+  `emacs_tui`

--- a/openspec/changes/add-macos-emacs-tui-profile/specs/macos-terminal-profiles/spec.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/specs/macos-terminal-profiles/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Managed Emacs TUI Profile Preset
+Alan for macOS SHALL provide a first-party Emacs TUI Terminal Profile preset
+that launches terminal Emacs as local terminal content without requiring manual
+custom-command setup.
+
+The preset SHALL use stable profile id `emacs_tui`, user-facing title `Emacs`,
+and Terminal Profile launch mode `custom_command`. The preset SHALL prefer
+`emacsclient -nw -a ""`, SHALL fall back to `emacs -nw`, and SHALL keep the
+profile channel-local rather than storing it in workspace manifests, agent
+definitions, provider connection profiles, or credential stores.
+
+#### Scenario: Emacs preset is available
+- **WHEN** Alan for macOS loads Terminal Profiles for the active install channel
+- **THEN** the profile list includes the managed Emacs TUI preset with
+  `terminal_profile_id` `emacs_tui`
+- **AND** the preset is not selected as the default Terminal Profile unless the
+  user explicitly chooses it as a Space or global default
+
+#### Scenario: Emacs preset uses terminal profile validation
+- **WHEN** Alan validates the managed Emacs TUI preset
+- **THEN** alan validates the existing custom-command runner needed to start the
+  profile
+- **AND** alan does not reject the profile solely because `emacsclient` or
+  `emacs` is not currently available on PATH
+
+#### Scenario: Emacs executable is missing
+- **WHEN** a terminal starts with the Emacs TUI preset and neither
+  `emacsclient` nor `emacs` is available in the terminal PATH
+- **THEN** the terminal prints a concise actionable message in the pane
+- **AND** alan returns the pane to a normal login shell rather than failing
+  Ghostty surface creation
+
+#### Scenario: Emacs profile metadata is non-secret
+- **WHEN** a terminal starts with the Emacs TUI preset
+- **THEN** alan exposes the existing non-secret Terminal Profile metadata,
+  including `ALAN_TERMINAL_PROFILE_ID=emacs_tui`, to the terminal environment
+- **AND** alan does not expose provider credentials, tokens, or arbitrary buffer
+  contents through that metadata

--- a/openspec/changes/add-macos-emacs-tui-profile/tasks.md
+++ b/openspec/changes/add-macos-emacs-tui-profile/tasks.md
@@ -1,0 +1,37 @@
+## 1. Terminal Profile Preset
+
+- [ ] 1.1 Add a managed Emacs TUI Terminal Profile preset with stable id `emacs_tui`, title `Emacs`, and presentation metadata.
+- [ ] 1.2 Define the preset custom command so it prefers `emacsclient -nw -a ""`, falls back to `emacs -nw`, and returns to a login shell with a concise message when Emacs is unavailable.
+- [ ] 1.3 Ensure the preset is available in Terminal Profile loading/settings surfaces without changing the user's default Terminal Profile.
+- [ ] 1.4 Keep the preset channel-local and confirm no workspace manifest, agent definition, provider connection, or credential store writes are introduced.
+
+## 2. Shell Workspace Action
+
+- [ ] 2.1 Add a `New Emacs Tab` shell action/command entry that routes through existing terminal tab creation with `terminal_profile_id` `emacs_tui`.
+- [ ] 2.2 Wire the action into the appropriate macOS command/menu or command-palette surface without adding a new `ShellTabKind` or content payload.
+- [ ] 2.3 Preserve current cwd resolution for Emacs tab creation, including runtime cwd, pane snapshot cwd, explicit cwd, and home fallback behavior.
+- [ ] 2.4 Confirm Space default Terminal Profile binding can use `emacs_tui` for ordinary new terminal tabs.
+
+## 3. Terminal Lifecycle And Metadata
+
+- [ ] 3.1 Verify Emacs TUI panes use the existing Ghostty-backed terminal boot profile path for command, cwd, and environment.
+- [ ] 3.2 Confirm `ALAN_SHELL_*` and `ALAN_TERMINAL_PROFILE_*` metadata are present for Emacs TUI panes and contain no provider secrets or buffer contents.
+- [ ] 3.3 Verify split, background tab, restore, title/metadata projection, and runtime identity behavior remain normal terminal ContentInstance behavior.
+- [ ] 3.4 Verify active Emacs panes use the existing destructive terminal close guard and finalization path.
+
+## 4. Focused Tests
+
+- [ ] 4.1 Add focused Terminal Profile tests for the Emacs preset id, title, launch command, validation behavior, and default-profile non-selection.
+- [ ] 4.2 Add shell model or control-plane tests proving New Emacs Tab creates terminal content with `terminal_profile_id` `emacs_tui` and normal focus/cwd state.
+- [ ] 4.3 Add or update runtime metadata tests proving Emacs profile environment projection and terminal ContentInstance identity remain stable.
+- [ ] 4.4 Add script-level or documented manual verification for Emacs TUI input: printable keys, Escape, Tab, Backspace, `C-x`, `C-c`, Meta input, paste, mouse mode, and alternate screen.
+- [ ] 4.5 Add lifecycle verification for Emacs exit, backgrounding, split behavior, restore, and active-work close confirmation.
+
+## 5. Validation And Archive Readiness
+
+- [ ] 5.1 Run the focused Apple client scripts touched by Terminal Profiles, shell runtime metadata, and shell state mutation changes.
+- [ ] 5.2 Run `openspec validate add-macos-emacs-tui-profile --strict`.
+- [ ] 5.3 Run `git diff --check`.
+- [ ] 5.4 Run the relevant macOS Xcode build command with signing disabled.
+- [ ] 5.5 Capture implementation notes and manual verification evidence in this change before requesting review.
+- [ ] 5.6 Before archiving after merge, sync accepted delta requirements into `openspec/specs/` and rerun strict OpenSpec validation.


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for a first-party Emacs TUI Terminal Profile preset in Alan for macOS.
- Scope the design to ordinary Ghostty-backed terminal content, with no GUI Emacs embed, new tab kind, or org preview work in this phase.
- Add spec deltas for terminal profiles, shell workspace interaction, terminal lifecycle, and focused build/test verification.

## Validation
- openspec validate add-macos-emacs-tui-profile --strict
- git diff --check