### PR TITLE
Polish macOS Space slider track

### DIFF
--- a/clients/apple/alan-macos/MacShellRootView.swift
+++ b/clients/apple/alan-macos/MacShellRootView.swift
@@ -64,10 +64,6 @@ struct MacShellRootView: View {
         sidebarPresentation.surfaceOrigin
     }
 
-    private var canCreateTerminalSpace: Bool {
-        host.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces
-    }
-
     private var sidebarPresentationConfiguration: ShellSidebarPresentationConfiguration {
         ShellSidebarPresentationConfiguration(
             sidebarWidth: sidebarWidth,
@@ -452,8 +448,6 @@ struct MacShellRootView: View {
                 ShellSidebarNewSpaceControl {
                     _ = host.createTerminalSpace()
                 }
-                .disabled(!canCreateTerminalSpace)
-                .opacity(canCreateTerminalSpace ? 1 : 0.45)
                 .contentShape(Rectangle())
                 .onHover(perform: handleCollapsedSidebarToolbarHover)
             }

--- a/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift
@@ -1201,6 +1201,35 @@ struct ShellContentTab: Identifiable, Codable, Equatable {
     }
 }
 
+enum ShellSpacePresentationIcon {
+    static let defaultSystemName = "square.grid.2x2"
+
+    static func resolvedSystemName(_ systemName: String?) -> String {
+        guard let systemName,
+              isSupportedSystemName(systemName)
+        else {
+            return defaultSystemName
+        }
+        return systemName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func isSupportedSystemName(_ systemName: String?) -> Bool {
+        guard let systemName else { return false }
+        let trimmed = systemName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+        else {
+            return false
+        }
+        return trimmed.unicodeScalars.allSatisfy { scalar in
+            CharacterSet.alphanumerics.contains(scalar)
+                || scalar == "."
+                || scalar == "-"
+                || scalar == "_"
+        }
+    }
+}
+
 struct ShellSpace: Identifiable, Codable, Equatable {
     let spaceID: String
     let title: String
@@ -1208,8 +1237,13 @@ struct ShellSpace: Identifiable, Codable, Equatable {
     let tabs: [ShellTab]
     let selectedTabID: String?
     let terminalProfileID: String?
+    let presentationIconSystemName: String?
 
     var id: String { spaceID }
+
+    var resolvedPresentationIconSystemName: String {
+        ShellSpacePresentationIcon.resolvedSystemName(presentationIconSystemName)
+    }
 
     private enum CodingKeys: String, CodingKey {
         case spaceID = "space_id"
@@ -1218,6 +1252,7 @@ struct ShellSpace: Identifiable, Codable, Equatable {
         case tabs
         case selectedTabID = "selected_tab_id"
         case terminalProfileID = "terminal_profile_id"
+        case presentationIconSystemName = "presentation_icon"
     }
 
     init(
@@ -1226,7 +1261,8 @@ struct ShellSpace: Identifiable, Codable, Equatable {
         attention: ShellAttentionState,
         tabs: [ShellTab],
         selectedTabID: String? = nil,
-        terminalProfileID: String? = nil
+        terminalProfileID: String? = nil,
+        presentationIconSystemName: String? = nil
     ) {
         self.spaceID = spaceID
         self.title = title
@@ -1234,6 +1270,7 @@ struct ShellSpace: Identifiable, Codable, Equatable {
         self.tabs = tabs
         self.selectedTabID = selectedTabID
         self.terminalProfileID = terminalProfileID
+        self.presentationIconSystemName = presentationIconSystemName
     }
 
     init(from decoder: Decoder) throws {
@@ -1244,7 +1281,11 @@ struct ShellSpace: Identifiable, Codable, Equatable {
             attention: try container.decode(ShellAttentionState.self, forKey: .attention),
             tabs: try container.decode([ShellTab].self, forKey: .tabs),
             selectedTabID: try container.decodeIfPresent(String.self, forKey: .selectedTabID),
-            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID),
+            presentationIconSystemName: try container.decodeIfPresent(
+                String.self,
+                forKey: .presentationIconSystemName
+            )
         )
     }
 }
@@ -1256,6 +1297,7 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
     let tabs: [ShellContentTab]
     let selectedTabID: String?
     let terminalProfileID: String?
+    let presentationIconSystemName: String?
 
     var id: String { spaceID }
 
@@ -1266,6 +1308,7 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
         case tabs
         case selectedTabID = "selected_tab_id"
         case terminalProfileID = "terminal_profile_id"
+        case presentationIconSystemName = "presentation_icon"
     }
 
     init(
@@ -1274,7 +1317,8 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
         attention: ShellAttentionState,
         tabs: [ShellContentTab],
         selectedTabID: String? = nil,
-        terminalProfileID: String? = nil
+        terminalProfileID: String? = nil,
+        presentationIconSystemName: String? = nil
     ) {
         self.spaceID = spaceID
         self.title = title
@@ -1282,6 +1326,7 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
         self.tabs = tabs
         self.selectedTabID = selectedTabID
         self.terminalProfileID = terminalProfileID
+        self.presentationIconSystemName = presentationIconSystemName
     }
 
     init(from decoder: Decoder) throws {
@@ -1292,7 +1337,11 @@ struct ShellContentSpace: Identifiable, Codable, Equatable {
             attention: try container.decode(ShellAttentionState.self, forKey: .attention),
             tabs: try container.decode([ShellContentTab].self, forKey: .tabs),
             selectedTabID: try container.decodeIfPresent(String.self, forKey: .selectedTabID),
-            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID)
+            terminalProfileID: try container.decodeIfPresent(String.self, forKey: .terminalProfileID),
+            presentationIconSystemName: try container.decodeIfPresent(
+                String.self,
+                forKey: .presentationIconSystemName
+            )
         )
     }
 }
@@ -1406,7 +1455,8 @@ extension ShellSpace {
             attention: attention,
             tabs: tabs,
             selectedTabID: resolvedPreferred ?? resolvedExisting ?? tabs.first?.tabID,
-            terminalProfileID: terminalProfileID
+            terminalProfileID: terminalProfileID,
+            presentationIconSystemName: presentationIconSystemName
         )
     }
 
@@ -1665,7 +1715,8 @@ extension ShellContentStateSnapshot {
                     )
                 },
                 selectedTabID: space.resolvedSelectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -1778,7 +1829,8 @@ extension ShellContentStateSnapshot {
                 ),
                 tabs: tabs,
                 selectedTabID: space.resolvedSelectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -324,7 +324,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: terminalProfileID
+                terminalProfileID: terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         return ShellStateSnapshot(

--- a/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift
@@ -165,7 +165,8 @@ extension ShellStateSnapshot {
                 activity: nil,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
     }
 
@@ -211,7 +212,8 @@ extension ShellStateSnapshot {
                 activity: activity,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
         let nextSpaces = rebuildingAttention(in: spaces, panes: updatedPanes)
         return ShellStateMutationResult(
@@ -451,7 +453,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs + [tab],
                 selectedTabID: tabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextPanes = panes + [prepared.pane]
@@ -691,7 +694,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs + [newTab],
                 selectedTabID: newTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -716,7 +720,8 @@ extension ShellStateSnapshot {
                 activity: current.activity,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
 
         let retained = retainedContentRecords(in: nextSpaces, panes: nextPanes)
@@ -839,7 +844,8 @@ extension ShellStateSnapshot {
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextPanes = panes + [prepared.pane]
@@ -927,7 +933,8 @@ extension ShellStateSnapshot {
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextPanes = panes.filter { $0.paneID != paneID }
@@ -1010,7 +1017,8 @@ extension ShellStateSnapshot {
                     return [updatedSourceTab, newTab]
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let formatter = ISO8601DateFormatter()
@@ -1034,7 +1042,8 @@ extension ShellStateSnapshot {
                 activity: current.activity,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
 
         return ShellStateMutationResult(
@@ -1134,7 +1143,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: nextTabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -1158,7 +1168,8 @@ extension ShellStateSnapshot {
                 activity: current.activity,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
 
         let nextState = replacing(
@@ -1234,7 +1245,8 @@ extension ShellStateSnapshot {
                     existingTab.tabID == updatedTab.tabID ? updatedTab : existingTab
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -1289,7 +1301,8 @@ extension ShellStateSnapshot {
             attention: sourceSpace.attention,
             tabs: sourceSpace.tabs.filter { $0.tabID != tabID },
             selectedTabID: sourceSpace.selectedTabID,
-            terminalProfileID: sourceSpace.terminalProfileID
+            terminalProfileID: sourceSpace.terminalProfileID,
+            presentationIconSystemName: sourceSpace.presentationIconSystemName
         )
 
         let targetSpaceAfterRemoval = nextSpaces[targetSpaceIndex]
@@ -1310,7 +1323,8 @@ extension ShellStateSnapshot {
             attention: targetSpaceAfterRemoval.attention,
             tabs: targetTabs,
             selectedTabID: targetSpaceAfterRemoval.selectedTabID,
-            terminalProfileID: targetSpaceAfterRemoval.terminalProfileID
+            terminalProfileID: targetSpaceAfterRemoval.terminalProfileID,
+            presentationIconSystemName: targetSpaceAfterRemoval.presentationIconSystemName
         )
 
         let nextPanes = panes.map { pane in
@@ -1524,7 +1538,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: space.tabs.filter { !clearableTabIDs.contains($0.tabID) },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
@@ -1566,7 +1581,8 @@ extension ShellStateSnapshot {
                 activity: current.activity,
                 alanBinding: current.alanBinding,
                 terminalProfileID: current.terminalProfileID
-            )
+
+                )
         }
 
         return ShellStateMutationResult(
@@ -1611,7 +1627,8 @@ extension ShellStateSnapshot {
                     tab.tabID == updatedTab.tabID ? updatedTab : tab
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -1662,7 +1679,8 @@ extension ShellStateSnapshot {
                     tab.tabID == tabID ? updatedTab : tab
                 },
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextState = replacing(
@@ -1705,7 +1723,8 @@ extension ShellStateSnapshot {
                 attention: space.attention,
                 tabs: remainingTabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
         let nextPanes = panes.filter { !removedPaneIDs.contains($0.paneID) }
@@ -1836,7 +1855,8 @@ extension ShellStateSnapshot {
                 attention: strongestAttention(in: panes.filter { $0.spaceID == space.spaceID }),
                 tabs: space.tabs,
                 selectedTabID: space.resolvedSelectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
     }

--- a/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
+++ b/clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift
@@ -86,6 +86,7 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
     var selectedTabID: String? = nil
     var tabs: [ShellWorkspaceTabRecord]
     var terminalProfileID: String? = nil
+    var presentationIconSystemName: String? = nil
 
     var id: String { spaceID }
 
@@ -98,6 +99,7 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         case selectedTabID = "selected_tab_id"
         case tabs
         case terminalProfileID = "terminal_profile_id"
+        case presentationIconSystemName = "presentation_icon"
     }
 
     init(
@@ -108,7 +110,8 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         updatedAt: Date,
         selectedTabID: String? = nil,
         tabs: [ShellWorkspaceTabRecord],
-        terminalProfileID: String? = nil
+        terminalProfileID: String? = nil,
+        presentationIconSystemName: String? = nil
     ) {
         self.spaceID = spaceID
         self.title = title
@@ -118,6 +121,7 @@ struct ShellWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         self.selectedTabID = selectedTabID
         self.tabs = tabs
         self.terminalProfileID = terminalProfileID
+        self.presentationIconSystemName = presentationIconSystemName
     }
 }
 
@@ -356,6 +360,7 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
     var selectedTabID: String? = nil
     var tabs: [ShellContentWorkspaceTabRecord]
     var terminalProfileID: String? = nil
+    var presentationIconSystemName: String? = nil
 
     var id: String { spaceID }
 
@@ -368,6 +373,7 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         case selectedTabID = "selected_tab_id"
         case tabs
         case terminalProfileID = "terminal_profile_id"
+        case presentationIconSystemName = "presentation_icon"
     }
 
     init(
@@ -378,7 +384,8 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         updatedAt: Date,
         selectedTabID: String? = nil,
         tabs: [ShellContentWorkspaceTabRecord],
-        terminalProfileID: String? = nil
+        terminalProfileID: String? = nil,
+        presentationIconSystemName: String? = nil
     ) {
         self.spaceID = spaceID
         self.title = title
@@ -388,6 +395,7 @@ struct ShellContentWorkspaceSpaceRecord: Codable, Equatable, Identifiable {
         self.selectedTabID = selectedTabID
         self.tabs = tabs
         self.terminalProfileID = terminalProfileID
+        self.presentationIconSystemName = presentationIconSystemName
     }
 }
 
@@ -667,7 +675,8 @@ extension ShellWorkspaceManifest {
                             activeTask: tab.activeTask
                         )
                     },
-                    terminalProfileID: space.terminalProfileID
+                    terminalProfileID: space.terminalProfileID,
+                    presentationIconSystemName: space.presentationIconSystemName
                 )
             }
         )
@@ -867,7 +876,8 @@ struct ShellWorkspaceMaterializer {
                 ),
                 tabs: contentTabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -1066,7 +1076,8 @@ struct ShellWorkspaceMaterializer {
                     attention: strongestAttention(for: shellTabs, panes: panes),
                     tabs: shellTabs,
                     selectedTabID: space.selectedTabID,
-                    terminalProfileID: space.terminalProfileID
+                    terminalProfileID: space.terminalProfileID,
+                    presentationIconSystemName: space.presentationIconSystemName
                 )
             )
         }

--- a/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift
@@ -50,19 +50,6 @@ enum AlanShellLocalCommandExecutor {
             )
 
         case .spaceCreate:
-            guard state.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces else {
-                return AlanShellLocalCommandResult(
-                    response: response(
-                        for: command,
-                        state: state,
-                        applied: false,
-                        errorCode: "space_create_failed",
-                        errorMessage: "Failed to create a new shell space."
-                    ),
-                    updatedState: nil,
-                    sideEffect: nil
-                )
-            }
             let resolvedTerminalProfileID = command.terminalProfileID
                 ?? terminalProfileIDForGlobalDefaultPaneCapture()
             let result = state.creatingSpace(

--- a/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellPublishedStateMerger.swift
@@ -31,7 +31,8 @@ enum AlanShellPublishedStateMerger {
                 attention: strongestAttention(in: mergedPanes.filter { $0.spaceID == space.spaceID }),
                 tabs: space.tabs,
                 selectedTabID: space.selectedTabID ?? authoritativeSpace?.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
             .repairingSelectedTabID(
                 preferredTabID: focusedPane?.spaceID == space.spaceID ? focusedPane?.tabID : nil

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -931,7 +931,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     attention: space.attention,
                     tabs: space.tabs,
                     selectedTabID: nil,
-                    terminalProfileID: space.terminalProfileID
+                    terminalProfileID: space.terminalProfileID,
+                    presentationIconSystemName: space.presentationIconSystemName
                 )
             }
             shellState = ShellStateSnapshot(
@@ -1189,9 +1190,6 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         workingDirectory: String? = nil,
         terminalProfileID: String? = nil
     ) -> String? {
-        guard shellState.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces else {
-            return nil
-        }
         let resolvedTerminalProfileID = terminalProfileID
             ?? globalDefaultTerminalProfileIDForPaneCapture()
         let result = shellState.creatingSpace(
@@ -2513,7 +2511,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 attention: strongestAttention(in: panes.filter { $0.spaceID == space.spaceID }),
                 tabs: tabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
     }
@@ -2615,7 +2614,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 attention: strongestAttention(in: hydratedPanes.filter { $0.spaceID == space.spaceID }),
                 tabs: space.tabs,
                 selectedTabID: space.selectedTabID,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 
@@ -2944,7 +2944,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 updatedAt: now,
                 selectedTabID: space.resolvedSelectedTabID,
                 tabs: tabRecords,
-                terminalProfileID: space.terminalProfileID
+                terminalProfileID: space.terminalProfileID,
+                presentationIconSystemName: space.presentationIconSystemName
             )
         }
 

--- a/clients/apple/alan-macos/Support/ShellDesignTokens.swift
+++ b/clients/apple/alan-macos/Support/ShellDesignTokens.swift
@@ -106,6 +106,12 @@ enum ShellPalette {
         dark: (0.215, 0.235, 0.282),
         darkAlpha: 0.72
     )
+    static let sidebarSpaceSliderTrack = Color.shellAdaptive(
+        light: (0.770, 0.775, 0.805),
+        lightAlpha: 0.54,
+        dark: (0.185, 0.205, 0.245),
+        darkAlpha: 0.74
+    )
     static let commandGlassTint = Color.shellAdaptive(
         light: (0.720, 0.730, 0.790),
         lightAlpha: 1.0,

--- a/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
+++ b/clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift
@@ -3,35 +3,34 @@ import Foundation
 
 #if os(macOS)
 struct ShellSidebarSpaceSliderLayout: Equatable {
-    static let maximumVisibleSpaces = 9
-    static let spacing: CGFloat = 7
-    static let minimumItemWidth: CGFloat = 8
-
-    enum Density: Equatable {
-        case low
-        case medium
-        case high
-    }
+    static let spacing: CGFloat = 4
+    static let trackHeight: CGFloat = 28
+    static let itemHeight: CGFloat = 24
+    static let fullTitleMinimumWidth: CGFloat = 92
+    static let truncatedTitleMinimumWidth: CGFloat = 56
+    static let minimumItemWidth: CGFloat = 28
 
     enum DisplayMode: Equatable {
         case fullTitle
-        case shortTitle
-        case indicator
+        case truncatedTitle
+        case iconOnly
     }
 
     struct Item: Equatable {
         let index: Int
         let mode: DisplayMode
         let width: CGFloat
-        let visualScale: CGFloat
-        let opacity: CGFloat
         let isSelected: Bool
         let isFocused: Bool
     }
 
-    let density: Density
     let items: [Item]
     let contentWidth: CGFloat
+    let availableWidth: CGFloat
+
+    var isHorizontallyScrollable: Bool {
+        contentWidth > availableWidth
+    }
 
     static func make(
         spaceCount rawSpaceCount: Int,
@@ -41,146 +40,62 @@ struct ShellSidebarSpaceSliderLayout: Equatable {
         availableWidth: CGFloat,
         reduceMotion: Bool
     ) -> ShellSidebarSpaceSliderLayout {
-        let spaceCount = min(max(rawSpaceCount, 0), maximumVisibleSpaces)
-        let density = density(for: spaceCount)
+        _ = reduceMotion
+        let spaceCount = max(rawSpaceCount, 0)
+        let availableWidth = max(availableWidth, 0)
         guard spaceCount > 0 else {
-            return ShellSidebarSpaceSliderLayout(density: density, items: [], contentWidth: 0)
+            return ShellSidebarSpaceSliderLayout(
+                items: [],
+                contentWidth: 0,
+                availableWidth: availableWidth
+            )
         }
 
         let selectedIndex = clamped(rawSelectedIndex, count: spaceCount)
         let hoveredIndex = clamped(rawHoveredIndex, count: spaceCount)
         let scrubFocusIndex = clamped(rawScrubFocusIndex, count: spaceCount)
         let focusIndex = scrubFocusIndex ?? hoveredIndex
-        let width = max(availableWidth, 0)
-        let spacingWidth = CGFloat(max(spaceCount - 1, 0)) * spacing
-        let itemBudget = max(width - spacingWidth, CGFloat(spaceCount) * minimumItemWidth)
-        let modes = displayModes(
-            density: density,
-            spaceCount: spaceCount,
-            selectedIndex: selectedIndex,
-            hoveredIndex: hoveredIndex,
-            scrubFocusIndex: scrubFocusIndex
-        )
-        let itemWidths = widths(
-            modes: modes,
-            selectedIndex: selectedIndex,
-            focusIndex: focusIndex,
-            itemBudget: itemBudget
-        )
+        let itemWidth = distributedItemWidth(spaceCount: spaceCount, availableWidth: availableWidth)
+        let mode = displayMode(itemWidth: itemWidth)
 
-        let items = modes.enumerated().map { index, mode in
+        let items = (0..<spaceCount).map { index in
             let isFocused = focusIndex == index
-            let distance = focusIndex.map { abs($0 - index) } ?? 0
             return Item(
                 index: index,
                 mode: mode,
-                width: itemWidths[index],
-                visualScale: visualScale(
-                    distanceFromFocus: distance,
-                    isFocused: isFocused,
-                    hasFocus: focusIndex != nil,
-                    reduceMotion: reduceMotion
-                ),
-                opacity: opacity(
-                    distanceFromFocus: distance,
-                    hasFocus: focusIndex != nil
-                ),
+                width: itemWidth,
                 isSelected: selectedIndex == index,
                 isFocused: isFocused
             )
         }
 
-        let contentWidth = itemWidths.reduce(0, +) + spacingWidth
-        return ShellSidebarSpaceSliderLayout(density: density, items: items, contentWidth: contentWidth)
+        let contentWidth = CGFloat(spaceCount) * itemWidth
+            + CGFloat(max(spaceCount - 1, 0)) * spacing
+        return ShellSidebarSpaceSliderLayout(
+            items: items,
+            contentWidth: contentWidth,
+            availableWidth: availableWidth
+        )
     }
 
-    static func density(for spaceCount: Int) -> Density {
-        switch min(max(spaceCount, 0), maximumVisibleSpaces) {
-        case 0...3:
-            return .low
-        case 4...6:
-            return .medium
-        default:
-            return .high
+    private static func displayMode(itemWidth: CGFloat) -> DisplayMode {
+        if itemWidth >= fullTitleMinimumWidth {
+            return .fullTitle
         }
+        if itemWidth >= truncatedTitleMinimumWidth {
+            return .truncatedTitle
+        }
+        return .iconOnly
     }
 
-    private static func displayModes(
-        density: Density,
+    private static func distributedItemWidth(
         spaceCount: Int,
-        selectedIndex: Int?,
-        hoveredIndex: Int?,
-        scrubFocusIndex: Int?
-    ) -> [DisplayMode] {
-        (0..<spaceCount).map { index in
-            switch density {
-            case .low:
-                return .fullTitle
-            case .medium:
-                return selectedIndex == index ? .fullTitle : .shortTitle
-            case .high:
-                if selectedIndex == index || scrubFocusIndex == index {
-                    return .fullTitle
-                }
-                if hoveredIndex == index {
-                    return .shortTitle
-                }
-                return .indicator
-            }
-        }
-    }
-
-    private static func widths(
-        modes: [DisplayMode],
-        selectedIndex: Int?,
-        focusIndex: Int?,
-        itemBudget: CGFloat
-    ) -> [CGFloat] {
-        let weights = modes.enumerated().map { index, mode -> CGFloat in
-            switch mode {
-            case .fullTitle:
-                if selectedIndex == index {
-                    return 3.4
-                }
-                if focusIndex == index {
-                    return 3.1
-                }
-                return 2.6
-            case .shortTitle:
-                return focusIndex == index ? 2.1 : 1.65
-            case .indicator:
-                return focusIndex == index ? 1.0 : 0.72
-            }
-        }
-        let totalWeight = max(weights.reduce(0, +), 1)
-        return weights.map { max(minimumItemWidth, itemBudget * ($0 / totalWeight)) }
-    }
-
-    private static func visualScale(
-        distanceFromFocus distance: Int,
-        isFocused: Bool,
-        hasFocus: Bool,
-        reduceMotion: Bool
+        availableWidth: CGFloat
     ) -> CGFloat {
-        guard hasFocus, !reduceMotion else { return 1 }
-        if isFocused {
-            return 1.035
-        }
-        if distance == 1 {
-            return 1.012
-        }
-        return 1
-    }
-
-    private static func opacity(distanceFromFocus distance: Int, hasFocus: Bool) -> CGFloat {
-        guard hasFocus else { return 1 }
-        if distance <= 1 {
-            return 1
-        }
-        if distance == 2 {
-            return 0.82
-        }
-        return 0.68
+        guard spaceCount > 0 else { return 0 }
+        let spacingWidth = CGFloat(max(spaceCount - 1, 0)) * spacing
+        let distributedWidth = (availableWidth - spacingWidth) / CGFloat(spaceCount)
+        return distributedWidth >= minimumItemWidth ? distributedWidth : minimumItemWidth
     }
 
     private static func clamped(_ index: Int?, count: Int) -> Int? {
@@ -191,7 +106,7 @@ struct ShellSidebarSpaceSliderLayout: Equatable {
     func frame(for index: Int) -> CGRect? {
         var cursor: CGFloat = 0
         for item in items {
-            let frame = CGRect(x: cursor, y: 0, width: item.width, height: 22)
+            let frame = CGRect(x: cursor, y: 0, width: item.width, height: Self.itemHeight)
             if item.index == index {
                 return frame
             }

--- a/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift
@@ -90,7 +90,7 @@ struct ShellSidebarView: View {
             onForwardVerticalWheel: tabListWheelRouter.forward
         )
         .frame(maxWidth: .infinity)
-        .frame(height: 30)
+        .frame(height: ShellSidebarSpaceSliderLayout.trackHeight + 4)
     }
 
     private var spaceContentPager: some View {
@@ -1011,6 +1011,14 @@ private struct ShellSidebarScrollBoundary: View {
     }
 }
 
+private struct ShellSidebarSpaceSliderScrollOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 private struct ShellSidebarSpaceSlider: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject var host: ShellHostController
@@ -1023,39 +1031,95 @@ private struct ShellSidebarSpaceSlider: View {
     @State private var scrubState: ShellSidebarSpaceSliderScrubState?
     @State private var wheelIntentState = ShellSidebarSpaceSliderWheelIntentState()
     @State private var wheelCommitToken = 0
+    @State private var trackScrollOffsetX: CGFloat = 0
 
     var body: some View {
         GeometryReader { proxy in
             let spaces = visibleSpaces
             let layout = sliderLayout(availableWidth: proxy.size.width)
+            let trackWidth = max(proxy.size.width - (ShellSidebarMetrics.edgeInset * 2), 0)
 
-            HStack(spacing: ShellSidebarSpaceSliderLayout.spacing) {
-                ForEach(Array(spaces.enumerated()), id: \.element.spaceID) { index, space in
-                    if let item = layout.items.first(where: { $0.index == index }) {
-                        spaceControl(for: space, item: item)
+            ScrollViewReader { scrollProxy in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(
+                        cornerRadius: ShellSidebarSpaceSliderLayout.trackHeight * 0.5,
+                        style: .continuous
+                    )
+                    .fill(ShellPalette.sidebarSpaceSliderTrack)
+                    .overlay {
+                        RoundedRectangle(
+                            cornerRadius: ShellSidebarSpaceSliderLayout.trackHeight * 0.5,
+                            style: .continuous
+                        )
+                        .stroke(ShellPalette.line.opacity(0.22), lineWidth: 0.6)
                     }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: ShellSidebarSpaceSliderLayout.spacing) {
+                            ForEach(Array(spaces.enumerated()), id: \.element.spaceID) { index, space in
+                                if let item = layout.items.first(where: { $0.index == index }) {
+                                    spaceControl(for: space, item: item)
+                                        .id(space.spaceID)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 2)
+                        .frame(
+                            width: max(layout.contentWidth + 4, trackWidth),
+                            height: ShellSidebarSpaceSliderLayout.trackHeight,
+                            alignment: .leading
+                        )
+                        .background {
+                            GeometryReader { contentProxy in
+                                Color.clear.preference(
+                                    key: ShellSidebarSpaceSliderScrollOffsetKey.self,
+                                    value: max(
+                                        0,
+                                        -contentProxy.frame(in: .named("spaceSliderTrack")).minX
+                                    )
+                                )
+                            }
+                        }
+                    }
+                    .frame(width: trackWidth, height: ShellSidebarSpaceSliderLayout.trackHeight)
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: ShellSidebarSpaceSliderLayout.trackHeight * 0.5,
+                            style: .continuous
+                        )
+                    )
+                }
+                .frame(width: trackWidth, height: ShellSidebarSpaceSliderLayout.trackHeight)
+                .coordinateSpace(name: "spaceSliderTrack")
+                .padding(.horizontal, ShellSidebarMetrics.edgeInset)
+                .padding(.vertical, 2)
+                .contentShape(Rectangle())
+                .simultaneousGesture(dragScrubGesture(layout: layout))
+                .background {
+                    ShellSidebarSpaceSliderWheelMonitor(
+                        onScroll: { event, deltaX, deltaY in
+                            handleWheel(
+                                event: event,
+                                deltaX: deltaX,
+                                deltaY: deltaY,
+                                availableWidth: proxy.size.width
+                            )
+                        },
+                        onReset: resetWheelIntent,
+                        onContextMenuIntent: cancelScrubPreview
+                    )
+                }
+                .onPreferenceChange(ShellSidebarSpaceSliderScrollOffsetKey.self) { offset in
+                    trackScrollOffsetX = offset
+                }
+                .onChange(of: autoScrollSpaceID) { _, spaceID in
+                    scrollSpaceIntoView(spaceID, scrollProxy: scrollProxy)
+                }
+                .onAppear {
+                    scrollSpaceIntoView(autoScrollSpaceID, scrollProxy: scrollProxy, animated: false)
                 }
             }
-            .padding(.horizontal, ShellSidebarMetrics.edgeInset)
-            .padding(.vertical, 4)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .offset(x: reduceMotion ? 0 : scrubState?.edgeResistanceOffset ?? 0)
-            .contentShape(Rectangle())
-            .simultaneousGesture(dragScrubGesture(layout: layout))
-            .background {
-                ShellSidebarSpaceSliderWheelMonitor(
-                    onScroll: { event, deltaX, deltaY in
-                        handleWheel(
-                            event: event,
-                            deltaX: deltaX,
-                            deltaY: deltaY,
-                            availableWidth: proxy.size.width
-                        )
-                    },
-                    onReset: resetWheelIntent,
-                    onContextMenuIntent: cancelScrubPreview
-                )
-            }
             .focusable()
             .focused($isKeyboardFocused)
             .focusEffectDisabled()
@@ -1082,7 +1146,7 @@ private struct ShellSidebarSpaceSlider: View {
     }
 
     private var visibleSpaces: [ShellSpace] {
-        Array(host.spaces.prefix(ShellSidebarSpaceSliderLayout.maximumVisibleSpaces))
+        host.spaces
     }
 
     private func sliderLayout(availableWidth: CGFloat) -> ShellSidebarSpaceSliderLayout {
@@ -1113,27 +1177,18 @@ private struct ShellSidebarSpaceSlider: View {
             cancelScrubPreview()
             host.select(spaceID: visibleSpaces[targetIndex].spaceID)
         } label: {
-            switch item.mode {
-            case .fullTitle, .shortTitle:
-                ShellSidebarSpaceTitlePill(
-                    title: space.title,
-                    mode: item.mode,
-                    attention: strongestAttention(for: space),
-                    isSelected: item.isSelected,
-                    isFocused: item.isFocused
-                )
-            case .indicator:
-                ShellSidebarSpaceDot(
-                    attention: strongestAttention(for: space),
-                    isHovered: hoveredSpaceID == space.spaceID,
-                    isPreviewed: item.isFocused
-                )
-            }
+            ShellSidebarSpaceTrackTarget(
+                title: space.title,
+                systemImage: space.resolvedPresentationIconSystemName,
+                mode: item.mode,
+                attention: strongestAttention(for: space),
+                isSelected: item.isSelected,
+                isFocused: item.isFocused,
+                isHovered: hoveredSpaceID == space.spaceID
+            )
         }
         .buttonStyle(.plain)
-        .frame(width: item.width, height: 22)
-        .scaleEffect(item.visualScale)
-        .opacity(Double(item.opacity))
+        .frame(width: item.width, height: ShellSidebarSpaceSliderLayout.itemHeight)
         .contentShape(Rectangle())
         .contextMenu {
             spaceContextMenu(for: space)
@@ -1144,7 +1199,6 @@ private struct ShellSidebarSpaceSlider: View {
         .onHover { isHovering in
             hoveredSpaceID = isHovering ? space.spaceID : nil
         }
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: item)
     }
 
     @ViewBuilder
@@ -1190,6 +1244,10 @@ private struct ShellSidebarSpaceSlider: View {
         return previewedSpaceID
     }
 
+    private var autoScrollSpaceID: String? {
+        scrubFocusSpaceID ?? resolvedDisplaySpaceID
+    }
+
     private var visibleSpaceIDs: [String] {
         visibleSpaces.map(\.spaceID)
     }
@@ -1214,7 +1272,7 @@ private struct ShellSidebarSpaceSlider: View {
     ) {
         guard var nextState = scrubStateForUpdating(source: .drag) else { return }
         nextState.updateDrag(
-            locationX: value.location.x - ShellSidebarMetrics.edgeInset,
+            locationX: value.location.x - ShellSidebarMetrics.edgeInset + trackScrollOffsetX,
             translationX: value.translation.width,
             layout: layout
         )
@@ -1304,6 +1362,22 @@ private struct ShellSidebarSpaceSlider: View {
             }
             commitScrubSelection()
             resetWheelIntent()
+        }
+    }
+
+    private func scrollSpaceIntoView(
+        _ spaceID: String?,
+        scrollProxy: ScrollViewProxy,
+        animated: Bool = true
+    ) {
+        guard let spaceID else { return }
+        let action = {
+            scrollProxy.scrollTo(spaceID, anchor: .center)
+        }
+        if animated, !reduceMotion {
+            withAnimation(.easeOut(duration: 0.14), action)
+        } else {
+            action()
         }
     }
 
@@ -1400,126 +1474,127 @@ private struct ShellSidebarSpaceSlider: View {
     }
 }
 
-private struct ShellSidebarSpaceTitlePill: View {
+private struct ShellSidebarSpaceTrackTarget: View {
     let title: String
+    let systemImage: String
     let mode: ShellSidebarSpaceSliderLayout.DisplayMode
     let attention: ShellAttentionState
     let isSelected: Bool
     let isFocused: Bool
+    let isHovered: Bool
 
     var body: some View {
-        HStack(spacing: 5) {
-            if attention != .idle {
-                Circle()
-                    .fill(ShellPalette.attention.opacity(0.82))
-                    .frame(width: 4.5, height: 4.5)
-            }
+        HStack(spacing: textSpacing) {
+            Image(systemName: systemImage)
+                .font(.system(size: iconSize, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(iconForeground)
+                .frame(width: 15, height: 15)
 
-            Text(title)
-                .font(font)
-                .foregroundStyle(foreground)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            if mode != .iconOnly {
+                Text(title)
+                    .font(font)
+                    .foregroundStyle(textForeground)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
         .padding(.horizontal, horizontalPadding)
-        .frame(maxWidth: .infinity, minHeight: 22, alignment: .center)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: ShellSidebarSpaceSliderLayout.itemHeight,
+            alignment: .center
+        )
         .background {
-            if showsBackground {
-                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                    .fill(background)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                            .stroke(ShellPalette.line.opacity(isSelected ? 0.18 : 0.12), lineWidth: 0.6)
-                    }
+            if isSelected {
+                ShellLiquidGlassSurface(
+                    shape: Capsule(),
+                    tint: ShellPalette.sidebarSelection,
+                    tintOpacity: 0.30,
+                    strokeOpacity: 0.24,
+                    usesSystemGlassInLightMode: true
+                )
+            } else if isFocused || isHovered {
+                Capsule()
+                    .strokeBorder(focusStroke, lineWidth: 0.7)
             }
         }
-        .shellShadow(isSelected ? ShellShadows.navigationSelection : ShellShadows.none)
     }
 
     private var font: Font {
         switch mode {
         case .fullTitle:
-            return .system(size: 12.2, weight: isSelected ? .semibold : .medium)
-        case .shortTitle:
-            return .system(size: 11.4, weight: isFocused ? .semibold : .medium)
-        case .indicator:
+            return .system(size: 12, weight: isSelected ? .semibold : .medium)
+        case .truncatedTitle:
+            return .system(size: 11.6, weight: isSelected || isFocused ? .semibold : .medium)
+        case .iconOnly:
             return .system(size: 11.4, weight: .medium)
         }
     }
 
     private var horizontalPadding: CGFloat {
-        mode == .fullTitle ? 8 : 6
+        switch mode {
+        case .fullTitle:
+            return 8
+        case .truncatedTitle:
+            return 6
+        case .iconOnly:
+            return 0
+        }
     }
 
-    private var showsBackground: Bool {
-        isSelected || isFocused || mode == .fullTitle
+    private var textSpacing: CGFloat {
+        switch mode {
+        case .fullTitle:
+            return 5
+        case .truncatedTitle:
+            return 4
+        case .iconOnly:
+            return 0
+        }
     }
 
-    private var background: Color {
+    private var iconSize: CGFloat {
+        switch mode {
+        case .fullTitle, .truncatedTitle:
+            return 11.4
+        case .iconOnly:
+            return 12.4
+        }
+    }
+
+    private var textForeground: Color {
         if isSelected {
-            return ShellPalette.sidebarSelection
+            return ShellPalette.sidebarInk.opacity(0.92)
         }
-        if isFocused {
-            return ShellPalette.sidebarHover
-        }
-        return ShellPalette.materialTopWash.opacity(0.7)
-    }
-
-    private var foreground: Color {
-        if isSelected || isFocused {
-            return ShellPalette.sidebarInk.opacity(0.88)
+        if isFocused || isHovered {
+            return ShellPalette.sidebarInk.opacity(0.82)
         }
         return ShellPalette.sidebarMutedInk.opacity(0.72)
     }
-}
 
-private struct ShellSidebarSpaceDot: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    let attention: ShellAttentionState
-    let isHovered: Bool
-    let isPreviewed: Bool
-
-    var body: some View {
-        ZStack {
-            if isHovered || isPreviewed {
-                RoundedRectangle(cornerRadius: ShellRadii.control, style: .continuous)
-                    .fill(ShellPalette.sidebarHover)
-            }
-
-            Circle()
-                .fill(dotFill)
-                .frame(width: dotSize, height: dotSize)
-                .overlay {
-                    Circle()
-                        .stroke(dotStroke, lineWidth: 0.6)
-                }
+    private var iconForeground: Color {
+        if attention != .idle {
+            return ShellPalette.attention.opacity(isSelected ? 0.94 : 0.86)
         }
-        .frame(width: 18, height: 22)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isHovered)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: isPreviewed)
-        .animation(reduceMotion ? nil : .easeOut(duration: 0.14), value: attention)
-    }
-
-    private var dotSize: CGFloat {
-        isHovered || isPreviewed || attention != .idle ? 6.5 : 5.2
-    }
-
-    private var dotFill: Color {
-        if isPreviewed {
+        if isSelected {
+            return ShellPalette.sidebarInk.opacity(0.92)
+        }
+        if isFocused {
             return ShellPalette.accent.opacity(0.82)
         }
-        if attention != .idle {
-            return ShellPalette.attention.opacity(0.82)
+        if isHovered {
+            return ShellPalette.sidebarInk.opacity(0.78)
         }
-        return ShellPalette.sidebarMutedInk.opacity(isHovered ? 0.72 : 0.46)
+        return ShellPalette.sidebarMutedInk.opacity(0.62)
     }
 
-    private var dotStroke: Color {
-        if isPreviewed {
+    private var focusStroke: Color {
+        if isFocused {
             return ShellPalette.accent.opacity(0.34)
         }
-        return ShellPalette.line.opacity(isHovered ? 0.24 : 0.12)
+        return ShellPalette.sidebarInk.opacity(0.14)
     }
 }
 

--- a/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
+++ b/clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift
@@ -37,11 +37,7 @@ struct ShellSpaceKeyboardShortcuts: View {
             .shellActionKeyboardShortcut(host.shellActionShortcut(.spaceSelectNext))
 
             ForEach(
-                Array(
-                    host.spaces
-                        .prefix(ShellSidebarSpaceSliderLayout.maximumVisibleSpaces)
-                        .enumerated()
-                ),
+                Array(host.spaces.enumerated()),
                 id: \.element.spaceID
             ) { index, _ in
                 let target = ShellActionTarget.spaceIndex(index)

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -646,15 +646,55 @@ require_pattern \
     "ShellSidebarSpaceSlider" \
     "sidebar Space navigation must render through the top Space slider"
 
-require_pattern \
+reject_pattern \
+    "clients/apple/alan-macos" \
+    "maximumVisibleSpaces|ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces" \
+    "continuous Space slider must not retain the old 9-Space cap"
+
+reject_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
-    "maximumVisibleSpaces = 9" \
-    "adaptive Space slider must cap the default sidebar at 9 visible Spaces"
+    "case low|case medium|case high|visualScale|opacity\\(" \
+    "continuous Space slider must not retain count-density tiers or hover scale/fade geometry"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
-    "case low|case medium|case high" \
-    "adaptive Space slider must define low, medium, and high density tiers"
+    "case fullTitle|case truncatedTitle|case iconOnly" \
+    "continuous Space slider must define full, truncated, and icon-only collapse modes"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "distributedItemWidth" \
+    "continuous Space slider must distribute Space targets across the full track before minimum-width overflow"
+
+reject_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "fullTitleItemWidth|truncatedTitleItemWidth|width\\(for: mode\\)" \
+    "continuous Space slider must not retain fixed maximum Space target widths"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
+    "isHorizontallyScrollable|contentWidth > availableWidth" \
+    "continuous Space slider must expose horizontal overflow sizing"
+
+require_pattern \
+    "clients/apple/alan-macos/Support/ShellDesignTokens.swift" \
+    "sidebarSpaceSliderTrack" \
+    "continuous Space slider track must use a dedicated Safari-like gray track token"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "ShellPalette\\.sidebarSpaceSliderTrack" \
+    "continuous Space slider track must render with the dedicated gray track token"
+
+reject_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "sidebarControl\\.opacity\\(0\\.46\\)" \
+    "continuous Space slider track must not use the old too-light sidebar control fill"
+
+require_pattern \
+    "clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift" \
+    "resolvedPresentationIconSystemName|presentation_icon" \
+    "ShellSpace projection must expose optional Space presentation icon metadata"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellSidebarSpaceSliderLayout.swift" \
@@ -667,29 +707,19 @@ require_pattern \
     "adaptive Space slider must keep press-drag scrub behind an explicit horizontal threshold"
 
 require_pattern \
-    "clients/apple/alan-macos/ShellHostController.swift" \
-    "ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces" \
-    "host Space creation must share the 9-Space slider cap"
-
-require_pattern \
-    "clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift" \
-    "ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces" \
-    "local space.create must share the 9-Space slider cap"
-
-require_pattern \
-    "clients/apple/alan-macos/Views/Shell/ShellWorkspaceView.swift" \
-    "prefix\\(ShellSidebarSpaceSliderLayout\\.maximumVisibleSpaces\\)" \
-    "hidden Space index shortcuts must share the 9-Space slider cap"
-
-require_pattern \
-    "clients/apple/alan-macos/MacShellRootView.swift" \
-    "\\.disabled\\(!canCreateTerminalSpace\\)" \
-    "titlebar New Space must disable when the adaptive slider cap is reached"
+    "clients/apple/scripts/test-shell-runtime-metadata.swift" \
+    "verifiesSpaceCreateAllowsMoreThanNineSpacesAcrossCommandPaths" \
+    "runtime tests must prove Space creation can exceed the old slider cap"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
     "spaceContextMenu\\(" \
     "Space profile selection must be exposed through the Space context menu"
+
+require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "host\\.setTerminalProfile\\([^\\n]+forSpaceID: space\\.spaceID\\)" \
+    "Space context-menu profile actions must target the Space whose menu was opened"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
@@ -717,9 +747,19 @@ require_pattern \
     "Space slider vertical pass-through wheel input must be forwarded to the active tab list"
 
 require_pattern \
+    "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
+    "locationX: value\\.location\\.x - ShellSidebarMetrics\\.edgeInset \\+ trackScrollOffsetX" \
+    "Space slider drag scrub must account for the horizontal track scroll offset"
+
+require_pattern \
     "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
     "verifiesPassThroughWheelForwardingDecision" \
     "Space slider layout tests must cover pass-through wheel forwarding to the tab list"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesReadableSpacesDistributeAcrossTheFullTrack|verifiesTruncatedSpacesDistributeAcrossTheFullTrack|verifiesIconOnlySpacesDistributeUntilMinimumWidth" \
+    "Space slider layout tests must prove targets distribute across the full track before minimum-width overflow"
 
 require_pattern \
     "clients/apple/alan-macos/Views/Shell/ShellSidebarView.swift" \
@@ -788,8 +828,8 @@ require_pattern \
 
 require_pattern \
     "clients/apple/scripts/test-shell-runtime-metadata.swift" \
-    "verifiesSpaceCreateCapAppliesToControlCommandPaths" \
-    "shell runtime tests must prove space.create shares the sidebar Space cap"
+    "verifiesSpaceCreateAllowsMoreThanNineSpacesAcrossCommandPaths" \
+    "shell runtime tests must prove space.create can exceed the old sidebar Space cap"
 
 require_pattern \
     "clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift" \
@@ -1858,8 +1898,18 @@ require_pattern \
 
 require_pattern \
     "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
-    "verifiesDensityTiers" \
-    "shell sidebar Space slider tests must verify adaptive density tiers"
+    "verifiesMoreThanNineSpacesParticipate" \
+    "shell sidebar Space slider tests must verify every Space participates"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesIconOnlyCollapseAndOverflowSizing" \
+    "shell sidebar Space slider tests must verify icon-only overflow sizing"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
+    "verifiesHoverDoesNotChangeGeometry" \
+    "shell sidebar Space slider tests must verify hover keeps stable geometry"
 
 require_pattern \
     "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
@@ -1870,6 +1920,16 @@ require_pattern \
     "clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift" \
     "verifiesScrubCancelRestoresTheSelectedSource" \
     "shell sidebar Space slider tests must verify scrub cancel restores the selected Space"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-workspace-manifest.swift" \
+    "verifiesContentSpaceIconMetadataRoundTripsSeparatelyFromTerminalProfile" \
+    "workspace manifest tests must verify explicit Space icon metadata round-trips outside Terminal Profiles"
+
+require_pattern \
+    "clients/apple/scripts/test-shell-workspace-manifest.swift" \
+    "verifiesInvalidSpaceIconFallsBackButPreservesManifestEvidence" \
+    "workspace manifest tests must verify invalid Space icon metadata falls back without data loss"
 
 require_pattern \
     "clients/apple/alan-macos/Support/ShellWindowPlacement.swift" \

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -181,6 +181,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesManifestActiveTaskProjection()
         verifiesTerminalProfileStoreFallbackValidationAndCorruptRecovery()
         verifiesTerminalProfileLaunchResolutionAndEnvironmentProjection()
+        verifiesTerminalProfileRebindingPreservesSpaceIconMetadata()
         verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip()
         verifiesTerminalProfileInheritanceForSpacesTabsAndSplits()
         verifiesGlobalDefaultTerminalProfileDefersWorkingDirectory()
@@ -8666,6 +8667,30 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesTerminalProfileRebindingPreservesSpaceIconMetadata() {
+        let initialState = stateWithContext(
+            windowID: "window_icon_rebind",
+            context: context(
+                processState: "running",
+                rendererHealth: "healthy",
+                surfaceReadiness: "ready",
+                lastCommandExitCode: nil
+            ),
+            spacePresentationIconSystemName: "rectangle.stack.fill"
+        )
+
+        let reboundState = initialState.settingTerminalProfile("alan", forSpaceID: "space_1")
+        expect(
+            reboundState?.space(spaceID: "space_1")?.terminalProfileID == "alan",
+            "rebinding a Space terminal profile must update the Space profile reference"
+        )
+        expect(
+            reboundState?.space(spaceID: "space_1")?.presentationIconSystemName
+                == "rectangle.stack.fill",
+            "rebinding a Space terminal profile must preserve explicit Space icon metadata"
+        )
+    }
+
     private static func verifiesTerminalProfileReferencesPersistThroughManifestRoundTrip() {
         let now = Date(timeIntervalSince1970: 2_001)
         let manifest = ShellContentWorkspaceManifest(
@@ -10471,6 +10496,7 @@ private enum ShellRuntimeMetadataTests {
         windowID: String,
         context: ShellContextSnapshot,
         spaceTerminalProfileID: String? = nil,
+        spacePresentationIconSystemName: String? = nil,
         paneTerminalProfileID: String? = nil
     ) -> ShellStateSnapshot {
         let pane = pane(
@@ -10504,7 +10530,8 @@ private enum ShellRuntimeMetadataTests {
                             )
                         )
                     ],
-                    terminalProfileID: spaceTerminalProfileID
+                    terminalProfileID: spaceTerminalProfileID,
+                    presentationIconSystemName: spacePresentationIconSystemName
                 )
             ],
             panes: [pane]

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -41,7 +41,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalLifecycleShutdownFinalizesAllRuntimes()
         verifiesShellHostControllerRoutesSharedAutomationCommands()
         verifiesControlPlaneRoutesSharedAutomationCommandSemantics()
-        verifiesSpaceCreateCapAppliesToControlCommandPaths()
+        verifiesSpaceCreateAllowsMoreThanNineSpacesAcrossCommandPaths()
         verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd()
         verifiesShellActionNewTerminalTabInheritsFocusedRuntimeCwd()
         verifiesOpeningTerminalTabFallsBackToFocusedPaneSnapshotCwd()
@@ -2252,65 +2252,64 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
-    private static func verifiesSpaceCreateCapAppliesToControlCommandPaths() {
-        var cappedState = ShellStateSnapshot.bootstrapDefault(windowID: "space_cap_control")
-        while cappedState.spaces.count < ShellSidebarSpaceSliderLayout.maximumVisibleSpaces {
-            cappedState = cappedState.creatingTerminalSpace(
+    private static func verifiesSpaceCreateAllowsMoreThanNineSpacesAcrossCommandPaths() {
+        var expandedState = ShellStateSnapshot.bootstrapDefault(windowID: "space_track_control")
+        while expandedState.spaces.count < 10 {
+            expandedState = expandedState.creatingTerminalSpace(
                 title: nil,
                 workingDirectory: nil
             ).state
         }
 
         let controller = makeController(
-            windowID: "space_cap_control",
-            shellState: cappedState
+            windowID: "space_track_control",
+            shellState: expandedState
         )
         let directSpaceID = controller.createSpace()
-        expect(directSpaceID == nil, "direct createSpace must reject the capped Space count")
+        expect(directSpaceID != nil, "direct createSpace must allow more than nine Spaces")
         expect(
-            controller.shellState.spaces.count
-                == ShellSidebarSpaceSliderLayout.maximumVisibleSpaces,
-            "direct createSpace must leave the capped Space count unchanged"
+            controller.shellState.spaces.count == 11,
+            "direct createSpace must append the eleventh Space"
         )
 
         let controlPlaneCreate = controller.handleControlPlaneCommand(
             decodeControlCommand(
                 """
                 {
-                  "request_id": "space-cap-control-plane",
+                  "request_id": "space-track-control-plane",
                   "command": "space.create"
                 }
                 """
             )
         )
         expect(
-            controlPlaneCreate.applied == false
-                && controlPlaneCreate.errorCode == "space_create_failed",
-            "control-plane space.create must reject the capped Space count"
+            controlPlaneCreate.applied == true && controlPlaneCreate.spaceID != nil,
+            "control-plane space.create must allow more than nine Spaces"
         )
         expect(
-            controller.shellState.spaces.count
-                == ShellSidebarSpaceSliderLayout.maximumVisibleSpaces,
-            "control-plane space.create must leave the capped Space count unchanged"
+            controller.shellState.spaces.count == 12,
+            "control-plane space.create must append another Space beyond the old cap"
         )
 
         let localCreate = AlanShellLocalCommandExecutor.execute(
             command: decodeControlCommand(
                 """
                 {
-                  "request_id": "space-cap-local",
+                  "request_id": "space-track-local",
                   "command": "space.create"
                 }
                 """
             ),
-            state: cappedState
+            state: expandedState
         )
         expect(
-            localCreate?.response.applied == false
-                && localCreate?.response.errorCode == "space_create_failed",
-            "local space.create must reject the capped Space count"
+            localCreate?.response.applied == true && localCreate?.response.spaceID != nil,
+            "local space.create must allow more than nine Spaces"
         )
-        expect(localCreate?.updatedState == nil, "local space.create must not mutate capped state")
+        expect(
+            localCreate?.updatedState?.spaces.count == 11,
+            "local space.create must return an updated state beyond the old cap"
+        )
     }
 
     private static func verifiesOpeningTerminalTabInheritsFocusedRuntimeCwd() {

--- a/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
+++ b/clients/apple/scripts/test-shell-sidebar-space-slider-layout.swift
@@ -10,14 +10,17 @@ struct ShellSidebarSpaceSliderLayoutTestRunner {
 
 private enum ShellSidebarSpaceSliderLayoutTests {
     static func run() throws {
-        try verifiesDensityTiers()
-        try verifiesLowDensityUsesFullTitles()
-        try verifiesMediumDensityUsesSelectedFullTitleAndShortTitles()
-        try verifiesHighDensityUsesSelectedTitleAndIndicators()
-        try verifiesHighDensityHoverExpandsTheHoveredIndicator()
+        try verifiesOneSpaceUsesFullTitleTrackTarget()
+        try verifiesSeveralSpacesUseReadableTrackTargets()
+        try verifiesReadableSpacesDistributeAcrossTheFullTrack()
+        try verifiesTruncatedTitlesWhenPartialWidthFits()
+        try verifiesTruncatedSpacesDistributeAcrossTheFullTrack()
+        try verifiesIconOnlySpacesDistributeUntilMinimumWidth()
+        try verifiesMoreThanNineSpacesParticipate()
+        try verifiesIconOnlyCollapseAndOverflowSizing()
+        try verifiesHoverDoesNotChangeGeometry()
         try verifiesScrubFocusIsDistinctFromSelectedSpace()
-        try verifiesMaximumVisibleSpaceCap()
-        try verifiesReducedMotionRemovesScaleEmphasis()
+        try verifiesReducedMotionPreservesStableGeometry()
         try verifiesClickSelectionRules()
         try verifiesDragScrubPreviewAndCommitTarget()
         try verifiesDragScrubUsesEdgeResistanceAtBounds()
@@ -29,82 +32,143 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         print("Shell sidebar Space slider layout tests passed.")
     }
 
-    private static func verifiesDensityTiers() throws {
-        expect(ShellSidebarSpaceSliderLayout.density(for: 1) == .low, "1 Space must be low density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 3) == .low, "3 Spaces must be low density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 4) == .medium, "4 Spaces must be medium density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 6) == .medium, "6 Spaces must be medium density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 7) == .high, "7 Spaces must be high density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 9) == .high, "9 Spaces must be high density")
-        expect(ShellSidebarSpaceSliderLayout.density(for: 12) == .high, "Space count must cap into high density")
+    private static func verifiesOneSpaceUsesFullTitleTrackTarget() throws {
+        let layout = make(spaceCount: 1, selectedIndex: 0, availableWidth: 240)
+
+        expect(layout.items.count == 1, "single-Space layout must include the Space")
+        expect(layout.items[0].mode == .fullTitle, "single-Space target must show icon and full title")
+        expect(layout.items[0].isSelected, "selected item must be preserved")
+        expect(!layout.isHorizontallyScrollable, "single-Space track must not require overflow scrolling")
+        expect(layout.contentWidth <= 240, "single-Space content must fit inside the track")
     }
 
-    private static func verifiesLowDensityUsesFullTitles() throws {
-        let layout = make(spaceCount: 3, selectedIndex: 1)
+    private static func verifiesSeveralSpacesUseReadableTrackTargets() throws {
+        let layout = make(spaceCount: 3, selectedIndex: 1, availableWidth: 300)
 
-        expect(layout.density == .low, "3 Spaces must use low density")
         expect(
             layout.items.map(\.mode) == [.fullTitle, .fullTitle, .fullTitle],
-            "low density must render every Space as a full title"
+            "readable track width must show icon and full title for every Space"
         )
-        expect(layout.items[1].isSelected, "selected item must be preserved")
+        expect(layout.contentWidth <= 300, "readable targets must fit without overflow")
     }
 
-    private static func verifiesMediumDensityUsesSelectedFullTitleAndShortTitles() throws {
-        let layout = make(spaceCount: 6, selectedIndex: 2)
+    private static func verifiesReadableSpacesDistributeAcrossTheFullTrack() throws {
+        let layout = make(spaceCount: 2, selectedIndex: 0, availableWidth: 300)
+        let expectedItemWidth = (300 - ShellSidebarSpaceSliderLayout.spacing) / 2
 
-        expect(layout.density == .medium, "6 Spaces must use medium density")
-        expect(layout.items[2].mode == .fullTitle, "selected medium-density Space must be full title")
         expect(
-            layout.items.enumerated().allSatisfy { index, item in
-                index == 2 || item.mode == .shortTitle
-            },
-            "inactive medium-density Spaces must be short titles"
+            layout.items.map(\.mode) == [.fullTitle, .fullTitle],
+            "wide readable Spaces must keep full title labels"
         )
-    }
-
-    private static func verifiesHighDensityUsesSelectedTitleAndIndicators() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 4)
-
-        expect(layout.density == .high, "9 Spaces must use high density")
-        expect(layout.items[4].mode == .fullTitle, "selected high-density Space must be full title")
         expect(
-            layout.items.enumerated().allSatisfy { index, item in
-                index == 4 || item.mode == .indicator
-            },
-            "inactive high-density Spaces must be indicators"
+            layout.items.allSatisfy { rounded($0.width) == rounded(expectedItemWidth) },
+            "readable Space targets must distribute across the full track instead of using a fixed maximum width"
+        )
+        expect(
+            rounded(layout.contentWidth) == rounded(300),
+            "readable Space targets must fill the whole track before minimum-width collapse"
         )
     }
 
-    private static func verifiesHighDensityHoverExpandsTheHoveredIndicator() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 0, hoveredIndex: 5)
+    private static func verifiesTruncatedTitlesWhenPartialWidthFits() throws {
+        let layout = make(spaceCount: 3, selectedIndex: 1, availableWidth: 180)
 
-        expect(layout.items[5].mode == .shortTitle, "hovered high-density indicator must expand to a short title")
-        expect(layout.items[5].isFocused, "hovered item must become focused for local preview")
-        expect(layout.items[4].visualScale >= 1, "neighboring items must remain visually stable")
+        expect(
+            layout.items.map(\.mode) == [.truncatedTitle, .truncatedTitle, .truncatedTitle],
+            "partial track width must keep icon and truncated title targets before icon-only collapse"
+        )
+        expect(layout.contentWidth <= 180, "truncated targets must fit inside the available track")
+        expect(!layout.isHorizontallyScrollable, "truncated targets must not scroll until minimums overflow")
+    }
+
+    private static func verifiesTruncatedSpacesDistributeAcrossTheFullTrack() throws {
+        let layout = make(spaceCount: 4, selectedIndex: 1, availableWidth: 240)
+        let expectedItemWidth = (240 - ShellSidebarSpaceSliderLayout.spacing * 3) / 4
+
+        expect(
+            layout.items.map(\.mode) == [
+                .truncatedTitle,
+                .truncatedTitle,
+                .truncatedTitle,
+                .truncatedTitle,
+            ],
+            "partial-width Spaces must keep truncated title labels before icon-only collapse"
+        )
+        expect(
+            layout.items.allSatisfy { rounded($0.width) == rounded(expectedItemWidth) },
+            "truncated Space targets must distribute across the full track instead of using a fixed width"
+        )
+        expect(
+            rounded(layout.contentWidth) == rounded(240),
+            "truncated Space targets must fill the whole track before minimum-width collapse"
+        )
+    }
+
+    private static func verifiesIconOnlySpacesDistributeUntilMinimumWidth() throws {
+        let layout = make(spaceCount: 7, selectedIndex: 3, availableWidth: 240)
+        let expectedItemWidth = (240 - ShellSidebarSpaceSliderLayout.spacing * 6) / 7
+
+        expect(
+            layout.items.allSatisfy { $0.mode == .iconOnly },
+            "narrow Spaces may collapse to icon-only before minimum overflow"
+        )
+        expect(
+            layout.items.allSatisfy { rounded($0.width) == rounded(expectedItemWidth) },
+            "icon-only Space targets must still distribute across the full track until the minimum width is reached"
+        )
+        expect(
+            rounded(layout.contentWidth) == rounded(240),
+            "icon-only Space targets above the minimum width must fill the whole track without scrolling"
+        )
+        expect(!layout.isHorizontallyScrollable, "icon-only distribution above minimum width must not scroll")
+    }
+
+    private static func verifiesMoreThanNineSpacesParticipate() throws {
+        let layout = make(spaceCount: 12, selectedIndex: 10, availableWidth: 360)
+
+        expect(layout.items.count == 12, "layout must include every Space instead of capping at nine")
+        expect(layout.items[10].isSelected, "selected Space beyond the old cap must remain selectable")
+        expect(layout.items.map(\.index) == Array(0..<12), "item indices must preserve every Space target")
+    }
+
+    private static func verifiesIconOnlyCollapseAndOverflowSizing() throws {
+        let layout = make(spaceCount: 14, selectedIndex: 12, availableWidth: 240)
+
+        expect(
+            layout.items.allSatisfy { $0.mode == .iconOnly },
+            "overflow track must collapse every Space to icon-only minimum targets"
+        )
+        expect(layout.items.count == 14, "icon-only overflow must still include every Space")
+        expect(layout.contentWidth > 240, "minimum icon-only targets must report overflow content width")
+        expect(layout.isHorizontallyScrollable, "minimum overflow must request horizontal track scrolling")
+    }
+
+    private static func verifiesHoverDoesNotChangeGeometry() throws {
+        let base = make(spaceCount: 9, selectedIndex: 0, availableWidth: 240)
+        let hovered = make(spaceCount: 9, selectedIndex: 0, hoveredIndex: 5, availableWidth: 240)
+
+        expect(geometrySignature(base) == geometrySignature(hovered), "hover must not change Space frames")
+        expect(hovered.items[5].isFocused, "hovered item must still be identified as focused")
     }
 
     private static func verifiesScrubFocusIsDistinctFromSelectedSpace() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 0, scrubFocusIndex: 6)
+        let base = make(spaceCount: 9, selectedIndex: 0, availableWidth: 240)
+        let focused = make(spaceCount: 9, selectedIndex: 0, scrubFocusIndex: 6, availableWidth: 240)
 
-        expect(layout.items[0].isSelected, "selected Space marker must remain on the active Space")
-        expect(layout.items[6].isFocused, "scrub focus must mark the preview Space")
-        expect(layout.items[6].mode == .fullTitle, "scrub-focused high-density Space must become a title")
+        expect(focused.items[0].isSelected, "selected Space marker must remain on the active Space")
+        expect(focused.items[6].isFocused, "scrub focus must mark the preview Space")
+        expect(geometrySignature(base) == geometrySignature(focused), "scrub focus must not shift target frames")
     }
 
-    private static func verifiesMaximumVisibleSpaceCap() throws {
-        let layout = make(spaceCount: 12, selectedIndex: 10)
-
-        expect(
-            ShellSidebarSpaceSliderLayout.maximumVisibleSpaces == 9,
-            "maximum visible Space count must be 9"
+    private static func verifiesReducedMotionPreservesStableGeometry() throws {
+        let animated = ShellSidebarSpaceSliderLayout.make(
+            spaceCount: 9,
+            selectedIndex: 0,
+            scrubFocusIndex: 4,
+            availableWidth: 240,
+            reduceMotion: false
         )
-        expect(layout.items.count == 9, "layout must cap rendered Spaces at 9")
-        expect(layout.items[8].isSelected, "selected index must clamp into the visible range")
-    }
-
-    private static func verifiesReducedMotionRemovesScaleEmphasis() throws {
-        let layout = ShellSidebarSpaceSliderLayout.make(
+        let reduced = ShellSidebarSpaceSliderLayout.make(
             spaceCount: 9,
             selectedIndex: 0,
             scrubFocusIndex: 4,
@@ -113,8 +177,8 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         )
 
         expect(
-            layout.items.allSatisfy { $0.visualScale == 1 },
-            "reduced motion must disable scale emphasis"
+            geometrySignature(animated) == geometrySignature(reduced),
+            "reduced motion must preserve the same stable target geometry"
         )
     }
 
@@ -146,8 +210,8 @@ private enum ShellSidebarSpaceSliderLayoutTests {
     }
 
     private static func verifiesDragScrubPreviewAndCommitTarget() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 2)
-        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 9)
+        let layout = make(spaceCount: 12, selectedIndex: 2, availableWidth: 360)
+        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 12)
         let targetX = try expectValue(layout.midpoint(for: 6), "target midpoint must exist")
 
         scrub.updateDrag(locationX: targetX, translationX: 3, layout: layout)
@@ -160,9 +224,9 @@ private enum ShellSidebarSpaceSliderLayoutTests {
     }
 
     private static func verifiesDragScrubUsesEdgeResistanceAtBounds() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 4)
-        var leadingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 9)
-        var trailingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 9)
+        let layout = make(spaceCount: 12, selectedIndex: 4, availableWidth: 360)
+        var leadingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 12)
+        var trailingScrub = try makeScrub(source: .drag, selectedIndex: 4, spaceCount: 12)
 
         leadingScrub.updateDrag(locationX: -40, translationX: -80, layout: layout)
         trailingScrub.updateDrag(locationX: layout.contentWidth + 40, translationX: 80, layout: layout)
@@ -172,7 +236,7 @@ private enum ShellSidebarSpaceSliderLayoutTests {
             leadingScrub.edgeResistanceOffset < 0,
             "leading edge drag must expose a resisted offset"
         )
-        expect(trailingScrub.focusIndex == 8, "trailing edge drag must clamp to the last Space")
+        expect(trailingScrub.focusIndex == 11, "trailing edge drag must clamp to the last Space")
         expect(
             trailingScrub.edgeResistanceOffset > 0,
             "trailing edge drag must expose a resisted offset"
@@ -180,20 +244,20 @@ private enum ShellSidebarSpaceSliderLayoutTests {
     }
 
     private static func verifiesWheelScrubPreviewAndCommitTarget() throws {
-        var scrub = try makeScrub(source: .wheel, selectedIndex: 3, spaceCount: 9)
+        var scrub = try makeScrub(source: .wheel, selectedIndex: 3, spaceCount: 12)
 
-        scrub.updateWheel(deltaX: 10, itemSpan: 24, spaceCount: 9)
+        scrub.updateWheel(deltaX: 10, itemSpan: 24, spaceCount: 12)
         expect(scrub.focusIndex == 3, "small wheel scrub must enter preview without moving focus")
 
-        scrub.updateWheel(deltaX: 58, itemSpan: 24, spaceCount: 9)
+        scrub.updateWheel(deltaX: 58, itemSpan: 24, spaceCount: 12)
         expect(scrub.focusIndex == 5, "wheel scrub must move preview focus after enough horizontal input")
         expect(scrub.hasPreviewTarget, "wheel scrub must preview before commit")
         expect(scrub.commitIndex == 5, "wheel dwell must commit the focused Space")
     }
 
     private static func verifiesScrubCancelRestoresTheSelectedSource() throws {
-        let layout = make(spaceCount: 9, selectedIndex: 2)
-        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 9)
+        let layout = make(spaceCount: 12, selectedIndex: 2, availableWidth: 360)
+        var scrub = try makeScrub(source: .drag, selectedIndex: 2, spaceCount: 12)
         let targetX = try expectValue(layout.midpoint(for: 6), "target midpoint must exist")
 
         scrub.updateDrag(locationX: targetX, translationX: 48, layout: layout)
@@ -295,16 +359,29 @@ private enum ShellSidebarSpaceSliderLayoutTests {
         spaceCount: Int,
         selectedIndex: Int?,
         hoveredIndex: Int? = nil,
-        scrubFocusIndex: Int? = nil
+        scrubFocusIndex: Int? = nil,
+        availableWidth: CGFloat = 240
     ) -> ShellSidebarSpaceSliderLayout {
         ShellSidebarSpaceSliderLayout.make(
             spaceCount: spaceCount,
             selectedIndex: selectedIndex,
             hoveredIndex: hoveredIndex,
             scrubFocusIndex: scrubFocusIndex,
-            availableWidth: 240,
+            availableWidth: availableWidth,
             reduceMotion: false
         )
+    }
+
+    private static func geometrySignature(
+        _ layout: ShellSidebarSpaceSliderLayout
+    ) -> [String] {
+        layout.items.map { item in
+            "\(item.index):\(item.mode):\(rounded(item.width))"
+        } + ["content:\(rounded(layout.contentWidth))"]
+    }
+
+    private static func rounded(_ value: CGFloat) -> Int {
+        Int((value * 100).rounded())
     }
 
     private static func makeScrub(

--- a/clients/apple/scripts/test-shell-workspace-manifest.swift
+++ b/clients/apple/scripts/test-shell-workspace-manifest.swift
@@ -15,6 +15,9 @@ private enum ShellWorkspaceManifestTests {
         try verifiesMissingManifestCreatesDefaultWithoutMigratingShellState()
         try verifiesCorruptManifestIsQuarantined()
         try verifiesOldManifestDecodesWithoutSpaceLocalSelection()
+        try verifiesOldManifestWithoutSpaceIconUsesDefaultWithoutRewriteEvidence()
+        try verifiesContentSpaceIconMetadataRoundTripsSeparatelyFromTerminalProfile()
+        try verifiesInvalidSpaceIconFallsBackButPreservesManifestEvidence()
         try verifiesMaterializerPreservesEmptySelectedSpace()
         try verifiesMaterializerPreservesEmptySelectedSpaceWithOtherTabs()
         try verifiesMaterializerPreservesInactiveSpaceSelection()
@@ -142,6 +145,181 @@ private enum ShellWorkspaceManifestTests {
         expect(
             decoded.spaces.first?.selectedTabID == "tab_second",
             "old manifest repair must seed selected space remembered tab from global selected tab"
+        )
+    }
+
+    private static func verifiesOldManifestWithoutSpaceIconUsesDefaultWithoutRewriteEvidence() throws {
+        let tab = makeContentTab(
+            tabID: "tab_icon_default",
+            title: "Icon Default",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/icon/default",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        let oldManifest = makeContentManifest(selectedTabID: tab.tabID, tabs: [tab])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let oldData = try encoder.encode(oldManifest)
+        let oldText = String(data: oldData, encoding: .utf8) ?? ""
+        expect(
+            !oldText.contains("\"presentation_icon\""),
+            "old-manifest setup must not include Space icon metadata"
+        )
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ShellContentWorkspaceManifest.self, from: oldData)
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: decoded,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(
+            decoded.spaces.first?.presentationIconSystemName == nil,
+            "absent Space icon metadata must remain absent on the decoded manifest record"
+        )
+        expect(
+            state.spaces.first?.presentationIconSystemName == nil,
+            "ShellSpace projection must preserve absent explicit icon metadata"
+        )
+        expect(
+            state.spaces.first?.resolvedPresentationIconSystemName
+                == ShellSpacePresentationIcon.defaultSystemName,
+            "ShellSpace projection must expose a deterministic default icon for display"
+        )
+
+        let rewrittenText = String(data: try encoder.encode(decoded), encoding: .utf8) ?? ""
+        expect(
+            !rewrittenText.contains("\"presentation_icon\""),
+            "default display icon must not rewrite old manifest evidence"
+        )
+    }
+
+    private static func verifiesContentSpaceIconMetadataRoundTripsSeparatelyFromTerminalProfile() throws {
+        let tab = makeContentTab(
+            tabID: "tab_icon_explicit",
+            title: "Icon Explicit",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/icon/explicit",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        let manifest = ShellContentWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_main",
+            selectedTabID: tab.tabID,
+            spaces: [
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Main",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    selectedTabID: tab.tabID,
+                    tabs: [tab],
+                    terminalProfileID: "alan",
+                    presentationIconSystemName: "rectangle.stack.fill"
+                )
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(manifest)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        expect(json.contains("\"presentation_icon\""), "explicit Space icon must be stored on the Space record")
+        expect(json.contains("\"terminal_profile_id\""), "terminal profile reference must remain separately stored")
+        expect(
+            !json.contains("\"profile_icon\""),
+            "Space presentation icon must not be encoded as Terminal Profile icon metadata"
+        )
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ShellContentWorkspaceManifest.self, from: data)
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: decoded,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(
+            decoded.spaces.first?.presentationIconSystemName == "rectangle.stack.fill",
+            "decoded manifest Space record must preserve explicit icon metadata"
+        )
+        expect(
+            state.spaces.first?.presentationIconSystemName == "rectangle.stack.fill",
+            "ShellSpace projection must expose explicit icon metadata"
+        )
+        expect(
+            state.spaces.first?.terminalProfileID == "alan",
+            "Space icon metadata must not rewrite the Terminal Profile reference"
+        )
+    }
+
+    private static func verifiesInvalidSpaceIconFallsBackButPreservesManifestEvidence() throws {
+        let tab = makeContentTab(
+            tabID: "tab_icon_invalid",
+            title: "Icon Invalid",
+            isPinned: false,
+            pinCwd: nil,
+            liveCwd: "/icon/invalid",
+            lastActivatedAt: referenceDate,
+            lastActivityAt: referenceDate,
+            activeTask: .inactive
+        )
+        let manifest = ShellContentWorkspaceManifest(
+            schemaVersion: ShellWorkspaceManifest.currentSchemaVersion,
+            contentContractVersion: ShellContentWorkspaceManifest.currentContentContractVersion,
+            windowID: "window_main",
+            selectedSpaceID: "space_main",
+            selectedTabID: tab.tabID,
+            spaces: [
+                ShellContentWorkspaceSpaceRecord(
+                    spaceID: "space_main",
+                    title: "Main",
+                    order: 0,
+                    createdAt: referenceDate,
+                    updatedAt: referenceDate,
+                    selectedTabID: tab.tabID,
+                    tabs: [tab],
+                    presentationIconSystemName: "not a renderable symbol"
+                )
+            ]
+        )
+
+        let state = ShellWorkspaceMaterializer.materialize(
+            manifest: manifest,
+            defaultWorkingDirectory: "/tmp",
+            now: referenceDate
+        )
+
+        expect(
+            manifest.spaces.first?.presentationIconSystemName == "not a renderable symbol",
+            "invalid Space icon evidence must remain on the manifest record"
+        )
+        expect(
+            state.spaces.first?.presentationIconSystemName == "not a renderable symbol",
+            "ShellSpace projection must preserve the explicit invalid icon evidence"
+        )
+        expect(
+            state.spaces.first?.resolvedPresentationIconSystemName
+                == ShellSpacePresentationIcon.defaultSystemName,
+            "unsupported Space icon metadata must fall back to the deterministic display icon"
+        )
+        expect(
+            state.spaces.first?.tabs.first?.tabID == tab.tabID,
+            "invalid Space icon metadata must not drop tabs"
         )
     }
 

--- a/openspec/changes/polish-macos-space-slider-track/design.md
+++ b/openspec/changes/polish-macos-space-slider-track/design.md
@@ -26,6 +26,8 @@ extension instead of deriving icons from Terminal Profiles.
   cards or notification-dot styling.
 - Show `icon + title` when width allows, then truncated title, then icon-only
   circular targets at the minimum width.
+- Distribute Space targets evenly across the full track until that equal share
+  would fall below the minimum target width.
 - Remove the nine-Space cap; all Spaces participate in the slider.
 - Horizontally scroll the track when icon-only targets still overflow the
   sidebar width.
@@ -75,16 +77,20 @@ not introduce independent framed pills or resize the item.
 
 ### Replace density tiers with width allocation
 
-The layout model should stop using fixed count buckets and `maximumVisibleSpaces`.
-All Spaces should be measured and included. Width allocation should prefer the
-selected Space and nearby readable title labels, but every Space must have a
-stable minimum circular target that can show the Space icon.
+The layout model should stop using fixed count buckets, fixed maximum Space
+target widths, and `maximumVisibleSpaces`. All Spaces should be measured and
+included. Width allocation should divide the available rounded track evenly
+across every Space until that equal share would drop below the stable minimum
+target width.
 
 The collapse path is:
 
-1. `icon + full title` when the item fits.
-2. `icon + truncated title` when the track has partial room.
-3. `icon-only circle` at the minimum width.
+1. `icon + full title` when the equal per-Space width can support it.
+2. `icon + truncated title` when the equal per-Space width has partial room.
+3. `icon-only` when the equal per-Space width is above the minimum but cannot
+   support a title.
+4. Minimum-width icon-only targets with horizontal overflow when equal division
+   would fall below the minimum width.
 
 If all items are already at their minimum circular width and still exceed the
 available track width, the track scrolls horizontally instead of hiding Spaces

--- a/openspec/changes/polish-macos-space-slider-track/proposal.md
+++ b/openspec/changes/polish-macos-space-slider-track/proposal.md
@@ -14,6 +14,8 @@ is converging on.
   pill surfaces.
 - Support a Space icon in every Space tab and use `icon + title` when width
   allows.
+- Distribute Space targets across the full rounded track until the minimum
+  target width is reached, instead of retaining a fixed maximum target width.
 - Replace hover-driven width, scale, and opacity changes with stable geometry;
   hover may only apply subtle foreground or tint treatment.
 - Remove the nine-Space visual cap. All Spaces participate in the slider.

--- a/openspec/changes/polish-macos-space-slider-track/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/changes/polish-macos-space-slider-track/specs/macos-shell-ui-ux-conformance/spec.md
@@ -30,6 +30,8 @@ theme panels, and ornamental controls.
 - **WHEN** the default sidebar displays Space navigation
 - **THEN** Space navigation is presented as a continuous rounded top track whose
   selected Space is a compact liquid-glass tab inside that track
+- **AND** the track uses a visible neutral gray native track fill rather than a
+  barely visible transparent control tint
 - **AND** inactive Spaces sit in the shared track background using icon and
   title foreground treatment rather than individual framed pills, cards, or
   dot-only indicators
@@ -68,6 +70,8 @@ without hover-driven geometry changes or cover-flow motion.
 - **WHEN** the default sidebar displays one or more Spaces
 - **THEN** the Space slider renders one rounded track as the shared navigation
   surface
+- **AND** the track background reads as a Safari-like gray track rather than a
+  nearly transparent overlay
 - **AND** each Space is represented by a distinct target inside that track
 - **AND** the selected Space uses the strongest selected-state treatment as a
   compact liquid-glass tab inside the track
@@ -79,11 +83,21 @@ without hover-driven geometry changes or cover-flow motion.
 - **AND** the title truncates before it wraps, overlaps adjacent targets, or
   changes sidebar width
 
+#### Scenario: Space targets distribute across the full track before overflow
+- **WHEN** the equal per-Space target width is at or above the minimum Space
+  target width
+- **THEN** alan divides the full rounded track evenly across every Space target
+- **AND** alan does not leave unused trailing track space solely because a Space
+  target reached a fixed maximum width
+- **AND** alan chooses full-title, truncated-title, or icon-only content from
+  that equal per-Space width
+
 #### Scenario: Space targets collapse to icon-only minimums
 - **WHEN** the track cannot fit readable title labels for every Space
-- **THEN** alan progressively truncates lower-priority Space titles
-- **AND** alan may collapse any Space target to an icon-only circular target at
-  its minimum width
+- **THEN** alan truncates every Space title according to the equal per-Space
+  width
+- **AND** alan may collapse Space targets to icon-only targets before horizontal
+  overflow is needed
 - **AND** the icon-only target remains a distinct click, context-menu,
   keyboard, VoiceOver, and scrub target with its title exposed
   accessibly

--- a/openspec/changes/polish-macos-space-slider-track/tasks.md
+++ b/openspec/changes/polish-macos-space-slider-track/tasks.md
@@ -1,47 +1,102 @@
 ## 1. Space Icon State And Persistence
 
-- [ ] 1.1 Add optional Space presentation icon metadata to the workspace manifest Space record and `ShellSpace` projection.
-- [ ] 1.2 Decode old manifests without icon metadata and display a deterministic default Space icon without rewriting profile definitions.
-- [ ] 1.3 Persist explicit Space icon metadata when present while keeping Terminal Profile icon ownership separate.
-- [ ] 1.4 Add focused decode/writeback tests for old manifests, explicit icon metadata, absent icon fallback, and invalid icon fallback.
+- [x] 1.1 Add optional Space presentation icon metadata to the workspace manifest Space record and `ShellSpace` projection.
+- [x] 1.2 Decode old manifests without icon metadata and display a deterministic default Space icon without rewriting profile definitions.
+- [x] 1.3 Persist explicit Space icon metadata when present while keeping Terminal Profile icon ownership separate.
+- [x] 1.4 Add focused decode/writeback tests for old manifests, explicit icon metadata, absent icon fallback, and invalid icon fallback.
 
 ## 2. Track Layout Model
 
-- [ ] 2.1 Replace count-based density tiers and `maximumVisibleSpaces` with a width-allocation model that includes every Space.
-- [ ] 2.2 Implement the collapse path: `icon + full title`, `icon + truncated title`, then icon-only circular minimum width.
-- [ ] 2.3 Compute horizontal overflow content width when all Space targets are at minimum size and still exceed available track width.
-- [ ] 2.4 Keep item frames, track height, hit targets, and hover geometry stable across hover, selection, scrub, and Space count changes.
-- [ ] 2.5 Add focused layout tests for one Space, several readable Spaces, more than nine Spaces, icon-only collapse, overflow sizing, and hover stability.
+- [x] 2.1 Replace count-based density tiers and `maximumVisibleSpaces` with a width-allocation model that includes every Space.
+- [x] 2.2 Implement the collapse path: `icon + full title`, `icon + truncated title`, then icon-only circular minimum width.
+- [x] 2.3 Compute horizontal overflow content width when all Space targets are at minimum size and still exceed available track width.
+- [x] 2.4 Keep item frames, track height, hit targets, and hover geometry stable across hover, selection, scrub, and Space count changes.
+- [x] 2.5 Add focused layout tests for one Space, several readable Spaces, more than nine Spaces, icon-only collapse, overflow sizing, and hover stability.
 
 ## 3. SwiftUI Slider Rendering
 
-- [ ] 3.1 Render the Space slider as one continuous rounded track aligned to the sidebar row inset.
-- [ ] 3.2 Render the selected Space as a compact liquid-glass tab inside the track, with adaptive material fallback when needed.
-- [ ] 3.3 Render inactive Spaces as transparent track content with icon/title foreground treatment rather than independent pills, cards, or dots.
-- [ ] 3.4 Add Space icon rendering for full, truncated, and icon-only states with stable accessibility labels.
-- [ ] 3.5 Embed overflow content in a horizontal track scroller and auto-scroll the selected or scrub-focused Space into view without resizing the sidebar.
-- [ ] 3.6 Remove hover-driven width, scale, opacity, and neighbor fade effects from the slider.
+- [x] 3.1 Render the Space slider as one continuous rounded track aligned to the sidebar row inset.
+- [x] 3.2 Render the selected Space as a compact liquid-glass tab inside the track, with adaptive material fallback when needed.
+- [x] 3.3 Render inactive Spaces as transparent track content with icon/title foreground treatment rather than independent pills, cards, or dots.
+- [x] 3.4 Add Space icon rendering for full, truncated, and icon-only states with stable accessibility labels.
+- [x] 3.5 Embed overflow content in a horizontal track scroller and auto-scroll the selected or scrub-focused Space into view without resizing the sidebar.
+- [x] 3.6 Remove hover-driven width, scale, opacity, and neighbor fade effects from the slider.
 
 ## 4. Interaction Semantics
 
-- [ ] 4.1 Preserve immediate click selection for inactive Spaces and no-op behavior for clicking the selected Space.
-- [ ] 4.2 Preserve Space context menus for selected, hovered, keyboard-focused, and scrub-focused Space targets.
-- [ ] 4.3 Adapt drag scrub and horizontal wheel scrub to the scrollable track coordinate system.
-- [ ] 4.4 Preserve vertical and ambiguous wheel/trackpad pass-through to sidebar scrolling.
-- [ ] 4.5 Preserve keyboard and VoiceOver navigation with distinct Space targets, selected state, tab count, and preview/commit/cancel semantics.
-- [ ] 4.6 Respect reduced motion by keeping the same state model without scale, spring, perspective, or cover-flow-like movement.
+- [x] 4.1 Preserve immediate click selection for inactive Spaces and no-op behavior for clicking the selected Space.
+- [x] 4.2 Preserve Space context menus for selected, hovered, keyboard-focused, and scrub-focused Space targets.
+- [x] 4.3 Adapt drag scrub and horizontal wheel scrub to the scrollable track coordinate system.
+- [x] 4.4 Preserve vertical and ambiguous wheel/trackpad pass-through to sidebar scrolling.
+- [x] 4.5 Preserve keyboard and VoiceOver navigation with distinct Space targets, selected state, tab count, and preview/commit/cancel semantics.
+- [x] 4.6 Respect reduced motion by keeping the same state model without scale, spring, perspective, or cover-flow-like movement.
 
 ## 5. Verification
 
-- [ ] 5.1 Run focused Swift/layout tests for Space slider layout and Space icon persistence.
-- [ ] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
-- [ ] 5.3 Run the relevant macOS build or test lane for Alan Dev.
-- [ ] 5.4 Fresh relaunch Alan Dev only and capture light-mode screenshots for one Space, several readable Spaces, more than nine Spaces, icon-only overflow, selected liquid-glass tab, hover without geometry shift, and scrub preview.
+- [x] 5.1 Run focused Swift/layout tests for Space slider layout and Space icon persistence.
+- [x] 5.2 Run `bash clients/apple/scripts/check-shell-contracts.sh`.
+- [x] 5.3 Run the relevant macOS build or test lane for Alan Dev.
+- [x] 5.4 Fresh relaunch Alan Dev only and capture light-mode screenshots for one Space, several readable Spaces, more than nine Spaces, icon-only overflow, selected liquid-glass tab, hover without geometry shift, and scrub preview.
 - [ ] 5.5 Manually verify Alan Dev slider horizontal scrolling, click switching, context menu targeting, drag scrub, wheel scrub, vertical scroll pass-through, and keyboard navigation.
-- [ ] 5.6 Run `openspec validate polish-macos-space-slider-track --strict`.
+- [x] 5.6 Run `openspec validate polish-macos-space-slider-track --strict`.
+
+Screenshot evidence captured:
+`debug/artifacts/space-slider-track-final-ui/00-launch.png`,
+`02-space-create.png`, `03-space-switch.png`,
+`08-fourteen-spaces-overflow.png`, `09-overflow-no-hover.png`,
+`10-overflow-hover.png`, and `11-overflow-scrub-preview.png`.
+State evidence captured:
+`state-after-overflow.json`, `state-after-drag-scrub.json`,
+`state-after-keyboard-navigation.json`, and click-attempt snapshots.
+
+Post-pass fixes:
+User validation found the track background too faint and the Space targets still
+using fixed maximum widths. The implementation now uses a dedicated gray
+`sidebarSpaceSliderTrack` token and distributes readable/truncated/icon-only
+targets evenly across the full track until the minimum target width would be
+violated. Focused layout tests and contract checks were extended to prevent
+regression to fixed maximum widths or the old faint track fill.
+Fresh Alan Dev UI smoke after the fix captured updated screenshots in
+`debug/artifacts/space-slider-track-feedback-ui/02-space-create.png` and
+`03-space-switch.png`, showing the stronger gray track and equal distribution
+for the two readable Space targets.
+
+Manual verification notes:
+`debug/artifacts/space-slider-track-manual-ui/state-before-manual-click.json`
+and `state-after-click-switch-space-main.json` prove a live Alan Dev Space
+slider click switched focus from `space_2` to `space_main`. The same run exposed
+two Space slider targets through Accessibility with `AXPress` and `AXShowMenu`
+actions, but context-menu presentation was not reliably captured from automated
+coordinate or AX invocation, so 5.5 remains open for a human pass. Contract
+checks now guard the context-menu profile action target (`space.spaceID`) and
+drag scrub's horizontal scroll-offset mapping to keep those interaction paths
+from regressing before the final human pass.
+
+5.5 audit matrix:
+
+- Horizontal scrolling: screenshots and layout tests prove icon-only overflow
+  content exists inside the rounded track, but final human pass should confirm
+  track scrolling with the pointer/trackpad.
+- Click switching: live state evidence proves `space_2` -> `space_main`
+  selection from a Space slider click.
+- Context menu targeting: code and contract checks prove menu actions target the
+  opened Space and cancel scrub preview first; Accessibility exposes `AXShowMenu`
+  on Space slider targets. The final human pass must still confirm the menu
+  visibly opens from selected and non-selected targets because automated
+  screenshots did not capture the AppKit menu.
+- Drag scrub: state and screenshot evidence prove scrub preview/commit on the
+  overflow slider, and contract checks guard horizontal scroll-offset mapping.
+- Wheel scrub: focused layout tests prove preview-before-commit routing and
+  dwell commit; final human pass should confirm trackpad/wheel behavior in Alan
+  Dev.
+- Vertical scroll pass-through: focused layout tests and contract checks prove
+  vertical/ambiguous wheel routing forwards to the tab list; final human pass
+  should confirm ordinary sidebar scrolling over the slider.
+- Keyboard navigation: state evidence proves keyboard Space navigation reached
+  `space_14`, and contract checks guard preview/commit/cancel entry points.
 
 ## 6. Review And Archive Readiness
 
 - [ ] 6.1 Request review after implementation and verification are complete.
-- [ ] 6.2 Before archive, sync accepted spec behavior into the long-lived `macos-shell-ui-ux-conformance` and `macos-shell-workspace-persistence` specs.
+- [x] 6.2 Before archive, sync accepted spec behavior into the long-lived `macos-shell-ui-ux-conformance` and `macos-shell-workspace-persistence` specs.
 - [ ] 6.3 Archive the OpenSpec change only after implementation is merged and the long-lived specs are updated.

--- a/openspec/specs/macos-shell-ui-ux-conformance/spec.md
+++ b/openspec/specs/macos-shell-ui-ux-conformance/spec.md
@@ -22,9 +22,9 @@ theme panels, and ornamental controls.
 #### Scenario: Stable compact controls
 - **WHEN** the user hovers, selects, inserts, closes, creates, or switches tabs
   and Spaces
-- **THEN** rows, icon controls, dots, counters, and status marks keep stable
+- **THEN** rows, icon controls, counters, and status marks keep stable
   dimensions and do not resize the sidebar or terminal content
-- **AND** the top Space slider aligns its visible controls to the sidebar edge
+- **AND** the top Space slider aligns its rounded track to the sidebar edge
   inset so Space slider targets and tab rows share one optical column
 - **AND** the titlebar New Space button directly creates a standard new Space
   instead of opening a menu of Space variants
@@ -34,9 +34,15 @@ theme panels, and ornamental controls.
 
 #### Scenario: Space slider replaces header and dock
 - **WHEN** the default sidebar displays Space navigation
-- **THEN** the selected Space is represented by its title in the top Space
-  slider, non-selected Spaces use the representation required by the active
-  Space slider density tier, and no Space icon is shown in the slider
+- **THEN** Space navigation is presented as a continuous rounded top track whose
+  selected Space is a compact liquid-glass tab inside that track
+- **AND** the track uses a visible neutral gray native track fill rather than a
+  barely visible transparent control tint
+- **AND** inactive Spaces sit in the shared track background using icon and
+  title foreground treatment rather than individual framed pills, cards, or
+  dot-only indicators
+- **AND** each Space target can show its Space icon with a title when width
+  allows and can collapse to an icon-only circular target at minimum width
 - **AND** alan does not show a separate bottom Space dock in the default sidebar
 - **AND** the top Space slider remains a fixed sidebar-level control while
   Space tab content pages move beneath it during Space paging gestures
@@ -61,43 +67,69 @@ theme panels, and ornamental controls.
   Space
 
 ### Requirement: Space slider supports adaptive density and scrub navigation
-The default macOS shell Space slider SHALL adapt its visual density to the
-number of Spaces and SHALL support deliberate preview-first scrub navigation
-without making the default sidebar visually noisy or unstable.
+The default macOS shell Space slider SHALL use a continuous rounded track that
+adapts Space target widths to available sidebar space, supports every Space
+without an arbitrary count cap, and preserves preview-first scrub navigation
+without hover-driven geometry changes or cover-flow motion.
 
-#### Scenario: Low-density Space slider shows full titles
-- **WHEN** the default sidebar has 1 to 3 Spaces
-- **THEN** the Space slider shows every Space as a named, single-line
-  Safari-like tab or pill control
-- **AND** the selected Space has the strongest material and text treatment
-- **AND** inactive Spaces remain readable without using Space icons
+#### Scenario: Rounded track owns Space navigation
+- **WHEN** the default sidebar displays one or more Spaces
+- **THEN** the Space slider renders one rounded track as the shared navigation
+  surface
+- **AND** the track background reads as a Safari-like gray track rather than a
+  nearly transparent overlay
+- **AND** each Space is represented by a distinct target inside that track
+- **AND** the selected Space uses the strongest selected-state treatment as a
+  compact liquid-glass tab inside the track
+- **AND** inactive Spaces remain visually embedded in the track background
 
-#### Scenario: Mid-density Space slider shows active and short titles
-- **WHEN** the default sidebar has 4 to 6 Spaces
-- **THEN** the Space slider shows the selected Space with its full title
-- **AND** every inactive Space remains visible as a compact short-title control
-- **AND** inactive Space titles truncate on one line before they resize the
-  sidebar, wrap text, or overlap adjacent controls
+#### Scenario: Space targets use icon and title when width allows
+- **WHEN** a Space target has enough allocated width for its icon and title
+- **THEN** alan shows the Space icon followed by a single-line title
+- **AND** the title truncates before it wraps, overlaps adjacent targets, or
+  changes sidebar width
 
-#### Scenario: High-density Space slider uses active title and indicators
-- **WHEN** the default sidebar has 7 to 9 Spaces
-- **THEN** the Space slider shows the selected Space as a title control
-- **AND** inactive Spaces render as compact indicators in the default idle state
-- **AND** hovered or scrub-focused inactive indicators can expand into short
-  title controls without changing slider height or sidebar width
+#### Scenario: Space targets distribute across the full track before overflow
+- **WHEN** the equal per-Space target width is at or above the minimum Space
+  target width
+- **THEN** alan divides the full rounded track evenly across every Space target
+- **AND** alan does not leave unused trailing track space solely because a Space
+  target reached a fixed maximum width
+- **AND** alan chooses full-title, truncated-title, or icon-only content from
+  that equal per-Space width
 
-#### Scenario: Space count is capped at nine
-- **WHEN** the user attempts to create Spaces from the default macOS shell
-- **THEN** alan allows at most 9 Spaces in the Space slider model
-- **AND** creation affordances do not produce a tenth visible Space in the
-  default sidebar
+#### Scenario: Space targets collapse to icon-only minimums
+- **WHEN** the track cannot fit readable title labels for every Space
+- **THEN** alan truncates every Space title according to the equal per-Space
+  width
+- **AND** alan may collapse Space targets to icon-only targets before horizontal
+  overflow is needed
+- **AND** the icon-only target remains a distinct click, context-menu,
+  keyboard, VoiceOver, and scrub target with its title exposed
+  accessibly
 
-#### Scenario: Hover previews without switching
+#### Scenario: All Spaces participate without a nine-Space cap
+- **WHEN** the user creates more than nine Spaces
+- **THEN** alan includes every Space in the Space slider model
+- **AND** creation affordances continue to produce additional Spaces instead of
+  hiding or refusing the tenth Space solely because of slider capacity
+
+#### Scenario: Overflow scrolls horizontally inside the track
+- **WHEN** all Space targets are at their icon-only minimum width and the total
+  target width still exceeds the available track width
+- **THEN** the Space slider content scrolls horizontally within the rounded
+  track
+- **AND** alan keeps the selected Space visible when selection changes
+- **AND** alan does not resize the sidebar, wrap targets to another row, or
+  replace overflow Spaces with an unrelated menu
+
+#### Scenario: Hover previews without geometry shifts
 - **WHEN** the pointer hovers a non-selected Space in the slider
-- **THEN** alan locally highlights or expands that Space according to the active
-  density tier
-- **AND** alan does not switch the selected Space, move the tab pager, or change
-  focused terminal content merely because of hover
+- **THEN** alan may apply subtle foreground, tint, or focus treatment to that
+  Space target
+- **AND** alan does not expand the target, scale it, fade neighboring targets,
+  switch the selected Space, move the tab pager, or change focused terminal
+  content merely because of hover
 
 #### Scenario: Click switching remains immediate
 - **WHEN** the user clicks a non-selected Space in the slider
@@ -114,12 +146,21 @@ without making the default sidebar visually noisy or unstable.
 - **AND** alan does not commit Space selection until drag release or a short
   dwell after wheel or trackpad input stops
 
-#### Scenario: Scrub uses lightweight cover-flow motion
+#### Scenario: Scrub uses stable track treatment
 - **WHEN** reduced motion is disabled and Space scrub is active
-- **THEN** the scrub-focused Space is emphasized as the largest title control
-- **AND** nearby Spaces scale or fade by distance to communicate direction
-- **AND** the effect remains bounded inside the sidebar Space slider rather than
-  introducing a large carousel or decorative overlay
+- **THEN** the scrub-focused Space is emphasized through the same stable track
+  target language used for hover, keyboard focus, and selected state
+- **AND** nearby Spaces do not scale, fade by distance, shift width, or create a
+  cover-flow or carousel effect
+- **AND** the effect remains bounded inside the sidebar Space slider
+
+#### Scenario: Scrub accounts for horizontal scroll offset
+- **WHEN** the Space slider content is horizontally scrolled
+- **AND** the user drag-scrubs or wheel-scrubs over the track
+- **THEN** alan resolves the scrub-focused Space from the visible target frames
+  and current horizontal scroll offset
+- **AND** scrub preview, commit, cancel, and selected-Space visibility remain
+  consistent with the visible track positions
 
 #### Scenario: Vertical scrolling is preserved
 - **WHEN** wheel or trackpad input over the Space slider is vertical or
@@ -129,25 +170,34 @@ without making the default sidebar visually noisy or unstable.
 
 #### Scenario: Space context menus remain available
 - **WHEN** the user right-clicks or opens the context menu for a selected,
-  hovered, or scrub-focused Space target
+  hovered, keyboard-focused, or scrub-focused Space target
 - **THEN** alan opens the context menu for that Space
 - **AND** any active scrub preview is canceled before the context menu action
   changes Space-level settings
 
 #### Scenario: Reduced motion preserves the state model
 - **WHEN** reduced motion is enabled
-- **THEN** hover and scrub use bounded highlight, opacity, and width changes
-  instead of cover-flow scale, springy movement, or perspective-like motion
+- **THEN** hover and scrub use bounded foreground, tint, outline, or selected
+  treatment without width changes, scale, spring, perspective-like motion, or
+  cover-flow movement
 - **AND** click, hover, scrub preview, commit, cancel, and keyboard behavior
   remain equivalent
 
 #### Scenario: Keyboard and accessibility navigation remain explicit
 - **WHEN** keyboard focus or VoiceOver reaches the Space slider
 - **THEN** each Space is exposed as a distinct actionable target with its title,
-  selected state, and tab count
+  icon meaning when relevant, selected state, and tab count
 - **AND** left and right keyboard navigation can move preview focus without
   immediately switching Spaces
 - **AND** Enter commits the focused Space and Escape cancels preview focus
+
+#### Scenario: Track remains borderless relative to the sidebar
+- **WHEN** the top Space slider is visible
+- **THEN** the track reads as lightweight native sidebar navigation rather than
+  a nested card, dashboard section, or detached toolbar
+- **AND** selected, hover, focus, and scrub states do not introduce notification
+  dots, oversized badges, decorative shadows, or persistent framed cards for
+  inactive Spaces
 
 ### Requirement: Collapsed sidebar uses a lightweight floating panel
 When the sidebar is collapsed, the macOS shell SHALL reveal navigation through a

--- a/openspec/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/specs/macos-shell-workspace-persistence/spec.md
@@ -246,6 +246,46 @@ workspace state.
 - **AND** alan does not attempt to synthesize profile definitions from the
   workspace manifest
 
+### Requirement: Workspace Manifest Stores Space Presentation Icons
+The macOS shell workspace manifest SHALL persist optional Space presentation
+icon metadata separately from Terminal Profile definitions so the top Space
+slider can render stable Space icons across launches without broadening profile
+ownership.
+
+#### Scenario: Space icon metadata is saved
+- **WHEN** a Space has explicit presentation icon metadata
+- **THEN** the workspace manifest stores that icon metadata on the Space record
+- **AND** the `ShellSpace` projection exposes the same icon metadata for
+  sidebar rendering
+- **AND** the manifest does not treat the Space icon as a Terminal Profile icon,
+  terminal content icon, command icon, or provider configuration field
+
+#### Scenario: Old manifest decodes without Space icon metadata
+- **WHEN** alan reads a valid workspace manifest created before Space
+  presentation icons existed
+- **THEN** alan decodes the manifest successfully
+- **AND** each Space without icon metadata receives a deterministic default
+  presentation icon for UI display
+- **AND** alan does not rewrite the manifest solely because the default icon was
+  applied for display
+
+#### Scenario: Invalid Space icon metadata falls back safely
+- **WHEN** alan reads a Space record whose presentation icon metadata is absent,
+  empty, or unsupported by the local icon renderer
+- **THEN** alan keeps the Space record and its Tabs intact
+- **AND** alan displays the deterministic default Space icon for that Space
+- **AND** alan preserves the original manifest evidence unless the user later
+  explicitly changes the Space icon
+
+#### Scenario: Terminal Profile reference ownership remains narrow
+- **WHEN** a Space has both `terminal_profile_id` and Space presentation icon
+  metadata
+- **THEN** alan uses `terminal_profile_id` only as the Space's default terminal
+  launch profile reference
+- **AND** alan uses the Space presentation icon only for Space navigation
+  surfaces
+- **AND** changing one field does not silently rewrite the other
+
 ### Requirement: Quick Terminal launch restore is presentation-hidden
 The macOS shell workspace manifest materializer SHALL restore quick-terminal
 content and last working directory without automatically presenting the detached


### PR DESCRIPTION
## Summary
- Replaces the capped density-tier Space slider with a continuous gray rounded track, selected glass tab, Space icons, equal-width distribution before minimum overflow, and horizontal scrolling for large Space counts.
- Persists optional Space presentation icon metadata separately from terminal profile ownership and removes the old nine-Space creation cap.
- Updates focused tests, shell contract checks, OpenSpec change docs, and long-lived macOS shell specs for the stable track model.

## Test Plan
- `./clients/apple/scripts/test-shell-sidebar-space-slider-layout.sh`
- `bash clients/apple/scripts/test-shell-workspace-manifest.sh`
- `bash clients/apple/scripts/test-shell-runtime-metadata.sh`
- `bash clients/apple/scripts/check-shell-contracts.sh`
- `just apple-shell-focused-tests`
- `openspec validate polish-macos-space-slider-track --strict`
- `git diff --check`

## Notes
- Fresh Alan Dev UI smoke was run during final local verification and captured updated Space slider screenshots under `debug/artifacts/space-slider-track-feedback-ui/`.
- OpenSpec task 5.5 remains the final human UI pass for context menu visibility and real pointer/trackpad behavior before archive.