### PR TITLE
Polish restored transcript layout

### DIFF
--- a/clients/apple/alan-macos/TerminalPaneView.swift
+++ b/clients/apple/alan-macos/TerminalPaneView.swift
@@ -787,6 +787,7 @@ private struct ShellSplitLayoutView: View {
                             onClosePane: onClosePane
                         )
                             .frame(width: primaryLength(total: proxy.size.width))
+                            .frame(maxHeight: .infinity, alignment: .topLeading)
                         ShellSplitDividerView(direction: .vertical)
                             .gesture(resizeGesture(totalLength: proxy.size.width))
                         ShellPaneTreeLayoutView(
@@ -796,6 +797,7 @@ private struct ShellSplitLayoutView: View {
                             onClosePane: onClosePane
                         )
                             .frame(width: secondaryLength(total: proxy.size.width))
+                            .frame(maxHeight: .infinity, alignment: .topLeading)
                     }
                 } else {
                     VStack(spacing: 0) {
@@ -806,6 +808,7 @@ private struct ShellSplitLayoutView: View {
                             onClosePane: onClosePane
                         )
                             .frame(height: primaryLength(total: proxy.size.height))
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
                         ShellSplitDividerView(direction: .horizontal)
                             .gesture(resizeGesture(totalLength: proxy.size.height))
                         ShellPaneTreeLayoutView(
@@ -815,6 +818,7 @@ private struct ShellSplitLayoutView: View {
                             onClosePane: onClosePane
                         )
                             .frame(height: secondaryLength(total: proxy.size.height))
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
                     }
                 }
             }
@@ -1032,6 +1036,7 @@ private struct ShellTerminalLeafView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
 
@@ -1053,25 +1058,28 @@ private struct RestoredTerminalTranscriptView: View {
 
     var body: some View {
         if !lines.isEmpty {
-            ScrollView([.vertical, .horizontal]) {
-                HStack(alignment: .top, spacing: 0) {
-                    Text(presentation.transcriptText)
-                        .font(
-                            .system(
-                                size: presentation.fontSize,
-                                weight: .regular,
-                                design: .monospaced
+            GeometryReader { proxy in
+                ScrollView([.vertical, .horizontal]) {
+                    HStack(alignment: .top, spacing: 0) {
+                        Text(presentation.transcriptText)
+                            .font(
+                                .system(
+                                    size: presentation.fontSize,
+                                    weight: .regular,
+                                    design: .monospaced
+                                )
                             )
-                        )
-                        .foregroundStyle(Color.white.opacity(0.72))
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: true, vertical: false)
-                    Spacer(minLength: 0)
+                            .foregroundStyle(Color.white.opacity(0.72))
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: true, vertical: false)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.leading, presentation.leadingInset)
+                    .padding(.trailing, presentation.trailingInset)
+                    .padding(.vertical, presentation.verticalInset)
+                    .frame(minWidth: proxy.size.width, alignment: .topLeading)
                 }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .padding(.leading, presentation.leadingInset)
-                .padding(.trailing, presentation.trailingInset)
-                .padding(.vertical, presentation.verticalInset)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
             .frame(
                 maxWidth: .infinity,

--- a/clients/apple/scripts/check-shell-contracts.sh
+++ b/clients/apple/scripts/check-shell-contracts.sh
@@ -187,6 +187,80 @@ require_pane_title_bar_trailing_close() {
     fi
 }
 
+require_restored_transcript_full_width_layout() {
+    local file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
+
+    if ! awk '
+        /private struct RestoredTerminalTranscriptView: View/ {
+            in_view = 1
+        }
+
+        in_view && /GeometryReader/ {
+            saw_geometry_reader = 1
+        }
+
+        in_view && /ScrollView\(\[\.vertical, \.horizontal\]\)/ {
+            saw_two_axis_scroll = 1
+        }
+
+        in_view && /frame\(minWidth: proxy\.size\.width, alignment: \.topLeading\)/ {
+            saw_viewport_min_width = 1
+        }
+
+        in_view && /private func paneMoveActionID/ {
+            in_view = 0
+        }
+
+        END {
+            exit saw_geometry_reader && saw_two_axis_scroll && saw_viewport_min_width ? 0 : 1
+        }
+    ' "$file"; then
+        printf 'error: restored transcript scroll content must fill the pane viewport before horizontal scrolling\n' >&2
+        exit 1
+    fi
+}
+
+require_split_terminal_full_pane_layout() {
+    local file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
+
+    if ! awk '
+        /private struct ShellSplitLayoutView: View/ {
+            in_split_layout = 1
+        }
+
+        in_split_layout && /frame\(maxHeight: \.infinity, alignment: \.topLeading\)/ {
+            split_max_height += 1
+        }
+
+        in_split_layout && /frame\(maxWidth: \.infinity, alignment: \.topLeading\)/ {
+            split_max_width += 1
+        }
+
+        in_split_layout && /private struct ShellSplitDividerView: View/ {
+            in_split_layout = 0
+        }
+
+        /private struct ShellTerminalLeafView: View/ {
+            in_terminal_leaf = 1
+        }
+
+        in_terminal_leaf && /frame\(maxWidth: \.infinity, maxHeight: \.infinity, alignment: \.topLeading\)/ {
+            saw_terminal_leaf_full_frame = 1
+        }
+
+        in_terminal_leaf && /private struct RestoredTerminalTranscriptView: View/ {
+            in_terminal_leaf = 0
+        }
+
+        END {
+            exit split_max_height >= 2 && split_max_width >= 2 && saw_terminal_leaf_full_frame ? 0 : 1
+        }
+    ' "$file"; then
+        printf 'error: split terminal panes must keep child terminals expanded and top-leading aligned\n' >&2
+        exit 1
+    fi
+}
+
 require_workspace_color_ownership_contract() {
     local pane_file="$REPO_ROOT/clients/apple/alan-macos/TerminalPaneView.swift"
 
@@ -501,6 +575,8 @@ reject_keydown_programmatic_text_delivery
 require_quick_terminal_peak_nonactivating_panel
 require_title_bar_full_width_hit_area
 require_pane_title_bar_trailing_close
+require_restored_transcript_full_width_layout
+require_split_terminal_full_pane_layout
 require_workspace_color_ownership_contract
 require_active_complex_split_count_contrast
 require_tab_organization_sidebar_contract


### PR DESCRIPTION
## Summary
- Keep restored transcript scroll content pinned to the full pane width before horizontal overflow.
- Keep split terminal children and terminal leaves expanded with top-leading alignment.
- Extend shell contract checks for both layout guarantees.

## Verification
- bash clients/apple/scripts/check-shell-contracts.sh
- bash clients/apple/scripts/test-shell-runtime-metadata.sh
- openspec validate --all --strict
- git diff --check
- xcodebuild -project clients/apple/alan-macos.xcodeproj -scheme alan-macos -configuration Debug -destination generic/platform=macOS -derivedDataPath /private/tmp/alan-restored-transcript-layout-derived CODE_SIGNING_ALLOWED=NO build