### PR TITLE
Restore Alan-owned PTY runtime OpenSpec

### DIFF
--- a/openspec/changes/add-macos-alan-owned-pty-runtime/.openspec.yaml
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
@@ -25,8 +25,8 @@ the process boundary becomes Alan-owned and testable.
   reports renderer/protocol metadata without owning child-process truth.
 - Vendor a pinned Alan-maintained Ghostty fork as a repository submodule and
   generate local build artifacts from that source.
-- Preserve the current service-backed runtime while migrating one boundary at a
-  time behind fakes and focused integration tests.
+- Replace the current Ghostty-owned process boundary on the implementation
+  branch before merging the feature to `main`.
 
 **Non-Goals:**
 
@@ -43,11 +43,11 @@ the process boundary becomes Alan-owned and testable.
 1. Make Alan the PTY and process owner.
 
    `AlanTerminalRuntimeService` should create an Alan-owned
-   `AlanTerminalPtyHandle` for each terminal ContentInstance selected for the
-   Alan-owned PTY runtime path. That handle owns PTY allocation, child launch,
-   process group metadata, resize propagation, stdin delivery, EOF, signal
-   requests, exit observation, and bounded transcript capture. Host views and
-   Ghostty adapters receive only the attachment interface they need.
+   `AlanTerminalPtyHandle` for each terminal ContentInstance. That handle owns
+   PTY allocation, child launch, process group metadata, resize propagation,
+   stdin delivery, EOF, signal requests, exit observation, and bounded transcript
+   capture. Host views and Ghostty adapters receive only the attachment
+   interface they need.
 
    Alternative considered: keep asking Ghostty for more process-control seams.
    That preserves the current shape but keeps Alan's lifecycle semantics behind
@@ -76,16 +76,18 @@ the process boundary becomes Alan-owned and testable.
    local checkout. That is useful for experimentation, but it makes review,
    bisecting, and CI reproduction depend on untracked local state.
 
-4. Introduce the runtime behind testable protocols.
+4. Replace the process owner on the implementation branch.
 
-   Production code should keep the current Ghostty-backed service path until the
-   Alan-owned PTY path is ready. The new PTY runtime, Ghostty attachment adapter,
-   and process controller should have fake implementations so most lifecycle and
-   control-plane tests do not require a live Ghostty renderer.
+   The implementation should happen on a dedicated feature branch where terminal
+   ContentInstances are cut over to the Alan-owned PTY runtime before the branch
+   is considered mergeable. The new PTY runtime, Ghostty attachment adapter, and
+   process controller should still have fake implementations so most lifecycle
+   and control-plane tests do not require a live Ghostty renderer.
 
-   Alternative considered: switch the whole terminal runtime in one PR. That
-   increases risk across input, scrollback, selection, rendering, and close
-   behavior at the same time.
+   Alternative considered: introduce a long-lived selector between the current
+   process owner and the Alan-owned PTY runtime. That lowers short-term
+   implementation risk, but it adds a fallback mode that the product does not
+   need if the work is isolated and verified before merge.
 
 5. Keep app-quit semantics honest.
 
@@ -97,33 +99,35 @@ the process boundary becomes Alan-owned and testable.
 ## Risks / Trade-offs
 
 - Ghostty may not expose a clean external-PTY attachment seam -> Patch the
-  Alan-maintained fork in small, reviewed slices and keep the current runtime
-  path available until the seam is proven.
+  Alan-maintained fork in small, reviewed slices and keep the implementation
+  branch unmerged until the seam is proven.
 - Submodule setup can make builds more complex -> Keep generated artifacts
   cached outside normal source diffs and make setup errors explicit.
 - PTY/process ownership touches security-sensitive local execution paths ->
   Keep launch environments, profiles, signals, and file descriptors behind
   narrow runtime APIs with focused tests.
-- Dual runtime paths can drift -> Add contract checks that both paths preserve
-  truthful delivery, metadata projection, and close behavior during migration.
+- One-step replacement has a larger branch-local blast radius -> Keep the work
+  isolated on the implementation branch and require focused fake-runtime,
+  Ghostty integration, and manual terminal UI verification before merge.
 
 ## Migration Plan
 
 1. Add the Ghostty fork submodule and update setup scripts to derive artifacts
    from the pinned revision.
 2. Add Alan PTY/process runtime protocols plus fake implementations.
-3. Implement the Alan-owned PTY runtime path behind a disabled or internal
-   runtime selection seam.
+3. Replace terminal runtime construction with the Alan-owned PTY runtime on the
+   implementation branch.
 4. Adapt the Ghostty bridge to attach to Alan-owned PTYs.
 5. Move terminal launch, resize, input delivery, signal delivery, and exit
    observation to the Alan runtime path.
 6. Run focused fake-runtime tests, Ghostty integration tests, and manual
-   terminal UI verification before making the Alan-owned path default.
-7. Remove the legacy Ghostty-owned process path after parity is proven.
+   terminal UI verification before merging.
+7. Remove obsolete Ghostty-owned process ownership code before the feature
+   branch is merged.
 
-Rollback before defaulting is to disable the Alan-owned PTY runtime selection
-and keep using the existing Ghostty-backed runtime. After defaulting, rollback
-requires restoring the prior runtime selector and dependency setup.
+Rollback before merge is to abandon or revert the implementation branch. After
+merge, rollback is a normal revert of the Alan-owned PTY runtime change set and
+Ghostty dependency setup.
 
 ## Open Questions
 

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
@@ -43,11 +43,11 @@ the process boundary becomes Alan-owned and testable.
 1. Make Alan the PTY and process owner.
 
    `AlanTerminalRuntimeService` should create an Alan-owned
-   `AlanTerminalPtyHandle` for each terminal ContentInstance. That handle owns
-   PTY allocation, child launch, process group metadata, resize propagation,
-   stdin delivery, EOF, signal requests, exit observation, and bounded transcript
-   capture. Host views and Ghostty adapters receive only the attachment
-   interface they need.
+   `AlanTerminalPtyHandle` for each terminal ContentInstance selected for the
+   Alan-owned PTY runtime path. That handle owns PTY allocation, child launch,
+   process group metadata, resize propagation, stdin delivery, EOF, signal
+   requests, exit observation, and bounded transcript capture. Host views and
+   Ghostty adapters receive only the attachment interface they need.
 
    Alternative considered: keep asking Ghostty for more process-control seams.
    That preserves the current shape but keeps Alan's lifecycle semantics behind

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/design.md
@@ -1,0 +1,136 @@
+## Context
+
+Alan already has a service-backed terminal runtime foundation: terminal
+ContentInstances own stable runtime identity, host views attach as adapters, and
+control-plane delivery is expected to be truthful. The remaining architectural
+gap is lower in the stack. The current Ghostty integration still makes Ghostty's
+runtime artifacts the practical source of truth for terminal process ownership,
+which limits Alan's ability to send process-group signals, inspect terminal
+activity, capture bounded transcript state, and evolve agent-facing terminal
+semantics.
+
+The restored direction is to make Alan own the PTY and child-process tree, then
+attach Ghostty as the terminal renderer/protocol engine. Alan can still use
+Ghostty's terminal quality, AppKit surface behavior, and rendering model, but
+the process boundary becomes Alan-owned and testable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce an Alan-owned PTY runtime service for terminal ContentInstances.
+- Keep terminal launch, resize, input, EOF, signals, process-group tracking,
+  exit status, and transcript capture behind Alan-owned runtime handles.
+- Adapt the Ghostty bridge so Ghostty consumes an Alan-provided PTY endpoint and
+  reports renderer/protocol metadata without owning child-process truth.
+- Vendor a pinned Alan-maintained Ghostty fork as a repository submodule and
+  generate local build artifacts from that source.
+- Preserve the current service-backed runtime while migrating one boundary at a
+  time behind fakes and focused integration tests.
+
+**Non-Goals:**
+
+- Do not rewrite Alan's terminal UI, sidebar, split model, or terminal surface
+  controller.
+- Do not implement a terminal emulator from scratch.
+- Do not claim terminal processes survive app quit unless a later daemon-owned
+  runtime explicitly provides that capability.
+- Do not replace all Ghostty APIs in one change; unsupported attachment seams
+  must be identified and either added to the fork or guarded as blockers.
+
+## Decisions
+
+1. Make Alan the PTY and process owner.
+
+   `AlanTerminalRuntimeService` should create an Alan-owned
+   `AlanTerminalPtyHandle` for each terminal ContentInstance. That handle owns
+   PTY allocation, child launch, process group metadata, resize propagation,
+   stdin delivery, EOF, signal requests, exit observation, and bounded transcript
+   capture. Host views and Ghostty adapters receive only the attachment
+   interface they need.
+
+   Alternative considered: keep asking Ghostty for more process-control seams.
+   That preserves the current shape but keeps Alan's lifecycle semantics behind
+   renderer-specific APIs and makes control-plane behavior hard to verify.
+
+2. Treat Ghostty as renderer/protocol adapter over an Alan PTY endpoint.
+
+   The Ghostty bridge should attach to a PTY file descriptor or equivalent
+   stream object supplied by Alan. Ghostty remains responsible for terminal
+   protocol parsing, rendering, scrollback behavior, input translation, and
+   AppKit surface callbacks. Alan remains responsible for the child process and
+   authoritative terminal lifecycle.
+
+   Alternative considered: fork Ghostty and keep its existing app/runtime model
+   as the primary process owner. That would provide a local patch point, but it
+   would not fix the ownership boundary.
+
+3. Vendor the Ghostty fork as a pinned submodule.
+
+   Add a repository-managed submodule for an Alan-maintained Ghostty fork rather
+   than requiring each developer to provide an arbitrary external checkout.
+   Setup scripts should build or reuse artifacts derived from the pinned
+   revision and report drift when artifacts do not match the submodule source.
+
+   Alternative considered: keep `ALAN_GHOSTTY_REPO` pointing to a developer's
+   local checkout. That is useful for experimentation, but it makes review,
+   bisecting, and CI reproduction depend on untracked local state.
+
+4. Introduce the runtime behind testable protocols.
+
+   Production code should keep the current Ghostty-backed service path until the
+   Alan-owned PTY path is ready. The new PTY runtime, Ghostty attachment adapter,
+   and process controller should have fake implementations so most lifecycle and
+   control-plane tests do not require a live Ghostty renderer.
+
+   Alternative considered: switch the whole terminal runtime in one PR. That
+   increases risk across input, scrollback, selection, rendering, and close
+   behavior at the same time.
+
+5. Keep app-quit semantics honest.
+
+   Alan-owned PTY/process state improves in-process control, but it does not by
+   itself make terminal sessions survive Alan app termination. The restore
+   contract should continue to create new terminal runtimes from persisted
+   snapshots unless a later daemon-backed PTY owner is introduced.
+
+## Risks / Trade-offs
+
+- Ghostty may not expose a clean external-PTY attachment seam -> Patch the
+  Alan-maintained fork in small, reviewed slices and keep the current runtime
+  path available until the seam is proven.
+- Submodule setup can make builds more complex -> Keep generated artifacts
+  cached outside normal source diffs and make setup errors explicit.
+- PTY/process ownership touches security-sensitive local execution paths ->
+  Keep launch environments, profiles, signals, and file descriptors behind
+  narrow runtime APIs with focused tests.
+- Dual runtime paths can drift -> Add contract checks that both paths preserve
+  truthful delivery, metadata projection, and close behavior during migration.
+
+## Migration Plan
+
+1. Add the Ghostty fork submodule and update setup scripts to derive artifacts
+   from the pinned revision.
+2. Add Alan PTY/process runtime protocols plus fake implementations.
+3. Implement the Alan-owned PTY runtime path behind a disabled or internal
+   runtime selection seam.
+4. Adapt the Ghostty bridge to attach to Alan-owned PTYs.
+5. Move terminal launch, resize, input delivery, signal delivery, and exit
+   observation to the Alan runtime path.
+6. Run focused fake-runtime tests, Ghostty integration tests, and manual
+   terminal UI verification before making the Alan-owned path default.
+7. Remove the legacy Ghostty-owned process path after parity is proven.
+
+Rollback before defaulting is to disable the Alan-owned PTY runtime selection
+and keep using the existing Ghostty-backed runtime. After defaulting, rollback
+requires restoring the prior runtime selector and dependency setup.
+
+## Open Questions
+
+- Should the first Alan-owned PTY runtime live only inside the macOS app process,
+  or should a later slice move ownership into an Alan daemon for cross-app
+  terminal continuity?
+- What exact Ghostty fork patch is needed to support an external PTY endpoint
+  without carrying unrelated Ghostty app architecture?
+- Where should the submodule live: `third_party/ghostty`,
+  `clients/apple/vendor/ghostty`, or another repo-standard dependency path?

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Alan's macOS terminal runtime still treats Ghostty as the place where child
+process and renderer ownership meet. That makes terminal process control,
+signal delivery, transcript capture, and future agent-readable terminal
+semantics depend on renderer-side seams that Alan cannot fully audit or evolve.
+
+This change restores the Alan-owned PTY runtime direction: Alan owns terminal
+child processes, PTYs, lifecycle metadata, and delivery semantics, while a
+forked Ghostty dependency supplies the terminal renderer and protocol engine
+through a reviewed integration boundary.
+
+## What Changes
+
+- Define an Alan-owned PTY/process runtime below terminal ContentInstances.
+- Move shell launch, PTY allocation, process-group tracking, resize, input
+  delivery, EOF, signal, and exit observation into Alan-owned runtime services.
+- Make Ghostty attach to an Alan-provided PTY endpoint rather than acting as the
+  primary owner of the child process tree.
+- Add a repository-managed Ghostty dependency strategy: an Alan-maintained
+  Ghostty fork is vendored as a git submodule, with generated framework,
+  resources, and terminfo produced from that pinned source.
+- Require migration compatibility so the current Ghostty-backed runtime can
+  continue to run while the Alan-owned PTY runtime is introduced behind a
+  focused boundary.
+- Add verification requirements for PTY lifecycle, process-group signaling,
+  renderer attachment, dependency pinning, and build/test reproducibility.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `macos-terminal-runtime-foundation`: Add Alan-owned PTY/process ownership and
+  Ghostty renderer attachment boundaries.
+- `macos-shell-terminal-lifecycle`: Add lifecycle semantics for Alan-owned
+  terminal child processes, signal delivery, and runtime replacement.
+- `macos-shell-build-test-contract`: Add repository-managed Ghostty fork and
+  submodule setup, validation, and integration-test requirements.
+
+## Impact
+
+- Apple client terminal runtime services, terminal host adapters, Ghostty
+  bridge code, shell launch profiles, transcript capture, close guards, and
+  control-plane text delivery.
+- Repository dependency layout, likely through a `third_party/ghostty` or
+  equivalent submodule path plus scripts that build or cache
+  `GhosttyKit.xcframework`, `ghostty-resources`, and `ghostty-terminfo` from the
+  pinned fork.
+- Build documentation, CI or focused local checks for Ghostty dependency
+  preparation, and tests that can run with fake PTY and fake Ghostty adapters.

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
@@ -36,7 +36,8 @@ None.
 - `macos-terminal-runtime-foundation`: Add Alan-owned PTY/process ownership and
   Ghostty renderer attachment boundaries.
 - `macos-shell-terminal-lifecycle`: Add lifecycle semantics for Alan-owned
-  terminal child processes, signal delivery, and runtime replacement.
+  terminal child processes, signal delivery, runtime replacement, and Terminal
+  Profile launch ownership.
 - `macos-shell-build-test-contract`: Add repository-managed Ghostty fork and
   submodule setup, validation, and integration-test requirements.
 

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/proposal.md
@@ -20,9 +20,8 @@ through a reviewed integration boundary.
 - Add a repository-managed Ghostty dependency strategy: an Alan-maintained
   Ghostty fork is vendored as a git submodule, with generated framework,
   resources, and terminfo produced from that pinned source.
-- Require migration compatibility so the current Ghostty-backed runtime can
-  continue to run while the Alan-owned PTY runtime is introduced behind a
-  focused boundary.
+- Replace the current Ghostty-owned process boundary on the implementation
+  branch; do not add a long-lived fallback runtime selector.
 - Add verification requirements for PTY lifecycle, process-group signaling,
   renderer attachment, dependency pinning, and build/test reproducibility.
 

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Ghostty fork is repository managed
+The Apple client SHALL use a repository-managed, pinned Alan-maintained Ghostty
+fork for Alan-owned PTY integration work instead of relying only on arbitrary
+developer-local Ghostty checkouts.
+
+#### Scenario: Submodule is initialized
+- **WHEN** a developer prepares macOS terminal dependencies
+- **THEN** the supported setup path initializes or verifies the pinned Ghostty fork submodule
+- **AND** generated Ghostty framework, resources, and terminfo artifacts are derived from that pinned source unless an explicit developer override is used
+
+#### Scenario: Submodule is missing
+- **WHEN** the Ghostty fork submodule is absent or uninitialized
+- **THEN** setup and build checks report the missing submodule and provide the supported initialization command
+- **AND** the failure does not look like an opaque linker or module-map error
+
+#### Scenario: Developer override is used
+- **WHEN** a developer intentionally points setup at a non-submodule Ghostty checkout
+- **THEN** the setup output identifies the override source and revision
+- **AND** review or CI paths continue to use the pinned repository-managed source by default
+
+### Requirement: Ghostty artifact drift is checked
+The Apple build/test setup SHALL detect when local Ghostty artifacts do not
+match the pinned Ghostty fork revision or declared cache key used for the
+current Alan checkout.
+
+#### Scenario: Artifacts match pinned revision
+- **WHEN** local Ghostty artifacts were built from the pinned submodule revision
+- **THEN** dependency checks accept them and record the revision in setup output or metadata
+
+#### Scenario: Artifacts are stale
+- **WHEN** local Ghostty artifacts were built from a different Ghostty revision without an explicit override
+- **THEN** dependency checks fail or warn according to the selected strictness mode
+- **AND** the output points to the supported rebuild command
+
+### Requirement: Alan-owned PTY runtime has focused verification
+The Apple client SHALL include focused tests or documented integration checks
+for Alan-owned PTY allocation, process launch, renderer attachment, text
+delivery, resize, signals, exit observation, and bounded transcript capture.
+
+#### Scenario: Fake PTY runtime accepts delivery
+- **WHEN** focused tests create a fake Alan-owned PTY runtime and send terminal text
+- **THEN** tests verify that delivery is acknowledged from the PTY runtime service rather than from renderer visibility
+
+#### Scenario: Fake process group receives interrupt
+- **WHEN** focused tests request interrupt for a fake active foreground process group
+- **THEN** tests verify that the runtime service records the attempted signal and reports a stable result
+
+#### Scenario: Ghostty integration lane runs
+- **WHEN** local Ghostty artifacts are prepared from the pinned fork
+- **THEN** the Ghostty integration lane verifies renderer attachment to the Alan-owned PTY path or reports a clear unsupported-seam failure

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-terminal-lifecycle/spec.md
@@ -59,3 +59,34 @@ terminal ContentInstance delivery policy.
 - **WHEN** `terminal.send_text` targets terminal content whose renderer is still attached but whose Alan-owned PTY is closed
 - **THEN** the response reports `applied: false` with a stable closed-runtime error
 - **AND** no accepted bytes are claimed
+
+## MODIFIED Requirements
+
+### Requirement: Terminal Startup Uses Resolved Terminal Profile
+The macOS terminal lifecycle SHALL launch terminal content by resolving the
+Terminal Profile into an Alan-owned terminal boot request used by the
+Alan-owned PTY runtime.
+
+#### Scenario: Terminal content starts with profile command
+- **WHEN** terminal content is created with `terminal_profile_id` `alan`
+- **AND** local Terminal Profile `alan` is a `sudo_user` profile for Unix user
+  `alan`
+- **THEN** alan resolves the terminal boot command to the structured sudo-user
+  launch for `alan`
+- **AND** the Alan-owned PTY runtime receives the command, working directory,
+  and environment through the terminal boot request before child process launch
+- **AND** Ghostty receives renderer attachment to Alan's PTY endpoint rather
+  than owning the launch command, working directory, or environment
+
+#### Scenario: Profile metadata is projected to terminal environment
+- **WHEN** terminal content starts with a resolved Terminal Profile
+- **THEN** alan exposes non-secret profile metadata such as profile id and launch
+  kind through terminal environment variables passed to the Alan-owned PTY
+  runtime
+- **AND** alan does not expose provider credentials or secret values through
+  those variables
+
+#### Scenario: Custom command startup is marked active
+- **WHEN** terminal content starts with a `custom_command` Terminal Profile
+- **THEN** alan treats the terminal startup as a foreground command until the
+  terminal runtime reports completion or a shell-integration state update

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-terminal-lifecycle/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-shell-terminal-lifecycle/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Alan-owned terminal process lifecycle is authoritative
+The macOS shell host SHALL treat Alan runtime service process state as
+authoritative for terminal lifecycle, close guards, control-plane delivery, and
+metadata projection when a terminal ContentInstance uses the Alan-owned PTY
+runtime path.
+
+#### Scenario: Foreground process changes
+- **WHEN** the Alan-owned PTY runtime observes foreground process or process-group changes
+- **THEN** shell lifecycle metadata updates the corresponding terminal ContentInstance
+- **AND** the update does not depend on the terminal view being visible
+
+#### Scenario: Renderer reports stale process state
+- **WHEN** renderer metadata conflicts with Alan-owned process lifecycle state
+- **THEN** Alan-owned runtime state wins for child-process status, close guards, signal eligibility, and text-delivery acceptance
+- **AND** renderer metadata may be retained as diagnostics
+
+### Requirement: Terminal shutdown uses Alan-owned process control
+For Alan-owned PTY runtimes, confirmed close and runtime shutdown SHALL use
+Alan-owned process and process-group controls before finalizing terminal
+ContentInstance state.
+
+#### Scenario: Graceful close is confirmed
+- **WHEN** a user confirms closing terminal content with active foreground work
+- **THEN** Alan requests graceful shutdown through the Alan-owned PTY/process runtime
+- **AND** Alan observes bounded output or exit state before force finalization policy runs
+
+#### Scenario: Force close is required
+- **WHEN** graceful shutdown times out or the process ignores the request
+- **THEN** Alan may escalate through configured process-group signal policy
+- **AND** the final shell state reports interrupted or forced shutdown metadata without exposing raw process handles
+
+### Requirement: Runtime replacement does not claim cross-app continuity
+Alan-owned PTY runtime ownership SHALL improve in-process terminal control, but
+MUST NOT claim terminal process continuity across Alan app termination unless a
+separate daemon-owned runtime capability is implemented.
+
+#### Scenario: App restarts after Alan-owned PTY runtime
+- **WHEN** alan restores a terminal ContentInstance after app restart
+- **THEN** alan creates a new runtime from persisted snapshot data
+- **AND** alan does not claim that the prior PTY, process group, foreground application, or file descriptors are still live
+
+#### Scenario: Daemon ownership is added later
+- **WHEN** a future change introduces daemon-owned PTY runtime survival across app quit
+- **THEN** that change updates lifecycle and persistence specs before exposing cross-app terminal continuity
+
+### Requirement: Terminal delivery follows PTY readiness
+For Alan-owned PTY runtimes, terminal text delivery SHALL be acknowledged only
+after Alan-owned PTY input accepts or durably queues the bytes according to the
+terminal ContentInstance delivery policy.
+
+#### Scenario: PTY accepts input
+- **WHEN** `terminal.send_text` targets terminal content with an input-ready Alan-owned PTY runtime
+- **THEN** the response reports `applied: true`, accepted byte count, and terminal `content_id`
+- **AND** the response does not depend on renderer visibility
+
+#### Scenario: Renderer is ready but PTY is closed
+- **WHEN** `terminal.send_text` targets terminal content whose renderer is still attached but whose Alan-owned PTY is closed
+- **THEN** the response reports `applied: false` with a stable closed-runtime error
+- **AND** no accepted bytes are claimed

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Terminal PTYs are Alan-owned
+The macOS terminal runtime SHALL allocate and own the PTY, child process,
+process group metadata, lifecycle phase, delivery state, and exit observation
+for each terminal ContentInstance through Alan terminal runtime services.
+
+#### Scenario: Terminal content starts with Alan-owned PTY
+- **WHEN** a terminal ContentInstance is created through the Alan-owned runtime path
+- **THEN** Alan allocates the PTY, launches the terminal child process, records the process group, and creates the runtime handle before attaching a renderer
+- **AND** the runtime handle is keyed by terminal ContentInstance identity
+
+#### Scenario: Runtime starts without renderer attachment
+- **WHEN** Alan creates an Alan-owned PTY runtime before a visible terminal host view is mounted
+- **THEN** the child process and PTY lifecycle remain owned by the runtime service
+- **AND** renderer attachment can occur later without starting a second child process
+
+### Requirement: Ghostty attaches to Alan-provided PTYs
+The Ghostty integration SHALL act as a renderer and terminal-protocol adapter
+over PTY endpoints supplied by Alan, and MUST NOT be the authoritative owner of
+terminal child-process lifecycle in the Alan-owned PTY runtime path.
+
+#### Scenario: Renderer attaches to live PTY
+- **WHEN** a terminal host view mounts for terminal content with an Alan-owned PTY runtime
+- **THEN** the Ghostty adapter attaches to the PTY endpoint supplied by Alan
+- **AND** renderer readiness is reported separately from PTY and child-process readiness
+
+#### Scenario: Renderer detaches
+- **WHEN** SwiftUI or AppKit removes the visible terminal host view
+- **THEN** the Ghostty renderer attachment may detach
+- **AND** the Alan-owned PTY runtime, child process, process group, and delivery state remain alive unless the terminal content is closing
+
+### Requirement: Runtime control uses Alan process handles
+The terminal runtime service SHALL implement resize, text delivery, EOF,
+interrupt, terminate, kill, and exit-status observation using Alan-owned PTY and
+process handles rather than renderer-owned process state.
+
+#### Scenario: Terminal is resized
+- **WHEN** a terminal ContentInstance size changes
+- **THEN** Alan applies the PTY window size to the Alan-owned PTY handle
+- **AND** renderer resize follows the same dimensions without becoming the source of process truth
+
+#### Scenario: Interrupt is requested
+- **WHEN** the shell host or control plane requests an interrupt for active terminal work
+- **THEN** Alan sends the configured interrupt signal to the terminal foreground process group when available
+- **AND** the result reports whether signal delivery was attempted, unavailable, or failed
+
+#### Scenario: Child process exits
+- **WHEN** the Alan-owned child process exits
+- **THEN** the runtime service records exit status, closes or drains PTY state according to policy, and projects final terminal metadata to shell state
+
+### Requirement: Alan-owned PTY snapshots remain bounded
+The Alan-owned PTY runtime SHALL maintain bounded transcript and activity state
+needed for restore, close guards, diagnostics, and agent-readable terminal
+metadata without persisting raw PTY handles, child-process handles, renderer
+objects, or unbounded scrollback.
+
+#### Scenario: Snapshot is captured
+- **WHEN** workspace persistence requests a terminal snapshot from an Alan-owned PTY runtime
+- **THEN** the runtime returns bounded transcript, dimensions, cwd, title, process summary, and capture metadata when available
+- **AND** the snapshot excludes live file descriptors and process handles
+
+#### Scenario: Renderer transcript is unavailable
+- **WHEN** Ghostty renderer extraction is unavailable for an Alan-owned PTY runtime
+- **THEN** Alan may use its bounded PTY transcript ring buffer for snapshot capture
+- **AND** the snapshot truthfully records the capture source and fidelity
+
+### Requirement: Legacy Ghostty-owned runtime can coexist during migration
+The terminal runtime service SHALL allow the existing Ghostty-owned process path
+and the Alan-owned PTY path to coexist behind an explicit runtime selection
+boundary until Alan-owned PTY parity is proven.
+
+#### Scenario: Existing runtime path is selected
+- **WHEN** runtime selection chooses the legacy Ghostty-backed path
+- **THEN** current terminal behavior continues to follow the existing Ghostty runtime service contracts
+
+#### Scenario: Alan-owned path is selected
+- **WHEN** runtime selection chooses the Alan-owned PTY path
+- **THEN** terminal launch, delivery, resize, signal, exit, snapshot, and renderer attachment go through the Alan-owned runtime handles
+- **AND** control-plane responses identify the selected runtime path in debug metadata

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,13 +1,12 @@
 ## ADDED Requirements
 
-### Requirement: Alan-owned PTY runtime path owns terminal PTYs
-For Alan-owned PTY runtime path selections, the macOS terminal runtime SHALL
-allocate and own the PTY, child process, process group metadata, lifecycle
-phase, delivery state, and exit observation through Alan terminal runtime
-services.
+### Requirement: Terminal PTYs are Alan-owned
+The macOS terminal runtime SHALL allocate and own the PTY, child process,
+process group metadata, lifecycle phase, delivery state, and exit observation
+through Alan terminal runtime services for each terminal ContentInstance.
 
 #### Scenario: Terminal content starts with Alan-owned PTY
-- **WHEN** a terminal ContentInstance is created through the Alan-owned PTY runtime path
+- **WHEN** a terminal ContentInstance is created
 - **THEN** Alan allocates the PTY, launches the terminal child process, records the process group, and creates the runtime handle before attaching a renderer
 - **AND** the runtime handle is keyed by terminal ContentInstance identity
 
@@ -17,10 +16,9 @@ services.
 - **AND** renderer attachment can occur later without starting a second child process
 
 ### Requirement: Ghostty attaches to Alan-provided PTYs
-When the Alan-owned PTY runtime path is selected, the Ghostty integration SHALL
-act as a renderer and terminal-protocol adapter over PTY endpoints supplied by
-Alan, and MUST NOT be the authoritative owner of terminal child-process
-lifecycle.
+The Ghostty integration SHALL act as a renderer and terminal-protocol adapter
+over PTY endpoints supplied by Alan, and MUST NOT be the authoritative owner of
+terminal child-process lifecycle.
 
 #### Scenario: Renderer attaches to live PTY
 - **WHEN** a terminal host view mounts for terminal content with an Alan-owned PTY runtime
@@ -68,16 +66,17 @@ objects, or unbounded scrollback.
 - **THEN** Alan may use its bounded PTY transcript ring buffer for snapshot capture
 - **AND** the snapshot truthfully records the capture source and fidelity
 
-### Requirement: Legacy Ghostty-owned runtime can coexist during migration
-The terminal runtime service SHALL allow the existing Ghostty-owned process path
-and the Alan-owned PTY path to coexist behind an explicit runtime selection
-boundary until Alan-owned PTY parity is proven.
+### Requirement: Alan-owned PTY runtime replaces Ghostty process ownership
+The terminal runtime service SHALL replace the current Ghostty-owned terminal
+process boundary with Alan-owned PTY runtime handles before the implementation
+branch is merged to `main`.
 
-#### Scenario: Existing runtime path is selected
-- **WHEN** runtime selection chooses the legacy Ghostty-backed path
-- **THEN** current terminal behavior continues to follow the existing Ghostty runtime service contracts
+#### Scenario: Implementation branch is ready to merge
+- **WHEN** the Alan-owned PTY runtime implementation is marked ready for review
+- **THEN** terminal launch, delivery, resize, signal, exit, snapshot, and renderer attachment go through Alan-owned runtime handles
+- **AND** terminal ContentInstances do not rely on a selectable fallback process owner
 
-#### Scenario: Alan-owned path is selected
-- **WHEN** runtime selection chooses the Alan-owned PTY path
-- **THEN** terminal launch, delivery, resize, signal, exit, snapshot, and renderer attachment go through the Alan-owned runtime handles
-- **AND** control-plane responses identify the selected runtime path in debug metadata
+#### Scenario: Obsolete process owner is removed
+- **WHEN** the feature branch removes renderer-owned process lifecycle code
+- **THEN** Ghostty remains responsible for renderer and terminal-protocol behavior
+- **AND** Alan remains responsible for PTY and child-process lifecycle

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
@@ -80,3 +80,44 @@ branch is merged to `main`.
 - **WHEN** the feature branch removes renderer-owned process lifecycle code
 - **THEN** Ghostty remains responsible for renderer and terminal-protocol behavior
 - **AND** Alan remains responsible for PTY and child-process lifecycle
+
+## MODIFIED Requirements
+
+### Requirement: Terminal runtime service supports bounded graceful shutdown requests
+The terminal runtime service SHALL expose a service-owned graceful shutdown
+request path backed by Alan-owned PTY and process handles for live terminal
+ContentInstances so confirmed close can give foreground work a chance to exit
+and print final transcript output before forced runtime finalization.
+
+#### Scenario: Graceful shutdown is requested for active terminal work
+- **WHEN** the shell host has received user confirmation for closing active
+  terminal work
+- **THEN** the runtime service requests graceful shutdown for the corresponding
+  terminal ContentInstance through Alan-owned PTY/process runtime handles without
+  exposing PTY handles, process handles, or Ghostty surface pointers to the shell
+  host
+- **AND** the shell host can observe whether the terminal returned to inactive
+  foreground-work state or exited before the bounded wait expires
+
+#### Scenario: Graceful shutdown cannot be requested
+- **WHEN** the Alan-owned runtime is missing, failed, exited, or unable to
+  receive the graceful shutdown request
+- **THEN** the runtime service returns an explicit request result
+- **AND** confirmed close may continue to capture the latest available transcript
+  and force-finalize the runtime
+
+#### Scenario: Alan-owned process signal delivery is available
+- **WHEN** active terminal work has an Alan-owned foreground process group
+  eligible for graceful signal delivery
+- **THEN** the runtime service delivers the configured graceful termination
+  signal through Alan-owned process handles according to policy
+- **AND** the result records the attempted delivery without using Ghostty-owned
+  process state
+
+#### Scenario: Alan-owned process signal delivery is unavailable
+- **WHEN** the Alan-owned runtime cannot identify an eligible foreground process
+  group or the platform refuses signal delivery
+- **THEN** the runtime service returns an explicit unavailable or failed result
+  and may continue bounded observation before forced finalization
+- **AND** Alan does not treat Ghostty terminal-level input or renderer-owned
+  process state as a fallback process owner

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/specs/macos-terminal-runtime-foundation/spec.md
@@ -1,12 +1,13 @@
 ## ADDED Requirements
 
-### Requirement: Terminal PTYs are Alan-owned
-The macOS terminal runtime SHALL allocate and own the PTY, child process,
-process group metadata, lifecycle phase, delivery state, and exit observation
-for each terminal ContentInstance through Alan terminal runtime services.
+### Requirement: Alan-owned PTY runtime path owns terminal PTYs
+For Alan-owned PTY runtime path selections, the macOS terminal runtime SHALL
+allocate and own the PTY, child process, process group metadata, lifecycle
+phase, delivery state, and exit observation through Alan terminal runtime
+services.
 
 #### Scenario: Terminal content starts with Alan-owned PTY
-- **WHEN** a terminal ContentInstance is created through the Alan-owned runtime path
+- **WHEN** a terminal ContentInstance is created through the Alan-owned PTY runtime path
 - **THEN** Alan allocates the PTY, launches the terminal child process, records the process group, and creates the runtime handle before attaching a renderer
 - **AND** the runtime handle is keyed by terminal ContentInstance identity
 
@@ -16,9 +17,10 @@ for each terminal ContentInstance through Alan terminal runtime services.
 - **AND** renderer attachment can occur later without starting a second child process
 
 ### Requirement: Ghostty attaches to Alan-provided PTYs
-The Ghostty integration SHALL act as a renderer and terminal-protocol adapter
-over PTY endpoints supplied by Alan, and MUST NOT be the authoritative owner of
-terminal child-process lifecycle in the Alan-owned PTY runtime path.
+When the Alan-owned PTY runtime path is selected, the Ghostty integration SHALL
+act as a renderer and terminal-protocol adapter over PTY endpoints supplied by
+Alan, and MUST NOT be the authoritative owner of terminal child-process
+lifecycle.
 
 #### Scenario: Renderer attaches to live PTY
 - **WHEN** a terminal host view mounts for terminal content with an Alan-owned PTY runtime
@@ -31,9 +33,10 @@ terminal child-process lifecycle in the Alan-owned PTY runtime path.
 - **AND** the Alan-owned PTY runtime, child process, process group, and delivery state remain alive unless the terminal content is closing
 
 ### Requirement: Runtime control uses Alan process handles
-The terminal runtime service SHALL implement resize, text delivery, EOF,
-interrupt, terminate, kill, and exit-status observation using Alan-owned PTY and
-process handles rather than renderer-owned process state.
+For Alan-owned PTY runtimes, the terminal runtime service SHALL implement
+resize, text delivery, EOF, interrupt, terminate, kill, and exit-status
+observation using Alan-owned PTY and process handles rather than renderer-owned
+process state.
 
 #### Scenario: Terminal is resized
 - **WHEN** a terminal ContentInstance size changes

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
@@ -10,7 +10,7 @@
 - [ ] 2.1 Add Alan-owned PTY/process runtime protocols for allocation, launch, resize, input, EOF, signals, exit observation, and bounded transcript capture.
 - [ ] 2.2 Add fake PTY and fake process-controller implementations for focused tests.
 - [ ] 2.3 Replace terminal runtime construction with the Alan-owned PTY runtime on the implementation branch, without adding a long-lived fallback selector.
-- [ ] 2.4 Route terminal launch profiles and environment projection into the Alan-owned PTY runtime.
+- [ ] 2.4 Route Terminal Profile command, cwd, environment, and non-secret metadata projection into the Alan-owned PTY runtime boot request.
 
 ## 3. Ghostty Attachment
 

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
@@ -9,14 +9,14 @@
 
 - [ ] 2.1 Add Alan-owned PTY/process runtime protocols for allocation, launch, resize, input, EOF, signals, exit observation, and bounded transcript capture.
 - [ ] 2.2 Add fake PTY and fake process-controller implementations for focused tests.
-- [ ] 2.3 Add runtime selection plumbing that can choose the existing Ghostty-owned path or the Alan-owned PTY path without changing default behavior initially.
-- [ ] 2.4 Route terminal launch profiles and environment projection into the Alan-owned PTY runtime path.
+- [ ] 2.3 Replace terminal runtime construction with the Alan-owned PTY runtime on the implementation branch, without adding a long-lived fallback selector.
+- [ ] 2.4 Route terminal launch profiles and environment projection into the Alan-owned PTY runtime.
 
 ## 3. Ghostty Attachment
 
 - [ ] 3.1 Identify the Ghostty fork seam required to attach a renderer to an externally owned PTY endpoint.
 - [ ] 3.2 Patch the Alan-maintained Ghostty fork with the minimal external-PTY attachment support needed by Alan.
-- [ ] 3.3 Update Alan's Ghostty bridge to attach to Alan-provided PTY endpoints in the Alan-owned PTY runtime path.
+- [ ] 3.3 Update Alan's Ghostty bridge to attach to Alan-provided PTY endpoints in the Alan-owned PTY runtime.
 - [ ] 3.4 Preserve renderer readiness, surface lifecycle, scrollback, input adapter, and metadata projection behavior across the new attachment path.
 
 ## 4. Process Control And Lifecycle

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
@@ -1,0 +1,41 @@
+## 1. Dependency Source
+
+- [ ] 1.1 Choose and document the repository path for the Alan-maintained Ghostty fork submodule.
+- [ ] 1.2 Add the Ghostty fork submodule at the chosen path and pin the reviewed revision.
+- [ ] 1.3 Update Ghostty setup scripts to prefer the pinned submodule source while keeping explicit developer overrides visible.
+- [ ] 1.4 Record Ghostty artifact revision/cache metadata so setup checks can detect stale artifacts.
+
+## 2. Alan PTY Runtime Foundation
+
+- [ ] 2.1 Add Alan-owned PTY/process runtime protocols for allocation, launch, resize, input, EOF, signals, exit observation, and bounded transcript capture.
+- [ ] 2.2 Add fake PTY and fake process-controller implementations for focused tests.
+- [ ] 2.3 Add runtime selection plumbing that can choose the existing Ghostty-owned path or the Alan-owned PTY path without changing default behavior initially.
+- [ ] 2.4 Route terminal launch profiles and environment projection into the Alan-owned PTY runtime path.
+
+## 3. Ghostty Attachment
+
+- [ ] 3.1 Identify the Ghostty fork seam required to attach a renderer to an externally owned PTY endpoint.
+- [ ] 3.2 Patch the Alan-maintained Ghostty fork with the minimal external-PTY attachment support needed by Alan.
+- [ ] 3.3 Update Alan's Ghostty bridge to attach to Alan-provided PTY endpoints in the Alan-owned runtime path.
+- [ ] 3.4 Preserve renderer readiness, surface lifecycle, scrollback, input adapter, and metadata projection behavior across the new attachment path.
+
+## 4. Process Control And Lifecycle
+
+- [ ] 4.1 Move resize and text delivery for the Alan-owned path to Alan PTY handles.
+- [ ] 4.2 Implement Alan-owned interrupt, terminate, kill, EOF, and forced-close result reporting.
+- [ ] 4.3 Project Alan-owned process state, foreground work, exit status, and signal diagnostics into terminal ContentInstance metadata.
+- [ ] 4.4 Keep app-restart restore semantics snapshot-based unless a later daemon-owned PTY runtime is specified.
+
+## 5. Verification
+
+- [ ] 5.1 Add focused fake-runtime tests for PTY allocation, launch, text delivery, resize, signal delivery, exit observation, and snapshot capture.
+- [ ] 5.2 Add setup checks for missing Ghostty submodule, stale artifacts, explicit overrides, and pinned-revision metadata.
+- [ ] 5.3 Extend the Ghostty integration lane to cover Alan-owned PTY renderer attachment when local artifacts are prepared.
+- [ ] 5.4 Run `openspec validate add-macos-alan-owned-pty-runtime --strict`.
+- [ ] 5.5 Run focused Apple shell contract or build checks relevant to dependency setup and terminal runtime boundaries.
+
+## 6. Review And Archive Readiness
+
+- [ ] 6.1 Keep the first PR spec-only unless implementation scope is explicitly requested.
+- [ ] 6.2 After implementation lands, sync accepted delta specs into `openspec/specs/`.
+- [ ] 6.3 Archive the completed OpenSpec change after synced specs validate.

--- a/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
+++ b/openspec/changes/add-macos-alan-owned-pty-runtime/tasks.md
@@ -16,7 +16,7 @@
 
 - [ ] 3.1 Identify the Ghostty fork seam required to attach a renderer to an externally owned PTY endpoint.
 - [ ] 3.2 Patch the Alan-maintained Ghostty fork with the minimal external-PTY attachment support needed by Alan.
-- [ ] 3.3 Update Alan's Ghostty bridge to attach to Alan-provided PTY endpoints in the Alan-owned runtime path.
+- [ ] 3.3 Update Alan's Ghostty bridge to attach to Alan-provided PTY endpoints in the Alan-owned PTY runtime path.
 - [ ] 3.4 Preserve renderer readiness, surface lifecycle, scrollback, input adapter, and metadata projection behavior across the new attachment path.
 
 ## 4. Process Control And Lifecycle


### PR DESCRIPTION
## Summary
- restore the add-macos-alan-owned-pty-runtime OpenSpec change
- define Alan-owned PTY/process runtime ownership beneath terminal ContentInstances
- specify Ghostty fork/submodule dependency setup and focused verification requirements

## Verification
- openspec validate add-macos-alan-owned-pty-runtime --strict
- git diff --check origin/main...HEAD