### PR TITLE
Add cross-platform shell core OpenSpec

### DIFF
--- a/openspec/changes/introduce-cross-platform-shell-core/.openspec.yaml
+++ b/openspec/changes/introduce-cross-platform-shell-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/introduce-cross-platform-shell-core/design.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/design.md
@@ -1,0 +1,245 @@
+## Context
+
+Alan's native macOS shell has become the product's richest terminal workspace
+surface. The current Swift implementation already contains durable domain logic
+that is not inherently macOS-specific:
+
+- workspace state models for Spaces, Tabs, PaneSlots, ContentInstances, and
+  split trees
+- reducer-style mutations for split, focus, movement, close, pinning, reordering,
+  zoom, resize, and attention
+- workspace manifest defaulting, legacy upgrade, materialization, pruning, and
+  restore snapshot behavior
+- shell action registry availability and effect mapping
+- control-plane command validation and response projection
+- Terminal Profile validation and launch resolution
+- settings summaries for local workspace/profile/account state
+
+Future Linux GTK work should not copy these semantics into another UI client.
+The cross-platform boundary should move the reusable shell workspace domain into
+Rust while leaving UI, terminal runtime hosting, file IO, IPC transport, and
+privileged OS operations in platform adapters.
+
+The current Apple architecture checks already identify large Swift files and
+controller/AppKit leakage as maintainability debt. This change treats that debt
+as migration evidence: domain truth should move out of Swift module by module,
+with parity fixtures proving equivalence before each replacement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a platform-neutral Rust shell workspace core as the long-term owner of
+  reusable shell domain logic.
+- Keep the Rust core pure: no Swift, GTK, AppKit, Ghostty, Axum daemon, socket,
+  file-system persistence, clipboard, file picker, or privileged executor
+  dependencies.
+- Use module boundaries that match the domain: model, manifest, reducer,
+  actions, control, terminal profiles, settings summaries, and fixtures.
+- Build a parity-first migration path where Rust behavior is proven against
+  Swift-exported fixture cases before macOS calls are replaced.
+- Use a coarse-grained, versioned binding facade for Swift integration after
+  Rust parity is established.
+- Preserve existing shell control-plane response shapes and stable error codes
+  unless a later spec explicitly changes them.
+- Make architecture warning reduction a completion criterion for Swift
+  replacement work.
+
+**Non-Goals:**
+
+- Do not implement Linux GTK UI in this change.
+- Do not move Ghostty/AppKit terminal hosting, PTY/process handles, renderer
+  state, or delivery queues into shell core.
+- Do not move macOS IPC transport, file polling, socket serving, clipboard,
+  folder opening, diagnostics presentation, Sparkle, App Intents, or windowing
+  into shell core.
+- Do not move privileged account application or AppleScript privilege execution
+  into shell core. Core may plan or validate portable domain state; platform
+  adapters own OS effects.
+- Do not expose async bindings, callbacks, foreign traits, or long-lived Rust
+  workspace objects in the first Swift integration path.
+- Do not replace Swift callers before the corresponding Rust module has parity
+  fixtures and adapter tests.
+
+## Decisions
+
+### Add `crates/shell-core` as a pure Rust domain crate
+
+The new crate should be named after the durable product/runtime contract, not
+after a platform. It should expose ordinary Rust APIs for internal use and tests.
+The crate should not depend on the Apple client, GTK, daemon server, terminal
+renderer, or platform IO.
+
+The module layout should be:
+
+- `model`: `WorkspaceState`, `Space`, `Tab`, `PaneSlot`, `ContentInstance`,
+  `SplitTree`, attention, lifecycle, content kind, terminal metadata, and
+  stable IDs.
+- `manifest`: versioned workspace manifest schema, default manifest, legacy
+  upgrade, materialization, TTL pruning, pin/live restore snapshots, and quick
+  terminal restore records.
+- `reducer`: pure mutations for space, tab, pane, content, split, focus, move,
+  close, pin, unpin, reorder, resize, zoom, attention, and agent activity.
+- `actions`: stable action IDs, target resolution, availability, shortcut
+  metadata, and action-to-effect mapping.
+- `control`: shell control command DTOs, validation, stable error codes,
+  authoritative response projection, and runtime intent separation.
+- `terminal_profile`: Terminal Profile document, editor/validation, resolution
+  order, and `TerminalLaunchIntent` construction.
+- `settings_summary`: reusable settings/domain summaries that are independent
+  from SwiftUI or GTK layout.
+- `fixtures`: test-only fixture loading and comparison helpers.
+
+Alternative considered: put this logic in `crates/tui` or `crates/alan`.
+`crates/tui` is a daemon-backed conversation UI, not the native shell workspace
+domain. `crates/alan` owns daemon/CLI hosting and would couple the core to a
+server implementation.
+
+### Keep data flow authority explicit
+
+The desired data flow is:
+
+```text
+Manifest -> WorkspaceState -> Platform Runtime -> Published Projection
+```
+
+The manifest is the restore authority and stores only restorable intent:
+Spaces, Tabs, layout, content restore payloads, profile references, TTL metadata,
+pin/live snapshots, and quick terminal restore data.
+
+`WorkspaceState` is the current domain state. Reducers return a new state plus
+events, runtime intents, manifest sync hints, and response fields. Platform
+runtime adapters execute intents such as starting terminal content, sending
+terminal input, closing terminal content, or capturing transcript snapshots.
+
+Published projection remains a compatibility surface for UI, automation, and
+control-plane clients. During migration, the Rust core should preserve the
+current JSON-visible shape where existing clients depend on it.
+
+Alternative considered: make platform runtime handles part of the state model.
+That would make the model non-portable and would violate the current manifest
+contract that excludes PTYs, process handles, renderer objects, and delivery
+queues.
+
+### Use parity-first migration before Swift replacement
+
+The first line of work should build Rust modules and tests without connecting
+them to the macOS app. Existing Swift script tests become behavior sources for
+fixture generation:
+
+- `test-shell-split-model`
+- `test-shell-workspace-manifest`
+- `test-shell-automation-command-seams`
+- `test-shell-sidebar-tab-rows`
+- `test-shell-settings-surface`
+
+Each migrated module should add fixture cases that include input state or
+manifest, operation input, and expected output. Rust tests should compare
+semantics against those fixtures. When exact JSON ordering is irrelevant, tests
+should compare normalized semantic forms rather than raw bytes.
+
+Alternative considered: replace Swift directly and rely on app smoke tests.
+That would make regressions harder to localize and would turn FFI/debugging
+issues into product behavior uncertainty.
+
+### Use a separate binding facade and keep the core binding-agnostic
+
+The pure Rust crate should not be shaped around Swift binding macros. A separate
+facade crate or module should expose cross-language entrypoints after parity
+exists. The first facade should be coarse-grained and versioned, passing
+request/response envelopes rather than many small functions.
+
+UniFFI may be used for the generated Swift layer, but it must not determine the
+core module boundaries. The first integration should avoid async UniFFI,
+foreign traits, platform callbacks, and long-lived Rust objects. If UniFFI is
+used initially, it should expose stable facade functions over bytes or a small
+number of stable DTOs instead of exporting the entire evolving workspace model.
+
+Alternative considered: hand-written C ABI only. That is simple and explicit,
+but UniFFI can reduce Swift wrapper boilerplate once the facade is constrained.
+The important decision is the facade shape, not the binding generator.
+
+### Keep platform adapters narrow
+
+macOS Swift and future GTK code should call shell core through platform
+adapters. Platform adapters own:
+
+- SwiftUI/GTK presentation and controller state
+- window, sidebar, drag/drop, keyboard, menu, and context-menu rendering
+- terminal widget/runtime attachment, PTY/process handles, renderer objects,
+  delivery queues, and transcript extraction
+- control-plane transport such as socket serving and file polling
+- file-system persistence locations and corrupt-file quarantine mechanics
+- clipboard, folder opening, file picker, update UI, and diagnostics
+  presentation
+- privileged account apply executors and platform-specific verification
+
+The Rust core owns whether a command is valid, how domain state changes, what
+stable result/error should be reported, and what runtime or persistence intent
+the platform adapter should execute.
+
+### Migrate modules from inner domain outward
+
+Implementation should follow dependency order:
+
+1. scaffold shell-core, schema/version envelopes, fixture format, and validation
+2. workspace model and split tree
+3. state reducer
+4. manifest default/upgrade/materialize/prune
+5. action registry
+6. control command reducer/result projection
+7. Terminal Profile domain
+8. settings summaries
+9. Swift binding adapter replacement module by module
+10. Swift logic deletion and architecture warning burn-down
+
+This order keeps each step testable and avoids building platform bindings before
+the underlying semantics are stable.
+
+## Risks / Trade-offs
+
+- JSON or byte-envelope bindings can be less ergonomic than typed Swift APIs ->
+  keep them behind `ShellCoreFFIAdapter` and upgrade only stable DTOs later.
+- UniFFI can generate large Swift/modulemap diffs and has Swift 6 concurrency
+  edges -> start with synchronous coarse-grained facade functions and pin the
+  generator version in build checks.
+- Rust and Swift semantic drift can hide in fixture gaps -> require fixtures for
+  every removed Swift branch and keep existing focused Swift scripts in the
+  validation matrix.
+- Large workspace states may make binding calls expensive -> keep high-frequency
+  terminal input/rendering outside shell core bindings and reserve core calls for
+  workspace mutations, manifest operations, action resolution, and command
+  reduction.
+- A compatibility bug in manifest migration could lose user workspace state ->
+  preserve current manifest JSON compatibility, keep corrupt evidence, and add
+  fixture cases for old and malformed manifests before replacing Swift manifest
+  logic.
+- Architecture warnings might remain unchanged if Swift wrappers simply call
+  Rust but old logic stays in place -> each replacement task must remove or
+  narrow the replaced Swift implementation and update the architecture ledger.
+
+## Migration Plan
+
+1. Add the Rust crate and fixture harness without changing the app.
+2. Build Rust modules and parity fixtures in dependency order.
+3. Add a constrained Swift binding facade once at least one module has parity.
+4. Replace Swift call sites module by module, retaining short-lived fallback or
+   oracle paths only while adapter tests are being introduced.
+5. Delete replaced Swift logic after the Rust-backed path passes focused Swift
+   scripts, Rust tests, and binding tests.
+6. Update `clients/apple/ARCHITECTURE.md` and architecture validation
+   expectations as warning debt decreases.
+
+Rollback for any app-connected slice should be module-scoped: restore the Swift
+call path for that module while keeping already-proven Rust modules and fixtures
+in place. Manifest-affecting slices must keep read compatibility with previously
+written files.
+
+## Open Questions
+
+- Whether the first binding facade should use UniFFI over byte envelopes or a
+  hand-written C ABI over byte envelopes can be decided during the binding slice.
+  The architectural requirement is a coarse-grained, versioned facade.
+- Whether `settings_summary` should live in `crates/shell-core` or a later
+  companion crate depends on how much of the summary logic remains shell-domain
+  rather than host-configuration presentation.

--- a/openspec/changes/introduce-cross-platform-shell-core/proposal.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+Alan for macOS currently owns substantial shell workspace logic in Swift files
+that are not UI-only: workspace state mutations, manifest materialization,
+action availability, control-plane command reduction, Terminal Profile
+resolution, and settings domain summaries. This makes a future Linux GTK client
+likely to reimplement the same behavior unless the reusable shell workspace
+domain is moved into a platform-neutral Rust core with strong parity tests.
+
+## What Changes
+
+- Introduce a platform-neutral Rust shell workspace core that owns reusable
+  Spaces, Tabs, PaneSlot, ContentInstance, split tree, mutation, manifest,
+  action, control-command, and Terminal Profile domain logic.
+- Keep macOS SwiftUI/AppKit, Ghostty runtime hosting, windowing, file pickers,
+  clipboard, IPC transport, diagnostics presentation, and privileged macOS
+  account apply paths in the Apple client platform layer.
+- Define a coarse-grained, versioned cross-language facade for Swift integration
+  after Rust parity is established. The first facade uses stable request/response
+  envelopes and must not expose async callbacks, foreign traits, or long-lived
+  Rust workspace objects.
+- Add Swift-exported parity fixtures and Rust tests before replacing each Swift
+  logic module.
+- Replace Swift shell workspace logic module by module only after the equivalent
+  Rust module passes parity and adapter tests.
+- Require architecture warning debt to decrease as Swift logic is replaced,
+  preventing new pure workspace domain logic from accumulating in large Swift
+  shell model/controller files.
+
+## Capabilities
+
+### New Capabilities
+
+- `shell-workspace-core-contract`: Defines the platform-neutral Rust shell
+  workspace core ownership, module boundaries, reducer/manifest/action/control
+  contracts, platform adapter responsibilities, binding facade rules, and
+  parity-test requirements.
+
+### Modified Capabilities
+
+- `macos-app-architecture-maintainability`: Clarify that reusable shell
+  workspace domain logic migrates out of Swift into the Rust shell core, and
+  Apple architecture warning debt must shrink as replacements land.
+- `macos-shell-workspace-persistence`: Delegate portable manifest semantics to
+  the shell workspace core while keeping macOS manifest file IO in the platform
+  layer.
+- `macos-shell-control-plane-reliability`: Separate control-plane transport and
+  runtime side effects from command validation, stable error codes, and
+  authoritative reducer results owned by the shell core.
+- `macos-shell-action-registry`: Move shared action IDs, target resolution,
+  availability, and effect mapping into the platform-neutral shell core while
+  keeping macOS menu, context menu, and keyboard presentation in Swift.
+- `macos-terminal-profiles`: Move Terminal Profile document validation,
+  resolution order, and launch-intent construction into shell core while keeping
+  platform process spawning and privileged account application outside it.
+- `macos-shell-build-test-contract`: Add parity-fixture, Rust core, binding
+  facade, and Swift replacement validation expectations.
+
+## Impact
+
+- Affected Rust workspace:
+  - New `crates/shell-core` pure Rust crate.
+  - Optional dedicated binding/facade crate or module for Swift integration.
+  - Workspace `Cargo.toml`, focused Rust unit tests, fixture tests, and
+    validation commands.
+- Affected Apple client code:
+  - `clients/apple/alan-macos/Models/Shell/ShellSnapshots.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellStateMutations.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellWorkspaceManifest.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellActionRegistry.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellValueTypes.swift`
+  - `clients/apple/alan-macos/Models/Shell/ShellSettingsSurfaceModel.swift`
+  - `clients/apple/alan-macos/Services/Shell/ShellLocalCommandExecutor.swift`
+  - `clients/apple/alan-macos/ShellHostController.swift`
+  - Apple script tests under `clients/apple/scripts/`
+- Future Linux GTK code should depend on the same Rust shell workspace core
+  through a platform adapter instead of reimplementing shell domain behavior.
+- No daemon API breaking change is intended. Existing shell control-plane JSON
+  shapes and stable error codes should be preserved unless a later spec
+  explicitly changes them.

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-app-architecture-maintainability/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-app-architecture-maintainability/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Reusable shell domain logic migrates to Rust shell core
+The Apple client architecture SHALL treat reusable shell workspace domain logic
+as Rust shell core ownership once the corresponding shell core module and parity
+fixtures exist.
+
+Swift files in the Apple client SHALL remain platform adapters, presentation
+layers, terminal runtime hosts, and compatibility wrappers rather than the
+stable home for reusable workspace reducer, manifest, action, control-command,
+or Terminal Profile domain semantics.
+
+#### Scenario: New reusable shell behavior is added
+- **WHEN** a developer adds behavior that changes platform-neutral shell
+  workspace semantics after the shell core module for that domain exists
+- **THEN** the behavior is implemented in the Rust shell core
+- **AND** the Apple client consumes it through a platform adapter rather than
+  adding a separate Swift implementation
+
+#### Scenario: Swift logic is replaced
+- **WHEN** a Swift shell domain module is replaced by Rust shell core behavior
+- **THEN** the replaced Swift implementation is removed or narrowed to adapter
+  code
+- **AND** `clients/apple/ARCHITECTURE.md` and architecture validation
+  expectations are updated when warning debt decreases
+
+### Requirement: Architecture debt burn-down follows shell core adoption
+Apple client architecture warning debt SHALL decrease as Swift shell domain
+logic is replaced by Rust shell core modules.
+
+#### Scenario: Rust-backed module lands
+- **WHEN** a Rust-backed shell core module replaces a Swift reducer, manifest,
+  action, control, profile, or settings domain implementation
+- **THEN** the implementation slice records which architecture warning class was
+  reduced or explains why the replacement is an intermediate adapter-only step
+- **AND** new pure domain logic is not added to the large Swift files that the
+  slice is meant to retire

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-action-registry/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-action-registry/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: macOS shell actions consume shared shell core action contract
+The macOS shell action registry SHALL consume shared action IDs, target
+resolution, availability, shortcut metadata, and action-to-effect mapping from
+the Rust shell core after the action module has parity fixtures and adapter
+tests.
+
+Swift SHALL continue to own menu bar, context menu, keyboard, drag/drop, and
+visual presentation of actions.
+
+#### Scenario: Menu invokes a shared action
+- **WHEN** a macOS menu item invokes a reusable shell action after shell core
+  action integration
+- **THEN** action availability and effect mapping come from the Rust shell core
+- **AND** Swift performs only platform presentation and dispatch through the
+  adapter
+
+#### Scenario: Context target is resolved
+- **WHEN** a macOS context menu supplies a clicked Tab, Space, or PaneSlot target
+- **THEN** the Rust shell core resolves the target according to shared action
+  rules
+- **AND** Swift does not maintain a separate target-resolution implementation
+  for the same reusable action
+
+### Requirement: macOS-only presentation actions remain platform-owned
+macOS-only presentation actions SHALL remain platform-owned.
+
+Actions that are purely macOS presentation, windowing, update UI, file picker,
+or AppKit behavior MUST NOT be forced into the shared shell core action
+registry.
+
+#### Scenario: Platform-only command is invoked
+- **WHEN** a command only opens a macOS panel, presents a Sparkle update UI, or
+  performs AppKit window behavior
+- **THEN** Swift may own that command outside the shell core action registry
+- **AND** the command does not duplicate reusable workspace mutation semantics

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-build-test-contract/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-build-test-contract/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Shell core migration has parity and adapter validation
+Shell core migration slices SHALL include focused Rust tests, Swift-exported
+parity fixtures, and Swift adapter validation before replacing macOS Swift shell
+domain logic.
+
+#### Scenario: Rust module is introduced
+- **WHEN** a Rust shell core module implements existing Swift shell domain
+  behavior
+- **THEN** focused Rust unit tests cover its local behavior
+- **AND** fixture tests compare it against Swift-exported cases for the same
+  domain
+
+#### Scenario: Swift call path is replaced
+- **WHEN** a macOS Swift call path switches to Rust shell core behavior through
+  a binding facade
+- **THEN** Swift adapter tests cover request encoding, response decoding, error
+  mapping, schema or ABI version mismatch, and fallback removal expectations
+- **AND** the focused Apple script tests for the affected domain run in the same
+  validation slice
+
+### Requirement: Existing shell checks remain in the migration matrix
+Shell core migration SHALL continue to run the existing focused macOS shell
+script checks that cover the replaced behavior.
+
+#### Scenario: Split and reducer behavior changes
+- **WHEN** split tree or workspace reducer behavior is migrated to Rust
+- **THEN** `clients/apple/scripts/test-shell-split-model.sh` and other affected
+  reducer-focused checks remain part of validation until their coverage is
+  replaced by stricter Rust-backed equivalents
+
+#### Scenario: Manifest behavior changes
+- **WHEN** workspace manifest behavior is migrated to Rust
+- **THEN** `clients/apple/scripts/test-shell-workspace-manifest.sh` remains part
+  of validation
+- **AND** existing manifest compatibility cases are represented in parity
+  fixtures
+
+#### Scenario: Control or automation command behavior changes
+- **WHEN** shell control command reduction or automation command seams are
+  migrated to Rust
+- **THEN** `clients/apple/scripts/test-shell-automation-command-seams.sh` and
+  `clients/apple/scripts/check-shell-contracts.sh` remain part of validation
+
+### Requirement: Binding generator output is pinned and checked
+If a binding generator such as UniFFI is used for Swift integration, Alan SHALL
+pin the generator version and validate generated Swift, header, and modulemap
+output so binding drift is intentional.
+
+#### Scenario: Binding facade is regenerated
+- **WHEN** generated binding output changes
+- **THEN** validation makes the generated Swift/header/modulemap drift visible
+- **AND** the change records whether the drift came from schema changes,
+  generator-version changes, or facade implementation changes

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-control-plane-reliability/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-control-plane-reliability/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: macOS control transport delegates reusable command semantics
+The macOS shell control plane SHALL delegate reusable command validation,
+workspace reducer dispatch, stable error codes, and authoritative response
+projection to the Rust shell core after the control reducer module has parity
+fixtures and adapter tests.
+
+The macOS control plane SHALL continue to own socket transport, file polling,
+request size limits, response deadlines, runtime service calls, event store IO,
+and diagnostics recording.
+
+#### Scenario: Domain command is received over socket
+- **WHEN** a socket client sends a workspace-domain control command after shell
+  core control integration
+- **THEN** the macOS transport decodes and bounds the request
+- **AND** the Rust shell core validates and reduces the command
+- **AND** the macOS control plane publishes the returned state, events, runtime
+  intents, and response through existing transport semantics
+
+#### Scenario: Runtime command is reduced
+- **WHEN** a control command targets terminal runtime behavior such as text
+  delivery
+- **THEN** the shell core returns domain target validation and a runtime intent
+- **AND** the macOS terminal runtime service supplies the platform-specific
+  delivery outcome for the final control response
+
+### Requirement: Stable control response compatibility is maintained
+Rust-backed control command reduction SHALL preserve existing macOS shell
+control response shapes and stable error codes unless a later spec explicitly
+changes them.
+
+#### Scenario: Missing target error is returned
+- **WHEN** a Rust-backed control command references a missing Space, Tab,
+  PaneSlot, or ContentInstance
+- **THEN** the returned response uses the same stable error semantics expected
+  by current macOS shell control clients
+- **AND** clients do not need to infer the failure from raw state snapshots

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: macOS delegates portable manifest semantics to shell core
+Alan for macOS SHALL delegate portable workspace manifest semantics to the Rust
+shell core after the manifest module has parity fixtures and adapter tests.
+
+The macOS platform layer SHALL continue to own Application Support path
+selection, file reads and writes, atomic persistence, corrupt-file evidence, and
+diagnostics presentation.
+
+#### Scenario: macOS loads a workspace manifest
+- **WHEN** Alan for macOS reads a workspace manifest from disk after shell core
+  manifest integration
+- **THEN** macOS passes the manifest bytes and platform context to the shell
+  core for decode, upgrade, materialization, and pruning semantics
+- **AND** macOS remains responsible for preserving corrupt evidence and choosing
+  the file path used for persistence
+
+#### Scenario: Manifest output is persisted
+- **WHEN** the shell core returns an updated manifest or manifest sync hint
+- **THEN** the macOS platform layer writes the result through its persistence
+  store
+- **AND** the shell core does not directly access the user's file system
+
+### Requirement: Manifest compatibility is preserved during migration
+Rust-backed manifest behavior SHALL preserve compatibility with existing macOS
+workspace manifest JSON unless a later spec explicitly changes the manifest
+schema.
+
+#### Scenario: Existing manifest is read by Rust-backed path
+- **WHEN** Alan for macOS reads a manifest written by the current Swift
+  implementation
+- **THEN** the Rust-backed path decodes or upgrades it according to the existing
+  manifest contract
+- **AND** Space, Tab, PaneSlot, ContentInstance, selection, pin/live snapshot,
+  lifecycle, Terminal Profile reference, and quick terminal restore semantics
+  remain intact

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/macos-terminal-profiles/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/macos-terminal-profiles/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: macOS delegates Terminal Profile domain semantics to shell core
+Alan for macOS SHALL delegate Terminal Profile document validation, editor
+semantics, deterministic resolution order, missing/unavailable profile state,
+and terminal launch-intent construction to the Rust shell core after the
+Terminal Profile module has parity fixtures and adapter tests.
+
+The macOS platform layer SHALL continue to own profile store file IO, channel
+Application Support path selection, terminal runtime spawn translation, and
+privileged Managed Terminal Account apply operations.
+
+#### Scenario: Terminal Profile is resolved for pane startup
+- **WHEN** macOS creates terminal content with a Terminal Profile reference
+  after shell core profile integration
+- **THEN** the Rust shell core resolves the profile and returns a launch intent
+- **AND** the macOS terminal runtime adapter translates that intent into the
+  concrete Ghostty or shell startup operation
+
+#### Scenario: Profile store is saved
+- **WHEN** a Terminal Profile document is edited after shell core profile
+  integration
+- **THEN** the Rust shell core validates document semantics
+- **AND** the macOS platform layer writes the document to its channel-scoped
+  store location
+
+### Requirement: Privileged account effects stay platform-owned
+Privileged account effects SHALL remain platform-owned.
+
+Managed Terminal Account privileged apply, sudoers writes, AppleScript
+authorization, account lookup commands, and platform verification executors SHALL
+remain outside the shell core and MUST stay platform-owned.
+
+The shell core MAY own portable request, plan, validation, handoff, or profile
+intent semantics only when those semantics do not execute OS effects directly.
+
+#### Scenario: Managed account apply is approved
+- **WHEN** the user approves a Managed Terminal Account provisioning plan on
+  macOS
+- **THEN** macOS executes privileged account and sudoers operations through the
+  platform-owned executor
+- **AND** shell core does not receive reusable privileged credentials or invoke
+  AppleScript, sudoers writes, or account-management commands directly

--- a/openspec/changes/introduce-cross-platform-shell-core/specs/shell-workspace-core-contract/spec.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/specs/shell-workspace-core-contract/spec.md
@@ -1,0 +1,174 @@
+## ADDED Requirements
+
+### Requirement: Rust shell core owns reusable workspace domain logic
+Alan SHALL provide a platform-neutral Rust shell workspace core that owns
+reusable shell workspace domain behavior shared by Alan for macOS and future
+Linux GTK clients.
+
+The shell core SHALL be independent from SwiftUI, AppKit, GTK, Ghostty, daemon
+hosting, socket transport, file-system persistence locations, clipboard, file
+pickers, and privileged OS executors.
+
+#### Scenario: Platform client mutates workspace state
+- **WHEN** a platform client requests a reusable workspace mutation such as tab
+  open, pane split, focus, move, close, pin, reorder, resize, zoom, or attention
+  update
+- **THEN** the mutation semantics are provided by the Rust shell core
+- **AND** the platform client does not reimplement the same domain mutation in
+  Swift, GTK, or platform-specific controller code
+
+#### Scenario: Shell core is built without platform UI
+- **WHEN** the Rust shell core crate is compiled in isolation
+- **THEN** it does not require Apple frameworks, GTK libraries, Ghostty, an Axum
+  daemon, or a terminal renderer
+
+### Requirement: Workspace model is platform neutral
+The shell core SHALL define platform-neutral workspace model types for Spaces,
+Tabs, PaneSlots, ContentInstances, split trees, attention, lifecycle state,
+content kinds, terminal metadata, restore identity, and stable IDs.
+
+#### Scenario: macOS and GTK represent the same workspace
+- **WHEN** macOS and a future GTK client load the same portable workspace model
+- **THEN** Space, Tab, PaneSlot, ContentInstance, split tree, focus, selection,
+  attention, and lifecycle fields have the same domain meaning on both clients
+- **AND** platform-specific window, view, renderer, process, and widget handles
+  are not part of the shell core model
+
+### Requirement: Reducers are pure state transitions
+The shell core reducer SHALL apply workspace operations as pure state
+transitions that return a next state, domain events, runtime intents, manifest
+sync hints, and stable result or error data.
+
+#### Scenario: Reducer accepts a valid split operation
+- **WHEN** a valid PaneSlot split operation is applied to a workspace state
+- **THEN** the reducer returns the updated workspace state
+- **AND** it identifies the created PaneSlot and ContentInstance
+- **AND** it returns runtime intents needed by the platform adapter without
+  creating terminal processes directly
+
+#### Scenario: Reducer rejects an invalid operation
+- **WHEN** a reducer operation references a missing Space, Tab, PaneSlot, split,
+  or unsupported content kind
+- **THEN** the reducer leaves the workspace state unchanged
+- **AND** it returns a stable error code that platform control surfaces can
+  report without inferring failure from raw state diffs
+
+### Requirement: Manifest semantics are portable and versioned
+The shell core SHALL own portable workspace manifest semantics, including schema
+versioning, default manifest creation, legacy upgrade, materialization into
+workspace state, TTL pruning, pinned and live restore snapshots, and quick
+terminal restore records.
+
+The manifest SHALL store restorable workspace intent and SHALL NOT store
+terminal process handles, PTY file descriptors, renderer objects, Ghostty
+surface pointers, platform window handles, delivery queues, or unbounded
+scrollback.
+
+#### Scenario: Manifest materializes workspace state
+- **WHEN** a valid workspace manifest is materialized by the shell core
+- **THEN** the resulting workspace state preserves Space, Tab, PaneSlot,
+  ContentInstance, selection, split tree, lifecycle, profile reference, and
+  restore snapshot semantics
+- **AND** platform adapters create new terminal runtimes from returned runtime
+  intents rather than restoring renderer or process objects from the manifest
+
+#### Scenario: Manifest pruning runs
+- **WHEN** the shell core prunes unpinned inactive Tabs outside the configured
+  lifecycle TTL
+- **THEN** pinned Tabs and Tabs protected by active-task metadata are retained
+- **AND** empty Spaces remain durable until explicitly deleted
+
+### Requirement: Action registry is shared by platform surfaces
+The shell core SHALL define stable action IDs, target resolution rules,
+availability, shortcut metadata, and action-to-effect mapping for reusable shell
+actions.
+
+#### Scenario: Different surfaces resolve one action
+- **WHEN** a menu item, keyboard shortcut, context menu, or future GTK action
+  invokes the same registered shell action
+- **THEN** action availability and target resolution come from the shell core
+- **AND** the platform surface owns only presentation, input gesture handling,
+  and platform-specific menu or shortcut rendering
+
+### Requirement: Control command reducer returns authoritative outcomes
+The shell core SHALL define reusable shell control command validation, stable
+error codes, domain reducer dispatch, and authoritative response projection for
+workspace-domain commands.
+
+The shell core SHALL NOT own socket serving, file polling, response deadlines,
+or terminal runtime execution.
+
+#### Scenario: Control command mutates workspace state
+- **WHEN** a control command such as `space.create`, `tab.open`, `pane.split`,
+  `tab.pin`, or `tab.move_to_space` is valid
+- **THEN** the shell core returns an authoritative applied response derived from
+  the updated state
+- **AND** it returns any runtime intents that the platform adapter must execute
+
+#### Scenario: Control command depends on runtime
+- **WHEN** a control command requires terminal runtime execution such as sending
+  text to terminal content
+- **THEN** the shell core validates domain target semantics and returns a
+  runtime intent
+- **AND** the platform runtime adapter owns the actual terminal delivery result
+
+### Requirement: Terminal Profile domain resolves launch intents
+The shell core SHALL own portable Terminal Profile document shape, editor and
+validation logic, deterministic resolution order, missing or unavailable profile
+states, and construction of terminal launch intents.
+
+The shell core SHALL NOT spawn processes, inspect platform-specific GUI state,
+edit sudoers files, invoke AppleScript, or apply privileged account changes.
+
+#### Scenario: Profile resolves to launch intent
+- **WHEN** terminal creation references a valid Terminal Profile
+- **THEN** the shell core resolves the profile according to the documented order
+- **AND** it returns a `TerminalLaunchIntent` that the platform terminal adapter
+  can translate into a macOS or Linux terminal startup operation
+
+#### Scenario: Profile is missing
+- **WHEN** terminal startup references a missing Terminal Profile id
+- **THEN** the shell core preserves the missing reference in the result
+- **AND** it returns fallback launch intent information without deleting the
+  reference from workspace state or manifest data
+
+### Requirement: Platform adapters own UI and OS effects
+Platform adapters SHALL own presentation, windowing, terminal runtime
+attachment, PTY/process handles, renderer objects, file-system persistence
+locations, IPC transport, clipboard, file picker, diagnostics presentation, and
+privileged OS effects.
+
+#### Scenario: Runtime intent is emitted
+- **WHEN** the shell core emits an intent to start, close, send input to, or
+  capture a snapshot from terminal content
+- **THEN** the platform adapter executes the intent using platform terminal
+  runtime facilities
+- **AND** the shell core receives only portable runtime metadata or command
+  outcomes in response
+
+### Requirement: Cross-language bindings use a constrained facade
+Cross-language bindings for platform clients SHALL use a coarse-grained,
+versioned facade over the Rust shell core before exposing fine-grained typed
+model APIs.
+
+The first binding facade MUST NOT expose async callbacks, foreign traits,
+platform callbacks, or long-lived Rust workspace objects.
+
+#### Scenario: Swift calls shell core through bindings
+- **WHEN** Swift integrates a Rust-backed shell core operation
+- **THEN** it calls a versioned facade entrypoint
+- **AND** the facade returns a structured success or error envelope
+- **AND** ABI or schema version mismatches are reported as explicit errors
+  rather than causing silent state corruption
+
+### Requirement: Parity fixtures gate Swift replacement
+Each Swift shell domain module replacement SHALL be gated by parity fixtures
+that compare current Swift behavior against Rust shell core behavior.
+
+#### Scenario: Swift reducer branch is replaced
+- **WHEN** a Swift workspace reducer branch is removed or replaced by a Rust
+  shell core call
+- **THEN** equivalent Swift-exported fixture cases exist
+- **AND** Rust tests pass against those fixtures
+- **AND** Swift adapter tests verify encode, decode, error mapping, and version
+  handling for the replacement path

--- a/openspec/changes/introduce-cross-platform-shell-core/tasks.md
+++ b/openspec/changes/introduce-cross-platform-shell-core/tasks.md
@@ -1,0 +1,96 @@
+## 1. Scaffold And Contracts
+
+- [ ] 1.1 Add `crates/shell-core` as a pure Rust workspace crate with no Apple, GTK, Ghostty, daemon-server, or platform IO dependencies.
+- [ ] 1.2 Define shell-core request/response envelope versioning, schema mismatch errors, and structured error envelope conventions.
+- [ ] 1.3 Add fixture directory layout and Rust fixture loader/comparison helpers for Swift-exported parity cases.
+- [ ] 1.4 Add scripts or just targets for shell-core unit tests and fixture tests.
+- [ ] 1.5 Document the shell-core module ownership boundary in crate docs and Apple architecture docs.
+- [ ] 1.6 Run `cargo test -p alan-shell-core` or the crate-specific equivalent and `cargo fmt --all`.
+
+## 2. Workspace Model And Split Tree
+
+- [ ] 2.1 Port platform-neutral workspace identity/value types for Spaces, Tabs, PaneSlots, ContentInstances, content kinds, lifecycle state, attention, and terminal metadata.
+- [ ] 2.2 Port split tree structures and traversal helpers from the Swift shell model.
+- [ ] 2.3 Implement split adjacency, spatial focus lookup, resize ratio, equalize, zoom metadata, and stable ID preservation semantics.
+- [ ] 2.4 Export Swift parity fixtures from `test-shell-split-model` covering split/focus/resize/equalize/zoom behavior.
+- [ ] 2.5 Add Rust fixture tests proving split tree behavior matches Swift-exported cases.
+- [ ] 2.6 Run shell-core tests plus `clients/apple/scripts/test-shell-split-model.sh`.
+
+## 3. State Reducer
+
+- [ ] 3.1 Implement Rust reducer results with next state, changed IDs, domain events, runtime intents, manifest sync hints, and stable errors.
+- [ ] 3.2 Port space and tab mutations: create, select, open terminal tab, duplicate, close, pin, unpin, reorder, move to Space, clear inactive temporary tabs, and selection repair.
+- [ ] 3.3 Port pane/content mutations: split, close, lift, cross-tab move, in-tab move, direct focus, spatial focus, resize split, equalize, zoom, unzoom, and unsupported-content handling.
+- [ ] 3.4 Port attention, agent activity, cwd/title/runtime metadata update, and active-task protection semantics.
+- [ ] 3.5 Export Swift parity fixtures from reducer-focused shell scripts for success and stable-error cases.
+- [ ] 3.6 Add Rust reducer unit tests and fixture tests for every Swift reducer branch planned for replacement.
+- [ ] 3.7 Run shell-core tests, `test-shell-split-model.sh`, `test-shell-sidebar-tab-rows.sh`, and any affected reducer-focused scripts.
+
+## 4. Workspace Manifest
+
+- [ ] 4.1 Port workspace manifest schema, content contract version, default manifest, quick terminal restore record, and restore snapshot value types.
+- [ ] 4.2 Port legacy terminal-only manifest upgrade into content-container manifest shape.
+- [ ] 4.3 Port materialization from manifest into workspace state while preserving current JSON-visible semantics.
+- [ ] 4.4 Port TTL pruning, active-task retention, empty-Space retention, selected Space/Tab repair, and pin/live snapshot selection.
+- [ ] 4.5 Export Swift parity fixtures covering valid manifests, old manifests, malformed/corrupt inputs, missing profiles, quick terminal state, pruning, and materialization.
+- [ ] 4.6 Add Rust manifest unit tests and fixture tests that preserve compatibility with existing macOS manifest JSON.
+- [ ] 4.7 Run shell-core tests and `clients/apple/scripts/test-shell-workspace-manifest.sh`.
+
+## 5. Action Registry
+
+- [ ] 5.1 Port stable action IDs, target kinds, explicit/current/context target resolution, and action availability states.
+- [ ] 5.2 Port shortcut metadata and action descriptors that are platform-neutral.
+- [ ] 5.3 Port action-to-reducer/effect mapping while keeping macOS-only presentation commands outside shell core.
+- [ ] 5.4 Export Swift parity fixtures from menu/context/keyboard/sidebar action tests.
+- [ ] 5.5 Add Rust action registry unit tests and fixture tests for availability, target resolution, and effect mapping.
+- [ ] 5.6 Run shell-core tests, `clients/apple/scripts/test-shell-sidebar-tab-rows.sh`, and `clients/apple/scripts/test-shell-action-registry.sh`.
+
+## 6. Control Command Reducer
+
+- [ ] 6.1 Port shell control command DTOs or request envelopes needed for workspace-domain command reduction.
+- [ ] 6.2 Port command validation, required-field checks, stable error codes, and authoritative response projection for domain commands.
+- [ ] 6.3 Separate runtime intents for terminal-dependent commands from platform terminal runtime outcomes.
+- [ ] 6.4 Export Swift parity fixtures from automation/control command seam tests for applied and rejected commands.
+- [ ] 6.5 Add Rust control reducer tests proving response compatibility and stable error semantics.
+- [ ] 6.6 Run shell-core tests, `clients/apple/scripts/test-shell-automation-command-seams.sh`, and `clients/apple/scripts/check-shell-contracts.sh`.
+
+## 7. Terminal Profile Domain
+
+- [ ] 7.1 Port Terminal Profile document, launch modes, editor drafts/results, validation errors, redacted display detail, and deterministic resolution state.
+- [ ] 7.2 Implement `TerminalLaunchIntent` construction without spawning processes or inspecting platform UI/runtime handles.
+- [ ] 7.3 Keep store path selection, file IO, process spawning, Managed Terminal Account apply, sudoers writes, and AppleScript execution in macOS platform code.
+- [ ] 7.4 Export Swift parity fixtures from terminal profile and managed terminal account dry-run tests.
+- [ ] 7.5 Add Rust tests for profile validation, missing/unavailable profile handling, fallback resolution, and launch-intent output.
+- [ ] 7.6 Run shell-core tests, `clients/apple/scripts/test-shell-settings-surface.sh`, and `clients/apple/scripts/test-terminal-account-dev-dry-run-smoke.sh`.
+
+## 8. Settings Summaries
+
+- [ ] 8.1 Identify settings/domain summaries that are reusable shell or host-domain state rather than SwiftUI presentation composition.
+- [ ] 8.2 Port reusable summaries for terminal profiles, workspace context, capabilities, diagnostics metadata, and local state where they do not require platform UI.
+- [ ] 8.3 Leave SwiftUI section/row layout, icons, local folder opening, update UI, and AppKit presentation code in the Apple client.
+- [ ] 8.4 Export Swift parity fixtures for settings summary inputs and expected semantic summaries.
+- [ ] 8.5 Add Rust tests for settings summary behavior and Swift adapter shape.
+- [ ] 8.6 Run shell-core tests and `clients/apple/scripts/test-shell-settings-surface.sh`.
+
+## 9. Swift Binding Facade And Replacement
+
+- [ ] 9.1 Choose the first binding implementation for the coarse-grained facade: UniFFI over versioned byte/envelope functions or hand-written C ABI over versioned byte/envelope functions.
+- [ ] 9.2 Add a dedicated binding facade crate or module that wraps shell-core without polluting the pure Rust API.
+- [ ] 9.3 Pin binding generator/tool versions when generated Swift/header/modulemap output is introduced.
+- [ ] 9.4 Add Swift `ShellCoreFFIAdapter` or equivalent that owns encode/decode, error mapping, version mismatch handling, and generated binding isolation.
+- [ ] 9.5 Replace Swift reducer calls with Rust-backed adapter calls after reducer parity passes; remove or quarantine the replaced Swift logic.
+- [ ] 9.6 Replace Swift manifest calls with Rust-backed adapter calls after manifest parity passes; preserve file IO in Swift.
+- [ ] 9.7 Replace Swift action/control/profile/settings call paths module by module after each module's parity and adapter tests pass.
+- [ ] 9.8 Run focused Swift scripts for every replaced module plus Rust shell-core tests and binding tests.
+
+## 10. Architecture Burn-Down, Review, And Archive Readiness
+
+- [ ] 10.1 Update `clients/apple/ARCHITECTURE.md` whenever a Swift warning class is reduced, removed, or intentionally left as adapter-only debt.
+- [ ] 10.2 Tighten architecture checks to prevent new reusable shell domain logic from being added to replaced Swift shell model/controller files.
+- [ ] 10.3 Run `bash clients/apple/scripts/check-architecture-maintainability.sh` and record warning-count changes.
+- [ ] 10.4 Run `cargo test --workspace` or the agreed narrower Rust validation set for the implemented migration slice.
+- [ ] 10.5 Run affected Apple shell scripts and `git diff --check`.
+- [ ] 10.6 Request or perform code review for the completed migration slice before merge.
+- [ ] 10.7 Sync accepted delta specs into `openspec/specs/` after implementation is merged.
+- [ ] 10.8 Run `openspec validate introduce-cross-platform-shell-core --type change --strict --json` and `openspec validate --all --strict --json`.
+- [ ] 10.9 Archive the change only after implementation, review, validation, and spec sync are complete.


### PR DESCRIPTION
## Summary
- add the introduce-cross-platform-shell-core OpenSpec proposal, design, and task plan
- define a new shell-workspace-core-contract for platform-neutral Rust shell workspace logic
- add macOS spec deltas for architecture, persistence, control plane, actions, terminal profiles, and validation

## Verification
- openspec validate introduce-cross-platform-shell-core --type change --strict --json
- openspec validate --all --strict --json
- git diff --check origin/main...HEAD