### PR TITLE
[codex] Define programmable environment product constitution

### DIFF
--- a/openspec/changes/define-programmable-environment-product/.openspec.yaml
+++ b/openspec/changes/define-programmable-environment-product/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/define-programmable-environment-product/design.md
+++ b/openspec/changes/define-programmable-environment-product/design.md
@@ -1,0 +1,168 @@
+## Context
+
+This change defines a product constitution for a new product line inside the
+alan repo. The product is a programmable personal computing environment:
+local-first, UNIX-respecting, object-oriented, command-driven, extensible, and
+agent-native.
+
+The current Alan product already has useful ideas around agents, terminal-first
+work, permissions, session state, and OpenSpec-driven planning. Those are
+references, not constraints. This product line should not be forced into the
+current macOS shell, daemon, or terminal-only surface.
+
+The key product boundary is that data ownership and activity organization are
+separate. Data may remain in files, directories, Git repositories, external
+services, databases, or OS resources. The environment organizes activity around
+runtime objects, commands, buffers, views, queries, humans, agents, and
+extensions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the product identity before implementation begins.
+- Treat the product as an independent product line within the repo.
+- Establish local-first, filesystem-first, UNIX-like composition as a core
+  principle.
+- Define object, command, buffer, view, and query as the core runtime
+  abstractions.
+- Make human and agent first-class actors in the same runtime.
+- Require ordinary UI for out-of-the-box use and modal grammar for power use.
+- Make Rust core plus WASM Component Model extensibility part of the product
+  identity.
+- Define incubation criteria without freezing the first interface or MVP.
+
+**Non-Goals:**
+
+- Specify a concrete implementation architecture, crate layout, UI, or storage
+  engine.
+- Merge this product into the current Alan macOS shell.
+- Require all data to be imported into a private object store.
+- Define a universal URI/resource protocol.
+- Replace current Alan runtime, daemon, or shell behavior.
+- Choose the first visual interface between editor-like, object workspace, or
+  agent workspace forms.
+
+## Decisions
+
+### 1. Product constitution first
+
+The first OpenSpec should define what the product is, not how to implement it.
+The idea is broad enough that an implementation-oriented first change would
+collapse it into whichever subsystem is easiest to build first.
+
+Alternative considered: write an architecture RFC for object graph, command
+registry, buffer/view, query, WASM, and agent actors. That is useful later, but
+too early for the first artifact because it would prematurely freeze technical
+interfaces.
+
+### 2. Independent product line inside the repo
+
+The product should live as a new product line in this repo while its identity is
+still being formed. It can reuse Alan engineering practices and later share
+runtime pieces where appropriate, but it is not a feature of the existing
+terminal shell.
+
+Alternative considered: describe this as Alan's long-term evolution. That would
+make current Alan shell concerns too influential and would encourage forced
+integration before the product boundary is clear.
+
+### 3. Local-first and filesystem-first
+
+The environment should respect UNIX philosophy: simple artifacts, inspectable
+state, ordinary files and directories where possible, composable commands, and
+clear capability boundaries. The runtime may add object identity, metadata,
+relationships, history, views, queries, and permissions, but it should not start
+by hiding user work behind a proprietary object store or complex URI layer.
+
+Alternative considered: define a unified resource addressing model from the
+start. That would be powerful, but it is too platform-shaped for the
+constitution and would obscure the simpler local-first boundary.
+
+### 4. Activity happens in the environment; data can stay where it is
+
+The long-term goal is for users to do more of their daily work inside the
+environment. That does not require the environment to own all data. Files,
+projects, tasks, terminal sessions, notes, Git state, mail, calendar items, and
+remote records can be represented as objects while their source of truth remains
+elsewhere.
+
+Alternative considered: make the environment's private workspace the primary
+storage model. That may become useful for some object types, but it should not
+be the first product principle.
+
+### 5. Ordinary UI plus modal power layer
+
+Out-of-the-box use needs ordinary UI: users should be able to browse objects,
+open buffers, switch views, run commands, and ask agents without first learning
+a grammar. Modal interaction remains part of the product identity as a power
+layer. Ordinary UI, command palette, automation, modal grammar, and agents all
+route through the same command model.
+
+Alternative considered: make modal interaction the mandatory primary interface.
+That would protect the Vim-like model but conflict with the out-of-the-box
+principle.
+
+### 6. Agents are actors, not a chat plugin
+
+Agents should participate through the same runtime abstractions as humans. They
+can query, inspect, create buffers, propose changes, and execute commands, but
+they do not bypass runtime permissions, command mediation, or audit surfaces.
+
+Alternative considered: make agents an overlay on the human UI. That would be
+easier to add to an existing interface, but it would miss the product premise:
+human and agent operate in one environment.
+
+### 7. WASM extensibility is part of the identity
+
+The product should inherit the programmability spirit of Emacs without adopting
+Lisp as the embedded substrate. Rust core plus WASM Component Model and WIT
+interfaces should be treated as the extension direction, with explicit
+capability grants.
+
+Alternative considered: leave extension technology to later RFCs. That would
+keep the constitution more abstract, but extensibility without Lisp is a core
+differentiator in the original idea.
+
+## Risks / Trade-offs
+
+- [Risk] A product constitution can stay too abstract to guide work. →
+  Include incubation criteria that future MVP/spec work must satisfy.
+- [Risk] Filesystem-first can be mistaken for "only files". → State that
+  external systems may be projected as objects, while filesystem remains the
+  default substrate and inspection boundary.
+- [Risk] Independent product line can drift away from Alan's engineering
+  strengths. → Allow reuse of Alan concepts where they fit, but do not force
+  current shell integration.
+- [Risk] Modal grammar can create onboarding friction. → Require ordinary UI to
+  be sufficient for first-use workflows.
+- [Risk] WASM as identity can overconstrain the first implementation. → Keep
+  the constitution at the principle level; detailed WIT interfaces belong in
+  later architecture changes.
+- [Risk] Agent-native can be misread as an AI chat app. → Require agents to act
+  through object, command, buffer, view, query, permission, and audit surfaces.
+
+## Incubation Path
+
+The next product work should validate product assumptions rather than build a
+complete environment. A future incubation or MVP change should prove:
+
+1. A first launch can reveal and organize real local work from the filesystem or
+   an existing project/workspace.
+2. One real personal workflow can move through file/project/task/terminal
+   objects, buffers, views, commands, queries, and agent help.
+3. Ordinary UI and modal grammar execute the same command surface.
+4. Agent actions are mediated by runtime abstractions and leave inspectable
+   results.
+5. Extension boundaries are capability-shaped from the start, even if the first
+   prototype only exposes a small subset.
+
+## Open Questions
+
+- What is the product name?
+- What is the first concrete interface: editor-like environment, object
+  workspace, agent workspace, or another form?
+- Which local-first object types are mandatory for the first prototype?
+- Which commands prove the shared command model without overbuilding the
+  registry?
+- Which WASM extension hook should be validated first?

--- a/openspec/changes/define-programmable-environment-product/proposal.md
+++ b/openspec/changes/define-programmable-environment-product/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+alan needs a clear product-level contract for a new, independent product line:
+a programmable personal computing environment for humans and agents. The idea is
+large enough that it should be protected as a product constitution before it is
+reduced into a macOS shell feature, editor feature, AI IDE, or implementation
+plan.
+
+## What Changes
+
+- Define a new independent product line inside this repo: a local-first,
+  UNIX-respecting programmable personal computing environment.
+- Establish the durable product identity: user activity happens inside one
+  object/command/buffer/view/query runtime while data may remain in ordinary
+  filesystems and external systems.
+- Make out-of-the-box usefulness a first principle: first launch should reveal
+  and organize real personal work rather than presenting an empty programmable
+  substrate.
+- Define human and agent as first-class runtime actors that share the same
+  object, command, buffer, view, query, permission, and audit model.
+- Define Rust core plus WASM Component Model extensions as a core product
+  principle, while keeping detailed extension interfaces for later architecture
+  changes.
+- Define modal interaction as a power layer over the same command model used by
+  ordinary UI, command palettes, automation, and agents.
+- Add an incubation path that validates the product assumptions without binding
+  the first interface to editor, IDE, app launcher, or current Alan shell
+  implementation choices.
+
+## Capabilities
+
+### New Capabilities
+
+- `programmable-environment-product`: Owns the product constitution for the
+  independent programmable personal computing environment, including local-first
+  data boundaries, core runtime abstractions, interaction principles,
+  agent-native participation, extension principles, and incubation criteria.
+
+### Modified Capabilities
+
+- None. This change intentionally does not modify existing Alan runtime,
+  daemon, terminal, or macOS shell behavior.
+
+## Impact
+
+- Affected product planning: introduces a new product-line contract in
+  OpenSpec.
+- Affected architecture planning: future runtime, UI, agent, and extension
+  proposals for this product should trace back to this constitution.
+- Affected current code: none in this change.
+- Affected current Alan shell behavior: none; current Alan features may inform
+  later work but are not the implementation boundary for this product line.

--- a/openspec/changes/define-programmable-environment-product/specs/programmable-environment-product/spec.md
+++ b/openspec/changes/define-programmable-environment-product/specs/programmable-environment-product/spec.md
@@ -1,0 +1,156 @@
+## ADDED Requirements
+
+### Requirement: Product line is independent
+The programmable environment SHALL be treated as an independent product line
+inside the repository rather than as a feature of the existing Alan macOS shell,
+daemon, terminal runtime, or agent session UI.
+
+#### Scenario: Future work scopes implementation
+- **WHEN** a future change implements programmable environment behavior
+- **THEN** the change identifies whether it belongs to this product line
+- **AND** it does not assume that existing Alan shell containers or terminal
+  workflows are the required implementation boundary
+
+### Requirement: Product identity is a programmable personal computing environment
+The product SHALL organize personal computing activity through a unified runtime
+of objects, commands, buffers, views, queries, humans, agents, and extensions.
+
+#### Scenario: Product is described
+- **WHEN** product, architecture, or implementation docs describe this product
+- **THEN** they describe it as a programmable personal computing environment
+- **AND** they do not reduce the product identity to an editor, IDE, AI chat
+  app, app launcher, or operating system shell
+
+### Requirement: Product is local-first and filesystem-first
+The product SHALL treat local-first operation, filesystem-backed inspection, and
+UNIX-like composition as core product principles.
+
+#### Scenario: Product stores or represents user work
+- **WHEN** the product stores state, discovers work, creates artifacts, or
+  represents resources
+- **THEN** it prefers ordinary files, directories, manifests, sidecars, caches,
+  imports, exports, mounts, or projections where those boundaries are practical
+- **AND** it does not require a proprietary object store or universal URI layer
+  as the first product principle
+
+### Requirement: Data ownership and activity organization are separate
+The product SHALL allow source data to remain in filesystems, projects,
+repositories, external services, databases, or OS resources while organizing
+user activity through runtime objects and commands.
+
+#### Scenario: External or existing data is used
+- **WHEN** a file, project, terminal, Git state, note, task, mail item, calendar
+  item, or remote record is brought into the environment
+- **THEN** the product can represent it as a runtime object without requiring
+  the environment to become the source of truth for the underlying data
+
+### Requirement: Core runtime abstractions are stable
+The product SHALL use Object, Command, Buffer, View, and Query as stable
+product-level runtime abstractions.
+
+#### Scenario: Runtime concepts are introduced
+- **WHEN** a future spec introduces product runtime behavior
+- **THEN** it states how the behavior relates to Object, Command, Buffer, View,
+  Query, or explicitly explains why it sits outside those abstractions
+
+### Requirement: Objects are inspectable runtime resources
+Objects SHALL have stable identity, metadata, relationships, capabilities, and
+runtime inspectability.
+
+#### Scenario: Resource becomes an object
+- **WHEN** the environment represents a resource as an object
+- **THEN** users and agents can inspect its identity, metadata, relationships,
+  and available capabilities through runtime surfaces
+
+### Requirement: Commands are first-class actions
+Commands SHALL be first-class runtime entities with stable names, descriptions,
+arguments, target types, permission or risk metadata, undo or recovery
+semantics when applicable, categories, and invocation hints.
+
+#### Scenario: Action is exposed
+- **WHEN** human UI, modal grammar, command palette, automation, extension, or
+  agent behavior exposes an action
+- **THEN** it routes through a command entry rather than creating a separate
+  hidden mutation path
+
+### Requirement: Buffers are work units
+Buffers SHALL be the primary units for active work and SHALL NOT be limited to
+text.
+
+#### Scenario: Non-text work is opened
+- **WHEN** terminal output, Git diff, search results, task lists, agent plans,
+  database results, or calendar ranges are opened for work
+- **THEN** the product can represent them as buffers with lifecycle, history,
+  dirty state, and restoration semantics appropriate to their kind
+
+### Requirement: Views are independent from data
+Views SHALL define presentation and navigation independently from the underlying
+object or buffer data.
+
+#### Scenario: Object has multiple presentations
+- **WHEN** an object or buffer supports multiple useful presentations
+- **THEN** the product can expose multiple views without duplicating the source
+  data or changing data ownership
+
+### Requirement: Runtime is queryable
+The runtime SHALL provide semantic query and introspection surfaces over
+objects, buffers, commands, tasks, symbols, relationships, and other registered
+runtime entities.
+
+#### Scenario: User or agent searches semantically
+- **WHEN** a user or agent asks for runtime state such as modified buffers,
+  Git commands, pending tasks, or function symbols
+- **THEN** the product provides queryable runtime surfaces rather than forcing
+  navigation only through app, window, or file hierarchy
+
+### Requirement: Out-of-the-box use is mandatory
+The product SHALL be useful on first launch without requiring the user to first
+configure a programmable substrate.
+
+#### Scenario: User opens product for the first time
+- **WHEN** a user first opens the product
+- **THEN** the product can reveal, organize, or create real personal work from
+  local files, projects, workspaces, notes, tasks, terminals, or similar
+  personal computing objects
+
+### Requirement: Modal grammar is a power layer over ordinary UI
+The product SHALL support ordinary UI for onboarding and a modal command grammar
+for power use, with both layers routing through the same command model.
+
+#### Scenario: Command has multiple invocations
+- **WHEN** a command can be invoked through UI controls, command palette,
+  shortcut, modal grammar, automation, or agent action
+- **THEN** those invocations preserve the same command identity, target
+  semantics, permission checks, and audit behavior
+
+### Requirement: Agents are first-class actors
+Agents SHALL be first-class runtime actors alongside humans and SHALL operate
+through the same object, command, buffer, view, query, permission, and audit
+abstractions.
+
+#### Scenario: Agent performs work
+- **WHEN** an agent reads context, creates a buffer, executes a command,
+  proposes a patch, opens a view, or performs a query
+- **THEN** the action is mediated by runtime abstractions
+- **AND** the agent does not bypass command permissions or audit surfaces to
+  mutate underlying systems directly
+
+### Requirement: Extensibility uses Rust core plus WASM components
+The product SHALL treat a Rust core plus WASM Component Model extensions and WIT
+interfaces as the product's extension direction.
+
+#### Scenario: Extension capability is added
+- **WHEN** a future change adds extension behavior
+- **THEN** it uses explicit capability grants for access such as filesystem
+  read/write, network access, command execution, buffer access, view
+  registration, query registration, or agent registration
+
+### Requirement: Incubation validates product assumptions
+Future incubation work SHALL validate the product constitution before expanding
+into a broad environment implementation.
+
+#### Scenario: First incubation scope is proposed
+- **WHEN** a future change proposes the first prototype or MVP for this product
+- **THEN** it identifies the concrete workflow that proves local-first discovery,
+  object representation, buffer/view use, command execution, query or
+  introspection, agent participation, and extension-shaped boundaries

--- a/openspec/changes/define-programmable-environment-product/tasks.md
+++ b/openspec/changes/define-programmable-environment-product/tasks.md
@@ -1,0 +1,54 @@
+## 1. Product Constitution
+
+- [ ] 1.1 Capture the product as an independent product line in the repo,
+  separate from current Alan macOS shell and terminal workflow implementation.
+- [ ] 1.2 Define the product as a programmable personal computing environment
+  organized around objects, commands, buffers, views, queries, humans, agents,
+  and extensions.
+- [ ] 1.3 Record local-first, filesystem-first, UNIX-like composition as a core
+  product principle.
+- [ ] 1.4 Record the data/activity boundary: data may remain in existing systems
+  while activity is organized inside the environment.
+- [ ] 1.5 Preserve out-of-the-box usefulness as a first principle.
+
+## 2. Runtime Abstraction Contracts
+
+- [ ] 2.1 Define Object, Command, Buffer, View, and Query as stable
+  product-level runtime abstractions.
+- [ ] 2.2 Define ordinary UI and modal grammar as invocation layers over the
+  same command model.
+- [ ] 2.3 Define agents as first-class actors mediated by runtime abstractions,
+  permissions, and audit surfaces.
+- [ ] 2.4 Define Rust core plus WASM Component Model and WIT interfaces as the
+  extension direction with explicit capability grants.
+
+## 3. Incubation Decomposition
+
+- [ ] 3.1 Identify that the first follow-up change should validate product
+  assumptions rather than implement the complete environment.
+- [ ] 3.2 Require the first follow-up prototype or MVP to prove local-first
+  discovery of real work.
+- [ ] 3.3 Require the first follow-up prototype or MVP to prove one workflow
+  through object, buffer, view, command, query, and agent participation.
+- [ ] 3.4 Defer the concrete first interface choice until a focused incubation
+  proposal selects editor-like environment, object workspace, agent workspace,
+  or another form.
+- [ ] 3.5 Defer universal URI/resource addressing until a later architecture RFC
+  proves it is needed beyond filesystem-first composition.
+
+## 4. Verification
+
+- [ ] 4.1 Run `openspec validate define-programmable-environment-product --strict`.
+- [ ] 4.2 Run `git diff --check -- openspec/changes/define-programmable-environment-product`.
+- [ ] 4.3 Review proposal, design, specs, and tasks for placeholders,
+  contradictions, premature implementation commitments, and unclear product
+  boundaries.
+- [ ] 4.4 Confirm the change does not modify current Alan runtime, daemon,
+  terminal, or macOS shell behavior.
+
+## 5. Archive Readiness
+
+- [ ] 5.1 After review and merge, sync
+  `programmable-environment-product` into `openspec/specs/`.
+- [ ] 5.2 Archive the completed change only after the long-lived spec has been
+  updated and validated.


### PR DESCRIPTION
## Summary

- Adds the `define-programmable-environment-product` OpenSpec change.
- Defines a new independent product line: a local-first, filesystem-first programmable personal computing environment.
- Establishes the product constitution around objects, commands, buffers, views, queries, first-class agents, ordinary UI plus modal power use, and Rust/WASM extensibility.
- Defers universal URI/resource addressing and current Alan shell integration to later focused changes.

## Validation

- `openspec validate define-programmable-environment-product --strict`
- `git diff --check HEAD~1..HEAD`

## Notes

This is spec-only. It does not modify current Alan runtime, daemon, terminal, or macOS shell behavior.
