### PR TITLE
chore: ignore local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ clients/apple/GhosttyKit.xcframework
 clients/apple/GhosttyKit.xcframework.bak-*/
 clients/apple/ghostty-resources
 clients/apple/ghostty-terminfo
+
+# Local Claude Code settings and session data.
+.claude/


### PR DESCRIPTION
## What

Add `.claude/` to `.gitignore`.

## Why

Claude Code writes local settings and session data under `.claude/`. It was showing up as an untracked directory in `git status` on every working tree. Ignoring it keeps status clean and prevents accidental commits of local-only tooling state.

## Notes for reviewer

- Single-line addition to `.gitignore`; no code or build impact.
- Ignored at the repo level (shared) on the assumption `.claude/` is local tooling state for any contributor, not project-tracked config.