### PR TITLE
perf(macos): take terminal persistence + boot-profile work off the main thread

### DIFF
--- a/clients/apple/alan-macos/App/AlanMacAppDelegate.swift
+++ b/clients/apple/alan-macos/App/AlanMacAppDelegate.swift
@@ -18,5 +18,11 @@ final class AlanMacAppDelegate: NSObject, NSApplicationDelegate {
         }
         return shellHost.requestTerminateApp() ? .terminateNow : .terminateCancel
     }
+
+    func applicationDidResignActive(_ notification: Notification) {
+        // Force pending debounced restore content to disk when the app loses
+        // focus, so backgrounding is a durable persistence point.
+        shellHost?.flushWorkspacePersistence()
+    }
 }
 #endif

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -12,6 +12,95 @@ enum ShellWorkspaceManifestRecovery: Equatable {
     case quarantinedCorruptFile(URL)
 }
 
+/// Threading seam for shell persistence. The encode + atomic disk writes for both
+/// the workspace manifest and the control-plane shell-state file run on a serial
+/// background executor; callers choose synchronous durability (structural
+/// mutations) or fire-and-forget (debounced terminal-callback churn) so the
+/// terminal callback path never blocks the main thread on disk.
+protocol ShellPersistenceWriting: AnyObject {
+    /// Blocks the caller until the manifest is written (structural mutations).
+    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest)
+    /// Enqueues the manifest write without blocking the caller (debounced content).
+    func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest)
+    /// Blocks the caller until the shell-state file is written (structural).
+    func writeShellStateSync(_ state: ShellStateSnapshot)
+    /// Enqueues the shell-state file write without blocking the caller (debounced).
+    func writeShellStateAsync(_ state: ShellStateSnapshot)
+}
+
+final class ShellPersistenceWriter: ShellPersistenceWriting {
+    private let manifestStore: ShellWorkspaceManifestStore?
+    private let stateStore: ShellStatePersistenceStore
+    private let queue: DispatchQueue
+    private let onError: (String) -> Void
+
+    init(
+        manifestStore: ShellWorkspaceManifestStore?,
+        stateStore: ShellStatePersistenceStore,
+        queue: DispatchQueue = DispatchQueue(label: "app.alan.shell.persistence", qos: .utility),
+        onError: @escaping (String) -> Void = { _ in }
+    ) {
+        self.manifestStore = manifestStore
+        self.stateStore = stateStore
+        self.queue = queue
+        self.onError = onError
+    }
+
+    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) {
+        queue.sync { self.writeManifest(manifest) }
+    }
+
+    func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) {
+        queue.async { self.writeManifest(manifest) }
+    }
+
+    func writeShellStateSync(_ state: ShellStateSnapshot) {
+        queue.sync { self.stateStore.save(state) }
+    }
+
+    func writeShellStateAsync(_ state: ShellStateSnapshot) {
+        queue.async { self.stateStore.save(state) }
+    }
+
+    private func writeManifest(_ manifest: ShellContentWorkspaceManifest) {
+        guard let manifestStore else { return }
+        do {
+            try manifestStore.save(manifest)
+        } catch {
+            onError("workspace manifest save failed: \(error)")
+        }
+    }
+}
+
+/// Debounce seam for coalescing high-frequency restore-content flush requests.
+/// Injected so tests can fire the pending flush deterministically.
+protocol ManifestFlushScheduling: AnyObject {
+    /// Schedule `work` to run after the debounce window. Implementations run the
+    /// most recently scheduled `work` once per window.
+    func schedule(_ work: @escaping () -> Void)
+}
+
+final class DebouncedManifestFlushScheduler: ManifestFlushScheduling {
+    private let window: DispatchTimeInterval
+    private let queue: DispatchQueue
+    private var pending: DispatchWorkItem?
+
+    init(
+        window: DispatchTimeInterval = .milliseconds(500),
+        queue: DispatchQueue = .main
+    ) {
+        self.window = window
+        self.queue = queue
+    }
+
+    func schedule(_ work: @escaping () -> Void) {
+        pending?.cancel()
+        let item = DispatchWorkItem(block: work)
+        pending = item
+        queue.asyncAfter(deadline: .now() + window, execute: item)
+    }
+}
+
 struct ShellWorkspaceManifestStore {
     let fileManager: FileManager
     let manifestURL: URL

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -19,8 +19,12 @@ enum ShellWorkspaceManifestRecovery: Equatable {
 /// terminal callback path never blocks the main thread on disk.
 protocol ShellPersistenceWriting: AnyObject {
     /// Blocks the caller until the manifest is written (structural mutations).
-    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest)
+    /// Returns `true` when the write succeeded so callers can advance their
+    /// last-saved state and surface failures.
+    @discardableResult
+    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) -> Bool
     /// Enqueues the manifest write without blocking the caller (debounced content).
+    /// Failures are reported through the writer's error sink, not the caller.
     func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest)
     /// Blocks the caller until the shell-state file is written (structural).
     func writeShellStateSync(_ state: ShellStateSnapshot)
@@ -38,7 +42,7 @@ final class ShellPersistenceWriter: ShellPersistenceWriting {
         manifestStore: ShellWorkspaceManifestStore?,
         stateStore: ShellStatePersistenceStore,
         queue: DispatchQueue = DispatchQueue(label: "app.alan.shell.persistence", qos: .utility),
-        onError: @escaping (String) -> Void = { _ in }
+        onError: @escaping (String) -> Void = { NSLog("%@", $0) }
     ) {
         self.manifestStore = manifestStore
         self.stateStore = stateStore
@@ -46,12 +50,17 @@ final class ShellPersistenceWriter: ShellPersistenceWriting {
         self.onError = onError
     }
 
-    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) {
-        queue.sync { self.writeManifest(manifest) }
+    @discardableResult
+    func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) -> Bool {
+        queue.sync { self.trySaveManifest(manifest) }
     }
 
     func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) {
-        queue.async { self.writeManifest(manifest) }
+        queue.async {
+            if !self.trySaveManifest(manifest) {
+                self.onError("workspace manifest async save failed")
+            }
+        }
     }
 
     func writeShellStateSync(_ state: ShellStateSnapshot) {
@@ -62,12 +71,14 @@ final class ShellPersistenceWriter: ShellPersistenceWriting {
         queue.async { self.stateStore.save(state) }
     }
 
-    private func writeManifest(_ manifest: ShellContentWorkspaceManifest) {
-        guard let manifestStore else { return }
+    /// Returns `true` on success (or when there is no manifest store to write to).
+    private func trySaveManifest(_ manifest: ShellContentWorkspaceManifest) -> Bool {
+        guard let manifestStore else { return true }
         do {
             try manifestStore.save(manifest)
+            return true
         } catch {
-            onError("workspace manifest save failed: \(error)")
+            return false
         }
     }
 }

--- a/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
+++ b/clients/apple/alan-macos/Services/Shell/ShellWorkspaceManifestStore.swift
@@ -36,7 +36,9 @@ final class ShellPersistenceWriter: ShellPersistenceWriting {
     private let manifestStore: ShellWorkspaceManifestStore?
     private let stateStore: ShellStatePersistenceStore
     private let queue: DispatchQueue
-    private let onError: (String) -> Void
+    /// Reports async-write failures. Set once after construction (before any write
+    /// is enqueued) so the owner can route failures to its diagnostics surface.
+    var onError: (String) -> Void
 
     init(
         manifestStore: ShellWorkspaceManifestStore?,

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -204,24 +204,28 @@ final class AlanShellControlPlane {
         persistPublished()
     }
 
-    /// Prompt, in-memory only: updates the published-state cache that shell IPC
-    /// clients read (`.state` / `.pane.list` / `.pane.snapshot`). Safe to call on
-    /// the high-frequency terminal callback path — it does no disk I/O.
+    /// Prompt path: updates the published-state cache that shell IPC clients read
+    /// (`.state` / `.pane.list` / `.pane.snapshot`) and ensures pane support
+    /// directories + binding-file poller tracking exist for the current panes.
+    /// The pane-directory work only touches disk for newly-appeared panes, so it
+    /// is cheap on the steady terminal-output path while keeping boot/structural
+    /// pane setup prompt (a restored pane's child needs its binding directory
+    /// before it can write `alan-binding.json`).
     @discardableResult
     func publishInMemory(state: ShellStateSnapshot) -> ShellStateSnapshot {
         let mergeResult = socketServer.mergePublishedState(state)
         latestMergedState = mergeResult.merged
+        synchronizePaneSupportDirectories(for: mergeResult.merged)
         return mergeResult.merged
     }
 
-    /// Deferred persistence for the latest in-memory state: pane support
-    /// directories, the change-event log (coalesced since the last persist), and
-    /// the `state.json` mirror (encode + write off the main thread). Run from the
-    /// debounced flush, not the per-callback path.
+    /// Deferred persistence for the latest in-memory state: the change-event log
+    /// (coalesced since the last persist) and the `state.json` mirror (encode +
+    /// write off the main thread). Run from the debounced flush, not the
+    /// per-callback path.
     func persistPublished() {
         guard let mergedState = latestMergedState else { return }
         ensureDirectories()
-        synchronizePaneSupportDirectories(for: mergedState)
         eventStore.recordChanges(from: lastPersistedState, to: mergedState)
         lastPersistedState = mergedState
         scheduleStateFilePersist()
@@ -429,7 +433,7 @@ final class AlanShellControlPlane {
         trackedPaneIDs = paneIDs
         filePoller?.updateTrackedPaneIDs(paneIDs)
 
-        for paneID in paneIDs {
+        for paneID in paneIDs.subtracting(previousPaneIDs) {
             let paneURL = alanShellPaneSupportDirectoryURL(
                 windowID: windowID,
                 paneID: paneID,

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -217,26 +217,36 @@ final class AlanShellControlPlane {
         pendingStateFileWrite = nil
         guard let mergedState = latestMergedState else { return }
         let url = stateFileURL
-        stateFileQueue.sync { Self.writeStateFile(mergedState, to: url) }
+        let succeeded = stateFileQueue.sync { Self.writeStateFile(mergedState, to: url) }
+        if !succeeded {
+            diagnostics.record("Failed to persist shell state to \(url.lastPathComponent)")
+        }
     }
 
     private func scheduleStateFilePersist() {
         pendingStateFileWrite?.cancel()
         guard let mergedState = latestMergedState else { return }
         let url = stateFileURL
-        let item = DispatchWorkItem { Self.writeStateFile(mergedState, to: url) }
+        let item = DispatchWorkItem { [weak self] in
+            guard Self.writeStateFile(mergedState, to: url) == false else { return }
+            DispatchQueue.main.async {
+                self?.diagnostics.record("Failed to persist shell state to \(url.lastPathComponent)")
+            }
+        }
         pendingStateFileWrite = item
         stateFileQueue.asyncAfter(deadline: .now() + .milliseconds(150), execute: item)
     }
 
-    private static func writeStateFile(_ state: ShellStateSnapshot, to url: URL) {
+    @discardableResult
+    private static func writeStateFile(_ state: ShellStateSnapshot, to url: URL) -> Bool {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
             let data = try encoder.encode(state)
             try data.write(to: url, options: .atomic)
+            return true
         } catch {
-            NSLog("alan: failed to persist control-plane state.json: %@", String(describing: error))
+            return false
         }
     }
 

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -97,6 +97,7 @@ final class AlanShellControlPlane {
     )
     private var pendingStateFileWrite: DispatchWorkItem?
     private var latestMergedState: ShellStateSnapshot?
+    private var lastPersistedState: ShellStateSnapshot?
 
     init(
         windowID: String,
@@ -196,17 +197,33 @@ final class AlanShellControlPlane {
         eventStore.latestEventID
     }
 
+    /// Full publish: prompt in-memory merge plus deferred disk/event persistence.
+    /// Used by structural mutations and the debounced flush.
     func publish(state: ShellStateSnapshot) {
-        ensureDirectories()
+        publishInMemory(state: state)
+        persistPublished()
+    }
+
+    /// Prompt, in-memory only: updates the published-state cache that shell IPC
+    /// clients read (`.state` / `.pane.list` / `.pane.snapshot`). Safe to call on
+    /// the high-frequency terminal callback path — it does no disk I/O.
+    @discardableResult
+    func publishInMemory(state: ShellStateSnapshot) -> ShellStateSnapshot {
         let mergeResult = socketServer.mergePublishedState(state)
-        let mergedState = mergeResult.merged
+        latestMergedState = mergeResult.merged
+        return mergeResult.merged
+    }
+
+    /// Deferred persistence for the latest in-memory state: pane support
+    /// directories, the change-event log (coalesced since the last persist), and
+    /// the `state.json` mirror (encode + write off the main thread). Run from the
+    /// debounced flush, not the per-callback path.
+    func persistPublished() {
+        guard let mergedState = latestMergedState else { return }
+        ensureDirectories()
         synchronizePaneSupportDirectories(for: mergedState)
-        eventStore.recordChanges(from: mergeResult.previous, to: mergedState)
-        // The in-memory merge + event recording above keep IPC consumers prompt.
-        // The state.json file is a live mirror; coalesce its encode + atomic
-        // write off the main thread so high-frequency terminal callbacks do not
-        // block on disk.
-        latestMergedState = mergedState
+        eventStore.recordChanges(from: lastPersistedState, to: mergedState)
+        lastPersistedState = mergedState
         scheduleStateFilePersist()
     }
 

--- a/clients/apple/alan-macos/ShellControlPlane.swift
+++ b/clients/apple/alan-macos/ShellControlPlane.swift
@@ -91,6 +91,12 @@ final class AlanShellControlPlane {
     private let eventStore: AlanShellEventStore
     private var filePoller: AlanShellControlFilePoller?
     private var trackedPaneIDs: Set<String> = []
+    private let stateFileQueue = DispatchQueue(
+        label: "app.alan.shell.control-plane-state",
+        qos: .utility
+    )
+    private var pendingStateFileWrite: DispatchWorkItem?
+    private var latestMergedState: ShellStateSnapshot?
 
     init(
         windowID: String,
@@ -196,11 +202,41 @@ final class AlanShellControlPlane {
         let mergedState = mergeResult.merged
         synchronizePaneSupportDirectories(for: mergedState)
         eventStore.recordChanges(from: mergeResult.previous, to: mergedState)
+        // The in-memory merge + event recording above keep IPC consumers prompt.
+        // The state.json file is a live mirror; coalesce its encode + atomic
+        // write off the main thread so high-frequency terminal callbacks do not
+        // block on disk.
+        latestMergedState = mergedState
+        scheduleStateFilePersist()
+    }
+
+    /// Forces the latest published state to `state.json` synchronously. Call on
+    /// app background/quit so the on-disk mirror is current before exit.
+    func flushStateFile() {
+        pendingStateFileWrite?.cancel()
+        pendingStateFileWrite = nil
+        guard let mergedState = latestMergedState else { return }
+        let url = stateFileURL
+        stateFileQueue.sync { Self.writeStateFile(mergedState, to: url) }
+    }
+
+    private func scheduleStateFilePersist() {
+        pendingStateFileWrite?.cancel()
+        guard let mergedState = latestMergedState else { return }
+        let url = stateFileURL
+        let item = DispatchWorkItem { Self.writeStateFile(mergedState, to: url) }
+        pendingStateFileWrite = item
+        stateFileQueue.asyncAfter(deadline: .now() + .milliseconds(150), execute: item)
+    }
+
+    private static func writeStateFile(_ state: ShellStateSnapshot, to url: URL) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
-            let data = try encoder.encode(mergedState)
-            try data.write(to: stateFileURL, options: .atomic)
+            let data = try encoder.encode(state)
+            try data.write(to: url, options: .atomic)
         } catch {
-            diagnostics.record("Failed to persist shell state: \(error.localizedDescription)")
+            NSLog("alan: failed to persist control-plane state.json: %@", String(describing: error))
         }
     }
 

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -491,6 +491,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     let terminalRuntimeRegistry: TerminalRuntimeRegistry
+    private let bootProfileCache: AlanShellBootProfileCache
     private let appIsActiveProvider: @MainActor () -> Bool
     private var routedActivityNotificationKeys: Set<String> = []
     private var pendingVisibleBackgroundRuntimeByPaneID: [String: TerminalHostRuntimeSnapshot] = [:]
@@ -508,9 +509,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
         gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
+        bootProfileCache: AlanShellBootProfileCache? = nil,
         appIsActiveProvider: @escaping @MainActor () -> Bool = { NSApp.isActive }
     ) {
         self.fileManager = fileManager
+        self.bootProfileCache = bootProfileCache ?? AlanShellBootProfileCache()
         let paneProjection = ShellPaneProjectionService(fileManager: fileManager)
         self.paneProjection = paneProjection
         self.terminalContentProjection = TerminalContentProjectionAdapter(
@@ -790,7 +793,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func bootProfile(for pane: ShellPane?) -> AlanShellBootProfile? {
         guard let pane else { return nil }
         seedRestoredTranscriptSnapshotIfNeeded(for: pane)
-        return AlanShellBootProfile.forPane(pane, shellState: shellState)
+        return bootProfileCache.profile(for: pane, shellState: shellState)
     }
 
     func restoredTranscriptSnapshot(for pane: ShellPane?) -> TerminalTranscriptSnapshot? {
@@ -2181,13 +2184,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             }
         }
         if runtime.paneID == selectedPane?.paneID || runtime.paneID == shellState.focusedPaneID {
-            terminalRuntime = runtime
+            setSelectedTerminalRuntime(runtime)
         }
 
         if let paneID = runtime.paneID,
            let pane = pane(paneID: paneID)
         {
-            let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
+            let bootProfile = bootProfileCache.profile(for: pane, shellState: shellState)
             let effectProjection = terminalContentProjection.projectRuntime(
                 runtime,
                 for: pane,
@@ -2210,10 +2213,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
             let paneStateStartedAt = performanceDiagnosticsStartTime()
             let didPublishPaneUpdate = updatePaneState(paneID: paneID) { current in
-                let currentBootProfile = AlanShellBootProfile.forPane(
-                    current,
-                    shellState: shellState
-                )
+                let currentBootProfile = bootProfileCache.profile(for: current, shellState: shellState)
                 return terminalContentProjection.projectRuntime(
                     runtime,
                     for: current,
@@ -2318,7 +2318,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     func updateTerminalMetadata(_ metadata: TerminalPaneMetadataSnapshot, for paneID: String) {
         let metadataStartedAt = performanceDiagnosticsStartTime()
         guard let pane = pane(paneID: paneID) else { return }
-        let bootProfile = AlanShellBootProfile.forPane(pane, shellState: shellState)
+        let bootProfile = bootProfileCache.profile(for: pane, shellState: shellState)
         let runtime = runtime(for: pane.paneID)
         defer {
             if let metadataStartedAt {
@@ -2354,10 +2354,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             paneID: pane.paneID,
             tabTitleOverride: metadata.title
         ) { current in
-            let currentBootProfile = AlanShellBootProfile.forPane(
-                current,
-                shellState: shellState
-            )
+            let currentBootProfile = bootProfileCache.profile(for: current, shellState: shellState)
             return terminalContentProjection.projectMetadata(
                 metadata,
                 runtime: runtime,
@@ -2374,10 +2371,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         guard let pane = pane(paneID: paneID) else { return }
         let runtime = runtime(for: pane.paneID)
         updatePaneState(paneID: paneID) { current in
-            let currentBootProfile = AlanShellBootProfile.forPane(
-                current,
-                shellState: shellState
-            )
+            let currentBootProfile = bootProfileCache.profile(for: current, shellState: shellState)
             return terminalContentProjection.projectAlanBinding(
                 binding,
                 runtime: runtime,
@@ -2392,10 +2386,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         let runtime = runtime(for: pane.paneID)
 
         updatePaneState(paneID: paneID) { current in
-            let currentBootProfile = AlanShellBootProfile.forPane(
-                current,
-                shellState: shellState
-            )
+            let currentBootProfile = bootProfileCache.profile(for: current, shellState: shellState)
             return terminalContentProjection.projectBootContext(
                 runtime: runtime,
                 for: current,
@@ -2657,7 +2648,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 return pane
             }
             guard paneProjection.needsBootContextProjection(pane) else { return pane }
-            let bootProfile = AlanShellBootProfile.forPane(pane, shellState: state)
+            let bootProfile = bootProfileCache.profile(for: pane, shellState: state)
             let projectedContext = paneProjection.projectedContext(
                 for: pane,
                 bootProfile: bootProfile,
@@ -2745,15 +2736,25 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         if let focusedPane = focusedPane {
             selectedSpaceID = focusedPane.spaceID
             selectedTabID = focusedPane.tabID
-            terminalRuntime = runtime(for: focusedPane.paneID)
+            setSelectedTerminalRuntime(runtime(for: focusedPane.paneID))
             synchronizeTerminalRenderPriorities()
             return
         }
 
         selectedSpaceID = shellState.focusedSpaceID ?? selectedSpaceID ?? shellState.spaces.first?.spaceID
         selectedTabID = shellState.focusedTabID ?? selectedSpace?.tabs.first?.tabID
-        terminalRuntime = runtime(for: selectedPane?.paneID)
+        setSelectedTerminalRuntime(runtime(for: selectedPane?.paneID))
         synchronizeTerminalRenderPriorities()
+    }
+
+    /// Assigns the selected-pane runtime snapshot only when it differs from the
+    /// current one in something other than its publish timestamp. The snapshot
+    /// is mirrored into the central `@Published` state, so a redundant write
+    /// would invalidate every view observing the controller at terminal-output
+    /// frequency.
+    private func setSelectedTerminalRuntime(_ runtime: TerminalHostRuntimeSnapshot) {
+        guard !terminalRuntime.equalsIgnoringTimestamp(runtime) else { return }
+        terminalRuntime = runtime
     }
 
     private func synchronizeTerminalRenderPriorities() {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -2908,6 +2908,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pendingContentFlushScheduled = false
         syncWorkspaceManifestFromShellState()
         persistShellState()
+        controlPlane.flushStateFile()
     }
 
     private func syncWorkspaceManifestFromShellState(

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -553,6 +553,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         self.selectedSpaceID = shellState.focusedSpaceID ?? shellState.spaces.first?.spaceID
         self.selectedTabID = shellState.focusedTabID ?? shellState.spaces.first?.tabs.first?.tabID
 
+        // Route async persistence-write failures (debounced restore content) to the
+        // control-plane diagnostics surface, mirroring the synchronous paths.
+        if let writer = persistenceWriter as? ShellPersistenceWriter {
+            writer.onError = { [weak self] message in
+                DispatchQueue.main.async { self?.recordControlPlaneDiagnostic(message) }
+            }
+        }
+
         if shellState.panes.isEmpty {
             publishControlPlaneState()
         } else {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -2899,6 +2899,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pendingContentFlushScheduled = false
         syncWorkspaceManifestFromShellState(coalesced: true)
         persistShellState(coalesced: true)
+        // Full control-plane publish at the debounce cadence: records coalesced
+        // change events and mirrors state.json (encode + write run off-main).
+        controlPlane.publish(state: shellState)
     }
 
     /// Forces pending debounced persistence to disk synchronously. Wired to app
@@ -2908,6 +2911,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pendingContentFlushScheduled = false
         syncWorkspaceManifestFromShellState()
         persistShellState()
+        // Record any pending change events and force the state.json mirror current
+        // before a clean exit / background transition.
+        controlPlane.publish(state: shellState)
         controlPlane.flushStateFile()
     }
 
@@ -3882,12 +3888,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pinSnapshotTabIDs: Set<String> = [],
         coalesced: Bool = false
     ) {
-        // The in-memory control-plane publication stays prompt for IPC/automation
-        // consumers. On the high-frequency terminal callback path the two disk
-        // writes are debounced off the main thread; structural mutations persist
-        // synchronously for prompt durability.
+        // The high-frequency terminal callback path defers ALL persistence to a
+        // debounced flush — manifest + shell-state file + the full control-plane
+        // publish (which records change events and mirrors state.json). Nothing on
+        // this path touches disk. Structural mutations persist synchronously for
+        // prompt durability.
         if coalesced {
-            controlPlane.publish(state: shellState)
             scheduleContentFlush()
         } else {
             syncWorkspaceManifestFromShellState(pinSnapshotTabIDs: pinSnapshotTabIDs)

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -382,6 +382,9 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     private let persistenceURL: URL
     private let persistenceStore: ShellStatePersistenceStore
     private let workspaceManifestStore: ShellWorkspaceManifestStore?
+    private let persistenceWriter: ShellPersistenceWriting
+    private let manifestFlushScheduler: ManifestFlushScheduling
+    private var pendingContentFlushScheduled = false
     private var workspaceManifest: ShellContentWorkspaceManifest?
     private var terminalActiveTasksByPaneID: [String: ShellTabActiveTaskState] = [:]
     private var terminalContentIDsSuppressingAutoClose: Set<String> = []
@@ -506,6 +509,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         terminalRuntimeRegistry: TerminalRuntimeRegistry? = nil,
         workspaceManifestStore: ShellWorkspaceManifestStore? = nil,
         workspaceManifest: ShellContentWorkspaceManifest? = nil,
+        persistenceWriter: ShellPersistenceWriting? = nil,
+        manifestFlushScheduler: ManifestFlushScheduling? = nil,
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
         gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
@@ -527,6 +532,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             persistenceURL: self.persistenceURL
         )
         self.workspaceManifestStore = workspaceManifestStore
+        self.persistenceWriter =
+            persistenceWriter
+            ?? ShellPersistenceWriter(
+                manifestStore: workspaceManifestStore,
+                stateStore: self.persistenceStore
+            )
+        self.manifestFlushScheduler = manifestFlushScheduler ?? DebouncedManifestFlushScheduler()
         self.workspaceManifest = workspaceManifest
         self.clipboardWriter = ShellClipboardWriter()
         self.closeConfirmationPresenter =
@@ -1198,10 +1210,12 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
     }
 
     private func requestCloseShellSurface(scope: ShellCloseGuardScope) -> Bool {
+        // Flush any debounced restore content before tearing down so a clean exit
+        // never loses the most recent transcript.
+        flushWorkspacePersistence()
         if let impact = closeGuardImpact(for: scope) {
             return confirmAndApplyClose(impact)
         }
-        syncWorkspaceManifestFromShellState()
         shutdownTerminalRuntimes()
         return true
     }
@@ -2227,8 +2241,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                     runtime: runtime
                 )
             }
-            if activeTaskChanged && !didPublishPaneUpdate {
-                syncWorkspaceManifestFromShellState()
+            if didPublishPaneUpdate || activeTaskChanged {
+                scheduleContentFlush()
             }
         }
     }
@@ -2362,8 +2376,8 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
                 bootProfile: currentBootProfile
             ).pane
         }
-        if activeTaskChanged && !didPublishPaneUpdate {
-            syncWorkspaceManifestFromShellState()
+        if didPublishPaneUpdate || activeTaskChanged {
+            scheduleContentFlush()
         }
     }
 
@@ -2438,7 +2452,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         )
         synchronizeSelection()
         routeActivityNotificationIfNeeded(from: existingPane, to: transformedPane)
-        publishControlPlaneState()
+        publishControlPlaneState(coalesced: true)
         return true
     }
 
@@ -2862,16 +2876,47 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         }
     }
 
-    private func persistShellState() {
-        persistenceStore.save(shellState)
+    private func persistShellState(coalesced: Bool = false) {
+        if coalesced {
+            persistenceWriter.writeShellStateAsync(shellState)
+        } else {
+            persistenceWriter.writeShellStateSync(shellState)
+        }
+    }
+
+    /// Marks restore content dirty and schedules a single debounced flush. The
+    /// terminal callback path calls this instead of writing synchronously, so a
+    /// burst of output coalesces into one off-main write per debounce window.
+    private func scheduleContentFlush() {
+        guard !pendingContentFlushScheduled else { return }
+        pendingContentFlushScheduled = true
+        manifestFlushScheduler.schedule { [weak self] in
+            self?.flushPendingPersistence()
+        }
+    }
+
+    private func flushPendingPersistence() {
+        pendingContentFlushScheduled = false
+        syncWorkspaceManifestFromShellState(coalesced: true)
+        persistShellState(coalesced: true)
+    }
+
+    /// Forces pending debounced persistence to disk synchronously. Wired to app
+    /// background/resign-active and quit so a clean exit never loses pending
+    /// restore content; also a deterministic flush point for tests.
+    func flushWorkspacePersistence() {
+        pendingContentFlushScheduled = false
+        syncWorkspaceManifestFromShellState()
+        persistShellState()
     }
 
     private func syncWorkspaceManifestFromShellState(
         now: Date = .now,
         pinSnapshotTabIDs: Set<String> = [],
-        transcriptSnapshotOverrides: [String: TerminalTranscriptSnapshot] = [:]
+        transcriptSnapshotOverrides: [String: TerminalTranscriptSnapshot] = [:],
+        coalesced: Bool = false
     ) {
-        guard let workspaceManifestStore else { return }
+        guard workspaceManifestStore != nil else { return }
 
         let nextManifest = makeWorkspaceManifestFromShellState(
             now: now,
@@ -2881,31 +2926,28 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         if !pinSnapshotTabIDs.isEmpty {
             applyPinSnapshotOverrides(to: &manifestToSave, tabIDs: pinSnapshotTabIDs)
         }
-        do {
-            try workspaceManifestStore.save(manifestToSave)
-            workspaceManifest = manifestToSave
-        } catch {
-            recordControlPlaneDiagnostic("workspace manifest save failed: \(error)")
+        // Track the intended last-saved manifest on the main actor for timestamp
+        // continuity; the disk write itself runs on the background writer.
+        workspaceManifest = manifestToSave
+        if coalesced {
+            persistenceWriter.writeManifestAsync(manifestToSave)
+        } else {
+            persistenceWriter.writeManifestSync(manifestToSave)
         }
     }
 
     private func clearRestoredTranscriptSnapshotFromWorkspaceManifest(
         forTerminalContentID contentID: String
     ) -> Bool {
-        guard let workspaceManifestStore, let workspaceManifest else { return false }
+        guard workspaceManifestStore != nil, let workspaceManifest else { return false }
 
         let result = workspaceManifest.clearingRestoredTranscriptSnapshot(
             forTerminalContentID: contentID
         )
         guard result.removed else { return false }
-        do {
-            try workspaceManifestStore.save(result.manifest)
-            self.workspaceManifest = result.manifest
-            return true
-        } catch {
-            recordControlPlaneDiagnostic("workspace manifest clear transcript save failed: \(error)")
-            return false
-        }
+        self.workspaceManifest = result.manifest
+        persistenceWriter.writeManifestSync(result.manifest)
+        return true
     }
 
     private func applyPinSnapshotOverrides(
@@ -2933,7 +2975,7 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         diagnostic: (String) -> String
     ) -> Bool {
         guard let tab = shellState.tab(tabID: tabID),
-              let workspaceManifestStore
+              workspaceManifestStore != nil
         else {
             return false
         }
@@ -2953,16 +2995,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
         guard didUpdate else { return false }
 
-        do {
-            try workspaceManifestStore.save(manifest)
-            workspaceManifest = manifest
-            objectWillChange.send()
-            recordControlPlaneDiagnostic(diagnostic(tabID))
-            return true
-        } catch {
-            recordControlPlaneDiagnostic("workspace manifest save failed: \(error)")
-            return false
-        }
+        workspaceManifest = manifest
+        persistenceWriter.writeManifestSync(manifest)
+        objectWillChange.send()
+        recordControlPlaneDiagnostic(diagnostic(tabID))
+        return true
     }
 
     private func makeWorkspaceManifestFromShellState(now: Date) -> ShellContentWorkspaceManifest {
@@ -3831,10 +3868,22 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             ?? .idle
     }
 
-    private func publishControlPlaneState(pinSnapshotTabIDs: Set<String> = []) {
-        syncWorkspaceManifestFromShellState(pinSnapshotTabIDs: pinSnapshotTabIDs)
-        persistShellState()
-        controlPlane.publish(state: shellState)
+    private func publishControlPlaneState(
+        pinSnapshotTabIDs: Set<String> = [],
+        coalesced: Bool = false
+    ) {
+        // The in-memory control-plane publication stays prompt for IPC/automation
+        // consumers. On the high-frequency terminal callback path the two disk
+        // writes are debounced off the main thread; structural mutations persist
+        // synchronously for prompt durability.
+        if coalesced {
+            controlPlane.publish(state: shellState)
+            scheduleContentFlush()
+        } else {
+            syncWorkspaceManifestFromShellState(pinSnapshotTabIDs: pinSnapshotTabIDs)
+            persistShellState()
+            controlPlane.publish(state: shellState)
+        }
     }
 
     static func attentionRank(for attention: ShellAttentionState) -> Int {

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -2899,9 +2899,10 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pendingContentFlushScheduled = false
         syncWorkspaceManifestFromShellState(coalesced: true)
         persistShellState(coalesced: true)
-        // Full control-plane publish at the debounce cadence: records coalesced
-        // change events and mirrors state.json (encode + write run off-main).
-        controlPlane.publish(state: shellState)
+        // Deferred control-plane persistence at the debounce cadence: records
+        // coalesced change events and mirrors state.json (encode + write off-main).
+        // The in-memory state was already merged promptly on the callback path.
+        controlPlane.persistPublished()
     }
 
     /// Forces pending debounced persistence to disk synchronously. Wired to app
@@ -3888,12 +3889,14 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         pinSnapshotTabIDs: Set<String> = [],
         coalesced: Bool = false
     ) {
-        // The high-frequency terminal callback path defers ALL persistence to a
-        // debounced flush — manifest + shell-state file + the full control-plane
-        // publish (which records change events and mirrors state.json). Nothing on
-        // this path touches disk. Structural mutations persist synchronously for
-        // prompt durability.
+        // The high-frequency terminal callback path keeps the in-memory
+        // control-plane state fresh (so IPC clients never read stale pane state)
+        // but defers all disk work — manifest + shell-state file + control-plane
+        // event log + state.json mirror — to a debounced flush. Nothing on this
+        // path touches disk. Structural mutations persist synchronously for prompt
+        // durability.
         if coalesced {
+            controlPlane.publishInMemory(state: shellState)
             scheduleContentFlush()
         } else {
             syncWorkspaceManifestFromShellState(pinSnapshotTabIDs: pinSnapshotTabIDs)

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -555,9 +555,13 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
         // Route async persistence-write failures (debounced restore content) to the
         // control-plane diagnostics surface, mirroring the synchronous paths.
-        if let writer = persistenceWriter as? ShellPersistenceWriter {
+        if let writer = self.persistenceWriter as? ShellPersistenceWriter {
             writer.onError = { [weak self] message in
-                DispatchQueue.main.async { self?.recordControlPlaneDiagnostic(message) }
+                if Thread.isMainThread {
+                    self?.recordControlPlaneDiagnostic(message)
+                } else {
+                    DispatchQueue.main.async { self?.recordControlPlaneDiagnostic(message) }
+                }
             }
         }
 

--- a/clients/apple/alan-macos/ShellHostController.swift
+++ b/clients/apple/alan-macos/ShellHostController.swift
@@ -2926,13 +2926,16 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
         if !pinSnapshotTabIDs.isEmpty {
             applyPinSnapshotOverrides(to: &manifestToSave, tabIDs: pinSnapshotTabIDs)
         }
-        // Track the intended last-saved manifest on the main actor for timestamp
-        // continuity; the disk write itself runs on the background writer.
-        workspaceManifest = manifestToSave
         if coalesced {
+            // Debounced restore content: advance the intended last-saved manifest
+            // optimistically (a failed write self-heals on the next flush, which
+            // rebuilds from current state). The writer surfaces async failures.
+            workspaceManifest = manifestToSave
             persistenceWriter.writeManifestAsync(manifestToSave)
+        } else if persistenceWriter.writeManifestSync(manifestToSave) {
+            workspaceManifest = manifestToSave
         } else {
-            persistenceWriter.writeManifestSync(manifestToSave)
+            recordControlPlaneDiagnostic("workspace manifest save failed")
         }
     }
 
@@ -2945,8 +2948,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
             forTerminalContentID: contentID
         )
         guard result.removed else { return false }
+        guard persistenceWriter.writeManifestSync(result.manifest) else {
+            recordControlPlaneDiagnostic("workspace manifest clear transcript save failed")
+            return false
+        }
         self.workspaceManifest = result.manifest
-        persistenceWriter.writeManifestSync(result.manifest)
         return true
     }
 
@@ -2995,8 +3001,11 @@ final class ShellHostController: ObservableObject, TerminalHostActivationDelegat
 
         guard didUpdate else { return false }
 
+        guard persistenceWriter.writeManifestSync(manifest) else {
+            recordControlPlaneDiagnostic("workspace manifest save failed")
+            return false
+        }
         workspaceManifest = manifest
-        persistenceWriter.writeManifestSync(manifest)
         objectWillChange.send()
         recordControlPlaneDiagnostic(diagnostic(tabID))
         return true

--- a/clients/apple/alan-macos/TerminalHostRuntime.swift
+++ b/clients/apple/alan-macos/TerminalHostRuntime.swift
@@ -595,6 +595,18 @@ struct AlanShellBootProfile: Equatable {
         environment.keys.sorted().map { ($0, environment[$0] ?? "") }
     }
 
+    /// Returns a copy with a different working directory. The expensive boot
+    /// inputs (command resolution, Ghostty discovery, environment) are
+    /// cwd-independent, so a `cd` only needs to overlay this one field.
+    func withWorkingDirectory(_ workingDirectory: String) -> AlanShellBootProfile {
+        AlanShellBootProfile(
+            command: command,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            ghostty: ghostty
+        )
+    }
+
     static func forPane(
         _ pane: ShellPane,
         shellState: ShellStateSnapshot,
@@ -695,6 +707,66 @@ struct AlanShellBootProfile: Equatable {
         guard !value.isEmpty else { return "''" }
         let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
         return "'\(escaped)'"
+    }
+}
+
+/// Memoizes `AlanShellBootProfile.forPane` results so the hot terminal
+/// callbacks (metadata and runtime projection) do not repeatedly hit the
+/// filesystem: Ghostty discovery (`stat` of every candidate path), the
+/// terminal-profile document load (disk read + JSON decode), and command
+/// resolution (PATH/repo lookup).
+///
+/// A pane's boot profile is its static launch configuration. It only changes
+/// when launch-relevant pane inputs change, so the cache keys on exactly those
+/// inputs and ignores high-frequency metadata churn (attention, viewport,
+/// activity, process binding, alan binding).
+final class AlanShellBootProfileCache {
+    struct Key: Hashable {
+        let paneID: String
+        let tabID: String
+        let spaceID: String
+        let launchTarget: String
+        let terminalProfileID: String?
+        let windowID: String
+
+        // `cwd` is deliberately excluded: the expensive resolution (Ghostty
+        // discovery, terminal-profile document load, command resolution) does
+        // not depend on it. The working directory is applied as a cheap overlay
+        // so a `cd` never busts the cache or repeats disk work.
+        init(pane: ShellPane, windowID: String) {
+            paneID = pane.paneID
+            tabID = pane.tabID
+            spaceID = pane.spaceID
+            launchTarget = pane.resolvedLaunchTarget.rawValue
+            terminalProfileID = pane.terminalProfileID
+            self.windowID = windowID
+        }
+    }
+
+    private let compute: (ShellPane, ShellStateSnapshot) -> AlanShellBootProfile
+    private var storage: [Key: AlanShellBootProfile] = [:]
+
+    init(
+        compute: @escaping (ShellPane, ShellStateSnapshot) -> AlanShellBootProfile = {
+            AlanShellBootProfile.forPane($0, shellState: $1)
+        }
+    ) {
+        self.compute = compute
+    }
+
+    func profile(for pane: ShellPane, shellState: ShellStateSnapshot) -> AlanShellBootProfile {
+        let key = Key(pane: pane, windowID: shellState.windowID)
+        let base: AlanShellBootProfile
+        if let cached = storage[key] {
+            base = cached
+        } else {
+            base = compute(pane, shellState)
+            storage[key] = base
+        }
+        guard let cwd = pane.cwd, cwd != base.workingDirectory else {
+            return base
+        }
+        return base.withWorkingDirectory(cwd)
     }
 }
 
@@ -1230,6 +1302,27 @@ struct TerminalHostRuntimeSnapshot: Equatable {
 
     var stageLabel: String {
         stage.rawValue.replacingOccurrences(of: "_", with: " ")
+    }
+
+    /// Equality that ignores the volatile publish timestamps. Two snapshots that
+    /// only differ in `lastUpdatedAt` represent the same observable shell state,
+    /// so callers can suppress redundant `@Published` mutations (and the
+    /// tree-wide SwiftUI invalidation they trigger).
+    func equalsIgnoringTimestamp(_ other: TerminalHostRuntimeSnapshot) -> Bool {
+        stage == other.stage
+            && contentID == other.contentID
+            && paneID == other.paneID
+            && tabID == other.tabID
+            && renderPriority == other.renderPriority
+            && logicalSize == other.logicalSize
+            && backingSize == other.backingSize
+            && displayName == other.displayName
+            && displayID == other.displayID
+            && attachedWindowTitle == other.attachedWindowTitle
+            && isFocused == other.isFocused
+            && renderer == other.renderer
+            && paneMetadata == other.paneMetadata
+            && surfaceState.equalsIgnoringTimestamp(other.surfaceState)
     }
 
     static let placeholder = TerminalHostRuntimeSnapshot(

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -25,6 +25,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesLifecycleFlushPersistsPendingContentSynchronously()
         verifiesFailedStructuralManifestSaveIsReported()
         verifiesAsyncPersistenceWriteFailureRoutesToDiagnostics()
+        verifiesPaneSupportDirectoryIsCreatedPromptlyAtBoot()
         verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
@@ -10385,6 +10386,27 @@ private enum ShellRuntimeMetadataTests {
         expect(
             writer.syncWrites == 0,
             "the coalesced flush must write off the main thread, not synchronously"
+        )
+    }
+
+    private static func verifiesPaneSupportDirectoryIsCreatedPromptlyAtBoot() {
+        let windowID = "pane_dir_boot_\(UUID().uuidString)"
+        // Manual scheduler: the debounced/deferred persistence never fires, so any
+        // boot-critical pane setup must happen on the prompt (in-memory) path.
+        let controller = makeController(
+            windowID: windowID,
+            manifestFlushScheduler: ManualManifestFlushScheduler()
+        )
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+        let paneURL = alanShellPaneSupportDirectoryURL(windowID: windowID, paneID: pane.paneID)
+        defer { try? FileManager.default.removeItem(at: alanShellControlPlaneRootURL(windowID: windowID)) }
+
+        expect(
+            FileManager.default.fileExists(atPath: paneURL.path),
+            "a pane's support directory must be created promptly at boot, before the debounced flush, "
+                + "so a fast shell integration can write its binding file"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -23,6 +23,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalCallbackPathDoesNotWriteManifestSynchronously()
         verifiesTerminalCallbackBurstCoalescesIntoOnePersistenceWrite()
         verifiesLifecycleFlushPersistsPendingContentSynchronously()
+        verifiesFailedStructuralManifestSaveIsReported()
         verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
@@ -10386,6 +10387,27 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesFailedStructuralManifestSaveIsReported() {
+        let windowID = "manifest_fail_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: manifestURL),
+            persistenceWriter: FailingPersistenceWriter(),
+            manifestFlushScheduler: ImmediateManifestFlushScheduler()
+        )
+
+        // A structural mutation persists synchronously; when the write fails the
+        // controller must surface it rather than silently appear to succeed.
+        _ = controller.splitPane(paneID: "pane_1", placement: .down)
+
+        expect(
+            controller.controlPlaneDiagnostics.contains { $0.contains("workspace manifest save failed") },
+            "a failed structural manifest save must record a control-plane diagnostic"
+        )
+    }
+
     private static func verifiesLifecycleFlushPersistsPendingContentSynchronously() {
         let writer = SpyPersistenceWriter()
         let scheduler = ManualManifestFlushScheduler()
@@ -10525,10 +10547,12 @@ private enum ShellRuntimeMetadataTests {
         private(set) var shellStateWrites = 0
         private(set) var lastManifest: ShellContentWorkspaceManifest?
 
-        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) {
+        @discardableResult
+        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) -> Bool {
             syncWrites += 1
             manifestWrites += 1
             lastManifest = manifest
+            return true
         }
 
         func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) {
@@ -10561,7 +10585,16 @@ private enum ShellRuntimeMetadataTests {
             self.stateStore = stateStore
         }
 
-        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) { try? manifestStore?.save(manifest) }
+        @discardableResult
+        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) -> Bool {
+            do {
+                try manifestStore?.save(manifest)
+                return true
+            } catch {
+                return false
+            }
+        }
+
         func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) { try? manifestStore?.save(manifest) }
         func writeShellStateSync(_ state: ShellStateSnapshot) { stateStore.save(state) }
         func writeShellStateAsync(_ state: ShellStateSnapshot) { stateStore.save(state) }
@@ -10569,6 +10602,14 @@ private enum ShellRuntimeMetadataTests {
 
     final class ImmediateManifestFlushScheduler: ManifestFlushScheduling {
         func schedule(_ work: @escaping () -> Void) { work() }
+    }
+
+    final class FailingPersistenceWriter: ShellPersistenceWriting {
+        @discardableResult
+        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) -> Bool { false }
+        func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) {}
+        func writeShellStateSync(_ state: ShellStateSnapshot) {}
+        func writeShellStateAsync(_ state: ShellStateSnapshot) {}
     }
 
     final class ManualManifestFlushScheduler: ManifestFlushScheduling {

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreGraphics
 import Darwin
 import Foundation
@@ -17,6 +18,9 @@ struct ShellRuntimeMetadataTestRunner {
 @MainActor
 private enum ShellRuntimeMetadataTests {
     static func run() {
+        verifiesBootProfileCacheMemoizesPerLaunchKey()
+        verifiesMetadataCallbackReusesCachedBootProfile()
+        verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
         verifiesShellSelectionAndFocusRecordPerformanceDiagnostics()
@@ -10141,6 +10145,188 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesBootProfileCacheMemoizesPerLaunchKey() {
+        var computeCount = 0
+        let cache = AlanShellBootProfileCache(compute: { pane, state in
+            computeCount += 1
+            return AlanShellBootProfile.forPane(pane, shellState: state)
+        })
+        let state = ShellStateSnapshot.bootstrapDefault(windowID: "boot_profile_cache_test")
+        let pane = ShellPane(
+            paneID: "pane_cache",
+            tabID: "tab_cache",
+            spaceID: "space_cache",
+            launchTarget: .shell,
+            cwd: "/tmp",
+            process: nil,
+            attention: .idle,
+            context: nil,
+            viewport: nil,
+            alanBinding: nil,
+            terminalProfileID: nil
+        )
+
+        _ = cache.profile(for: pane, shellState: state)
+        _ = cache.profile(for: pane, shellState: state)
+        expect(
+            computeCount == 1,
+            "boot profile cache must compute once for repeated identical panes (got \(computeCount))"
+        )
+
+        let metadataChurnedPane = ShellPane(
+            paneID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID,
+            launchTarget: pane.launchTarget,
+            cwd: pane.cwd,
+            process: pane.process,
+            attention: .awaitingUser,
+            context: pane.context,
+            viewport: ShellViewportSnapshot(
+                title: "busy",
+                summary: "lots of output",
+                visibleExcerpt: nil,
+                lastActivityAt: "2026-06-15T00:00:00Z"
+            ),
+            alanBinding: pane.alanBinding,
+            terminalProfileID: pane.terminalProfileID
+        )
+        _ = cache.profile(for: metadataChurnedPane, shellState: state)
+        expect(
+            computeCount == 1,
+            "metadata churn (attention/viewport) must not recompute boot profile (got \(computeCount))"
+        )
+
+        // A working-directory change (e.g. `cd`) must NOT redo the expensive
+        // resolution — Ghostty discovery and the profile document load are
+        // cwd-independent. The new cwd is applied as a cheap overlay.
+        let relaunchedPane = ShellPane(
+            paneID: pane.paneID,
+            tabID: pane.tabID,
+            spaceID: pane.spaceID,
+            launchTarget: pane.launchTarget,
+            cwd: "/var/data",
+            process: pane.process,
+            attention: pane.attention,
+            context: pane.context,
+            viewport: pane.viewport,
+            alanBinding: pane.alanBinding,
+            terminalProfileID: pane.terminalProfileID
+        )
+        let relaunchedProfile = cache.profile(for: relaunchedPane, shellState: state)
+        expect(
+            computeCount == 1,
+            "a cwd change must not recompute the boot profile (got \(computeCount))"
+        )
+        expect(
+            relaunchedProfile.workingDirectory == "/var/data",
+            "a cwd change must be reflected in the boot profile working directory "
+                + "(got \(relaunchedProfile.workingDirectory))"
+        )
+    }
+
+    private static func verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges() {
+        let controller = makeController()
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        func snapshot(at timestamp: TimeInterval) -> TerminalHostRuntimeSnapshot {
+            TerminalHostRuntimeSnapshot(
+                stage: .windowAttached,
+                contentID: pane.terminalContentID,
+                paneID: pane.paneID,
+                tabID: pane.tabID,
+                renderPriority: .foregroundInteractive,
+                logicalSize: .zero,
+                backingSize: .zero,
+                displayName: "Studio Display",
+                displayID: "display_1",
+                attachedWindowTitle: "alan",
+                isFocused: false,
+                renderer: .placeholder,
+                paneMetadata: TerminalPaneMetadataSnapshot(
+                    title: "cargo test",
+                    workingDirectory: "/repo/app",
+                    summary: "build running",
+                    attention: .active,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: 5)
+                ),
+                surfaceState: .placeholder,
+                lastUpdatedAt: Date(timeIntervalSince1970: timestamp)
+            )
+        }
+
+        var changeCount = 0
+        let cancellable = controller.objectWillChange.sink { _ in changeCount += 1 }
+        defer { cancellable.cancel() }
+
+        controller.updateTerminalRuntime(snapshot(at: 1))
+        let afterFirst = changeCount
+        expect(afterFirst > 0, "first runtime publish must notify shell observers")
+
+        // Identical snapshot except for the outer publish timestamp: this is the
+        // per-refresh churn that must not invalidate the whole observing tree.
+        controller.updateTerminalRuntime(snapshot(at: 2))
+        expect(
+            changeCount == afterFirst,
+            "runtime snapshot identical except for its timestamp must not re-notify "
+                + "shell observers (delta \(changeCount - afterFirst))"
+        )
+    }
+
+    private static func verifiesMetadataCallbackReusesCachedBootProfile() {
+        var computeCount = 0
+        let cache = AlanShellBootProfileCache(compute: { pane, state in
+            computeCount += 1
+            return AlanShellBootProfile.forPane(pane, shellState: state)
+        })
+        let controller = makeController(bootProfileCache: cache)
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        func deliverMetadata(burst: Int) {
+            controller.updateTerminalMetadata(
+                TerminalPaneMetadataSnapshot(
+                    title: "cargo test",
+                    workingDirectory: "/repo/app",
+                    summary: "output burst \(burst)",
+                    attention: .active,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: Double(burst))
+                ),
+                for: pane.paneID
+            )
+        }
+
+        // The first callbacks settle the pane's launch-relevant fields (e.g.
+        // cwd from the reported working directory), which legitimately compute
+        // the boot profile. Those settle within the warm-up window.
+        for burst in 0..<3 {
+            deliverMetadata(burst: burst)
+        }
+        let warmComputeCount = computeCount
+        expect(
+            warmComputeCount >= 1,
+            "metadata callbacks must route boot-profile resolution through the cache"
+        )
+
+        // Steady state: a high-output burst of identical callbacks must not
+        // recompute the boot profile (no Ghostty discovery / profile disk read).
+        for burst in 3..<20 {
+            deliverMetadata(burst: burst)
+        }
+        expect(
+            computeCount == warmComputeCount,
+            "steady-state metadata callbacks must reuse the cached boot profile "
+                + "(recomputed \(computeCount - warmComputeCount) extra times across 17 callbacks)"
+        )
+    }
+
     private static func makeController(
         windowID: String = "metadata_test_\(UUID().uuidString)",
         shellState: ShellStateSnapshot? = nil,
@@ -10150,6 +10336,7 @@ private enum ShellRuntimeMetadataTests {
         closeConfirmationPresenter: ShellCloseConfirmationPresenting? = nil,
         gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
+        bootProfileCache: AlanShellBootProfileCache? = nil,
         appIsActive: Bool = true
     ) -> ShellHostController {
         let registry =
@@ -10171,6 +10358,7 @@ private enum ShellRuntimeMetadataTests {
             closeConfirmationPresenter: closeConfirmationPresenter,
             gracefulShutdownTimeout: gracefulShutdownTimeout,
             performanceDiagnosticsRecorder: performanceDiagnosticsRecorder,
+            bootProfileCache: bootProfileCache,
             appIsActiveProvider: { appIsActive }
         )
     }

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -24,6 +24,7 @@ private enum ShellRuntimeMetadataTests {
         verifiesTerminalCallbackBurstCoalescesIntoOnePersistenceWrite()
         verifiesLifecycleFlushPersistsPendingContentSynchronously()
         verifiesFailedStructuralManifestSaveIsReported()
+        verifiesAsyncPersistenceWriteFailureRoutesToDiagnostics()
         verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
@@ -10384,6 +10385,37 @@ private enum ShellRuntimeMetadataTests {
         expect(
             writer.syncWrites == 0,
             "the coalesced flush must write off the main thread, not synchronously"
+        )
+    }
+
+    private static func verifiesAsyncPersistenceWriteFailureRoutesToDiagnostics() {
+        let windowID = "manifest_async_fail_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let stateURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID)-state.json")
+        // Inject the real persistence writer and verify the controller wires its
+        // async error sink to control-plane diagnostics. (This exercises the
+        // wiring/routing closure; the param-vs-resolved-writer selection itself
+        // is only observable with the internal default writer, which is verified
+        // by inspection.)
+        let writer = ShellPersistenceWriter(
+            manifestStore: ShellWorkspaceManifestStore(manifestURL: manifestURL),
+            stateStore: ShellStatePersistenceStore(persistenceURL: stateURL)
+        )
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: manifestURL),
+            persistenceWriter: writer
+        )
+
+        writer.onError("workspace manifest async save failed")
+
+        expect(
+            controller.controlPlaneDiagnostics.contains {
+                $0.contains("workspace manifest async save failed")
+            },
+            "async persistence-write failures must be routed to control-plane diagnostics"
         )
     }
 

--- a/clients/apple/scripts/test-shell-runtime-metadata.swift
+++ b/clients/apple/scripts/test-shell-runtime-metadata.swift
@@ -20,6 +20,9 @@ private enum ShellRuntimeMetadataTests {
     static func run() {
         verifiesBootProfileCacheMemoizesPerLaunchKey()
         verifiesMetadataCallbackReusesCachedBootProfile()
+        verifiesTerminalCallbackPathDoesNotWriteManifestSynchronously()
+        verifiesTerminalCallbackBurstCoalescesIntoOnePersistenceWrite()
+        verifiesLifecycleFlushPersistsPendingContentSynchronously()
         verifiesSelectedRuntimeAssignmentIgnoresTimestampOnlyChanges()
         verifiesRuntimeProjectsTerminalStatusIntoPaneMetadata()
         verifiesRuntimeProjectionRecordsPerformanceDiagnostics()
@@ -7852,6 +7855,7 @@ private enum ShellRuntimeMetadataTests {
         )
 
         controller.updateTerminalMetadata(metadata(title: "Moved", cwd: "/moved"), for: "pane_1")
+        controller.flushWorkspacePersistence()
         guard let updatedManifest = decodeManifest(at: manifestURL),
               let updatedTab = updatedManifest.spaces
                 .flatMap(\.tabs)
@@ -8165,6 +8169,7 @@ private enum ShellRuntimeMetadataTests {
             metadata(title: "npm run dev", cwd: "/repo/app", activeTaskState: .foregroundCommand),
             for: "pane_1"
         )
+        controller.flushWorkspacePersistence()
 
         guard let savedManifest = decodeManifest(at: manifestURL),
               let transcript = terminalPayload(
@@ -10277,6 +10282,145 @@ private enum ShellRuntimeMetadataTests {
         )
     }
 
+    private static func verifiesTerminalCallbackPathDoesNotWriteManifestSynchronously() {
+        let writer = SpyPersistenceWriter()
+        let scheduler = ManualManifestFlushScheduler()
+        let windowID = "manifest_io_test_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        let controller = makeController(
+            windowID: windowID,
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: manifestURL),
+            persistenceWriter: writer,
+            manifestFlushScheduler: scheduler
+        )
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        // A burst of metadata callbacks, alternating active-task state to exercise
+        // the path that previously wrote the manifest synchronously.
+        let states: [ShellTabActiveTaskState] = [.foregroundCommand, .alanRunning]
+        for index in 0..<8 {
+            controller.updateTerminalMetadata(
+                TerminalPaneMetadataSnapshot(
+                    title: "cargo test",
+                    workingDirectory: "/repo/app",
+                    summary: "burst \(index)",
+                    attention: .active,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: Double(index)),
+                    activeTaskState: states[index % states.count]
+                ),
+                for: pane.paneID
+            )
+        }
+
+        expect(
+            writer.syncWrites == 0,
+            "terminal metadata callbacks must not write the manifest or shell-state file "
+                + "synchronously (got \(writer.syncWrites) synchronous writes)"
+        )
+    }
+
+    private static func makeManifestIOController(
+        writer: SpyPersistenceWriter,
+        scheduler: ManifestFlushScheduling
+    ) -> ShellHostController {
+        let windowID = "manifest_io_\(UUID().uuidString)"
+        let manifestURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(windowID).json")
+        return makeController(
+            windowID: windowID,
+            workspaceManifestStore: ShellWorkspaceManifestStore(manifestURL: manifestURL),
+            persistenceWriter: writer,
+            manifestFlushScheduler: scheduler
+        )
+    }
+
+    private static func verifiesTerminalCallbackBurstCoalescesIntoOnePersistenceWrite() {
+        let writer = SpyPersistenceWriter()
+        let scheduler = ManualManifestFlushScheduler()
+        let controller = makeManifestIOController(writer: writer, scheduler: scheduler)
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        for index in 0..<10 {
+            controller.updateTerminalMetadata(
+                TerminalPaneMetadataSnapshot(
+                    title: "cargo test",
+                    workingDirectory: "/repo/app",
+                    summary: "burst \(index)",
+                    attention: .active,
+                    processExited: false,
+                    lastCommandExitCode: nil,
+                    lastUpdatedAt: Date(timeIntervalSince1970: Double(index)),
+                    activeTaskState: .foregroundCommand
+                ),
+                for: pane.paneID
+            )
+        }
+
+        expect(
+            scheduler.scheduleCount == 1,
+            "a burst of terminal callbacks must schedule one debounced flush "
+                + "(scheduled \(scheduler.scheduleCount))"
+        )
+        expect(
+            writer.asyncWrites == 0 && writer.syncWrites == 0,
+            "nothing must be written before the debounce window fires"
+        )
+
+        scheduler.fire()
+
+        expect(
+            writer.manifestWrites == 1 && writer.shellStateWrites == 1,
+            "the coalesced flush must write the manifest and shell-state file exactly once each "
+                + "(manifest \(writer.manifestWrites), shellState \(writer.shellStateWrites))"
+        )
+        expect(
+            writer.syncWrites == 0,
+            "the coalesced flush must write off the main thread, not synchronously"
+        )
+    }
+
+    private static func verifiesLifecycleFlushPersistsPendingContentSynchronously() {
+        let writer = SpyPersistenceWriter()
+        let scheduler = ManualManifestFlushScheduler()
+        let controller = makeManifestIOController(writer: writer, scheduler: scheduler)
+        guard let pane = controller.selectedPane else {
+            fail("bootstrap shell must expose a selected pane")
+        }
+
+        controller.updateTerminalMetadata(
+            TerminalPaneMetadataSnapshot(
+                title: "cargo test",
+                workingDirectory: "/repo/app",
+                summary: "pending output",
+                attention: .active,
+                processExited: false,
+                lastCommandExitCode: nil,
+                lastUpdatedAt: Date(timeIntervalSince1970: 1),
+                activeTaskState: .foregroundCommand
+            ),
+            for: pane.paneID
+        )
+        expect(
+            writer.syncWrites == 0 && writer.asyncWrites == 0,
+            "a terminal callback alone must not write before the debounce fires"
+        )
+
+        controller.flushWorkspacePersistence()
+
+        expect(
+            writer.syncWrites >= 2,
+            "lifecycle flush must synchronously persist the manifest and shell-state file "
+                + "(synchronous writes \(writer.syncWrites))"
+        )
+    }
+
     private static func verifiesMetadataCallbackReusesCachedBootProfile() {
         var computeCount = 0
         let cache = AlanShellBootProfileCache(compute: { pane, state in
@@ -10337,6 +10481,8 @@ private enum ShellRuntimeMetadataTests {
         gracefulShutdownTimeout: TimeInterval = 3.0,
         performanceDiagnosticsRecorder: AlanPerformanceDiagnosticsRecorder? = nil,
         bootProfileCache: AlanShellBootProfileCache? = nil,
+        persistenceWriter: ShellPersistenceWriting? = nil,
+        manifestFlushScheduler: ManifestFlushScheduling? = nil,
         appIsActive: Bool = true
     ) -> ShellHostController {
         let registry =
@@ -10348,6 +10494,13 @@ private enum ShellRuntimeMetadataTests {
         )
         let persistenceURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(windowID).json")
+        let resolvedWriter =
+            persistenceWriter
+            ?? SynchronousPersistenceWriter(
+                manifestStore: workspaceManifestStore,
+                stateStore: ShellStatePersistenceStore(persistenceURL: persistenceURL)
+            )
+        let resolvedScheduler = manifestFlushScheduler ?? ImmediateManifestFlushScheduler()
         return ShellHostController(
             shellState: shellState ?? .bootstrapDefault(windowID: windowID),
             windowContext: context,
@@ -10355,12 +10508,85 @@ private enum ShellRuntimeMetadataTests {
             terminalRuntimeRegistry: registry,
             workspaceManifestStore: workspaceManifestStore,
             workspaceManifest: workspaceManifest,
+            persistenceWriter: resolvedWriter,
+            manifestFlushScheduler: resolvedScheduler,
             closeConfirmationPresenter: closeConfirmationPresenter,
             gracefulShutdownTimeout: gracefulShutdownTimeout,
             performanceDiagnosticsRecorder: performanceDiagnosticsRecorder,
             bootProfileCache: bootProfileCache,
             appIsActiveProvider: { appIsActive }
         )
+    }
+
+    final class SpyPersistenceWriter: ShellPersistenceWriting {
+        private(set) var syncWrites = 0
+        private(set) var asyncWrites = 0
+        private(set) var manifestWrites = 0
+        private(set) var shellStateWrites = 0
+        private(set) var lastManifest: ShellContentWorkspaceManifest?
+
+        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) {
+            syncWrites += 1
+            manifestWrites += 1
+            lastManifest = manifest
+        }
+
+        func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) {
+            asyncWrites += 1
+            manifestWrites += 1
+            lastManifest = manifest
+        }
+
+        func writeShellStateSync(_ state: ShellStateSnapshot) {
+            syncWrites += 1
+            shellStateWrites += 1
+        }
+
+        func writeShellStateAsync(_ state: ShellStateSnapshot) {
+            asyncWrites += 1
+            shellStateWrites += 1
+        }
+    }
+
+    /// Default test writer: persists synchronously to the real stores so the
+    /// majority of tests observe persistence inline. The off-main/debounced
+    /// contract is exercised explicitly by tests that inject the spy + manual
+    /// scheduler instead.
+    final class SynchronousPersistenceWriter: ShellPersistenceWriting {
+        private let manifestStore: ShellWorkspaceManifestStore?
+        private let stateStore: ShellStatePersistenceStore
+
+        init(manifestStore: ShellWorkspaceManifestStore?, stateStore: ShellStatePersistenceStore) {
+            self.manifestStore = manifestStore
+            self.stateStore = stateStore
+        }
+
+        func writeManifestSync(_ manifest: ShellContentWorkspaceManifest) { try? manifestStore?.save(manifest) }
+        func writeManifestAsync(_ manifest: ShellContentWorkspaceManifest) { try? manifestStore?.save(manifest) }
+        func writeShellStateSync(_ state: ShellStateSnapshot) { stateStore.save(state) }
+        func writeShellStateAsync(_ state: ShellStateSnapshot) { stateStore.save(state) }
+    }
+
+    final class ImmediateManifestFlushScheduler: ManifestFlushScheduling {
+        func schedule(_ work: @escaping () -> Void) { work() }
+    }
+
+    final class ManualManifestFlushScheduler: ManifestFlushScheduling {
+        private(set) var scheduleCount = 0
+        private var pending: (() -> Void)?
+
+        func schedule(_ work: @escaping () -> Void) {
+            scheduleCount += 1
+            pending = work
+        }
+
+        @discardableResult
+        func fire() -> Bool {
+            guard let work = pending else { return false }
+            pending = nil
+            work()
+            return true
+        }
     }
 
     private static func fakeSurfaceHandle(

--- a/openspec/changes/redesign-macos-workspace-persistence/.openspec.yaml
+++ b/openspec/changes/redesign-macos-workspace-persistence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/redesign-macos-workspace-persistence/design.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/design.md
@@ -36,6 +36,15 @@ modify the same spec via non-overlapping requirements.
 
 ## Decisions
 
+### Decision 0: Split `publishControlPlaneState` into prompt publish + debounced disk
+`publishControlPlaneState` (called by `updatePaneState` on every pane-state
+change) does three things: write the manifest, write the control-plane shell-state
+file (`persistShellState`), and publish in-memory control-plane state. The
+in-memory publish stays synchronous (IPC/automation need it prompt); the two disk
+writes become debounced + off-main on the hot path and synchronous on structural
+mutations. Both files route through one persistence-writer seam so the test can
+assert the whole callback path performs zero synchronous main-thread disk writes.
+
 ### Decision 1: Serial background `DispatchQueue`, not a Swift `actor`
 Move encode + `Data.write(atomic:)` onto one serial `DispatchQueue`. Structural
 writes call it synchronously (low-frequency user actions — a brief main-thread

--- a/openspec/changes/redesign-macos-workspace-persistence/design.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/design.md
@@ -1,0 +1,109 @@
+## Context
+
+`ShellHostController.syncWorkspaceManifestFromShellState` rebuilds the entire
+`ShellContentWorkspaceManifest` (structure + per-Tab transcript `liveSnapshot`)
+and writes it via `ShellWorkspaceManifestStore.save` →
+`Data.write(to:options:.atomic)` **synchronously on the `@MainActor`
+controller**. The dominant hot-path trigger is
+`activeTaskChanged && !didPublishPaneUpdate` inside `updateTerminalMetadata` /
+`projectTerminalRuntime`.
+
+Evidence: `terminalMetadataCallback` avg 10.8ms, **max 24.9ms** (real usage). An
+instrumented run attributed the residual to the manifest write (`shellSpacesRebuild`
+was negligible). An equality guard that skipped writes differing only in volatile
+`now` stamps did not help, because the trigger (`activeTask`) and the heavy field
+(transcript) genuinely change — the cost is structural, not redundant.
+
+This change is the **platform-IO half** of `macos-shell-workspace-persistence`.
+The cross-platform-shell-core change owns the **portable semantics half**
+(manifest schema, materialization, retention, `activeTask` durability) and
+explicitly leaves "macOS manifest file IO in the platform layer". The two changes
+modify the same spec via non-overlapping requirements.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove synchronous main-thread manifest writes from the terminal callback path.
+- Decouple transcript persistence cadence from `activeTask` churn.
+- Keep structural mutations promptly durable.
+- Be forward-compatible: the writer is what a future Rust-core facade feeds.
+
+**Non-Goals:**
+- Changing the manifest model/schema, removing the `activeTask` field, or
+  splitting the manifest into multiple files (all owned by shell-core).
+- Changing TTL/retention or restore semantics.
+- A general async-persistence framework — scope is this one store.
+
+## Decisions
+
+### Decision 1: Serial background `DispatchQueue`, not a Swift `actor`
+Move encode + `Data.write(atomic:)` onto one serial `DispatchQueue`. Structural
+writes call it synchronously (low-frequency user actions — a brief main-thread
+block is acceptable and keeps the existing "persist immediately" tests passing
+without `await`). Content writes are dispatched async.
+- *Why not an actor*: the focused test harness runs synchronously via
+  `MainActor.run`; `await` across an actor boundary is awkward to drive
+  deterministically. GCD keeps both the synchronous-structure and
+  deterministic-test paths simple.
+- *Concurrency*: the immutable `ShellContentWorkspaceManifest` value is built on
+  the main actor (reads `shellState`), then handed to the writer; only the value
+  crosses threads, serialized by the queue. Confirm the manifest type is
+  `Sendable`.
+
+### Decision 2: Debounced content flush via an injectable scheduler
+Content changes set a dirty flag and schedule a single flush (default
+`DispatchQueue.main.asyncAfter(window)`, window tunable ~250ms–1s). On fire, the
+flush rebuilds the manifest on the main actor and dispatches the encode+write to
+the background queue. The scheduler is injected so tests fire it deterministically.
+- *Why not next-tick `async` coalescing*: output bursts span many runloop
+  iterations, so next-tick neither coalesces nor leaves the main thread.
+
+### Decision 3: Replace the `activeTask` write trigger, keep the field
+Remove the `activeTaskChanged → syncWorkspaceManifest` calls on the hot path; the
+transcript that those incidentally persisted is now persisted by the debounced
+content path. The `activeTask` field stays in the model (its durability is a
+shell-core decision). This is purely a change of *when* we write.
+
+### Decision 4: One file in v1 (defer the structure/content split)
+Keep the single manifest file. Each write emits a complete current manifest, so a
+serialized writer cannot tear or lose data regardless of which cadence triggered
+it. Splitting into structure/content files (incremental writes) is a later
+optimization and overlaps shell-core's model work — out of scope here.
+
+### Decision 5: Restate the durability contract in tests
+Tests that synchronously read the manifest right after `updateTerminalMetadata`
+move to: perform the callback, fire the injected scheduler (or the
+background/quit flush), then assert.
+
+## Risks / Trade-offs
+
+- **[Hard-crash transcript loss within the debounce window]** → acceptable for
+  scrollback; bound the window and flush on background/quit.
+- **[Background write races main-actor state mutation]** → build the immutable
+  manifest value on the main actor; serialize writes on one queue.
+- **[Quit before flush]** → use the app-termination hook (e.g.
+  `applicationShouldTerminate` → `.terminateLater` if needed) to complete a
+  synchronous flush before exit.
+- **[Existing durability tests break]** → intended; migrate to the new contract
+  with the injectable scheduler so they stay deterministic.
+
+## Migration Plan
+
+1. Add the serial background writer + injectable scheduler behind
+   `ShellWorkspaceManifestStore` / its caller.
+2. Make structural writes synchronous-on-write; route content changes through the
+   debounced flush; remove the `activeTask` write trigger.
+3. Add background/resign-active/quit flush hooks.
+4. Migrate the durability tests to the new contract.
+5. Re-run `capture-performance-diagnostics-workload.sh`; confirm the main-thread
+   write is gone and `terminalMetadataCallback` tail latency (max) drops.
+
+Rollback is local to the macOS persistence layer; the manifest file format is
+unchanged.
+
+## Open Questions
+
+- Debounce window (250ms vs ~1s) — tune against the diagnostics workload.
+- Whether building the manifest value on the main actor at flush time (transcript
+  snapshot assembly) is itself cheap enough at ~1/s, or whether the snapshot
+  assembly should also move off-main later.

--- a/openspec/changes/redesign-macos-workspace-persistence/proposal.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The macOS workspace manifest is rebuilt and written to disk with an **atomic,
+synchronous write on the main thread**, triggered by `activeTask` changes on the
+terminal metadata/runtime callback path. Because the manifest carries heavy
+per-Tab transcript `liveSnapshot` content, this write is a main-thread
+tail-latency source: in real usage `terminalMetadataCallback` ran avg 10.8ms but
+**max 24.9ms** — past the 16.7ms frame budget, i.e. the dropped frame users feel
+as stutter. Prior optimization passes (background-rendering, lazy rendering,
+boot-profile caching) did not touch this path.
+
+## Scope boundary (coordination with `introduce-cross-platform-shell-core`)
+
+This change is deliberately scoped to the **macOS platform persistence IO layer**
+— *when* and *how* (threading/cadence) the manifest is written to disk — which
+the cross-platform-shell-core change explicitly leaves in the platform layer
+("keeping macOS manifest file IO in the platform layer").
+
+**Out of scope here** (owned by `shell-workspace-core-contract` and handled in
+that change): the manifest *schema/model*, materialization, TTL/retention
+semantics, and whether `activeTask` is a durable field. This change does **not**
+change the manifest model, does **not** remove the `activeTask` field, and does
+**not** split the manifest into multiple files — it only changes write
+threading/cadence and the write trigger. It is forward-compatible: the off-main
+debounced writer it introduces is exactly what a future Rust-core facade hands a
+serialized manifest to.
+
+## What Changes
+
+- Move manifest JSON encode + `Data.write(atomic:)` **off the main thread** onto
+  a serial background writer; the `@MainActor` controller must not block on disk.
+- Replace the single `activeTaskChanged`-triggered synchronous write with a
+  cadence split:
+  - **Structural mutations** (Tab/Space create/close/reorder/pin/move,
+    selection) persist synchronously (preserves existing "persist immediately").
+  - **Restore content** (terminal transcript snapshots) is marked dirty on change
+    and flushed on a **debounced** cadence plus a forced flush on
+    background/resign-active/quit.
+- **Stop using `activeTask` changes as a manifest write trigger.** (Timing change
+  only — the `activeTask` field and its semantics are untouched and remain owned
+  by the shell-core contract.)
+- **BREAKING (durability contract)**: terminal transcript snapshots are now
+  durable "within a bounded window and on background/quit" instead of
+  "synchronously after each terminal callback". Update the tests that assert
+  synchronous post-callback persistence.
+
+## Capabilities
+
+### New Capabilities
+<!-- None: this restructures persistence timing within an existing capability. -->
+
+### Modified Capabilities
+- `macos-shell-workspace-persistence`: Add platform-IO requirements — manifest
+  persistence must not block the main thread, and persistence cadence is
+  separated by durability class (synchronous structure, debounced off-main
+  restore content, transient runtime-state changes do not trigger a write). This
+  is additive and IO-only; it does not touch manifest semantics, which the
+  cross-platform-shell-core change covers in the same spec via separate
+  (non-overlapping) requirements.
+
+## Impact
+
+- **Code**: `ShellHostController.syncWorkspaceManifestFromShellState` (write
+  trigger + threading + cadence), `ShellWorkspaceManifestStore` (off-main serial
+  write; an injectable scheduler/clock for testability), app lifecycle hooks
+  (background/quit flush). No manifest model or `activeTask` field change.
+- **Tests**: `clients/apple/scripts/test-shell-runtime-metadata.swift` durability
+  assertions that read the manifest synchronously after `updateTerminalMetadata`
+  move to the bounded-window/flush contract via the injectable scheduler; relates
+  to `macos-shell-build-test-contract`.
+- **Durability tradeoff**: a hard crash may lose up to the debounce window of the
+  most recent transcript scrollback (acceptable); structure and pin snapshots
+  remain synchronously durable.
+- **Sequencing**: lands independently of (and before) the shell-core
+  rust-ification; that change later moves manifest *semantics* into Rust and
+  reuses this IO layer unchanged.

--- a/openspec/changes/redesign-macos-workspace-persistence/proposal.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/proposal.md
@@ -27,8 +27,15 @@ serialized manifest to.
 
 ## What Changes
 
-- Move manifest JSON encode + `Data.write(atomic:)` **off the main thread** onto
-  a serial background writer; the `@MainActor` controller must not block on disk.
+> Scope note (found during implementation): the hot path makes **two**
+> synchronous main-thread disk writes per pane-state change, both via
+> `publishControlPlaneState` — the workspace manifest **and** the control-plane
+> shell-state snapshot file (`persistShellState`). This change covers both, and
+> keeps the in-memory control-plane publication (`controlPlane.publish`) prompt.
+
+- Move manifest **and** shell-state-file JSON encode + `Data.write(atomic:)`
+  **off the main thread** onto a serial background writer; the `@MainActor`
+  controller must not block on disk.
 - Replace the single `activeTaskChanged`-triggered synchronous write with a
   cadence split:
   - **Structural mutations** (Tab/Space create/close/reorder/pin/move,
@@ -60,10 +67,13 @@ serialized manifest to.
 
 ## Impact
 
-- **Code**: `ShellHostController.syncWorkspaceManifestFromShellState` (write
-  trigger + threading + cadence), `ShellWorkspaceManifestStore` (off-main serial
-  write; an injectable scheduler/clock for testability), app lifecycle hooks
-  (background/quit flush). No manifest model or `activeTask` field change.
+- **Code**: `ShellHostController.publishControlPlaneState` (splits prompt IPC
+  publish from debounced disk writes), `syncWorkspaceManifestFromShellState` /
+  `persistShellState` (write trigger + threading + cadence),
+  `ShellWorkspaceManifestStore` + `ShellStatePersistenceStore` (off-main serial
+  write behind one persistence-writer seam; an injectable scheduler for
+  testability), app lifecycle hooks (background/quit flush). No manifest model or
+  `activeTask` field change.
 - **Tests**: `clients/apple/scripts/test-shell-runtime-metadata.swift` durability
   assertions that read the manifest synchronously after `updateTerminalMetadata`
   move to the bounded-window/flush contract via the injectable scheduler; relates

--- a/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Workspace manifest persistence does not block the main thread
+The macOS shell SHALL perform workspace manifest JSON encoding and disk writes
+off the main thread, and SHALL NOT perform a synchronous main-thread manifest
+disk write on the terminal metadata or runtime callback path.
+
+#### Scenario: High-output terminal does not stall the UI
+- **WHEN** one or more terminals produce sustained high-frequency output
+- **THEN** alan does not perform a synchronous main-thread manifest disk write on the terminal metadata or runtime callback path
+
+#### Scenario: Encode and write run off the main thread
+- **WHEN** alan persists the workspace manifest
+- **THEN** the JSON encode and atomic file write run on a background executor rather than blocking the main actor
+
+### Requirement: Workspace persistence cadence is separated by durability class
+The macOS shell SHALL persist workspace state on cadences matched to each class
+of state rather than rewriting the whole manifest on every runtime event:
+- **Structural state** (Spaces, Tabs, order, pin state, pin snapshots, selected
+  Space/Tab) SHALL be persisted when its mutation is accepted.
+- **Restore content** (per-Tab terminal transcript snapshots) SHALL be persisted
+  on a bounded debounced cadence and SHALL be force-flushed on app
+  background/resign-active and on quit.
+- A change to transient runtime state (such as a Tab's active-task state) SHALL
+  NOT by itself trigger a manifest write.
+
+#### Scenario: Structural mutation persists promptly
+- **WHEN** the user creates, closes, reorders, pins, unpins, or moves a Tab or Space
+- **THEN** alan persists the structural change for that mutation
+
+#### Scenario: Active-task change is not a write trigger
+- **WHEN** a Tab's terminal-aware active-task state changes
+- **THEN** alan does not write the workspace manifest solely because of that change
+
+#### Scenario: Transcript is flushed on background and quit
+- **WHEN** Alan for macOS resigns active, is backgrounded, or is asked to quit
+- **THEN** alan force-flushes pending transcript snapshots to disk before completing the transition
+
+#### Scenario: Recent transcript persists within the bounded window
+- **WHEN** a terminal's transcript changes and the app keeps running
+- **THEN** alan persists the latest transcript snapshot within the configured debounce window
+- **AND** a hard crash may lose at most that window of the most recent scrollback

--- a/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
@@ -1,14 +1,15 @@
 ## ADDED Requirements
 
 ### Requirement: Shell persistence does not block the main thread
-The macOS shell SHALL perform JSON encoding and atomic disk writes for both the
-workspace manifest and the control-plane shell-state snapshot file off the main
-thread, and SHALL NOT perform a synchronous main-thread disk write for either on
-the terminal metadata or runtime callback path.
+The macOS shell SHALL perform JSON encoding and atomic disk writes for every
+state file it persists on the terminal callback path — the workspace manifest,
+the shell-state snapshot, and the control-plane `state.json` mirror — off the
+main thread, and SHALL NOT perform a synchronous main-thread disk write for any of
+them on the terminal metadata or runtime callback path.
 
 #### Scenario: High-output terminal does not stall the UI
 - **WHEN** one or more terminals produce sustained high-frequency output
-- **THEN** alan does not perform a synchronous main-thread disk write of the workspace manifest or the control-plane shell-state file on the terminal metadata or runtime callback path
+- **THEN** alan does not perform a synchronous main-thread disk write of the workspace manifest, the shell-state snapshot, or the control-plane state file on the terminal metadata or runtime callback path
 
 #### Scenario: Encode and write run off the main thread
 - **WHEN** alan persists the workspace manifest or the control-plane shell-state file

--- a/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
@@ -1,28 +1,34 @@
 ## ADDED Requirements
 
-### Requirement: Workspace manifest persistence does not block the main thread
-The macOS shell SHALL perform workspace manifest JSON encoding and disk writes
-off the main thread, and SHALL NOT perform a synchronous main-thread manifest
-disk write on the terminal metadata or runtime callback path.
+### Requirement: Shell persistence does not block the main thread
+The macOS shell SHALL perform JSON encoding and atomic disk writes for both the
+workspace manifest and the control-plane shell-state snapshot file off the main
+thread, and SHALL NOT perform a synchronous main-thread disk write for either on
+the terminal metadata or runtime callback path.
 
 #### Scenario: High-output terminal does not stall the UI
 - **WHEN** one or more terminals produce sustained high-frequency output
-- **THEN** alan does not perform a synchronous main-thread manifest disk write on the terminal metadata or runtime callback path
+- **THEN** alan does not perform a synchronous main-thread disk write of the workspace manifest or the control-plane shell-state file on the terminal metadata or runtime callback path
 
 #### Scenario: Encode and write run off the main thread
-- **WHEN** alan persists the workspace manifest
+- **WHEN** alan persists the workspace manifest or the control-plane shell-state file
 - **THEN** the JSON encode and atomic file write run on a background executor rather than blocking the main actor
+
+#### Scenario: Control-plane in-memory publication stays prompt
+- **WHEN** shell state changes on the terminal callback path
+- **THEN** alan publishes the in-memory control-plane state promptly without waiting on a disk write
 
 ### Requirement: Workspace persistence cadence is separated by durability class
 The macOS shell SHALL persist workspace state on cadences matched to each class
-of state rather than rewriting the whole manifest on every runtime event:
+of state rather than rewriting and disk-writing every file on every runtime event:
 - **Structural state** (Spaces, Tabs, order, pin state, pin snapshots, selected
   Space/Tab) SHALL be persisted when its mutation is accepted.
-- **Restore content** (per-Tab terminal transcript snapshots) SHALL be persisted
-  on a bounded debounced cadence and SHALL be force-flushed on app
-  background/resign-active and on quit.
+- **Restore content and runtime snapshot** (per-Tab terminal transcript snapshots
+  in the manifest, and the control-plane shell-state file) driven by terminal
+  callbacks SHALL be persisted on a bounded debounced cadence and SHALL be
+  force-flushed on app background/resign-active and on quit.
 - A change to transient runtime state (such as a Tab's active-task state) SHALL
-  NOT by itself trigger a manifest write.
+  NOT by itself trigger a synchronous disk write.
 
 #### Scenario: Structural mutation persists promptly
 - **WHEN** the user creates, closes, reorders, pins, unpins, or moves a Tab or Space

--- a/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/specs/macos-shell-workspace-persistence/spec.md
@@ -1,11 +1,11 @@
 ## ADDED Requirements
 
 ### Requirement: Shell persistence does not block the main thread
-The macOS shell SHALL perform JSON encoding and atomic disk writes for every
-state file it persists on the terminal callback path — the workspace manifest,
-the shell-state snapshot, and the control-plane `state.json` mirror — off the
-main thread, and SHALL NOT perform a synchronous main-thread disk write for any of
-them on the terminal metadata or runtime callback path.
+The macOS shell SHALL NOT perform any synchronous main-thread disk write on the
+terminal metadata or runtime callback path. Every state file it persists on that
+path — the workspace manifest, the shell-state snapshot, the control-plane
+`state.json` mirror, and the control-plane change-event log — SHALL have its
+encode + write deferred to a debounced flush and/or run off the main thread.
 
 #### Scenario: High-output terminal does not stall the UI
 - **WHEN** one or more terminals produce sustained high-frequency output

--- a/openspec/changes/redesign-macos-workspace-persistence/tasks.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/tasks.md
@@ -1,28 +1,28 @@
-## 1. Off-main serial writer
+## 1. Off-main serial persistence writer
 
-- [ ] 1.1 Confirm `ShellContentWorkspaceManifest` (and nested records) are `Sendable`; address any non-Sendable nested type.
-- [ ] 1.2 Add a serial background `DispatchQueue` writer behind `ShellWorkspaceManifestStore`: encode + `Data.write(atomic:)` off the main thread, preserving corrupt-file quarantine behavior.
-- [ ] 1.3 Provide a synchronous-write entry (for structural mutations) and an async-write entry (for content), both serialized on the one queue.
-- [ ] 1.4 Add a focused test proving the terminal metadata/runtime callback path performs no synchronous main-thread disk write.
+- [x] 1.1 Confirm `ShellContentWorkspaceManifest` and `ShellStateSnapshot` (and nested records) are `Sendable`; address any non-Sendable nested type.
+- [x] 1.2 Add one persistence-writer seam covering both files (workspace manifest + control-plane shell-state file): encode + `Data.write(atomic:)` on a serial background queue, preserving corrupt-file quarantine behavior.
+- [x] 1.3 Provide synchronous-write entries (structural mutations) and async-write entries (debounced content), both serialized on the one queue.
+- [x] 1.4 Add a focused test proving the terminal metadata/runtime callback path performs no synchronous main-thread disk write of either file.
 
-## 2. Cadence split + debounced content flush
+## 2. Split publishControlPlaneState + debounced flush
 
-- [ ] 2.1 Add an injectable scheduler/clock so the debounce + flush are deterministically testable (no wall-clock waits).
-- [ ] 2.2 Mark restore content dirty on transcript change; schedule a single debounced flush that rebuilds the manifest on the main actor and dispatches the write to the background queue.
-- [ ] 2.3 Keep structural mutations (create/close/reorder/pin/move/selection) persisting synchronously through the synchronous-write entry.
-- [ ] 2.4 Remove the `activeTaskChanged → syncWorkspaceManifestFromShellState` write trigger on the hot path (do NOT change the `activeTask` field/model).
-- [ ] 2.5 Tests: a burst of content changes coalesces into one write; a structural mutation writes synchronously; an active-task change alone triggers no write.
+- [x] 2.1 Add an injectable scheduler/clock so the debounce + flush are deterministically testable (no wall-clock waits).
+- [x] 2.2 Split `publishControlPlaneState` into a prompt in-memory publish (always synchronous) and disk persistence (debounced off-main on the hot path, synchronous on structural mutations).
+- [x] 2.3 Route `updatePaneState`'s publish through the debounced (coalesced) path; keep all other (structural/lifecycle) callers synchronous.
+- [x] 2.4 Debounced flush rebuilds manifest + shell-state on the main actor and dispatches both writes to the background queue; remove the `activeTaskChanged → sync write` trigger (do NOT change the `activeTask` field/model).
+- [x] 2.5 Tests: a burst of terminal callbacks coalesces into one write of each file; a structural mutation writes synchronously; an active-task-only change triggers no synchronous write.
 
 ## 3. Lifecycle flush
 
-- [ ] 3.1 Force a synchronous content flush on `resignActive`/background and on app termination so a clean exit never loses pending transcript.
-- [ ] 3.2 Test the background/quit flush path persists the latest transcript snapshot.
+- [x] 3.1 Force a synchronous content flush on `resignActive`/background and on app termination so a clean exit never loses pending transcript.
+- [x] 3.2 Test the background/quit flush path persists the latest transcript snapshot.
 
 ## 4. Durability contract + test migration
 
-- [ ] 4.1 Migrate the durability tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` that assert synchronous manifest content after `updateTerminalMetadata` to the new bounded-window/flush contract using the injectable scheduler.
-- [ ] 4.2 Run `just apple-shell-focused-tests` and confirm green.
-- [ ] 4.3 Build and run `clients/apple/scripts/capture-performance-diagnostics-workload.sh`; confirm the main-thread manifest write is gone and `terminalMetadataCallback` tail latency (max) drops materially.
+- [x] 4.1 Migrate the durability tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` that assert synchronous manifest content after `updateTerminalMetadata` to the new bounded-window/flush contract using the injectable scheduler.
+- [x] 4.2 Run `just apple-shell-focused-tests` and confirm green.
+- [x] 4.3 Build and run `clients/apple/scripts/capture-performance-diagnostics-workload.sh`; confirm the main-thread manifest write is gone and `terminalMetadataCallback` tail latency (max) drops materially.
 
 ## 5. Spec sync and archive
 

--- a/openspec/changes/redesign-macos-workspace-persistence/tasks.md
+++ b/openspec/changes/redesign-macos-workspace-persistence/tasks.md
@@ -1,0 +1,30 @@
+## 1. Off-main serial writer
+
+- [ ] 1.1 Confirm `ShellContentWorkspaceManifest` (and nested records) are `Sendable`; address any non-Sendable nested type.
+- [ ] 1.2 Add a serial background `DispatchQueue` writer behind `ShellWorkspaceManifestStore`: encode + `Data.write(atomic:)` off the main thread, preserving corrupt-file quarantine behavior.
+- [ ] 1.3 Provide a synchronous-write entry (for structural mutations) and an async-write entry (for content), both serialized on the one queue.
+- [ ] 1.4 Add a focused test proving the terminal metadata/runtime callback path performs no synchronous main-thread disk write.
+
+## 2. Cadence split + debounced content flush
+
+- [ ] 2.1 Add an injectable scheduler/clock so the debounce + flush are deterministically testable (no wall-clock waits).
+- [ ] 2.2 Mark restore content dirty on transcript change; schedule a single debounced flush that rebuilds the manifest on the main actor and dispatches the write to the background queue.
+- [ ] 2.3 Keep structural mutations (create/close/reorder/pin/move/selection) persisting synchronously through the synchronous-write entry.
+- [ ] 2.4 Remove the `activeTaskChanged → syncWorkspaceManifestFromShellState` write trigger on the hot path (do NOT change the `activeTask` field/model).
+- [ ] 2.5 Tests: a burst of content changes coalesces into one write; a structural mutation writes synchronously; an active-task change alone triggers no write.
+
+## 3. Lifecycle flush
+
+- [ ] 3.1 Force a synchronous content flush on `resignActive`/background and on app termination so a clean exit never loses pending transcript.
+- [ ] 3.2 Test the background/quit flush path persists the latest transcript snapshot.
+
+## 4. Durability contract + test migration
+
+- [ ] 4.1 Migrate the durability tests in `clients/apple/scripts/test-shell-runtime-metadata.swift` that assert synchronous manifest content after `updateTerminalMetadata` to the new bounded-window/flush contract using the injectable scheduler.
+- [ ] 4.2 Run `just apple-shell-focused-tests` and confirm green.
+- [ ] 4.3 Build and run `clients/apple/scripts/capture-performance-diagnostics-workload.sh`; confirm the main-thread manifest write is gone and `terminalMetadataCallback` tail latency (max) drops materially.
+
+## 5. Spec sync and archive
+
+- [ ] 5.1 After implementation and verification, sync the accepted delta into `openspec/specs/macos-shell-workspace-persistence/spec.md` (IO requirements only; do not touch the semantics requirements owned by introduce-cross-platform-shell-core).
+- [ ] 5.2 Archive the change only after implementation is merged and the long-lived spec is updated.


### PR DESCRIPTION
## Why

Investigating reported macOS shell sluggishness under multiple high-output Codex
sessions. Diagnostics showed the stutter was main-thread **tail latency**:
`terminalMetadataCallback` ran avg 10.8ms but **max 24.9ms** in real usage — a
single callback past the 16.7ms frame budget drops a frame. Root cause was two
classes of avoidable main-thread work on the hot terminal callback path:

1. **Uncached boot-profile resolution** — `AlanShellBootProfile.forPane` did
   uncached filesystem work (Ghostty discovery stat-storm, terminal-profile
   document read+decode, command resolution) on every metadata/runtime callback.
2. **Synchronous atomic disk writes** — `publishControlPlaneState` wrote *two*
   files synchronously on the main thread per pane-state change (the workspace
   manifest and the control-plane shell-state file), triggered by `activeTask`
   changes and pane-state publications.

## What changed

**`perf(macos): cache terminal boot profile and dedupe runtime publishes`**
- `AlanShellBootProfileCache`: memoizes the boot profile per pane keyed on
  launch-relevant inputs, **excluding cwd** (the expensive resolution is
  cwd-independent) and overlaying the working directory cheaply so `cd` never
  re-hits disk. All `forPane` call sites route through it.
- Guards the selected-pane `terminalRuntime` `@Published` assignment with
  `equalsIgnoringTimestamp`, so a per-refresh snapshot that differs only in its
  publish timestamp no longer invalidates the whole observing view tree.

**`feat(macos): move shell persistence off the main thread`**
- `ShellPersistenceWriting` seam (manifest + shell-state file) backed by a serial
  background queue, with synchronous (structural) and async (debounced) entries.
- Splits `publishControlPlaneState`: the in-memory control-plane publish stays
  prompt; the two disk writes are debounced off-main on the hot path
  (`updatePaneState`) and synchronous on structural mutations.
- Injectable debounce scheduler; a burst of terminal callbacks coalesces into one
  off-main write of each file. `activeTask` changes no longer trigger a sync write
  (the field/model is unchanged).
- `flushWorkspacePersistence()` wired to app resign-active and quit so a clean
  exit never loses pending transcript.

**OpenSpec**
- New change `redesign-macos-workspace-persistence` (proposal + design + spec
  delta + tasks) documenting the persistence-IO redesign. Scoped to the platform
  IO layer so it composes cleanly with `introduce-cross-platform-shell-core`
  (which owns the portable manifest semantics and leaves file IO in the platform
  layer).

## Results

Same Debug build + synthetic multi-pane workload (A/B):

| metric | baseline | this PR |
|---|---|---|
| `terminalMetadataCallback` avg | 8.55ms | **3.69ms** |
| total main-thread handler time | ~105 ms/s | **53 ms/s** |
| sync main-thread disk write on callback path | yes | **none** |

## Notes for reviewers

- The durability contract for terminal transcripts changes from "synchronous
  after each callback" to "bounded debounce window + forced flush on
  background/quit"; a hard crash may lose up to the debounce window of the most
  recent scrollback (structure and pin snapshots remain synchronously durable).
  The affected durability tests were migrated to this contract.
- Test controllers default to **synchronous** persistence; the off-main/debounced
  contract is verified explicitly by tests that inject a spy writer + manual
  scheduler.
- Absolute numbers above are from a Debug build; the remaining ~3.7ms is in-memory
  projection / manifest build (Debug-inflated), no longer disk. A real-Release
  re-measurement is the recommended next confirmation.
- Verification: focused shell suite green (`just apple-shell-focused-tests`);
  full app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)