### PR TITLE
[codex] Add agent workflow docs

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,45 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the
+codebase.
+
+## Before exploring, read these
+
+- `CONTEXT.md` at the repo root if it exists.
+- `docs/adr/` if it exists, reading ADRs that touch the area about to be changed.
+- `openspec/specs/` for Alan's long-lived contracts and accepted behavior.
+- `openspec/changes/` for active proposals, task lists, and spec deltas related to the current
+  work.
+
+If any of these files or directories do not exist, proceed silently. Do not flag their absence or
+suggest creating them upfront. The domain-modeling workflows create domain docs lazily when terms
+or decisions actually get resolved.
+
+## File structure
+
+This repo uses a single-context layout:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+└── openspec/
+    ├── specs/
+    └── changes/
+```
+
+Do not assume a `CONTEXT-MAP.md` multi-context layout unless that file is introduced later.
+
+## Use the glossary's vocabulary
+
+When output names a domain concept in an issue title, refactor proposal, hypothesis, or test name,
+use the term as defined in `CONTEXT.md` when that file exists. Do not drift to synonyms the glossary
+explicitly avoids.
+
+If the concept needed is not in the glossary yet, either reconsider whether the project already uses
+different language or note the gap for domain modeling.
+
+## Flag decision conflicts
+
+If output contradicts an existing ADR or OpenSpec contract, surface it explicitly instead of silently
+overriding the prior decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,23 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `realmorrisliu/Alan`.
+Use the `gh` CLI for all issue operations from inside this checkout.
+
+## Conventions
+
+- Create an issue: `gh issue create --title "..." --body "..."`
+- Read an issue: `gh issue view <number> --comments`
+- List issues: `gh issue list --state open --json number,title,body,labels,comments`
+- Comment on an issue: `gh issue comment <number> --body "..."`
+- Apply or remove labels: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- Close an issue: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside the clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,18 +1,17 @@
 # Issue Tracker: GitHub
 
 Issues and PRDs for this repo live in GitHub Issues for `realmorrisliu/Alan`.
-Use the `gh` CLI for all issue operations from inside this checkout.
+Use the `gh` CLI with `--repo realmorrisliu/Alan` for all issue operations.
 
 ## Conventions
 
-- Create an issue: `gh issue create --title "..." --body "..."`
-- Read an issue: `gh issue view <number> --comments`
-- List issues: `gh issue list --state open --json number,title,body,labels,comments`
-- Comment on an issue: `gh issue comment <number> --body "..."`
-- Apply or remove labels: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- Close an issue: `gh issue close <number> --comment "..."`
-
-Infer the repo from `git remote -v`; `gh` does this automatically when run inside the clone.
+- Create an issue: `gh issue create --repo realmorrisliu/Alan --title "..." --body "..."`
+- Read an issue: `gh issue view <number> --repo realmorrisliu/Alan --comments`
+- List issues: `gh issue list --repo realmorrisliu/Alan --state open --json number,title,body,labels,comments`
+- Comment on an issue: `gh issue comment <number> --repo realmorrisliu/Alan --body "..."`
+- Apply a label: `gh issue edit <number> --repo realmorrisliu/Alan --add-label "..."`
+- Remove a label: `gh issue edit <number> --repo realmorrisliu/Alan --remove-label "..."`
+- Close an issue: `gh issue close <number> --repo realmorrisliu/Alan --comment "..."`
 
 ## When a skill says "publish to the issue tracker"
 
@@ -20,4 +19,4 @@ Create a GitHub issue.
 
 ## When a skill says "fetch the relevant ticket"
 
-Run `gh issue view <number> --comments`.
+Run `gh issue view <number> --repo realmorrisliu/Alan --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,16 @@
+# Triage Labels
+
+The skills use five canonical triage roles. This repo uses those exact label strings with no
+aliases or remapping.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+Do not map these roles to legacy or adjacent labels such as `question`.
+If an older triage-equivalent label exists, migrate affected issues to the canonical label and
+remove the old label.


### PR DESCRIPTION
## Summary

- add the `docs/agents` files referenced by `AGENTS.md`
- document the GitHub issue tracker, canonical triage labels, and domain-doc lookup rules

## Validation

- `git diff --check --cached`