### PR TITLE
[codex] Align programmable environment foundation specs

### DIFF
--- a/openspec/changes/add-macos-shell-component-system/design.md
+++ b/openspec/changes/add-macos-shell-component-system/design.md
@@ -37,6 +37,27 @@ visual/interaction rules (materials, space slider, collapsed sidebar). The new
 token single-source, the primitive catalog, style/structure separation, the preview
 gallery + accessibility baseline, and the migration discipline.
 
+## Programmable Environment Alignment
+
+`add-macos-shell-component-system` is a **host-surface/design-system** change under
+the programmable environment direction, not an environment-core or app-domain change.
+Its responsibility is to make the macOS host surface capable of rendering future
+environment views with native SwiftUI primitives that are reusable, accessible,
+previewable, and token-governed.
+
+- **Environment role:** host surface / macOS design-system capability.
+- **Runtime mapping:** none at the environment core layer. These primitives may render
+  environment views and buffers later, but they do not define object, command, buffer,
+  view, query, ledger, or agent semantics.
+- **Native authority:** SwiftUI component files, semantic design tokens, preview
+  galleries, accessibility behavior, and the design-token guard.
+- **Host boundary:** layout, chrome, native controls, input presentation, selection
+  affordances, and visual migration discipline. The host composes environment state; it
+  is not the source of truth for that state.
+- **Deferred migration:** terminal-host AppKit internals, Rust workbench/runtime
+  capability, environment apps, and the current shell runtime remain outside this
+  change.
+
 ## Goals / Non-Goals
 
 **Goals:**

--- a/openspec/changes/add-macos-shell-component-system/proposal.md
+++ b/openspec/changes/add-macos-shell-component-system/proposal.md
@@ -51,6 +51,15 @@ existing raw-literal guard into CI — so duplication grows unchecked.
   existing canonical `ShellButtonPressStyle` / `ShellTextField` rather than ad-hoc
   styles.
 
+## Programmable Environment Alignment
+
+This change is a **host-surface/design-system** capability in the programmable
+environment model. It owns the macOS SwiftUI presentation primitives, token usage,
+accessibility baseline, previews, and visual migration discipline that future
+environment surfaces can compose. It does **not** define environment core semantics:
+objects, commands, buffers, views, queries, ledgers, agent policy, or app domain truth
+remain owned by the programmable environment/runtime and by each environment app.
+
 Scope is the primary macOS **shell** SwiftUI presentation layer only. Ghostty/AppKit
 terminal-host internals (`TerminalHostView`, terminal surface input/attachment) and
 the legacy/mobile remote-control console (`Views/Console/`) are explicitly out of

--- a/openspec/changes/add-macos-shell-component-system/specs/macos-shell-component-system/spec.md
+++ b/openspec/changes/add-macos-shell-component-system/specs/macos-shell-component-system/spec.md
@@ -1,5 +1,33 @@
 ## ADDED Requirements
 
+### Requirement: Component system is a macOS host-surface capability
+
+The macOS shell component system SHALL be treated as a host-surface/design-system
+capability in the programmable environment model. It SHALL own reusable SwiftUI
+presentation primitives, semantic token consumption, accessibility behavior, preview
+coverage, and visual migration discipline for macOS environment surfaces. It SHALL NOT
+define or store environment core semantics such as objects, commands, buffers, views,
+queries, ledgers, agent policy, or app domain truth.
+
+#### Scenario: The component system role is inspected
+
+- **WHEN** a developer evaluates where shell component-system behavior belongs in the
+  programmable environment architecture
+- **THEN** this capability is classified as the macOS host-surface/design-system layer
+- **AND** its owned concerns are SwiftUI presentation primitives, token usage,
+  accessibility behavior, preview coverage, and visual migration discipline
+- **AND** environment core semantics remain owned by the programmable
+  environment/runtime or by environment apps, not by the component layer
+
+#### Scenario: A future environment view renders on macOS
+
+- **WHEN** a programmable environment view, buffer, or app surface is rendered through
+  the macOS host
+- **THEN** the host may compose the reusable SwiftUI primitives defined by this
+  capability
+- **AND** the component layer does not become the source of truth for object, command,
+  buffer, view, query, ledger, or app-domain state
+
 ### Requirement: Presentational primitives live in a single design-system home
 
 The macOS SwiftUI client SHALL keep reusable presentational primitives — surfaces,

--- a/openspec/changes/add-macos-shell-component-system/tasks.md
+++ b/openspec/changes/add-macos-shell-component-system/tasks.md
@@ -1,3 +1,7 @@
+## 0. Programmable Environment Alignment
+
+- [x] 0.1 Record the macOS shell component system as a host-surface/design-system capability that may render programmable environment views later, while leaving object, command, buffer, view, query, ledger, agent-policy, and app-domain semantics outside the component layer
+
 ## 1. Establish the design-system home
 
 - [ ] 1.1 Create `clients/apple/alan-macos/Views/Shell/Components/` and add it to the Xcode project group

--- a/openspec/changes/define-groove-master-environment-app/design.md
+++ b/openspec/changes/define-groove-master-environment-app/design.md
@@ -24,6 +24,33 @@ Master owns the music-practice logic and user experience. The first design
 therefore defines Groove Master as a serious environment app, while keeping the
 first implementation slice small enough to become a daily-use tool.
 
+## Programmable Environment Alignment
+
+`define-groove-master-environment-app` is an **environment app** change. It is not a
+host-surface design-system change and not an Alan runtime-platform change. The product
+should be able to run inside Alan's programmable environment while preserving a
+portable domain core that can later support iOS/iPadOS capture or another host.
+
+- **Environment role:** environment app.
+- **Domain core:** practice phases, plan generation, practice blocks, inspiration
+  cards, loop metadata, session lifecycle, recording references, markers, reflections,
+  pocket-tracker signals, journal schema, and producer-note records.
+- **Runtime mapping:** `PracticePlan`, `GrooveSession`, `RecordingTake`, `Marker`,
+  `Clip`, `GrooveEntry`, `DrumLoop`, `Reflection`, and `ProducerNote` map to
+  environment objects; session, playback, marker, import, reflection, and plan
+  generation actions map to commands; active session, recording review, Groove Journal,
+  Groove Stream, and Loop Library map to buffers/views; recent marked moments, sessions
+  by phase, loops by style, and entries needing reflection map to queries.
+- **Native authority:** local Groove Master journal/audio/domain store. The current
+  macOS shell and future host surfaces render and command domain state; they do not own
+  it.
+- **Adapter boundary:** the Alan adapter translates domain state into environment
+  objects, commands, buffers, views, queries, local-first persistence, and producer
+  agent participation without pushing Alan shell internals into the domain core.
+- **Deferred migration:** implementation waits for the programmable environment
+  substrate; this proposal stays adapter-shaped so the first macOS surface can mount
+  Groove Master without making the shell the product model.
+
 ## Goals / Non-Goals
 
 **Goals:**

--- a/openspec/changes/define-groove-master-environment-app/proposal.md
+++ b/openspec/changes/define-groove-master-environment-app/proposal.md
@@ -39,6 +39,16 @@ reflect, and save the session into a Groove Journal.
 - Decompose follow-up implementation slices instead of building the full
   product in one change.
 
+## Programmable Environment Alignment
+
+Groove Master is an **environment app** in the programmable environment model. Its
+domain core owns music-practice truth: phases, plans, practice blocks, loop metadata,
+recording references, markers, reflections, pocket-tracker signals, journal entries,
+and producer notes. Alan integration is an adapter that exposes that domain through
+environment objects, commands, buffers, views, queries, local-first persistence, and
+agent participation. The macOS surface is the first host, not the domain authority,
+and the current Alan shell must not leak into the portable Groove Master core.
+
 ## Capabilities
 
 ### New Capabilities

--- a/openspec/changes/define-groove-master-environment-app/specs/groove-master-environment-app/spec.md
+++ b/openspec/changes/define-groove-master-environment-app/specs/groove-master-environment-app/spec.md
@@ -19,6 +19,28 @@ purpose SHALL be daily bass practice rather than proving Alan.
 - **AND** Groove Master domain logic remains separate from current macOS shell
   implementation details
 
+### Requirement: Groove Master Uses Environment App Boundaries
+Groove Master SHALL be classified as an environment app with separate domain core,
+audio runtime, Alan environment adapter, and host-surface boundaries. The domain core
+SHALL own music-practice truth; the Alan adapter SHALL expose that truth through
+programmable environment abstractions; host surfaces SHALL render and command the
+domain through the adapter rather than becoming the source of truth.
+
+#### Scenario: Environment app architecture is proposed
+- **WHEN** a future implementation change proposes Groove Master architecture
+- **THEN** it identifies the domain core for practice phases, plan generation,
+  practice blocks, loop metadata, session lifecycle, recordings, markers, reflections,
+  pocket-tracker signals, journal entries, and producer-note records
+- **AND** it identifies the Alan environment adapter for objects, commands, buffers,
+  views, queries, local-first persistence, and producer-agent participation
+- **AND** it identifies the audio runtime and first host surface as separate boundaries
+
+#### Scenario: Host surface renders Groove Master
+- **WHEN** Groove Master is mounted in a macOS or future environment host surface
+- **THEN** the host renders views and invokes commands through the Alan adapter
+- **AND** the host does not own Groove Master domain state, journal records, audio
+  references, plan generation, or producer-note truth
+
 ### Requirement: V1 Provides A Complete Daily Practice Loop
 V1 Groove Master SHALL support one complete daily loop from plan to recorded
 journal entry.

--- a/openspec/changes/define-groove-master-environment-app/tasks.md
+++ b/openspec/changes/define-groove-master-environment-app/tasks.md
@@ -1,3 +1,7 @@
+## 0. Programmable Environment Alignment
+
+- [x] 0.1 Record Groove Master as an environment app with a portable domain core, separate audio runtime, Alan environment adapter, and host-surface boundary; keep current Alan shell internals out of the domain model
+
 ## 1. Product Boundary
 
 - [ ] 1.1 Define Groove Master as a real bass practice app inside the future

--- a/openspec/changes/define-programmable-environment-product/design.md
+++ b/openspec/changes/define-programmable-environment-product/design.md
@@ -1,27 +1,38 @@
 ## Context
 
-This change defines a product constitution for a new product line inside the
-alan repo. The product is a programmable personal computing environment:
-local-first, UNIX-respecting, object-oriented, command-driven, extensible, and
-agent-native.
+This change defines the product constitution for the alan repo. The long-term
+product model is a programmable personal computing environment: local-first,
+UNIX-respecting, object-oriented, command-driven, extensible, and agent-native.
+
+This is larger than adding a new product beside Alan. Alan agent, Alan for
+macOS, future environment apps such as Groove Master, host surfaces, runtime
+substrates, and adapters should all be able to describe their role in this
+environment. The constitution is therefore a repo-level organizing model, not a
+current implementation boundary.
 
 The current Alan product already has useful ideas around agents, terminal-first
-work, permissions, session state, and OpenSpec-driven planning. Those are
-references, not constraints. This product line should not be forced into the
-current macOS shell, daemon, or terminal-only surface.
+work, permissions, session state, shell workspaces, content instances, and
+OpenSpec-driven planning. Those are real assets, but they are not allowed to
+define the whole environment by accident. The programmable environment should
+not be forced into the current macOS shell, daemon, Rust TUI, or terminal-only
+surface. Conversely, existing Alan work should not be treated as unrelated to
+the environment direction. It should be classified and aligned deliberately.
 
 The key product boundary is that data ownership and activity organization are
 separate. Data may remain in files, directories, Git repositories, external
 services, databases, or OS resources. The environment organizes activity around
-runtime objects, commands, buffers, views, queries, humans, agents, and
-extensions.
+runtime objects, commands, buffers, views, queries, humans, agents, extensions,
+and host surfaces.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Define the product identity before implementation begins.
-- Treat the product as an independent product line within the repo.
+- Define the repo-level product identity before implementation expands.
+- Treat the programmable environment as the long-term organizing model for Alan
+  agent, Alan for macOS, environment apps, hosts, adapters, and future products.
+- Preserve the product boundary from being collapsed into the current macOS
+  shell, TUI, daemon, or agent session protocol.
 - Establish local-first, filesystem-first, UNIX-like composition as a core
   principle.
 - Define object, command, buffer, view, and query as the core runtime
@@ -30,44 +41,131 @@ extensions.
 - Require ordinary UI for out-of-the-box use and modal grammar for power use.
 - Make Rust core plus WASM Component Model extensibility part of the product
   identity.
+- Define how existing and future OpenSpec changes declare their environment
+  role and migration boundary.
 - Define incubation criteria without freezing the first interface or MVP.
 
 **Non-Goals:**
 
 - Specify a concrete implementation architecture, crate layout, UI, or storage
-  engine.
-- Merge this product into the current Alan macOS shell.
+  engine for the entire environment.
+- Replace current Alan runtime, daemon, Rust TUI, terminal, or macOS shell
+  behavior in this change.
+- Treat the current Alan shell as the mandatory implementation boundary for the
+  environment.
 - Require all data to be imported into a private object store.
 - Define a universal URI/resource protocol.
-- Replace current Alan runtime, daemon, or shell behavior.
-- Choose the first visual interface between editor-like, object workspace, or
-  agent workspace forms.
+- Rewrite every existing OpenSpec in this change.
+- Choose the first complete visual interface between editor-like environment,
+  object workspace, agent workspace, app launcher, or another form.
+
+## Product Family Model
+
+Future specs should classify themselves against this map:
+
+```text
+Programmable Environment Constitution
+  |
+  +-- Environment core
+  |     objects, commands, buffers, views, queries, ledgers,
+  |     permissions, extension capabilities
+  |
+  +-- Agent runtime / actors
+  |     Alan agent sessions, tools, child runs, plans, memory,
+  |     task execution, governed side effects
+  |
+  +-- Host surfaces
+  |     Alan for macOS, Rust TUI, future iOS/iPadOS/web hosts;
+  |     physical layout, native chrome, input, rendering, windowing
+  |
+  +-- Environment apps
+  |     Groove Master, UPDF-like workflows, future domain products;
+  |     app-owned domain models plus environment adapters
+  |
+  +-- Adapters
+  |     filesystem, Git, terminal, mail, calendar, databases,
+  |     remote services, model/provider systems
+  |
+  +-- Legacy / compatibility surfaces
+        current implementation paths that must stay stable while
+        they are adapted, retired, or reclassified
+```
+
+This model lets a spec be concrete without pretending to be the whole product.
+For example:
+
+- `introduce-workbench-runtime` is a candidate environment-core/runtime
+  substrate incubation slice.
+- Alan agent work is agent runtime/actor work and should project into objects,
+  commands, buffers, views, queries, tasks, artifacts, and evidence rather than
+  remaining only a chat/session UI.
+- Alan for macOS is a native host surface. Its Spaces, Tabs, PaneSlots,
+  ContentInstances, command menus, and design system are host responsibilities
+  that mount and render environment objects/buffers/views.
+- `add-macos-shell-component-system` is a macOS host surface/design-system
+  capability. It can make environment views coherent in the macOS host, but it
+  is not environment core.
+- Groove Master is an environment app. Its domain core owns musical practice
+  behavior while an Alan adapter maps sessions, loops, journals, and producer
+  agent behavior into environment abstractions.
 
 ## Decisions
 
 ### 1. Product constitution first
 
-The first OpenSpec should define what the product is, not how to implement it.
-The idea is broad enough that an implementation-oriented first change would
-collapse it into whichever subsystem is easiest to build first.
+The first OpenSpec should define what the product family is, not how to
+implement it. The idea is broad enough that an implementation-oriented first
+change would collapse it into whichever subsystem is easiest to build first.
 
 Alternative considered: write an architecture RFC for object graph, command
 registry, buffer/view, query, WASM, and agent actors. That is useful later, but
 too early for the first artifact because it would prematurely freeze technical
 interfaces.
 
-### 2. Independent product line inside the repo
+### 2. Repo-level organizing model, not a side product
 
-The product should live as a new product line in this repo while its identity is
-still being formed. It can reuse Alan engineering practices and later share
-runtime pieces where appropriate, but it is not a feature of the existing
-terminal shell.
+The programmable environment should become the repo's long-term product model.
+That does not mean every current Alan subsystem is immediately rewritten. It
+means every substantial future spec should know whether it is environment core,
+agent runtime, host surface, environment app, adapter, or legacy/compatibility
+work.
 
-Alternative considered: describe this as Alan's long-term evolution. That would
-make current Alan shell concerns too influential and would encourage forced
-integration before the product boundary is clear.
+Alternative considered: describe the programmable environment as an independent
+new product line next to Alan. That protected the idea from being swallowed by
+the current shell, but it was too weak: the intended direction is broader than a
+side product. It should organize Alan itself.
 
-### 3. Local-first and filesystem-first
+### 3. Current Alan is source material, not the product boundary
+
+Current Alan agent, daemon, macOS shell, Rust TUI, terminal runtime, and
+OpenSpec workflow are valid starting points. They should be mined for durable
+concepts and kept stable while migration happens. They should not force the
+environment to inherit their current boundaries, naming, or UI shape.
+
+For instance, a macOS `ContentInstance` is a host/content mounting concept. It
+may later mount an environment buffer or view, but it is not the universal
+environment object model. Similarly, an Alan agent session is an agent runtime
+authority that can project into environment tasks, buffers, and views; it is not
+the whole product model.
+
+### 4. Specs need environment alignment metadata
+
+Future specs, and selected active specs as they are touched, should include a
+short alignment statement:
+
+```text
+Environment role: core | agent-runtime | host-surface | environment-app |
+  adapter | legacy-compat
+Runtime mapping: objects / commands / buffers / views / queries / actors
+Native authority: which file, service, runtime, domain store, or host owns truth
+Host boundary: what is renderer/window/layout/input-specific
+Deferred migration: what stays compatibility-only for now
+```
+
+This prevents two common failures: host-specific specs accidentally defining the
+whole product, and product/app specs ignoring real host and runtime constraints.
+
+### 5. Local-first and filesystem-first
 
 The environment should respect UNIX philosophy: simple artifacts, inspectable
 state, ordinary files and directories where possible, composable commands, and
@@ -79,19 +177,19 @@ Alternative considered: define a unified resource addressing model from the
 start. That would be powerful, but it is too platform-shaped for the
 constitution and would obscure the simpler local-first boundary.
 
-### 4. Activity happens in the environment; data can stay where it is
+### 6. Activity happens in the environment; data can stay where it is
 
 The long-term goal is for users to do more of their daily work inside the
 environment. That does not require the environment to own all data. Files,
-projects, tasks, terminal sessions, notes, Git state, mail, calendar items, and
-remote records can be represented as objects while their source of truth remains
-elsewhere.
+projects, tasks, terminal sessions, notes, Git state, mail, calendar items,
+recordings, and remote records can be represented as objects while their source
+of truth remains elsewhere.
 
 Alternative considered: make the environment's private workspace the primary
 storage model. That may become useful for some object types, but it should not
 be the first product principle.
 
-### 5. Ordinary UI plus modal power layer
+### 7. Ordinary UI plus modal power layer
 
 Out-of-the-box use needs ordinary UI: users should be able to browse objects,
 open buffers, switch views, run commands, and ask agents without first learning
@@ -103,7 +201,7 @@ Alternative considered: make modal interaction the mandatory primary interface.
 That would protect the Vim-like model but conflict with the out-of-the-box
 principle.
 
-### 6. Agents are actors, not a chat plugin
+### 8. Agents are actors, not a chat plugin
 
 Agents should participate through the same runtime abstractions as humans. They
 can query, inspect, create buffers, propose changes, and execute commands, but
@@ -113,7 +211,18 @@ Alternative considered: make agents an overlay on the human UI. That would be
 easier to add to an existing interface, but it would miss the product premise:
 human and agent operate in one environment.
 
-### 7. WASM extensibility is part of the identity
+### 9. Environment apps are real products
+
+Domain products such as Groove Master should be treated as real apps inside the
+environment, not demos whose primary job is to prove Alan. Their domain cores
+own product logic. The environment adapter maps their objects, commands,
+buffers, views, queries, and agent behavior into the shared runtime.
+
+Alternative considered: build demo apps primarily to exercise platform
+features. That produces shallow examples and lets platform needs dominate the
+user-facing product.
+
+### 10. WASM extensibility is part of the identity
 
 The product should inherit the programmability spirit of Emacs without adopting
 Lisp as the embedded substrate. Rust core plus WASM Component Model and WIT
@@ -126,21 +235,26 @@ differentiator in the original idea.
 
 ## Risks / Trade-offs
 
-- [Risk] A product constitution can stay too abstract to guide work. →
-  Include incubation criteria that future MVP/spec work must satisfy.
-- [Risk] Filesystem-first can be mistaken for "only files". → State that
+- [Risk] A repo-level constitution can stay too abstract to guide work. ->
+  Include alignment metadata and incubation criteria that future specs must use.
+- [Risk] Existing Alan specs could be invalidated too broadly. -> Classify and
+  migrate specs incrementally; do not rewrite current behavior in this change.
+- [Risk] Host surfaces may accidentally define environment core. -> Require
+  host specs to name host-owned concerns such as layout, rendering, windowing,
+  input, and native chrome.
+- [Risk] Product apps can become platform demos. -> Require environment apps to
+  state their user-facing product boundary before their Alan adapter.
+- [Risk] Filesystem-first can be mistaken for "only files". -> State that
   external systems may be projected as objects, while filesystem remains the
   default substrate and inspection boundary.
-- [Risk] Independent product line can drift away from Alan's engineering
-  strengths. → Allow reuse of Alan concepts where they fit, but do not force
-  current shell integration.
-- [Risk] Modal grammar can create onboarding friction. → Require ordinary UI to
-  be sufficient for first-use workflows.
-- [Risk] WASM as identity can overconstrain the first implementation. → Keep
+- [Risk] Modal grammar can create onboarding friction. -> Require ordinary UI
+  to be sufficient for first-use workflows.
+- [Risk] WASM as identity can overconstrain the first implementation. -> Keep
   the constitution at the principle level; detailed WIT interfaces belong in
   later architecture changes.
-- [Risk] Agent-native can be misread as an AI chat app. → Require agents to act
-  through object, command, buffer, view, query, permission, and audit surfaces.
+- [Risk] Agent-native can be misread as an AI chat app. -> Require agents to
+  act through object, command, buffer, view, query, permission, and audit
+  surfaces.
 
 ## Incubation Path
 
@@ -149,19 +263,36 @@ complete environment. A future incubation or MVP change should prove:
 
 1. A first launch can reveal and organize real local work from the filesystem or
    an existing project/workspace.
-2. One real personal workflow can move through file/project/task/terminal
-   objects, buffers, views, commands, queries, and agent help.
+2. One real personal workflow can move through file/project/task/terminal or
+   app-domain objects, buffers, views, commands, queries, and agent help.
 3. Ordinary UI and modal grammar execute the same command surface.
 4. Agent actions are mediated by runtime abstractions and leave inspectable
    results.
 5. Extension boundaries are capability-shaped from the start, even if the first
    prototype only exposes a small subset.
+6. Host surfaces can render the workflow without owning the product runtime.
+7. Existing Alan subsystems used by the slice are classified as core, agent,
+   host, app, adapter, or compatibility boundaries.
+
+Candidate sequencing:
+
+1. Accept this constitution as the long-lived spec baseline.
+2. Add alignment notes to active specs that are likely to shape the
+   environment, starting with `introduce-workbench-runtime`,
+   `add-macos-shell-component-system`, `define-groove-master-environment-app`,
+   and future UPDF-style product specs.
+3. Implement the workbench runtime as a small environment-core substrate slice,
+   not as the full product.
+4. Prove one end-to-end workflow through a real host and a real product or
+   workspace surface.
 
 ## Open Questions
 
 - What is the product name?
+- Which existing active specs should be aligned before the constitution is
+  archived, and which should wait until touched?
 - What is the first concrete interface: editor-like environment, object
-  workspace, agent workspace, or another form?
+  workspace, agent workspace, app workspace, or another form?
 - Which local-first object types are mandatory for the first prototype?
 - Which commands prove the shared command model without overbuilding the
   registry?

--- a/openspec/changes/define-programmable-environment-product/proposal.md
+++ b/openspec/changes/define-programmable-environment-product/proposal.md
@@ -1,18 +1,30 @@
 ## Why
 
-alan needs a clear product-level contract for a new, independent product line:
-a programmable personal computing environment for humans and agents. The idea is
-large enough that it should be protected as a product constitution before it is
-reduced into a macOS shell feature, editor feature, AI IDE, or implementation
-plan.
+alan needs a repo-level product constitution: a programmable personal
+computing environment for humans and agents. This should become the organizing
+model for Alan agent, Alan for macOS, environment apps such as Groove Master,
+and future products in this repository.
+
+The idea is broad enough that it should be protected before it is reduced into
+a macOS shell feature, editor feature, AI IDE, agent chat UI, or one
+implementation plan. At the same time, it should not remain a side product that
+sits next to Alan. Existing and future Alan specs should be able to state how
+they fit into this environment model.
 
 ## What Changes
 
-- Define a new independent product line inside this repo: a local-first,
-  UNIX-respecting programmable personal computing environment.
+- Define the programmable environment as the long-term product constitution for
+  the alan repo: a local-first, UNIX-respecting programmable personal computing
+  environment.
+- Define a product-family role model for future and existing specs: environment
+  core, agent runtime/actor, host surface, environment app, adapter, and
+  legacy/compatibility surface.
 - Establish the durable product identity: user activity happens inside one
   object/command/buffer/view/query runtime while data may remain in ordinary
   filesystems and external systems.
+- Require future Alan specs, and selected existing active specs, to identify
+  their environment role and their relationship to objects, commands, buffers,
+  views, queries, actors, source-of-truth boundaries, and host responsibilities.
 - Make out-of-the-box usefulness a first principle: first launch should reveal
   and organize real personal work rather than presenting an empty programmable
   substrate.
@@ -26,15 +38,18 @@ plan.
 - Add an incubation path that validates the product assumptions without binding
   the first interface to editor, IDE, app launcher, or current Alan shell
   implementation choices.
+- Classify `introduce-workbench-runtime` as a candidate runtime substrate
+  incubation slice rather than the complete programmable environment product.
 
 ## Capabilities
 
 ### New Capabilities
 
 - `programmable-environment-product`: Owns the product constitution for the
-  independent programmable personal computing environment, including local-first
-  data boundaries, core runtime abstractions, interaction principles,
-  agent-native participation, extension principles, and incubation criteria.
+  alan repo's programmable personal computing environment, including
+  product-family roles, local-first data boundaries, core runtime abstractions,
+  interaction principles, agent-native participation, extension principles,
+  spec-alignment rules, and incubation criteria.
 
 ### Modified Capabilities
 
@@ -43,10 +58,17 @@ plan.
 
 ## Impact
 
-- Affected product planning: introduces a new product-line contract in
+- Affected product planning: introduces a repo-level product constitution in
   OpenSpec.
-- Affected architecture planning: future runtime, UI, agent, and extension
-  proposals for this product should trace back to this constitution.
+- Affected architecture planning: future runtime, UI, agent, app, host, adapter,
+  and extension proposals should trace back to this constitution or explicitly
+  declare themselves legacy/compatibility work.
+- Affected OpenSpec maintenance: selected active specs should be aligned over
+  follow-up changes by adding environment role, abstraction mapping, and
+  source-of-truth boundary notes. For example,
+  `add-macos-shell-component-system` should be classified as a macOS host
+  surface/design-system capability, not an environment core runtime.
 - Affected current code: none in this change.
 - Affected current Alan shell behavior: none; current Alan features may inform
-  later work but are not the implementation boundary for this product line.
+  later work but are not the required implementation boundary for the
+  programmable environment.

--- a/openspec/changes/define-programmable-environment-product/specs/programmable-environment-product/spec.md
+++ b/openspec/changes/define-programmable-environment-product/specs/programmable-environment-product/spec.md
@@ -1,15 +1,22 @@
 ## ADDED Requirements
 
-### Requirement: Product line is independent
-The programmable environment SHALL be treated as an independent product line
-inside the repository rather than as a feature of the existing Alan macOS shell,
-daemon, terminal runtime, or agent session UI.
+### Requirement: Programmable environment is the repo-level product constitution
+The programmable environment SHALL be the long-term organizing product model for
+the alan repository, including Alan agent, Alan for macOS, environment apps such
+as Groove Master, host surfaces, adapters, and future products.
+
+It SHALL NOT be treated merely as a feature of the existing Alan macOS shell,
+daemon, terminal runtime, or agent session UI. It also SHALL NOT be treated as
+an unrelated side product whose direction does not apply to the rest of the
+repo.
 
 #### Scenario: Future work scopes implementation
-- **WHEN** a future change implements programmable environment behavior
-- **THEN** the change identifies whether it belongs to this product line
-- **AND** it does not assume that existing Alan shell containers or terminal
-  workflows are the required implementation boundary
+- **WHEN** a future OpenSpec change implements product, runtime, agent, host,
+  app, adapter, extension, or surface behavior
+- **THEN** the change identifies how the scope relates to the programmable
+  environment model, or explicitly marks itself as legacy/compatibility work
+- **AND** it does not assume that existing Alan shell containers, terminal
+  workflows, or agent session UI are the required implementation boundary
 
 ### Requirement: Product identity is a programmable personal computing environment
 The product SHALL organize personal computing activity through a unified runtime
@@ -19,7 +26,68 @@ of objects, commands, buffers, views, queries, humans, agents, and extensions.
 - **WHEN** product, architecture, or implementation docs describe this product
 - **THEN** they describe it as a programmable personal computing environment
 - **AND** they do not reduce the product identity to an editor, IDE, AI chat
-  app, app launcher, or operating system shell
+  app, app launcher, terminal UI, or operating system shell
+
+### Requirement: Environment roles are explicit
+Future and aligned existing specs SHALL identify their role in the programmable
+environment family as one or more of:
+
+- environment core;
+- agent runtime or agent actor;
+- host surface;
+- environment app;
+- adapter;
+- legacy or compatibility surface.
+
+#### Scenario: A runtime substrate is proposed
+- **WHEN** a future change proposes a runtime substrate such as workbench core
+- **THEN** it identifies whether it owns environment-core abstractions,
+  projections, ledgers, command/query surfaces, or extension capabilities
+- **AND** it does not claim to be the whole programmable environment product
+
+#### Scenario: A host-surface change is proposed
+- **WHEN** a future change modifies Alan for macOS, the Rust TUI, or another host
+- **THEN** it identifies host-owned concerns such as layout, windowing, native
+  chrome, renderer state, input translation, and platform-specific presentation
+- **AND** it does not redefine environment objects, buffers, commands, queries,
+  or app-domain truth as host-owned state
+
+#### Scenario: An environment app is proposed
+- **WHEN** a future change proposes a domain product such as Groove Master
+- **THEN** it states the real user-facing product boundary first
+- **AND** it identifies the environment adapter that maps domain objects,
+  commands, buffers, views, queries, and agent participation into the shared
+  environment
+
+### Requirement: Existing specs align through environment metadata
+Selected active and future OpenSpec changes SHALL include enough environment
+alignment metadata for reviewers to understand how the change fits the
+constitution.
+
+At minimum, aligned specs SHOULD state:
+
+- environment role;
+- runtime abstraction mapping for objects, commands, buffers, views, queries,
+  actors, or why those abstractions do not apply;
+- native source-of-truth boundary;
+- host/rendering/layout boundary where relevant;
+- deferred migration or compatibility boundary.
+
+#### Scenario: Existing macOS shell component work is reviewed
+- **WHEN** `add-macos-shell-component-system` or equivalent host presentation
+  work is aligned with this constitution
+- **THEN** it is classified as a macOS host surface/design-system capability
+- **AND** it may own presentational primitives, tokens, preview galleries, and
+  host accessibility rules
+- **AND** it does not claim ownership of environment-core runtime abstractions
+
+#### Scenario: Existing Alan agent work is reviewed
+- **WHEN** Alan agent runtime, session, tool, plan, memory, child-run, or
+  governance work is aligned with this constitution
+- **THEN** it is classified as agent runtime/actor work or adapter work
+- **AND** it identifies how agent actions project into objects, commands,
+  buffers, views, queries, tasks, artifacts, evidence, permissions, or audit
+  surfaces where applicable
 
 ### Requirement: Product is local-first and filesystem-first
 The product SHALL treat local-first operation, filesystem-backed inspection, and
@@ -40,7 +108,7 @@ user activity through runtime objects and commands.
 
 #### Scenario: External or existing data is used
 - **WHEN** a file, project, terminal, Git state, note, task, mail item, calendar
-  item, or remote record is brought into the environment
+  item, recording, loop, or remote record is brought into the environment
 - **THEN** the product can represent it as a runtime object without requiring
   the environment to become the source of truth for the underlying data
 
@@ -51,7 +119,7 @@ product-level runtime abstractions.
 #### Scenario: Runtime concepts are introduced
 - **WHEN** a future spec introduces product runtime behavior
 - **THEN** it states how the behavior relates to Object, Command, Buffer, View,
-  Query, or explicitly explains why it sits outside those abstractions
+  Query, Actor, or explicitly explains why it sits outside those abstractions
 
 ### Requirement: Objects are inspectable runtime resources
 Objects SHALL have stable identity, metadata, relationships, capabilities, and
@@ -79,7 +147,8 @@ text.
 
 #### Scenario: Non-text work is opened
 - **WHEN** terminal output, Git diff, search results, task lists, agent plans,
-  database results, or calendar ranges are opened for work
+  recordings, loop libraries, database results, or calendar ranges are opened
+  for work
 - **THEN** the product can represent them as buffers with lifecycle, history,
   dirty state, and restoration semantics appropriate to their kind
 
@@ -99,7 +168,8 @@ runtime entities.
 
 #### Scenario: User or agent searches semantically
 - **WHEN** a user or agent asks for runtime state such as modified buffers,
-  Git commands, pending tasks, or function symbols
+  Git commands, pending tasks, marked recordings, available loops, or function
+  symbols
 - **THEN** the product provides queryable runtime surfaces rather than forcing
   navigation only through app, window, or file hierarchy
 
@@ -110,8 +180,8 @@ configure a programmable substrate.
 #### Scenario: User opens product for the first time
 - **WHEN** a user first opens the product
 - **THEN** the product can reveal, organize, or create real personal work from
-  local files, projects, workspaces, notes, tasks, terminals, or similar
-  personal computing objects
+  local files, projects, workspaces, notes, tasks, terminals, domain app data,
+  or similar personal computing objects
 
 ### Requirement: Modal grammar is a power layer over ordinary UI
 The product SHALL support ordinary UI for onboarding and a modal command grammar
@@ -130,10 +200,22 @@ abstractions.
 
 #### Scenario: Agent performs work
 - **WHEN** an agent reads context, creates a buffer, executes a command,
-  proposes a patch, opens a view, or performs a query
+  proposes a patch, opens a view, performs a query, curates a journal entry, or
+  updates a plan
 - **THEN** the action is mediated by runtime abstractions
 - **AND** the agent does not bypass command permissions or audit surfaces to
   mutate underlying systems directly
+
+### Requirement: Environment apps are real products
+Environment apps SHALL be treated as user-facing domain products inside the
+environment, not as demos whose primary purpose is proving the platform.
+
+#### Scenario: App product is proposed
+- **WHEN** a future change proposes or updates an environment app
+- **THEN** it defines the app's user-facing job, domain objects, domain commands,
+  and product experience before describing platform proof value
+- **AND** its domain core remains separable from the current Alan host
+  implementation
 
 ### Requirement: Extensibility uses Rust core plus WASM components
 The product SHALL treat a Rust core plus WASM Component Model extensions and WIT
@@ -150,7 +232,11 @@ Future incubation work SHALL validate the product constitution before expanding
 into a broad environment implementation.
 
 #### Scenario: First incubation scope is proposed
-- **WHEN** a future change proposes the first prototype or MVP for this product
-- **THEN** it identifies the concrete workflow that proves local-first discovery,
-  object representation, buffer/view use, command execution, query or
-  introspection, agent participation, and extension-shaped boundaries
+- **WHEN** a future change proposes the first prototype, runtime substrate, or
+  MVP for this product
+- **THEN** it identifies the concrete workflow or substrate boundary that proves
+  local-first discovery, object representation, buffer/view use, command
+  execution, query or introspection, agent participation, host rendering, and
+  extension-shaped boundaries
+- **AND** it states which constitution criteria are proven by the slice and
+  which are intentionally deferred

--- a/openspec/changes/define-programmable-environment-product/tasks.md
+++ b/openspec/changes/define-programmable-environment-product/tasks.md
@@ -1,54 +1,94 @@
 ## 1. Product Constitution
 
-- [ ] 1.1 Capture the product as an independent product line in the repo,
-  separate from current Alan macOS shell and terminal workflow implementation.
-- [ ] 1.2 Define the product as a programmable personal computing environment
+- [x] 1.1 Capture the programmable environment as the repo-level product
+  constitution for Alan agent, Alan for macOS, environment apps, hosts,
+  adapters, and future products.
+- [x] 1.2 Define the product as a programmable personal computing environment
   organized around objects, commands, buffers, views, queries, humans, agents,
   and extensions.
-- [ ] 1.3 Record local-first, filesystem-first, UNIX-like composition as a core
+- [x] 1.3 Record that the product must not collapse into the current macOS shell,
+  Rust TUI, daemon, terminal workflow, or agent session UI.
+- [x] 1.4 Record local-first, filesystem-first, UNIX-like composition as a core
   product principle.
-- [ ] 1.4 Record the data/activity boundary: data may remain in existing systems
+- [x] 1.5 Record the data/activity boundary: data may remain in existing systems
   while activity is organized inside the environment.
-- [ ] 1.5 Preserve out-of-the-box usefulness as a first principle.
+- [x] 1.6 Preserve out-of-the-box usefulness as a first principle.
 
-## 2. Runtime Abstraction Contracts
+## 2. Product Family And Spec Alignment
 
-- [ ] 2.1 Define Object, Command, Buffer, View, and Query as stable
-  product-level runtime abstractions.
-- [ ] 2.2 Define ordinary UI and modal grammar as invocation layers over the
-  same command model.
-- [ ] 2.3 Define agents as first-class actors mediated by runtime abstractions,
+- [x] 2.1 Define the product-family role model: environment core, agent
+  runtime/actor, host surface, environment app, adapter, and
+  legacy/compatibility surface.
+- [x] 2.2 Require future and aligned existing specs to state their environment
+  role, runtime abstraction mapping, native source-of-truth boundary,
+  host/rendering boundary, and deferred compatibility boundary.
+- [x] 2.3 Classify `introduce-workbench-runtime` as a candidate environment-core
+  runtime substrate incubation slice rather than the complete product.
+- [x] 2.4 Classify Alan agent work as agent runtime/actor work that should project
+  into environment tasks, objects, buffers, views, commands, artifacts, evidence,
   permissions, and audit surfaces.
-- [ ] 2.4 Define Rust core plus WASM Component Model and WIT interfaces as the
+- [x] 2.5 Classify Alan for macOS as a host surface responsible for native layout,
+  windowing, input, rendering, chrome, and mounting environment views.
+- [x] 2.6 Classify `add-macos-shell-component-system` as a macOS host
+  surface/design-system capability, not environment core.
+- [x] 2.7 Classify Groove Master and future app products as environment apps with
+  app-owned domain cores plus Alan environment adapters.
+
+## 3. Runtime Abstraction Contracts
+
+- [x] 3.1 Define Object, Command, Buffer, View, Query, and Actor as stable
+  product-level runtime abstractions.
+- [x] 3.2 Define ordinary UI and modal grammar as invocation layers over the same
+  command model.
+- [x] 3.3 Define agents as first-class actors mediated by runtime abstractions,
+  permissions, and audit surfaces.
+- [x] 3.4 Define environment apps as real user-facing products rather than
+  platform demos.
+- [x] 3.5 Define Rust core plus WASM Component Model and WIT interfaces as the
   extension direction with explicit capability grants.
 
-## 3. Incubation Decomposition
+## 4. Incubation Decomposition
 
-- [ ] 3.1 Identify that the first follow-up change should validate product
+- [x] 4.1 Identify that the first follow-up changes should validate product
   assumptions rather than implement the complete environment.
-- [ ] 3.2 Require the first follow-up prototype or MVP to prove local-first
+- [x] 4.2 Require the first follow-up prototype or MVP to prove local-first
   discovery of real work.
-- [ ] 3.3 Require the first follow-up prototype or MVP to prove one workflow
+- [x] 4.3 Require the first follow-up prototype or MVP to prove one workflow
   through object, buffer, view, command, query, and agent participation.
-- [ ] 3.4 Defer the concrete first interface choice until a focused incubation
-  proposal selects editor-like environment, object workspace, agent workspace,
-  or another form.
-- [ ] 3.5 Defer universal URI/resource addressing until a later architecture RFC
+- [x] 4.4 Require host surfaces used in incubation to render environment state
+  without owning product runtime truth.
+- [x] 4.5 Defer the concrete first complete interface choice until a focused
+  incubation proposal selects editor-like environment, object workspace, agent
+  workspace, app workspace, or another form.
+- [x] 4.6 Defer universal URI/resource addressing until a later architecture RFC
   proves it is needed beyond filesystem-first composition.
 
-## 4. Verification
+## 5. Existing-Spec Alignment Backlog
 
-- [ ] 4.1 Run `openspec validate define-programmable-environment-product --strict`.
-- [ ] 4.2 Run `git diff --check -- openspec/changes/define-programmable-environment-product`.
-- [ ] 4.3 Review proposal, design, specs, and tasks for placeholders,
+- [x] 5.1 Add an alignment note to `introduce-workbench-runtime` that identifies
+  it as a runtime substrate slice and records which constitution criteria it
+  proves or defers.
+- [x] 5.2 Plan a follow-up review of `add-macos-shell-component-system` to add its
+  macOS host-surface/design-system role without broadening it into runtime core.
+- [x] 5.3 Plan a follow-up review of `define-groove-master-environment-app` so its
+  app/domain-core/adapter split remains aligned after the constitution is
+  accepted.
+- [x] 5.4 Plan future reviews for UPDF-like product specs, terminal/content specs,
+  and agent runtime specs when they are next touched.
+
+## 6. Verification
+
+- [x] 6.1 Run `openspec validate define-programmable-environment-product --strict`.
+- [x] 6.2 Run `git diff --check -- openspec/changes/define-programmable-environment-product`.
+- [x] 6.3 Review proposal, design, specs, and tasks for placeholders,
   contradictions, premature implementation commitments, and unclear product
   boundaries.
-- [ ] 4.4 Confirm the change does not modify current Alan runtime, daemon,
+- [x] 6.4 Confirm the change does not modify current Alan runtime, daemon,
   terminal, or macOS shell behavior.
 
-## 5. Archive Readiness
+## 7. Archive Readiness
 
-- [ ] 5.1 After review and merge, sync
+- [ ] 7.1 After review and merge, sync
   `programmable-environment-product` into `openspec/specs/`.
-- [ ] 5.2 Archive the completed change only after the long-lived spec has been
+- [ ] 7.2 Archive the completed change only after the long-lived spec has been
   updated and validated.

--- a/openspec/changes/introduce-workbench-runtime/.openspec.yaml
+++ b/openspec/changes/introduce-workbench-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/introduce-workbench-runtime/design.md
+++ b/openspec/changes/introduce-workbench-runtime/design.md
@@ -1,0 +1,250 @@
+## Context
+
+`crates/tui` is currently a daemon-backed Ratatui application. It owns terminal
+input, creates or attaches to an Alan daemon session, hydrates history, streams
+`alan_protocol::EventEnvelope` values, reduces them into transcript state, and
+renders the result with Ratatui. That shape is pragmatic for the current Alan
+conversation UI, but it is not the right abstraction boundary for a future
+programmable environment or for non-terminal hosts such as SwiftUI.
+
+Alan already has several related concepts:
+
+- The agent runtime owns sessions, tape, tool calls, yields, child runs, policy,
+  and rollout/event persistence.
+- The macOS shell owns native spaces, tabs, pane slots, `ContentInstance`
+  mounting, and renderer-specific state.
+- The programmable environment product direction names objects, commands,
+  buffers, views, queries, humans, agents, and extensions as the durable product
+  model.
+
+This change introduces a workbench runtime contract that sits between those
+systems. It is not another TEA framework for Ratatui, and it is not a rewrite of
+the Alan agent runtime. It is a semantic workbench model that can be consumed by
+Ratatui, SwiftUI, agents, automation, and future extensions.
+
+## Programmable Environment Relationship
+
+`introduce-workbench-runtime` is an environment-core/runtime-substrate
+incubation slice under `programmable-environment-product`. It is intentionally
+smaller than the full product constitution:
+
+| Constitution criterion | Workbench slice stance |
+| --- | --- |
+| Object/command/buffer/view/query runtime | Proves the shared semantic model in `workbench-core`. |
+| Humans and agents as actors | Proves actor metadata and Alan agent adaptation. |
+| Commands as shared invocation model | Proves descriptors and command invocation for UI/agent/control surfaces. |
+| Queryable runtime | Proves query descriptors and semantic snapshots at the runtime layer. |
+| Local-first native authority | Proves native references and rebuildable projections, but does not build broad local work discovery. |
+| Activity ledger and inspectable evidence | Proves task, artifact, evidence, and no-side-effect replay boundaries. |
+| Host surfaces do not own runtime truth | Proves Ratatui as renderer host; SwiftUI is deferred. |
+| Out-of-the-box product workflow | Deferred; first slice uses Alan agent conversation rather than a complete product/app workflow. |
+| WASM extension model | Deferred; dynamic view payloads keep a schema-versioned opening without loading extensions. |
+| Environment apps | Deferred; Groove Master and other apps should adapt through this substrate later. |
+
+This means workbench can be the first substrate implementation without becoming
+the entire programmable environment. Follow-up changes should still prove
+first-launch local work discovery, a real app or workspace workflow, SwiftUI host
+integration, and extension-shaped capabilities.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the workbench runtime boundary before implementation starts.
+- Make the workbench boundary traceable to the programmable environment
+  constitution without claiming to implement the complete product.
+- Keep the core independent from `alan-protocol`, Ratatui, SwiftUI, Tokio
+  handles, macOS `ContentInstance`, and any future product name.
+- Make commands, queries, subscriptions, actors, tasks, buffers, views,
+  artifacts, evidence, event ledgers, and projections first-class runtime
+  concepts.
+- Preserve native source-of-truth boundaries for files, Git repositories,
+  terminals, agent sessions, domain stores, and external systems.
+- Make Ratatui a renderer host and input adapter rather than the application
+  runtime.
+- Use the existing Alan agent conversation path as the first vertical slice.
+- Keep the migration compatibility-first so the current TUI keeps working while
+  semantic projections are introduced.
+
+**Non-Goals:**
+
+- Implement a general-purpose Ratatui component framework.
+- Replace the Alan agent runtime, daemon APIs, or `alan-protocol`.
+- Make the macOS shell `ContentInstance` model the workbench core model.
+- Implement a full text editor, full terminal emulator, SwiftUI host, WASM
+  component runtime, renderer extensions, or generic object browser breadth in
+  the first slice.
+- Define a universal URI/resource protocol or private object database.
+- Prove first-launch local work discovery or a complete environment-app
+  workflow in this slice.
+
+## Decisions
+
+### 1. Use `workbench-*` crates and keep the core renderer-independent
+
+The implementation should start with `workbench-core`, `workbench-agent`, and
+`workbench-ratatui`.
+
+`workbench-core` owns semantic descriptors, events, registries, projections, and
+snapshot contracts. It must not depend on `alan-protocol`, Ratatui, SwiftUI, or
+Tokio handles. Async implementation details may exist in adapters, but public
+core state is model-driven and executor-neutral.
+
+Alternative considered: put the abstraction directly inside `crates/tui`. That
+would be faster initially but would bias the model toward daemon session events,
+Ratatui frames, terminal input, and the current transcript reducer.
+
+### 2. Treat objects, buffers, and views as separate concepts
+
+Objects represent inspectable runtime resources with identity, metadata,
+capabilities, and native authority references. Buffers represent active work
+contexts over objects, tasks, query results, or domain state. Views represent a
+presentation of a buffer.
+
+The core should use typed opaque ids such as `ObjectId`, `BufferId`, `ViewId`,
+`TaskId`, and `CommandId`. External authority stays in `native_ref` fields. For
+example, a file object references a path, a Git object references a worktree and
+revision, an agent object references a session id, and a domain app object
+references app-owned state.
+
+Alternative considered: introduce a universal URI model. That is too early and
+would obscure the simpler local-first boundary.
+
+### 3. Make commands, queries, and subscriptions distinct
+
+Commands mutate or initiate work. Queries read semantic state. Subscriptions
+observe changes and invalidate or update views. Mutation must not happen through
+queries or subscriptions.
+
+Command descriptors are shared by UI controls, command palette, modal grammar,
+automation, and agent tool projections. Permission and audit metadata belong on
+commands; tools are only one possible execution backend.
+
+Alternative considered: keep command handling as Rust callbacks owned by each
+view. That would hide actions from agents, command palettes, modal grammar, and
+audit surfaces.
+
+### 4. Model actors and causation from the start
+
+Every command, task event, artifact, and evidence record should carry actor and
+causation metadata. Actor kinds include humans, agents, extensions, and system
+actors. Causation and correlation ids connect chains such as user input, command
+invocation, agent turn, tool task, child run, artifact, and evidence.
+
+Alternative considered: add actor/audit metadata later. That would make early
+events and tasks ambiguous and would weaken the "humans and agents share the
+same runtime" premise.
+
+### 5. Use an activity ledger plus rebuildable projections
+
+The workbench ledger records activity: command intent, policy decisions, task
+lifecycle, yields, committed side effects, artifacts, evidence, and semantic
+buffer/view lifecycle. It is not a universal object store.
+
+Replay must never re-run side effects. Replay rebuilds workbench state and
+refreshes native resources through their owning systems. Projection state is a
+cache that can be rebuilt from the ledger plus native resource inspection.
+
+First implementations should include an in-memory ledger and a JSONL ledger.
+SQLite or graph storage can be added later if projection performance requires
+it.
+
+Alternative considered: store all object data and projection changes directly
+in one database. That conflicts with local-first/native-authority boundaries.
+
+### 6. Render semantic snapshots, not render patches
+
+Renderer hosts should consume `ViewSnapshot` values. The core marks views dirty
+through subscription updates; the host pulls a semantic snapshot and renders it
+using its own layout/cache/diff strategy.
+
+The core should define strongly typed built-in view models for the first slice:
+conversation, task tree, object list, command palette, form, text document
+read/review, diff, and log stream. Dynamic extension views may use schema id,
+version, and JSON payloads. The first slice should not promise a full terminal
+semantic renderer.
+
+Alternative considered: emit render patches or a generic UI element tree. That
+would become a UI toolkit and make Ratatui/SwiftUI/agent inspection harder to
+keep aligned.
+
+### 7. Keep view state semantic and render state host-local
+
+Semantic view state includes selection, focused field, filter text, scroll
+anchor, active mode, and other state that another renderer, restore path,
+command, query, or agent would care about. Host render state includes measured
+line wraps, terminal cell cache, pixel geometry, hover state, and animation
+frames.
+
+Alternative considered: keep all state in the renderer host. That would break
+restore, SwiftUI parity, and agent inspection.
+
+### 8. Adapt Alan agent sessions instead of merging them into core
+
+`workbench-agent` should depend on both `workbench-core` and `alan-protocol`.
+It maps Alan session metadata, event envelopes, yields, tool lifecycle events,
+child-run records, and operations into workbench objects, buffers, commands,
+task events, forms, artifacts, and evidence.
+
+The agent runtime remains the execution backend for agent work. The workbench
+core does not learn about tape, provider continuation, compaction internals, or
+tool orchestration.
+
+Alternative considered: fold the agent runtime into workbench core. That would
+make non-agent workflows inherit agent-specific concepts and increase migration
+risk.
+
+### 9. Treat Ratatui and SwiftUI as renderer hosts
+
+Ratatui should translate crossterm input into semantic input intents or command
+invocations and render semantic snapshots. SwiftUI can do the same later with
+native events and views. Hosts own physical layout; the workbench owns semantic
+open buffers, open views, active view, task state, and command/query surfaces.
+
+Alternative considered: make Ratatui the primary app framework and port other
+hosts later. That would preserve the current terminal bias and undercut the
+programmable environment boundary.
+
+## Risks / Trade-offs
+
+- [Risk] The workbench contract becomes too broad to implement. -> Keep the
+  first implementation to an Alan agent conversation vertical slice with
+  conversation, form/yield, task tree, and command invocation.
+- [Risk] The semantic model duplicates existing agent runtime events. -> Keep
+  agent events in `workbench-agent` as adapter input; do not expose them from
+  `workbench-core`.
+- [Risk] A new core crate could drift into a private object store. -> Keep
+  native resources authoritative and make projections rebuildable caches.
+- [Risk] Renderer hosts may need capabilities not covered by the first snapshot
+  model. -> Add strongly typed built-in view models only when a real host or
+  workflow needs them; keep extension views schema-versioned.
+- [Risk] Compatibility work doubles code temporarily. -> Use a parallel
+  semantic path first, then retire old reducer/rendering code only after tests
+  prove parity.
+
+## Migration Plan
+
+1. Add `workbench-core` with descriptor, event, registry, ledger, projection,
+   task, artifact, evidence, and view snapshot skeletons.
+2. Add `workbench-agent` fixtures that map representative Alan event envelopes
+   into workbench task events and conversation/form/task-tree snapshots.
+3. Add `workbench-ratatui` renderers for conversation, form, task tree, and
+   command palette snapshots.
+4. Integrate the semantic path into `crates/tui` behind a compatibility-first
+   path while preserving daemon creation, hydration, reconnect, submission, and
+   pending-yield behavior.
+5. Replace the old TUI reducer/rendering pieces only after focused tests cover
+   the semantic projection and Ratatui output.
+
+Rollback for the first slice is removing the new workbench crates and reverting
+the optional TUI integration path; existing daemon and agent runtime behavior
+remain untouched.
+
+## Open Questions
+
+- Whether the first command registry implementation should live entirely in
+  `workbench-core` or split descriptor storage from adapter-owned execution.
+- Which JSON schema representation should be used for extension view payloads
+  and command/query args before a WASM runtime exists.
+- How much of the current TUI history/composer behavior should move into
+  semantic view state versus remain host-local during the first slice.

--- a/openspec/changes/introduce-workbench-runtime/proposal.md
+++ b/openspec/changes/introduce-workbench-runtime/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+Alan needs a higher-level runtime model for modern agent/editor/IDE-style work
+without turning Ratatui into another app framework or folding the future
+programmable environment into the current agent session protocol. The current
+Rust TUI proves the pressure point: conversation, yields, tool calls, task-like
+child runs, and streaming UI are hard-coded around Alan agent events instead of
+a reusable semantic workbench model.
+
+This change is an incubation slice under the programmable environment
+constitution. It aims to prove a reusable runtime substrate boundary for
+objects, commands, buffers, views, queries, actors, tasks, artifacts, evidence,
+ledgers, and renderer hosts. It does not claim to implement the complete
+programmable environment product.
+
+## What Changes
+
+- Introduce a `workbench-core` contract for semantic runtime primitives:
+  actors, objects, buffers, views, commands, queries, subscriptions, tasks,
+  events, artifacts, evidence, activity ledgers, and projections.
+- Declare workbench as an environment-core/runtime-substrate slice that is
+  constrained by `programmable-environment-product`, while explicitly deferring
+  full product MVP scope such as first-launch local work discovery, broad object
+  browsing, WASM extension loading, SwiftUI hosting, and environment apps.
+- Define command, query, task, and replay boundaries so mutations are mediated
+  through commands, reads through queries, observation through subscriptions,
+  and ledger replay never re-executes side effects.
+- Keep the workbench core independent from `alan-protocol`, Ratatui, SwiftUI,
+  Tokio handles, macOS shell `ContentInstance`, and any specific renderer.
+- Define an Alan agent adapter contract that maps existing session metadata,
+  `alan_protocol::EventEnvelope`, yields, tool calls, and child-run records into
+  workbench tasks, conversation views, forms, artifacts, and evidence.
+- Define a renderer-host contract where Ratatui and SwiftUI consume semantic
+  view snapshots and translate host input into workbench input intents or
+  command invocations, without owning the application runtime.
+- Scope the first implementation slice to an Alan agent conversation vertical
+  slice: conversation view, task tree, form/yield handling, command invocation,
+  and compatibility-first integration with the existing `crates/tui` daemon
+  wiring.
+- Defer WASM runtime loading, renderer extensions, full terminal emulation,
+  full text-editor behavior, generic object-browser breadth, and SwiftUI host
+  implementation until the core contract and Ratatui slice are proven.
+
+## Capabilities
+
+### New Capabilities
+
+- `workbench-core-contract`: Defines the renderer-independent semantic runtime
+  model, including descriptors, command/query/subscription surfaces, task
+  events, actor provenance, artifact/evidence provenance, activity ledgers,
+  projection replay, and native-authority boundaries.
+- `workbench-agent-adapter-contract`: Defines how the existing Alan agent
+  daemon/session protocol is adapted into workbench objects, buffers, views,
+  commands, task events, forms, artifacts, and evidence without making
+  workbench core depend on `alan-protocol`.
+- `workbench-renderer-host-contract`: Defines the boundary for Ratatui, SwiftUI,
+  and future renderer hosts: semantic view snapshots, renderer adapters, host
+  input adapters, view-local state, and host-local layout.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- New crates are expected in a future implementation slice, initially shaped as
+  `workbench-core`, `workbench-agent`, and `workbench-ratatui`.
+- `crates/tui` remains daemon-backed and becomes the first compatibility-first
+  consumer of the workbench agent and Ratatui adapters.
+- Existing Alan agent runtime, daemon APIs, `alan-protocol`, macOS shell
+  `ContentInstance`, and accepted Ratatui behavior remain intact during the
+  first slice.
+- The design is compatible with later SwiftUI and WASM extension work, but this
+  change does not implement either one.
+- This change proves only a subset of the programmable environment constitution:
+  runtime semantics, agent adaptation, task/projection modeling, command/query
+  surfaces, host snapshot rendering, and compatibility migration. Local-first
+  first-launch discovery, complete app workflows, and WASM extensions are
+  deferred to follow-up incubation changes.

--- a/openspec/changes/introduce-workbench-runtime/specs/workbench-agent-adapter-contract/spec.md
+++ b/openspec/changes/introduce-workbench-runtime/specs/workbench-agent-adapter-contract/spec.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### Requirement: Agent adapter isolates Alan protocol
+The workbench agent adapter SHALL translate Alan agent daemon/session protocol
+state into workbench semantics without making workbench core depend on
+`alan-protocol`.
+
+#### Scenario: Adapter crate dependencies are inspected
+- **WHEN** workbench crates are built or audited
+- **THEN** `workbench-agent` may depend on `alan-protocol` and Alan daemon
+  client types
+- **AND** `workbench-core` remains free of those dependencies
+
+#### Scenario: Alan event enters the workbench
+- **WHEN** an `alan_protocol::EventEnvelope` is received by an Alan session
+  consumer
+- **THEN** `workbench-agent` maps it into workbench task events, conversation
+  updates, form state, artifacts, or evidence before it reaches renderer hosts
+
+### Requirement: Agent sessions project as objects and buffers
+The workbench agent adapter SHALL represent an Alan agent session as an
+inspectable object with conversation and task-oriented buffers.
+
+#### Scenario: Session is attached
+- **WHEN** the TUI or another host creates or attaches to an Alan daemon session
+- **THEN** the adapter creates or resolves an agent session object
+- **AND** it exposes at least one conversation buffer and view for that session
+
+#### Scenario: Session metadata is available
+- **WHEN** profile, provider, model, durability, workspace, or session metadata
+  is returned by daemon APIs
+- **THEN** the adapter records it as object or buffer metadata without making it
+  the workbench core identity format
+
+### Requirement: Agent operations project as commands
+The workbench agent adapter SHALL expose supported Alan session operations as
+workbench command descriptors and invocations.
+
+#### Scenario: User submits an agent turn
+- **WHEN** a human or agent submits text or structured input to an Alan session
+- **THEN** the adapter represents the operation as a workbench command
+  invocation
+- **AND** successful dispatch to the daemon starts or resumes a workbench task
+
+#### Scenario: User interrupts active agent work
+- **WHEN** the user requests interruption of active agent work
+- **THEN** the adapter invokes a cancel or interrupt command against the active
+  task
+- **AND** daemon submission remains the adapter-owned execution detail
+
+#### Scenario: Session control command is invoked
+- **WHEN** compact, rollback, resume, or another supported Alan session control
+  operation is requested
+- **THEN** the adapter exposes it through command descriptors with target,
+  argument, actor, and audit metadata
+
+### Requirement: Agent events map to task lifecycle
+The workbench agent adapter SHALL map Alan turns, tool calls, yields, child
+runs, and stream progress into workbench task descriptors and task events.
+
+#### Scenario: Turn starts and streams
+- **WHEN** Alan emits turn and text or thinking stream events
+- **THEN** the adapter maps the turn to a workbench task
+- **AND** streamed text or thinking updates the conversation projection without
+  requiring renderer hosts to parse Alan event variants
+
+#### Scenario: Tool call starts and completes
+- **WHEN** Alan emits tool call lifecycle events
+- **THEN** the adapter maps the tool call to a child task of the active turn
+- **AND** completion updates task status, artifacts, evidence, and conversation
+  summaries as applicable
+
+#### Scenario: Child run is observed
+- **WHEN** Alan child-run records or child lifecycle events are available
+- **THEN** the adapter maps them to workbench child tasks with parent links,
+  status, progress, terminal outcome, and evidence references
+
+### Requirement: Agent yields project as task pauses and forms
+The workbench agent adapter SHALL map Alan yields into task yielded states and
+semantic form or approval views.
+
+#### Scenario: Confirmation yield is received
+- **WHEN** Alan emits a confirmation yield
+- **THEN** the adapter maps it to a workbench task yielded state
+- **AND** it projects a form or approval view that can resume the task through a
+  command invocation
+
+#### Scenario: Structured input yield is received
+- **WHEN** Alan emits a structured input yield with questions or schema-like
+  payload
+- **THEN** the adapter maps it to a semantic form view model
+- **AND** form submission is represented as a resume command against the yielded
+  task
+
+#### Scenario: Dynamic tool yield is received
+- **WHEN** Alan emits a dynamic tool yield
+- **THEN** the adapter preserves the yielded task checkpoint and payload
+- **AND** execution or rejection of the client-side tool result remains mediated
+  by a workbench command path
+
+### Requirement: Conversation views preserve agent semantics
+The workbench agent adapter SHALL project Alan conversation state into typed
+conversation view models rather than plain logs.
+
+#### Scenario: Conversation snapshot is requested
+- **WHEN** a renderer host requests the active Alan conversation view
+- **THEN** the adapter-backed projection includes typed blocks for user text,
+  assistant text, thinking, tool summaries, plans, yields, errors, artifacts,
+  and linked tasks when available
+
+#### Scenario: Persisted history is hydrated
+- **WHEN** an Alan session is hydrated from daemon history and reconnect state
+- **THEN** the adapter reconstructs conversation and pending-input projections
+  without requiring the host renderer to know daemon hydration details
+
+### Requirement: Agent adapter preserves compatibility with daemon behavior
+The workbench agent adapter SHALL preserve existing daemon-backed session
+creation, hydration, replay, reconnect, submission, resume, interrupt,
+compaction, rollback, and pending-yield behavior during the first integration.
+
+#### Scenario: Existing TUI reconnects
+- **WHEN** the Ratatui TUI reconnects to an existing Alan daemon session through
+  the workbench adapter path
+- **THEN** it still reads persisted history or reconnect snapshots before
+  consuming new events
+- **AND** it does not lose buffered yield or stream events that the existing TUI
+  path would preserve
+
+#### Scenario: Adapter path is disabled or removed
+- **WHEN** the workbench adapter integration is disabled during migration
+- **THEN** existing daemon-backed TUI behavior can continue through the legacy
+  path until semantic parity is proven

--- a/openspec/changes/introduce-workbench-runtime/specs/workbench-core-contract/spec.md
+++ b/openspec/changes/introduce-workbench-runtime/specs/workbench-core-contract/spec.md
@@ -1,0 +1,220 @@
+## ADDED Requirements
+
+### Requirement: Workbench is a runtime-substrate incubation slice
+The workbench core SHALL be treated as an environment-core runtime substrate
+slice under `programmable-environment-product`, not as the complete
+programmable environment product.
+
+#### Scenario: Workbench scope is reviewed
+- **WHEN** a workbench implementation or architecture change is reviewed
+- **THEN** it identifies the programmable-environment constitution criteria it
+  proves, such as objects, commands, buffers, views, queries, actors, ledgers,
+  tasks, artifacts, evidence, native references, and host snapshots
+- **AND** it explicitly defers complete product concerns such as broad
+  first-launch local work discovery, complete environment apps, SwiftUI hosting,
+  WASM extension loading, and universal resource addressing unless those scopes
+  are added by separate future changes
+
+### Requirement: Workbench core remains adapter independent
+The workbench core SHALL define renderer-independent and agent-protocol-
+independent runtime primitives for workbench behavior.
+
+#### Scenario: Core dependencies are inspected
+- **WHEN** the workbench core crate is built or audited
+- **THEN** it has no dependency on `alan-protocol`, Ratatui, Crossterm, SwiftUI,
+  AppKit, macOS shell `ContentInstance` types, or Tokio task handles
+- **AND** adapter crates own dependencies on those systems
+
+#### Scenario: Adapter-specific event is handled
+- **WHEN** an Alan agent event, terminal host event, SwiftUI event, or macOS
+  shell content event enters the system
+- **THEN** it is translated by an adapter before it affects workbench core state
+
+### Requirement: Runtime entities use typed opaque identity
+The workbench core SHALL identify runtime entities with typed opaque ids and
+SHALL represent external source-of-truth resources through native references.
+
+#### Scenario: File is represented as an object
+- **WHEN** a local file is represented in the workbench
+- **THEN** the workbench object has a typed object id
+- **AND** its descriptor records a native file reference rather than requiring a
+  universal workbench URI or private object-store copy
+
+#### Scenario: Agent session is represented as an object
+- **WHEN** an Alan agent session is represented in the workbench
+- **THEN** the workbench object has a typed object id
+- **AND** its descriptor records the adapter-owned session reference as native
+  authority
+
+### Requirement: Objects, buffers, and views are distinct
+The workbench core SHALL separate inspectable resources, active work contexts,
+and presentations.
+
+#### Scenario: Object is opened for work
+- **WHEN** a command opens an object
+- **THEN** the workbench creates or resolves a buffer as the active work context
+- **AND** it creates or resolves a view snapshot for presentation without making
+  the object itself own presentation state
+
+#### Scenario: Query result is opened
+- **WHEN** a query result is opened for inspection
+- **THEN** the workbench can represent it as a buffer even when no external
+  object owns the result data
+
+### Requirement: Commands mutate, queries read, subscriptions observe
+The workbench core SHALL expose commands for mutation or work initiation,
+queries for read-only semantic inspection, and subscriptions for observing
+changes.
+
+#### Scenario: Mutating action is requested
+- **WHEN** a human, agent, extension, or system actor requests a mutation or
+  side effect
+- **THEN** the request is represented as a command invocation
+- **AND** it is not performed through a query or subscription path
+
+#### Scenario: Semantic state is inspected
+- **WHEN** a client asks for open buffers, available commands, blocked tasks, or
+  artifacts
+- **THEN** the workbench answers through a query or snapshot
+- **AND** the operation does not mutate runtime or native resource state
+
+#### Scenario: View observes changes
+- **WHEN** a view depends on an object, buffer, task, or query result
+- **THEN** a subscription can notify the renderer host that the view is dirty or
+  updated without owning business logic
+
+### Requirement: Command descriptors are shared invocation contracts
+The workbench core SHALL describe commands through queryable descriptors used by
+UI controls, command palettes, modal grammar, automation, and agent projections.
+
+#### Scenario: Command appears in multiple surfaces
+- **WHEN** a command is exposed through a UI button, command palette, modal
+  grammar, automation, or agent-facing schema
+- **THEN** each surface preserves the same command identity, target semantics,
+  argument schema, permission metadata, and audit behavior
+
+#### Scenario: Command availability is computed
+- **WHEN** a renderer host or agent asks what actions are available for a target
+- **THEN** the answer is derived from command descriptors, target state, actor
+  authority, and policy decisions rather than hidden view-local callbacks
+
+### Requirement: Actor and causation metadata are first-class
+The workbench core SHALL record actor, causation, and correlation metadata for
+commands, tasks, artifacts, evidence, and activity events.
+
+#### Scenario: Agent invokes a command
+- **WHEN** an agent invokes a command
+- **THEN** the command invocation identifies the agent actor
+- **AND** subsequent task events, artifacts, and evidence remain linked through
+  causation or correlation ids
+
+#### Scenario: Human action triggers agent work
+- **WHEN** a human action causes an agent task that creates tool tasks and
+  artifacts
+- **THEN** the task tree can preserve the human-originating correlation while
+  identifying the agent and tool actors that performed each step
+
+### Requirement: Tasks are first-class runtime state
+The workbench core SHALL model command execution and long-running work as tasks
+with lifecycle, hierarchy, cancellation, yields, output, artifacts, and
+evidence.
+
+#### Scenario: Command starts asynchronous work
+- **WHEN** a command invocation starts work that may stream, block, yield, or
+  produce outputs
+- **THEN** the workbench creates a task descriptor and task events for the
+  lifecycle
+
+#### Scenario: Work has nested activity
+- **WHEN** a task launches tool calls, child runs, shell commands, or extension
+  work
+- **THEN** child tasks preserve parent task links and can be rendered as a task
+  tree
+
+#### Scenario: Task waits for input
+- **WHEN** running work needs human, agent, or extension input before continuing
+- **THEN** the task emits a yielded state with a resumable request
+- **AND** presentation layers can project that yield as a form or approval
+  surface
+
+### Requirement: Activity ledger records intent and committed effects
+The workbench core SHALL distinguish command intent, policy decisions, task
+lifecycle, yielded checkpoints, planned side effects, committed side effects,
+artifacts, and evidence.
+
+#### Scenario: Command is denied
+- **WHEN** a command invocation is denied by policy
+- **THEN** the ledger records the invocation and decision
+- **AND** no committed side-effect event is recorded
+
+#### Scenario: External mutation succeeds
+- **WHEN** a command performs an external mutation such as writing a file
+- **THEN** the ledger records the committed side effect only after the mutation
+  succeeds
+- **AND** evidence identifies the native resource state that was observed or
+  changed
+
+### Requirement: Ledger replay has no side effects
+The workbench core SHALL replay activity ledgers only to rebuild workbench state
+and SHALL NOT re-execute external side effects during replay.
+
+#### Scenario: Activity ledger is replayed
+- **WHEN** a workbench ledger is replayed after restart
+- **THEN** replay rebuilds tasks, buffers, views, artifacts, evidence, and
+  projection indexes
+- **AND** it does not rerun shell commands, resubmit agent turns, rewrite files,
+  send terminal input, call networks, or restart imports
+
+#### Scenario: Native resource state is stale
+- **WHEN** a replayed projection references a native resource whose current
+  state may have changed
+- **THEN** the workbench refreshes or marks the resource through its native
+  authority path rather than trusting replay to recreate external state
+
+### Requirement: Projections are rebuildable caches
+The workbench core SHALL treat projection state as rebuildable cache derived
+from ledgers and native resource inspection.
+
+#### Scenario: Projection cache is missing
+- **WHEN** a projection cache is absent or invalid
+- **THEN** the workbench can rebuild semantic task, object, buffer, view,
+  artifact, evidence, and command-availability state from authoritative ledger
+  events and native resource inspection
+
+#### Scenario: Projection checkpoint exists
+- **WHEN** a projection checkpoint is used to accelerate startup
+- **THEN** it is identified as a cache with source event metadata
+- **AND** it does not replace the activity ledger as authority
+
+### Requirement: Semantic view snapshots are typed
+The workbench core SHALL expose renderer-independent semantic view snapshots
+with strongly typed built-in view models and schema-versioned dynamic extension
+payloads.
+
+#### Scenario: Built-in conversation view is requested
+- **WHEN** a renderer host requests a conversation view snapshot
+- **THEN** the workbench returns a typed conversation model rather than raw
+  terminal lines or renderer-specific widgets
+
+#### Scenario: Extension view is requested
+- **WHEN** a view is provided by an extension or domain-specific adapter outside
+  the built-in set
+- **THEN** the workbench returns a schema id, schema version, and JSON payload
+  that renderer hosts can render with a fallback or future host-specific
+  adapter
+
+### Requirement: Artifacts and evidence preserve provenance
+The workbench core SHALL model produced results as artifacts and supporting
+observations as evidence.
+
+#### Scenario: Task produces a patch
+- **WHEN** a task produces a patch, report, screenshot, search result, or other
+  result
+- **THEN** the workbench records an artifact linked to the producing task and
+  available object or buffer references
+
+#### Scenario: Task result is justified
+- **WHEN** a task claims success, failure, or partial completion
+- **THEN** the workbench can attach evidence such as command status, file hash,
+  event id, approval decision, screenshot capture, or external response
+  metadata

--- a/openspec/changes/introduce-workbench-runtime/specs/workbench-renderer-host-contract/spec.md
+++ b/openspec/changes/introduce-workbench-runtime/specs/workbench-renderer-host-contract/spec.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### Requirement: Renderer hosts do not own workbench runtime
+Workbench renderer hosts SHALL render semantic workbench snapshots and translate
+host input, but SHALL NOT own command registries, query registries, task
+supervision, projection authority, or activity ledger authority.
+
+#### Scenario: Ratatui host is inspected
+- **WHEN** the Ratatui workbench host is implemented
+- **THEN** it owns terminal frame rendering, terminal input capture, layout, and
+  renderer caches
+- **AND** it obtains semantic state through workbench snapshots, commands,
+  queries, and subscriptions rather than a Ratatui-private application model
+
+#### Scenario: SwiftUI host is added later
+- **WHEN** a SwiftUI host renders the same workbench view
+- **THEN** it can consume the same semantic snapshot and command/query surfaces
+  without depending on Ratatui or Crossterm types
+
+### Requirement: Hosts consume semantic snapshots
+Renderer hosts SHALL pull semantic view snapshots after invalidation or update
+signals instead of consuming renderer-specific render patches from the core.
+
+#### Scenario: View changes
+- **WHEN** a task, buffer, object, command, or query update invalidates a view
+- **THEN** the host can pull a versioned semantic view snapshot
+- **AND** the host chooses its own diffing, caching, layout, and rendering
+  strategy
+
+#### Scenario: Snapshot is rendered in different hosts
+- **WHEN** a conversation, task tree, form, diff, text document, or log stream
+  snapshot is rendered by multiple hosts
+- **THEN** each host renders it using host-native widgets or terminal cells
+  while preserving the semantic content and action identities
+
+### Requirement: Built-in view models have host adapters
+Renderer hosts SHALL provide adapters for the built-in semantic view models
+needed by the first workbench slice.
+
+#### Scenario: Agent conversation vertical slice is rendered
+- **WHEN** the first Ratatui workbench slice renders Alan agent work
+- **THEN** it supports conversation, form, task tree, and command palette
+  semantic view snapshots
+
+#### Scenario: Read/review surfaces are rendered
+- **WHEN** text document, diff, object list, or log stream snapshots are
+  introduced in the workbench core
+- **THEN** renderer hosts can add adapters for those built-in models without
+  changing the core snapshot contract
+
+### Requirement: Dynamic extension views use fallback rendering
+Renderer hosts SHALL render unknown or extension-provided semantic views through
+schema-versioned fallback behavior unless a host-specific renderer capability is
+explicitly added later.
+
+#### Scenario: Extension view is unknown to host
+- **WHEN** a renderer host receives an extension view snapshot with a schema id
+  it does not recognize
+- **THEN** it presents a bounded fallback representation or unsupported-view
+  diagnostic
+- **AND** it does not execute extension renderer code by default
+
+#### Scenario: Future renderer extension is considered
+- **WHEN** a future change adds host-specific renderer extension support
+- **THEN** it defines explicit renderer capabilities and permission boundaries
+  separate from the semantic workbench core contract
+
+### Requirement: Host input becomes semantic input or command invocation
+Renderer hosts SHALL translate raw host events into workbench input intents,
+view-local input, or command invocations before crossing the runtime boundary.
+
+#### Scenario: Terminal key is pressed
+- **WHEN** Crossterm reports a key, paste, resize, or mouse event to the Ratatui
+  host
+- **THEN** the host translates it into a semantic input intent, view-local
+  input, command invocation, or host-local layout change
+- **AND** raw Crossterm event types do not become workbench core state
+
+#### Scenario: Native control is activated
+- **WHEN** a SwiftUI button, menu item, keyboard shortcut, or responder action
+  is activated in a future host
+- **THEN** the host invokes the same command identity or semantic input intent
+  that other hosts use for the equivalent action
+
+### Requirement: View-local state is separated from host render state
+Renderer hosts SHALL keep renderer-only cache and layout state separate from
+semantic view state managed by the workbench.
+
+#### Scenario: Selection matters semantically
+- **WHEN** selection, focused field, filter text, scroll anchor, expanded
+  semantic node, or active view mode is needed for restore, agent inspection,
+  command routing, or another renderer
+- **THEN** it is stored as workbench semantic view state
+
+#### Scenario: Layout cache is renderer-specific
+- **WHEN** measured line wraps, terminal cell cache, pixel geometry, hover
+  state, animation frame, or renderer-specific scroll detail is needed
+- **THEN** it remains host render state and is not written as semantic
+  workbench state
+
+### Requirement: Host layout remains separate from semantic workbench state
+Renderer hosts SHALL own physical layout while the workbench owns semantic open
+buffers, views, active view, focus relationships, and task state.
+
+#### Scenario: Host splits a pane
+- **WHEN** a host splits, resizes, moves, or collapses panes, tabs, windows, or
+  overlays
+- **THEN** the physical layout change remains host-local unless it changes which
+  semantic view is open or active
+
+#### Scenario: Workbench opens a view
+- **WHEN** a command opens or focuses a semantic view
+- **THEN** the host decides where and how to mount that view
+- **AND** the workbench records the semantic open/focus state independent of the
+  host's physical placement
+
+### Requirement: Ratatui integration preserves terminal behavior
+The Ratatui workbench host SHALL preserve the current daemon-backed TUI
+behavior while semantic rendering is introduced.
+
+#### Scenario: Semantic path is introduced
+- **WHEN** the Ratatui TUI starts consuming workbench semantic snapshots
+- **THEN** daemon session creation, hydration, reconnect replay, submissions,
+  resume operations, interrupts, compaction, rollback, frame coalescing, and
+  terminal scrollback behavior remain compatible with the accepted Rust inline
+  TUI contract
+
+#### Scenario: Semantic renderer fails during migration
+- **WHEN** a semantic renderer path is incomplete or disabled during the first
+  integration phase
+- **THEN** the implementation can continue to use the existing TUI path for
+  unsupported surfaces until focused tests prove semantic parity

--- a/openspec/changes/introduce-workbench-runtime/tasks.md
+++ b/openspec/changes/introduce-workbench-runtime/tasks.md
@@ -1,0 +1,81 @@
+## 0. Programmable Environment Alignment
+
+- [x] 0.1 Declare workbench as an environment-core runtime substrate incubation
+  slice under `programmable-environment-product`, not the complete product.
+- [x] 0.2 Record which constitution criteria the first slice proves: objects,
+  commands, buffers, views, queries, actors, tasks, artifacts, evidence, ledgers,
+  native references, no-side-effect replay, and renderer-host snapshots.
+- [x] 0.3 Record deferred constitution criteria: broad first-launch local work
+  discovery, complete environment app workflow, SwiftUI host implementation,
+  WASM extension loading, and universal resource addressing.
+- [x] 0.4 Keep the Alan agent conversation path as the first vertical slice while
+  documenting that it is a compatibility-first substrate proof, not the whole
+  programmable environment MVP.
+
+## 1. Core Crate Skeleton
+
+- [ ] 1.1 Add `workbench-core` to the Cargo workspace with no dependency on `alan-protocol`, Ratatui, Crossterm, AppKit, SwiftUI, or Tokio task handles.
+- [ ] 1.2 Define typed opaque ids for actors, objects, buffers, views, commands, queries, subscriptions, tasks, artifacts, evidence, and events.
+- [ ] 1.3 Define descriptor types for actors, objects, buffers, views, commands, queries, subscriptions, tasks, artifacts, and evidence.
+- [ ] 1.4 Add native-reference descriptor support so files, Git repositories, agent sessions, terminal handles, and domain-owned resources keep external authority outside workbench ids.
+- [ ] 1.5 Add compile-time or focused tests proving `workbench-core` remains independent from Alan protocol and renderer-host crates.
+
+## 2. Command, Query, And Subscription Model
+
+- [ ] 2.1 Implement command descriptor and invocation types with target, args schema, actor, capability, risk, undo or recovery, and invocation-hint metadata.
+- [ ] 2.2 Implement query descriptor and invocation types with read-only result references and capability metadata.
+- [ ] 2.3 Implement subscription descriptors and update or invalidation messages for object, buffer, view, task, query, and command-availability dependencies.
+- [ ] 2.4 Add registry traits or lightweight in-memory registries for commands, queries, and subscriptions.
+- [ ] 2.5 Add tests proving mutation routes through command invocation while queries and subscriptions remain read-only or observational.
+
+## 3. Ledger, Projection, And Task Runtime State
+
+- [ ] 3.1 Define `WorkbenchEvent` with schema version, event id, sequence, timestamp, actor id, causation id, correlation id, and typed event kind.
+- [ ] 3.2 Define task events for started, progress, output appended, yielded, resumed, side-effect planned, side-effect committed, artifact created, evidence attached, completed, failed, and cancelled states.
+- [ ] 3.3 Implement in-memory activity ledger replay with no side effects.
+- [ ] 3.4 Implement JSONL activity ledger append and replay behind the same ledger trait.
+- [ ] 3.5 Implement an in-memory projection store for current objects, buffers, views, tasks, artifacts, evidence, command availability, and dirty-view invalidation.
+- [ ] 3.6 Add replay tests proving projections rebuild from ledger state without rerunning shell commands, agent turns, file writes, network calls, terminal input, or imports.
+
+## 4. Semantic View Snapshots
+
+- [ ] 4.1 Define `ViewSnapshot` with view id, buffer id, version, view kind, semantic model, actions, diagnostics, selection, and focus state.
+- [ ] 4.2 Define strongly typed built-in view models for conversation, task tree, command palette, form, object list, text document read/review, diff, and log stream.
+- [ ] 4.3 Define schema-versioned dynamic extension view payload support using JSON for unknown or domain-specific views.
+- [ ] 4.4 Separate semantic view state from host render state in the type model and tests.
+- [ ] 4.5 Add snapshot tests for conversation, form, task tree, and command palette models as the first implementation surface.
+
+## 5. Alan Agent Adapter
+
+- [ ] 5.1 Add `workbench-agent` to the workspace with dependencies on `workbench-core` and the Alan protocol/runtime client surfaces needed for adaptation.
+- [ ] 5.2 Map Alan session metadata into an agent session object, conversation buffer, and initial conversation view descriptor.
+- [ ] 5.3 Register agent commands for submit turn, resume yielded task, interrupt or cancel active work, compact context, and rollback turn history.
+- [ ] 5.4 Map `alan_protocol::EventEnvelope` turn, text, thinking, tool, plan, warning, error, and yield events into workbench events and projections.
+- [ ] 5.5 Map Alan child-run records or lifecycle events into workbench child task descriptors and task events.
+- [ ] 5.6 Project Alan confirmation, structured input, and dynamic tool yields into yielded task state and semantic form or approval snapshots.
+- [ ] 5.7 Add fixture tests using representative Alan event envelopes to verify conversation, form, task tree, artifact, and evidence projections.
+
+## 6. Ratatui Renderer Host
+
+- [ ] 6.1 Add `workbench-ratatui` to the workspace as a renderer host and input adapter over `workbench-core`.
+- [ ] 6.2 Implement Ratatui renderers for conversation, form, task tree, and command palette semantic snapshots.
+- [ ] 6.3 Translate Crossterm key, paste, resize, and mouse events into host-local layout changes, semantic input intents, view-local input, or command invocations.
+- [ ] 6.4 Keep renderer-only state such as line wrapping, terminal cell cache, geometry, and frame timing out of workbench semantic state.
+- [ ] 6.5 Add Ratatui snapshot or test-backend coverage for the first built-in semantic view renderers.
+
+## 7. Existing TUI Compatibility Integration
+
+- [ ] 7.1 Integrate `workbench-agent` and `workbench-ratatui` into `crates/tui` behind a compatibility-first path while preserving existing daemon wiring.
+- [ ] 7.2 Preserve session creation or attach, hydration, replay cursor handling, event stream reconnect, submission, resume, interrupt, compact, rollback, and pending-yield behavior.
+- [ ] 7.3 Run the semantic projection path in parallel with the existing reducer where useful and add parity tests before removing old reducer behavior.
+- [ ] 7.4 Migrate supported conversation, form, task-tree, and command-palette rendering to semantic snapshots after focused tests pass.
+- [ ] 7.5 Leave unsupported surfaces on the current TUI path until a semantic model and renderer are implemented.
+
+## 8. Verification And Review
+
+- [ ] 8.1 Run focused `cargo test` coverage for `workbench-core`, `workbench-agent`, `workbench-ratatui`, and affected `alan-terminal-ui` tests.
+- [ ] 8.2 Run `cargo fmt --all` and the relevant clippy or workspace check target, or document any environment-blocked gate with focused passing tests.
+- [ ] 8.3 Run `openspec validate introduce-workbench-runtime --strict`.
+- [ ] 8.4 Run `git diff --check -- openspec/changes/introduce-workbench-runtime crates`.
+- [ ] 8.5 Perform a PR review pass against the workbench contracts, adapter boundaries, replay no-side-effects rule, and existing TUI compatibility.
+- [ ] 8.6 After implementation is merged, sync accepted delta specs into `openspec/specs/` and prepare archive-readiness notes before archiving the change.


### PR DESCRIPTION
## Summary

- Align the programmable environment foundation specs with the Alan OS product direction.
- Classify macOS component-system and Groove Master work against the Alan OS app/host model.
- Keep the changes scoped to OpenSpec planning and documentation.

## Validation

- `openspec validate --all --strict` (66 passed, 0 failed)
- `git diff --check origin/main...HEAD`