### PR TITLE
feat(ap): add alan-ap, the wire-shaped aP file-service protocol (Plan 9 PR 1/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-ap"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "alan-auth"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/ap",
     "crates/auth",
     "crates/protocol",
     "crates/llm",

--- a/crates/ap/Cargo.toml
+++ b/crates/ap/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "alan-ap"
+description = "aP — Alan's 9P-analog file-service protocol (FileServer trait, fids, byte/offset streams, in-process transport)"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true }

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -1,0 +1,23 @@
+//! aP — Alan's file-service protocol (the 9P analog).
+//!
+//! Everything in Alan OS is a file; aP is the single contract every file server
+//! and client speaks. This crate owns the protocol shape only: the
+//! [`FileServer`] trait, fid/qid value types, byte/offset stream conventions,
+//! the wire [`Request`]/[`Response`] messages, error codes, and the in-process
+//! fast-path transport. It depends on no other Alan crate (ADR-0025 D1/D2).
+//!
+//! The contract is *wire-shaped* (ADR-0024 D5): every operation is expressible
+//! over fids, paths, byte buffers, offsets, and error codes, so the same
+//! operations can later cross a process boundary unchanged. v1 runs servers
+//! in-process over [`InProcessTransport`] with no serialization cost.
+
+pub mod reference;
+mod server;
+mod stream;
+mod types;
+mod wire;
+
+pub use server::{FileServer, InProcessTransport};
+pub use stream::Stream;
+pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
+pub use wire::{Request, Response};

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -217,9 +217,10 @@ impl FileServer for MemFs {
                 // Honor the byte offset: the aP contract addresses writes by
                 // offset, so place bytes at `offset` (out-of-order, retried, or
                 // overwriting chunks build the document the caller addressed),
-                // rather than blindly appending.
-                let start = offset as usize;
-                let end = start + data.len();
+                // rather than blindly appending. Use checked arithmetic so a
+                // hostile/huge offset returns an aP error instead of panicking.
+                let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+                let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
                 if f.write_buf.len() < end {
                     f.write_buf.resize(end, 0);
                 }
@@ -262,6 +263,15 @@ impl FileServer for MemFs {
 
     async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
         if fid == Fid::ROOT {
+            // Root is the reusable pre-bound anchor: never remove it, but clear
+            // its per-open state so it can be opened again (otherwise the
+            // reopen guard would lock root out for the server's lifetime).
+            let mut state = self.state.lock().await;
+            if let Some(root) = state.fids.get_mut(&Fid::ROOT) {
+                root.mode = None;
+                root.clone_name = None;
+                root.write_buf.clear();
+            }
             return Ok(());
         }
         let mut state = self.state.lock().await;

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -1,0 +1,249 @@
+//! A reference in-memory [`FileServer`] used to exercise the aP conventions and
+//! as a worked template for real servers (and alan-shell's M1 echo milestone).
+//!
+//! It is intentionally small but conformant on the points that are easy to get
+//! wrong: the fid lifecycle (§5.2), clone-via-open allocating independent
+//! resources (§5.4), and commit-on-clunk document writes whose malformed
+//! commit is a commit-time [`ErrorCode::BadRequest`] (§5.5). It is not the
+//! kernel's `/proc`/`/srv` and stores no durable state.
+
+use std::collections::{BTreeMap, HashMap};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+
+type NodeId = usize;
+
+enum Node {
+    Dir(BTreeMap<String, NodeId>),
+    Bytes(Vec<u8>),
+    /// A clone file: each `open` allocates a fresh connection directory.
+    Clone {
+        next: u64,
+    },
+    /// A commit-on-clunk document file that must hold valid JSON at commit.
+    Doc,
+}
+
+struct FidState {
+    node: NodeId,
+    mode: Option<OpenMode>,
+    /// Buffered document for a commit-on-clunk write, committed at `clunk`.
+    write_buf: Vec<u8>,
+    /// For an opened clone fid: the resource name allocated at `open`, returned
+    /// when the caller `read`s the clone fid.
+    clone_name: Option<String>,
+}
+
+impl FidState {
+    fn at(node: NodeId) -> Self {
+        Self {
+            node,
+            mode: None,
+            write_buf: Vec::new(),
+            clone_name: None,
+        }
+    }
+}
+
+struct State {
+    nodes: Vec<Node>,
+    fids: HashMap<Fid, FidState>,
+}
+
+impl State {
+    fn push(&mut self, node: Node) -> NodeId {
+        self.nodes.push(node);
+        self.nodes.len() - 1
+    }
+
+    fn qid(&self, node: NodeId) -> Qid {
+        let kind = match self.nodes[node] {
+            Node::Dir(_) => FileKind::Dir,
+            Node::Bytes(_) => FileKind::File,
+            Node::Clone { .. } => FileKind::Clone,
+            Node::Doc => FileKind::File,
+        };
+        Qid {
+            kind,
+            version: 0,
+            path: node as u64,
+        }
+    }
+
+    fn dir_entry(&self, dir: NodeId, name: &str) -> Result<NodeId, ErrorCode> {
+        match &self.nodes[dir] {
+            Node::Dir(entries) => entries.get(name).copied().ok_or(ErrorCode::NotFound),
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    fn fid(&self, fid: Fid) -> Result<&FidState, ErrorCode> {
+        self.fids.get(&fid).ok_or(ErrorCode::NotFound)
+    }
+}
+
+/// A small in-memory aP file server: a root directory containing `greeting`
+/// (bytes), `clone` (clone-via-open), and `submit` (commit-on-clunk JSON doc).
+pub struct MemFs {
+    state: Mutex<State>,
+}
+
+impl Default for MemFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemFs {
+    pub fn new() -> Self {
+        // Root is node 0 so `Fid::ROOT` can be pre-bound to it.
+        let nodes = vec![Node::Dir(BTreeMap::new())];
+        let mut state = State {
+            nodes,
+            fids: HashMap::new(),
+        };
+
+        let greeting = state.push(Node::Bytes(b"hi".to_vec()));
+        let clone = state.push(Node::Clone { next: 0 });
+        let submit = state.push(Node::Doc);
+        if let Node::Dir(entries) = &mut state.nodes[0] {
+            entries.insert("greeting".into(), greeting);
+            entries.insert("clone".into(), clone);
+            entries.insert("submit".into(), submit);
+        }
+        state.fids.insert(Fid::ROOT, FidState::at(0));
+
+        Self {
+            state: Mutex::new(state),
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for MemFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let mut node = state.fid(fid)?.node;
+        for name in names {
+            node = state.dir_entry(node, name)?;
+        }
+        state.fids.insert(newfid, FidState::at(node));
+        Ok(state.qid(node))
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.fid(fid)?.node;
+
+        // Clone-via-open: allocate a fresh connection directory under root and
+        // remember its name for this fid's subsequent read.
+        let clone_name = if let Node::Clone { next } = &mut state.nodes[node] {
+            let n = *next;
+            *next += 1;
+            let name = format!("conn-{n}");
+            let id_file = state.push(Node::Bytes(name.clone().into_bytes()));
+            let mut entries = BTreeMap::new();
+            entries.insert("id".to_string(), id_file);
+            let conn_dir = state.push(Node::Dir(entries));
+            if let Node::Dir(root) = &mut state.nodes[0] {
+                root.insert(name.clone(), conn_dir);
+            }
+            Some(name)
+        } else {
+            None
+        };
+
+        let qid = state.qid(node);
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        f.mode = Some(mode);
+        f.clone_name = clone_name;
+        Ok(qid)
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        let f = state.fid(fid)?;
+        // An opened clone fid reads back the allocated resource name.
+        let bytes = if let Some(name) = &f.clone_name {
+            name.clone().into_bytes()
+        } else {
+            match &state.nodes[f.node] {
+                Node::Bytes(b) => b.clone(),
+                Node::Dir(entries) => entries
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join("\n")
+                    .into_bytes(),
+                _ => return Err(ErrorCode::Unsupported),
+            }
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+
+    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.fid(fid)?.node;
+        match state.nodes[node] {
+            // Commit-on-clunk: buffer the document; it is acted on only at clunk.
+            Node::Doc => {
+                let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+                f.write_buf.extend_from_slice(data);
+                Ok(data.len() as u32)
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let f = state.fid(fid)?;
+        let qid = state.qid(f.node);
+        let length = match &state.nodes[f.node] {
+            Node::Bytes(b) => b.len() as u64,
+            _ => 0,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid,
+            length,
+            writable: matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let f = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        // Commit-on-clunk validation: a Doc opened for write must hold a valid
+        // document at commit, else a commit-time error (§5.5).
+        if matches!(state.nodes[f.node], Node::Doc)
+            && matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite))
+        {
+            serde_json::from_slice::<serde_json::Value>(&f.write_buf)
+                .map_err(|_| ErrorCode::BadRequest)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -152,6 +152,13 @@ impl FileServer for MemFs {
         }
         let node = existing.node;
 
+        // Dial-time access check (§5.5): reject a mode the node cannot service —
+        // a write to a read-only node or a read of the write-only document fails
+        // at open, not later as a misclassified "successful" interaction.
+        if !serviceable(&state.nodes[node], mode) {
+            return Err(ErrorCode::NoAccess);
+        }
+
         // Clone-via-open: allocate a fresh connection directory under root and
         // remember its name for this fid's subsequent read.
         let clone_name = if let Node::Clone { next } = &mut state.nodes[node] {
@@ -180,6 +187,12 @@ impl FileServer for MemFs {
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         let state = self.state.lock().await;
         let f = state.fid(fid)?;
+        // Reading needs read authority established by a successful read-open;
+        // mirror the write path so bytes are never served before the per-fid
+        // access intent is set (§5.2 / three-phase model).
+        if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+            return Err(ErrorCode::NoAccess);
+        }
         // An opened clone fid reads back the allocated resource name.
         let bytes = if let Some(name) = &f.clone_name {
             name.clone().into_bytes()
@@ -285,5 +298,16 @@ impl FileServer for MemFs {
                 .map_err(|_| ErrorCode::BadRequest)?;
         }
         Ok(())
+    }
+}
+
+/// Whether `node` can service an open in `mode`. Read-only nodes (bytes,
+/// directories, the clone file) serve only `Read`; the write-only document
+/// serves only `Write`. Anything else is a dial-time access error, not a
+/// success that fails later.
+fn serviceable(node: &Node, mode: OpenMode) -> bool {
+    match node {
+        Node::Doc => matches!(mode, OpenMode::Write),
+        Node::Bytes(_) | Node::Dir(_) | Node::Clone { .. } => matches!(mode, OpenMode::Read),
     }
 }

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -126,6 +126,12 @@ impl MemFs {
 impl FileServer for MemFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
         let mut state = self.state.lock().await;
+        // A fid is a handle to one interaction (§5.2): never rebind the reserved
+        // root or an already-live fid, or two callers reusing a number would
+        // clobber each other's state.
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
         let mut node = state.fid(fid)?.node;
         for name in names {
             node = state.dir_entry(node, name)?;
@@ -193,6 +199,13 @@ impl FileServer for MemFs {
             // Commit-on-clunk: buffer the document; it is acted on only at clunk.
             Node::Doc => {
                 let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+                // Writing needs write authority: a fid opened read-only (or not
+                // opened for write) must not buffer, or its malformed payload
+                // would be silently skipped at commit and defeat the
+                // commit-on-clunk error model this server demonstrates.
+                if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+                    return Err(ErrorCode::NoAccess);
+                }
                 f.write_buf.extend_from_slice(data);
                 Ok(data.len() as u32)
             }

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -14,6 +14,10 @@ use tokio::sync::Mutex;
 
 use crate::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
 
+/// Upper bound on a buffered commit-on-clunk document, so a huge/sparse write
+/// offset cannot make the reference server allocate unbounded memory.
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+
 type NodeId = usize;
 
 enum Node {
@@ -234,6 +238,13 @@ impl FileServer for MemFs {
                 // hostile/huge offset returns an aP error instead of panicking.
                 let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
                 let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+                // Bound the buffered document: a representable-but-huge offset (a
+                // sparse 1 TiB write) would otherwise resize/zero-fill gigabytes
+                // and OOM the in-process server. Cap the addressable size so it
+                // returns an aP error instead.
+                if end > MAX_DOC_BYTES {
+                    return Err(ErrorCode::BadRequest);
+                }
                 if f.write_buf.len() < end {
                     f.write_buf.resize(end, 0);
                 }

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -142,7 +142,15 @@ impl FileServer for MemFs {
 
     async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
         let mut state = self.state.lock().await;
-        let node = state.fid(fid)?.node;
+        let existing = state.fid(fid)?;
+        // A fid is a handle to one interaction (§5.2): reopening an already-open
+        // fid before clunk is rejected, so a second `open` cannot downgrade the
+        // write intent and let a buffered malformed document bypass commit-time
+        // validation.
+        if existing.mode.is_some() {
+            return Err(ErrorCode::BadRequest);
+        }
+        let node = existing.node;
 
         // Clone-via-open: allocate a fresh connection directory under root and
         // remember its name for this fid's subsequent read.
@@ -192,7 +200,7 @@ impl FileServer for MemFs {
         Ok(bytes[start..end].to_vec())
     }
 
-    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         let mut state = self.state.lock().await;
         let node = state.fid(fid)?.node;
         match state.nodes[node] {
@@ -206,7 +214,16 @@ impl FileServer for MemFs {
                 if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
                     return Err(ErrorCode::NoAccess);
                 }
-                f.write_buf.extend_from_slice(data);
+                // Honor the byte offset: the aP contract addresses writes by
+                // offset, so place bytes at `offset` (out-of-order, retried, or
+                // overwriting chunks build the document the caller addressed),
+                // rather than blindly appending.
+                let start = offset as usize;
+                let end = start + data.len();
+                if f.write_buf.len() < end {
+                    f.write_buf.resize(end, 0);
+                }
+                f.write_buf[start..end].copy_from_slice(data);
                 Ok(data.len() as u32)
             }
             _ => Err(ErrorCode::Unsupported),

--- a/crates/ap/src/server.rs
+++ b/crates/ap/src/server.rs
@@ -1,0 +1,110 @@
+//! The [`FileServer`] trait — the aP contract every server implements — and the
+//! [`InProcessTransport`] that carries calls to it.
+//!
+//! Servers implement typed async methods (ergonomic, owned returns); the
+//! transport is the seam that turns wire [`Request`]s into method calls and
+//! method results into [`Response`]s. v1's transport is in-process and does no
+//! serialization (§5.6); a future wire transport substitutes here without
+//! changing servers or clients.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Request, Response, Stat};
+
+/// A file server: the backing implementation of one mountable tree.
+///
+/// Methods take fids, name components, byte buffers, offsets, and counts and
+/// return owned, serializable values or an [`ErrorCode`] (§5.1) — nothing
+/// borrowed from server-internal memory, so the same calls can later cross a
+/// process boundary. Fid lifecycle is the caller's: `walk`/`create` bind a
+/// caller-chosen `newfid`, `open` acts on an existing fid, `clunk` releases one
+/// (§5.2).
+#[async_trait]
+pub trait FileServer: Send + Sync {
+    /// Walk `names` from `fid`, binding `newfid` to the destination file.
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode>;
+
+    /// Open `fid` with the given access intent. On a [`FileKind::Clone`] file
+    /// this allocates a new resource as a side effect (§5.4); the caller then
+    /// `read`s `fid` to learn the allocated name. A denied/absent/rate-limited
+    /// open is a dial-time failure (§5.5).
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode>;
+
+    /// Read up to `count` bytes from `offset`. On a [`FileKind::Stream`] this
+    /// blocks until bytes at or after `offset` exist (§5.3).
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode>;
+
+    /// Write `data` at `offset`, returning the byte count accepted. Document
+    /// entry points commit on `clunk`, never on a partial write.
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode>;
+
+    /// Return metadata for `fid`.
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode>;
+
+    /// Create child `name` of `kind` under directory `fid`, binding `newfid`.
+    async fn create(
+        &self,
+        fid: Fid,
+        newfid: Fid,
+        name: &str,
+        kind: FileKind,
+    ) -> Result<Qid, ErrorCode>;
+
+    /// Remove the file `fid` refers to, then release `fid`.
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode>;
+
+    /// Release `fid`. For commit-on-clunk document writes this is the commit
+    /// point, and MAY return a commit-time [`ErrorCode::BadRequest`] (§5.5).
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode>;
+}
+
+/// The in-process fast path: dispatches a wire [`Request`] to a [`FileServer`]
+/// and returns its [`Response`] with no serialization (§5.6).
+#[derive(Clone)]
+pub struct InProcessTransport {
+    server: Arc<dyn FileServer>,
+}
+
+impl InProcessTransport {
+    pub fn new(server: Arc<dyn FileServer>) -> Self {
+        Self { server }
+    }
+
+    /// Carry one operation to the server. This is the single dispatch point that
+    /// maps each `Request` variant onto the matching typed method; a future wire
+    /// transport offers the same `call` shape over serialized bytes.
+    pub async fn call(&self, request: Request) -> Result<Response, ErrorCode> {
+        let s = &self.server;
+        match request {
+            Request::Walk { fid, newfid, names } => s
+                .walk(fid, newfid, &names)
+                .await
+                .map(|qid| Response::Walk { qid }),
+            Request::Open { fid, mode } => {
+                s.open(fid, mode).await.map(|qid| Response::Open { qid })
+            }
+            Request::Read { fid, offset, count } => s
+                .read(fid, offset, count)
+                .await
+                .map(|data| Response::Read { data }),
+            Request::Write { fid, offset, data } => s
+                .write(fid, offset, &data)
+                .await
+                .map(|count| Response::Write { count }),
+            Request::Stat { fid } => s.stat(fid).await.map(|stat| Response::Stat { stat }),
+            Request::Create {
+                fid,
+                newfid,
+                name,
+                kind,
+            } => s
+                .create(fid, newfid, &name, kind)
+                .await
+                .map(|qid| Response::Create { qid }),
+            Request::Remove { fid } => s.remove(fid).await.map(|()| Response::Remove),
+            Request::Clunk { fid } => s.clunk(fid).await.map(|()| Response::Clunk),
+        }
+    }
+}

--- a/crates/ap/src/stream.rs
+++ b/crates/ap/src/stream.rs
@@ -1,0 +1,93 @@
+//! The byte/offset stream primitive (§5.3): an append-only byte log with
+//! retained history that backs every aP stream file (a process's `io/output`,
+//! an agent's `events`, an `llmfs` generation's `data`).
+//!
+//! Reads are offset-addressed and resumable, history is retained so a reader
+//! that opens late still reads from offset 0, and a read at the live edge blocks
+//! until new bytes arrive — observation is a blocking read, not a separate
+//! notification primitive (ADR-0024). Record typing (e.g. one JSON object per
+//! line) is a consumer convention layered on top, not part of this primitive.
+
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, watch};
+
+use crate::Offset;
+
+/// A shared, cheaply cloneable handle to one append-only byte stream. Clones
+/// observe the same underlying log; each reader supplies its own offset, so many
+/// consumers watch one stream independently (§5.3).
+#[derive(Clone)]
+pub struct Stream {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    buf: Mutex<Vec<u8>>,
+    /// Carries the current length; bumped on every append. Readers waiting at
+    /// the live edge wake on a change. `watch` retains the latest value, so an
+    /// append between a reader's length check and its await is never lost.
+    len_tx: watch::Sender<u64>,
+}
+
+impl Default for Stream {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Stream {
+    pub fn new() -> Self {
+        let (len_tx, _len_rx) = watch::channel(0u64);
+        Self {
+            inner: Arc::new(Inner {
+                buf: Mutex::new(Vec::new()),
+                len_tx,
+            }),
+        }
+    }
+
+    /// Append `bytes` to the log and wake any readers parked at the live edge.
+    pub async fn append(&self, bytes: &[u8]) {
+        let new_len = {
+            let mut buf = self.inner.buf.lock().await;
+            buf.extend_from_slice(bytes);
+            buf.len() as u64
+        };
+        // Ignored if there are no receivers; the retained value still updates.
+        let _ = self.inner.len_tx.send(new_len);
+    }
+
+    /// The number of bytes retained so far.
+    pub async fn len(&self) -> u64 {
+        self.inner.buf.lock().await.len() as u64
+    }
+
+    /// Whether no bytes have been appended yet.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.buf.lock().await.is_empty()
+    }
+
+    /// Read up to `count` bytes starting at `offset`. If `offset` is at or beyond
+    /// the live edge, block until bytes at `offset` exist, then return them
+    /// (§5.3). Subscribe to length changes *before* the first check so an append
+    /// racing the check is observed rather than missed.
+    pub async fn read(&self, offset: Offset, count: u32) -> Vec<u8> {
+        let mut len_rx = self.inner.len_tx.subscribe();
+        loop {
+            {
+                let buf = self.inner.buf.lock().await;
+                let start = offset as usize;
+                if start < buf.len() {
+                    let end = buf.len().min(start + count as usize);
+                    return buf[start..end].to_vec();
+                }
+            }
+            // No bytes at `offset` yet; wait for the next append. A closed
+            // channel (stream dropped) ends the wait with no more bytes.
+            if len_rx.changed().await.is_err() {
+                return Vec::new();
+            }
+        }
+    }
+}

--- a/crates/ap/src/types.rs
+++ b/crates/ap/src/types.rs
@@ -1,0 +1,107 @@
+//! aP value types: the wire-shaped vocabulary shared by every operation.
+//!
+//! All types here are plain serializable data (ADR-0024 D5): fids, qids,
+//! offsets, file kinds, open modes, error codes, and stat. None of them borrow
+//! or carry an in-process-only handle, so each can cross a byte transport
+//! unchanged.
+
+use serde::{Deserialize, Serialize};
+
+/// A fid is a handle to one interaction with a file server (§5.2). `walk`/`open`
+/// allocate it, `clunk` releases it. Fids are scoped to one client/server
+/// session and are not global capabilities (the namespace is — D6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Fid(pub u64);
+
+impl Fid {
+    /// The well-known fid naming a server's root, pre-bound by convention so an
+    /// aP-only client can `walk` from it without a separate attach operation. It
+    /// is never allocated by `walk`/`create` nor released by `clunk`.
+    pub const ROOT: Fid = Fid(0);
+}
+
+/// A byte offset into a file or stream. Streams are resumable from a
+/// caller-held offset (§5.3).
+pub type Offset = u64;
+
+/// What kind of file a qid names. Typing of stream *records* is a convention a
+/// consumer interprets, not a kernel/protocol schema; this only distinguishes
+/// the file *kind*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileKind {
+    /// A directory: `walk`able, its `read` yields child entries.
+    Dir,
+    /// A flat byte file with a length.
+    File,
+    /// A byte/offset stream with retained history: `read` blocks until new bytes
+    /// are available and resumes from a caller-held offset (§5.3).
+    Stream,
+    /// A clone file: `open` allocates a new resource and returns its handle
+    /// (§5.4), e.g. `/proc/clone` or an `llmfs` connection `clone`.
+    Clone,
+}
+
+/// The unique identity of a file at a point in time (the 9P qid analog): its
+/// kind, a version that bumps on change, and a server-unique path number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Qid {
+    pub kind: FileKind,
+    pub version: u32,
+    pub path: u64,
+}
+
+/// How a fid is opened. Authority comes from the namespace mount (read-only vs
+/// read-write); `OpenMode` is the per-fid intent within granted authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenMode {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+/// File metadata returned by `stat`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Stat {
+    pub name: String,
+    pub qid: Qid,
+    /// Byte length for files; for streams, the highest offset currently retained.
+    pub length: u64,
+    /// Whether this fid's mount grants write authority.
+    pub writable: bool,
+}
+
+/// Wire-shaped error codes. The *phase* of a failure is determined by which
+/// operation returns it (§5.5): a denied/absent/rate-limited `open` is a
+/// dial-time failure; a malformed document at `clunk`/`write` is a commit-time
+/// failure; a failure after a stream has begun surfaces as a terminal record in
+/// the stream, not as an op error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// The named file/path does not exist (dial-time).
+    #[error("not found")]
+    NotFound,
+    /// Access denied by mount/access rights (dial-time).
+    #[error("no access")]
+    NoAccess,
+    /// The server is rate limiting this dial (dial-time).
+    #[error("rate limited")]
+    RateLimited,
+    /// A committed document was malformed or truncated (commit-time).
+    #[error("bad request")]
+    BadRequest,
+    /// A directory operation was attempted on a non-directory.
+    #[error("not a directory")]
+    NotDirectory,
+    /// A byte operation was attempted on a directory.
+    #[error("is a directory")]
+    IsDirectory,
+    /// The server does not support this operation on this file.
+    #[error("unsupported")]
+    Unsupported,
+    /// An underlying I/O or backend failure.
+    #[error("io error")]
+    Io,
+}

--- a/crates/ap/src/wire.rs
+++ b/crates/ap/src/wire.rs
@@ -1,0 +1,75 @@
+//! aP wire messages: the request/response pairs every operation reduces to.
+//!
+//! These are the bytes a transport carries (§5.7). The in-process fast path
+//! ([`crate::InProcessTransport`]) dispatches the same `Request`/`Response`
+//! values without serializing them; a future wire transport serializes them
+//! unchanged. Keeping operations as explicit data — rather than method calls —
+//! is what makes "a dumb byte transport could carry every operation" checkable.
+//!
+//! Fid allocation is client-driven (9P-faithful): `walk` and `create` carry the
+//! `newfid` the client picked, `open` operates on an existing fid, and `clunk`
+//! releases a fid (§5.2). Clone-via-open (§5.4) needs no dedicated operation:
+//! the caller `open`s a [`FileKind::Clone`](crate::FileKind) file and `read`s it
+//! to learn the allocated resource's name, then `walk`s to that name.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Fid, FileKind, Offset, OpenMode, Qid, Stat};
+
+/// One aP operation request. Inputs are fids, paths (name components), byte
+/// buffers, offsets, and counts — nothing in-process-only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "op")]
+pub enum Request {
+    /// Walk `names` from `fid`, binding `newfid` to the destination file.
+    Walk {
+        fid: Fid,
+        newfid: Fid,
+        names: Vec<String>,
+    },
+    /// Open `fid` for the given access intent. On a clone file this allocates a
+    /// new resource (§5.4); its name is then read from `fid`.
+    Open { fid: Fid, mode: OpenMode },
+    /// Read up to `count` bytes from `offset`. On a stream this blocks until new
+    /// bytes are available at or after `offset` (§5.3).
+    Read {
+        fid: Fid,
+        offset: Offset,
+        count: u32,
+    },
+    /// Write `data` at `offset`. Document entry points commit on `clunk`, not on
+    /// a partial write (commit-on-clunk).
+    Write {
+        fid: Fid,
+        offset: Offset,
+        data: Vec<u8>,
+    },
+    /// Return metadata for `fid`.
+    Stat { fid: Fid },
+    /// Create child `name` of `kind` under directory `fid`, binding `newfid` to it.
+    Create {
+        fid: Fid,
+        newfid: Fid,
+        name: String,
+        kind: FileKind,
+    },
+    /// Remove the file `fid` refers to, then release `fid`.
+    Remove { fid: Fid },
+    /// Release `fid`. For commit-on-clunk document writes, this is the commit point.
+    Clunk { fid: Fid },
+}
+
+/// One aP operation response. Every output is owned and serializable (no borrows
+/// into server memory), so it survives a byte transport unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "op")]
+pub enum Response {
+    Walk { qid: Qid },
+    Open { qid: Qid },
+    Read { data: Vec<u8> },
+    Write { count: u32 },
+    Stat { stat: Stat },
+    Create { qid: Qid },
+    Remove,
+    Clunk,
+}

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -154,6 +154,84 @@ async fn dial_time_failure_returns_open_error() {
     .expect_err("walking a missing name fails");
 }
 
+// §5.2 — a fid is a handle to one interaction: walk must not rebind the reserved
+// root or an already-live fid (PR #573 review).
+#[tokio::test]
+async fn walk_rejects_rebinding_reserved_or_live_fids() {
+    let t = transport();
+
+    // Rebinding the well-known root is rejected (would corrupt the whole server).
+    assert_eq!(
+        t.call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid::ROOT,
+            names: vec!["greeting".into()]
+        })
+        .await,
+        Err(ErrorCode::BadRequest)
+    );
+
+    // A second walk onto an already-live fid is rejected, not a silent clobber.
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(60),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(60),
+            names: vec!["clone".into()]
+        })
+        .await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+// §5.5 — a write without write authority must be rejected, not silently buffered
+// and skipped at commit (PR #573 review).
+#[tokio::test]
+async fn write_without_write_intent_is_rejected() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(70),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+
+    // No open at all: a write is denied.
+    assert_eq!(
+        t.call(Request::Write {
+            fid: Fid(70),
+            offset: 0,
+            data: b"{}".to_vec()
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+
+    // Opened read-only: still denied (cannot escalate to write).
+    t.call(Request::Open {
+        fid: Fid(70),
+        mode: OpenMode::Read,
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Write {
+            fid: Fid(70),
+            offset: 0,
+            data: b"{}".to_vec()
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
 // §5.5 — commit-time failure: a document write commits on clunk and a malformed
 // document is rejected at clunk, distinct from a dial-time error.
 #[tokio::test]

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -1,0 +1,217 @@
+//! End-to-end conformance of the aP conventions against the reference in-memory
+//! server (`alan_ap::reference::MemFs`). The reference server is the worked
+//! example that gives the fid lifecycle (§5.2), clone-via-open (§5.4), and the
+//! three-phase error model (§5.5) teeth, and the template downstream file
+//! servers (and alan-shell's M1 echo milestone) build from.
+
+use std::sync::Arc;
+
+use alan_ap::reference::MemFs;
+use alan_ap::{ErrorCode, Fid, InProcessTransport, OpenMode, Request, Response};
+
+fn transport() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(MemFs::new()))
+}
+
+// §5.2 — fid lifecycle: walk allocates a fid, clunk releases it, and a released
+// fid is no longer usable.
+#[tokio::test]
+async fn fid_is_allocated_by_walk_and_released_by_clunk() {
+    let t = transport();
+
+    // walk from the well-known root binds a fresh fid to "greeting".
+    let walked = t
+        .call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(10),
+            names: vec!["greeting".into()],
+        })
+        .await;
+    assert!(
+        matches!(walked, Ok(Response::Walk { .. })),
+        "walk should allocate the fid: {walked:?}"
+    );
+
+    t.call(Request::Open {
+        fid: Fid(10),
+        mode: OpenMode::Read,
+    })
+    .await
+    .unwrap();
+    let read = t
+        .call(Request::Read {
+            fid: Fid(10),
+            offset: 0,
+            count: 64,
+        })
+        .await;
+    assert_eq!(
+        read,
+        Ok(Response::Read {
+            data: b"hi".to_vec()
+        })
+    );
+
+    // After clunk the fid is gone; reusing it is an error, not stale data.
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid(10) }).await,
+        Ok(Response::Clunk)
+    );
+    let after = t
+        .call(Request::Read {
+            fid: Fid(10),
+            offset: 0,
+            count: 64,
+        })
+        .await;
+    assert_eq!(after, Err(ErrorCode::NotFound));
+}
+
+// §5.4 — clone-via-open: opening the clone file allocates a new resource and its
+// name is read back; two callers get independent resources.
+#[tokio::test]
+async fn clone_via_open_yields_independent_resources() {
+    let t = transport();
+
+    let open_clone = |fid: Fid| {
+        let t = t.clone();
+        async move {
+            t.call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: fid,
+                names: vec!["clone".into()],
+            })
+            .await
+            .unwrap();
+            t.call(Request::Open {
+                fid,
+                mode: OpenMode::Read,
+            })
+            .await
+            .unwrap();
+            // Reading the clone fid returns the allocated resource's name.
+            let Response::Read { data } = t
+                .call(Request::Read {
+                    fid,
+                    offset: 0,
+                    count: 64,
+                })
+                .await
+                .unwrap()
+            else {
+                panic!("expected read response");
+            };
+            String::from_utf8(data).unwrap()
+        }
+    };
+
+    let first = open_clone(Fid(20)).await;
+    let second = open_clone(Fid(21)).await;
+    assert_ne!(
+        first, second,
+        "two clone opens must allocate distinct resources"
+    );
+
+    // Each allocated resource is a real, walkable child carrying its own id.
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(30),
+        names: vec![first.clone(), "id".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(30),
+        mode: OpenMode::Read,
+    })
+    .await
+    .unwrap();
+    let Response::Read { data } = t
+        .call(Request::Read {
+            fid: Fid(30),
+            offset: 0,
+            count: 64,
+        })
+        .await
+        .unwrap()
+    else {
+        panic!("expected read response");
+    };
+    assert_eq!(String::from_utf8(data).unwrap(), first);
+}
+
+// §5.5 — dial-time failure: a denied/absent open returns an operation error and
+// starts no interaction.
+#[tokio::test]
+async fn dial_time_failure_returns_open_error() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(40),
+        names: vec!["nope".into()],
+    })
+    .await
+    .expect_err("walking a missing name fails");
+}
+
+// §5.5 — commit-time failure: a document write commits on clunk and a malformed
+// document is rejected at clunk, distinct from a dial-time error.
+#[tokio::test]
+async fn commit_time_failure_is_reported_at_clunk() {
+    let t = transport();
+
+    // "submit" is a commit-on-clunk document file expecting valid JSON.
+    let walk_submit = |fid: Fid| {
+        let t = t.clone();
+        async move {
+            t.call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: fid,
+                names: vec!["submit".into()],
+            })
+            .await
+            .unwrap();
+            t.call(Request::Open {
+                fid,
+                mode: OpenMode::Write,
+            })
+            .await
+            .unwrap();
+        }
+    };
+
+    // Valid document: writes across two chunks, commits cleanly on clunk.
+    walk_submit(Fid(50)).await;
+    t.call(Request::Write {
+        fid: Fid(50),
+        offset: 0,
+        data: b"{\"ok\":".to_vec(),
+    })
+    .await
+    .unwrap();
+    t.call(Request::Write {
+        fid: Fid(50),
+        offset: 6,
+        data: b"true}".to_vec(),
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid(50) }).await,
+        Ok(Response::Clunk)
+    );
+
+    // Malformed document: writes succeed, the rejection lands at clunk.
+    walk_submit(Fid(51)).await;
+    t.call(Request::Write {
+        fid: Fid(51),
+        offset: 0,
+        data: b"{ truncated".to_vec(),
+    })
+    .await
+    .expect("partial writes are accepted; commit has not happened yet");
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid(51) }).await,
+        Err(ErrorCode::BadRequest)
+    );
+}

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -316,6 +316,67 @@ async fn document_writes_honor_offset() {
     );
 }
 
+// A huge/overflowing write offset returns an aP error instead of panicking the
+// in-process server (PR #573 review).
+#[tokio::test]
+async fn overflowing_write_offset_is_rejected_not_panicked() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(100),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(100),
+        mode: OpenMode::Write,
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Write {
+            fid: Fid(100),
+            offset: u64::MAX,
+            data: b"x".to_vec()
+        })
+        .await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+// Root is the reusable anchor: opening then clunking it must leave it openable
+// again, not locked out for the server's lifetime (PR #573 review).
+#[tokio::test]
+async fn root_fid_can_be_opened_again_after_clunk() {
+    let t = transport();
+    t.call(Request::Open {
+        fid: Fid::ROOT,
+        mode: OpenMode::Read,
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid::ROOT }).await,
+        Ok(Response::Clunk)
+    );
+    // Reopening root succeeds — its per-open state was cleared on clunk.
+    t.call(Request::Open {
+        fid: Fid::ROOT,
+        mode: OpenMode::Read,
+    })
+    .await
+    .expect("root remains the reusable anchor after clunk");
+    // And it still resolves walks afterward.
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(101),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .expect("root still anchors walks");
+}
+
 // §5.5 — commit-time failure: a document write commits on clunk and a malformed
 // document is rejected at clunk, distinct from a dial-time error.
 #[tokio::test]

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -232,6 +232,90 @@ async fn write_without_write_intent_is_rejected() {
     );
 }
 
+// §5.2 — reopening a live fid is rejected, so a second open cannot downgrade
+// write intent and bypass commit-time validation (PR #573 review).
+#[tokio::test]
+async fn reopening_a_live_fid_is_rejected() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(80),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(80),
+        mode: OpenMode::Write,
+    })
+    .await
+    .unwrap();
+    t.call(Request::Write {
+        fid: Fid(80),
+        offset: 0,
+        data: b"{ truncated".to_vec(),
+    })
+    .await
+    .unwrap();
+
+    // A second open (e.g. read) on the same fid must not succeed and clobber mode.
+    assert_eq!(
+        t.call(Request::Open {
+            fid: Fid(80),
+            mode: OpenMode::Read
+        })
+        .await,
+        Err(ErrorCode::BadRequest)
+    );
+    // The malformed document is still rejected at clunk — validation not bypassed.
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid(80) }).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+// The document write honors the byte offset, so overwriting a chunk at a lower
+// offset changes the committed document (PR #573 review).
+#[tokio::test]
+async fn document_writes_honor_offset() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(90),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(90),
+        mode: OpenMode::Write,
+    })
+    .await
+    .unwrap();
+    // Placeholder `{"ok":zzzz}` (11 bytes), then overwrite the 4-byte value at
+    // offset 6 with `true` → `{"ok":true}`.
+    t.call(Request::Write {
+        fid: Fid(90),
+        offset: 0,
+        data: br#"{"ok":zzzz}"#.to_vec(),
+    })
+    .await
+    .unwrap();
+    t.call(Request::Write {
+        fid: Fid(90),
+        offset: 6,
+        data: b"true".to_vec(),
+    })
+    .await
+    .unwrap();
+    // Offset-correct overwrite yields valid JSON → commits cleanly. (An append-
+    // only buffer would instead build `{"ok":zzzz}true` and fail validation.)
+    assert_eq!(
+        t.call(Request::Clunk { fid: Fid(90) }).await,
+        Ok(Response::Clunk)
+    );
+}
+
 // §5.5 — commit-time failure: a document write commits on clunk and a malformed
 // document is rejected at clunk, distinct from a dial-time error.
 #[tokio::test]

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -427,6 +427,36 @@ async fn read_requires_read_intent() {
     );
 }
 
+// A representable-but-huge sparse write offset is rejected instead of
+// allocating gigabytes and OOMing the server (PR #573 review).
+#[tokio::test]
+async fn huge_sparse_write_offset_is_rejected() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(130),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(130),
+        mode: OpenMode::Write,
+    })
+    .await
+    .unwrap();
+    // 1 TiB offset with a 1-byte payload: representable, but far past the cap.
+    assert_eq!(
+        t.call(Request::Write {
+            fid: Fid(130),
+            offset: 1 << 40,
+            data: b"x".to_vec()
+        })
+        .await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
 // §5.5 — commit-time failure: a document write commits on clunk and a malformed
 // document is rejected at clunk, distinct from a dial-time error.
 #[tokio::test]

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -203,24 +203,9 @@ async fn write_without_write_intent_is_rejected() {
     .await
     .unwrap();
 
-    // No open at all: a write is denied.
-    assert_eq!(
-        t.call(Request::Write {
-            fid: Fid(70),
-            offset: 0,
-            data: b"{}".to_vec()
-        })
-        .await,
-        Err(ErrorCode::NoAccess)
-    );
-
-    // Opened read-only: still denied (cannot escalate to write).
-    t.call(Request::Open {
-        fid: Fid(70),
-        mode: OpenMode::Read,
-    })
-    .await
-    .unwrap();
+    // No open at all: a write is denied (write intent never established).
+    // (Opening the document read-only is itself rejected at open now — see
+    // `open_rejects_modes_a_node_cannot_service`.)
     assert_eq!(
         t.call(Request::Write {
             fid: Fid(70),
@@ -375,6 +360,71 @@ async fn root_fid_can_be_opened_again_after_clunk() {
     })
     .await
     .expect("root still anchors walks");
+}
+
+// §5.5 — a mode the node cannot service fails at open (dial-time), not later as a
+// misclassified success (PR #573 review).
+#[tokio::test]
+async fn open_rejects_modes_a_node_cannot_service() {
+    let t = transport();
+
+    // A read-only node opened for write fails at open.
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(110),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Open {
+            fid: Fid(110),
+            mode: OpenMode::Write
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+
+    // The write-only document opened for read fails at open.
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(111),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        t.call(Request::Open {
+            fid: Fid(111),
+            mode: OpenMode::Read
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
+// §5.2 — read requires read authority from a successful read-open; bytes are not
+// served before the per-fid access intent is set (PR #573 review).
+#[tokio::test]
+async fn read_requires_read_intent() {
+    let t = transport();
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(120),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .unwrap();
+    // Reading without any open leaks no data.
+    assert_eq!(
+        t.call(Request::Read {
+            fid: Fid(120),
+            offset: 0,
+            count: 64
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
 }
 
 // §5.5 — commit-time failure: a document write commits on clunk and a malformed

--- a/crates/ap/tests/stream.rs
+++ b/crates/ap/tests/stream.rs
@@ -1,0 +1,93 @@
+//! Byte/offset stream semantics (substrate §5.3): retained history, resume from
+//! a caller-held offset, and a read that blocks until new bytes arrive — with no
+//! separate notification primitive (§ "observation is a blocking read"). This is
+//! the reusable primitive every file server's stream files build on, so the
+//! "no missed / no mis-replayed records" guarantee is verified once here.
+
+use std::time::Duration;
+
+use alan_ap::Stream;
+
+#[tokio::test]
+async fn read_returns_all_bytes_from_offset_zero() {
+    let stream = Stream::new();
+    stream.append(b"hello ").await;
+    stream.append(b"world").await;
+
+    let bytes = stream.read(0, 64).await;
+    assert_eq!(bytes, b"hello world");
+}
+
+#[tokio::test]
+async fn read_resumes_from_a_caller_held_offset() {
+    let stream = Stream::new();
+    stream.append(b"hello world").await;
+
+    // A reader holding offset 6 sees only the tail; it neither re-reads nor
+    // misses the earlier bytes.
+    let tail = stream.read(6, 64).await;
+    assert_eq!(tail, b"world");
+}
+
+#[tokio::test]
+async fn late_reader_still_reads_retained_history_from_zero() {
+    let stream = Stream::new();
+    // All records are produced before the reader ever opens.
+    stream.append(b"record-1\n").await;
+    stream.append(b"record-2\n").await;
+
+    let replay = stream.read(0, 1024).await;
+    assert_eq!(replay, b"record-1\nrecord-2\n");
+}
+
+#[tokio::test]
+async fn read_blocks_until_new_bytes_are_appended() {
+    let stream = Stream::new();
+    let reader = stream.clone();
+
+    // Reader parks at the live edge (offset 0, empty stream): it must not return
+    // empty, it must wait for the first bytes.
+    let handle = tokio::spawn(async move { reader.read(0, 64).await });
+
+    // Give the reader time to block, then produce.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !handle.is_finished(),
+        "read returned before any bytes were appended"
+    );
+
+    stream.append(b"late").await;
+    let got = tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .expect("read did not wake within timeout")
+        .expect("reader task panicked");
+    assert_eq!(got, b"late");
+}
+
+// §5.5 — a failure that occurs after an interaction has begun streaming is a
+// terminal record in the stream itself, observed by reading, not via a side
+// channel. Here record typing is the consumer convention (one line per record).
+#[tokio::test]
+async fn mid_interaction_failure_is_a_terminal_record_in_the_stream() {
+    let stream = Stream::new();
+    stream.append(b"chunk-1\n").await;
+    stream.append(b"chunk-2\n").await;
+    // The interaction fails mid-flight; the failure is appended as a record.
+    stream.append(b"error: upstream reset\n").await;
+
+    let all = stream.read(0, 1024).await;
+    let text = String::from_utf8(all).unwrap();
+    let last = text.lines().last().unwrap();
+    assert_eq!(last, "error: upstream reset");
+}
+
+#[tokio::test]
+async fn many_readers_each_hold_their_own_offset() {
+    let stream = Stream::new();
+    stream.append(b"abcdef").await;
+
+    let a = stream.read(0, 64).await;
+    let b = stream.read(3, 64).await;
+    assert_eq!(a, b"abcdef");
+    assert_eq!(b, b"def");
+}

--- a/crates/ap/tests/transport.rs
+++ b/crates/ap/tests/transport.rs
@@ -1,0 +1,120 @@
+//! In-process fast-path transport (substrate §5.6): the transport dispatches an
+//! aP `Request` to a `FileServer` and returns its `Response` without
+//! serializing, so high-rate streams pay no protocol cost. These tests pin the
+//! dispatch mapping (each `Request` variant → the matching typed method → the
+//! matching `Response`) and that typed errors propagate as `ErrorCode`.
+
+use std::sync::Arc;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Request,
+    Response, Stat,
+};
+
+/// Minimal server: one readable file at fid 1 holding `b"hi"`; everything else
+/// is `NotFound`. Just enough to prove the transport's dispatch wiring.
+struct OneFile;
+
+#[async_trait::async_trait]
+impl FileServer for OneFile {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, _names: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(Qid {
+                kind: FileKind::File,
+                version: 0,
+                path: 1,
+            })
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+    async fn read(&self, fid: Fid, offset: Offset, _count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if fid == Fid(1) {
+            Ok(b"hi".to_vec().split_off(offset as usize))
+        } else {
+            Err(ErrorCode::NotFound)
+        }
+    }
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NoAccess)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn transport_dispatches_read_to_the_server() {
+    let transport = InProcessTransport::new(Arc::new(OneFile));
+
+    let opened = transport
+        .call(Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read,
+        })
+        .await;
+    assert_eq!(
+        opened,
+        Ok(Response::Open {
+            qid: Qid {
+                kind: FileKind::File,
+                version: 0,
+                path: 1
+            }
+        })
+    );
+
+    let read = transport
+        .call(Request::Read {
+            fid: Fid(1),
+            offset: 0,
+            count: 16,
+        })
+        .await;
+    assert_eq!(
+        read,
+        Ok(Response::Read {
+            data: b"hi".to_vec()
+        })
+    );
+}
+
+#[tokio::test]
+async fn transport_propagates_typed_errors() {
+    let transport = InProcessTransport::new(Arc::new(OneFile));
+
+    let denied = transport
+        .call(Request::Write {
+            fid: Fid(1),
+            offset: 0,
+            data: b"x".to_vec(),
+        })
+        .await;
+    assert_eq!(denied, Err(ErrorCode::NoAccess));
+
+    let missing = transport
+        .call(Request::Open {
+            fid: Fid(9),
+            mode: OpenMode::Read,
+        })
+        .await;
+    assert_eq!(missing, Err(ErrorCode::NotFound));
+}

--- a/crates/ap/tests/wire.rs
+++ b/crates/ap/tests/wire.rs
@@ -1,0 +1,144 @@
+//! aP wire-shape conformance (substrate §5.7).
+//!
+//! Proves a dumb byte transport could carry every value type and every
+//! operation unchanged: each type survives a JSON serialize → deserialize round
+//! trip. If any aP type stops being wire-shaped (borrows, non-serializable
+//! fields), these tests fail before any wire transport exists.
+
+use alan_ap::{ErrorCode, Fid, FileKind, OpenMode, Qid, Request, Response, Stat};
+
+fn roundtrip<T>(value: &T) -> T
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    let bytes = serde_json::to_vec(value).expect("serialize");
+    serde_json::from_slice(&bytes).expect("deserialize")
+}
+
+#[test]
+fn qid_survives_roundtrip() {
+    let qid = Qid {
+        kind: FileKind::Stream,
+        version: 7,
+        path: 0xdead_beef,
+    };
+    assert_eq!(roundtrip(&qid), qid);
+}
+
+#[test]
+fn file_kinds_survive_roundtrip() {
+    for kind in [
+        FileKind::Dir,
+        FileKind::File,
+        FileKind::Stream,
+        FileKind::Clone,
+    ] {
+        assert_eq!(roundtrip(&kind), kind);
+    }
+}
+
+#[test]
+fn open_modes_survive_roundtrip() {
+    for mode in [OpenMode::Read, OpenMode::Write, OpenMode::ReadWrite] {
+        assert_eq!(roundtrip(&mode), mode);
+    }
+}
+
+#[test]
+fn error_codes_survive_roundtrip() {
+    for code in [
+        ErrorCode::NotFound,
+        ErrorCode::NoAccess,
+        ErrorCode::RateLimited,
+        ErrorCode::BadRequest,
+        ErrorCode::NotDirectory,
+        ErrorCode::IsDirectory,
+        ErrorCode::Unsupported,
+        ErrorCode::Io,
+    ] {
+        assert_eq!(roundtrip(&code), code);
+    }
+}
+
+#[test]
+fn stat_survives_roundtrip() {
+    let stat = Stat {
+        name: "output".to_string(),
+        qid: Qid {
+            kind: FileKind::Stream,
+            version: 1,
+            path: 42,
+        },
+        length: 1024,
+        writable: false,
+    };
+    assert_eq!(roundtrip(&stat), stat);
+}
+
+#[test]
+fn every_request_operation_survives_roundtrip() {
+    let requests = [
+        Request::Walk {
+            fid: Fid(1),
+            newfid: Fid(2),
+            names: vec!["proc".into(), "7".into()],
+        },
+        Request::Open {
+            fid: Fid(2),
+            mode: OpenMode::Read,
+        },
+        Request::Read {
+            fid: Fid(2),
+            offset: 0,
+            count: 4096,
+        },
+        Request::Write {
+            fid: Fid(2),
+            offset: 0,
+            data: b"hello".to_vec(),
+        },
+        Request::Stat { fid: Fid(2) },
+        Request::Create {
+            fid: Fid(2),
+            newfid: Fid(3),
+            name: "child".into(),
+            kind: FileKind::File,
+        },
+        Request::Remove { fid: Fid(2) },
+        Request::Clunk { fid: Fid(2) },
+    ];
+    for req in requests {
+        assert_eq!(roundtrip(&req), req);
+    }
+}
+
+#[test]
+fn every_response_operation_survives_roundtrip() {
+    let qid = Qid {
+        kind: FileKind::File,
+        version: 0,
+        path: 9,
+    };
+    let responses = [
+        Response::Walk { qid },
+        Response::Open { qid },
+        Response::Read {
+            data: b"hello".to_vec(),
+        },
+        Response::Write { count: 5 },
+        Response::Stat {
+            stat: Stat {
+                name: "child".into(),
+                qid,
+                length: 5,
+                writable: true,
+            },
+        },
+        Response::Create { qid },
+        Response::Remove,
+        Response::Clunk,
+    ];
+    for resp in responses {
+        assert_eq!(roundtrip(&resp), resp);
+    }
+}

--- a/openspec/changes/define-plan9-kernel-substrate/tasks.md
+++ b/openspec/changes/define-plan9-kernel-substrate/tasks.md
@@ -30,31 +30,31 @@
 
 ## 5. aP protocol crate (`alan-ap`)
 
-- [ ] 5.0 Create the standalone `alan-ap` crate (ADR-0025 D2) — the aP protocol
+- [x] 5.0 Create the standalone `alan-ap` crate (ADR-0025 D2) — the aP protocol
   (9P analog) — with no alan-specific dependencies; `alan-kernel` depends on it.
-- [ ] 5.1 Define the `FileServer` trait over fids: `walk`, `open`, `read`,
+- [x] 5.1 Define the `FileServer` trait over fids: `walk`, `open`, `read`,
   `write`, `stat`, `create`, `remove`, `clunk`. Inputs/outputs are paths/fids,
   byte buffers, offsets, and error codes only — no borrows, no rich return types
   (D5, wire-shaped).
-- [ ] 5.2 Define the fid lifecycle: a fid is a handle to one interaction;
+- [x] 5.2 Define the fid lifecycle: a fid is a handle to one interaction;
   `walk`/`open` allocate it, `clunk` releases it, and `open` MAY have allocation
   side effects (see clone-via-open, 5.5). Each `open` yields an independent fid so
   concurrent callers do not interfere.
-- [ ] 5.3 Define a byte/offset stream file kind with retained history: `read`
+- [x] 5.3 Define a byte/offset stream file kind with retained history: `read`
   blocks until new bytes are available, resumes from a caller-held offset, and
   retains records up to a server policy so a reconnecting reader neither misses
   nor mis-replays (D8). No separate notification primitive.
-- [ ] 5.4 Define clone-via-open: opening a `clone` file allocates a new resource
+- [x] 5.4 Define clone-via-open: opening a `clone` file allocates a new resource
   (for example a connection directory) and returns its name/handle — an
   open-with-allocation convention, not a new operation. (Used by `alan-llmfs`
   Generations.)
-- [ ] 5.5 Define the three-phase error model: dial-time failures (no access, rate
+- [x] 5.5 Define the three-phase error model: dial-time failures (no access, rate
   limited, not found) return an `open` error; commit-time failures (malformed/
   truncated request at `clunk`) return a `write`/`clunk` error and start nothing;
   mid-interaction failures surface as a terminal error record in the stream.
-- [ ] 5.6 Implement the in-process fast-path transport that dispatches aP calls
+- [x] 5.6 Implement the in-process fast-path transport that dispatches aP calls
   without serialization, so high-rate streams pay no protocol cost.
-- [ ] 5.7 Add a serialization round-trip test over the aP wire shape to prove a
+- [x] 5.7 Add a serialization round-trip test over the aP wire shape to prove a
   dumb byte transport could carry every operation unchanged (guards the D5
   discipline before any wire transport exists).
 


### PR DESCRIPTION
**Plan 9 substrate chain — PR 1 of 5.** Stacked; review/merge in order: ap → kernel → rename → agentfs → shell.

Layer 0 of ADR-0025: `alan-ap` is the file-service protocol every server and client speaks, with no other Alan crate as a dependency (D1/D2). Implements `define-plan9-kernel-substrate` §5.

- `FileServer` trait over fids (walk/open/read/write/stat/create/remove/clunk), owned + serializable returns (§5.1)
- Wire `Request`/`Response` + round-trip conformance test proving a dumb byte transport could carry every operation unchanged (§5.7)
- Client-driven fid lifecycle; `Fid::ROOT` well-known root, no attach op (§5.2)
- `Stream` primitive: retained history, offset resume, blocking read via a watch channel — no second event system (§5.3)
- clone-via-open and the three-phase error model demonstrated end-to-end by a reference in-memory `MemFs` (§5.4, §5.5)
- `InProcessTransport` fast path: dispatch with no serialization (§5.6)

19 tests; `cargo fmt` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)