### PR TITLE
feat(kernel): add alan-kernel substrate — namespace, process table, /proc, /srv (Plan 9 PR 2/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-kernel"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "alan-llm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/ap",
     "crates/auth",
+    "crates/kernel",
     "crates/protocol",
     "crates/llm",
     "crates/runtime",

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "alan-kernel"
+description = "Alan Kernel — the Plan 9 substrate: namespace engine, process table, and the synthetic /proc and /srv devices. Depends only on alan-ap."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true }

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -20,4 +20,4 @@ mod srvfs;
 pub use namespace::{Access, Namespace, Resolved, Unreachable};
 pub use process::{Credentials, ExecSpec, Pid, Process, ProcessTable, Status};
 pub use procfs::ProcFs;
-pub use srvfs::{SrvFs, SrvView};
+pub use srvfs::SrvFs;

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -1,0 +1,23 @@
+//! Alan Kernel — the Plan 9 substrate.
+//!
+//! The kernel owns exactly three things (ADR-0024 D9): the per-process
+//! **namespace engine** (mount/bind/union/walk), the **process table** (one
+//! `Process` category), and the synthetic devices **`/proc`** and **`/srv`**.
+//! It depends only on [`alan_ap`] and knows nothing of agents, LLM providers,
+//! tape, memory, tools, or any product concept — those are user-space file
+//! servers above it (ADR-0025 D1). This is what makes "the kernel changes least"
+//! a structural fact rather than a hope.
+//!
+//! The kernel is **ephemeral** (D7): the process table, namespaces, and fids are
+//! runtime state that starts empty on restart. Durability is a property of
+//! storage-backed file servers, never of the kernel.
+
+mod namespace;
+mod process;
+mod procfs;
+mod srvfs;
+
+pub use namespace::{Access, Namespace, Resolved, Unreachable};
+pub use process::{Credentials, ExecSpec, Pid, Process, ProcessTable, Status};
+pub use procfs::ProcFs;
+pub use srvfs::{SrvFs, SrvView};

--- a/crates/kernel/src/namespace.rs
+++ b/crates/kernel/src/namespace.rs
@@ -12,7 +12,7 @@
 //! and may only *restrict* its own view; changes never affect another
 //! namespace. Mount state is ephemeral kernel runtime state (D7).
 
-use alan_ap::{InProcessTransport, OpenMode};
+use alan_ap::{ErrorCode, InProcessTransport, OpenMode, Request, Response};
 
 /// Whether a mount grants only awareness or also authority.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +42,35 @@ pub struct Resolved {
     pub tree: InProcessTransport,
     pub rel: Vec<String>,
     pub access: Access,
+}
+
+impl Resolved {
+    /// Carry one operation to the resolved tree, enforcing the mount's access
+    /// rights: a read-only mount rejects any mutating request (open-for-write,
+    /// write, create, remove) with [`ErrorCode::NoAccess`], so awareness never
+    /// implies authority (D6). Read/walk/stat/clunk and read-opens pass through.
+    /// Callers operate through this rather than the raw `tree` so the access
+    /// boundary is enforced, not advisory.
+    pub async fn call(&self, request: Request) -> Result<Response, ErrorCode> {
+        if self.access == Access::ReadOnly && is_mutating(&request) {
+            return Err(ErrorCode::NoAccess);
+        }
+        self.tree.call(request).await
+    }
+}
+
+/// Whether a request would mutate the tree (and so requires write authority).
+fn is_mutating(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::Write { .. }
+            | Request::Create { .. }
+            | Request::Remove { .. }
+            | Request::Open {
+                mode: OpenMode::Write | OpenMode::ReadWrite,
+                ..
+            }
+    )
 }
 
 /// A resolution failure. The kernel keeps a single, namespace-scoped failure
@@ -166,6 +195,55 @@ impl Namespace {
             rel: components[mount.prefix.len()..].to_vec(),
             access: mount.access,
         })
+    }
+
+    /// A human/inspectable summary of this namespace's mounts as
+    /// `(absolute path, access)` pairs, in mount order. Used to render
+    /// `/proc/<pid>/namespace` so a process's capability set is visible there.
+    pub fn describe(&self) -> Vec<(String, Access)> {
+        self.mounts
+            .iter()
+            .map(|m| {
+                let path = if m.prefix.is_empty() {
+                    "/".to_string()
+                } else {
+                    format!("/{}", m.prefix.join("/"))
+                };
+                (path, m.access)
+            })
+            .collect()
+    }
+
+    /// Every mount that could serve `path`, ordered by preference: longest
+    /// matching prefix first, and among equal prefixes the most recent mount
+    /// first. A union directory (several trees at one prefix) yields several
+    /// candidates; the caller walks each in order until one resolves, so a file
+    /// present only in an earlier contributor (e.g. binfs under a `/bin` union
+    /// also fed by agent-bin) stays reachable instead of being shadowed by a
+    /// last-wins collapse.
+    pub fn resolve_candidates(&self, path: &str) -> Vec<Resolved> {
+        let components = split_path(path);
+        let mut matches: Vec<&Mount> = self
+            .mounts
+            .iter()
+            .filter(|m| is_prefix(&m.prefix, &components))
+            .collect();
+        // Longest prefix first; within equal prefix, most-recently-mounted first.
+        matches.sort_by(|a, b| {
+            b.prefix.len().cmp(&a.prefix.len()).then_with(|| {
+                let ai = self.mounts.iter().position(|m| std::ptr::eq(m, *a));
+                let bi = self.mounts.iter().position(|m| std::ptr::eq(m, *b));
+                bi.cmp(&ai)
+            })
+        });
+        matches
+            .into_iter()
+            .map(|m| Resolved {
+                tree: m.tree.clone(),
+                rel: components[m.prefix.len()..].to_vec(),
+                access: m.access,
+            })
+            .collect()
     }
 }
 

--- a/crates/kernel/src/namespace.rs
+++ b/crates/kernel/src/namespace.rs
@@ -57,7 +57,17 @@ impl Resolved {
         if self.access == Access::ReadOnly && is_mutating(&request) {
             return Err(ErrorCode::NoAccess);
         }
-        self.tree.call(request).await
+        let response = self.tree.call(request).await?;
+        // `stat.writable` reports mount-granted authority: a read-only mount masks
+        // it to false even if the backing node is writable, so a caller never sees
+        // a capability this mount would reject.
+        if self.access == Access::ReadOnly
+            && let Response::Stat { mut stat } = response
+        {
+            stat.writable = false;
+            return Ok(Response::Stat { stat });
+        }
+        Ok(response)
     }
 }
 

--- a/crates/kernel/src/namespace.rs
+++ b/crates/kernel/src/namespace.rs
@@ -1,0 +1,183 @@
+//! The per-process namespace engine: a mount table assembled by mount/bind/
+//! union over file servers, resolved by longest-prefix walk.
+//!
+//! The namespace is the **sole capability boundary** (ADR-0024 D6): a resource
+//! is reachable iff it is present in this namespace. There is no global ambient
+//! addressing — an unmounted path simply does not resolve. Access rights
+//! separate awareness ([`Access::ReadOnly`]: walk/read/watch) from authority
+//! ([`Access::ReadWrite`]: mutation); a read-only mount cannot be escalated to
+//! write from within the namespace (§2.5a).
+//!
+//! A child namespace is constructed from its spawner's ([`Namespace::child`])
+//! and may only *restrict* its own view; changes never affect another
+//! namespace. Mount state is ephemeral kernel runtime state (D7).
+
+use alan_ap::{InProcessTransport, OpenMode};
+
+/// Whether a mount grants only awareness or also authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Access {
+    /// Awareness: walk, read, and watch — but no mutation.
+    ReadOnly,
+    /// Authority: read and mutate.
+    ReadWrite,
+}
+
+impl Access {
+    /// Whether this access permits opening with `mode`. A read-only mount denies
+    /// any write intent, so it can never be escalated to write.
+    pub fn allows(self, mode: OpenMode) -> bool {
+        match (self, mode) {
+            (Access::ReadWrite, _) => true,
+            (Access::ReadOnly, OpenMode::Read) => true,
+            (Access::ReadOnly, OpenMode::Write | OpenMode::ReadWrite) => false,
+        }
+    }
+}
+
+/// A successful path resolution: the file server backing the path, the path
+/// components to walk within it, and the access the mount grants.
+#[derive(Clone)]
+pub struct Resolved {
+    pub tree: InProcessTransport,
+    pub rel: Vec<String>,
+    pub access: Access,
+}
+
+/// A resolution failure. The kernel keeps a single, namespace-scoped failure
+/// reason: the path is not present in this namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Unreachable;
+
+struct Mount {
+    /// Absolute path components this tree is mounted at (`/mnt/llm` → `["mnt",
+    /// "llm"]`; `/` → `[]`).
+    prefix: Vec<String>,
+    tree: InProcessTransport,
+    access: Access,
+}
+
+/// A per-process namespace: an ordered mount table resolved by longest-prefix.
+pub struct Namespace {
+    mounts: Vec<Mount>,
+}
+
+impl Default for Namespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Namespace {
+    pub fn new() -> Self {
+        Self { mounts: Vec::new() }
+    }
+
+    /// Mount `tree` at absolute path `at` with the given access. A later mount at
+    /// the same prefix shadows an earlier one (last wins), which is how a
+    /// namespace is re-assembled.
+    pub fn mount(&mut self, at: &str, tree: InProcessTransport, access: Access) {
+        self.mounts.push(Mount {
+            prefix: split_path(at),
+            tree,
+            access,
+        });
+    }
+
+    /// Bind the tree(s) mounted at `existing` under the new path `new` (an
+    /// alias). This is how a union root such as `/bin` is assembled from posted
+    /// handles like `/srv/bin` and `/srv/agent-bin`. v1 aliases whole mount
+    /// points (the bound prefix must name a mount), preserving each tree's
+    /// access.
+    pub fn bind(&mut self, new: &str, existing: &str) {
+        let existing_prefix = split_path(existing);
+        let new_prefix = split_path(new);
+        let aliases: Vec<Mount> = self
+            .mounts
+            .iter()
+            .filter(|m| m.prefix == existing_prefix)
+            .map(|m| Mount {
+                prefix: new_prefix.clone(),
+                tree: m.tree.clone(),
+                access: m.access,
+            })
+            .collect();
+        self.mounts.extend(aliases);
+    }
+
+    /// Remove every mount at exactly `at`. Restricting one's own view never
+    /// affects another namespace.
+    pub fn unmount(&mut self, at: &str) {
+        let prefix = split_path(at);
+        self.mounts.retain(|m| m.prefix != prefix);
+    }
+
+    /// Every tree mounted at exactly `path`, in mount order. A union directory
+    /// has more than one; a lister merges their entries while the contributors
+    /// stay independent (§ "A standard root is assembled").
+    pub fn union_at(&self, path: &str) -> Vec<Resolved> {
+        let prefix = split_path(path);
+        self.mounts
+            .iter()
+            .filter(|m| m.prefix == prefix)
+            .map(|m| Resolved {
+                tree: m.tree.clone(),
+                rel: Vec::new(),
+                access: m.access,
+            })
+            .collect()
+    }
+
+    /// Construct a child namespace from this one. The child inherits the current
+    /// mounts and may only restrict its own view thereafter.
+    pub fn child(&self) -> Namespace {
+        let mounts = self
+            .mounts
+            .iter()
+            .map(|m| Mount {
+                prefix: m.prefix.clone(),
+                tree: m.tree.clone(),
+                access: m.access,
+            })
+            .collect();
+        Namespace { mounts }
+    }
+
+    /// Resolve an absolute path to its backing tree and the components to walk
+    /// within it. The mount with the longest matching prefix wins; among equal
+    /// prefixes, the most recent mount wins. An unmounted path is [`Unreachable`].
+    pub fn resolve(&self, path: &str) -> Result<Resolved, Unreachable> {
+        let components = split_path(path);
+        let mut best: Option<&Mount> = None;
+        for mount in &self.mounts {
+            if is_prefix(&mount.prefix, &components) {
+                let better = match best {
+                    Some(b) => mount.prefix.len() >= b.prefix.len(),
+                    None => true,
+                };
+                if better {
+                    best = Some(mount);
+                }
+            }
+        }
+        let mount = best.ok_or(Unreachable)?;
+        Ok(Resolved {
+            tree: mount.tree.clone(),
+            rel: components[mount.prefix.len()..].to_vec(),
+            access: mount.access,
+        })
+    }
+}
+
+/// Split an absolute path into its non-empty components. `/` → `[]`.
+fn split_path(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether `prefix` is a path-prefix of `components`.
+fn is_prefix(prefix: &[String], components: &[String]) -> bool {
+    components.len() >= prefix.len() && prefix.iter().zip(components).all(|(a, b)| a == b)
+}

--- a/crates/kernel/src/namespace.rs
+++ b/crates/kernel/src/namespace.rs
@@ -35,11 +35,13 @@ impl Access {
     }
 }
 
-/// A successful path resolution: the file server backing the path, the path
-/// components to walk within it, and the access the mount grants.
+/// A successful path resolution: the path components to walk within the backing
+/// tree and the access the mount grants. The backing transport is intentionally
+/// **private** — callers operate through [`Resolved::call`], which enforces the
+/// mount's access, so the boundary cannot be bypassed by reaching the raw tree.
 #[derive(Clone)]
 pub struct Resolved {
-    pub tree: InProcessTransport,
+    tree: InProcessTransport,
     pub rel: Vec<String>,
     pub access: Access,
 }
@@ -49,8 +51,8 @@ impl Resolved {
     /// rights: a read-only mount rejects any mutating request (open-for-write,
     /// write, create, remove) with [`ErrorCode::NoAccess`], so awareness never
     /// implies authority (D6). Read/walk/stat/clunk and read-opens pass through.
-    /// Callers operate through this rather than the raw `tree` so the access
-    /// boundary is enforced, not advisory.
+    /// This is the only way to reach the backing tree, so the access boundary is
+    /// enforced, not advisory.
     pub async fn call(&self, request: Request) -> Result<Response, ErrorCode> {
         if self.access == Access::ReadOnly && is_mutating(&request) {
             return Err(ErrorCode::NoAccess);
@@ -214,31 +216,31 @@ impl Namespace {
             .collect()
     }
 
-    /// Every mount that could serve `path`, ordered by preference: longest
-    /// matching prefix first, and among equal prefixes the most recent mount
-    /// first. A union directory (several trees at one prefix) yields several
-    /// candidates; the caller walks each in order until one resolves, so a file
-    /// present only in an earlier contributor (e.g. binfs under a `/bin` union
-    /// also fed by agent-bin) stays reachable instead of being shadowed by a
-    /// last-wins collapse.
+    /// The union contributors at the **longest** matching prefix for `path`,
+    /// most-recently-mounted first. Only equal-prefix contributors are returned —
+    /// resolution never falls through from a more-specific overmount to a broader
+    /// mount, preserving longest-prefix shadowing (a deeper mount hides what `/`
+    /// would otherwise expose). A union directory (several trees at that same
+    /// prefix) yields several candidates; the caller walks each in order until one
+    /// resolves, so a file present only in an earlier contributor stays reachable.
     pub fn resolve_candidates(&self, path: &str) -> Vec<Resolved> {
         let components = split_path(path);
-        let mut matches: Vec<&Mount> = self
+        let max_len = self
             .mounts
             .iter()
             .filter(|m| is_prefix(&m.prefix, &components))
-            .collect();
-        // Longest prefix first; within equal prefix, most-recently-mounted first.
-        matches.sort_by(|a, b| {
-            b.prefix.len().cmp(&a.prefix.len()).then_with(|| {
-                let ai = self.mounts.iter().position(|m| std::ptr::eq(m, *a));
-                let bi = self.mounts.iter().position(|m| std::ptr::eq(m, *b));
-                bi.cmp(&ai)
-            })
-        });
-        matches
-            .into_iter()
-            .map(|m| Resolved {
+            .map(|m| m.prefix.len())
+            .max();
+        let Some(max_len) = max_len else {
+            return Vec::new();
+        };
+        // Only the longest-prefix contributors; most-recently-mounted first.
+        self.mounts
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| is_prefix(&m.prefix, &components) && m.prefix.len() == max_len)
+            .rev()
+            .map(|(_, m)| Resolved {
                 tree: m.tree.clone(),
                 rel: components[m.prefix.len()..].to_vec(),
                 access: m.access,

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -156,9 +156,13 @@ impl ProcessTable {
         self.pending.remove(&slot);
     }
 
-    /// Record a process's termination.
+    /// Record a process's termination. Terminal state is recorded once: a later
+    /// cancel/termination notification for an already-exited process is ignored,
+    /// so the real exit code is not clobbered.
     pub fn exit(&mut self, pid: Pid, code: i32) {
-        if let Some(proc) = self.processes.get_mut(&pid) {
+        if let Some(proc) = self.processes.get_mut(&pid)
+            && proc.status != Status::Exited
+        {
             proc.status = Status::Exited;
             proc.exit_code = Some(code);
         }

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -10,8 +10,9 @@
 //! Spawn is staged so process creation can be driven by aP clone-via-open
 //! (§7.1a): [`clone_begin`](ProcessTable::clone_begin) allocates a **pending**
 //! slot that is not yet in the public listing; [`commit`](ProcessTable::commit)
-//! writes the exec spec and starts it (now public); [`discard`] drops a pending
-//! slot so a failed spawn leaks nothing into `/proc`.
+//! writes the exec spec and starts it (now public);
+//! [`discard`](ProcessTable::discard) drops a pending slot so a failed spawn
+//! leaks nothing into `/proc`.
 
 use std::collections::BTreeMap;
 

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -1,0 +1,176 @@
+//! The process table and the single `Process` category (substrate §6.4–§6.5).
+//!
+//! There is exactly one process category. Whether a process is an agent, a
+//! tool, a service, or the root agent is observable only at the file/namespace
+//! layer (its `/proc`/`/agent` files and what it mounts), never as a kernel type
+//! (ADR-0024 D3). The table is ephemeral runtime state and starts empty on
+//! restart (D7); durable identity lives in storage-backed file servers, keyed by
+//! path, not by the ephemeral pid.
+//!
+//! Spawn is staged so process creation can be driven by aP clone-via-open
+//! (§7.1a): [`clone_begin`](ProcessTable::clone_begin) allocates a **pending**
+//! slot that is not yet in the public listing; [`commit`](ProcessTable::commit)
+//! writes the exec spec and starts it (now public); [`discard`] drops a pending
+//! slot so a failed spawn leaks nothing into `/proc`.
+
+use std::collections::BTreeMap;
+
+use crate::Namespace;
+
+/// A process identity. Ephemeral: never reused as a durable reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Pid(pub u64);
+
+/// Who a process runs as. The kernel keeps this minimal; richer identity is a
+/// file-server concern above the substrate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Credentials {
+    pub uname: String,
+}
+
+impl Credentials {
+    /// The system credential used by boot/Service Manager processes.
+    pub fn system() -> Self {
+        Self {
+            uname: "system".to_string(),
+        }
+    }
+
+    pub fn user(name: &str) -> Self {
+        Self {
+            uname: name.to_string(),
+        }
+    }
+}
+
+/// What a process runs: an executable path and its arguments. The executable is
+/// a command file bound into the namespace (`/bin/...`), not an RPC method. It
+/// deserializes from the exec-spec document written to `/proc/clone` (§7.1a).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub struct ExecSpec {
+    pub executable: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+/// A process's lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Spawned and running its image.
+    Running,
+    /// Terminated; see [`Process::exit_code`].
+    Exited,
+}
+
+/// One process-table entry — the whole kernel ontology of a running thing.
+pub struct Process {
+    pub pid: Pid,
+    pub parent: Option<Pid>,
+    pub credentials: Credentials,
+    pub namespace: Namespace,
+    pub exec: ExecSpec,
+    pub status: Status,
+    pub exit_code: Option<i32>,
+}
+
+/// A pending process slot allocated by clone-begin but not yet committed. It
+/// carries the child's intended credentials and namespace and is private to the
+/// spawner until commit.
+struct Pending {
+    parent: Option<Pid>,
+    credentials: Credentials,
+    namespace: Namespace,
+}
+
+/// The ephemeral process table.
+pub struct ProcessTable {
+    next: u64,
+    pending: BTreeMap<Pid, Pending>,
+    processes: BTreeMap<Pid, Process>,
+}
+
+impl Default for ProcessTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProcessTable {
+    pub fn new() -> Self {
+        Self {
+            next: 1,
+            pending: BTreeMap::new(),
+            processes: BTreeMap::new(),
+        }
+    }
+
+    fn alloc_pid(&mut self) -> Pid {
+        let pid = Pid(self.next);
+        self.next += 1;
+        pid
+    }
+
+    /// Begin a spawn: allocate a pending slot with the child's parent,
+    /// credentials, and namespace. The returned pid is private to the caller and
+    /// is **not** yet listed in public `/proc`.
+    pub fn clone_begin(
+        &mut self,
+        parent: Option<Pid>,
+        namespace: Namespace,
+        credentials: Credentials,
+    ) -> Option<Pid> {
+        let pid = self.alloc_pid();
+        self.pending.insert(
+            pid,
+            Pending {
+                parent,
+                credentials,
+                namespace,
+            },
+        );
+        Some(pid)
+    }
+
+    /// Commit a pending slot with its exec spec, starting the process and making
+    /// `/proc/<pid>` public. Returns `None` if `slot` is not a pending slot.
+    pub fn commit(&mut self, slot: Pid, exec: ExecSpec) -> Option<Pid> {
+        let pending = self.pending.remove(&slot)?;
+        self.processes.insert(
+            slot,
+            Process {
+                pid: slot,
+                parent: pending.parent,
+                credentials: pending.credentials,
+                namespace: pending.namespace,
+                exec,
+                status: Status::Running,
+                exit_code: None,
+            },
+        );
+        Some(slot)
+    }
+
+    /// Discard a pending slot (spawn aborted/rejected). It was never public, so
+    /// nothing leaks and no `/proc` watcher observed it.
+    pub fn discard(&mut self, slot: Pid) {
+        self.pending.remove(&slot);
+    }
+
+    /// Record a process's termination.
+    pub fn exit(&mut self, pid: Pid, code: i32) {
+        if let Some(proc) = self.processes.get_mut(&pid) {
+            proc.status = Status::Exited;
+            proc.exit_code = Some(code);
+        }
+    }
+
+    /// The publicly visible pids, in pid order. Pending slots are excluded.
+    pub fn list(&self) -> Vec<Pid> {
+        self.processes.keys().copied().collect()
+    }
+
+    /// Borrow a committed process by pid.
+    pub fn get(&self, pid: Pid) -> Option<&Process> {
+        self.processes.get(&pid)
+    }
+}

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -1,0 +1,337 @@
+//! `/proc` — the synthetic device that renders the process table as files
+//! (§7.1) and creates processes via clone-via-open (§7.1a).
+//!
+//! `/proc` is the single source of truth for processes; any `/agent`-style view
+//! is derived from it. Its tree is:
+//!
+//! ```text
+//! /proc
+//!   clone                 # open → pending pid; write exec spec; clunk → start
+//!   <pid>/
+//!     status              # "running" | "exited"
+//!     parent              # parent pid, or "" for none
+//!     credentials         # uname
+//!     exit                # exit code once exited, else ""
+//!     ctl                 # write "interrupt"/"cancel" (generic process control)
+//!     io/output           # the process's output stream
+//! ```
+//!
+//! Process creation is pure aP: opening `clone` allocates a fid-private pending
+//! pid (not yet in the public listing), the caller writes the exec-spec document
+//! and `clunk`s to commit (commit-on-clunk; a malformed spec is rejected at
+//! clunk and the pending slot is discarded, leaking nothing).
+//!
+//! v1 limitation (ADR-0024 R1): the kernel runs in one address space and `/proc`
+//! does not yet thread the spawner's namespace through `clone`, so spawn uses
+//! system credentials and an empty child namespace and the capability-preserving
+//! amplification check lands when the namespace is plumbed in. This is the
+//! convention-vs-isolation gap R1 already records.
+
+use std::collections::HashMap;
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::{Credentials, ExecSpec, Namespace, Pid, ProcessTable, Status};
+
+/// What a fid in `/proc` points at.
+#[derive(Clone)]
+enum Node {
+    Root,
+    Clone,
+    Proc(Pid),
+    Status(Pid),
+    Parent(Pid),
+    Credentials(Pid),
+    Exit(Pid),
+    Ctl(Pid),
+    IoDir(Pid),
+    Output(Pid),
+}
+
+struct ProcFid {
+    node: Node,
+    /// For a fid that opened `clone`: the pending pid awaiting its exec spec.
+    clone_pid: Option<Pid>,
+    /// Buffered exec-spec document for a `clone` fid (commit-on-clunk).
+    write_buf: Vec<u8>,
+}
+
+impl ProcFid {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            clone_pid: None,
+            write_buf: Vec::new(),
+        }
+    }
+}
+
+struct State {
+    table: ProcessTable,
+    fids: HashMap<Fid, ProcFid>,
+    /// One output stream per committed process (the kernel owns the file; the
+    /// process's execution, in user space, writes to it).
+    outputs: HashMap<Pid, Stream>,
+}
+
+/// The `/proc` file server.
+pub struct ProcFs {
+    state: Mutex<State>,
+}
+
+impl Default for ProcFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProcFs {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(State {
+                table: ProcessTable::new(),
+                fids: HashMap::new(),
+                outputs: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl State {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    /// Resolve one path component from a node to its child node.
+    fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
+        match node {
+            Node::Root => {
+                if name == "clone" {
+                    Ok(Node::Clone)
+                } else if let Some(pid) = parse_pid(name).filter(|p| self.table.get(*p).is_some()) {
+                    Ok(Node::Proc(pid))
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            Node::Proc(pid) => match name {
+                "status" => Ok(Node::Status(*pid)),
+                "parent" => Ok(Node::Parent(*pid)),
+                "credentials" => Ok(Node::Credentials(*pid)),
+                "exit" => Ok(Node::Exit(*pid)),
+                "ctl" => Ok(Node::Ctl(*pid)),
+                "io" => Ok(Node::IoDir(*pid)),
+                _ => Err(ErrorCode::NotFound),
+            },
+            Node::IoDir(pid) if name == "output" => Ok(Node::Output(*pid)),
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    /// The readable bytes of a non-directory node.
+    fn file_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let bytes = match node {
+            Node::Root => {
+                let mut names = vec!["clone".to_string()];
+                names.extend(self.table.list().iter().map(|p| p.0.to_string()));
+                names.join("\n").into_bytes()
+            }
+            Node::Proc(_) => "status\nparent\ncredentials\nexit\nctl\nio"
+                .to_string()
+                .into_bytes(),
+            Node::IoDir(_) => b"output".to_vec(),
+            Node::Status(pid) => match self.table.get(*pid).map(|p| p.status) {
+                Some(Status::Running) => b"running\n".to_vec(),
+                Some(Status::Exited) => b"exited\n".to_vec(),
+                None => return Err(ErrorCode::NotFound),
+            },
+            Node::Parent(pid) => {
+                let p = self.table.get(*pid).ok_or(ErrorCode::NotFound)?;
+                p.parent
+                    .map(|pp| pp.0.to_string())
+                    .unwrap_or_default()
+                    .into_bytes()
+            }
+            Node::Credentials(pid) => {
+                let p = self.table.get(*pid).ok_or(ErrorCode::NotFound)?;
+                p.credentials.uname.clone().into_bytes()
+            }
+            Node::Exit(pid) => {
+                let p = self.table.get(*pid).ok_or(ErrorCode::NotFound)?;
+                p.exit_code
+                    .map(|c| c.to_string())
+                    .unwrap_or_default()
+                    .into_bytes()
+            }
+            // `clone` and `ctl` are write/allocation surfaces; reading the clone
+            // fid is handled via the opened fid's pending pid, not here.
+            Node::Clone | Node::Ctl(_) | Node::Output(_) => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+}
+
+#[async_trait]
+impl FileServer for ProcFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let mut node = state.node_of(fid)?;
+        for name in names {
+            node = state.child(&node, name)?;
+        }
+        let qid = qid_of(&node);
+        state.fids.insert(newfid, ProcFid::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        // Clone-via-open: allocate a pending pid private to this fid.
+        if matches!(node, Node::Clone) {
+            let slot = state
+                .table
+                .clone_begin(None, Namespace::new(), Credentials::system())
+                .ok_or(ErrorCode::Io)?;
+            let f = state
+                .fids
+                .entry(fid)
+                .or_insert_with(|| ProcFid::at(Node::Clone));
+            f.clone_pid = Some(slot);
+        }
+        Ok(qid_of(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        // An opened clone fid reads back its pending pid (the allocated name).
+        if let Some(f) = state.fids.get(&fid)
+            && let Some(pid) = f.clone_pid
+        {
+            return Ok(slice(pid.0.to_string().into_bytes(), offset, count));
+        }
+        let node = state.node_of(fid)?;
+        Ok(slice(state.file_bytes(&node)?, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        match node {
+            // Exec-spec document for a clone fid: buffer until clunk.
+            Node::Clone => {
+                let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+                if f.clone_pid.is_none() {
+                    return Err(ErrorCode::BadRequest);
+                }
+                f.write_buf.extend_from_slice(data);
+                Ok(data.len() as u32)
+            }
+            // Generic process control (interrupt/cancel) routes through ctl.
+            Node::Ctl(pid) => {
+                match data {
+                    b"cancel" | b"interrupt" => state.table.exit(pid, 130),
+                    _ => return Err(ErrorCode::BadRequest),
+                }
+                Ok(data.len() as u32)
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
+        Ok(Stat {
+            name: String::new(),
+            qid: qid_of(&node),
+            length: 0,
+            writable: is_writable(&node),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        // Processes are created through clone-via-open, not generic create.
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let Some(f) = state.fids.remove(&fid) else {
+            return Err(ErrorCode::NotFound);
+        };
+        // Commit-on-clunk: a clone fid commits its pending process here.
+        if let Some(pid) = f.clone_pid {
+            match serde_json::from_slice::<ExecSpec>(&f.write_buf) {
+                Ok(exec) => {
+                    state.table.commit(pid, exec);
+                    state.outputs.insert(pid, Stream::new());
+                    Ok(())
+                }
+                Err(_) => {
+                    // Reject at commit and discard the fid-private slot — it was
+                    // never public, so nothing leaks.
+                    state.table.discard(pid);
+                    Err(ErrorCode::BadRequest)
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn qid_of(node: &Node) -> Qid {
+    let (kind, path) = match node {
+        Node::Root => (FileKind::Dir, 0),
+        Node::Clone => (FileKind::Clone, 1),
+        Node::Proc(p) => (FileKind::Dir, 0x1000 + p.0),
+        Node::IoDir(p) => (FileKind::Dir, 0x2000 + p.0),
+        Node::Output(p) => (FileKind::Stream, 0x3000 + p.0),
+        Node::Status(p) => (FileKind::File, 0x4000 + p.0),
+        Node::Parent(p) => (FileKind::File, 0x5000 + p.0),
+        Node::Credentials(p) => (FileKind::File, 0x6000 + p.0),
+        Node::Exit(p) => (FileKind::File, 0x7000 + p.0),
+        Node::Ctl(p) => (FileKind::File, 0x8000 + p.0),
+    };
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
+}
+
+fn is_writable(node: &Node) -> bool {
+    matches!(node, Node::Clone | Node::Ctl(_))
+}
+
+fn parse_pid(name: &str) -> Option<Pid> {
+    name.parse::<u64>().ok().map(Pid)
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -48,10 +48,14 @@ enum Node {
     Ctl(Pid),
     IoDir(Pid),
     Output(Pid),
+    NamespaceInfo(Pid),
 }
 
 struct ProcFid {
     node: Node,
+    /// The mode this fid was opened with (None until opened). Write surfaces
+    /// require write intent, so a read-only mount/open cannot spawn or cancel.
+    mode: Option<OpenMode>,
     /// For a fid that opened `clone`: the pending pid awaiting its exec spec.
     clone_pid: Option<Pid>,
     /// Buffered exec-spec document for a `clone` fid (commit-on-clunk).
@@ -62,11 +66,16 @@ impl ProcFid {
     fn at(node: Node) -> Self {
         Self {
             node,
+            mode: None,
             clone_pid: None,
             write_buf: Vec::new(),
         }
     }
 }
+
+/// Upper bound on a buffered exec-spec document, so a huge/sparse write offset
+/// cannot make `/proc` allocate unbounded memory.
+const MAX_EXEC_SPEC_BYTES: usize = 1 << 16; // 64 KiB
 
 struct State {
     table: ProcessTable,
@@ -129,6 +138,7 @@ impl State {
                 "exit" => Ok(Node::Exit(*pid)),
                 "ctl" => Ok(Node::Ctl(*pid)),
                 "io" => Ok(Node::IoDir(*pid)),
+                "namespace" => Ok(Node::NamespaceInfo(*pid)),
                 _ => Err(ErrorCode::NotFound),
             },
             Node::IoDir(pid) if name == "output" => Ok(Node::Output(*pid)),
@@ -144,7 +154,7 @@ impl State {
                 names.extend(self.table.list().iter().map(|p| p.0.to_string()));
                 names.join("\n").into_bytes()
             }
-            Node::Proc(_) => "status\nparent\ncredentials\nexit\nctl\nio"
+            Node::Proc(_) => "status\nparent\ncredentials\nexit\nctl\nio\nnamespace"
                 .to_string()
                 .into_bytes(),
             Node::IoDir(_) => b"output".to_vec(),
@@ -171,8 +181,24 @@ impl State {
                     .unwrap_or_default()
                     .into_bytes()
             }
-            // `clone` and `ctl` are write/allocation surfaces; reading the clone
-            // fid is handled via the opened fid's pending pid, not here.
+            Node::NamespaceInfo(pid) => {
+                let p = self.table.get(*pid).ok_or(ErrorCode::NotFound)?;
+                p.namespace
+                    .describe()
+                    .iter()
+                    .map(|(path, access)| {
+                        let rights = match access {
+                            crate::Access::ReadOnly => "ro",
+                            crate::Access::ReadWrite => "rw",
+                        };
+                        format!("{path} {rights}")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+                    .into_bytes()
+            }
+            // `clone`/`ctl` are write surfaces; `output` is a stream served
+            // directly in `read`, not here.
             Node::Clone | Node::Ctl(_) | Node::Output(_) => return Err(ErrorCode::Unsupported),
         };
         Ok(bytes)
@@ -183,6 +209,12 @@ impl State {
 impl FileServer for ProcFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
         let mut state = self.state.lock().await;
+        // A fid is a handle to one interaction: never rebind the reserved root or
+        // an already-live fid, or a retry/collision would clobber another fid's
+        // state (e.g. drop a pending clone pid, leaking the slot).
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
         let mut node = state.node_of(fid)?;
         for name in names {
             node = state.child(&node, name)?;
@@ -192,11 +224,21 @@ impl FileServer for ProcFs {
         Ok(qid)
     }
 
-    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
         let mut state = self.state.lock().await;
         let node = state.node_of(fid)?;
-        // Clone-via-open: allocate a pending pid private to this fid.
+        // Reopening a live fid before clunk is rejected, so a retried open cannot
+        // overwrite a pending clone slot (leaking it) or downgrade write intent.
+        if state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        // Clone-via-open: spawning requires write intent (you write the exec
+        // spec), so a read-only open cannot allocate an uncommittable — and thus
+        // leaked — pending slot.
         if matches!(node, Node::Clone) {
+            if !matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+                return Err(ErrorCode::NoAccess);
+            }
             let slot = state
                 .table
                 .clone_begin(None, Namespace::new(), Credentials::system())
@@ -206,37 +248,74 @@ impl FileServer for ProcFs {
                 .entry(fid)
                 .or_insert_with(|| ProcFid::at(Node::Clone));
             f.clone_pid = Some(slot);
+            f.mode = Some(mode);
+            return Ok(qid_of(&node));
         }
+        let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
+        f.mode = Some(mode);
         Ok(qid_of(&node))
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        let state = self.state.lock().await;
-        // An opened clone fid reads back its pending pid (the allocated name).
-        if let Some(f) = state.fids.get(&fid)
-            && let Some(pid) = f.clone_pid
-        {
-            return Ok(slice(pid.0.to_string().into_bytes(), offset, count));
-        }
-        let node = state.node_of(fid)?;
-        Ok(slice(state.file_bytes(&node)?, offset, count))
+        // A process's output is a stream: clone it out and serve a blocking read
+        // without holding the state lock (so tailing one process never stalls
+        // the whole `/proc`).
+        let output = {
+            let state = self.state.lock().await;
+            // An opened clone fid reads back its pending pid (the allocated name).
+            if let Some(f) = state.fids.get(&fid)
+                && let Some(pid) = f.clone_pid
+            {
+                return Ok(slice(pid.0.to_string().into_bytes(), offset, count));
+            }
+            let node = state.node_of(fid)?;
+            match node {
+                Node::Output(pid) => state
+                    .outputs
+                    .get(&pid)
+                    .cloned()
+                    .ok_or(ErrorCode::NotFound)?,
+                other => return Ok(slice(state.file_bytes(&other)?, offset, count)),
+            }
+        };
+        Ok(output.read(offset, count).await)
     }
 
-    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         let mut state = self.state.lock().await;
         let node = state.node_of(fid)?;
+        // Write surfaces require write authority established at open.
+        let has_write_intent = state
+            .fids
+            .get(&fid)
+            .is_some_and(|f| matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)));
         match node {
-            // Exec-spec document for a clone fid: buffer until clunk.
+            // Exec-spec document for a clone fid: buffer at the given offset until
+            // clunk (commit-on-clunk; honor offsets, bound size, reject overflow).
             Node::Clone => {
+                if !has_write_intent {
+                    return Err(ErrorCode::NoAccess);
+                }
                 let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
                 if f.clone_pid.is_none() {
                     return Err(ErrorCode::BadRequest);
                 }
-                f.write_buf.extend_from_slice(data);
+                let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+                let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+                if end > MAX_EXEC_SPEC_BYTES {
+                    return Err(ErrorCode::BadRequest);
+                }
+                if f.write_buf.len() < end {
+                    f.write_buf.resize(end, 0);
+                }
+                f.write_buf[start..end].copy_from_slice(data);
                 Ok(data.len() as u32)
             }
             // Generic process control (interrupt/cancel) routes through ctl.
             Node::Ctl(pid) => {
+                if !has_write_intent {
+                    return Err(ErrorCode::NoAccess);
+                }
                 match data {
                     b"cancel" | b"interrupt" => state.table.exit(pid, 130),
                     _ => return Err(ErrorCode::BadRequest),
@@ -303,17 +382,24 @@ impl FileServer for ProcFs {
 }
 
 fn qid_of(node: &Node) -> Qid {
+    // Give each per-process file kind its own 2^48 path space keyed by a tag, so
+    // qids stay server-unique even after millions of pids (the old 0x1000 stride
+    // collided once pids passed 4096).
+    fn tagged(tag: u64, pid: Pid) -> u64 {
+        (tag << 48) | pid.0
+    }
     let (kind, path) = match node {
         Node::Root => (FileKind::Dir, 0),
         Node::Clone => (FileKind::Clone, 1),
-        Node::Proc(p) => (FileKind::Dir, 0x1000 + p.0),
-        Node::IoDir(p) => (FileKind::Dir, 0x2000 + p.0),
-        Node::Output(p) => (FileKind::Stream, 0x3000 + p.0),
-        Node::Status(p) => (FileKind::File, 0x4000 + p.0),
-        Node::Parent(p) => (FileKind::File, 0x5000 + p.0),
-        Node::Credentials(p) => (FileKind::File, 0x6000 + p.0),
-        Node::Exit(p) => (FileKind::File, 0x7000 + p.0),
-        Node::Ctl(p) => (FileKind::File, 0x8000 + p.0),
+        Node::Proc(p) => (FileKind::Dir, tagged(1, *p)),
+        Node::IoDir(p) => (FileKind::Dir, tagged(2, *p)),
+        Node::Output(p) => (FileKind::Stream, tagged(3, *p)),
+        Node::Status(p) => (FileKind::File, tagged(4, *p)),
+        Node::Parent(p) => (FileKind::File, tagged(5, *p)),
+        Node::Credentials(p) => (FileKind::File, tagged(6, *p)),
+        Node::Exit(p) => (FileKind::File, tagged(7, *p)),
+        Node::Ctl(p) => (FileKind::File, tagged(8, *p)),
+        Node::NamespaceInfo(p) => (FileKind::File, tagged(9, *p)),
     };
     Qid {
         kind,

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -225,6 +225,11 @@ impl FileServer for ProcFs {
     }
 
     async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        // The pre-bound root fid is openable directly (to read the listing)
+        // without a redundant empty walk, matching SrvFs and the reference server.
+        if fid == Fid::ROOT {
+            return Ok(qid_of(&Node::Root));
+        }
         let mut state = self.state.lock().await;
         let node = state.node_of(fid)?;
         // Reopening a live fid before clunk is rejected, so a retried open cannot
@@ -329,10 +334,20 @@ impl FileServer for ProcFs {
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
         let state = self.state.lock().await;
         let node = state.node_of(fid)?;
+        // Report the readable byte length so clients can size reads; write-only
+        // surfaces (clone/ctl) are 0, and a process output is its retained length.
+        let length = match &node {
+            Node::Output(pid) => match state.outputs.get(pid) {
+                Some(stream) => stream.len().await,
+                None => 0,
+            },
+            Node::Clone | Node::Ctl(_) => 0,
+            other => state.file_bytes(other).map(|b| b.len() as u64).unwrap_or(0),
+        };
         Ok(Stat {
             name: String::new(),
             qid: qid_of(&node),
-            length: 0,
+            length,
             writable: is_writable(&node),
         })
     }

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -3,9 +3,10 @@
 //! `/srv` exists before any user-space file server so servers have a place to
 //! publish mountable handles and clients have a place to mount from. It is **not
 //! an ambient backdoor**: a service withheld from a process is filtered out of
-//! its `/srv` and is not remountable — denial-by-absent-mount (D6). The filtered
-//! view is itself a [`SrvFs`] (a real `FileServer`), so the denial holds on the
-//! aP surface a process actually reads, not just in a Rust-side snapshot.
+//! its `/srv` and is not remountable — denial-by-absent-mount (D6). A filtered
+//! view shares the **live** registry and applies its deny set per operation, so
+//! it is a real `FileServer` *and* stays current as services post/restart — not
+//! a stale snapshot.
 //!
 //! In v1 (in-process) a handle is an [`InProcessTransport`]; the aP surface lists
 //! handle *names* and the in-process kernel mounts a named handle via
@@ -14,6 +15,7 @@
 //! instead, with the same access-filtered listing.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat,
@@ -32,6 +34,13 @@ struct Handle {
     qid_path: u64,
 }
 
+/// The shared, live registry of posted handles. Views hold an `Arc` to the same
+/// registry so they observe later posts/restarts.
+struct Registry {
+    handles: Vec<Handle>,
+    next_qid: u64,
+}
+
 /// What a fid in `/srv` points at.
 #[derive(Clone)]
 enum Node {
@@ -39,15 +48,13 @@ enum Node {
     Handle(String),
 }
 
-struct SrvState {
-    handles: Vec<Handle>,
-    fids: HashMap<Fid, Node>,
-    next_qid: u64,
-}
-
-/// The `/srv` rendezvous registry (or a filtered view of one).
+/// The `/srv` rendezvous device, or an access-filtered view of one. A view shares
+/// the same live registry and only adds names to its `denied` set; fids are
+/// per-view.
 pub struct SrvFs {
-    state: Mutex<SrvState>,
+    registry: Arc<Mutex<Registry>>,
+    denied: HashSet<String>,
+    fids: Mutex<HashMap<Fid, Node>>,
 }
 
 impl Default for SrvFs {
@@ -59,23 +66,28 @@ impl Default for SrvFs {
 impl SrvFs {
     pub fn new() -> Self {
         Self {
-            state: Mutex::new(SrvState {
+            registry: Arc::new(Mutex::new(Registry {
                 handles: Vec::new(),
-                fids: HashMap::new(),
                 next_qid: 1,
-            }),
+            })),
+            denied: HashSet::new(),
+            fids: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn visible(&self, name: &str) -> bool {
+        !self.denied.contains(name)
     }
 
     /// Post a mountable handle under `name`. A repeat post of the same name
     /// **replaces** the previous handle (a restarted service supersedes its stale
     /// transport), so a name identifies exactly one rendezvous entry.
     pub async fn post(&self, name: &str, tree: InProcessTransport, access: Access) {
-        let mut state = self.state.lock().await;
-        let qid_path = state.next_qid;
-        state.next_qid += 1;
-        state.handles.retain(|h| h.name != name);
-        state.handles.push(Handle {
+        let mut reg = self.registry.lock().await;
+        let qid_path = reg.next_qid;
+        reg.next_qid += 1;
+        reg.handles.retain(|h| h.name != name);
+        reg.handles.push(Handle {
             name: name.to_string(),
             tree,
             access,
@@ -83,20 +95,24 @@ impl SrvFs {
         });
     }
 
-    /// Every posted handle name, in post order.
+    /// Every posted handle name visible through this view, in post order.
     pub async fn list(&self) -> Vec<String> {
-        self.state
+        self.registry
             .lock()
             .await
             .handles
             .iter()
+            .filter(|h| self.visible(&h.name))
             .map(|h| h.name.clone())
             .collect()
     }
 
-    /// Resolve a handle to its mountable tree and access, or `None`.
+    /// Resolve a visible handle to its mountable tree and access, or `None`.
     pub async fn lookup(&self, name: &str) -> Option<(InProcessTransport, Access)> {
-        self.state
+        if !self.visible(name) {
+            return None;
+        }
+        self.registry
             .lock()
             .await
             .handles
@@ -105,37 +121,21 @@ impl SrvFs {
             .map(|h| (h.tree.clone(), h.access))
     }
 
-    /// A real, access-filtered `/srv` for a restricted process: handles in
-    /// `denied` are absent from the returned server's listing and unresolvable —
-    /// and because it is a [`FileServer`], the denial holds on the aP surface the
-    /// process reads, not only in a snapshot.
+    /// An access-filtered `/srv` for a restricted process: handles in `denied`
+    /// are absent and unresolvable. The view shares the **live** registry, so a
+    /// later permitted post/restart on the parent is immediately visible to it.
     pub async fn view(&self, denied: &HashSet<String>) -> SrvFs {
-        let state = self.state.lock().await;
-        let visible: Vec<Handle> = state
-            .handles
-            .iter()
-            .filter(|h| !denied.contains(&h.name))
-            .cloned()
-            .collect();
+        let mut combined = self.denied.clone();
+        combined.extend(denied.iter().cloned());
         SrvFs {
-            state: Mutex::new(SrvState {
-                handles: visible,
-                fids: HashMap::new(),
-                next_qid: state.next_qid,
-            }),
+            registry: Arc::clone(&self.registry),
+            denied: combined,
+            fids: Mutex::new(HashMap::new()),
         }
     }
-}
 
-impl SrvState {
-    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
-        if fid == Fid::ROOT {
-            return Ok(Node::Root);
-        }
-        self.fids.get(&fid).cloned().ok_or(ErrorCode::NotFound)
-    }
-
-    fn qid_of(&self, node: &Node) -> Qid {
+    /// The qid for a node, looked up against the live registry.
+    async fn qid_of(&self, node: &Node) -> Qid {
         match node {
             Node::Root => Qid {
                 kind: FileKind::Dir,
@@ -144,6 +144,9 @@ impl SrvState {
             },
             Node::Handle(name) => {
                 let path = self
+                    .registry
+                    .lock()
+                    .await
                     .handles
                     .iter()
                     .find(|h| &h.name == name)
@@ -157,41 +160,66 @@ impl SrvState {
             }
         }
     }
+
+    async fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids
+            .lock()
+            .await
+            .get(&fid)
+            .cloned()
+            .ok_or(ErrorCode::NotFound)
+    }
 }
 
 #[async_trait]
 impl FileServer for SrvFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
-        let mut state = self.state.lock().await;
-        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+        if newfid == Fid::ROOT || self.fids.lock().await.contains_key(&newfid) {
             return Err(ErrorCode::BadRequest);
         }
-        let start = state.node_of(fid)?;
+        let start = self.node_of(fid).await?;
         let node = match (&start, names) {
             (_, []) => start.clone(),
-            (Node::Root, [name]) if state.handles.iter().any(|h| &h.name == name) => {
-                Node::Handle(name.clone())
+            (Node::Root, [name]) if self.visible(name) => {
+                let present = self
+                    .registry
+                    .lock()
+                    .await
+                    .handles
+                    .iter()
+                    .any(|h| &h.name == name);
+                if present {
+                    Node::Handle(name.clone())
+                } else {
+                    return Err(ErrorCode::NotFound);
+                }
             }
             (Node::Root, [_]) => return Err(ErrorCode::NotFound),
             _ => return Err(ErrorCode::NotDirectory),
         };
-        let qid = state.qid_of(&node);
-        state.fids.insert(newfid, node);
+        let qid = self.qid_of(&node).await;
+        self.fids.lock().await.insert(newfid, node);
         Ok(qid)
     }
 
     async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        let state = self.state.lock().await;
-        Ok(state.qid_of(&state.node_of(fid)?))
+        let node = self.node_of(fid).await?;
+        Ok(self.qid_of(&node).await)
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        let state = self.state.lock().await;
-        let bytes = match state.node_of(fid)? {
-            // The root lists the (filtered) handle names this server exposes.
-            Node::Root => state
+        let bytes = match self.node_of(fid).await? {
+            // The root lists the handle names visible through this view (live).
+            Node::Root => self
+                .registry
+                .lock()
+                .await
                 .handles
                 .iter()
+                .filter(|h| self.visible(&h.name))
                 .map(|h| h.name.clone())
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -209,11 +237,10 @@ impl FileServer for SrvFs {
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
-        let state = self.state.lock().await;
-        let node = state.node_of(fid)?;
+        let node = self.node_of(fid).await?;
         Ok(Stat {
             name: String::new(),
-            qid: state.qid_of(&node),
+            qid: self.qid_of(&node).await,
             length: 0,
             writable: false,
         })
@@ -234,7 +261,7 @@ impl FileServer for SrvFs {
     }
 
     async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
-        self.state.lock().await.fids.remove(&fid);
+        self.fids.lock().await.remove(&fid);
         Ok(())
     }
 }

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -2,18 +2,18 @@
 //!
 //! `/srv` exists before any user-space file server so servers have a place to
 //! publish mountable handles and clients have a place to mount from. It is **not
-//! an ambient backdoor**: each posted handle carries access rights, and a
-//! process sees and mounts only the handles its namespace/access permit. A
-//! service withheld from a process (filtered out of its `/srv` view) is not
-//! remountable — denial-by-absent-mount (D6).
+//! an ambient backdoor**: a service withheld from a process is filtered out of
+//! its `/srv` and is not remountable — denial-by-absent-mount (D6). The filtered
+//! view is itself a [`SrvFs`] (a real `FileServer`), so the denial holds on the
+//! aP surface a process actually reads, not just in a Rust-side snapshot.
 //!
-//! In v1 (in-process) a handle is an [`InProcessTransport`]; the aP surface
-//! lists handle *names*, and the in-process kernel mounts a named handle via
+//! In v1 (in-process) a handle is an [`InProcessTransport`]; the aP surface lists
+//! handle *names* and the in-process kernel mounts a named handle via
 //! [`SrvFs::lookup`] (an Arc cannot ride a byte transport, so the actual channel
 //! passes on the fast path). A future wire transport carries a dialable address
 //! instead, with the same access-filtered listing.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat,
@@ -28,11 +28,26 @@ struct Handle {
     name: String,
     tree: InProcessTransport,
     access: Access,
+    /// Server-unique qid path for this handle instance.
+    qid_path: u64,
 }
 
-/// The `/srv` rendezvous registry.
+/// What a fid in `/srv` points at.
+#[derive(Clone)]
+enum Node {
+    Root,
+    Handle(String),
+}
+
+struct SrvState {
+    handles: Vec<Handle>,
+    fids: HashMap<Fid, Node>,
+    next_qid: u64,
+}
+
+/// The `/srv` rendezvous registry (or a filtered view of one).
 pub struct SrvFs {
-    handles: Mutex<Vec<Handle>>,
+    state: Mutex<SrvState>,
 }
 
 impl Default for SrvFs {
@@ -44,126 +59,161 @@ impl Default for SrvFs {
 impl SrvFs {
     pub fn new() -> Self {
         Self {
-            handles: Mutex::new(Vec::new()),
+            state: Mutex::new(SrvState {
+                handles: Vec::new(),
+                fids: HashMap::new(),
+                next_qid: 1,
+            }),
         }
     }
 
-    /// Post a mountable handle under `name` with the given access rights.
+    /// Post a mountable handle under `name`. A repeat post of the same name
+    /// **replaces** the previous handle (a restarted service supersedes its stale
+    /// transport), so a name identifies exactly one rendezvous entry.
     pub async fn post(&self, name: &str, tree: InProcessTransport, access: Access) {
-        self.handles.lock().await.push(Handle {
+        let mut state = self.state.lock().await;
+        let qid_path = state.next_qid;
+        state.next_qid += 1;
+        state.handles.retain(|h| h.name != name);
+        state.handles.push(Handle {
             name: name.to_string(),
             tree,
             access,
+            qid_path,
         });
     }
 
-    /// Every posted handle name, in post order (the unfiltered view).
+    /// Every posted handle name, in post order.
     pub async fn list(&self) -> Vec<String> {
-        self.handles
+        self.state
             .lock()
             .await
+            .handles
             .iter()
             .map(|h| h.name.clone())
             .collect()
     }
 
-    /// Resolve a handle to its mountable tree and access. Returns `None` if no
-    /// such handle is posted.
+    /// Resolve a handle to its mountable tree and access, or `None`.
     pub async fn lookup(&self, name: &str) -> Option<(InProcessTransport, Access)> {
-        self.handles
+        self.state
             .lock()
             .await
+            .handles
             .iter()
             .find(|h| h.name == name)
             .map(|h| (h.tree.clone(), h.access))
     }
 
-    /// An access-filtered view of `/srv` for a restricted process: handles in
-    /// `denied` are absent from listing and unresolvable, so a withheld service
-    /// cannot be regained via `/srv`.
-    pub async fn view(&self, denied: &HashSet<String>) -> SrvView {
-        let visible: Vec<Handle> = self
+    /// A real, access-filtered `/srv` for a restricted process: handles in
+    /// `denied` are absent from the returned server's listing and unresolvable —
+    /// and because it is a [`FileServer`], the denial holds on the aP surface the
+    /// process reads, not only in a snapshot.
+    pub async fn view(&self, denied: &HashSet<String>) -> SrvFs {
+        let state = self.state.lock().await;
+        let visible: Vec<Handle> = state
             .handles
-            .lock()
-            .await
             .iter()
             .filter(|h| !denied.contains(&h.name))
             .cloned()
             .collect();
-        SrvView { visible }
+        SrvFs {
+            state: Mutex::new(SrvState {
+                handles: visible,
+                fids: HashMap::new(),
+                next_qid: state.next_qid,
+            }),
+        }
     }
 }
 
-/// A filtered snapshot of `/srv` as seen by one process.
-pub struct SrvView {
-    visible: Vec<Handle>,
-}
-
-impl SrvView {
-    pub fn list(&self) -> Vec<String> {
-        self.visible.iter().map(|h| h.name.clone()).collect()
+impl SrvState {
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        self.fids.get(&fid).cloned().ok_or(ErrorCode::NotFound)
     }
 
-    pub fn lookup(&self, name: &str) -> Option<(InProcessTransport, Access)> {
-        self.visible
-            .iter()
-            .find(|h| h.name == name)
-            .map(|h| (h.tree.clone(), h.access))
+    fn qid_of(&self, node: &Node) -> Qid {
+        match node {
+            Node::Root => Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            },
+            Node::Handle(name) => {
+                let path = self
+                    .handles
+                    .iter()
+                    .find(|h| &h.name == name)
+                    .map(|h| h.qid_path)
+                    .unwrap_or(0);
+                Qid {
+                    kind: FileKind::File,
+                    version: 0,
+                    path,
+                }
+            }
+        }
     }
 }
 
 #[async_trait]
 impl FileServer for SrvFs {
-    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
-        // `/srv` is flat: the root plus one level of handle names.
-        match names {
-            [] => Ok(Qid {
-                kind: FileKind::Dir,
-                version: 0,
-                path: 0,
-            }),
-            [name] => {
-                if self.handles.lock().await.iter().any(|h| &h.name == name) {
-                    Ok(Qid {
-                        kind: FileKind::File,
-                        version: 0,
-                        path: 1,
-                    })
-                } else {
-                    Err(ErrorCode::NotFound)
-                }
-            }
-            _ => Err(ErrorCode::NotDirectory),
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
         }
+        let start = state.node_of(fid)?;
+        let node = match (&start, names) {
+            (_, []) => start.clone(),
+            (Node::Root, [name]) if state.handles.iter().any(|h| &h.name == name) => {
+                Node::Handle(name.clone())
+            }
+            (Node::Root, [_]) => return Err(ErrorCode::NotFound),
+            _ => return Err(ErrorCode::NotDirectory),
+        };
+        let qid = state.qid_of(&node);
+        state.fids.insert(newfid, node);
+        Ok(qid)
     }
 
-    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        Ok(Qid {
-            kind: FileKind::Dir,
-            version: 0,
-            path: 0,
-        })
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let state = self.state.lock().await;
+        Ok(state.qid_of(&state.node_of(fid)?))
     }
 
-    async fn read(&self, _fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        let listing = self.list().await.join("\n").into_bytes();
-        let start = (offset as usize).min(listing.len());
-        let end = listing.len().min(start + count as usize);
-        Ok(listing[start..end].to_vec())
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        let bytes = match state.node_of(fid)? {
+            // The root lists the (filtered) handle names this server exposes.
+            Node::Root => state
+                .handles
+                .iter()
+                .map(|h| h.name.clone())
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into_bytes(),
+            // A handle file reads back its name (the rendezvous identity).
+            Node::Handle(name) => name.into_bytes(),
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
     }
 
     async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
         Err(ErrorCode::Unsupported)
     }
 
-    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = state.node_of(fid)?;
         Ok(Stat {
-            name: "srv".to_string(),
-            qid: Qid {
-                kind: FileKind::Dir,
-                version: 0,
-                path: 0,
-            },
+            name: String::new(),
+            qid: state.qid_of(&node),
             length: 0,
             writable: false,
         })
@@ -183,7 +233,8 @@ impl FileServer for SrvFs {
         Err(ErrorCode::Unsupported)
     }
 
-    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.state.lock().await.fids.remove(&fid);
         Ok(())
     }
 }

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -1,0 +1,189 @@
+//! `/srv` — the bootstrap rendezvous device (§7.2).
+//!
+//! `/srv` exists before any user-space file server so servers have a place to
+//! publish mountable handles and clients have a place to mount from. It is **not
+//! an ambient backdoor**: each posted handle carries access rights, and a
+//! process sees and mounts only the handles its namespace/access permit. A
+//! service withheld from a process (filtered out of its `/srv` view) is not
+//! remountable — denial-by-absent-mount (D6).
+//!
+//! In v1 (in-process) a handle is an [`InProcessTransport`]; the aP surface
+//! lists handle *names*, and the in-process kernel mounts a named handle via
+//! [`SrvFs::lookup`] (an Arc cannot ride a byte transport, so the actual channel
+//! passes on the fast path). A future wire transport carries a dialable address
+//! instead, with the same access-filtered listing.
+
+use std::collections::HashSet;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat,
+};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::Access;
+
+#[derive(Clone)]
+struct Handle {
+    name: String,
+    tree: InProcessTransport,
+    access: Access,
+}
+
+/// The `/srv` rendezvous registry.
+pub struct SrvFs {
+    handles: Mutex<Vec<Handle>>,
+}
+
+impl Default for SrvFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SrvFs {
+    pub fn new() -> Self {
+        Self {
+            handles: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Post a mountable handle under `name` with the given access rights.
+    pub async fn post(&self, name: &str, tree: InProcessTransport, access: Access) {
+        self.handles.lock().await.push(Handle {
+            name: name.to_string(),
+            tree,
+            access,
+        });
+    }
+
+    /// Every posted handle name, in post order (the unfiltered view).
+    pub async fn list(&self) -> Vec<String> {
+        self.handles
+            .lock()
+            .await
+            .iter()
+            .map(|h| h.name.clone())
+            .collect()
+    }
+
+    /// Resolve a handle to its mountable tree and access. Returns `None` if no
+    /// such handle is posted.
+    pub async fn lookup(&self, name: &str) -> Option<(InProcessTransport, Access)> {
+        self.handles
+            .lock()
+            .await
+            .iter()
+            .find(|h| h.name == name)
+            .map(|h| (h.tree.clone(), h.access))
+    }
+
+    /// An access-filtered view of `/srv` for a restricted process: handles in
+    /// `denied` are absent from listing and unresolvable, so a withheld service
+    /// cannot be regained via `/srv`.
+    pub async fn view(&self, denied: &HashSet<String>) -> SrvView {
+        let visible: Vec<Handle> = self
+            .handles
+            .lock()
+            .await
+            .iter()
+            .filter(|h| !denied.contains(&h.name))
+            .cloned()
+            .collect();
+        SrvView { visible }
+    }
+}
+
+/// A filtered snapshot of `/srv` as seen by one process.
+pub struct SrvView {
+    visible: Vec<Handle>,
+}
+
+impl SrvView {
+    pub fn list(&self) -> Vec<String> {
+        self.visible.iter().map(|h| h.name.clone()).collect()
+    }
+
+    pub fn lookup(&self, name: &str) -> Option<(InProcessTransport, Access)> {
+        self.visible
+            .iter()
+            .find(|h| h.name == name)
+            .map(|h| (h.tree.clone(), h.access))
+    }
+}
+
+#[async_trait]
+impl FileServer for SrvFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        // `/srv` is flat: the root plus one level of handle names.
+        match names {
+            [] => Ok(Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            }),
+            [name] => {
+                if self.handles.lock().await.iter().any(|h| &h.name == name) {
+                    Ok(Qid {
+                        kind: FileKind::File,
+                        version: 0,
+                        path: 1,
+                    })
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0,
+        })
+    }
+
+    async fn read(&self, _fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let listing = self.list().await.join("\n").into_bytes();
+        let start = (offset as usize).min(listing.len());
+        let end = listing.len().min(start + count as usize);
+        Ok(listing[start..end].to_vec())
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: "srv".to_string(),
+            qid: Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            },
+            length: 0,
+            writable: false,
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -177,10 +177,19 @@ impl SrvFs {
 #[async_trait]
 impl FileServer for SrvFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
-        if newfid == Fid::ROOT || self.fids.lock().await.contains_key(&newfid) {
+        // Hold the fid table across check-and-insert so a concurrent walk reusing
+        // the same `newfid` cannot observe it as free and rebind it. The start
+        // node is read from the held guard (not `node_of`, which would re-lock and
+        // deadlock); the registry lock is always taken *after* the fid lock.
+        let mut fids = self.fids.lock().await;
+        if newfid == Fid::ROOT || fids.contains_key(&newfid) {
             return Err(ErrorCode::BadRequest);
         }
-        let start = self.node_of(fid).await?;
+        let start = if fid == Fid::ROOT {
+            Node::Root
+        } else {
+            fids.get(&fid).cloned().ok_or(ErrorCode::NotFound)?
+        };
         let node = match (&start, names) {
             (_, []) => start.clone(),
             (Node::Root, [name]) if self.visible(name) => {
@@ -201,7 +210,7 @@ impl FileServer for SrvFs {
             _ => return Err(ErrorCode::NotDirectory),
         };
         let qid = self.qid_of(&node).await;
-        self.fids.lock().await.insert(newfid, node);
+        fids.insert(newfid, node);
         Ok(qid)
     }
 

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -238,10 +238,24 @@ impl FileServer for SrvFs {
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
         let node = self.node_of(fid).await?;
+        // Report the readable byte length so clients can size reads.
+        let length = match &node {
+            Node::Root => {
+                let reg = self.registry.lock().await;
+                reg.handles
+                    .iter()
+                    .filter(|h| self.visible(&h.name))
+                    .map(|h| h.name.clone())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+                    .len() as u64
+            }
+            Node::Handle(name) => name.len() as u64,
+        };
         Ok(Stat {
             name: String::new(),
             qid: self.qid_of(&node).await,
-            length: 0,
+            length,
             writable: false,
         })
     }

--- a/crates/kernel/tests/dependency_boundary.rs
+++ b/crates/kernel/tests/dependency_boundary.rs
@@ -1,0 +1,120 @@
+//! Dependency boundary (substrate §8.3, ADR-0025 D1): `alan-kernel` depends only
+//! on `alan-ap` among Alan crates, and never on the agent runtime, the legacy
+//! session protocol, provider clients, memory stores, sandbox backends, or
+//! renderers. Enforced structurally so "the kernel changes least" is a fact, not
+//! a hope — and so the retired V1 ontology cannot creep back in.
+
+use std::path::Path;
+
+/// Parse the crate names declared in the `[dependencies]` table of a Cargo
+/// manifest. Handles both `name = { ... }` and `name.workspace = true` forms.
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    let mut deps = Vec::new();
+    let mut in_deps = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_deps = line == "[dependencies]";
+            continue;
+        }
+        if !in_deps || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // The dependency name is the token before `=` or the first `.`.
+        let head = line.split('=').next().unwrap_or("").trim();
+        let name = head.split('.').next().unwrap_or("").trim();
+        if !name.is_empty() {
+            deps.push(name.to_string());
+        }
+    }
+    deps
+}
+
+#[test]
+fn kernel_depends_only_on_alan_ap_among_alan_crates() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read kernel Cargo.toml");
+
+    let alan_deps: Vec<String> = declared_dependencies(&manifest)
+        .into_iter()
+        .filter(|d| d.starts_with("alan-"))
+        .collect();
+
+    assert_eq!(
+        alan_deps,
+        vec!["alan-ap".to_string()],
+        "alan-kernel must depend only on alan-ap among Alan crates (ADR-0025 D1); found {alan_deps:?}"
+    );
+}
+
+#[test]
+fn kernel_does_not_declare_runtime_provider_or_renderer_crates() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read kernel Cargo.toml");
+    let deps = declared_dependencies(&manifest);
+
+    // Crates whose presence would mean the kernel learned about agents, the
+    // legacy protocol, providers, or a renderer.
+    let forbidden = [
+        "alan-runtime",
+        "alan-agent-engine",
+        "alan-protocol",
+        "alan-agent-protocol",
+        "alan-llm",
+        "alan-tools",
+        "reqwest",
+        "ratatui",
+        "crossterm",
+    ];
+    for crate_name in forbidden {
+        assert!(
+            !deps.iter().any(|d| d == crate_name),
+            "alan-kernel must not depend on `{crate_name}` (substrate §8.3)"
+        );
+    }
+}
+
+#[test]
+fn kernel_source_does_not_reference_the_runtime_or_legacy_protocol() {
+    // A leak would show up as a `use` of these crates or the retired ontology.
+    let forbidden_tokens = [
+        "alan_runtime",
+        "alan_protocol",
+        "alan_agent_engine",
+        "alan_agent_protocol",
+        "agent_capability",
+        "ViewModel",
+        "renderer_host",
+    ];
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    visit_rs_files(&src, &mut |path, contents| {
+        for token in forbidden_tokens {
+            if contents.contains(token) {
+                offenders.push(format!("{}: {token}", path.display()));
+            }
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "kernel source leaks retired/runtime concepts: {offenders:?}"
+    );
+}
+
+fn visit_rs_files(dir: &Path, f: &mut impl FnMut(&Path, &str)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            visit_rs_files(&path, f);
+        } else if path.extension().is_some_and(|e| e == "rs")
+            && let Ok(contents) = std::fs::read_to_string(&path)
+        {
+            f(&path, &contents);
+        }
+    }
+}

--- a/crates/kernel/tests/namespace.rs
+++ b/crates/kernel/tests/namespace.rs
@@ -1,0 +1,175 @@
+//! Namespace engine (substrate §6.1–§6.3, §2.5a): a per-process mount table with
+//! mount/bind/unmount, longest-prefix resolution, union directories, read-only
+//! vs read-write access, and inheritance where a child may only restrict its own
+//! view. Resolution is the *sole* way to reach a resource — there is no global
+//! ambient addressing (§6.3): an unmounted path is unreachable.
+
+use std::sync::Arc;
+
+use alan_ap::reference::MemFs;
+use alan_ap::{Fid, InProcessTransport, OpenMode, Request, Response};
+use alan_kernel::{Access, Namespace};
+
+fn memfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(MemFs::new()))
+}
+
+#[tokio::test]
+async fn resolve_routes_a_path_into_the_mounted_tree() {
+    let mut ns = Namespace::new();
+    ns.mount("/srv/echo", memfs(), Access::ReadWrite);
+
+    let resolved = ns.resolve("/srv/echo/greeting").expect("path is mounted");
+    assert_eq!(resolved.rel, vec!["greeting".to_string()]);
+    assert_eq!(resolved.access, Access::ReadWrite);
+
+    // The returned tree is live: walking the rel path and reading works.
+    resolved
+        .tree
+        .call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(1),
+            names: resolved.rel.clone(),
+        })
+        .await
+        .unwrap();
+    resolved
+        .tree
+        .call(Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read,
+        })
+        .await
+        .unwrap();
+    let read = resolved
+        .tree
+        .call(Request::Read {
+            fid: Fid(1),
+            offset: 0,
+            count: 64,
+        })
+        .await;
+    assert_eq!(
+        read,
+        Ok(Response::Read {
+            data: b"hi".to_vec()
+        })
+    );
+}
+
+#[test]
+fn union_directory_exposes_every_contributor_at_one_path() {
+    // /bin is contributed to by several file servers (e.g. binfs + agent-bin);
+    // the namespace presents a union of their mounts at that path.
+    let mut ns = Namespace::new();
+    ns.mount("/bin", memfs(), Access::ReadOnly);
+    ns.mount("/bin", memfs(), Access::ReadOnly);
+
+    let contributors = ns.union_at("/bin");
+    assert_eq!(
+        contributors.len(),
+        2,
+        "both contributors remain independent under the union"
+    );
+}
+
+#[tokio::test]
+async fn bind_aliases_a_mounted_tree_under_a_new_path() {
+    // The agent-bin tree is posted at /srv/agent-bin and bound into /bin.
+    let mut ns = Namespace::new();
+    ns.mount("/srv/agent-bin", memfs(), Access::ReadOnly);
+    ns.bind("/bin", "/srv/agent-bin");
+
+    let resolved = ns.resolve("/bin/greeting").expect("bound path resolves");
+    assert_eq!(resolved.rel, vec!["greeting".to_string()]);
+    resolved
+        .tree
+        .call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(1),
+            names: resolved.rel.clone(),
+        })
+        .await
+        .unwrap();
+    resolved
+        .tree
+        .call(Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read,
+        })
+        .await
+        .unwrap();
+    let read = resolved
+        .tree
+        .call(Request::Read {
+            fid: Fid(1),
+            offset: 0,
+            count: 64,
+        })
+        .await;
+    assert_eq!(
+        read,
+        Ok(Response::Read {
+            data: b"hi".to_vec()
+        })
+    );
+}
+
+#[tokio::test]
+async fn longest_prefix_mount_wins() {
+    let mut ns = Namespace::new();
+    ns.mount("/", memfs(), Access::ReadOnly);
+    ns.mount("/mnt/llm", memfs(), Access::ReadWrite);
+
+    let general = ns.resolve("/greeting").unwrap();
+    assert_eq!(general.access, Access::ReadOnly);
+    assert_eq!(general.rel, vec!["greeting".to_string()]);
+
+    let specific = ns.resolve("/mnt/llm/greeting").unwrap();
+    assert_eq!(specific.access, Access::ReadWrite);
+    assert_eq!(specific.rel, vec!["greeting".to_string()]);
+}
+
+#[test]
+fn unmounted_path_is_unreachable() {
+    let ns = Namespace::new();
+    assert!(
+        ns.resolve("/srv/echo/greeting").is_err(),
+        "no global ambient addressing"
+    );
+}
+
+#[test]
+fn read_only_mount_cannot_be_escalated_to_write() {
+    let mut ns = Namespace::new();
+    ns.mount("/lib", memfs(), Access::ReadOnly);
+
+    let resolved = ns.resolve("/lib/skill").unwrap();
+    assert_eq!(resolved.access, Access::ReadOnly);
+    assert!(resolved.access.allows(OpenMode::Read));
+    assert!(!resolved.access.allows(OpenMode::Write));
+    assert!(!resolved.access.allows(OpenMode::ReadWrite));
+}
+
+#[test]
+fn child_inherits_namespace_and_may_only_restrict_its_own_view() {
+    let mut parent = Namespace::new();
+    parent.mount("/bin", memfs(), Access::ReadOnly);
+    parent.mount("/mnt/llm", memfs(), Access::ReadWrite);
+
+    // A child receives a namespace constructed from the parent's.
+    let mut child = parent.child();
+    assert!(child.resolve("/mnt/llm/x").is_ok());
+
+    // The child restricts its own view; the parent is unaffected (§ "only that
+    // process's view changes").
+    child.unmount("/mnt/llm");
+    assert!(
+        child.resolve("/mnt/llm/x").is_err(),
+        "child restricted its own view"
+    );
+    assert!(
+        parent.resolve("/mnt/llm/x").is_ok(),
+        "parent view is independent"
+    );
+}

--- a/crates/kernel/tests/namespace.rs
+++ b/crates/kernel/tests/namespace.rs
@@ -135,7 +135,6 @@ async fn resolve_candidates_searches_union_contributors() {
     // so the file is reachable instead of shadowed by last-wins.
     assert!(
         candidates[0]
-            .tree
             .call(Request::Walk {
                 fid: Fid::ROOT,
                 newfid: Fid(1),
@@ -146,7 +145,6 @@ async fn resolve_candidates_searches_union_contributors() {
         "the last-mounted contributor lacks the file"
     );
     candidates[1]
-        .tree
         .call(Request::Walk {
             fid: Fid::ROOT,
             newfid: Fid(2),
@@ -154,6 +152,33 @@ async fn resolve_candidates_searches_union_contributors() {
         })
         .await
         .expect("an earlier contributor still serves the file");
+}
+
+// resolve_candidates keeps only the longest-prefix contributors — a deeper
+// overmount shadows the broader mount, never falls through to it (PR #574 review).
+#[tokio::test]
+async fn resolve_candidates_keeps_only_the_longest_prefix() {
+    let mut ns = Namespace::new();
+    ns.mount("/", memfs(), Access::ReadOnly); // broad: has "greeting"
+    ns.mount("/mnt/llm", emptyfs(), Access::ReadOnly); // deeper overmount: empty
+
+    let candidates = ns.resolve_candidates("/mnt/llm/greeting");
+    assert_eq!(
+        candidates.len(),
+        1,
+        "only the longest-prefix mount, no fall-through to /"
+    );
+    assert!(
+        candidates[0]
+            .call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["greeting".into()]
+            })
+            .await
+            .is_err(),
+        "the deeper overmount shadows the broader mount"
+    );
 }
 
 #[tokio::test]
@@ -167,7 +192,6 @@ async fn resolve_routes_a_path_into_the_mounted_tree() {
 
     // The returned tree is live: walking the rel path and reading works.
     resolved
-        .tree
         .call(Request::Walk {
             fid: Fid::ROOT,
             newfid: Fid(1),
@@ -176,7 +200,6 @@ async fn resolve_routes_a_path_into_the_mounted_tree() {
         .await
         .unwrap();
     resolved
-        .tree
         .call(Request::Open {
             fid: Fid(1),
             mode: OpenMode::Read,
@@ -184,7 +207,6 @@ async fn resolve_routes_a_path_into_the_mounted_tree() {
         .await
         .unwrap();
     let read = resolved
-        .tree
         .call(Request::Read {
             fid: Fid(1),
             offset: 0,
@@ -225,7 +247,6 @@ async fn bind_aliases_a_mounted_tree_under_a_new_path() {
     let resolved = ns.resolve("/bin/greeting").expect("bound path resolves");
     assert_eq!(resolved.rel, vec!["greeting".to_string()]);
     resolved
-        .tree
         .call(Request::Walk {
             fid: Fid::ROOT,
             newfid: Fid(1),
@@ -234,7 +255,6 @@ async fn bind_aliases_a_mounted_tree_under_a_new_path() {
         .await
         .unwrap();
     resolved
-        .tree
         .call(Request::Open {
             fid: Fid(1),
             mode: OpenMode::Read,
@@ -242,7 +262,6 @@ async fn bind_aliases_a_mounted_tree_under_a_new_path() {
         .await
         .unwrap();
     let read = resolved
-        .tree
         .call(Request::Read {
             fid: Fid(1),
             offset: 0,

--- a/crates/kernel/tests/namespace.rs
+++ b/crates/kernel/tests/namespace.rs
@@ -7,11 +7,153 @@
 use std::sync::Arc;
 
 use alan_ap::reference::MemFs;
-use alan_ap::{Fid, InProcessTransport, OpenMode, Request, Response};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Request,
+    Response, Stat,
+};
 use alan_kernel::{Access, Namespace};
 
 fn memfs() -> InProcessTransport {
     InProcessTransport::new(Arc::new(MemFs::new()))
+}
+
+/// A server with no files — every walk fails. Used to model a union contributor
+/// that does not hold the requested file.
+struct EmptyFs;
+
+#[async_trait::async_trait]
+impl FileServer for EmptyFs {
+    async fn walk(&self, _: Fid, _: Fid, _: &[String]) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn open(&self, _: Fid, _: OpenMode) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn write(&self, _: Fid, _: Offset, _: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn stat(&self, _: Fid) -> Result<Stat, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NotFound)
+    }
+    async fn clunk(&self, _: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+fn emptyfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(EmptyFs))
+}
+
+// §2.5a / D6 — a read-only mount enforces awareness-only: mutating calls through
+// the resolved handle are denied, not merely advisory (PR #574 review).
+#[tokio::test]
+async fn read_only_mount_enforces_access_on_calls() {
+    let mut ns = Namespace::new();
+    ns.mount("/lib", memfs(), Access::ReadOnly);
+    ns.mount("/mnt/llm", memfs(), Access::ReadWrite);
+
+    let ro = ns.resolve("/lib/submit").unwrap();
+    // Read-opens and reads pass through.
+    ro.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(1),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        ro.call(Request::Open {
+            fid: Fid(1),
+            mode: OpenMode::Read
+        })
+        .await,
+        Ok(Response::Open { .. })
+    ));
+    // Mutating calls are rejected by the mount, before reaching the tree.
+    assert_eq!(
+        ro.call(Request::Open {
+            fid: Fid(2),
+            mode: OpenMode::Write
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+    assert_eq!(
+        ro.call(Request::Write {
+            fid: Fid(1),
+            offset: 0,
+            data: b"x".to_vec()
+        })
+        .await,
+        Err(ErrorCode::NoAccess)
+    );
+
+    // A read-write mount allows the same mutating call to reach the tree.
+    let rw = ns.resolve("/mnt/llm/submit").unwrap();
+    rw.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(3),
+        names: vec!["submit".into()],
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        rw.call(Request::Open {
+            fid: Fid(3),
+            mode: OpenMode::Write
+        })
+        .await,
+        Ok(Response::Open { .. })
+    ));
+}
+
+// A union directory's earlier contributor stays reachable: resolve_candidates
+// returns every contributor so the caller can search past a last-mounted tree
+// that lacks the file (PR #574 review).
+#[tokio::test]
+async fn resolve_candidates_searches_union_contributors() {
+    let mut ns = Namespace::new();
+    ns.mount("/bin", memfs(), Access::ReadOnly); // earlier: has "greeting"
+    ns.mount("/bin", emptyfs(), Access::ReadOnly); // later: has nothing
+
+    let candidates = ns.resolve_candidates("/bin/greeting");
+    assert_eq!(candidates.len(), 2, "both union contributors are returned");
+    for c in &candidates {
+        assert_eq!(c.rel, vec!["greeting".to_string()]);
+    }
+
+    // Walking the most-recent (empty) candidate fails; the earlier one resolves —
+    // so the file is reachable instead of shadowed by last-wins.
+    assert!(
+        candidates[0]
+            .tree
+            .call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: Fid(1),
+                names: vec!["greeting".into()]
+            })
+            .await
+            .is_err(),
+        "the last-mounted contributor lacks the file"
+    );
+    candidates[1]
+        .tree
+        .call(Request::Walk {
+            fid: Fid::ROOT,
+            newfid: Fid(2),
+            names: vec!["greeting".into()],
+        })
+        .await
+        .expect("an earlier contributor still serves the file");
 }
 
 #[tokio::test]

--- a/crates/kernel/tests/namespace.rs
+++ b/crates/kernel/tests/namespace.rs
@@ -154,6 +154,51 @@ async fn resolve_candidates_searches_union_contributors() {
         .expect("an earlier contributor still serves the file");
 }
 
+// stat through a read-only mount masks `writable`, so a caller never sees a
+// capability the mount would reject (PR #574 review). `/proc`'s `clone` reports
+// writable:true at the backing node, making it the right fixture.
+#[tokio::test]
+async fn read_only_mount_masks_stat_writability() {
+    use alan_kernel::ProcFs;
+    let procfs_ro = InProcessTransport::new(Arc::new(ProcFs::new()));
+    let procfs_rw = InProcessTransport::new(Arc::new(ProcFs::new()));
+    let mut ns = Namespace::new();
+    ns.mount("/proc-ro", procfs_ro, Access::ReadOnly);
+    ns.mount("/proc-rw", procfs_rw, Access::ReadWrite);
+
+    let ro = ns.resolve("/proc-ro/clone").unwrap();
+    ro.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(1),
+        names: vec!["clone".into()],
+    })
+    .await
+    .unwrap();
+    let Response::Stat { stat } = ro.call(Request::Stat { fid: Fid(1) }).await.unwrap() else {
+        panic!("expected stat");
+    };
+    assert!(
+        !stat.writable,
+        "read-only mount masks the writable clone node"
+    );
+
+    let rw = ns.resolve("/proc-rw/clone").unwrap();
+    rw.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(2),
+        names: vec!["clone".into()],
+    })
+    .await
+    .unwrap();
+    let Response::Stat { stat } = rw.call(Request::Stat { fid: Fid(2) }).await.unwrap() else {
+        panic!("expected stat");
+    };
+    assert!(
+        stat.writable,
+        "read-write mount reports the node's writability"
+    );
+}
+
 // resolve_candidates keeps only the longest-prefix contributors — a deeper
 // overmount shadows the broader mount, never falls through to it (PR #574 review).
 #[tokio::test]

--- a/crates/kernel/tests/process.rs
+++ b/crates/kernel/tests/process.rs
@@ -82,4 +82,13 @@ fn exit_records_terminal_status_and_code() {
     let proc = table.get(pid).unwrap();
     assert_eq!(proc.status, Status::Exited);
     assert_eq!(proc.exit_code, Some(0));
+
+    // A later cancel/termination must not clobber the recorded terminal status.
+    table.exit(pid, 130);
+    let proc = table.get(pid).unwrap();
+    assert_eq!(
+        proc.exit_code,
+        Some(0),
+        "terminal exit code is recorded once"
+    );
 }

--- a/crates/kernel/tests/process.rs
+++ b/crates/kernel/tests/process.rs
@@ -1,0 +1,85 @@
+//! Process table (substrate §6.4–§6.5): one `Process` category with identity,
+//! parentage, credentials, namespace, status, and exit state — and no
+//! `Agent Process` type. Spawn is staged (clone-begin → commit | discard) so a
+//! pending slot is never publicly visible until it commits (§7.1a). The table is
+//! ephemeral: a fresh table starts empty (D7).
+
+use alan_kernel::{Credentials, ExecSpec, Namespace, ProcessTable, Status};
+
+fn exec(bin: &str) -> ExecSpec {
+    ExecSpec {
+        executable: bin.to_string(),
+        args: vec![],
+    }
+}
+
+#[test]
+fn a_fresh_table_is_empty() {
+    let table = ProcessTable::new();
+    assert!(
+        table.list().is_empty(),
+        "the kernel is ephemeral; the table starts empty"
+    );
+}
+
+#[test]
+fn commit_publishes_a_process_with_full_identity() {
+    let mut table = ProcessTable::new();
+    let parent = table
+        .clone_begin(None, Namespace::new(), Credentials::system())
+        .and_then(|slot| table.commit(slot, exec("/bin/root")))
+        .unwrap();
+
+    let slot = table
+        .clone_begin(Some(parent), Namespace::new(), Credentials::user("alan"))
+        .unwrap();
+    // Pending slot is fid-private: not yet in the public listing.
+    assert!(
+        !table.list().contains(&slot),
+        "a pending slot is not publicly visible"
+    );
+
+    let pid = table.commit(slot, exec("/bin/agent")).unwrap();
+    assert!(
+        table.list().contains(&pid),
+        "a committed process becomes public"
+    );
+
+    let proc = table.get(pid).unwrap();
+    assert_eq!(proc.parent, Some(parent));
+    assert_eq!(proc.credentials, Credentials::user("alan"));
+    assert_eq!(proc.status, Status::Running);
+    assert_eq!(proc.exec.executable, "/bin/agent");
+    assert!(proc.exit_code.is_none());
+}
+
+#[test]
+fn a_discarded_pending_slot_never_becomes_public() {
+    let mut table = ProcessTable::new();
+    let slot = table
+        .clone_begin(None, Namespace::new(), Credentials::system())
+        .unwrap();
+
+    table.discard(slot);
+
+    assert!(
+        !table.list().contains(&slot),
+        "discarded slot leaks nothing into public /proc"
+    );
+    assert!(table.get(slot).is_none());
+}
+
+#[test]
+fn exit_records_terminal_status_and_code() {
+    let mut table = ProcessTable::new();
+    let pid = table
+        .clone_begin(None, Namespace::new(), Credentials::system())
+        .and_then(|slot| table.commit(slot, exec("/bin/tool")))
+        .unwrap();
+
+    table.exit(pid, 0);
+
+    let proc = table.get(pid).unwrap();
+    assert_eq!(proc.status, Status::Exited);
+    assert_eq!(proc.exit_code, Some(0));
+}

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -12,6 +12,20 @@ fn proc() -> ProcFs {
     ProcFs::new()
 }
 
+/// Spawn a process via clone-via-open using a distinct fid base; returns its pid.
+async fn spawn(fs: &ProcFs, clone_fid: Fid) -> String {
+    fs.walk(Fid::ROOT, clone_fid, &["clone".to_string()])
+        .await
+        .unwrap();
+    fs.open(clone_fid, OpenMode::ReadWrite).await.unwrap();
+    let pid = String::from_utf8(fs.read(clone_fid, 0, 64).await.unwrap()).unwrap();
+    fs.write(clone_fid, 0, br#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    fs.clunk(clone_fid).await.unwrap();
+    pid
+}
+
 async fn read_at(fs: &ProcFs, names: &[&str], fid: Fid) -> Result<Vec<u8>, ErrorCode> {
     let names: Vec<String> = names.iter().map(|s| s.to_string()).collect();
     fs.walk(Fid::ROOT, fid, &names).await?;
@@ -84,4 +98,126 @@ async fn a_malformed_exec_spec_is_rejected_at_clunk_and_leaks_nothing() {
         !listing.lines().any(|l| l == pid_name),
         "rejected spawn leaks nothing"
     );
+}
+
+// /proc/<pid>/io/output is wired to the process output stream, not Unsupported:
+// reading an empty live output blocks (stream semantics) rather than erroring
+// (PR #574 review).
+#[tokio::test]
+async fn proc_output_serves_the_stream() {
+    use std::time::Duration;
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+
+    fs.walk(Fid::ROOT, Fid(11), &[pid, "io".into(), "output".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(11), OpenMode::Read).await.unwrap();
+    // Empty output stream → the read blocks; it must NOT return Unsupported.
+    let r = tokio::time::timeout(Duration::from_millis(30), fs.read(Fid(11), 0, 64)).await;
+    assert!(
+        r.is_err(),
+        "reading io/output should block on the stream, not error"
+    );
+}
+
+// Spawning requires write intent: opening /proc/clone read-only is rejected, and
+// a ctl write needs write authority (PR #574 review).
+#[tokio::test]
+async fn write_surfaces_require_write_intent() {
+    let fs = proc();
+
+    // Read-only open of clone cannot allocate a (would-be leaked) pending slot.
+    fs.walk(Fid::ROOT, Fid(10), &["clone".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.open(Fid(10), OpenMode::Read).await,
+        Err(ErrorCode::NoAccess)
+    );
+
+    // ctl opened read-only cannot cancel the process.
+    let pid = spawn(&fs, Fid(20)).await;
+    fs.walk(Fid::ROOT, Fid(21), &[pid.clone(), "ctl".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(21), OpenMode::Read).await.unwrap();
+    assert_eq!(
+        fs.write(Fid(21), 0, b"cancel").await,
+        Err(ErrorCode::NoAccess)
+    );
+    // Still running — the read-only cancel did not take effect.
+    fs.walk(Fid::ROOT, Fid(22), &[pid, "status".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(22), OpenMode::Read).await.unwrap();
+    assert_eq!(
+        String::from_utf8(fs.read(Fid(22), 0, 64).await.unwrap())
+            .unwrap()
+            .trim(),
+        "running"
+    );
+}
+
+// walk rejects reused/reserved newfids; open rejects reopening a live fid — so a
+// retry cannot clobber a pending clone slot (PR #574 review).
+#[tokio::test]
+async fn fid_reuse_and_reopen_are_rejected() {
+    let fs = proc();
+    fs.walk(Fid::ROOT, Fid(10), &["clone".to_string()])
+        .await
+        .unwrap();
+    // Reusing a live fid is rejected, not a silent clobber.
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(10), &["clone".to_string()]).await,
+        Err(ErrorCode::BadRequest)
+    );
+    // Reopening a live fid before clunk is rejected.
+    fs.open(Fid(10), OpenMode::ReadWrite).await.unwrap();
+    assert_eq!(
+        fs.open(Fid(10), OpenMode::ReadWrite).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+// The clone exec-spec write honors byte offsets, so out-of-order chunks build the
+// addressed document (PR #574 review).
+#[tokio::test]
+async fn clone_exec_spec_write_honors_offset() {
+    let fs = proc();
+    fs.walk(Fid::ROOT, Fid(10), &["clone".to_string()])
+        .await
+        .unwrap();
+    fs.open(Fid(10), OpenMode::ReadWrite).await.unwrap();
+    let pid = String::from_utf8(fs.read(Fid(10), 0, 64).await.unwrap()).unwrap();
+    // Write the tail first (at offset 14), then the head (offset 0).
+    fs.write(Fid(10), 14, br#""/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    fs.write(Fid(10), 0, br#"{"executable":"#).await.unwrap();
+    assert_eq!(fs.clunk(Fid(10)).await, Ok(()));
+    // Committed cleanly → the process is public.
+    let listing = String::from_utf8(read_at(&fs, &[], Fid(11)).await.unwrap()).unwrap();
+    assert!(
+        listing.lines().any(|l| l == pid),
+        "offset-assembled spec spawned the process"
+    );
+}
+
+// /proc/<pid>/namespace renders the process's mounted capability set
+// (PR #574 review).
+#[tokio::test]
+async fn proc_exposes_the_process_namespace() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+    // The file exists and is listed in the process directory.
+    let dir = String::from_utf8(read_at(&fs, &[&pid], Fid(11)).await.unwrap()).unwrap();
+    assert!(
+        dir.lines().any(|l| l == "namespace"),
+        "namespace is listed: {dir:?}"
+    );
+    // And it reads (empty for a system-spawned process with an empty namespace).
+    read_at(&fs, &[&pid, "namespace"], Fid(12))
+        .await
+        .expect("namespace is readable");
 }

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -204,6 +204,34 @@ async fn clone_exec_spec_write_honors_offset() {
     );
 }
 
+// stat reports the readable byte length, so clients can size reads (PR #574).
+#[tokio::test]
+async fn stat_reports_readable_length() {
+    let fs = proc();
+    let pid = spawn(&fs, Fid(10)).await;
+    fs.walk(Fid::ROOT, Fid(11), &[pid, "status".into()])
+        .await
+        .unwrap();
+    let st = fs.stat(Fid(11)).await.unwrap();
+    // status reads "running\n" (8 bytes); stat must not report 0.
+    assert_eq!(st.length, 8, "stat length matches the bytes read returns");
+}
+
+// The pre-bound /proc root fid can be opened directly (no redundant empty walk),
+// matching SrvFs and the reference server (PR #574 review).
+#[tokio::test]
+async fn root_fid_is_openable_directly() {
+    let fs = proc();
+    fs.open(Fid::ROOT, OpenMode::Read)
+        .await
+        .expect("root fid opens directly");
+    let listing = String::from_utf8(fs.read(Fid::ROOT, 0, 64).await.unwrap()).unwrap();
+    assert!(
+        listing.lines().any(|l| l == "clone"),
+        "root listing is readable via the root fid"
+    );
+}
+
 // /proc/<pid>/namespace renders the process's mounted capability set
 // (PR #574 review).
 #[tokio::test]

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -1,0 +1,87 @@
+//! `/proc` synthetic device (substrate §7.1) and spawn via clone-via-open
+//! (§7.1a). `/proc` renders the process table as files: a `clone` file plus a
+//! directory per pid (`status`, `parent`, `credentials`, `exit`, `ctl`, `io/`).
+//! Process creation is pure aP — open `/proc/clone` (a pending pid, not yet
+//! public), write the exec spec, and `clunk` to commit — so an aP-only client
+//! needs no side API to launch a process.
+
+use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
+use alan_kernel::ProcFs;
+
+fn proc() -> ProcFs {
+    ProcFs::new()
+}
+
+async fn read_at(fs: &ProcFs, names: &[&str], fid: Fid) -> Result<Vec<u8>, ErrorCode> {
+    let names: Vec<String> = names.iter().map(|s| s.to_string()).collect();
+    fs.walk(Fid::ROOT, fid, &names).await?;
+    fs.open(fid, OpenMode::Read).await?;
+    fs.read(fid, 0, 4096).await
+}
+
+#[tokio::test]
+async fn empty_proc_lists_only_clone() {
+    let fs = proc();
+    let listing = read_at(&fs, &[], Fid(1)).await.unwrap();
+    let text = String::from_utf8(listing).unwrap();
+    assert_eq!(text.lines().collect::<Vec<_>>(), vec!["clone"]);
+}
+
+#[tokio::test]
+async fn spawn_via_clone_open_write_clunk_makes_a_public_process() {
+    let fs = proc();
+
+    // open /proc/clone → the pending pid is returned by reading the clone fid.
+    fs.walk(Fid::ROOT, Fid(10), &["clone".to_string()])
+        .await
+        .unwrap();
+    fs.open(Fid(10), OpenMode::ReadWrite).await.unwrap();
+    let pid_name = String::from_utf8(fs.read(Fid(10), 0, 64).await.unwrap()).unwrap();
+    assert!(!pid_name.is_empty());
+
+    // The pending slot is not yet visible in public /proc.
+    let before = String::from_utf8(read_at(&fs, &[], Fid(11)).await.unwrap()).unwrap();
+    assert!(
+        !before.lines().any(|l| l == pid_name),
+        "pending slot is fid-private"
+    );
+
+    // Write the exec spec (commit-on-clunk) and clunk to start.
+    fs.write(Fid(10), 0, br#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    assert_eq!(fs.clunk(Fid(10)).await, Ok(()));
+
+    // Now /proc/<pid> is public and its status reads "running".
+    let after = String::from_utf8(read_at(&fs, &[], Fid(12)).await.unwrap()).unwrap();
+    assert!(
+        after.lines().any(|l| l == pid_name),
+        "committed process is public: {after:?}"
+    );
+
+    let status =
+        String::from_utf8(read_at(&fs, &[&pid_name, "status"], Fid(13)).await.unwrap()).unwrap();
+    assert_eq!(status.trim(), "running");
+}
+
+#[tokio::test]
+async fn a_malformed_exec_spec_is_rejected_at_clunk_and_leaks_nothing() {
+    let fs = proc();
+
+    fs.walk(Fid::ROOT, Fid(20), &["clone".to_string()])
+        .await
+        .unwrap();
+    fs.open(Fid(20), OpenMode::ReadWrite).await.unwrap();
+    let pid_name = String::from_utf8(fs.read(Fid(20), 0, 64).await.unwrap()).unwrap();
+
+    // Truncated exec spec: rejected at the commit point, not before.
+    fs.write(Fid(20), 0, b"{ truncated").await.unwrap();
+    assert_eq!(fs.clunk(Fid(20)).await, Err(ErrorCode::BadRequest));
+
+    // The fid-private slot was discarded; public /proc never shows it.
+    let listing = String::from_utf8(read_at(&fs, &[], Fid(21)).await.unwrap()).unwrap();
+    assert!(
+        !listing.lines().any(|l| l == pid_name),
+        "rejected spawn leaks nothing"
+    );
+}

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -120,6 +120,38 @@ async fn reposting_a_name_replaces_the_stale_handle() {
     );
 }
 
+// A filtered view shares the live registry: a later permitted post on the parent
+// is visible to the child, and a withheld name stays hidden (PR #574 review).
+#[tokio::test]
+async fn filtered_view_stays_live() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+
+    let denied: HashSet<String> = ["mem".to_string()].into_iter().collect();
+    let view = srv.view(&denied).await;
+    assert_eq!(view.list().await, vec!["llm".to_string()]);
+
+    // Parent posts a newly permitted handle and a denied one after the view exists.
+    srv.post("route", memfs(), Access::ReadWrite).await;
+    srv.post("mem", memfs(), Access::ReadOnly).await;
+
+    let mut names = view.list().await;
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["llm".to_string(), "route".to_string()],
+        "view sees new allowed post, not the denied one"
+    );
+    assert!(
+        view.lookup("route").await.is_some(),
+        "newly posted permitted handle resolves"
+    );
+    assert!(
+        view.lookup("mem").await.is_none(),
+        "denied handle stays hidden"
+    );
+}
+
 #[tokio::test]
 async fn srv_root_lists_posted_handles_over_ap() {
     let srv = SrvFs::new();

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -165,6 +165,28 @@ async fn handle_stat_reports_real_length() {
     );
 }
 
+// Concurrent walks reusing the same newfid don't both succeed: the fid table is
+// reserved atomically, so exactly one binds and the other is rejected (PR #574).
+#[tokio::test]
+async fn concurrent_walks_on_one_newfid_do_not_clobber() {
+    use std::sync::Arc;
+    let srv = Arc::new(SrvFs::new());
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    srv.post("mem", memfs(), Access::ReadOnly).await;
+
+    let a = srv.clone();
+    let b = srv.clone();
+    let h1 = tokio::spawn(async move { a.walk(Fid::ROOT, Fid(1), &["llm".into()]).await });
+    let h2 = tokio::spawn(async move { b.walk(Fid::ROOT, Fid(1), &["mem".into()]).await });
+    let (r1, r2) = (h1.await.unwrap(), h2.await.unwrap());
+
+    // Exactly one walk binds Fid(1); the other is rejected, not a silent rebind.
+    assert!(
+        r1.is_ok() ^ r2.is_ok(),
+        "exactly one of the racing walks binds the shared newfid: {r1:?} {r2:?}"
+    );
+}
+
 #[tokio::test]
 async fn srv_root_lists_posted_handles_over_ap() {
     let srv = SrvFs::new();

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -36,27 +36,87 @@ async fn a_posted_handle_is_discoverable_and_mountable() {
 }
 
 #[tokio::test]
-async fn a_withheld_handle_is_filtered_and_not_remountable() {
+async fn a_withheld_handle_is_filtered_on_the_ap_surface_and_not_remountable() {
     let srv = SrvFs::new();
     srv.post("llm", memfs(), Access::ReadWrite).await;
     srv.post("mem", memfs(), Access::ReadOnly).await;
 
-    // A restricted child's /srv view withholds "llm".
+    // A restricted child's /srv is a real filtered file server withholding "llm".
     let denied: HashSet<String> = ["llm".to_string()].into_iter().collect();
     let view = srv.view(&denied).await;
 
     assert_eq!(
-        view.list(),
+        view.list().await,
         vec!["mem".to_string()],
-        "withheld handle is absent from the view"
+        "withheld handle absent from listing"
     );
     assert!(
-        view.lookup("mem").is_some(),
+        view.lookup("mem").await.is_some(),
         "permitted handle still mounts"
     );
     assert!(
-        view.lookup("llm").is_none(),
-        "withheld service cannot be regained via /srv"
+        view.lookup("llm").await.is_none(),
+        "withheld service not resolvable"
+    );
+
+    // Crucially, the filter holds on the aP surface the process reads: reading
+    // /srv lists only "mem", and walking the withheld handle fails.
+    view.walk(Fid::ROOT, Fid(1), &[]).await.unwrap();
+    view.open(Fid(1), OpenMode::Read).await.unwrap();
+    let listing = String::from_utf8(view.read(Fid(1), 0, 1024).await.unwrap()).unwrap();
+    assert_eq!(
+        listing.lines().collect::<Vec<_>>(),
+        vec!["mem"],
+        "aP read is filtered too"
+    );
+    assert_eq!(
+        view.walk(Fid::ROOT, Fid(2), &["llm".into()]).await,
+        Err(alan_ap::ErrorCode::NotFound),
+        "withheld handle is not walkable over aP"
+    );
+}
+
+#[tokio::test]
+async fn srv_walk_binds_fids_and_handles_get_unique_qids() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    srv.post("mem", memfs(), Access::ReadOnly).await;
+
+    // Walking a handle binds the fid to that handle; reading it returns the
+    // handle name (not the root listing), and the qids are distinct per handle.
+    let llm_qid = srv.walk(Fid::ROOT, Fid(1), &["llm".into()]).await.unwrap();
+    let mem_qid = srv.walk(Fid::ROOT, Fid(2), &["mem".into()]).await.unwrap();
+    assert_ne!(
+        llm_qid.path, mem_qid.path,
+        "distinct handles get distinct qids"
+    );
+
+    srv.open(Fid(1), OpenMode::Read).await.unwrap();
+    let bytes = srv.read(Fid(1), 0, 64).await.unwrap();
+    assert_eq!(
+        String::from_utf8(bytes).unwrap(),
+        "llm",
+        "the handle fid reads its own entry"
+    );
+}
+
+#[tokio::test]
+async fn reposting_a_name_replaces_the_stale_handle() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadOnly).await;
+    // A restart re-posts the same name with new access; it supersedes, not dupes.
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+
+    assert_eq!(
+        srv.list().await,
+        vec!["llm".to_string()],
+        "one entry per name"
+    );
+    let (_tree, access) = srv.lookup("llm").await.unwrap();
+    assert_eq!(
+        access,
+        Access::ReadWrite,
+        "lookup returns the current handle, not the stale one"
     );
 }
 

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -152,6 +152,19 @@ async fn filtered_view_stays_live() {
     );
 }
 
+// stat on a /srv handle reports its readable byte length, not 0 (PR #574 review).
+#[tokio::test]
+async fn handle_stat_reports_real_length() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    srv.walk(Fid::ROOT, Fid(1), &["llm".into()]).await.unwrap();
+    let st = srv.stat(Fid(1)).await.unwrap();
+    assert_eq!(
+        st.length, 3,
+        "handle file length matches the bytes read returns (\"llm\")"
+    );
+}
+
 #[tokio::test]
 async fn srv_root_lists_posted_handles_over_ap() {
     let srv = SrvFs::new();

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -1,0 +1,72 @@
+//! `/srv` — the bootstrap rendezvous device (substrate §7.2). File servers post
+//! mountable handles here; a process sees and mounts only the handles its access
+//! permits. `/srv` is not an ambient backdoor: a service withheld from a process
+//! (its handle filtered out) is **not** remountable via `/srv`, which is what
+//! makes denial-by-absent-mount hold (D6).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use alan_ap::reference::MemFs;
+use alan_ap::{Fid, FileServer, InProcessTransport, OpenMode};
+use alan_kernel::{Access, SrvFs};
+
+fn memfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(MemFs::new()))
+}
+
+#[tokio::test]
+async fn a_posted_handle_is_discoverable_and_mountable() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    srv.post("mem", memfs(), Access::ReadOnly).await;
+
+    assert_eq!(srv.list().await, vec!["llm".to_string(), "mem".to_string()]);
+
+    // Looking a handle up yields the mountable tree and its access.
+    let (tree, access) = srv.lookup("llm").await.expect("posted handle is mountable");
+    assert_eq!(access, Access::ReadWrite);
+    tree.call(alan_ap::Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(1),
+        names: vec!["greeting".into()],
+    })
+    .await
+    .expect("the handle resolves to a live tree");
+}
+
+#[tokio::test]
+async fn a_withheld_handle_is_filtered_and_not_remountable() {
+    let srv = SrvFs::new();
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    srv.post("mem", memfs(), Access::ReadOnly).await;
+
+    // A restricted child's /srv view withholds "llm".
+    let denied: HashSet<String> = ["llm".to_string()].into_iter().collect();
+    let view = srv.view(&denied).await;
+
+    assert_eq!(
+        view.list(),
+        vec!["mem".to_string()],
+        "withheld handle is absent from the view"
+    );
+    assert!(
+        view.lookup("mem").is_some(),
+        "permitted handle still mounts"
+    );
+    assert!(
+        view.lookup("llm").is_none(),
+        "withheld service cannot be regained via /srv"
+    );
+}
+
+#[tokio::test]
+async fn srv_root_lists_posted_handles_over_ap() {
+    let srv = SrvFs::new();
+    srv.post("agent-runtime", memfs(), Access::ReadWrite).await;
+
+    srv.walk(Fid::ROOT, Fid(1), &[]).await.unwrap();
+    srv.open(Fid(1), OpenMode::Read).await.unwrap();
+    let listing = String::from_utf8(srv.read(Fid(1), 0, 1024).await.unwrap()).unwrap();
+    assert_eq!(listing.lines().collect::<Vec<_>>(), vec!["agent-runtime"]);
+}

--- a/openspec/changes/define-plan9-kernel-substrate/tasks.md
+++ b/openspec/changes/define-plan9-kernel-substrate/tasks.md
@@ -60,22 +60,22 @@
 
 ## 6. Namespace engine and process table (crate)
 
-- [ ] 6.1 Implement the per-process namespace: a mount table with `mount`,
+- [x] 6.1 Implement the per-process namespace: a mount table with `mount`,
   `bind`, `unmount`, union directories, and `walk` resolution.
-- [ ] 6.2 Implement namespace inheritance: a child receives a namespace
+- [x] 6.2 Implement namespace inheritance: a child receives a namespace
   constructed by its spawner and may only restrict its own view (D6).
-- [ ] 6.3 Enforce no global ambient addressing: resolution is only through the
+- [x] 6.3 Enforce no global ambient addressing: resolution is only through the
   namespace; opaque ids resolve within a namespace and are never a global
   capability (D6).
-- [ ] 6.4 Implement the process table with one `Process` category — identity,
+- [x] 6.4 Implement the process table with one `Process` category — identity,
   parentage, credentials, namespace, lifecycle, status, exit state — and no
   `Agent Process` type (D3).
-- [ ] 6.5 Keep the process table, namespaces, and fids as ephemeral runtime state
+- [x] 6.5 Keep the process table, namespaces, and fids as ephemeral runtime state
   that starts empty on restart (D7).
 
 ## 7. Synthetic devices (crate)
 
-- [ ] 7.1 Implement `/proc` as a file server rendering the process table, with
+- [x] 7.1 Implement `/proc` as a file server rendering the process table, with
   per-process `io/`, `status`, `ctl`, and standard files (D9); `/proc/<pid>` is
   the single source of truth.
 - [ ] 7.1a Implement process creation (spawn) via clone-via-open on
@@ -88,7 +88,7 @@
   open+write+clunk, no side API. Spawn is capability-preserving: reject any
   exec-spec namespace entry/descriptor the spawner could not itself open or
   delegate (no amplification; D6).
-- [ ] 7.2 Implement `/srv` as the bootstrap rendezvous device, access-filtered:
+- [x] 7.2 Implement `/srv` as the bootstrap rendezvous device, access-filtered:
   posted handles carry access rights; a process sees/mounts only permitted
   handles; a withheld service is not remountable via `/srv` (D6).
 - [ ] 7.3 Bring the kernel up with only `/proc`, `/srv`, and the namespace engine,
@@ -96,7 +96,7 @@
 
 ## 8. Keep the retired ontology out of the new crate
 
-- [ ] 8.1 Build `alan-kernel` as a new crate containing only the substrate (no
+- [x] 8.1 Build `alan-kernel` as a new crate containing only the substrate (no
   retired V1 modules such as `agent_capability`, `descriptors`,
   Object/Buffer/View/Command/Query/Subscription/Task/Artifact/Evidence, `views`,
   `ledger`, `registry`, `invocation`, or V1 `ids`). There is no current
@@ -104,14 +104,14 @@
 - [ ] 8.2 Relocate any V1 surfaces still needed during migration from the actual
   current owners (`alan-runtime`, `alan-protocol`, `crates/alan`, `crates/tui`)
   into a compat/app crate (for example `alan-compat`), never into `alan-kernel`.
-- [ ] 8.3 Extend `tests/dependency_boundary.rs` to fail if `alan-kernel` gains a
+- [x] 8.3 Extend `tests/dependency_boundary.rs` to fail if `alan-kernel` gains a
   dependency on `alan-runtime`, `alan-protocol`, provider clients, memory stores,
   sandbox backends, renderers, or async task handles — and to fail if the retired
   module names reappear (automated D9/D3 discipline).
 
 ## 9. Verification
 
-- [ ] 9.1 Run focused `cargo test -p alan-kernel`.
+- [x] 9.1 Run focused `cargo test -p alan-kernel`.
 - [ ] 9.2 Run `just verify`.
 - [ ] 9.3 Re-run `openspec validate --all --strict`.
 


### PR DESCRIPTION
**Plan 9 substrate chain — PR 2 of 5.** Base is `feat/alan-ap-protocol` (PR #573); merge that first.

Layer 1 of ADR-0025: depends only on `alan-ap` (D1), enforced by a `dependency_boundary` test. Implements `define-plan9-kernel-substrate` §6–§9.

- Namespace engine: mount/bind/unmount, longest-prefix resolution, union directories, read-only vs read-write access (no escalation), child inheritance where a child may only restrict its own view (§6.1–6.3, §2.5a)
- Process table: one `Process` category (identity/parent/credentials/namespace/status/exit), staged spawn (clone-begin → commit | discard), ephemeral — starts empty on restart (§6.4–6.5)
- `ProcFs`: renders the table at `/proc` and creates processes via clone-via-open on `/proc/clone` (open → fid-private pending pid; write exec spec; commit on clunk; malformed spec rejected at clunk and discarded, leaking nothing) (§7.1, §7.1a spawn mechanics)
- `SrvFs`: access-filtered `/srv` rendezvous; a withheld handle is absent from the view and not remountable (denial-by-absent-mount, §7.2)
- `dependency_boundary`: only `alan-ap` among Alan crates; no runtime/protocol/provider/renderer deps; source free of retired-ontology tokens (§8.1, §8.3)

20 tests; fmt + clippy -D warnings clean.

**Deferred** (tracked, not yet checked in tasks.md): §7.1a capability-preserving amplification check needs the spawner's namespace threaded through clone (per R1, v1 boundary is convention-enforced, not isolation-enforced); §7.3 boot assembly and §8.2 compat relocation belong to the `alan` binary / later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)