### PR TITLE
feat(shell): add alan-shell — the aP-only client with M1 echo demo (Plan 9 PR 5/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-shell"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-kernel",
+ "async-trait",
+ "tokio",
+]
+
+[[package]]
 name = "alan-shell-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/llm",
     "crates/agent-engine",
     "crates/agent-engine/skills/swebench/tooling",
+    "crates/shell",
     "crates/shell-core",
     "crates/shell-core-ffi",
     "crates/tools",

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "alan-shell"
+description = "Alan Shell — the aP-only client: generic file builtins (ls/cat/echo/tail/spawn) over the namespace, with no agent-specific commands. Depends only on alan-ap."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+
+[dev-dependencies]
+alan-kernel = { path = "../kernel" }
+async-trait.workspace = true
+tokio = { workspace = true }

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -97,8 +97,10 @@ impl Shell {
     }
 
     /// Write the whole buffer, looping on short writes: a server may legally accept
-    /// only a prefix per call, so committing after one `Write` could truncate. No
-    /// forward progress is a protocol error rather than an infinite loop.
+    /// only a prefix per call, so committing after one `Write` could truncate. A
+    /// count of zero (no progress) or one larger than the bytes offered is a
+    /// protocol error — a buggy/hostile service must not spin the loop or crash the
+    /// shell by indexing past the buffer.
     async fn write_all(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
         let mut offset: Offset = 0;
         let mut remaining = data;
@@ -115,7 +117,7 @@ impl Shell {
                 Response::Write { count } => count as usize,
                 _ => return Err(ErrorCode::Io),
             };
-            if accepted == 0 {
+            if accepted == 0 || accepted > remaining.len() {
                 return Err(ErrorCode::Io);
             }
             offset += accepted as u64;

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -1,0 +1,160 @@
+//! Alan Shell — the aP-only client.
+//!
+//! Every builtin is generic file IO over aP: `ls` (walk + read a directory),
+//! `cat` (open + read), `write`/`echo >` (open + write + clunk), `tail`
+//! (blocking read from an offset), and `spawn` (clone-via-open on `/proc/clone`).
+//! There is **no agent-specific command** and no `attach` sugar — an agent is
+//! just files under `/agent/<pid>`, reached with the same builtins (ADR-0025 D3).
+//! The shell depends only on [`alan_ap`]; it never links a server or backend.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use alan_ap::{ErrorCode, Fid, InProcessTransport, Offset, OpenMode, Request, Response};
+
+/// The shell's view of one mounted namespace, addressed by absolute path.
+pub struct Shell {
+    fs: InProcessTransport,
+    next_fid: AtomicU64,
+}
+
+impl Shell {
+    /// Build a shell over a mounted file tree (in v1, the kernel's assembled
+    /// namespace presented as one aP server).
+    pub fn new(fs: InProcessTransport) -> Self {
+        // Fid 0 is the well-known root; client fids start above it.
+        Self {
+            fs,
+            next_fid: AtomicU64::new(1),
+        }
+    }
+
+    fn alloc_fid(&self) -> Fid {
+        Fid(self.next_fid.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Walk an absolute path, binding and returning a fresh fid at its target.
+    async fn walk_to(&self, path: &str) -> Result<Fid, ErrorCode> {
+        let names = split_path(path);
+        let fid = self.alloc_fid();
+        match self
+            .fs
+            .call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: fid,
+                names,
+            })
+            .await?
+        {
+            Response::Walk { .. } => Ok(fid),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    async fn read_once(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self.fs.call(Request::Read { fid, offset, count }).await? {
+            Response::Read { data } => Ok(data),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    /// `cat path` — read a finite file in full (reads until end of file).
+    pub async fn cat(&self, path: &str) -> Result<Vec<u8>, ErrorCode> {
+        let fid = self.walk_to(path).await?;
+        self.fs
+            .call(Request::Open {
+                fid,
+                mode: OpenMode::Read,
+            })
+            .await?;
+        let mut out = Vec::new();
+        let mut offset = 0;
+        loop {
+            let chunk = self.read_once(fid, offset, 4096).await?;
+            if chunk.is_empty() {
+                break;
+            }
+            offset += chunk.len() as u64;
+            out.extend_from_slice(&chunk);
+        }
+        self.fs.call(Request::Clunk { fid }).await?;
+        Ok(out)
+    }
+
+    /// `ls path` — list a directory's entries.
+    pub async fn ls(&self, path: &str) -> Result<Vec<String>, ErrorCode> {
+        let listing = self.cat(path).await?;
+        let text = String::from_utf8(listing).map_err(|_| ErrorCode::Io)?;
+        Ok(text
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+
+    /// `echo data > path` — write a document and commit it on clunk.
+    pub async fn write(&self, path: &str, data: &[u8]) -> Result<(), ErrorCode> {
+        let fid = self.walk_to(path).await?;
+        self.fs
+            .call(Request::Open {
+                fid,
+                mode: OpenMode::Write,
+            })
+            .await?;
+        self.fs
+            .call(Request::Write {
+                fid,
+                offset: 0,
+                data: data.to_vec(),
+            })
+            .await?;
+        self.fs.call(Request::Clunk { fid }).await?;
+        Ok(())
+    }
+
+    /// `tail path` — read from `offset`, blocking at the live edge until new
+    /// bytes arrive (the watch builtin; observation is a blocking read).
+    pub async fn tail(&self, path: &str, offset: Offset) -> Result<Vec<u8>, ErrorCode> {
+        let fid = self.walk_to(path).await?;
+        self.fs
+            .call(Request::Open {
+                fid,
+                mode: OpenMode::Read,
+            })
+            .await?;
+        let data = self.read_once(fid, offset, 65536).await?;
+        self.fs.call(Request::Clunk { fid }).await?;
+        Ok(data)
+    }
+
+    /// `spawn` — launch a process via clone-via-open on `/proc/clone`: open the
+    /// clone file (returns the pending pid), write the exec spec, and clunk to
+    /// commit. Pure aP, no side API. Returns the new pid.
+    pub async fn spawn(&self, exec_spec: &str) -> Result<String, ErrorCode> {
+        let fid = self.walk_to("/clone").await?;
+        self.fs
+            .call(Request::Open {
+                fid,
+                mode: OpenMode::ReadWrite,
+            })
+            .await?;
+        let pid =
+            String::from_utf8(self.read_once(fid, 0, 64).await?).map_err(|_| ErrorCode::Io)?;
+        self.fs
+            .call(Request::Write {
+                fid,
+                offset: 0,
+                data: exec_spec.as_bytes().to_vec(),
+            })
+            .await?;
+        self.fs.call(Request::Clunk { fid }).await?;
+        Ok(pid)
+    }
+}
+
+/// Split an absolute path into its non-empty components. `/` → `[]`.
+fn split_path(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -79,8 +79,19 @@ impl Shell {
         }
     }
 
-    /// Best-effort release: used on every exit path so a failed builtin never
-    /// leaks the fid it opened.
+    /// Release a fid, propagating a commit-time error. On a commit-on-clunk
+    /// endpoint (a document file, `/proc/clone`) the `Clunk` *is* the commit, so a
+    /// rejected/malformed document surfaces here — the success path must not
+    /// swallow it.
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.fs.call(Request::Clunk { fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    /// Best-effort release for the *cleanup* path: the builtin already failed, so a
+    /// clunk error is irrelevant and must not mask the original error.
     async fn clunk_quietly(&self, fid: Fid) {
         let _ = self.fs.call(Request::Clunk { fid }).await;
     }
@@ -181,12 +192,19 @@ impl Shell {
             .collect())
     }
 
-    /// `echo data > path` — write a document and commit it on clunk.
+    /// `echo data > path` — write a document and commit it on clunk. A commit-time
+    /// rejection (the server discards a malformed document at clunk) surfaces as an
+    /// error rather than a false success.
     pub async fn write(&self, path: &str, data: &[u8]) -> Result<(), ErrorCode> {
         let (fid, _) = self.walk_to(path).await?;
-        let result = self.write_body(fid, data).await;
-        self.clunk_quietly(fid).await;
-        result
+        match self.write_body(fid, data).await {
+            // The write reached the commit step: the clunk *is* the commit.
+            Ok(()) => self.clunk(fid).await,
+            Err(e) => {
+                self.clunk_quietly(fid).await;
+                Err(e)
+            }
+        }
     }
 
     async fn write_body(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
@@ -216,9 +234,18 @@ impl Shell {
     /// path is `/proc/clone`, not `/clone`. Returns the new pid.
     pub async fn spawn(&self, exec_spec: &str) -> Result<String, ErrorCode> {
         let (fid, _) = self.walk_to("/proc/clone").await?;
-        let result = self.spawn_body(fid, exec_spec).await;
-        self.clunk_quietly(fid).await;
-        result
+        match self.spawn_body(fid, exec_spec).await {
+            // Clunk commits the spawn: a malformed exec spec is rejected here, so a
+            // failed commit must fail spawn rather than return a bogus pid.
+            Ok(pid) => {
+                self.clunk(fid).await?;
+                Ok(pid)
+            }
+            Err(e) => {
+                self.clunk_quietly(fid).await;
+                Err(e)
+            }
+        }
     }
 
     async fn spawn_body(&self, fid: Fid, exec_spec: &str) -> Result<String, ErrorCode> {

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -1,39 +1,47 @@
 //! Alan Shell — the aP-only client.
 //!
-//! Every builtin is generic file IO over aP: `ls` (walk + read a directory),
-//! `cat` (open + read), `write`/`echo >` (open + write + clunk), `tail`
-//! (blocking read from an offset), and `spawn` (clone-via-open on `/proc/clone`).
-//! There is **no agent-specific command** and no `attach` sugar — an agent is
-//! just files under `/agent/<pid>`, reached with the same builtins (ADR-0025 D3).
-//! The shell depends only on [`alan_ap`]; it never links a server or backend.
+//! Every builtin is generic file IO over aP: `ls` (walk a directory + read its
+//! entries), `cat` (open + read a finite snapshot), `write`/`echo >` (open +
+//! write + clunk), `tail` (a live session of blocking reads), and `spawn`
+//! (clone-via-open on `/proc/clone`). There is **no agent-specific command** and
+//! no `attach` sugar — an agent is just files under `/agent/<pid>`, reached with
+//! the same builtins (ADR-0025 D3). The shell depends only on [`alan_ap`]; it
+//! never links a server or backend, and it addresses a whole assembled namespace
+//! (`/proc`, `/agent`, `/mnt/llm`) through one transport — in v1 the kernel's
+//! namespace presented as one aP server (`alan-kernel::MountFs`).
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use alan_ap::{ErrorCode, Fid, InProcessTransport, Offset, OpenMode, Request, Response};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, InProcessTransport, Offset, OpenMode, Qid, Request, Response,
+};
+
+/// A process-global fid allocator. aP fid state lives in the server keyed only by
+/// [`Fid`], so two shells over the same transport (two tabs on one namespace) must
+/// never draw the same number or one would clobber the other's open file. A single
+/// global sequence guarantees uniqueness across every shell in the process.
+static NEXT_FID: AtomicU64 = AtomicU64::new(1);
 
 /// The shell's view of one mounted namespace, addressed by absolute path.
 pub struct Shell {
     fs: InProcessTransport,
-    next_fid: AtomicU64,
 }
 
 impl Shell {
     /// Build a shell over a mounted file tree (in v1, the kernel's assembled
     /// namespace presented as one aP server).
     pub fn new(fs: InProcessTransport) -> Self {
-        // Fid 0 is the well-known root; client fids start above it.
-        Self {
-            fs,
-            next_fid: AtomicU64::new(1),
-        }
+        Self { fs }
     }
 
+    /// Draw a fresh fid unique across the whole process (see [`NEXT_FID`]).
     fn alloc_fid(&self) -> Fid {
-        Fid(self.next_fid.fetch_add(1, Ordering::Relaxed))
+        Fid(NEXT_FID.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Walk an absolute path, binding and returning a fresh fid at its target.
-    async fn walk_to(&self, path: &str) -> Result<Fid, ErrorCode> {
+    /// Walk an absolute path, binding a fresh fid at its target and returning that
+    /// fid with the target's qid (whose `kind` distinguishes dir/file/stream).
+    async fn walk_to(&self, path: &str) -> Result<(Fid, Qid), ErrorCode> {
         let names = split_path(path);
         let fid = self.alloc_fid();
         match self
@@ -45,45 +53,127 @@ impl Shell {
             })
             .await?
         {
-            Response::Walk { .. } => Ok(fid),
+            Response::Walk { qid } => Ok((fid, qid)),
             _ => Err(ErrorCode::Io),
         }
     }
 
-    async fn read_once(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        match self.fs.call(Request::Open { fid, mode }).await? {
+            Response::Open { qid } => Ok(qid),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    async fn read_at(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         match self.fs.call(Request::Read { fid, offset, count }).await? {
             Response::Read { data } => Ok(data),
             _ => Err(ErrorCode::Io),
         }
     }
 
-    /// `cat path` — read a finite file in full (reads until end of file).
-    pub async fn cat(&self, path: &str) -> Result<Vec<u8>, ErrorCode> {
-        let fid = self.walk_to(path).await?;
-        self.fs
-            .call(Request::Open {
-                fid,
-                mode: OpenMode::Read,
-            })
-            .await?;
-        let mut out = Vec::new();
-        let mut offset = 0;
-        loop {
-            let chunk = self.read_once(fid, offset, 4096).await?;
-            if chunk.is_empty() {
-                break;
-            }
-            offset += chunk.len() as u64;
-            out.extend_from_slice(&chunk);
+    async fn length(&self, fid: Fid) -> Result<u64, ErrorCode> {
+        match self.fs.call(Request::Stat { fid }).await? {
+            Response::Stat { stat } => Ok(stat.length),
+            _ => Err(ErrorCode::Io),
         }
-        self.fs.call(Request::Clunk { fid }).await?;
+    }
+
+    /// Best-effort release: used on every exit path so a failed builtin never
+    /// leaks the fid it opened.
+    async fn clunk_quietly(&self, fid: Fid) {
+        let _ = self.fs.call(Request::Clunk { fid }).await;
+    }
+
+    /// Write the whole buffer, looping on short writes: a server may legally accept
+    /// only a prefix per call, so committing after one `Write` could truncate. No
+    /// forward progress is a protocol error rather than an infinite loop.
+    async fn write_all(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
+        let mut offset: Offset = 0;
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let accepted = match self
+                .fs
+                .call(Request::Write {
+                    fid,
+                    offset,
+                    data: remaining.to_vec(),
+                })
+                .await?
+            {
+                Response::Write { count } => count as usize,
+                _ => return Err(ErrorCode::Io),
+            };
+            if accepted == 0 {
+                return Err(ErrorCode::Io);
+            }
+            offset += accepted as u64;
+            remaining = &remaining[accepted..];
+        }
+        Ok(())
+    }
+
+    /// `cat path` — read a finite snapshot of a file. A flat file is read to EOF;
+    /// a **stream** is bounded by its current length so `cat` never blocks at the
+    /// live edge (that is `tail`'s job).
+    pub async fn cat(&self, path: &str) -> Result<Vec<u8>, ErrorCode> {
+        let (fid, qid) = self.walk_to(path).await?;
+        let result = self.cat_body(fid, qid.kind).await;
+        self.clunk_quietly(fid).await;
+        result
+    }
+
+    async fn cat_body(&self, fid: Fid, kind: FileKind) -> Result<Vec<u8>, ErrorCode> {
+        self.open(fid, OpenMode::Read).await?;
+        let mut out = Vec::new();
+        if kind == FileKind::Stream {
+            // Snapshot: read only up to the length observed now, so a read never
+            // lands on the (blocking) live edge.
+            let len = self.length(fid).await?;
+            while (out.len() as u64) < len {
+                let want = (len - out.len() as u64).min(4096) as u32;
+                let chunk = self.read_at(fid, out.len() as u64, want).await?;
+                if chunk.is_empty() {
+                    break;
+                }
+                out.extend_from_slice(&chunk);
+            }
+        } else {
+            // A finite file returns empty at EOF.
+            loop {
+                let chunk = self.read_at(fid, out.len() as u64, 4096).await?;
+                if chunk.is_empty() {
+                    break;
+                }
+                out.extend_from_slice(&chunk);
+            }
+        }
         Ok(out)
     }
 
-    /// `ls path` — list a directory's entries.
+    /// `ls path` — list a directory's entries. The target must be a directory; a
+    /// regular file is rejected rather than having its bytes read as entries.
     pub async fn ls(&self, path: &str) -> Result<Vec<String>, ErrorCode> {
-        let listing = self.cat(path).await?;
-        let text = String::from_utf8(listing).map_err(|_| ErrorCode::Io)?;
+        let (fid, qid) = self.walk_to(path).await?;
+        let result = self.ls_body(fid, qid.kind).await;
+        self.clunk_quietly(fid).await;
+        result
+    }
+
+    async fn ls_body(&self, fid: Fid, kind: FileKind) -> Result<Vec<String>, ErrorCode> {
+        if kind != FileKind::Dir {
+            return Err(ErrorCode::NotDirectory);
+        }
+        self.open(fid, OpenMode::Read).await?;
+        let mut bytes = Vec::new();
+        loop {
+            let chunk = self.read_at(fid, bytes.len() as u64, 4096).await?;
+            if chunk.is_empty() {
+                break;
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::Io)?;
         Ok(text
             .lines()
             .filter(|l| !l.is_empty())
@@ -93,61 +183,94 @@ impl Shell {
 
     /// `echo data > path` — write a document and commit it on clunk.
     pub async fn write(&self, path: &str, data: &[u8]) -> Result<(), ErrorCode> {
-        let fid = self.walk_to(path).await?;
-        self.fs
-            .call(Request::Open {
-                fid,
-                mode: OpenMode::Write,
-            })
-            .await?;
-        self.fs
-            .call(Request::Write {
-                fid,
-                offset: 0,
-                data: data.to_vec(),
-            })
-            .await?;
-        self.fs.call(Request::Clunk { fid }).await?;
-        Ok(())
+        let (fid, _) = self.walk_to(path).await?;
+        let result = self.write_body(fid, data).await;
+        self.clunk_quietly(fid).await;
+        result
     }
 
-    /// `tail path` — read from `offset`, blocking at the live edge until new
-    /// bytes arrive (the watch builtin; observation is a blocking read).
-    pub async fn tail(&self, path: &str, offset: Offset) -> Result<Vec<u8>, ErrorCode> {
-        let fid = self.walk_to(path).await?;
-        self.fs
-            .call(Request::Open {
-                fid,
-                mode: OpenMode::Read,
-            })
-            .await?;
-        let data = self.read_once(fid, offset, 65536).await?;
-        self.fs.call(Request::Clunk { fid }).await?;
-        Ok(data)
+    async fn write_body(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
+        self.open(fid, OpenMode::Write).await?;
+        self.write_all(fid, data).await
+    }
+
+    /// `tail path` — open a live tail session: repeated blocking reads that advance
+    /// a held offset, keeping the fid open so a multi-append stream is fully
+    /// observed (not just its first chunk). Close it with [`Tail::close`].
+    pub async fn tail(&self, path: &str) -> Result<Tail, ErrorCode> {
+        let (fid, _) = self.walk_to(path).await?;
+        if let Err(e) = self.open(fid, OpenMode::Read).await {
+            self.clunk_quietly(fid).await;
+            return Err(e);
+        }
+        Ok(Tail {
+            fs: self.fs.clone(),
+            fid,
+            offset: 0,
+        })
     }
 
     /// `spawn` — launch a process via clone-via-open on `/proc/clone`: open the
     /// clone file (returns the pending pid), write the exec spec, and clunk to
-    /// commit. Pure aP, no side API. Returns the new pid.
+    /// commit. Pure aP, no side API. `/proc` is a mount in the namespace, so the
+    /// path is `/proc/clone`, not `/clone`. Returns the new pid.
     pub async fn spawn(&self, exec_spec: &str) -> Result<String, ErrorCode> {
-        let fid = self.walk_to("/clone").await?;
-        self.fs
-            .call(Request::Open {
-                fid,
-                mode: OpenMode::ReadWrite,
-            })
-            .await?;
-        let pid =
-            String::from_utf8(self.read_once(fid, 0, 64).await?).map_err(|_| ErrorCode::Io)?;
-        self.fs
-            .call(Request::Write {
-                fid,
-                offset: 0,
-                data: exec_spec.as_bytes().to_vec(),
-            })
-            .await?;
-        self.fs.call(Request::Clunk { fid }).await?;
+        let (fid, _) = self.walk_to("/proc/clone").await?;
+        let result = self.spawn_body(fid, exec_spec).await;
+        self.clunk_quietly(fid).await;
+        result
+    }
+
+    async fn spawn_body(&self, fid: Fid, exec_spec: &str) -> Result<String, ErrorCode> {
+        self.open(fid, OpenMode::ReadWrite).await?;
+        let pid = String::from_utf8(self.read_at(fid, 0, 64).await?).map_err(|_| ErrorCode::Io)?;
+        self.write_all(fid, exec_spec.as_bytes()).await?;
         Ok(pid)
+    }
+}
+
+/// A live tail over a file/stream: repeated blocking reads that advance a held
+/// offset, keeping one fid open until [`close`](Tail::close). This is how a
+/// multi-append stream (an agent's `io/output` emitting several records) is fully
+/// followed — a single read would see only the first append.
+pub struct Tail {
+    fs: InProcessTransport,
+    fid: Fid,
+    offset: Offset,
+}
+
+impl Tail {
+    /// Block until bytes at the current offset exist, return them, and advance the
+    /// offset past them. On a stream at the live edge this parks until the next
+    /// append; on a closed/drained stream it returns empty.
+    pub async fn read(&mut self, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let data = match self
+            .fs
+            .call(Request::Read {
+                fid: self.fid,
+                offset: self.offset,
+                count,
+            })
+            .await?
+        {
+            Response::Read { data } => data,
+            _ => return Err(ErrorCode::Io),
+        };
+        self.offset += data.len() as u64;
+        Ok(data)
+    }
+
+    /// The offset the next [`read`](Tail::read) will resume from.
+    pub fn offset(&self) -> Offset {
+        self.offset
+    }
+
+    /// Release the tail's fid.
+    pub async fn close(self) -> Result<(), ErrorCode> {
+        match self.fs.call(Request::Clunk { fid: self.fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::Io),
+        }
     }
 }
 

--- a/crates/shell/tests/dependency_boundary.rs
+++ b/crates/shell/tests/dependency_boundary.rs
@@ -1,0 +1,43 @@
+//! Dependency boundary (introduce-alan-shell §2.2, ADR-0025 D3): the shell is a
+//! client and depends on `alan-ap` only among Alan crates — never a server or
+//! backend (kernel, agentfs, llmfs, agent-engine, …). A front-end reads files,
+//! writes `ctl`, and watches streams; it must not link the things it talks to.
+//! (alan-kernel appears only as a dev-dependency for tests, not in `[dependencies]`.)
+
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    let mut deps = Vec::new();
+    let mut in_deps = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_deps = line == "[dependencies]";
+            continue;
+        }
+        if !in_deps || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let head = line.split('=').next().unwrap_or("").trim();
+        let name = head.split('.').next().unwrap_or("").trim();
+        if !name.is_empty() {
+            deps.push(name.to_string());
+        }
+    }
+    deps
+}
+
+#[test]
+fn shell_depends_only_on_alan_ap_among_alan_crates() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read shell Cargo.toml");
+
+    let alan_deps: Vec<String> = declared_dependencies(&manifest)
+        .into_iter()
+        .filter(|d| d.starts_with("alan-"))
+        .collect();
+
+    assert_eq!(
+        alan_deps,
+        vec!["alan-ap".to_string()],
+        "the shell is an aP-only client (ADR-0025 D3); found Alan deps {alan_deps:?}"
+    );
+}

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -342,6 +342,25 @@ async fn shell_resolves_paths_across_a_real_namespace() {
 }
 
 #[tokio::test]
+async fn write_surfaces_a_commit_on_clunk_rejection() {
+    // MemFs's `/submit` validates its document at clunk; a non-JSON body is
+    // rejected at commit, and the shell must surface that, not report success.
+    let shell = namespace_shell();
+    assert_eq!(
+        shell.write("/data/submit", b"not json").await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn spawn_surfaces_a_malformed_exec_spec() {
+    // /proc/clone commits the process at clunk; a malformed exec spec is discarded
+    // with a commit-time error, which spawn must propagate instead of a bogus pid.
+    let shell = namespace_shell();
+    assert_eq!(shell.spawn("not json").await, Err(ErrorCode::BadRequest));
+}
+
+#[tokio::test]
 async fn spawn_launches_a_process_through_proc_clone_across_the_mount() {
     // The aP-only shell launches a process through `/proc/clone` (a mount in the
     // namespace) with no side API, then reads its status back across the mount.

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -299,6 +299,54 @@ impl FileServer for ChunkFs {
     }
 }
 
+/// A server whose `buf` file over-reports its write count (accepted > offered),
+/// to prove the shell rejects it instead of panicking on an out-of-range slice.
+struct LiarFs;
+
+#[async_trait::async_trait]
+impl FileServer for LiarFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match names {
+            [n] if n == "buf" => Ok(qid(FileKind::File)),
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(qid(FileKind::File))
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+    async fn write(&self, _fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        // Claim one more byte than was offered — an illegal, buffer-overrunning count.
+        Ok(data.len() as u32 + 1)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(FileKind::File),
+            length: 0,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn write_rejects_an_over_reported_count() {
+    let shell = Shell::new(InProcessTransport::new(Arc::new(LiarFs)));
+    // The server claims to accept more than offered; the shell must error, not panic.
+    assert_eq!(shell.write("/buf", b"abc").await, Err(ErrorCode::Io));
+}
+
 #[tokio::test]
 async fn write_handles_short_writes() {
     let fs = InProcessTransport::new(Arc::new(ChunkFs {

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -1,0 +1,183 @@
+//! Alan Shell builtins over aP (introduce-alan-shell §3, §5.1). The shell is an
+//! aP-only client: every builtin is generic file IO (walk/open/read/write/clunk
+//! and clone-via-open for spawn) with no agent-specific command. These tests run
+//! the builtins against an in-memory echo file server (the M1 milestone — input
+//! echoed back through files, no LLM) and against the kernel's `/proc` for spawn.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
+};
+use alan_kernel::ProcFs;
+use alan_shell::Shell;
+
+/// A tiny read-write echo server: a `buf` byte file and a `stream` stream file.
+struct EchoFs {
+    state: tokio::sync::Mutex<EchoState>,
+}
+
+struct EchoState {
+    buf: Vec<u8>,
+    stream: Stream,
+    fids: HashMap<Fid, EchoNode>,
+}
+
+#[derive(Clone, Copy)]
+enum EchoNode {
+    Root,
+    Buf,
+    StreamFile,
+}
+
+impl EchoFs {
+    fn new() -> Self {
+        Self {
+            state: tokio::sync::Mutex::new(EchoState {
+                buf: Vec::new(),
+                stream: Stream::new(),
+                fids: HashMap::new(),
+            }),
+        }
+    }
+    fn transport() -> InProcessTransport {
+        InProcessTransport::new(Arc::new(Self::new()))
+    }
+}
+
+#[async_trait::async_trait]
+impl FileServer for EchoFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let node = match names {
+            [] => EchoNode::Root,
+            [n] if n == "buf" => EchoNode::Buf,
+            [n] if n == "stream" => EchoNode::StreamFile,
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.state.lock().await.fids.insert(newfid, node);
+        Ok(Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::File,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let node = *self
+            .state
+            .lock()
+            .await
+            .fids
+            .get(&fid)
+            .unwrap_or(&EchoNode::Root);
+        let bytes = match node {
+            EchoNode::Root => b"buf\nstream".to_vec(),
+            EchoNode::Buf => self.state.lock().await.buf.clone(),
+            EchoNode::StreamFile => {
+                let stream = self.state.lock().await.stream.clone();
+                return Ok(stream.read(offset, count).await);
+            }
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        match state.fids.get(&fid).copied() {
+            Some(EchoNode::Buf) => {
+                state.buf.extend_from_slice(data);
+                Ok(data.len() as u32)
+            }
+            Some(EchoNode::StreamFile) => {
+                let stream = state.stream.clone();
+                drop(state);
+                stream.append(data).await;
+                Ok(data.len() as u32)
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind: FileKind::File,
+                version: 0,
+                path: 0,
+            },
+            length: 0,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.state.lock().await.fids.remove(&fid);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn m1_input_is_echoed_back_through_files() {
+    // M1: write into a file, read it back — the whole round trip is files.
+    let shell = Shell::new(EchoFs::transport());
+    shell.write("/buf", b"hello shell").await.unwrap();
+    assert_eq!(shell.cat("/buf").await.unwrap(), b"hello shell");
+}
+
+#[tokio::test]
+async fn ls_lists_a_directory() {
+    let shell = Shell::new(EchoFs::transport());
+    assert_eq!(
+        shell.ls("/").await.unwrap(),
+        vec!["buf".to_string(), "stream".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn tail_blocks_until_new_bytes_then_returns_them() {
+    use std::time::Duration;
+
+    let transport = EchoFs::transport();
+    let shell = Arc::new(Shell::new(transport));
+    let watcher = shell.clone();
+    let handle = tokio::spawn(async move { watcher.tail("/stream", 0).await.unwrap() });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!handle.is_finished(), "tail should block at the live edge");
+
+    shell.write("/stream", b"streamed").await.unwrap();
+    let got = tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got, b"streamed");
+}
+
+#[tokio::test]
+async fn spawn_launches_a_process_via_clone_over_ap_only() {
+    // The aP-only shell launches a process through /proc/clone with no side API.
+    let shell = Shell::new(InProcessTransport::new(Arc::new(ProcFs::new())));
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+
+    // The new pid is now a public /proc entry whose status reads "running".
+    assert_eq!(
+        shell.cat(&format!("/{pid}/status")).await.unwrap(),
+        b"running\n"
+    );
+}

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -2,18 +2,23 @@
 //! aP-only client: every builtin is generic file IO (walk/open/read/write/clunk
 //! and clone-via-open for spawn) with no agent-specific command. These tests run
 //! the builtins against an in-memory echo file server (the M1 milestone — input
-//! echoed back through files, no LLM) and against the kernel's `/proc` for spawn.
+//! echoed back through files, no LLM), against a partial-write server (short-write
+//! handling), and against a real assembled namespace (`MountFs` over `/proc` and a
+//! data mount) so path resolution crosses mounts as it will in production.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use alan_ap::reference::MemFs;
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
 };
-use alan_kernel::ProcFs;
+use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 use alan_shell::Shell;
 
-/// A tiny read-write echo server: a `buf` byte file and a `stream` stream file.
+/// A tiny read-write echo server: a `buf` byte file and a `stream` stream file
+/// under a directory root. Each node reports its true [`FileKind`], so the shell's
+/// dir/stream-aware builtins behave as they would against a real server.
 struct EchoFs {
     state: tokio::sync::Mutex<EchoState>,
 }
@@ -31,6 +36,16 @@ enum EchoNode {
     StreamFile,
 }
 
+impl EchoNode {
+    fn kind(self) -> FileKind {
+        match self {
+            EchoNode::Root => FileKind::Dir,
+            EchoNode::Buf => FileKind::File,
+            EchoNode::StreamFile => FileKind::Stream,
+        }
+    }
+}
+
 impl EchoFs {
     fn new() -> Self {
         Self {
@@ -46,6 +61,14 @@ impl EchoFs {
     }
 }
 
+fn qid(kind: FileKind) -> Qid {
+    Qid {
+        kind,
+        version: 0,
+        path: 0,
+    }
+}
+
 #[async_trait::async_trait]
 impl FileServer for EchoFs {
     async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
@@ -56,18 +79,17 @@ impl FileServer for EchoFs {
             _ => return Err(ErrorCode::NotFound),
         };
         self.state.lock().await.fids.insert(newfid, node);
-        Ok(Qid {
-            kind: FileKind::File,
-            version: 0,
-            path: 0,
-        })
+        Ok(qid(node.kind()))
     }
-    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        Ok(Qid {
-            kind: FileKind::File,
-            version: 0,
-            path: 0,
-        })
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let node = *self
+            .state
+            .lock()
+            .await
+            .fids
+            .get(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        Ok(qid(node.kind()))
     }
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         let node = *self
@@ -105,15 +127,18 @@ impl FileServer for EchoFs {
             _ => Err(ErrorCode::Unsupported),
         }
     }
-    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = *state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        let length = match node {
+            EchoNode::Root => b"buf\nstream".len() as u64,
+            EchoNode::Buf => state.buf.len() as u64,
+            EchoNode::StreamFile => state.stream.len().await,
+        };
         Ok(Stat {
             name: String::new(),
-            qid: Qid {
-                kind: FileKind::File,
-                version: 0,
-                path: 0,
-            },
-            length: 0,
+            qid: qid(node.kind()),
+            length,
             writable: true,
         })
     }
@@ -147,37 +172,186 @@ async fn ls_lists_a_directory() {
 }
 
 #[tokio::test]
-async fn tail_blocks_until_new_bytes_then_returns_them() {
+async fn ls_rejects_a_non_directory() {
+    // Pointed at a regular file, `ls` fails rather than reporting the file's bytes
+    // as directory entries.
+    let shell = Shell::new(EchoFs::transport());
+    assert_eq!(shell.ls("/buf").await, Err(ErrorCode::NotDirectory));
+}
+
+#[tokio::test]
+async fn cat_snapshots_a_stream_without_blocking_at_the_live_edge() {
+    // A stream with retained bytes: `cat` returns the snapshot and does not block
+    // waiting for more (that is `tail`'s job).
+    let shell = Shell::new(EchoFs::transport());
+    shell.write("/stream", b"retained").await.unwrap();
+    let snapshot =
+        tokio::time::timeout(std::time::Duration::from_millis(500), shell.cat("/stream"))
+            .await
+            .expect("cat must not block on a stream")
+            .unwrap();
+    assert_eq!(snapshot, b"retained");
+}
+
+#[tokio::test]
+async fn tail_follows_multiple_appends() {
     use std::time::Duration;
 
     let transport = EchoFs::transport();
     let shell = Arc::new(Shell::new(transport));
+
+    // A tail session blocks at the live edge until bytes arrive, then keeps reading
+    // subsequent appends from the advancing offset.
     let watcher = shell.clone();
-    let handle = tokio::spawn(async move { watcher.tail("/stream", 0).await.unwrap() });
+    let handle = tokio::spawn(async move {
+        let mut tail = watcher.tail("/stream").await.unwrap();
+        let first = tail.read(65536).await.unwrap();
+        let second = tail.read(65536).await.unwrap();
+        tail.close().await.unwrap();
+        (first, second)
+    });
 
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert!(!handle.is_finished(), "tail should block at the live edge");
 
-    shell.write("/stream", b"streamed").await.unwrap();
-    let got = tokio::time::timeout(Duration::from_millis(500), handle)
+    shell.write("/stream", b"first").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    shell.write("/stream", b"second").await.unwrap();
+
+    let (first, second) = tokio::time::timeout(Duration::from_millis(500), handle)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(got, b"streamed");
+    assert_eq!(first, b"first");
+    assert_eq!(
+        second, b"second",
+        "the tail keeps reading past the first chunk"
+    );
+}
+
+/// A server whose writable `buf` file accepts at most 3 bytes per `write`, to
+/// exercise the shell's short-write loop.
+struct ChunkFs {
+    state: tokio::sync::Mutex<ChunkState>,
+}
+struct ChunkState {
+    buf: Vec<u8>,
+    fids: HashMap<Fid, bool>, // fid -> is the `buf` file (vs root dir)
+}
+
+#[async_trait::async_trait]
+impl FileServer for ChunkFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let (is_file, kind) = match names {
+            [] => (false, FileKind::Dir),
+            [n] if n == "buf" => (true, FileKind::File),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.state.lock().await.fids.insert(newfid, is_file);
+        Ok(qid(kind))
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(qid(FileKind::File))
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        if *state.fids.get(&fid).unwrap_or(&false) {
+            let bytes = &state.buf;
+            let start = (offset as usize).min(bytes.len());
+            let end = bytes.len().min(start + count as usize);
+            Ok(bytes[start..end].to_vec())
+        } else {
+            Err(ErrorCode::Unsupported)
+        }
+    }
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if !*state.fids.get(&fid).unwrap_or(&false) {
+            return Err(ErrorCode::Unsupported);
+        }
+        // Accept at most 3 bytes per call (a legal short write), honoring offset.
+        let n = data.len().min(3);
+        let start = offset as usize;
+        let end = start + n;
+        if state.buf.len() < end {
+            state.buf.resize(end, 0);
+        }
+        state.buf[start..end].copy_from_slice(&data[..n]);
+        Ok(n as u32)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(FileKind::File),
+            length: self.state.lock().await.buf.len() as u64,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.state.lock().await.fids.remove(&fid);
+        Ok(())
+    }
 }
 
 #[tokio::test]
-async fn spawn_launches_a_process_via_clone_over_ap_only() {
-    // The aP-only shell launches a process through /proc/clone with no side API.
-    let shell = Shell::new(InProcessTransport::new(Arc::new(ProcFs::new())));
+async fn write_handles_short_writes() {
+    let fs = InProcessTransport::new(Arc::new(ChunkFs {
+        state: tokio::sync::Mutex::new(ChunkState {
+            buf: Vec::new(),
+            fids: HashMap::new(),
+        }),
+    }));
+    let shell = Shell::new(fs);
+    // 8 bytes with a 3-byte-per-write cap: the shell must loop until all land.
+    shell.write("/buf", b"abcdefgh").await.unwrap();
+    assert_eq!(shell.cat("/buf").await.unwrap(), b"abcdefgh");
+}
+
+/// A real assembled namespace: `/proc` (ProcFs) and `/data` (MemFs) unioned by
+/// `MountFs` and presented to the shell as one transport.
+fn namespace_shell() -> Shell {
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/proc",
+        InProcessTransport::new(Arc::new(ProcFs::new())),
+        Access::ReadWrite,
+    );
+    ns.mount(
+        "/data",
+        InProcessTransport::new(Arc::new(MemFs::new())),
+        Access::ReadWrite,
+    );
+    Shell::new(InProcessTransport::new(Arc::new(MountFs::new(ns))))
+}
+
+#[tokio::test]
+async fn shell_resolves_paths_across_a_real_namespace() {
+    let shell = namespace_shell();
+    // `cat` reaches a file under a mount.
+    assert_eq!(shell.cat("/data/greeting").await.unwrap(), b"hi");
+    // `ls /` lists the namespace's mount points (a synthetic directory).
+    let mut root = shell.ls("/").await.unwrap();
+    root.sort();
+    assert_eq!(root, vec!["data".to_string(), "proc".to_string()]);
+}
+
+#[tokio::test]
+async fn spawn_launches_a_process_through_proc_clone_across_the_mount() {
+    // The aP-only shell launches a process through `/proc/clone` (a mount in the
+    // namespace) with no side API, then reads its status back across the mount.
+    let shell = namespace_shell();
     let pid = shell
         .spawn(r#"{"executable":"/bin/agent","args":[]}"#)
         .await
         .unwrap();
-
-    // The new pid is now a public /proc entry whose status reads "running".
     assert_eq!(
-        shell.cat(&format!("/{pid}/status")).await.unwrap(),
+        shell.cat(&format!("/proc/{pid}/status")).await.unwrap(),
         b"running\n"
     );
 }

--- a/openspec/changes/introduce-alan-shell/tasks.md
+++ b/openspec/changes/introduce-alan-shell/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Prerequisites
 
-- [ ] 1.1 aP protocol + namespace with `/proc` available
+- [x] 1.1 aP protocol + namespace with `/proc` available
   (`define-plan9-kernel-substrate`).
 
 ## 2. Crate skeleton
 
-- [ ] 2.1 Add `alan-shell` depending only on `alan-ap` (no server/backend deps).
-- [ ] 2.2 Add a `dependency_boundary` test enforcing the aP-only rule.
+- [x] 2.1 Add `alan-shell` depending only on `alan-ap` (no server/backend deps).
+- [x] 2.2 Add a `dependency_boundary` test enforcing the aP-only rule.
 
 ## 3. Generic builtins
 
-- [ ] 3.1 Implement list/walk, `cat` (open+read), `echo >`/write, `tail`
+- [x] 3.1 Implement list/walk, `cat` (open+read), `echo >`/write, `tail`
   (blocking watch from an offset), and `spawn`.
-- [ ] 3.2 Route control to `ctl` writes; add no agent-specific command or
+- [x] 3.2 Route control to `ctl` writes; add no agent-specific command or
   `attach` sugar.
 
 ## 4. Stdio driver and concurrency
@@ -23,13 +23,13 @@
 
 ## 5. Milestone demos
 
-- [ ] 5.1 M1: against an echo file server, type input and see it echoed back
+- [x] 5.1 M1: against an echo file server, type input and see it echoed back
   through files (no LLM).
 - [ ] 5.2 M2: against `alan-agentfs` + `alan-llmfs`, talk to a real agent and see
   the streamed response — using only generic builtins.
 
 ## 6. Verification
 
-- [ ] 6.1 Tests for builtins against an in-memory aP file server.
+- [x] 6.1 Tests for builtins against an in-memory aP file server.
 - [ ] 6.2 Run `just verify`.
-- [ ] 6.3 Run `openspec validate introduce-alan-shell --strict`.
+- [x] 6.3 Run `openspec validate introduce-alan-shell --strict`.


### PR DESCRIPTION
**Plan 9 substrate chain — PR 5 of 5.** Base is `feat/alan-agentfs` (PR #576); merge that first.

`introduce-alan-shell` §1–5.1. Layer 4 client: depends on `alan-ap` only among Alan crates (ADR-0025 D3, enforced by `dependency_boundary`; `alan-kernel` is a dev-dependency for tests only).

Generic file builtins over aP, no agent-specific command and no `attach` sugar — an agent is just files under `/agent/<pid>`, reached the same way:
- `ls` (walk + read a directory), `cat` (open + read-to-end)
- `write` / `echo >` (open + write + clunk)
- `tail` (blocking read from an offset — the watch builtin)
- `spawn` (clone-via-open on `/proc/clone`: open → pending pid; write exec spec; clunk to commit) — launching a process with no side API

**M1 milestone met**: input echoed back through files with no LLM. `spawn` verified end-to-end against the kernel's `/proc`. 5 tests; fmt + clippy -D warnings clean.

**Deferred** (not checked): the interactive stdio REPL with concurrent tail+stdin tasks (§4), and **M2** (talk to a real agent via `alan-agentfs` + `alan-llmfs`, §5.2) — M2 needs `alan-llmfs`, the open scope gap (does llmfs join the Plan 9 core?) flagged at the start of this program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)