### PR TITLE
feat(llmfs): add alan-llmfs — LLM-as-a-file Generation slice (Plan 9 PR 6/7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ version = "0.1.0"
 dependencies = [
  "alan-ap",
  "alan-llm",
+ "anyhow",
  "async-trait",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-llmfs"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-llm",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "alan-shell"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kernel",
     "crates/agent-protocol",
     "crates/llm",
+    "crates/llmfs",
     "crates/agent-engine",
     "crates/agent-engine/skills/swebench/tooling",
     "crates/shell",

--- a/crates/llmfs/Cargo.toml
+++ b/crates/llmfs/Cargo.toml
@@ -16,3 +16,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 alan-llm = { workspace = true, features = ["mock"] }
+anyhow.workspace = true
+async-trait.workspace = true

--- a/crates/llmfs/Cargo.toml
+++ b/crates/llmfs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "alan-llmfs"
+description = "alan-llmfs — the LLM file server: serves callable Connections at /mnt/llm, modeling a Generation as a clone-via-open directory (data → events token stream). Wraps alan-llm; speaks aP."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+alan-llm.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true }
+
+[dev-dependencies]
+alan-llm = { workspace = true, features = ["mock"] }

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -1,0 +1,402 @@
+//! alan-llmfs — the LLM file server (add-llm-file-server, the minimal callable
+//! slice brought into the Plan 9 core).
+//!
+//! It serves callable **Connections** and models a **Generation** as a
+//! clone-via-open directory: a caller opens `connections/<conn>/clone`
+//! (allocating a fresh Generation), writes one neutral request document to
+//! `data` (committed on clunk), and reads a typed token stream from `events`.
+//! `ctl` aborts and `status` reports progress. This realizes ADR-0024's core
+//! framing — *an LLM is a typed stream a process reads* — as files, wrapping
+//! `alan-llm` providers and speaking aP.
+//!
+//! This slice is deliberately minimal (the rest of add-llm-file-server —
+//! provider introspection, connection management, the versioned wire DTO,
+//! metering/rate-limiting/cost — stays deferred so the "core" does not absorb a
+//! whole product surface).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream};
+use alan_llm::{GenerationRequest, LlmProvider};
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// The neutral request document written to a Generation's `data` file. Minimal
+/// for this slice; the full versioned wire DTO is deferred.
+#[derive(Deserialize)]
+struct RequestDoc {
+    #[serde(default)]
+    system: Option<String>,
+    user: String,
+}
+
+/// A callable connection: a provider behind an async lock so a Generation can
+/// hold it across `generate_stream`.
+struct Connection {
+    provider: AsyncMutex<Box<dyn LlmProvider>>,
+}
+
+/// One Generation's projected surfaces.
+struct Generation {
+    connection: String,
+    events: Stream,
+    status: StdMutex<&'static str>,
+}
+
+/// What a fid points at within the llmfs tree.
+#[derive(Clone)]
+enum Node {
+    Root,
+    ConnectionsDir,
+    Connection(String),
+    Clone(String),
+    Gen(String),
+    GenData(String),
+    GenEvents(String),
+    GenCtl(String),
+    GenStatus(String),
+}
+
+struct LlmFid {
+    node: Node,
+    /// For a fid that opened a `clone` file: the allocated Generation id.
+    clone_gen: Option<String>,
+    /// Buffered request document for a `data` fid (commit-on-clunk).
+    write_buf: Vec<u8>,
+}
+
+impl LlmFid {
+    fn at(node: Node) -> Self {
+        Self {
+            node,
+            clone_gen: None,
+            write_buf: Vec::new(),
+        }
+    }
+}
+
+struct State {
+    connections: HashMap<String, Arc<Connection>>,
+    gens: HashMap<String, Arc<Generation>>,
+    fids: HashMap<Fid, LlmFid>,
+    next_gen: u64,
+}
+
+/// The LLM file server.
+pub struct LlmFs {
+    state: StdMutex<State>,
+}
+
+impl Default for LlmFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LlmFs {
+    pub fn new() -> Self {
+        Self {
+            state: StdMutex::new(State {
+                connections: HashMap::new(),
+                gens: HashMap::new(),
+                fids: HashMap::new(),
+                next_gen: 0,
+            }),
+        }
+    }
+
+    /// Register a callable connection backed by an `alan-llm` provider. (In the
+    /// full server, connections are assembled from provider + model + credential;
+    /// this slice takes a ready provider.)
+    pub fn register_connection(&self, name: &str, provider: Box<dyn LlmProvider>) {
+        let mut state = self.state.lock().unwrap();
+        state.connections.insert(
+            name.to_string(),
+            Arc::new(Connection {
+                provider: AsyncMutex::new(provider),
+            }),
+        );
+    }
+
+    fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(Node::Root);
+        }
+        let state = self.state.lock().unwrap();
+        state
+            .fids
+            .get(&fid)
+            .map(|f| f.node.clone())
+            .ok_or(ErrorCode::NotFound)
+    }
+
+    fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
+        let state = self.state.lock().unwrap();
+        match node {
+            Node::Root if name == "connections" => Ok(Node::ConnectionsDir),
+            Node::ConnectionsDir if state.connections.contains_key(name) => {
+                Ok(Node::Connection(name.to_string()))
+            }
+            Node::Connection(conn) => {
+                if name == "clone" {
+                    Ok(Node::Clone(conn.clone()))
+                } else if state.gens.get(name).is_some_and(|g| &g.connection == conn) {
+                    Ok(Node::Gen(name.to_string()))
+                } else {
+                    Err(ErrorCode::NotFound)
+                }
+            }
+            Node::Gen(id) => match name {
+                "data" => Ok(Node::GenData(id.clone())),
+                "events" => Ok(Node::GenEvents(id.clone())),
+                "ctl" => Ok(Node::GenCtl(id.clone())),
+                "status" => Ok(Node::GenStatus(id.clone())),
+                _ => Err(ErrorCode::NotFound),
+            },
+            _ => Err(ErrorCode::NotDirectory),
+        }
+    }
+}
+
+#[async_trait]
+impl FileServer for LlmFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut node = self.node_of(fid)?;
+        for name in names {
+            node = self.child(&node, name)?;
+        }
+        let qid = qid_of(&node);
+        self.state
+            .lock()
+            .unwrap()
+            .fids
+            .insert(newfid, LlmFid::at(node));
+        Ok(qid)
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let node = self.node_of(fid)?;
+        // Clone-via-open: allocate a fresh Generation under the connection.
+        if let Node::Clone(conn) = &node {
+            let mut state = self.state.lock().unwrap();
+            let id = format!("g{}", state.next_gen);
+            state.next_gen += 1;
+            state.gens.insert(
+                id.clone(),
+                Arc::new(Generation {
+                    connection: conn.clone(),
+                    events: Stream::new(),
+                    status: StdMutex::new("open"),
+                }),
+            );
+            if let Some(f) = state.fids.get_mut(&fid) {
+                f.clone_gen = Some(id);
+            }
+        }
+        Ok(qid_of(&node))
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        // An opened clone fid reads back the allocated Generation id.
+        let (node, clone_gen) = {
+            let state = self.state.lock().unwrap();
+            let f = state.fids.get(&fid);
+            (
+                f.map(|f| f.node.clone()).or(if fid == Fid::ROOT {
+                    Some(Node::Root)
+                } else {
+                    None
+                }),
+                f.and_then(|f| f.clone_gen.clone()),
+            )
+        };
+        if let Some(id) = clone_gen {
+            return Ok(slice(id.into_bytes(), offset, count));
+        }
+        let node = node.ok_or(ErrorCode::NotFound)?;
+
+        // Stream node: clone the Stream out, then read without holding the lock.
+        if let Node::GenEvents(id) = &node {
+            let events = {
+                let state = self.state.lock().unwrap();
+                state
+                    .gens
+                    .get(id)
+                    .ok_or(ErrorCode::NotFound)?
+                    .events
+                    .clone()
+            };
+            return Ok(events.read(offset, count).await);
+        }
+
+        let bytes = self.computed_bytes(&node)?;
+        Ok(slice(bytes, offset, count))
+    }
+
+    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let node = self.node_of(fid)?;
+        match node {
+            // Request document: buffer until clunk (commit-on-clunk).
+            Node::GenData(_) => {
+                let mut state = self.state.lock().unwrap();
+                state
+                    .fids
+                    .get_mut(&fid)
+                    .ok_or(ErrorCode::NotFound)?
+                    .write_buf
+                    .extend_from_slice(data);
+                Ok(data.len() as u32)
+            }
+            Node::GenCtl(id) => {
+                if data == b"abort" {
+                    let state = self.state.lock().unwrap();
+                    if let Some(g) = state.gens.get(&id) {
+                        *g.status.lock().unwrap() = "aborted";
+                    }
+                    Ok(data.len() as u32)
+                } else {
+                    Err(ErrorCode::BadRequest)
+                }
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let node = self.node_of(fid)?;
+        Ok(Stat {
+            name: String::new(),
+            qid: qid_of(&node),
+            length: 0,
+            writable: is_writable(&node),
+        })
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            return Ok(());
+        }
+        // Take the fid; if it was a `data` write, commit-on-clunk starts the
+        // Generation. Collect what we need, then release the state lock before
+        // awaiting the provider.
+        let commit = {
+            let mut state = self.state.lock().unwrap();
+            let Some(f) = state.fids.remove(&fid) else {
+                return Err(ErrorCode::NotFound);
+            };
+            match f.node {
+                Node::GenData(id) if !f.write_buf.is_empty() => {
+                    let generation = state.gens.get(&id).cloned();
+                    let conn = generation
+                        .as_ref()
+                        .and_then(|g| state.connections.get(&g.connection).cloned());
+                    Some((f.write_buf, generation, conn))
+                }
+                _ => None,
+            }
+        };
+
+        let Some((buf, Some(generation), Some(conn))) = commit else {
+            return Ok(());
+        };
+
+        // Parse the request document; a malformed document is a commit-time error.
+        let doc: RequestDoc = serde_json::from_slice(&buf).map_err(|_| ErrorCode::BadRequest)?;
+        let mut request = GenerationRequest::new().with_user_message(doc.user);
+        if let Some(system) = doc.system {
+            request = request.with_system_prompt(system);
+        }
+
+        let mut rx = {
+            let mut provider = conn.provider.lock().await;
+            provider
+                .generate_stream(request)
+                .await
+                .map_err(|_| ErrorCode::Io)?
+        };
+        *generation.status.lock().unwrap() = "running";
+
+        // Drain the provider stream into the Generation's events file.
+        let events = generation.events.clone();
+        let generation = generation.clone();
+        tokio::spawn(async move {
+            while let Some(chunk) = rx.recv().await {
+                if let Some(text) = chunk.text {
+                    let record = serde_json::json!({ "text": text }).to_string();
+                    events.append(format!("{record}\n").as_bytes()).await;
+                }
+                if chunk.is_finished {
+                    events.append(b"{\"done\":true}\n").await;
+                    *generation.status.lock().unwrap() = "done";
+                    break;
+                }
+            }
+        });
+        Ok(())
+    }
+}
+
+impl LlmFs {
+    fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().unwrap();
+        let bytes = match node {
+            Node::Root => b"connections".to_vec(),
+            Node::ConnectionsDir => {
+                let mut names: Vec<_> = state.connections.keys().cloned().collect();
+                names.sort();
+                names.join("\n").into_bytes()
+            }
+            Node::Connection(_) => b"clone".to_vec(),
+            Node::Gen(_) => b"data\nevents\nctl\nstatus".to_vec(),
+            Node::GenStatus(id) => {
+                let g = state.gens.get(id).ok_or(ErrorCode::NotFound)?;
+                format!("{}\n", g.status.lock().unwrap()).into_bytes()
+            }
+            // clone, data, ctl, events are open/write/stream surfaces, not read here.
+            _ => return Err(ErrorCode::Unsupported),
+        };
+        Ok(bytes)
+    }
+}
+
+fn qid_of(node: &Node) -> Qid {
+    let (kind, path) = match node {
+        Node::Root | Node::ConnectionsDir | Node::Connection(_) | Node::Gen(_) => {
+            (FileKind::Dir, 0)
+        }
+        Node::Clone(_) => (FileKind::Clone, 1),
+        Node::GenEvents(_) => (FileKind::Stream, 2),
+        Node::GenData(_) | Node::GenCtl(_) | Node::GenStatus(_) => (FileKind::File, 3),
+    };
+    Qid {
+        kind,
+        version: 0,
+        path,
+    }
+}
+
+fn is_writable(node: &Node) -> bool {
+    matches!(node, Node::Clone(_) | Node::GenData(_) | Node::GenCtl(_))
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -117,6 +117,18 @@ impl Generation {
         self.version.fetch_add(1, Ordering::Relaxed);
         true
     }
+    /// Claim the single initial transition out of `Open` (to `Running` on commit,
+    /// or `Rejected` on a malformed request). Atomic compare-and-set: exactly one
+    /// caller wins, so two concurrent commits cannot both reach the provider.
+    fn claim(&self, to: GenStatus) -> bool {
+        let mut s = self.status.lock().unwrap();
+        if *s != GenStatus::Open {
+            return false;
+        }
+        *s = to;
+        self.version.fetch_add(1, Ordering::Relaxed);
+        true
+    }
 }
 
 /// What a fid points at within the llmfs tree.
@@ -314,10 +326,12 @@ impl FileServer for LlmFs {
             return Err(ErrorCode::NoAccess);
         }
 
-        // Clone-via-open allocates a fresh Generation; it mutates server state, so
-        // it requires write intent (an awareness-only open must not consume state).
+        // Clone-via-open allocates a fresh Generation *and* the caller must read the
+        // fid back to learn its id, so it requires ReadWrite: a read-only observer
+        // can't allocate, and a write-only open can't strand a Generation whose id
+        // it could never read.
         if let Node::Clone(conn) = &node {
-            if !matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+            if !matches!(mode, OpenMode::ReadWrite) {
                 return Err(ErrorCode::NoAccess);
             }
             let connection = state
@@ -501,7 +515,13 @@ impl FileServer for LlmFs {
                 return Err(ErrorCode::NotFound);
             };
             match f.node {
-                Node::GenData(id) => {
+                // Only a *write-opened* data fid commits a request; a walked or
+                // read-only data fid is just released. Otherwise an observer could
+                // clunk an empty data fid and wrongly reject the Generation the real
+                // writer is about to start.
+                Node::GenData(id)
+                    if matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) =>
+                {
                     let generation = state.gens.get(&id).cloned();
                     Some((f.write_buf, generation))
                 }
@@ -513,15 +533,7 @@ impl FileServer for LlmFs {
             return Ok(());
         };
 
-        // The commit is the single `open` → `running` transition: reject a second
-        // request into the same Generation (already running/terminal), and reject
-        // one that was aborted before commit.
-        if generation.status() != GenStatus::Open {
-            return Err(ErrorCode::BadRequest);
-        }
-
-        // An empty request is malformed, as is invalid JSON: mark the Generation
-        // rejected (with a terminal event) so an observer never waits forever.
+        // Parse the request first (pure): an empty or invalid document is malformed.
         let doc: Result<RequestDoc, ()> = if buf.is_empty() {
             Err(())
         } else {
@@ -530,11 +542,22 @@ impl FileServer for LlmFs {
         let doc = match doc {
             Ok(doc) => doc,
             Err(()) => {
-                self.fail(&generation, GenStatus::Rejected, "rejected")
-                    .await;
+                // Reject only if we still own the initial transition, so a malformed
+                // second commit cannot clobber a Generation a concurrent valid
+                // commit already started.
+                if generation.claim(GenStatus::Rejected) {
+                    generation.events.append(b"{\"rejected\":true}\n").await;
+                }
                 return Err(ErrorCode::BadRequest);
             }
         };
+
+        // Reserve the Generation *before* awaiting the provider: the single
+        // `open`→`running` transition. A concurrent data commit (or a post-abort
+        // revive) fails here, so only one request ever reaches the provider.
+        if !generation.claim(GenStatus::Running) {
+            return Err(ErrorCode::BadRequest);
+        }
 
         let mut request = GenerationRequest::new().with_user_message(doc.user);
         if let Some(system) = doc.system {
@@ -542,7 +565,7 @@ impl FileServer for LlmFs {
         }
 
         // Start the provider stream. A startup failure is terminal (error), not a
-        // Generation left `open` with an empty `events`.
+        // Generation left running with an empty `events`.
         let rx = {
             let mut provider = generation.connection.provider.lock().await;
             provider.generate_stream(request).await
@@ -556,7 +579,7 @@ impl FileServer for LlmFs {
         };
 
         // An abort that raced startup wins: do not begin streaming.
-        if !generation.advance(GenStatus::Running) {
+        if generation.status() == GenStatus::Aborted {
             return Ok(());
         }
 

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -240,6 +240,9 @@ impl LlmFs {
                 provider: AsyncMutex::new(provider),
             }),
         );
+        // The `connections/` listing changed: bump its qid version so a cached
+        // directory listing goes stale and the new endpoint is seen.
+        state.listing_version += 1;
     }
 
     fn node_of(&self, fid: Fid) -> Result<Node, ErrorCode> {
@@ -466,9 +469,10 @@ impl FileServer for LlmFs {
             generation.events.append(b"{\"aborted\":true}\n").await;
             generation.advance(GenStatus::Aborted);
         }
-        // Wake a running drain task so it stops promptly (belt-and-suspenders: it
-        // also re-checks the terminal status under the same lock).
-        generation.abort.notify_waiters();
+        // Wake a running drain task (or a pending provider startup) so it stops
+        // promptly. `notify_one` stores a permit if no waiter is parked yet, so an
+        // abort that arrives before the drain reaches `notified()` is not lost.
+        generation.abort.notify_one();
         Ok(data.len() as u32)
     }
 
@@ -581,11 +585,21 @@ impl FileServer for LlmFs {
             request = request.with_system_prompt(system);
         }
 
-        // Start the provider stream. A startup failure is terminal (error), not a
-        // Generation left running with an empty `events`.
+        // Start the provider stream, but race it against an abort: a `ctl` abort
+        // during startup drops the in-flight `generate_stream` future (cancelling
+        // the provider request) instead of paying for a stream nobody will read. A
+        // startup failure is terminal (error).
         let rx = {
             let mut provider = generation.connection.provider.lock().await;
-            provider.generate_stream(request).await
+            tokio::select! {
+                biased;
+                _ = generation.abort.notified() => {
+                    // Aborted during startup: ctl already recorded the terminal
+                    // state; drop the provider future and do not stream.
+                    return Ok(());
+                }
+                result = provider.generate_stream(request) => result,
+            }
         };
         let mut rx = match rx {
             Ok(rx) => rx,
@@ -595,7 +609,7 @@ impl FileServer for LlmFs {
             }
         };
 
-        // An abort that raced startup wins: do not begin streaming.
+        // An abort that landed just as startup finished also wins.
         if generation.status() == GenStatus::Aborted {
             return Ok(());
         }
@@ -763,8 +777,10 @@ fn chunk_record(chunk: &StreamChunk) -> Option<String> {
             "usage".to_string(),
             serde_json::json!({
                 "prompt_tokens": u.prompt_tokens,
+                "cached_prompt_tokens": u.cached_prompt_tokens,
                 "completion_tokens": u.completion_tokens,
                 "total_tokens": u.total_tokens,
+                "reasoning_tokens": u.reasoning_tokens,
             }),
         );
     }

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -97,6 +97,10 @@ struct Generation {
     version: AtomicU32,
     /// Signals the drain task to stop promptly on abort.
     abort: Arc<Notify>,
+    /// Serializes every `events` append and terminal transition, so a `ctl` abort
+    /// and the drain task cannot interleave — no chunk or `done` record is ever
+    /// written after the Generation is aborted.
+    finalize: AsyncMutex<()>,
 }
 
 impl Generation {
@@ -320,9 +324,14 @@ impl FileServer for LlmFs {
                 .ok_or(ErrorCode::NotFound)?
         };
 
-        // Dial-time access check: a write-intent open on a read-only node, or a
-        // read/awareness-only open of the write-only surfaces, fails here.
+        // Dial-time access check: an intent the node cannot service fails here, not
+        // later as `Unsupported` on read/write. A write intent needs a writable
+        // node; a read intent needs a readable node (`data`/`ctl` are write-only
+        // sinks with no readable surface).
         if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
+            return Err(ErrorCode::NoAccess);
+        }
+        if matches!(mode, OpenMode::Read | OpenMode::ReadWrite) && !is_readable(&node) {
             return Err(ErrorCode::NoAccess);
         }
 
@@ -351,6 +360,7 @@ impl FileServer for LlmFs {
                     status: StdMutex::new(GenStatus::Open),
                     version: AtomicU32::new(0),
                     abort: Arc::new(Notify::new()),
+                    finalize: AsyncMutex::new(()),
                 }),
             );
             if let Some(f) = state.fids.get_mut(&fid) {
@@ -445,14 +455,19 @@ impl FileServer for LlmFs {
             }
         };
 
-        // Abort is valid only for a non-terminal Generation; aborting a finished or
-        // rejected one would rewrite a settled status.
-        if !generation.advance(GenStatus::Aborted) {
-            return Err(ErrorCode::BadRequest);
+        // Finalize under the per-Generation lock so this abort and the drain task
+        // cannot interleave: once aborted, no further chunk or `done` record is
+        // written. Aborting a terminal Generation is refused (settled status).
+        {
+            let _guard = generation.finalize.lock().await;
+            if generation.status().is_terminal() {
+                return Err(ErrorCode::BadRequest);
+            }
+            generation.events.append(b"{\"aborted\":true}\n").await;
+            generation.advance(GenStatus::Aborted);
         }
-        // A terminal record so a watcher tailing `events` unblocks, and a signal so
-        // a running drain task stops promptly.
-        generation.events.append(b"{\"aborted\":true}\n").await;
+        // Wake a running drain task so it stops promptly (belt-and-suspenders: it
+        // also re-checks the terminal status under the same lock).
         generation.abort.notify_waiters();
         Ok(data.len() as u32)
     }
@@ -542,9 +557,11 @@ impl FileServer for LlmFs {
         let doc = match doc {
             Ok(doc) => doc,
             Err(()) => {
-                // Reject only if we still own the initial transition, so a malformed
-                // second commit cannot clobber a Generation a concurrent valid
-                // commit already started.
+                // Reject only if we still own the initial transition (under the
+                // finalize lock, so a racing abort can't also append a terminal
+                // record): a malformed second commit cannot clobber a Generation a
+                // concurrent valid commit already started.
+                let _guard = generation.finalize.lock().await;
                 if generation.claim(GenStatus::Rejected) {
                     generation.events.append(b"{\"rejected\":true}\n").await;
                 }
@@ -594,10 +611,12 @@ impl FileServer for LlmFs {
                     _ = abort.notified() => break, // aborted: status/record already set
                     chunk = rx.recv() => match chunk {
                         Some(chunk) => {
-                            // Catch an abort whose notify raced before this task
-                            // parked on `notified()`: stop without appending more.
-                            if drain_gen.status() == GenStatus::Aborted {
-                                break;
+                            // Serialize with `ctl` abort: hold the finalize lock while
+                            // checking status and appending, so a concurrent abort
+                            // cannot let a chunk or `done` slip in after it.
+                            let _guard = drain_gen.finalize.lock().await;
+                            if drain_gen.status().is_terminal() {
+                                break; // aborted (or already finished) while we waited
                             }
                             if let Some(record) = chunk_record(&chunk) {
                                 events.append(format!("{record}\n").as_bytes()).await;
@@ -612,6 +631,7 @@ impl FileServer for LlmFs {
                             // The provider stream closed before a finished chunk:
                             // convert it to a terminal error so a tailing reader
                             // does not block at the live edge forever.
+                            let _guard = drain_gen.finalize.lock().await;
                             if drain_gen.advance(GenStatus::Error) {
                                 events.append(b"{\"error\":\"stream closed\"}\n").await;
                             }
@@ -629,6 +649,9 @@ impl LlmFs {
     /// Record a terminal failure (rejected/error) on a Generation before returning
     /// the commit error, so an observer of `status`/`events` sees a terminal state.
     async fn fail(&self, generation: &Generation, status: GenStatus, tag: &str) {
+        // Under the finalize lock so a racing abort can't also append a terminal
+        // record: only the winner of the status transition writes one.
+        let _guard = generation.finalize.lock().await;
         if generation.advance(status) {
             generation
                 .events
@@ -766,6 +789,12 @@ fn chunk_record(chunk: &StreamChunk) -> Option<String> {
 
 fn is_writable(node: &Node) -> bool {
     matches!(node, Node::Clone(_) | Node::GenData(_) | Node::GenCtl(_))
+}
+
+/// Whether a node has a readable surface. `data` and `ctl` are write-only sinks;
+/// `clone` is readable (the caller reads the allocated id back).
+fn is_readable(node: &Node) -> bool {
+    !matches!(node, Node::GenData(_) | Node::GenCtl(_))
 }
 
 fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -636,8 +636,22 @@ impl FileServer for LlmFs {
                                 events.append(format!("{record}\n").as_bytes()).await;
                             }
                             if chunk.is_finished {
-                                events.append(b"{\"done\":true}\n").await;
-                                drain_gen.advance(GenStatus::Done);
+                                // A finished chunk carrying a `stream_error` reason is
+                                // an upstream failure, not success: map it to a
+                                // terminal error, not `done`.
+                                let errored = chunk
+                                    .finish_reason
+                                    .as_deref()
+                                    .is_some_and(|r| r.starts_with("stream_error"));
+                                if errored {
+                                    let reason = chunk.finish_reason.clone().unwrap_or_default();
+                                    let record = serde_json::json!({ "error": reason }).to_string();
+                                    events.append(format!("{record}\n").as_bytes()).await;
+                                    drain_gen.advance(GenStatus::Error);
+                                } else {
+                                    events.append(b"{\"done\":true}\n").await;
+                                    drain_gen.advance(GenStatus::Done);
+                                }
                                 break;
                             }
                         }

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -292,19 +292,22 @@ impl LlmFs {
 #[async_trait]
 impl FileServer for LlmFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
-        // A fid handles one interaction: never rebind the root or a live fid, or
-        // a caller could drop a `data` fid mid-request and lose the buffered write.
-        {
-            let state = self.state.lock().unwrap();
-            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
-                return Err(ErrorCode::BadRequest);
-            }
+        // Never rebind the root. (Resolution below re-locks per step; the binding
+        // is checked-and-inserted atomically at the end.)
+        if newfid == Fid::ROOT {
+            return Err(ErrorCode::BadRequest);
         }
         let mut node = self.node_of(fid)?;
         for name in names {
             node = self.child(&node, name)?;
         }
+        // Check-and-insert under a single lock hold: two concurrent walks that
+        // chose the same `newfid` cannot both pass and clobber a live fid (e.g. a
+        // write-open `data` fid that already buffered a request).
         let mut state = self.state.lock().unwrap();
+        if state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
         let qid = state.qid(&node);
         state.fids.insert(newfid, LlmFid::at(node));
         Ok(qid)

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -13,19 +13,34 @@
 //! provider introspection, connection management, the versioned wire DTO,
 //! metering/rate-limiting/cost — stays deferred so the "core" does not absorb a
 //! whole product surface).
+//!
+//! A Generation moves through a small lifecycle: `open` (allocated, awaiting the
+//! request) → `running` (provider streaming) → a terminal state (`done`,
+//! `error`, `rejected`, or `aborted`). Every path that ends a Generation writes a
+//! terminal record to `events` and a terminal `status`, so a consumer tailing
+//! `events` at the live edge never blocks forever.
 
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream};
-use alan_llm::{GenerationRequest, LlmProvider};
+use alan_llm::{GenerationRequest, LlmProvider, StreamChunk};
 use async_trait::async_trait;
 use serde::Deserialize;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, Notify};
+
+/// Cap on a buffered request document, so a hostile writer cannot exhaust the
+/// server before the commit-time validation runs.
+const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
 
 /// The neutral request document written to a Generation's `data` file. Minimal
-/// for this slice; the full versioned wire DTO is deferred.
+/// for this slice; the full versioned wire DTO is deferred. Unknown fields are
+/// rejected so an unsupported request (e.g. `tools`, `temperature`) fails at the
+/// commit boundary instead of silently running a different prompt.
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RequestDoc {
     #[serde(default)]
     system: Option<String>,
@@ -38,11 +53,70 @@ struct Connection {
     provider: AsyncMutex<Box<dyn LlmProvider>>,
 }
 
-/// One Generation's projected surfaces.
+/// A Generation's lifecycle status.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GenStatus {
+    Open,
+    Running,
+    Done,
+    Error,
+    Rejected,
+    Aborted,
+}
+
+impl GenStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            GenStatus::Open => "open",
+            GenStatus::Running => "running",
+            GenStatus::Done => "done",
+            GenStatus::Error => "error",
+            GenStatus::Rejected => "rejected",
+            GenStatus::Aborted => "aborted",
+        }
+    }
+    fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            GenStatus::Done | GenStatus::Error | GenStatus::Rejected | GenStatus::Aborted
+        )
+    }
+}
+
+/// One Generation's projected surfaces and lifecycle.
 struct Generation {
-    connection: String,
+    /// The connection captured at allocation, so a later `register_connection`
+    /// replacing the name cannot reroute this Generation's request.
+    connection: Arc<Connection>,
+    /// The connection name, for directory membership under `connections/<conn>`.
+    connection_name: String,
     events: Stream,
-    status: StdMutex<&'static str>,
+    status: StdMutex<GenStatus>,
+    /// qid version, bumped on every status change so a cached `status`/dir qid
+    /// goes stale.
+    version: AtomicU32,
+    /// Signals the drain task to stop promptly on abort.
+    abort: Arc<Notify>,
+}
+
+impl Generation {
+    fn status(&self) -> GenStatus {
+        *self.status.lock().unwrap()
+    }
+    fn connection_name(&self) -> String {
+        self.connection_name.clone()
+    }
+    /// Move to a terminal (or running) status unless already terminal, bumping the
+    /// version. Returns whether the transition happened.
+    fn advance(&self, to: GenStatus) -> bool {
+        let mut s = self.status.lock().unwrap();
+        if s.is_terminal() {
+            return false;
+        }
+        *s = to;
+        self.version.fetch_add(1, Ordering::Relaxed);
+        true
+    }
 }
 
 /// What a fid points at within the llmfs tree.
@@ -61,6 +135,8 @@ enum Node {
 
 struct LlmFid {
     node: Node,
+    /// The open mode, once opened. `None` means walked-but-not-opened.
+    mode: Option<OpenMode>,
     /// For a fid that opened a `clone` file: the allocated Generation id.
     clone_gen: Option<String>,
     /// Buffered request document for a `data` fid (commit-on-clunk).
@@ -71,6 +147,7 @@ impl LlmFid {
     fn at(node: Node) -> Self {
         Self {
             node,
+            mode: None,
             clone_gen: None,
             write_buf: Vec::new(),
         }
@@ -82,6 +159,34 @@ struct State {
     gens: HashMap<String, Arc<Generation>>,
     fids: HashMap<Fid, LlmFid>,
     next_gen: u64,
+    /// Version of directory listings (`connections/`, a connection's contents),
+    /// bumped when a Generation is allocated so cached directory qids go stale.
+    listing_version: u32,
+}
+
+impl State {
+    /// The qid for a node, with its server-unique path and current version.
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, key) = node_identity(node);
+        let version = match node {
+            Node::Gen(id)
+            | Node::GenData(id)
+            | Node::GenEvents(id)
+            | Node::GenCtl(id)
+            | Node::GenStatus(id) => self
+                .gens
+                .get(id)
+                .map(|g| g.version.load(Ordering::Relaxed))
+                .unwrap_or(0),
+            Node::ConnectionsDir | Node::Connection(_) => self.listing_version,
+            Node::Root | Node::Clone(_) => 0,
+        };
+        Qid {
+            kind,
+            version,
+            path: hash_path(&key),
+        }
+    }
 }
 
 /// The LLM file server.
@@ -103,6 +208,7 @@ impl LlmFs {
                 gens: HashMap::new(),
                 fids: HashMap::new(),
                 next_gen: 0,
+                listing_version: 0,
             }),
         }
     }
@@ -142,7 +248,11 @@ impl LlmFs {
             Node::Connection(conn) => {
                 if name == "clone" {
                     Ok(Node::Clone(conn.clone()))
-                } else if state.gens.get(name).is_some_and(|g| &g.connection == conn) {
+                } else if state
+                    .gens
+                    .get(name)
+                    .is_some_and(|g| &g.connection_name() == conn)
+                {
                     Ok(Node::Gen(name.to_string()))
                 } else {
                     Err(ErrorCode::NotFound)
@@ -163,59 +273,103 @@ impl LlmFs {
 #[async_trait]
 impl FileServer for LlmFs {
     async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        // A fid handles one interaction: never rebind the root or a live fid, or
+        // a caller could drop a `data` fid mid-request and lose the buffered write.
+        {
+            let state = self.state.lock().unwrap();
+            if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+                return Err(ErrorCode::BadRequest);
+            }
+        }
         let mut node = self.node_of(fid)?;
         for name in names {
             node = self.child(&node, name)?;
         }
-        let qid = qid_of(&node);
-        self.state
-            .lock()
-            .unwrap()
-            .fids
-            .insert(newfid, LlmFid::at(node));
+        let mut state = self.state.lock().unwrap();
+        let qid = state.qid(&node);
+        state.fids.insert(newfid, LlmFid::at(node));
         Ok(qid)
     }
 
-    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
-        let node = self.node_of(fid)?;
-        // Clone-via-open: allocate a fresh Generation under the connection.
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().unwrap();
+        // A fid opens once: a second open would allocate a second Generation on a
+        // clone file or re-establish intent, so reject it.
+        if state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let node = if fid == Fid::ROOT {
+            Node::Root
+        } else {
+            state
+                .fids
+                .get(&fid)
+                .map(|f| f.node.clone())
+                .ok_or(ErrorCode::NotFound)?
+        };
+
+        // Dial-time access check: a write-intent open on a read-only node, or a
+        // read/awareness-only open of the write-only surfaces, fails here.
+        if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) && !is_writable(&node) {
+            return Err(ErrorCode::NoAccess);
+        }
+
+        // Clone-via-open allocates a fresh Generation; it mutates server state, so
+        // it requires write intent (an awareness-only open must not consume state).
         if let Node::Clone(conn) = &node {
-            let mut state = self.state.lock().unwrap();
+            if !matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+                return Err(ErrorCode::NoAccess);
+            }
+            let connection = state
+                .connections
+                .get(conn)
+                .cloned()
+                .ok_or(ErrorCode::NotFound)?;
             let id = format!("g{}", state.next_gen);
             state.next_gen += 1;
+            state.listing_version += 1;
             state.gens.insert(
                 id.clone(),
                 Arc::new(Generation {
-                    connection: conn.clone(),
+                    connection,
+                    connection_name: conn.clone(),
                     events: Stream::new(),
-                    status: StdMutex::new("open"),
+                    status: StdMutex::new(GenStatus::Open),
+                    version: AtomicU32::new(0),
+                    abort: Arc::new(Notify::new()),
                 }),
             );
             if let Some(f) = state.fids.get_mut(&fid) {
                 f.clone_gen = Some(id);
             }
         }
-        Ok(qid_of(&node))
+
+        let qid = state.qid(&node);
+        if let Some(f) = state.fids.get_mut(&fid) {
+            f.mode = Some(mode);
+        }
+        Ok(qid)
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        // An opened clone fid reads back the allocated Generation id.
+        // Reads need read authority from a successful read-open (ROOT is the
+        // pre-bound anchor and is always readable).
         let (node, clone_gen) = {
             let state = self.state.lock().unwrap();
-            let f = state.fids.get(&fid);
-            (
-                f.map(|f| f.node.clone()).or(if fid == Fid::ROOT {
-                    Some(Node::Root)
-                } else {
-                    None
-                }),
-                f.and_then(|f| f.clone_gen.clone()),
-            )
+            if fid == Fid::ROOT {
+                (Node::Root, None)
+            } else {
+                let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+                if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
+                    return Err(ErrorCode::NoAccess);
+                }
+                (f.node.clone(), f.clone_gen.clone())
+            }
         };
+        // An opened clone fid reads back the allocated Generation id.
         if let Some(id) = clone_gen {
             return Ok(slice(id.into_bytes(), offset, count));
         }
-        let node = node.ok_or(ErrorCode::NotFound)?;
 
         // Stream node: clone the Stream out, then read without holding the lock.
         if let Node::GenEvents(id) = &node {
@@ -235,41 +389,88 @@ impl FileServer for LlmFs {
         Ok(slice(bytes, offset, count))
     }
 
-    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        let node = self.node_of(fid)?;
-        match node {
-            // Request document: buffer until clunk (commit-on-clunk).
-            Node::GenData(_) => {
-                let mut state = self.state.lock().unwrap();
-                state
-                    .fids
-                    .get_mut(&fid)
-                    .ok_or(ErrorCode::NotFound)?
-                    .write_buf
-                    .extend_from_slice(data);
-                Ok(data.len() as u32)
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        // Phase 1, under the lock: check write intent, resolve the node, and either
+        // buffer a `data` write or extract the Generation for a `ctl` command. The
+        // lock is released before any await (a `MutexGuard` is not `Send`, and the
+        // ctl path appends to `events`).
+        let generation = {
+            let mut state = self.state.lock().unwrap();
+            let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+            if !matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) {
+                return Err(ErrorCode::NoAccess);
             }
-            Node::GenCtl(id) => {
-                if data == b"abort" {
-                    let state = self.state.lock().unwrap();
-                    if let Some(g) = state.gens.get(&id) {
-                        *g.status.lock().unwrap() = "aborted";
+            match f.node.clone() {
+                // Request document: buffer at the caller's offset until clunk
+                // (commit-on-clunk), honoring out-of-order/retried writes.
+                Node::GenData(_) => {
+                    let start = usize::try_from(offset).map_err(|_| ErrorCode::BadRequest)?;
+                    let end = start.checked_add(data.len()).ok_or(ErrorCode::BadRequest)?;
+                    if end > MAX_DOC_BYTES {
+                        return Err(ErrorCode::BadRequest);
                     }
-                    Ok(data.len() as u32)
-                } else {
-                    Err(ErrorCode::BadRequest)
+                    let buf = &mut state
+                        .fids
+                        .get_mut(&fid)
+                        .ok_or(ErrorCode::NotFound)?
+                        .write_buf;
+                    if buf.len() < end {
+                        buf.resize(end, 0);
+                    }
+                    buf[start..end].copy_from_slice(data);
+                    return Ok(data.len() as u32);
                 }
+                Node::GenCtl(id) => {
+                    // Accept newline-terminated commands (`echo abort > ctl`).
+                    if String::from_utf8_lossy(data).trim() != "abort" {
+                        return Err(ErrorCode::BadRequest);
+                    }
+                    state.gens.get(&id).cloned().ok_or(ErrorCode::NotFound)?
+                }
+                _ => return Err(ErrorCode::Unsupported),
             }
-            _ => Err(ErrorCode::Unsupported),
+        };
+
+        // Abort is valid only for a non-terminal Generation; aborting a finished or
+        // rejected one would rewrite a settled status.
+        if !generation.advance(GenStatus::Aborted) {
+            return Err(ErrorCode::BadRequest);
         }
+        // A terminal record so a watcher tailing `events` unblocks, and a signal so
+        // a running drain task stops promptly.
+        generation.events.append(b"{\"aborted\":true}\n").await;
+        generation.abort.notify_waiters();
+        Ok(data.len() as u32)
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
         let node = self.node_of(fid)?;
+        // Resolve the qid and length under the lock; for the `events` stream, clone
+        // it out and await its length *without* the lock held.
+        let (qid, len) = {
+            let state = self.state.lock().unwrap();
+            let qid = state.qid(&node);
+            let len = match &node {
+                Node::GenEvents(id) => match state.gens.get(id) {
+                    Some(g) => Len::Events(g.events.clone()),
+                    None => Len::Now(0),
+                },
+                other => Len::Now(
+                    computed_bytes(&state, other)
+                        .map(|b| b.len() as u64)
+                        .unwrap_or(0),
+                ),
+            };
+            (qid, len)
+        };
+        let length = match len {
+            Len::Now(n) => n,
+            Len::Events(s) => s.len().await,
+        };
         Ok(Stat {
             name: String::new(),
-            qid: qid_of(&node),
-            length: 0,
+            qid,
+            length,
             writable: is_writable(&node),
         })
     }
@@ -292,59 +493,108 @@ impl FileServer for LlmFs {
         if fid == Fid::ROOT {
             return Ok(());
         }
-        // Take the fid; if it was a `data` write, commit-on-clunk starts the
-        // Generation. Collect what we need, then release the state lock before
-        // awaiting the provider.
+        // Take the fid; a `data` write commits the request on clunk. Collect what
+        // we need, then release the state lock before awaiting the provider.
         let commit = {
             let mut state = self.state.lock().unwrap();
             let Some(f) = state.fids.remove(&fid) else {
                 return Err(ErrorCode::NotFound);
             };
             match f.node {
-                Node::GenData(id) if !f.write_buf.is_empty() => {
+                Node::GenData(id) => {
                     let generation = state.gens.get(&id).cloned();
-                    let conn = generation
-                        .as_ref()
-                        .and_then(|g| state.connections.get(&g.connection).cloned());
-                    Some((f.write_buf, generation, conn))
+                    Some((f.write_buf, generation))
                 }
                 _ => None,
             }
         };
 
-        let Some((buf, Some(generation), Some(conn))) = commit else {
+        let Some((buf, Some(generation))) = commit else {
             return Ok(());
         };
 
-        // Parse the request document; a malformed document is a commit-time error.
-        let doc: RequestDoc = serde_json::from_slice(&buf).map_err(|_| ErrorCode::BadRequest)?;
+        // The commit is the single `open` → `running` transition: reject a second
+        // request into the same Generation (already running/terminal), and reject
+        // one that was aborted before commit.
+        if generation.status() != GenStatus::Open {
+            return Err(ErrorCode::BadRequest);
+        }
+
+        // An empty request is malformed, as is invalid JSON: mark the Generation
+        // rejected (with a terminal event) so an observer never waits forever.
+        let doc: Result<RequestDoc, ()> = if buf.is_empty() {
+            Err(())
+        } else {
+            serde_json::from_slice(&buf).map_err(|_| ())
+        };
+        let doc = match doc {
+            Ok(doc) => doc,
+            Err(()) => {
+                self.fail(&generation, GenStatus::Rejected, "rejected")
+                    .await;
+                return Err(ErrorCode::BadRequest);
+            }
+        };
+
         let mut request = GenerationRequest::new().with_user_message(doc.user);
         if let Some(system) = doc.system {
             request = request.with_system_prompt(system);
         }
 
-        let mut rx = {
-            let mut provider = conn.provider.lock().await;
-            provider
-                .generate_stream(request)
-                .await
-                .map_err(|_| ErrorCode::Io)?
+        // Start the provider stream. A startup failure is terminal (error), not a
+        // Generation left `open` with an empty `events`.
+        let rx = {
+            let mut provider = generation.connection.provider.lock().await;
+            provider.generate_stream(request).await
         };
-        *generation.status.lock().unwrap() = "running";
+        let mut rx = match rx {
+            Ok(rx) => rx,
+            Err(_) => {
+                self.fail(&generation, GenStatus::Error, "error").await;
+                return Err(ErrorCode::Io);
+            }
+        };
+
+        // An abort that raced startup wins: do not begin streaming.
+        if !generation.advance(GenStatus::Running) {
+            return Ok(());
+        }
 
         // Drain the provider stream into the Generation's events file.
         let events = generation.events.clone();
-        let generation = generation.clone();
+        let abort = generation.abort.clone();
+        let drain_gen = generation.clone();
         tokio::spawn(async move {
-            while let Some(chunk) = rx.recv().await {
-                if let Some(text) = chunk.text {
-                    let record = serde_json::json!({ "text": text }).to_string();
-                    events.append(format!("{record}\n").as_bytes()).await;
-                }
-                if chunk.is_finished {
-                    events.append(b"{\"done\":true}\n").await;
-                    *generation.status.lock().unwrap() = "done";
-                    break;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = abort.notified() => break, // aborted: status/record already set
+                    chunk = rx.recv() => match chunk {
+                        Some(chunk) => {
+                            // Catch an abort whose notify raced before this task
+                            // parked on `notified()`: stop without appending more.
+                            if drain_gen.status() == GenStatus::Aborted {
+                                break;
+                            }
+                            if let Some(record) = chunk_record(&chunk) {
+                                events.append(format!("{record}\n").as_bytes()).await;
+                            }
+                            if chunk.is_finished {
+                                events.append(b"{\"done\":true}\n").await;
+                                drain_gen.advance(GenStatus::Done);
+                                break;
+                            }
+                        }
+                        None => {
+                            // The provider stream closed before a finished chunk:
+                            // convert it to a terminal error so a tailing reader
+                            // does not block at the live edge forever.
+                            if drain_gen.advance(GenStatus::Error) {
+                                events.append(b"{\"error\":\"stream closed\"}\n").await;
+                            }
+                            break;
+                        }
+                    }
                 }
             }
         });
@@ -353,41 +603,141 @@ impl FileServer for LlmFs {
 }
 
 impl LlmFs {
+    /// Record a terminal failure (rejected/error) on a Generation before returning
+    /// the commit error, so an observer of `status`/`events` sees a terminal state.
+    async fn fail(&self, generation: &Generation, status: GenStatus, tag: &str) {
+        if generation.advance(status) {
+            generation
+                .events
+                .append(format!("{{\"{tag}\":true}}\n").as_bytes())
+                .await;
+        }
+    }
+
     fn computed_bytes(&self, node: &Node) -> Result<Vec<u8>, ErrorCode> {
         let state = self.state.lock().unwrap();
-        let bytes = match node {
-            Node::Root => b"connections".to_vec(),
-            Node::ConnectionsDir => {
-                let mut names: Vec<_> = state.connections.keys().cloned().collect();
-                names.sort();
-                names.join("\n").into_bytes()
-            }
-            Node::Connection(_) => b"clone".to_vec(),
-            Node::Gen(_) => b"data\nevents\nctl\nstatus".to_vec(),
-            Node::GenStatus(id) => {
-                let g = state.gens.get(id).ok_or(ErrorCode::NotFound)?;
-                format!("{}\n", g.status.lock().unwrap()).into_bytes()
-            }
-            // clone, data, ctl, events are open/write/stream surfaces, not read here.
-            _ => return Err(ErrorCode::Unsupported),
-        };
-        Ok(bytes)
+        computed_bytes(&state, node)
     }
 }
 
-fn qid_of(node: &Node) -> Qid {
-    let (kind, path) = match node {
-        Node::Root | Node::ConnectionsDir | Node::Connection(_) | Node::Gen(_) => {
-            (FileKind::Dir, 0)
+/// The stat length for a node: for `events` the caller awaits `Stream::len`; every
+/// other surface has a synchronously-computable length.
+enum Len {
+    Now(u64),
+    Events(Stream),
+}
+
+/// Render a readable node's bytes from already-locked state (so both `read` and
+/// `stat`'s length use one definition).
+fn computed_bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
+    let bytes = match node {
+        Node::Root => b"connections".to_vec(),
+        Node::ConnectionsDir => {
+            let mut names: Vec<_> = state.connections.keys().cloned().collect();
+            names.sort();
+            names.join("\n").into_bytes()
         }
-        Node::Clone(_) => (FileKind::Clone, 1),
-        Node::GenEvents(_) => (FileKind::Stream, 2),
-        Node::GenData(_) | Node::GenCtl(_) | Node::GenStatus(_) => (FileKind::File, 3),
+        // A connection lists `clone` plus its allocated Generation ids, so a
+        // permitted observer can discover live/finished Generations as files.
+        Node::Connection(conn) => {
+            let mut names = vec!["clone".to_string()];
+            let mut ids: Vec<_> = state
+                .gens
+                .iter()
+                .filter(|(_, g)| &g.connection_name() == conn)
+                .map(|(id, _)| id.clone())
+                .collect();
+            ids.sort();
+            names.extend(ids);
+            names.join("\n").into_bytes()
+        }
+        Node::Gen(_) => b"data\nevents\nctl\nstatus".to_vec(),
+        Node::GenStatus(id) => {
+            let g = state.gens.get(id).ok_or(ErrorCode::NotFound)?;
+            format!("{}\n", g.status().as_str()).into_bytes()
+        }
+        // clone, data, ctl, events are open/write/stream surfaces, not read here.
+        _ => return Err(ErrorCode::Unsupported),
     };
-    Qid {
-        kind,
-        version: 0,
-        path,
+    Ok(bytes)
+}
+
+/// The kind and a server-unique identity key for a node (so distinct connections
+/// and Generations get distinct qids).
+fn node_identity(node: &Node) -> (FileKind, String) {
+    match node {
+        Node::Root => (FileKind::Dir, "/".to_string()),
+        Node::ConnectionsDir => (FileKind::Dir, "connections".to_string()),
+        Node::Connection(c) => (FileKind::Dir, format!("connections/{c}")),
+        Node::Clone(c) => (FileKind::Clone, format!("connections/{c}/clone")),
+        Node::Gen(id) => (FileKind::Dir, format!("gen/{id}")),
+        Node::GenData(id) => (FileKind::File, format!("gen/{id}/data")),
+        Node::GenEvents(id) => (FileKind::Stream, format!("gen/{id}/events")),
+        Node::GenCtl(id) => (FileKind::File, format!("gen/{id}/ctl")),
+        Node::GenStatus(id) => (FileKind::File, format!("gen/{id}/status")),
+    }
+}
+
+fn hash_path(key: &str) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut h);
+    h.finish()
+}
+
+/// Build one `events` record from the meaningful fields of a stream chunk, so a
+/// non-text chunk (thinking, usage, finish metadata, tool-call delta) is not
+/// dropped. Returns `None` for a chunk with nothing to record.
+fn chunk_record(chunk: &StreamChunk) -> Option<String> {
+    let mut map = serde_json::Map::new();
+    let put = |m: &mut serde_json::Map<String, serde_json::Value>, k: &str, v: &Option<String>| {
+        if let Some(s) = v {
+            m.insert(k.to_string(), serde_json::Value::String(s.clone()));
+        }
+    };
+    put(&mut map, "text", &chunk.text);
+    put(&mut map, "thinking", &chunk.thinking);
+    put(&mut map, "thinking_signature", &chunk.thinking_signature);
+    put(&mut map, "redacted_thinking", &chunk.redacted_thinking);
+    put(&mut map, "finish_reason", &chunk.finish_reason);
+    put(
+        &mut map,
+        "provider_response_id",
+        &chunk.provider_response_id,
+    );
+    put(
+        &mut map,
+        "provider_response_status",
+        &chunk.provider_response_status,
+    );
+    if let Some(seq) = chunk.sequence_number {
+        map.insert("sequence_number".to_string(), seq.into());
+    }
+    if let Some(u) = &chunk.usage {
+        map.insert(
+            "usage".to_string(),
+            serde_json::json!({
+                "prompt_tokens": u.prompt_tokens,
+                "completion_tokens": u.completion_tokens,
+                "total_tokens": u.total_tokens,
+            }),
+        );
+    }
+    if let Some(tc) = &chunk.tool_call_delta {
+        map.insert(
+            "tool_call".to_string(),
+            serde_json::json!({
+                "index": tc.index,
+                "id": tc.id,
+                "name": tc.name,
+                "arguments_delta": tc.arguments_delta,
+                "arguments": tc.arguments,
+            }),
+        );
+    }
+    if map.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(map).to_string())
     }
 }
 

--- a/crates/llmfs/tests/dependency_boundary.rs
+++ b/crates/llmfs/tests/dependency_boundary.rs
@@ -1,0 +1,42 @@
+//! Dependency boundary (ADR-0025 D3): a file server depends on `alan-ap` plus
+//! its own backend only — never on the kernel, another file server, or a client.
+//! llmfs's backend is `alan-llm`; it must not reach into `alan-kernel`, another
+//! `*fs`, or a UI/client crate.
+
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    let mut deps = Vec::new();
+    let mut in_deps = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_deps = line == "[dependencies]";
+            continue;
+        }
+        if !in_deps || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let head = line.split('=').next().unwrap_or("").trim();
+        let name = head.split('.').next().unwrap_or("").trim();
+        if !name.is_empty() {
+            deps.push(name.to_string());
+        }
+    }
+    deps
+}
+
+#[test]
+fn llmfs_depends_on_alan_ap_and_its_backend_only() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read llmfs Cargo.toml");
+    let alan_deps: Vec<String> = declared_dependencies(&manifest)
+        .into_iter()
+        .filter(|d| d.starts_with("alan-"))
+        .collect();
+
+    // The protocol plus its backend (alan-llm) — nothing else among Alan crates.
+    assert_eq!(
+        alan_deps,
+        vec!["alan-ap".to_string(), "alan-llm".to_string()],
+        "llmfs is a file server: alan-ap + its alan-llm backend only (ADR-0025 D3); found {alan_deps:?}"
+    );
+}

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -4,6 +4,7 @@
 //! request document to `data` (committed on clunk), and reads the streamed token
 //! records from `events`. Backed by the mock provider — no real API key.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
@@ -761,4 +762,82 @@ async fn a_startup_failure_is_terminal() {
         Err(ErrorCode::Io)
     );
     assert_eq!(status_of(&fs, &g, Fid(3)).await, "error");
+}
+
+/// A provider whose `generate_stream` startup takes a while before returning a
+/// receiver, so a test can abort *during* startup.
+struct SlowStartupProvider;
+
+#[async_trait::async_trait]
+impl LlmProvider for SlowStartupProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            let _ = tx.send(text_chunk("late", true)).await;
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "slow-startup"
+    }
+}
+
+#[tokio::test]
+async fn abort_during_provider_startup_cancels_it() {
+    let fs = Arc::new(llmfs_with(SlowStartupProvider));
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "data".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, br#"{"user":"hi"}"#).await.unwrap();
+
+    // Commit in a task: it parks awaiting the slow provider startup.
+    let committer = fs.clone();
+    let commit = tokio::spawn(async move { committer.clunk(Fid(2)).await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Abort while startup is still in flight.
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "ctl".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Write).await.unwrap();
+    fs.write(Fid(3), 0, b"abort").await.unwrap();
+
+    // The commit returns promptly (the provider future is dropped), well before
+    // the 5s startup would finish, and the Generation is aborted.
+    let r = tokio::time::timeout(Duration::from_millis(500), commit)
+        .await
+        .expect("commit did not cancel on abort")
+        .unwrap();
+    assert_eq!(r, Ok(()));
+    assert_eq!(status_of(&fs, &g, Fid(4)).await, "aborted");
 }

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -1,0 +1,170 @@
+//! Generation as a clone-via-open connection directory (add-llm-file-server §4,
+//! the minimal callable slice brought into the Plan 9 core). A caller opens
+//! `connections/<conn>/clone` (allocating a Generation directory), writes one
+//! request document to `data` (committed on clunk), and reads the streamed token
+//! records from `events`. Backed by the mock provider — no real API key.
+
+use std::time::Duration;
+
+use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
+use alan_llm::mock::MockLlmProvider;
+use alan_llmfs::LlmFs;
+
+fn llmfs() -> LlmFs {
+    let fs = LlmFs::new();
+    fs.register_connection("default", Box::new(MockLlmProvider::new()));
+    fs
+}
+
+async fn read_all(fs: &LlmFs, path: &[&str], fid: Fid) -> Vec<u8> {
+    let names: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+    fs.walk(Fid::ROOT, fid, &names).await.expect("walk");
+    fs.open(fid, OpenMode::Read).await.expect("open");
+    fs.read(fid, 0, 65536).await.expect("read")
+}
+
+/// Tail `events` until a terminal `done` record appears, accumulating the text.
+async fn drain_events(fs: &LlmFs, gen_id: &str, fid: Fid) -> String {
+    let path = [
+        "connections".to_string(),
+        "default".to_string(),
+        gen_id.to_string(),
+        "events".to_string(),
+    ];
+    fs.walk(Fid::ROOT, fid, &path).await.unwrap();
+    fs.open(fid, OpenMode::Read).await.unwrap();
+    let mut acc = String::new();
+    let mut offset = 0u64;
+    loop {
+        let chunk = tokio::time::timeout(Duration::from_millis(500), fs.read(fid, offset, 65536))
+            .await
+            .expect("events stream stalled")
+            .unwrap();
+        offset += chunk.len() as u64;
+        acc.push_str(&String::from_utf8_lossy(&chunk));
+        if acc.contains("\"done\"") {
+            break;
+        }
+    }
+    acc
+}
+
+#[tokio::test]
+async fn clone_open_allocates_a_generation_directory() {
+    let fs = llmfs();
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let gen_id = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+    assert!(!gen_id.is_empty());
+
+    // The allocated generation is a real, walkable directory with its files.
+    let listing =
+        String::from_utf8(read_all(&fs, &["connections", "default", &gen_id], Fid(2)).await)
+            .unwrap();
+    for f in ["data", "events", "ctl", "status"] {
+        assert!(
+            listing.lines().any(|l| l == f),
+            "generation dir lists {f}: {listing:?}"
+        );
+    }
+}
+
+async fn open_clone(fs: &LlmFs, fid: Fid) -> String {
+    fs.walk(
+        Fid::ROOT,
+        fid,
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(fid, OpenMode::ReadWrite).await.unwrap();
+    String::from_utf8(fs.read(fid, 0, 64).await.unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn two_clone_opens_allocate_independent_generations() {
+    let fs = llmfs();
+    let a = open_clone(&fs, Fid(1)).await;
+    let b = open_clone(&fs, Fid(2)).await;
+    assert_ne!(a, b, "each clone-open allocates a distinct Generation");
+}
+
+#[tokio::test]
+async fn writing_the_request_streams_tokens_to_events() {
+    let fs = llmfs();
+
+    // clone-via-open → generation id
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let gen_id = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+
+    // write the request document to data; commit on clunk starts the generation
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            gen_id.clone(),
+            "data".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, br#"{"user":"hi"}"#).await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+
+    // events carries the streamed tokens, ending with a done record
+    let events = drain_events(&fs, &gen_id, Fid(3)).await;
+    assert!(
+        events.contains("Mock response"),
+        "events should carry the model tokens: {events:?}"
+    );
+    assert!(
+        events.contains("\"done\""),
+        "events should end with a terminal record"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_request_is_rejected_at_clunk() {
+    let fs = llmfs();
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let gen_id = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            gen_id,
+            "data".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"{ truncated").await.unwrap();
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::BadRequest));
+}

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -168,3 +168,515 @@ async fn a_malformed_request_is_rejected_at_clunk() {
     fs.write(Fid(2), 0, b"{ truncated").await.unwrap();
     assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::BadRequest));
 }
+
+// ---------------------------------------------------------------------------
+// Hardening regressions (add-llm-file-server review): lifecycle, access intent,
+// discovery, qids, stat, and terminal-event guarantees.
+// ---------------------------------------------------------------------------
+
+use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, StreamChunk};
+use tokio::sync::mpsc;
+
+fn text_chunk(text: &str, is_finished: bool) -> StreamChunk {
+    StreamChunk {
+        text: Some(text.to_string()),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: None,
+        usage: None,
+        provider_response_id: None,
+        provider_response_status: None,
+        sequence_number: None,
+        tool_call_delta: None,
+        is_finished,
+        finish_reason: None,
+    }
+}
+
+/// Yields one text chunk then drops the sender WITHOUT a finished chunk.
+struct EarlyCloseProvider;
+/// Returns an error before handing back a receiver.
+struct StartupFailProvider;
+/// Returns a receiver that never yields (its sender is parked), so the Generation
+/// stays running until aborted.
+struct HangingProvider;
+
+#[async_trait::async_trait]
+impl LlmProvider for EarlyCloseProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            let _ = tx.send(text_chunk("partial", false)).await;
+            // tx dropped here: the stream closes before a finished chunk.
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "early-close"
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for StartupFailProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        Err(anyhow::anyhow!("startup failed"))
+    }
+    fn provider_name(&self) -> &'static str {
+        "startup-fail"
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for HangingProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        let (tx, rx) = mpsc::channel(4);
+        // Park the sender so the receiver stays open (the Generation is "running").
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            drop(tx);
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "hanging"
+    }
+}
+
+fn llmfs_with(provider: impl LlmProvider + 'static) -> LlmFs {
+    let fs = LlmFs::new();
+    fs.register_connection("default", Box::new(provider));
+    fs
+}
+
+async fn clone_gen(fs: &LlmFs, fid: Fid) -> String {
+    fs.walk(
+        Fid::ROOT,
+        fid,
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(fid, OpenMode::ReadWrite).await.unwrap();
+    String::from_utf8(fs.read(fid, 0, 64).await.unwrap()).unwrap()
+}
+
+async fn commit_request(fs: &LlmFs, gen_id: &str, fid: Fid, body: &[u8]) -> Result<(), ErrorCode> {
+    fs.walk(
+        Fid::ROOT,
+        fid,
+        &[
+            "connections".into(),
+            "default".into(),
+            gen_id.into(),
+            "data".into(),
+        ],
+    )
+    .await?;
+    fs.open(fid, OpenMode::Write).await?;
+    fs.write(fid, 0, body).await?;
+    fs.clunk(fid).await
+}
+
+async fn status_of(fs: &LlmFs, gen_id: &str, fid: Fid) -> String {
+    String::from_utf8(read_all(fs, &["connections", "default", gen_id, "status"], fid).await)
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+#[tokio::test]
+async fn clone_open_requires_write_intent() {
+    let fs = llmfs();
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        fs.open(Fid(1), OpenMode::Read).await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test]
+async fn reading_requires_a_read_open() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["connections".into(), "default".into(), g, "status".into()],
+    )
+    .await
+    .unwrap();
+    // No open: read is denied.
+    assert_eq!(fs.read(Fid(2), 0, 64).await, Err(ErrorCode::NoAccess));
+}
+
+#[tokio::test]
+async fn writing_requires_a_write_open() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["connections".into(), "default".into(), g, "data".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Read).await.unwrap();
+    assert_eq!(fs.write(Fid(2), 0, b"{}").await, Err(ErrorCode::NoAccess));
+}
+
+#[tokio::test]
+async fn an_empty_request_is_rejected() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "data".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    // Zero bytes written: an empty request is malformed.
+    assert_eq!(fs.clunk(Fid(2)).await, Err(ErrorCode::BadRequest));
+    assert_eq!(status_of(&fs, &g, Fid(3)).await, "rejected");
+}
+
+#[tokio::test]
+async fn unknown_request_fields_are_rejected() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    assert_eq!(
+        commit_request(&fs, &g, Fid(2), br#"{"user":"hi","temperature":1}"#).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn a_started_generation_cannot_be_restarted() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    // A second request document into the same Generation is refused.
+    assert_eq!(
+        commit_request(&fs, &g, Fid(3), br#"{"user":"again"}"#).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn a_connection_lists_its_generations() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    let listing =
+        String::from_utf8(read_all(&fs, &["connections", "default"], Fid(2)).await).unwrap();
+    assert!(listing.lines().any(|l| l == "clone"));
+    assert!(
+        listing.lines().any(|l| l == g),
+        "connection lists gen {g}: {listing:?}"
+    );
+}
+
+#[tokio::test]
+async fn distinct_generations_get_distinct_status_qids() {
+    let fs = llmfs();
+    let a = clone_gen(&fs, Fid(1)).await;
+    let b = clone_gen(&fs, Fid(2)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &["connections".into(), "default".into(), a, "status".into()],
+    )
+    .await
+    .unwrap();
+    let pa = fs.stat(Fid(3)).await.unwrap().qid.path;
+    fs.walk(
+        Fid::ROOT,
+        Fid(4),
+        &["connections".into(), "default".into(), b, "status".into()],
+    )
+    .await
+    .unwrap();
+    let pb = fs.stat(Fid(4)).await.unwrap().qid.path;
+    assert_ne!(
+        pa, pb,
+        "distinct generations must have distinct status qids"
+    );
+}
+
+#[tokio::test]
+async fn status_qid_version_bumps_as_the_generation_advances() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "status".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    let v0 = fs.stat(Fid(2)).await.unwrap().qid.version;
+    commit_request(&fs, &g, Fid(3), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    drain_events(&fs, &g, Fid(4)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(5),
+        &["connections".into(), "default".into(), g, "status".into()],
+    )
+    .await
+    .unwrap();
+    let v1 = fs.stat(Fid(5)).await.unwrap().qid.version;
+    assert_ne!(v0, v1, "status qid version must change as status advances");
+}
+
+#[tokio::test]
+async fn stat_reports_real_status_length() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["connections".into(), "default".into(), g, "status".into()],
+    )
+    .await
+    .unwrap();
+    // "open\n" is 5 bytes — not the hardcoded 0.
+    assert_eq!(fs.stat(Fid(2)).await.unwrap().length, "open\n".len() as u64);
+}
+
+#[tokio::test]
+async fn a_reused_fid_is_rejected() {
+    let fs = llmfs();
+    fs.walk(Fid::ROOT, Fid(1), &["connections".into()])
+        .await
+        .unwrap();
+    // Fid(1) is live; rebinding it must be refused.
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(1), &["connections".into()]).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn a_repeated_clone_open_is_rejected() {
+    let fs = llmfs();
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "default".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    // A second open of the same clone fid must not allocate a second Generation.
+    assert_eq!(
+        fs.open(Fid(1), OpenMode::ReadWrite).await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn ctl_accepts_a_newline_terminated_abort() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "ctl".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    // `echo abort > ctl` delivers "abort\n".
+    fs.write(Fid(2), 0, b"abort\n").await.unwrap();
+    assert_eq!(status_of(&fs, &g, Fid(3)).await, "aborted");
+}
+
+#[tokio::test]
+async fn abort_before_commit_makes_the_later_commit_fail() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    // Abort while still open.
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "ctl".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, b"abort").await.unwrap();
+    fs.clunk(Fid(2)).await.unwrap();
+    // The aborted Generation cannot then be started by committing a request.
+    assert_eq!(
+        commit_request(&fs, &g, Fid(3), br#"{"user":"hi"}"#).await,
+        Err(ErrorCode::BadRequest)
+    );
+    // And a watcher sees a terminal record rather than blocking forever.
+    let events =
+        String::from_utf8(read_all(&fs, &["connections", "default", &g, "events"], Fid(4)).await)
+            .unwrap();
+    assert!(
+        events.contains("aborted"),
+        "events has a terminal abort record: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn abort_after_done_is_rejected() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    drain_events(&fs, &g, Fid(3)).await; // runs to done
+    fs.walk(
+        Fid::ROOT,
+        Fid(4),
+        &["connections".into(), "default".into(), g, "ctl".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(4), OpenMode::Write).await.unwrap();
+    assert_eq!(
+        fs.write(Fid(4), 0, b"abort").await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn a_running_generation_can_be_aborted() {
+    let fs = llmfs_with(HangingProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    // The provider never finishes; abort settles the Generation and records it.
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "ctl".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Write).await.unwrap();
+    fs.write(Fid(3), 0, b"abort").await.unwrap();
+    assert_eq!(status_of(&fs, &g, Fid(4)).await, "aborted");
+}
+
+#[tokio::test]
+async fn an_early_closed_stream_ends_with_a_terminal_error() {
+    let fs = llmfs_with(EarlyCloseProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    // Tail events: a stream that closes without a finished chunk must still reach a
+    // terminal record (error), not block the reader forever.
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "events".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Read).await.unwrap();
+    let mut acc = String::new();
+    let mut offset = 0u64;
+    loop {
+        let chunk =
+            tokio::time::timeout(Duration::from_millis(500), fs.read(Fid(3), offset, 65536))
+                .await
+                .expect("events stalled without a terminal record")
+                .unwrap();
+        offset += chunk.len() as u64;
+        acc.push_str(&String::from_utf8_lossy(&chunk));
+        if acc.contains("error") {
+            break;
+        }
+    }
+    assert!(
+        acc.contains("partial"),
+        "the partial text was recorded: {acc:?}"
+    );
+    assert_eq!(status_of(&fs, &g, Fid(5)).await, "error");
+}
+
+#[tokio::test]
+async fn a_startup_failure_is_terminal() {
+    let fs = llmfs_with(StartupFailProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    // generate_stream errors before a receiver: the commit fails and the
+    // Generation is left in a terminal error state (not stuck open).
+    assert_eq!(
+        commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#).await,
+        Err(ErrorCode::Io)
+    );
+    assert_eq!(status_of(&fs, &g, Fid(3)).await, "error");
+}

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -409,8 +409,34 @@ async fn writing_requires_a_write_open() {
     )
     .await
     .unwrap();
-    fs.open(Fid(2), OpenMode::Read).await.unwrap();
+    // Walked but not opened for write: a write is refused.
     assert_eq!(fs.write(Fid(2), 0, b"{}").await, Err(ErrorCode::NoAccess));
+}
+
+#[tokio::test]
+async fn read_open_of_a_write_only_file_is_refused() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    // `data` and `ctl` are write-only sinks: a read-intent open fails at dial time.
+    for leaf in ["data", "ctl"] {
+        fs.walk(
+            Fid::ROOT,
+            Fid(2),
+            &[
+                "connections".into(),
+                "default".into(),
+                g.clone(),
+                leaf.into(),
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            fs.open(Fid(2), OpenMode::Read).await,
+            Err(ErrorCode::NoAccess)
+        );
+        fs.clunk(Fid(2)).await.ok();
+    }
 }
 
 #[tokio::test]

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -312,19 +312,75 @@ async fn status_of(fs: &LlmFs, gen_id: &str, fid: Fid) -> String {
 }
 
 #[tokio::test]
-async fn clone_open_requires_write_intent() {
+async fn clone_open_requires_read_write() {
     let fs = llmfs();
+    // Clone-open allocates a Generation and must read its id back, so it requires
+    // ReadWrite: both read-only and write-only opens are refused.
+    for mode in [OpenMode::Read, OpenMode::Write] {
+        fs.walk(
+            Fid::ROOT,
+            Fid(1),
+            &["connections".into(), "default".into(), "clone".into()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(fs.open(Fid(1), mode).await, Err(ErrorCode::NoAccess));
+        fs.clunk(Fid(1)).await.ok();
+    }
+}
+
+#[tokio::test]
+async fn a_non_write_data_fid_clunk_does_not_reject_the_generation() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    // An observer walks `data` and clunks it without a write-open: this must not
+    // commit an empty request or mark the Generation rejected.
     fs.walk(
         Fid::ROOT,
-        Fid(1),
-        &["connections".into(), "default".into(), "clone".into()],
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "data".into(),
+        ],
     )
     .await
     .unwrap();
-    assert_eq!(
-        fs.open(Fid(1), OpenMode::Read).await,
-        Err(ErrorCode::NoAccess)
-    );
+    fs.clunk(Fid(2)).await.unwrap();
+    assert_eq!(status_of(&fs, &g, Fid(3)).await, "open");
+    // The real writer can still start it.
+    commit_request(&fs, &g, Fid(4), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn only_one_of_two_concurrent_data_commits_starts_the_generation() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+    // Two write-opened data fids for the same Generation, both buffered before
+    // either commits.
+    for fid in [Fid(2), Fid(3)] {
+        fs.walk(
+            Fid::ROOT,
+            fid,
+            &[
+                "connections".into(),
+                "default".into(),
+                g.clone(),
+                "data".into(),
+            ],
+        )
+        .await
+        .unwrap();
+        fs.open(fid, OpenMode::Write).await.unwrap();
+        fs.write(fid, 0, br#"{"user":"hi"}"#).await.unwrap();
+    }
+    // The first commit reserves the Generation; the second is refused, so only one
+    // request reaches the provider.
+    fs.clunk(Fid(2)).await.unwrap();
+    assert_eq!(fs.clunk(Fid(3)).await, Err(ErrorCode::BadRequest));
 }
 
 #[tokio::test]

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -841,3 +841,76 @@ async fn abort_during_provider_startup_cancels_it() {
     assert_eq!(r, Ok(()));
     assert_eq!(status_of(&fs, &g, Fid(4)).await, "aborted");
 }
+
+/// Emits some text then a *finished* chunk whose finish_reason is `stream_error`
+/// (an upstream failure after partial output), like the real adapters.
+struct StreamErrorProvider;
+
+#[async_trait::async_trait]
+impl LlmProvider for StreamErrorProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            let _ = tx.send(text_chunk("partial", false)).await;
+            let mut err = text_chunk("", true);
+            err.text = None;
+            err.finish_reason = Some("stream_error".to_string());
+            let _ = tx.send(err).await;
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "stream-error"
+    }
+}
+
+#[tokio::test]
+async fn a_stream_error_finish_reason_is_terminal_error_not_done() {
+    let fs = llmfs_with(StreamErrorProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    // Tail events to a terminal record.
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "events".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Read).await.unwrap();
+    let mut acc = String::new();
+    let mut offset = 0u64;
+    loop {
+        let chunk =
+            tokio::time::timeout(Duration::from_millis(500), fs.read(Fid(3), offset, 65536))
+                .await
+                .expect("events stalled")
+                .unwrap();
+        offset += chunk.len() as u64;
+        acc.push_str(&String::from_utf8_lossy(&chunk));
+        if acc.contains("error") {
+            break;
+        }
+    }
+    assert!(
+        !acc.contains("\"done\""),
+        "a stream error must not record done: {acc:?}"
+    );
+    assert_eq!(status_of(&fs, &g, Fid(4)).await, "error");
+}

--- a/openspec/changes/add-llm-file-server/tasks.md
+++ b/openspec/changes/add-llm-file-server/tasks.md
@@ -20,9 +20,9 @@
 
 ## 4. Generation as a connection directory
 
-- [ ] 4.1 Implement clone-via-open: `open clone` allocates
+- [x] 4.1 Implement clone-via-open: `open clone` allocates
   `/mnt/llm/connections/<connection>/<n>/` with `data`, `events`, `ctl`, `status`.
-- [ ] 4.2 Accept the request across multiple `data` writes; commit on `data`
+- [x] 4.2 Accept the request across multiple `data` writes; commit on `data`
   clunk (no start command); reject a truncated/malformed document at commit.
   Drive `alan-llm` streaming.
 - [ ] 4.3 Stream typed events to `events` (retained, offset-resumable); `status`


### PR DESCRIPTION
**Plan 9 substrate chain — PR 6 of 7.** Base is `feat/alan-shell` (PR #577); merge that first.

Brings the minimal callable slice of `add-llm-file-server` (§4) into the Plan 9 core, per the decision to make llmfs a core file server. Realizes ADR-0024's load-bearing framing — **an LLM is a typed stream a process reads** — as files. Layer 3 file server: depends on `alan-ap` + its `alan-llm` backend only (ADR-0025 D3, enforced by `dependency_boundary`).

**Generation as a clone-via-open connection directory:**
- open `connections/<conn>/clone` → allocates a fresh Generation dir (`data`/`events`/`ctl`/`status`); two opens get independent generations (§4.1)
- write a neutral request document to `data`, committed on clunk; a malformed document is rejected at clunk (commit-on-clunk); commit drives `alan-llm` `generate_stream` (§4.2)
- provider `StreamChunk`s drain into the `events` byte/offset stream (one record per chunk + terminal `done`), readable/tailable by offset
- `ctl` abort; `status` reports open/running/done

Backed by the mock provider in tests — no real API key. 5 tests including the end-to-end write-request → events-streams-tokens path. fmt + clippy -D warnings clean.

**Deferred** (rest of add-llm-file-server): provider-introspection tree, connection management, versioned wire DTO, metering/rate-limiting/cost, directory reaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)