### PR TITLE
feat(ap): qid version tracking across file servers

### DIFF
--- a/crates/agentfs/src/lib.rs
+++ b/crates/agentfs/src/lib.rs
@@ -31,7 +31,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream, VersionTable,
+};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
@@ -82,6 +84,10 @@ struct State {
     /// The fid currently holding the exclusive-write lease on `machine/tape`, if
     /// any; a second write-open of the tape is refused while this is set.
     tape_writer: Option<Fid>,
+    /// Per-node qid versions, keyed by the node's qid path; bumped when a
+    /// directory listing or flat file's content changes (streams are versioned
+    /// by read offset, not qid version, so they are not tracked here).
+    versions: VersionTable,
     fids: HashMap<Fid, AgentFid>,
 }
 
@@ -163,6 +169,7 @@ impl AgentFs {
                 next_request: 0,
                 next_action: 0,
                 tape_writer: None,
+                versions: VersionTable::new(),
                 fids: HashMap::new(),
             }),
         }
@@ -178,6 +185,22 @@ impl State {
             .get(&fid)
             .map(|f| f.node.clone())
             .ok_or(ErrorCode::NotFound)
+    }
+
+    /// The qid for `node`, with its current version from the table.
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        Qid {
+            kind,
+            version: self.versions.get(path),
+            path,
+        }
+    }
+
+    /// Record that `node`'s content changed: bump its qid version.
+    fn bump(&mut self, node: &Node) {
+        let (_, path) = node_identity(node);
+        self.versions.bump(path);
     }
 
     fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
@@ -326,7 +349,7 @@ impl FileServer for AgentFs {
         for name in names {
             node = state.child(&node, name)?;
         }
-        let qid = qid_of(&node);
+        let qid = state.qid(&node);
         state.fids.insert(newfid, AgentFid::at(node));
         Ok(qid)
     }
@@ -338,7 +361,7 @@ impl FileServer for AgentFs {
             if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
                 return Err(ErrorCode::NoAccess);
             }
-            return Ok(qid_of(&Node::Root));
+            return Ok(qid_v0(&Node::Root));
         }
         let mut state = self.state.lock().await;
         if state.fids.get(&fid).is_some_and(|f| f.mode.is_some()) {
@@ -392,6 +415,8 @@ impl FileServer for AgentFs {
                     .events
                     .append(format!("request:{id}\n").as_bytes())
                     .await;
+                // The requests/ directory listing gained an entry.
+                state.bump(&Node::RequestsDir);
                 Some(id)
             }
             Node::ActionsClone => {
@@ -412,6 +437,8 @@ impl FileServer for AgentFs {
                     .events
                     .append(format!("action:{id}\n").as_bytes())
                     .await;
+                // The actions/ directory listing gained an entry.
+                state.bump(&Node::ActionsDir);
                 Some(id)
             }
             _ => None,
@@ -422,7 +449,7 @@ impl FileServer for AgentFs {
         if is_tape_write {
             state.tape_writer = Some(fid);
         }
-        Ok(qid_of(&node))
+        Ok(state.qid(&node))
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
@@ -532,7 +559,7 @@ impl FileServer for AgentFs {
         };
         Ok(Stat {
             name: String::new(),
-            qid: qid_of(&node),
+            qid: state.qid(&node),
             length,
             writable: is_writable(&node),
         })
@@ -602,6 +629,11 @@ impl FileServer for AgentFs {
                     _ => {}
                 }
             }
+            // The field's content changed; answering also changes status.
+            state.bump(&Node::RequestField(id.clone(), field));
+            if *field == "response" {
+                state.bump(&Node::RequestField(id.clone(), "status"));
+            }
             let record = format!("{id}:{field}\n");
             state.request_events.append(record.as_bytes()).await;
             state
@@ -623,6 +655,7 @@ impl FileServer for AgentFs {
                     _ => {}
                 }
             }
+            state.bump(&Node::ActionField(id.clone(), field));
             let record = format!("{id}:{field}\n");
             state.action_events.append(record.as_bytes()).await;
             state
@@ -634,10 +667,12 @@ impl FileServer for AgentFs {
     }
 }
 
-fn qid_of(node: &Node) -> Qid {
+/// A node's stable identity: its file kind and a server-unique qid path, keyed by
+/// its full file identity so distinct files (and distinct request/action ids)
+/// never share a qid. The qid *version* is layered on top from the state's
+/// [`VersionTable`] (see [`State::qid`]); this part never changes for a node.
+fn node_identity(node: &Node) -> (FileKind, u64) {
     use std::hash::{Hash, Hasher};
-    // A stable, server-unique path per node, keyed by its full file identity, so
-    // distinct files (and distinct request/action ids) never share a qid.
     fn path_of(key: &str) -> u64 {
         let mut h = std::collections::hash_map::DefaultHasher::new();
         key.hash(&mut h);
@@ -667,10 +702,18 @@ fn qid_of(node: &Node) -> Qid {
         Node::RequestField(id, field) => (FileKind::File, format!("requests/{id}/{field}")),
         Node::ActionField(id, field) => (FileKind::File, format!("actions/{id}/{field}")),
     };
+    (kind, path_of(&key))
+}
+
+/// The qid for a node at version 0, for the stateless contexts (the pre-bound
+/// root, whose listing never changes). Mutable nodes get their version through
+/// [`State::qid`].
+fn qid_v0(node: &Node) -> Qid {
+    let (kind, path) = node_identity(node);
     Qid {
         kind,
         version: 0,
-        path: path_of(&key),
+        path,
     }
 }
 

--- a/crates/agentfs/tests/agent_files.rs
+++ b/crates/agentfs/tests/agent_files.rs
@@ -608,3 +608,38 @@ async fn the_events_stream_is_watchable_by_blocking_read() {
         .unwrap();
     assert!(String::from_utf8(rec).unwrap().contains("output:"));
 }
+
+async fn qid_version(fs: &AgentFs, path: &[&str], fid: Fid) -> u32 {
+    let names: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+    fs.walk(Fid::ROOT, fid, &names).await.unwrap();
+    fs.stat(fid).await.unwrap().qid.version
+}
+
+#[tokio::test]
+async fn qid_versions_bump_when_dirs_and_fields_change() {
+    let fs = AgentFs::new();
+
+    // requests/ dir version bumps when a request is created.
+    let r0 = qid_version(&fs, &["requests"], Fid(1)).await;
+    fs.walk(Fid::ROOT, Fid(2), &["requests".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(2), OpenMode::ReadWrite).await.unwrap();
+    let id = String::from_utf8(fs.read(Fid(2), 0, 64).await.unwrap()).unwrap();
+    let r1 = qid_version(&fs, &["requests"], Fid(3)).await;
+    assert_eq!(r1, r0 + 1, "requests/ listing changed");
+
+    // requests/<id>/status version bumps when answering settles the request.
+    let s0 = qid_version(&fs, &["requests", &id, "status"], Fid(4)).await;
+    write_doc(&fs, &["requests", &id, "response"], Fid(5), b"approved")
+        .await
+        .unwrap();
+    let s1 = qid_version(&fs, &["requests", &id, "status"], Fid(6)).await;
+    assert_eq!(s1, s0 + 1, "answering changed status");
+
+    // A stream's qid version stays stable (freshness is the read offset).
+    write_doc(&fs, &["io", "output"], Fid(7), b"hi")
+        .await
+        .unwrap();
+    assert_eq!(qid_version(&fs, &["io", "output"], Fid(8)).await, 0);
+}

--- a/crates/ap/src/lib.rs
+++ b/crates/ap/src/lib.rs
@@ -15,9 +15,11 @@ pub mod reference;
 mod server;
 mod stream;
 mod types;
+mod version;
 mod wire;
 
 pub use server::{FileServer, InProcessTransport};
 pub use stream::Stream;
 pub use types::{ErrorCode, Fid, FileKind, Offset, OpenMode, Qid, Stat};
+pub use version::VersionTable;
 pub use wire::{Request, Response};

--- a/crates/ap/src/reference.rs
+++ b/crates/ap/src/reference.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, HashMap};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
-use crate::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat};
+use crate::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, VersionTable};
 
 /// Upper bound on a buffered commit-on-clunk document, so a huge/sparse write
 /// offset cannot make the reference server allocate unbounded memory.
@@ -55,6 +55,9 @@ impl FidState {
 struct State {
     nodes: Vec<Node>,
     fids: HashMap<Fid, FidState>,
+    /// Per-node qid versions, keyed by `NodeId`; bumped when a node's content
+    /// changes (here, the root listing when a clone allocates a connection).
+    versions: VersionTable,
 }
 
 impl State {
@@ -72,7 +75,7 @@ impl State {
         };
         Qid {
             kind,
-            version: 0,
+            version: self.versions.get(node as u64),
             path: node as u64,
         }
     }
@@ -108,6 +111,7 @@ impl MemFs {
         let mut state = State {
             nodes,
             fids: HashMap::new(),
+            versions: VersionTable::new(),
         };
 
         let greeting = state.push(Node::Bytes(b"hi".to_vec()));
@@ -176,6 +180,8 @@ impl FileServer for MemFs {
             if let Node::Dir(root) = &mut state.nodes[0] {
                 root.insert(name.clone(), conn_dir);
             }
+            // The root directory's listing changed: bump its qid version.
+            state.versions.bump(0);
             Some(name)
         } else {
             None

--- a/crates/ap/src/types.rs
+++ b/crates/ap/src/types.rs
@@ -43,7 +43,14 @@ pub enum FileKind {
 }
 
 /// The unique identity of a file at a point in time (the 9P qid analog): its
-/// kind, a version that bumps on change, and a server-unique path number.
+/// kind, a version, and a server-unique path number.
+///
+/// `version` bumps when the file's observable content changes, so a client
+/// comparing cached qid/version pairs detects a change instead of serving stale
+/// data. Servers track this with [`VersionTable`](crate::VersionTable). A
+/// [`Stream`](crate::Stream) file is the exception: its freshness is the read
+/// offset (history is retained and reads resume by offset), so its qid `version`
+/// is stable and need not bump per append.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Qid {
     pub kind: FileKind,

--- a/crates/ap/src/version.rs
+++ b/crates/ap/src/version.rs
@@ -1,0 +1,59 @@
+//! Per-file qid version tracking (§5.1): a [`Qid`](crate::Qid)'s `version` must
+//! bump when that file's observable content changes, so a client comparing
+//! qid/version pairs detects a change rather than retaining stale cached data.
+//!
+//! A file server keeps one [`VersionTable`] in the state that owns its mutations
+//! and `bump`s a node's key whenever it changes that node's content; qid
+//! construction reads the node's current `version`. The key is the server's own
+//! choice (a node path, a pid, a name hash) — whatever uniquely identifies the
+//! mutable file. Streams need not be tracked here: their freshness is the read
+//! offset, not the qid version.
+
+use std::collections::HashMap;
+
+/// Tracks the current qid version of each mutable file, keyed by a server-chosen
+/// identifier. Unseen keys are version `0`; [`bump`](Self::bump) increments.
+#[derive(Debug, Default, Clone)]
+pub struct VersionTable {
+    versions: HashMap<u64, u32>,
+}
+
+impl VersionTable {
+    /// A table in which every key is at version `0`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The current version for `key` (`0` if it has never been bumped).
+    pub fn get(&self, key: u64) -> u32 {
+        self.versions.get(&key).copied().unwrap_or(0)
+    }
+
+    /// Record that the file identified by `key` changed: bump its version. Wraps
+    /// on overflow (a version that has changed 2^32 times has long since been
+    /// re-read); the contract only needs distinct-on-change, not monotonic.
+    pub fn bump(&mut self, key: u64) {
+        let v = self.versions.entry(key).or_insert(0);
+        *v = v.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unseen_key_is_version_zero() {
+        let t = VersionTable::new();
+        assert_eq!(t.get(42), 0);
+    }
+
+    #[test]
+    fn bump_increments_only_that_key() {
+        let mut t = VersionTable::new();
+        t.bump(1);
+        t.bump(1);
+        assert_eq!(t.get(1), 2);
+        assert_eq!(t.get(2), 0, "other keys are unaffected");
+    }
+}

--- a/crates/ap/tests/reference.rs
+++ b/crates/ap/tests/reference.rs
@@ -518,3 +518,36 @@ async fn commit_time_failure_is_reported_at_clunk() {
         Err(ErrorCode::BadRequest)
     );
 }
+
+// §5.1 — a mutable directory's qid version bumps when its listing changes, so a
+// client caching qid/version detects the change. Allocating a clone connection
+// adds an entry to root, bumping root's version.
+#[tokio::test]
+async fn root_qid_version_bumps_when_a_clone_connection_appears() {
+    let t = transport();
+
+    let version_of = |resp: Result<Response, ErrorCode>| match resp {
+        Ok(Response::Stat { stat }) => stat.qid.version,
+        other => panic!("expected Stat, got {other:?}"),
+    };
+
+    let v0 = version_of(t.call(Request::Stat { fid: Fid::ROOT }).await);
+
+    // Allocate a connection via clone-via-open (adds a `conn-*` entry to root).
+    t.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: Fid(20),
+        names: vec!["clone".into()],
+    })
+    .await
+    .unwrap();
+    t.call(Request::Open {
+        fid: Fid(20),
+        mode: OpenMode::Read,
+    })
+    .await
+    .unwrap();
+
+    let v1 = version_of(t.call(Request::Stat { fid: Fid::ROOT }).await);
+    assert_eq!(v1, v0 + 1, "root listing changed, so its qid version bumps");
+}

--- a/crates/kernel/src/process.rs
+++ b/crates/kernel/src/process.rs
@@ -16,6 +16,8 @@
 
 use std::collections::BTreeMap;
 
+use alan_ap::VersionTable;
+
 use crate::Namespace;
 
 /// A process identity. Ephemeral: never reused as a durable reference.
@@ -88,7 +90,16 @@ pub struct ProcessTable {
     next: u64,
     pending: BTreeMap<Pid, Pending>,
     processes: BTreeMap<Pid, Process>,
+    /// qid generations: key `0` (no pid is ever `0` — `next` starts at 1) is the
+    /// public listing generation (bumped when a process appears); key `pid.0` is a
+    /// per-process generation (bumped when that process's state changes, e.g. on
+    /// exit). A `/proc` view reads these so a cached qid/version goes stale.
+    versions: VersionTable,
 }
+
+/// The `VersionTable` key for the public `/proc` listing generation (no real pid
+/// is `0`, so it never collides with a per-process key).
+const LISTING_KEY: u64 = 0;
 
 impl Default for ProcessTable {
     fn default() -> Self {
@@ -102,7 +113,19 @@ impl ProcessTable {
             next: 1,
             pending: BTreeMap::new(),
             processes: BTreeMap::new(),
+            versions: VersionTable::new(),
         }
+    }
+
+    /// The qid version of the public `/proc` listing (bumped when a process
+    /// becomes public).
+    pub fn listing_generation(&self) -> u32 {
+        self.versions.get(LISTING_KEY)
+    }
+
+    /// The qid version of a process's files (bumped when its state changes).
+    pub fn generation(&self, pid: Pid) -> u32 {
+        self.versions.get(pid.0)
     }
 
     fn alloc_pid(&mut self) -> Pid {
@@ -148,6 +171,8 @@ impl ProcessTable {
                 exit_code: None,
             },
         );
+        // A process became public: the /proc listing changed.
+        self.versions.bump(LISTING_KEY);
         Some(slot)
     }
 
@@ -166,6 +191,8 @@ impl ProcessTable {
         {
             proc.status = Status::Exited;
             proc.exit_code = Some(code);
+            // The process's status/exit changed: bump its per-process generation.
+            self.versions.bump(pid.0);
         }
     }
 

--- a/crates/kernel/src/procfs.rs
+++ b/crates/kernel/src/procfs.rs
@@ -119,6 +119,31 @@ impl State {
             .ok_or(ErrorCode::NotFound)
     }
 
+    /// The qid for `node`, with its current version from the process table's
+    /// generations: the public listing for the root, a per-process generation for
+    /// per-pid files, and a stable 0 for the clone file and the output stream
+    /// (a stream's freshness is its read offset, not the qid version).
+    fn qid(&self, node: &Node) -> Qid {
+        let (kind, path) = node_identity(node);
+        let version = match node {
+            Node::Root => self.table.listing_generation(),
+            Node::Clone | Node::Output(_) => 0,
+            Node::Proc(p)
+            | Node::IoDir(p)
+            | Node::Status(p)
+            | Node::Parent(p)
+            | Node::Credentials(p)
+            | Node::Exit(p)
+            | Node::Ctl(p)
+            | Node::NamespaceInfo(p) => self.table.generation(*p),
+        };
+        Qid {
+            kind,
+            version,
+            path,
+        }
+    }
+
     /// Resolve one path component from a node to its child node.
     fn child(&self, node: &Node, name: &str) -> Result<Node, ErrorCode> {
         match node {
@@ -219,7 +244,7 @@ impl FileServer for ProcFs {
         for name in names {
             node = state.child(&node, name)?;
         }
-        let qid = qid_of(&node);
+        let qid = state.qid(&node);
         state.fids.insert(newfid, ProcFid::at(node));
         Ok(qid)
     }
@@ -228,7 +253,8 @@ impl FileServer for ProcFs {
         // The pre-bound root fid is openable directly (to read the listing)
         // without a redundant empty walk, matching SrvFs and the reference server.
         if fid == Fid::ROOT {
-            return Ok(qid_of(&Node::Root));
+            let state = self.state.lock().await;
+            return Ok(state.qid(&Node::Root));
         }
         let mut state = self.state.lock().await;
         let node = state.node_of(fid)?;
@@ -254,11 +280,11 @@ impl FileServer for ProcFs {
                 .or_insert_with(|| ProcFid::at(Node::Clone));
             f.clone_pid = Some(slot);
             f.mode = Some(mode);
-            return Ok(qid_of(&node));
+            return Ok(state.qid(&node));
         }
         let f = state.fids.get_mut(&fid).ok_or(ErrorCode::NotFound)?;
         f.mode = Some(mode);
-        Ok(qid_of(&node))
+        Ok(state.qid(&node))
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
@@ -346,7 +372,7 @@ impl FileServer for ProcFs {
         };
         Ok(Stat {
             name: String::new(),
-            qid: qid_of(&node),
+            qid: state.qid(&node),
             length,
             writable: is_writable(&node),
         })
@@ -396,14 +422,17 @@ impl FileServer for ProcFs {
     }
 }
 
-fn qid_of(node: &Node) -> Qid {
+/// A node's stable identity: file kind and a server-unique qid path. The qid
+/// *version* is layered on from the process table's generations (see
+/// [`State::qid`]); this part never changes for a node.
+fn node_identity(node: &Node) -> (FileKind, u64) {
     // Give each per-process file kind its own 2^48 path space keyed by a tag, so
     // qids stay server-unique even after millions of pids (the old 0x1000 stride
     // collided once pids passed 4096).
     fn tagged(tag: u64, pid: Pid) -> u64 {
         (tag << 48) | pid.0
     }
-    let (kind, path) = match node {
+    match node {
         Node::Root => (FileKind::Dir, 0),
         Node::Clone => (FileKind::Clone, 1),
         Node::Proc(p) => (FileKind::Dir, tagged(1, *p)),
@@ -415,11 +444,6 @@ fn qid_of(node: &Node) -> Qid {
         Node::Exit(p) => (FileKind::File, tagged(7, *p)),
         Node::Ctl(p) => (FileKind::File, tagged(8, *p)),
         Node::NamespaceInfo(p) => (FileKind::File, tagged(9, *p)),
-    };
-    Qid {
-        kind,
-        version: 0,
-        path,
     }
 }
 

--- a/crates/kernel/src/srvfs.rs
+++ b/crates/kernel/src/srvfs.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat,
+    VersionTable,
 };
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -39,7 +40,14 @@ struct Handle {
 struct Registry {
     handles: Vec<Handle>,
     next_qid: u64,
+    /// qid version of the `/srv` listing (key `LISTING_KEY`), bumped whenever a
+    /// handle is posted or replaced so a cached root qid/version goes stale. A
+    /// handle's own identity already changes via a fresh `qid_path` on each post.
+    versions: VersionTable,
 }
+
+/// The `VersionTable` key for the `/srv` listing generation.
+const LISTING_KEY: u64 = 0;
 
 /// What a fid in `/srv` points at.
 #[derive(Clone)]
@@ -69,6 +77,7 @@ impl SrvFs {
             registry: Arc::new(Mutex::new(Registry {
                 handles: Vec::new(),
                 next_qid: 1,
+                versions: VersionTable::new(),
             })),
             denied: HashSet::new(),
             fids: Mutex::new(HashMap::new()),
@@ -93,6 +102,8 @@ impl SrvFs {
             access,
             qid_path,
         });
+        // The /srv listing (or a handle it names) changed.
+        reg.versions.bump(LISTING_KEY);
     }
 
     /// Every posted handle name visible through this view, in post order.
@@ -136,17 +147,15 @@ impl SrvFs {
 
     /// The qid for a node, looked up against the live registry.
     async fn qid_of(&self, node: &Node) -> Qid {
+        let reg = self.registry.lock().await;
         match node {
             Node::Root => Qid {
                 kind: FileKind::Dir,
-                version: 0,
+                version: reg.versions.get(LISTING_KEY),
                 path: 0,
             },
             Node::Handle(name) => {
-                let path = self
-                    .registry
-                    .lock()
-                    .await
+                let path = reg
                     .handles
                     .iter()
                     .find(|h| &h.name == name)
@@ -154,6 +163,8 @@ impl SrvFs {
                     .unwrap_or(0);
                 Qid {
                     kind: FileKind::File,
+                    // A handle's identity changes via a fresh qid_path on each
+                    // post; its content within one post does not change.
                     version: 0,
                     path,
                 }

--- a/crates/kernel/tests/procfs.rs
+++ b/crates/kernel/tests/procfs.rs
@@ -249,3 +249,31 @@ async fn proc_exposes_the_process_namespace() {
         .await
         .expect("namespace is readable");
 }
+
+// §5.1 — qid versions bump when content changes, so a cached qid/version goes
+// stale: the /proc listing on process appearance, a process's files on exit.
+#[tokio::test]
+async fn proc_qid_versions_bump_on_change() {
+    let fs = proc();
+    let v0 = fs.stat(Fid::ROOT).await.unwrap().qid.version;
+    let pid = spawn(&fs, Fid(10)).await;
+    let v1 = fs.stat(Fid::ROOT).await.unwrap().qid.version;
+    assert_eq!(v1, v0 + 1, "/proc listing changed when a process appeared");
+
+    // A process's status qid version bumps when it exits.
+    fs.walk(Fid::ROOT, Fid(11), &[pid.clone(), "status".to_string()])
+        .await
+        .unwrap();
+    let s0 = fs.stat(Fid(11)).await.unwrap().qid.version;
+    fs.walk(Fid::ROOT, Fid(12), &[pid.clone(), "ctl".to_string()])
+        .await
+        .unwrap();
+    fs.open(Fid(12), OpenMode::Write).await.unwrap();
+    fs.write(Fid(12), 0, b"cancel").await.unwrap();
+    fs.clunk(Fid(12)).await.unwrap();
+    fs.walk(Fid::ROOT, Fid(13), &[pid, "status".to_string()])
+        .await
+        .unwrap();
+    let s1 = fs.stat(Fid(13)).await.unwrap().qid.version;
+    assert_eq!(s1, s0 + 1, "status changed when the process exited");
+}

--- a/crates/kernel/tests/srvfs.rs
+++ b/crates/kernel/tests/srvfs.rs
@@ -197,3 +197,14 @@ async fn srv_root_lists_posted_handles_over_ap() {
     let listing = String::from_utf8(srv.read(Fid(1), 0, 1024).await.unwrap()).unwrap();
     assert_eq!(listing.lines().collect::<Vec<_>>(), vec!["agent-runtime"]);
 }
+
+// §5.1 — the /srv listing's qid version bumps when a handle is posted, so a
+// client caching the root qid/version detects the new (or replaced) service.
+#[tokio::test]
+async fn srv_root_qid_version_bumps_on_post() {
+    let srv = SrvFs::new();
+    let v0 = srv.stat(Fid::ROOT).await.unwrap().qid.version;
+    srv.post("llm", memfs(), Access::ReadWrite).await;
+    let v1 = srv.stat(Fid::ROOT).await.unwrap().qid.version;
+    assert_eq!(v1, v0 + 1, "posting a handle changed the /srv listing");
+}


### PR DESCRIPTION
## Why

The aP `Qid` contract says `version` bumps on change, but every file server in the
tree returned `version: 0` unconditionally — including the reference `MemFs`, the
kernel's `procfs`/`srvfs`, and `agentfs`. A client caching qid/version pairs could
retain stale directory listings or field contents. Flagged by Codex review on
[#576](https://github.com/realmorrisliu/Alan/pull/576); fixed uniformly here rather
than agentfs-locally (which would diverge from the other servers and give clients
false confidence in a guarantee no other surface honored).

## What

- **alan-ap**: a shared `VersionTable` helper. Each server keeps one in the state
  that owns its mutations and `bump`s a node's key when its content changes; qid
  construction reads the version. `Qid`'s doc now states the policy: directories
  and flat files bump on change; a `Stream`'s freshness is its read offset, so its
  qid version is stable (not bumped per append).
- **MemFs**: bumps the root listing when a clone connection is allocated.
- **procfs / srvfs**: the kernel tables (`ProcessTable`, the `/srv` `Registry`) own
  the mutations, so generations live there — bumped on process commit/exit and on
  `/srv` post — and the view servers read them. (A view-local check couldn't catch
  mutations made through the shared table by another holder.)
- **agentfs**: bumps `requests/`//`actions/` listings on create and request/action
  fields on commit (answering also bumps the request's `status`).

## Tests

Per-server regressions: MemFs root-on-clone, procfs listing-on-spawn +
status-on-exit, srvfs listing-on-post, agentfs dir+field bumps with streams
staying at version 0. `cargo clippy --workspace -D warnings`, `cargo test
--workspace`, and `cargo doc` all green.

> Stacked on [#576](https://github.com/realmorrisliu/Alan/pull/576) (base
> `feat/alan-agentfs`); retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)