### PR TITLE
feat(kernel): add MountFs — the namespace as one aP FileServer (D1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alan-shell"
+version = "0.1.0"
+dependencies = [
+ "alan-ap",
+ "alan-kernel",
+ "async-trait",
+ "tokio",
+]
+
+[[package]]
 name = "alan-shell-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/llm",
     "crates/agent-engine",
     "crates/agent-engine/skills/swebench/tooling",
+    "crates/shell",
     "crates/shell-core",
     "crates/shell-core-ffi",
     "crates/tools",

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -12,11 +12,13 @@
 //! runtime state that starts empty on restart. Durability is a property of
 //! storage-backed file servers, never of the kernel.
 
+mod mountfs;
 mod namespace;
 mod process;
 mod procfs;
 mod srvfs;
 
+pub use mountfs::MountFs;
 pub use namespace::{Access, Namespace, Resolved, Unreachable};
 pub use process::{Credentials, ExecSpec, Pid, Process, ProcessTable, Status};
 pub use procfs::ProcFs;

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -32,6 +32,15 @@ struct Backing {
     backing_fid: Fid,
 }
 
+/// What a fid resolves to for a leaf operation, extracted from the fid table so
+/// the state lock is released *before* the (possibly blocking) backing call.
+enum Target {
+    /// A node in a backing tree: its resolved mount and bound fid.
+    Backing(Resolved, Fid),
+    /// A synthetic namespace directory at this path.
+    Synthetic(Vec<String>),
+}
+
 /// What a `MountFs` fid points at.
 struct Entry {
     /// The absolute path components this fid names (so a further walk can extend
@@ -107,6 +116,18 @@ impl MountFs {
             .iter()
             .any(|prefix| prefix.len() > path.len() && prefix[..path.len()] == *path)
     }
+
+    /// Resolve a fid to its leaf [`Target`] and release the state lock, so a leaf
+    /// op forwards to the backing tree **without** holding the namespace lock — a
+    /// tail parked on a stream's live edge must not freeze every other operation.
+    async fn target(&self, fid: Fid) -> Result<Target, ErrorCode> {
+        let state = self.state.lock().await;
+        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        Ok(match &entry.backing {
+            Some(b) => Target::Backing(b.resolved.clone(), b.backing_fid),
+            None => Target::Synthetic(entry.path.clone()),
+        })
+    }
 }
 
 #[async_trait]
@@ -168,91 +189,87 @@ impl FileServer for MountFs {
     }
 
     async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
-        let state = self.state.lock().await;
-        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
-        match &entry.backing {
-            Some(b) => match b
-                .resolved
-                .call(Request::Open {
-                    fid: b.backing_fid,
-                    mode,
-                })
-                .await?
-            {
-                Response::Open { qid } => Ok(qid),
-                _ => Err(ErrorCode::Io),
-            },
+        match self.target(fid).await? {
+            Target::Backing(resolved, backing_fid) => {
+                match resolved
+                    .call(Request::Open {
+                        fid: backing_fid,
+                        mode,
+                    })
+                    .await?
+                {
+                    Response::Open { qid } => Ok(qid),
+                    _ => Err(ErrorCode::Io),
+                }
+            }
             // A synthetic directory is read-only; a write intent is refused.
-            None => {
+            Target::Synthetic(path) => {
                 if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
                     return Err(ErrorCode::NoAccess);
                 }
-                Ok(synthetic_qid(&entry.path))
+                Ok(synthetic_qid(&path))
             }
         }
     }
 
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
-        let state = self.state.lock().await;
-        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
-        match &entry.backing {
-            Some(b) => match b
-                .resolved
-                .call(Request::Read {
-                    fid: b.backing_fid,
-                    offset,
-                    count,
-                })
-                .await?
-            {
-                Response::Read { data } => Ok(data),
-                _ => Err(ErrorCode::Io),
-            },
-            None => {
-                let listing = self.synthetic_children(&entry.path).join("\n").into_bytes();
+        match self.target(fid).await? {
+            // Forward with the state lock released: a stream read may block at the
+            // live edge, and holding the namespace lock across it would freeze every
+            // other operation (a tail would deadlock concurrent input).
+            Target::Backing(resolved, backing_fid) => {
+                match resolved
+                    .call(Request::Read {
+                        fid: backing_fid,
+                        offset,
+                        count,
+                    })
+                    .await?
+                {
+                    Response::Read { data } => Ok(data),
+                    _ => Err(ErrorCode::Io),
+                }
+            }
+            Target::Synthetic(path) => {
+                let listing = self.synthetic_children(&path).join("\n").into_bytes();
                 Ok(slice(listing, offset, count))
             }
         }
     }
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
-        let state = self.state.lock().await;
-        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
-        match &entry.backing {
-            Some(b) => match b
-                .resolved
-                .call(Request::Write {
-                    fid: b.backing_fid,
-                    offset,
-                    data: data.to_vec(),
-                })
-                .await?
-            {
-                Response::Write { count } => Ok(count),
-                _ => Err(ErrorCode::Io),
-            },
+        match self.target(fid).await? {
+            Target::Backing(resolved, backing_fid) => {
+                match resolved
+                    .call(Request::Write {
+                        fid: backing_fid,
+                        offset,
+                        data: data.to_vec(),
+                    })
+                    .await?
+                {
+                    Response::Write { count } => Ok(count),
+                    _ => Err(ErrorCode::Io),
+                }
+            }
             // A synthetic directory is not writable.
-            None => Err(ErrorCode::IsDirectory),
+            Target::Synthetic(_) => Err(ErrorCode::IsDirectory),
         }
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
-        let state = self.state.lock().await;
-        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
-        match &entry.backing {
-            Some(b) => match b
-                .resolved
-                .call(Request::Stat { fid: b.backing_fid })
-                .await?
-            {
-                Response::Stat { stat } => Ok(stat),
-                _ => Err(ErrorCode::Io),
-            },
-            None => {
-                let length = self.synthetic_children(&entry.path).join("\n").len() as u64;
+        match self.target(fid).await? {
+            Target::Backing(resolved, backing_fid) => {
+                match resolved.call(Request::Stat { fid: backing_fid }).await? {
+                    Response::Stat { stat } => Ok(stat),
+                    _ => Err(ErrorCode::Io),
+                }
+            }
+            Target::Synthetic(path) => {
+                let length = self.synthetic_children(&path).join("\n").len() as u64;
                 Ok(Stat {
                     name: String::new(),
-                    qid: synthetic_qid(&entry.path),
+                    qid: synthetic_qid(&path),
                     length,
                     writable: false,
                 })
@@ -273,9 +290,12 @@ impl FileServer for MountFs {
     }
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
-        let mut state = self.state.lock().await;
-        let entry = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
-        match entry.backing {
+        // Drop the entry under the lock, then forward without it held.
+        let backing = {
+            let mut state = self.state.lock().await;
+            state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?.backing
+        };
+        match backing {
             Some(b) => {
                 b.resolved
                     .call(Request::Remove { fid: b.backing_fid })
@@ -291,16 +311,19 @@ impl FileServer for MountFs {
             // The root is the pre-bound namespace anchor: never released.
             return Ok(());
         }
-        let mut state = self.state.lock().await;
-        let Some(entry) = state.fids.remove(&fid) else {
-            return Err(ErrorCode::NotFound);
+        // Drop the entry under the lock, then forward the backing clunk without the
+        // lock held (a commit-on-clunk commit must not serialize the namespace).
+        let backing = {
+            let mut state = self.state.lock().await;
+            let Some(entry) = state.fids.remove(&fid) else {
+                return Err(ErrorCode::NotFound);
+            };
+            entry.backing
         };
-        if let Some(b) = entry.backing {
-            // Release the fid bound in the backing tree too (the MountFs fid is
-            // already dropped above, so it never leaks even on error), and
-            // propagate the backing clunk result: on a commit-on-clunk endpoint the
-            // clunk *is* the commit, so a rejected document must surface, not be
-            // swallowed.
+        if let Some(b) = backing {
+            // The MountFs fid is already dropped (no leak even on error). Propagate
+            // the backing clunk result: on a commit-on-clunk endpoint the clunk *is*
+            // the commit, so a rejected document must surface, not be swallowed.
             return match b
                 .resolved
                 .call(Request::Clunk { fid: b.backing_fid })

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -140,25 +140,30 @@ impl MountFs {
         };
         for cand in self.ns.resolve_candidates(&join_path(path)) {
             let backing_fid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
-            if !matches!(
-                cand.call(Request::Walk {
+            // A contributor that simply lacks this path (NotFound) is skipped; any
+            // other error (Io/RateLimited/NoAccess) is an operational failure and
+            // must surface, not be masked as a partial/empty listing.
+            match cand
+                .call(Request::Walk {
                     fid: Fid::ROOT,
                     newfid: backing_fid,
                     names: cand.rel.clone(),
                 })
-                .await,
-                Ok(Response::Walk { .. })
-            ) {
-                continue;
+                .await
+            {
+                Ok(Response::Walk { .. }) => {}
+                Err(ErrorCode::NotFound) => continue,
+                Err(e) => return Err(e),
+                Ok(_) => return Err(ErrorCode::Io),
             }
-            let _ = cand
-                .call(Request::Open {
-                    fid: backing_fid,
-                    mode: OpenMode::Read,
-                })
-                .await;
-            let bytes = read_all(&cand, backing_fid).await.unwrap_or_default();
+            // Read this contributor's listing, clunking on every path.
+            let listing = read_contributor_listing(&cand, backing_fid).await;
             let _ = cand.call(Request::Clunk { fid: backing_fid }).await;
+            let bytes = match listing {
+                Ok(bytes) => bytes,
+                Err(ErrorCode::NotFound) => continue,
+                Err(e) => return Err(e),
+            };
             let text = String::from_utf8_lossy(&bytes);
             for line in text.lines() {
                 push(line.to_string(), &mut names);
@@ -196,6 +201,16 @@ impl FileServer for MountFs {
             return Err(ErrorCode::BadRequest);
         }
         let base = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        // A non-empty walk descends into a child, so the base must be a directory.
+        // A backing *file* base is rejected here rather than re-resolving the
+        // absolute path (which could otherwise traverse a non-directory into a
+        // mounted descendant, e.g. a `/` file `mnt` walking into a `/mnt/llm` mount).
+        if !names.is_empty()
+            && let Some(b) = &base.backing
+            && !b.is_dir
+        {
+            return Err(ErrorCode::NotDirectory);
+        }
         let mut path = base.path.clone();
         path.extend(names.iter().cloned());
 
@@ -426,6 +441,22 @@ impl FileServer for MountFs {
         }
         Ok(())
     }
+}
+
+/// Open an already-walked contributor directory fid for read and return its full
+/// listing, propagating the open/read error (the caller clunks the fid).
+async fn read_contributor_listing(resolved: &Resolved, fid: Fid) -> Result<Vec<u8>, ErrorCode> {
+    match resolved
+        .call(Request::Open {
+            fid,
+            mode: OpenMode::Read,
+        })
+        .await?
+    {
+        Response::Open { .. } => {}
+        _ => return Err(ErrorCode::Io),
+    }
+    read_all(resolved, fid).await
 }
 
 /// Read a backing node's full contents by looping until a read returns empty

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -16,6 +16,7 @@
 //!   holds exactly as it does for a directly-mounted server.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Request, Response, Stat,
@@ -24,6 +25,13 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::namespace::{Namespace, Resolved};
+
+/// A process-global allocator for fids bound in backing trees. It must be unique
+/// across *every* `MountFs` — two wrappers over namespaces that share a backing
+/// server (child namespaces cloning the same `/proc` transport) would otherwise
+/// both start at 1 and send colliding `newfid`s into that shared server, so one
+/// wrapper's walk would be rejected while the other holds a live fid.
+static NEXT_BACKING: AtomicU64 = AtomicU64::new(1);
 
 /// A node reached inside a backing tree: the resolved mount (tree + access) and
 /// the fid bound in that tree, which every forwarded op addresses.
@@ -52,10 +60,6 @@ struct Entry {
 
 struct State {
     fids: HashMap<Fid, Entry>,
-    /// Monotonic allocator for fids bound in backing trees. A global counter keeps
-    /// them unique even across trees (each tree has its own space, but uniqueness
-    /// is harmless and simpler).
-    next_backing: u64,
 }
 
 /// The namespace-as-`FileServer`.
@@ -78,10 +82,7 @@ impl MountFs {
         );
         Self {
             ns,
-            state: Mutex::new(State {
-                fids,
-                next_backing: 1,
-            }),
+            state: Mutex::new(State { fids }),
         }
     }
 
@@ -144,35 +145,35 @@ impl FileServer for MountFs {
         // At or below a mount: forward the walk to the backing tree(s), trying each
         // union contributor (longest-prefix, most-recent-first) until one resolves.
         let candidates = self.ns.resolve_candidates(&join_path(&path));
-        if !candidates.is_empty() {
-            for resolved in candidates {
-                let backing_fid = Fid(state.next_backing);
-                let walked = resolved
-                    .call(Request::Walk {
-                        fid: Fid::ROOT,
-                        newfid: backing_fid,
-                        names: resolved.rel.clone(),
-                    })
-                    .await;
-                if let Ok(Response::Walk { qid }) = walked {
-                    state.next_backing += 1;
-                    state.fids.insert(
-                        newfid,
-                        Entry {
-                            path,
-                            backing: Some(Backing {
-                                resolved,
-                                backing_fid,
-                            }),
-                        },
-                    );
-                    return Ok(qid);
-                }
+        for resolved in candidates {
+            let backing_fid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
+            let walked = resolved
+                .call(Request::Walk {
+                    fid: Fid::ROOT,
+                    newfid: backing_fid,
+                    names: resolved.rel.clone(),
+                })
+                .await;
+            if let Ok(Response::Walk { qid }) = walked {
+                state.fids.insert(
+                    newfid,
+                    Entry {
+                        path,
+                        backing: Some(Backing {
+                            resolved,
+                            backing_fid,
+                        }),
+                    },
+                );
+                return Ok(qid);
             }
-            return Err(ErrorCode::NotFound);
         }
 
-        // Above the mounts: a synthetic directory (its children are mount points).
+        // No backing tree resolved this path. Fall through to the synthetic check:
+        // an intermediate parent of a deeper mount (e.g. `/mnt` for `/mnt/llm`) is a
+        // synthetic directory even when a broader mount (like `/`) exists but does
+        // not contain that component — so a component-at-a-time walk still reaches
+        // the deeper mount.
         if path.is_empty() || self.is_synthetic_dir(&path) {
             let qid = synthetic_qid(&path);
             state.fids.insert(
@@ -290,6 +291,11 @@ impl FileServer for MountFs {
     }
 
     async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            // The root is the pre-bound namespace anchor: never unbind it, or every
+            // later walk/open on this handle would fail with NotFound.
+            return Err(ErrorCode::Unsupported);
+        }
         // Drop the entry under the lock, then forward without it held.
         let backing = {
             let mut state = self.state.lock().await;

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -126,6 +126,50 @@ impl MountFs {
             .any(|prefix| prefix.len() > path.len() && prefix[..path.len()] == *path)
     }
 
+    /// Merge a directory listing across every union contributor at `path` plus the
+    /// synthetic mount-point children, deduplicated by name. Each contributor is
+    /// read through its own fresh backing fid (walk → open → read → clunk); a
+    /// contributor that does not resolve the path is skipped. Runs without the
+    /// state lock held (it only reads the immutable namespace).
+    async fn merged_dir_listing(&self, path: &[String]) -> Result<Vec<u8>, ErrorCode> {
+        let mut names: Vec<String> = Vec::new();
+        let push = |name: String, names: &mut Vec<String>| {
+            if !name.is_empty() && !names.contains(&name) {
+                names.push(name);
+            }
+        };
+        for cand in self.ns.resolve_candidates(&join_path(path)) {
+            let backing_fid = Fid(NEXT_BACKING.fetch_add(1, Ordering::Relaxed));
+            if !matches!(
+                cand.call(Request::Walk {
+                    fid: Fid::ROOT,
+                    newfid: backing_fid,
+                    names: cand.rel.clone(),
+                })
+                .await,
+                Ok(Response::Walk { .. })
+            ) {
+                continue;
+            }
+            let _ = cand
+                .call(Request::Open {
+                    fid: backing_fid,
+                    mode: OpenMode::Read,
+                })
+                .await;
+            let bytes = read_all(&cand, backing_fid).await.unwrap_or_default();
+            let _ = cand.call(Request::Clunk { fid: backing_fid }).await;
+            let text = String::from_utf8_lossy(&bytes);
+            for line in text.lines() {
+                push(line.to_string(), &mut names);
+            }
+        }
+        for child in self.synthetic_children(path) {
+            push(child, &mut names);
+        }
+        Ok(names.join("\n").into_bytes())
+    }
+
     /// Resolve a fid to its leaf [`Target`] and release the state lock, so a leaf
     /// op forwards to the backing tree **without** holding the namespace lock — a
     /// tail parked on a stream's live edge must not freeze every other operation.
@@ -242,16 +286,16 @@ impl FileServer for MountFs {
                 is_dir,
                 path,
             } => {
-                // A backed directory that also has mounted descendants must list
-                // those mount points too, or a broad mount (e.g. `/`) would hide the
-                // deeper mounts (`/proc`, `/mnt/llm`) from its listing. Overlay the
-                // synthetic mount-point children onto the backing listing; a file is
-                // forwarded byte-for-byte.
+                // A directory listing must merge every contributor at this prefix
+                // (a union mount such as `/bin`) plus the synthetic mount-point
+                // children (deeper mounts under a broad mount), so neither a union
+                // sibling nor a nested mount is hidden. A single non-union directory
+                // with no mounted descendants, and every file, is forwarded
+                // byte-for-byte.
                 if is_dir {
-                    let extra = self.synthetic_children(&path);
-                    if !extra.is_empty() {
-                        let backing = read_all(&resolved, backing_fid).await?;
-                        return Ok(slice(overlay_listing(backing, extra), offset, count));
+                    let is_union = self.ns.resolve_candidates(&join_path(&path)).len() > 1;
+                    if is_union || !self.synthetic_children(&path).is_empty() {
+                        return Ok(slice(self.merged_dir_listing(&path).await?, offset, count));
                     }
                 }
                 match resolved
@@ -406,23 +450,6 @@ async fn read_all(resolved: &Resolved, fid: Fid) -> Result<Vec<u8>, ErrorCode> {
         out.extend_from_slice(&chunk);
     }
     Ok(out)
-}
-
-/// Overlay synthetic mount-point child names onto a backing directory listing,
-/// appending only names the backing tree does not already list (newline-joined).
-fn overlay_listing(backing: Vec<u8>, extra: Vec<String>) -> Vec<u8> {
-    let text = String::from_utf8_lossy(&backing);
-    let mut names: Vec<String> = text
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(str::to_string)
-        .collect();
-    for name in extra {
-        if !names.contains(&name) {
-            names.push(name);
-        }
-    }
-    names.join("\n").into_bytes()
 }
 
 /// Split an absolute path into its non-empty components. `/` → `[]`.

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -1,0 +1,341 @@
+//! `MountFs` — the per-process [`Namespace`] presented as one aP [`FileServer`].
+//!
+//! A namespace is a path-addressed mount table; aP is a fid-addressed file
+//! protocol. `MountFs` bridges the two so a single client (the shell, the agent
+//! engine) reaches a whole assembled namespace — `/proc`, `/agent`, `/mnt/llm` —
+//! through one transport, instead of holding a separate handle per mounted
+//! server and re-implementing longest-prefix resolution itself.
+//!
+//! Each fid is one of two things:
+//! - a **synthetic directory**: a path that is strictly above every mount (e.g.
+//!   `/`, `/mnt`). No backing server owns it; `MountFs` renders it and lists its
+//!   child mount points.
+//! - a **backing node**: a path at or below a mount. The operation is forwarded
+//!   to the backing tree through [`Resolved::call`], so the mount's access rights
+//!   are enforced (a read-only mount cannot be written) — the namespace boundary
+//!   holds exactly as it does for a directly-mounted server.
+
+use std::collections::HashMap;
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Request, Response, Stat,
+};
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::namespace::{Namespace, Resolved};
+
+/// A node reached inside a backing tree: the resolved mount (tree + access) and
+/// the fid bound in that tree, which every forwarded op addresses.
+struct Backing {
+    resolved: Resolved,
+    backing_fid: Fid,
+}
+
+/// What a `MountFs` fid points at.
+struct Entry {
+    /// The absolute path components this fid names (so a further walk can extend
+    /// it).
+    path: Vec<String>,
+    /// `Some` when the path is at/below a mount; `None` for a synthetic directory.
+    backing: Option<Backing>,
+}
+
+struct State {
+    fids: HashMap<Fid, Entry>,
+    /// Monotonic allocator for fids bound in backing trees. A global counter keeps
+    /// them unique even across trees (each tree has its own space, but uniqueness
+    /// is harmless and simpler).
+    next_backing: u64,
+}
+
+/// The namespace-as-`FileServer`.
+pub struct MountFs {
+    ns: Namespace,
+    state: Mutex<State>,
+}
+
+impl MountFs {
+    /// Wrap an assembled [`Namespace`] as a single aP file server.
+    pub fn new(ns: Namespace) -> Self {
+        let mut fids = HashMap::new();
+        // The root fid is the namespace root: the synthetic directory at `/`.
+        fids.insert(
+            Fid::ROOT,
+            Entry {
+                path: Vec::new(),
+                backing: None,
+            },
+        );
+        Self {
+            ns,
+            state: Mutex::new(State {
+                fids,
+                next_backing: 1,
+            }),
+        }
+    }
+
+    /// The mount prefixes of the namespace, as component vectors.
+    fn mount_prefixes(&self) -> Vec<Vec<String>> {
+        self.ns
+            .describe()
+            .into_iter()
+            .map(|(path, _)| split_path(&path))
+            .collect()
+    }
+
+    /// The child mount-point names directly under the synthetic directory `path`,
+    /// deduplicated. `path` must be a strict prefix of each contributing mount.
+    fn synthetic_children(&self, path: &[String]) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        for prefix in self.mount_prefixes() {
+            if prefix.len() > path.len() && prefix[..path.len()] == *path {
+                let child = prefix[path.len()].clone();
+                if !names.contains(&child) {
+                    names.push(child);
+                }
+            }
+        }
+        names
+    }
+
+    /// Whether `path` is a synthetic directory: strictly above at least one mount
+    /// (and so not itself at/below a mount).
+    fn is_synthetic_dir(&self, path: &[String]) -> bool {
+        self.mount_prefixes()
+            .iter()
+            .any(|prefix| prefix.len() > path.len() && prefix[..path.len()] == *path)
+    }
+}
+
+#[async_trait]
+impl FileServer for MountFs {
+    async fn walk(&self, fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if newfid == Fid::ROOT || state.fids.contains_key(&newfid) {
+            return Err(ErrorCode::BadRequest);
+        }
+        let base = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        let mut path = base.path.clone();
+        path.extend(names.iter().cloned());
+
+        // At or below a mount: forward the walk to the backing tree(s), trying each
+        // union contributor (longest-prefix, most-recent-first) until one resolves.
+        let candidates = self.ns.resolve_candidates(&join_path(&path));
+        if !candidates.is_empty() {
+            for resolved in candidates {
+                let backing_fid = Fid(state.next_backing);
+                let walked = resolved
+                    .call(Request::Walk {
+                        fid: Fid::ROOT,
+                        newfid: backing_fid,
+                        names: resolved.rel.clone(),
+                    })
+                    .await;
+                if let Ok(Response::Walk { qid }) = walked {
+                    state.next_backing += 1;
+                    state.fids.insert(
+                        newfid,
+                        Entry {
+                            path,
+                            backing: Some(Backing {
+                                resolved,
+                                backing_fid,
+                            }),
+                        },
+                    );
+                    return Ok(qid);
+                }
+            }
+            return Err(ErrorCode::NotFound);
+        }
+
+        // Above the mounts: a synthetic directory (its children are mount points).
+        if path.is_empty() || self.is_synthetic_dir(&path) {
+            let qid = synthetic_qid(&path);
+            state.fids.insert(
+                newfid,
+                Entry {
+                    path,
+                    backing: None,
+                },
+            );
+            return Ok(qid);
+        }
+
+        Err(ErrorCode::NotFound)
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let state = self.state.lock().await;
+        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        match &entry.backing {
+            Some(b) => match b
+                .resolved
+                .call(Request::Open {
+                    fid: b.backing_fid,
+                    mode,
+                })
+                .await?
+            {
+                Response::Open { qid } => Ok(qid),
+                _ => Err(ErrorCode::Io),
+            },
+            // A synthetic directory is read-only; a write intent is refused.
+            None => {
+                if matches!(mode, OpenMode::Write | OpenMode::ReadWrite) {
+                    return Err(ErrorCode::NoAccess);
+                }
+                Ok(synthetic_qid(&entry.path))
+            }
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        match &entry.backing {
+            Some(b) => match b
+                .resolved
+                .call(Request::Read {
+                    fid: b.backing_fid,
+                    offset,
+                    count,
+                })
+                .await?
+            {
+                Response::Read { data } => Ok(data),
+                _ => Err(ErrorCode::Io),
+            },
+            None => {
+                let listing = self.synthetic_children(&entry.path).join("\n").into_bytes();
+                Ok(slice(listing, offset, count))
+            }
+        }
+    }
+
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let state = self.state.lock().await;
+        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        match &entry.backing {
+            Some(b) => match b
+                .resolved
+                .call(Request::Write {
+                    fid: b.backing_fid,
+                    offset,
+                    data: data.to_vec(),
+                })
+                .await?
+            {
+                Response::Write { count } => Ok(count),
+                _ => Err(ErrorCode::Io),
+            },
+            // A synthetic directory is not writable.
+            None => Err(ErrorCode::IsDirectory),
+        }
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        match &entry.backing {
+            Some(b) => match b
+                .resolved
+                .call(Request::Stat { fid: b.backing_fid })
+                .await?
+            {
+                Response::Stat { stat } => Ok(stat),
+                _ => Err(ErrorCode::Io),
+            },
+            None => {
+                let length = self.synthetic_children(&entry.path).join("\n").len() as u64;
+                Ok(Stat {
+                    name: String::new(),
+                    qid: synthetic_qid(&entry.path),
+                    length,
+                    writable: false,
+                })
+            }
+        }
+    }
+
+    async fn create(
+        &self,
+        _fid: Fid,
+        _newfid: Fid,
+        _name: &str,
+        _kind: FileKind,
+    ) -> Result<Qid, ErrorCode> {
+        // v1 does not multiplex create across a mount (the newfid mapping is a
+        // later slice); the backing servers do not support it either.
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, fid: Fid) -> Result<(), ErrorCode> {
+        let mut state = self.state.lock().await;
+        let entry = state.fids.remove(&fid).ok_or(ErrorCode::NotFound)?;
+        match entry.backing {
+            Some(b) => {
+                b.resolved
+                    .call(Request::Remove { fid: b.backing_fid })
+                    .await?;
+                Ok(())
+            }
+            None => Err(ErrorCode::Unsupported),
+        }
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if fid == Fid::ROOT {
+            // The root is the pre-bound namespace anchor: never released.
+            return Ok(());
+        }
+        let mut state = self.state.lock().await;
+        let Some(entry) = state.fids.remove(&fid) else {
+            return Err(ErrorCode::NotFound);
+        };
+        if let Some(b) = entry.backing {
+            // Release the fid bound in the backing tree too, so it does not leak.
+            let _ = b.resolved.call(Request::Clunk { fid: b.backing_fid }).await;
+        }
+        Ok(())
+    }
+}
+
+/// Split an absolute path into its non-empty components. `/` → `[]`.
+fn split_path(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Join components back into an absolute path (`[]` → `/`).
+fn join_path(components: &[String]) -> String {
+    if components.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", components.join("/"))
+    }
+}
+
+/// A stable directory qid for a synthetic namespace path, keyed by the path so
+/// distinct synthetic directories never share a qid.
+fn synthetic_qid(path: &[String]) -> Qid {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    "synthetic".hash(&mut h);
+    path.hash(&mut h);
+    Qid {
+        kind: FileKind::Dir,
+        version: 0,
+        path: h.finish(),
+    }
+}
+
+fn slice(bytes: Vec<u8>, offset: Offset, count: u32) -> Vec<u8> {
+    let start = (offset as usize).min(bytes.len());
+    let end = bytes.len().min(start + count as usize);
+    bytes[start..end].to_vec()
+}

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -33,18 +33,26 @@ use crate::namespace::{Namespace, Resolved};
 /// wrapper's walk would be rejected while the other holds a live fid.
 static NEXT_BACKING: AtomicU64 = AtomicU64::new(1);
 
-/// A node reached inside a backing tree: the resolved mount (tree + access) and
-/// the fid bound in that tree, which every forwarded op addresses.
+/// A node reached inside a backing tree: the resolved mount (tree + access), the
+/// fid bound in that tree that every forwarded op addresses, and whether the node
+/// is a directory (so a listing can be overlaid with mount-point children).
 struct Backing {
     resolved: Resolved,
     backing_fid: Fid,
+    is_dir: bool,
 }
 
 /// What a fid resolves to for a leaf operation, extracted from the fid table so
 /// the state lock is released *before* the (possibly blocking) backing call.
 enum Target {
-    /// A node in a backing tree: its resolved mount and bound fid.
-    Backing(Resolved, Fid),
+    /// A node in a backing tree: its resolved mount, bound fid, whether it is a
+    /// directory, and its absolute path (to overlay mount-point children).
+    Backing {
+        resolved: Resolved,
+        backing_fid: Fid,
+        is_dir: bool,
+        path: Vec<String>,
+    },
     /// A synthetic namespace directory at this path.
     Synthetic(Vec<String>),
 }
@@ -125,7 +133,12 @@ impl MountFs {
         let state = self.state.lock().await;
         let entry = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
         Ok(match &entry.backing {
-            Some(b) => Target::Backing(b.resolved.clone(), b.backing_fid),
+            Some(b) => Target::Backing {
+                resolved: b.resolved.clone(),
+                backing_fid: b.backing_fid,
+                is_dir: b.is_dir,
+                path: entry.path.clone(),
+            },
             None => Target::Synthetic(entry.path.clone()),
         })
     }
@@ -162,6 +175,7 @@ impl FileServer for MountFs {
                         backing: Some(Backing {
                             resolved,
                             backing_fid,
+                            is_dir: qid.kind == FileKind::Dir,
                         }),
                     },
                 );
@@ -191,7 +205,11 @@ impl FileServer for MountFs {
 
     async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
         match self.target(fid).await? {
-            Target::Backing(resolved, backing_fid) => {
+            Target::Backing {
+                resolved,
+                backing_fid,
+                ..
+            } => {
                 match resolved
                     .call(Request::Open {
                         fid: backing_fid,
@@ -218,7 +236,24 @@ impl FileServer for MountFs {
             // Forward with the state lock released: a stream read may block at the
             // live edge, and holding the namespace lock across it would freeze every
             // other operation (a tail would deadlock concurrent input).
-            Target::Backing(resolved, backing_fid) => {
+            Target::Backing {
+                resolved,
+                backing_fid,
+                is_dir,
+                path,
+            } => {
+                // A backed directory that also has mounted descendants must list
+                // those mount points too, or a broad mount (e.g. `/`) would hide the
+                // deeper mounts (`/proc`, `/mnt/llm`) from its listing. Overlay the
+                // synthetic mount-point children onto the backing listing; a file is
+                // forwarded byte-for-byte.
+                if is_dir {
+                    let extra = self.synthetic_children(&path);
+                    if !extra.is_empty() {
+                        let backing = read_all(&resolved, backing_fid).await?;
+                        return Ok(slice(overlay_listing(backing, extra), offset, count));
+                    }
+                }
                 match resolved
                     .call(Request::Read {
                         fid: backing_fid,
@@ -240,7 +275,11 @@ impl FileServer for MountFs {
 
     async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
         match self.target(fid).await? {
-            Target::Backing(resolved, backing_fid) => {
+            Target::Backing {
+                resolved,
+                backing_fid,
+                ..
+            } => {
                 match resolved
                     .call(Request::Write {
                         fid: backing_fid,
@@ -260,12 +299,14 @@ impl FileServer for MountFs {
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
         match self.target(fid).await? {
-            Target::Backing(resolved, backing_fid) => {
-                match resolved.call(Request::Stat { fid: backing_fid }).await? {
-                    Response::Stat { stat } => Ok(stat),
-                    _ => Err(ErrorCode::Io),
-                }
-            }
+            Target::Backing {
+                resolved,
+                backing_fid,
+                ..
+            } => match resolved.call(Request::Stat { fid: backing_fid }).await? {
+                Response::Stat { stat } => Ok(stat),
+                _ => Err(ErrorCode::Io),
+            },
             Target::Synthetic(path) => {
                 let length = self.synthetic_children(&path).join("\n").len() as u64;
                 Ok(Stat {
@@ -341,6 +382,47 @@ impl FileServer for MountFs {
         }
         Ok(())
     }
+}
+
+/// Read a backing node's full contents by looping until a read returns empty
+/// (used to get a whole directory listing before overlaying mount points).
+async fn read_all(resolved: &Resolved, fid: Fid) -> Result<Vec<u8>, ErrorCode> {
+    let mut out = Vec::new();
+    loop {
+        let chunk = match resolved
+            .call(Request::Read {
+                fid,
+                offset: out.len() as u64,
+                count: 4096,
+            })
+            .await?
+        {
+            Response::Read { data } => data,
+            _ => return Err(ErrorCode::Io),
+        };
+        if chunk.is_empty() {
+            break;
+        }
+        out.extend_from_slice(&chunk);
+    }
+    Ok(out)
+}
+
+/// Overlay synthetic mount-point child names onto a backing directory listing,
+/// appending only names the backing tree does not already list (newline-joined).
+fn overlay_listing(backing: Vec<u8>, extra: Vec<String>) -> Vec<u8> {
+    let text = String::from_utf8_lossy(&backing);
+    let mut names: Vec<String> = text
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    for name in extra {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names.join("\n").into_bytes()
 }
 
 /// Split an absolute path into its non-empty components. `/` → `[]`.

--- a/crates/kernel/src/mountfs.rs
+++ b/crates/kernel/src/mountfs.rs
@@ -296,8 +296,19 @@ impl FileServer for MountFs {
             return Err(ErrorCode::NotFound);
         };
         if let Some(b) = entry.backing {
-            // Release the fid bound in the backing tree too, so it does not leak.
-            let _ = b.resolved.call(Request::Clunk { fid: b.backing_fid }).await;
+            // Release the fid bound in the backing tree too (the MountFs fid is
+            // already dropped above, so it never leaks even on error), and
+            // propagate the backing clunk result: on a commit-on-clunk endpoint the
+            // clunk *is* the commit, so a rejected document must surface, not be
+            // swallowed.
+            return match b
+                .resolved
+                .call(Request::Clunk { fid: b.backing_fid })
+                .await?
+            {
+                Response::Clunk => Ok(()),
+                _ => Err(ErrorCode::Io),
+            };
         }
         Ok(())
     }

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -284,6 +284,63 @@ async fn a_parked_stream_read_does_not_freeze_the_namespace() {
 }
 
 #[tokio::test]
+async fn two_wrappers_sharing_a_backing_server_do_not_collide_backing_fids() {
+    // Two MountFs over namespaces that share the SAME ProcFs transport (as child
+    // namespaces cloning /proc would). Backing fids must be unique across wrappers,
+    // or the second wrapper's walk reuses a live fid and the shared server rejects
+    // it with BadRequest.
+    let shared = InProcessTransport::new(Arc::new(ProcFs::new()));
+    let mut ns1 = Namespace::new();
+    ns1.mount("/proc", shared.clone(), Access::ReadWrite);
+    let mut ns2 = Namespace::new();
+    ns2.mount("/proc", shared.clone(), Access::ReadWrite);
+    let fs1 = MountFs::new(ns1);
+    let fs2 = MountFs::new(ns2);
+
+    // fs1 holds a live delegated fid on the shared ProcFs.
+    fs1.walk(Fid::ROOT, Fid(1), &["proc".into(), "clone".into()])
+        .await
+        .unwrap();
+    // fs2's first walk must not collide with it.
+    fs2.walk(Fid::ROOT, Fid(1), &["proc".into(), "clone".into()])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn remove_of_root_is_refused_and_preserves_the_handle() {
+    let fs = MountFs::new(ns());
+    assert_eq!(fs.remove(Fid::ROOT).await, Err(ErrorCode::Unsupported));
+    // The root anchor survives, so the handle still resolves absolute paths.
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_synthetic_parent_resolves_under_a_broad_mount() {
+    // A broad `/` mount (a MemFs with no `mnt` entry) plus a deeper `/mnt/llm`.
+    let mut ns = Namespace::new();
+    ns.mount("/", memfs(), Access::ReadWrite);
+    ns.mount("/mnt/llm", memfs(), Access::ReadWrite);
+    let fs = MountFs::new(ns);
+
+    // Walking to /mnt one component at a time must yield the synthetic parent of
+    // /mnt/llm, not NotFound from the broad mount lacking `mnt`.
+    assert_eq!(read_lines(&fs, &["mnt"], Fid(1)).await, vec!["llm"]);
+    // And the deeper mount is still reachable through it.
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["mnt".into(), "llm".into(), "greeting".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Read).await.unwrap();
+    assert_eq!(fs.read(Fid(2), 0, 64).await.unwrap(), b"hi");
+}
+
+#[tokio::test]
 async fn a_clunked_fid_is_released() {
     let fs = MountFs::new(ns());
     fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -401,6 +401,90 @@ async fn a_union_mount_lists_all_contributors_merged() {
     assert_eq!(entries, vec!["cat", "grep", "ls"]);
 }
 
+/// A directory server whose reads fail with `Io`, to prove a union merge surfaces
+/// a contributor's operational failure instead of masking it as a partial listing.
+struct FailReadDirFs;
+
+#[async_trait::async_trait]
+impl FileServer for FailReadDirFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match names {
+            [] => Ok(Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            }),
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Err(ErrorCode::Io)
+    }
+    async fn write(&self, _: Fid, _: Offset, _: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            },
+            length: 0,
+            writable: false,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_union_listing_surfaces_a_contributor_failure() {
+    // One contributor's read fails operationally (Io). The merge must surface it,
+    // not silently return only the other contributor's entries.
+    let mut ns = Namespace::new();
+    ns.mount("/bin", DirFs::transport(&["ls"]), Access::ReadWrite);
+    ns.mount(
+        "/bin",
+        InProcessTransport::new(Arc::new(FailReadDirFs)),
+        Access::ReadWrite,
+    );
+    let fs = MountFs::new(ns);
+
+    fs.walk(Fid::ROOT, Fid(1), &["bin".into()]).await.unwrap();
+    fs.open(Fid(1), OpenMode::Read).await.unwrap();
+    assert_eq!(fs.read(Fid(1), 0, 4096).await, Err(ErrorCode::Io));
+}
+
+#[tokio::test]
+async fn a_relative_walk_from_a_backing_file_is_rejected() {
+    // `/data/greeting` is a file. A non-empty walk descending from it must be
+    // NotDirectory, not a re-resolution that could traverse a non-directory.
+    let fs = MountFs::new(ns());
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.walk(Fid(1), Fid(2), &["child".into()]).await,
+        Err(ErrorCode::NotDirectory)
+    );
+}
+
 #[tokio::test]
 async fn a_backed_directory_lists_its_mount_point_children() {
     // A broad `/` mount (MemFs: greeting/clone/submit) plus a deeper `/mnt/llm`.

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -1,0 +1,148 @@
+//! `MountFs` — the kernel namespace presented as one aP [`FileServer`], so a
+//! single client (the shell, the engine) reaches a whole assembled namespace
+//! (`/proc`, `/agent`, `/mnt/llm`) through one transport. Paths that cross a
+//! mount are delegated to the backing tree (through `Resolved::call`, so the
+//! mount's access is enforced); paths above the mounts are synthetic directories
+//! that list their child mount points.
+
+use std::sync::Arc;
+
+use alan_ap::reference::MemFs;
+use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode};
+use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+
+fn memfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(MemFs::new()))
+}
+
+fn procfs() -> InProcessTransport {
+    InProcessTransport::new(Arc::new(ProcFs::new()))
+}
+
+/// A namespace with `/proc` (ProcFs) and `/data` (MemFs), both read-write.
+fn ns() -> Namespace {
+    let mut ns = Namespace::new();
+    ns.mount("/proc", procfs(), Access::ReadWrite);
+    ns.mount("/data", memfs(), Access::ReadWrite);
+    ns
+}
+
+async fn read_lines(fs: &MountFs, path: &[&str], fid: Fid) -> Vec<String> {
+    let names: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+    fs.walk(Fid::ROOT, fid, &names).await.unwrap();
+    fs.open(fid, OpenMode::Read).await.unwrap();
+    let bytes = fs.read(fid, 0, 4096).await.unwrap();
+    String::from_utf8(bytes)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+#[tokio::test]
+async fn root_lists_its_mount_points_as_a_synthetic_directory() {
+    let fs = MountFs::new(ns());
+    let mut entries = read_lines(&fs, &[], Fid(1)).await;
+    entries.sort();
+    assert_eq!(entries, vec!["data", "proc"]);
+}
+
+#[tokio::test]
+async fn walk_crosses_a_mount_into_the_backing_tree() {
+    let fs = MountFs::new(ns());
+    // /proc/clone resolves to ProcFs's clone file (a Clone-kind node).
+    let qid = fs
+        .walk(Fid::ROOT, Fid(1), &["proc".into(), "clone".into()])
+        .await
+        .unwrap();
+    assert_eq!(qid.kind, FileKind::Clone);
+}
+
+#[tokio::test]
+async fn read_delegates_to_the_backing_file() {
+    let fs = MountFs::new(ns());
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(1), OpenMode::Read).await.unwrap();
+    assert_eq!(fs.read(Fid(1), 0, 64).await.unwrap(), b"hi");
+}
+
+#[tokio::test]
+async fn spawn_through_proc_clone_works_across_the_mount() {
+    let fs = MountFs::new(ns());
+    // Open /proc/clone, read the pending pid, write the exec spec, clunk to commit.
+    fs.walk(Fid::ROOT, Fid(1), &["proc".into(), "clone".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+    let pid = String::from_utf8(fs.read(Fid(1), 0, 64).await.unwrap()).unwrap();
+    fs.write(Fid(1), 0, br#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+
+    // The process is now public: /proc/<pid>/status reads "running".
+    let status = read_lines(&fs, &["proc", &pid, "status"], Fid(2)).await;
+    assert_eq!(status, vec!["running"]);
+}
+
+#[tokio::test]
+async fn an_unmounted_path_is_not_found() {
+    let fs = MountFs::new(ns());
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(1), &["nope".into()]).await,
+        Err(ErrorCode::NotFound)
+    );
+}
+
+#[tokio::test]
+async fn a_read_only_mount_denies_a_write_open() {
+    let mut ns = Namespace::new();
+    ns.mount("/ro", memfs(), Access::ReadOnly);
+    let fs = MountFs::new(ns);
+    // The mount enforces access: a write-intent open is refused even though the
+    // backing node is writable.
+    fs.walk(Fid::ROOT, Fid(1), &["ro".into(), "submit".into()])
+        .await
+        .unwrap();
+    assert_eq!(
+        fs.open(Fid(1), OpenMode::Write).await,
+        Err(ErrorCode::NoAccess)
+    );
+}
+
+#[tokio::test]
+async fn a_nested_mount_appears_through_synthetic_parents() {
+    let mut ns = Namespace::new();
+    ns.mount("/mnt/llm", memfs(), Access::ReadWrite);
+    let fs = MountFs::new(ns);
+
+    // Root lists the first component of the deep mount.
+    assert_eq!(read_lines(&fs, &[], Fid(1)).await, vec!["mnt"]);
+    // /mnt is a synthetic directory listing its child mount point.
+    assert_eq!(read_lines(&fs, &["mnt"], Fid(2)).await, vec!["llm"]);
+    // /mnt/llm/greeting reaches the backing tree.
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &["mnt".into(), "llm".into(), "greeting".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Read).await.unwrap();
+    assert_eq!(fs.read(Fid(3), 0, 64).await.unwrap(), b"hi");
+}
+
+#[tokio::test]
+async fn a_clunked_fid_is_released() {
+    let fs = MountFs::new(ns());
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])
+        .await
+        .unwrap();
+    fs.clunk(Fid(1)).await.unwrap();
+    // The fid is free again: walking onto it succeeds rather than BadRequest.
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])
+        .await
+        .unwrap();
+}

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -135,6 +135,20 @@ async fn a_nested_mount_appears_through_synthetic_parents() {
 }
 
 #[tokio::test]
+async fn clunk_propagates_a_backing_commit_error() {
+    // MemFs's `/submit` validates its document at clunk; a non-JSON body is
+    // rejected at commit. MountFs must surface that error, not swallow it, so a
+    // commit-on-clunk write through a mount can fail.
+    let fs = MountFs::new(ns());
+    fs.walk(Fid::ROOT, Fid(1), &["data".into(), "submit".into()])
+        .await
+        .unwrap();
+    fs.open(Fid(1), OpenMode::Write).await.unwrap();
+    fs.write(Fid(1), 0, b"not json").await.unwrap();
+    assert_eq!(fs.clunk(Fid(1)).await, Err(ErrorCode::BadRequest));
+}
+
+#[tokio::test]
 async fn a_clunked_fid_is_released() {
     let fs = MountFs::new(ns());
     fs.walk(Fid::ROOT, Fid(1), &["data".into(), "greeting".into()])

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -308,6 +308,21 @@ async fn two_wrappers_sharing_a_backing_server_do_not_collide_backing_fids() {
 }
 
 #[tokio::test]
+async fn a_backed_directory_lists_its_mount_point_children() {
+    // A broad `/` mount (MemFs: greeting/clone/submit) plus a deeper `/mnt/llm`.
+    // Listing `/` must show the backing entries AND the `mnt` mount point, or the
+    // deeper mount is reachable but invisible in its parent's listing.
+    let mut ns = Namespace::new();
+    ns.mount("/", memfs(), Access::ReadWrite);
+    ns.mount("/mnt/llm", memfs(), Access::ReadWrite);
+    let fs = MountFs::new(ns);
+
+    let mut entries = read_lines(&fs, &[], Fid(1)).await;
+    entries.sort();
+    assert_eq!(entries, vec!["clone", "greeting", "mnt", "submit"]);
+}
+
+#[tokio::test]
 async fn remove_of_root_is_refused_and_preserves_the_handle() {
     let fs = MountFs::new(ns());
     assert_eq!(fs.remove(Fid::ROOT).await, Err(ErrorCode::Unsupported));

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -307,6 +307,100 @@ async fn two_wrappers_sharing_a_backing_server_do_not_collide_backing_fids() {
         .unwrap();
 }
 
+/// A read-only directory server whose root lists a fixed set of file names, so a
+/// union of two of them (with different names) proves listing merge.
+struct DirFs {
+    entries: Vec<String>,
+    fids: tokio::sync::Mutex<HashMap<Fid, bool>>, // fid -> is the root dir
+}
+
+impl DirFs {
+    fn transport(entries: &[&str]) -> InProcessTransport {
+        InProcessTransport::new(Arc::new(DirFs {
+            entries: entries.iter().map(|s| s.to_string()).collect(),
+            fids: tokio::sync::Mutex::new(HashMap::new()),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl FileServer for DirFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let (is_root, kind) = match names {
+            [] => (true, FileKind::Dir),
+            [n] if self.entries.contains(n) => (false, FileKind::File),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.fids.lock().await.insert(newfid, is_root);
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::Dir,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let is_root = *self.fids.lock().await.get(&fid).unwrap_or(&false);
+        let bytes = if is_root {
+            self.entries.join("\n").into_bytes()
+        } else {
+            Vec::new()
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+    async fn write(&self, _: Fid, _: Offset, _: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind: FileKind::Dir,
+                version: 0,
+                path: 0,
+            },
+            length: 0,
+            writable: false,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids.lock().await.remove(&fid);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_union_mount_lists_all_contributors_merged() {
+    // Two servers mounted at the same prefix (a union, as `/bin` is assembled by
+    // bind). Listing must merge both contributors' entries, deduplicated.
+    let mut ns = Namespace::new();
+    ns.mount("/bin", DirFs::transport(&["ls", "cat"]), Access::ReadWrite);
+    ns.mount(
+        "/bin",
+        DirFs::transport(&["grep", "cat"]),
+        Access::ReadWrite,
+    );
+    let fs = MountFs::new(ns);
+
+    let mut entries = read_lines(&fs, &["bin"], Fid(1)).await;
+    entries.sort();
+    assert_eq!(entries, vec!["cat", "grep", "ls"]);
+}
+
 #[tokio::test]
 async fn a_backed_directory_lists_its_mount_point_children() {
     // A broad `/` mount (MemFs: greeting/clone/submit) plus a deeper `/mnt/llm`.

--- a/crates/kernel/tests/mountfs.rs
+++ b/crates/kernel/tests/mountfs.rs
@@ -5,10 +5,13 @@
 //! mount's access is enforced); paths above the mounts are synthetic directories
 //! that list their child mount points.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use alan_ap::reference::MemFs;
-use alan_ap::{ErrorCode, Fid, FileKind, FileServer, InProcessTransport, OpenMode};
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
+};
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
 
 fn memfs() -> InProcessTransport {
@@ -146,6 +149,138 @@ async fn clunk_propagates_a_backing_commit_error() {
     fs.open(Fid(1), OpenMode::Write).await.unwrap();
     fs.write(Fid(1), 0, b"not json").await.unwrap();
     assert_eq!(fs.clunk(Fid(1)).await, Err(ErrorCode::BadRequest));
+}
+
+/// A backing server with one stream file `out` (blocks at the live edge) under a
+/// directory root, used to prove a parked tail does not freeze the namespace.
+struct StreamFs {
+    stream: Stream,
+    fids: tokio::sync::Mutex<HashMap<Fid, bool>>, // fid -> is the `out` stream
+}
+
+impl StreamFs {
+    /// The server plus a direct handle to its stream, so a test can append to it
+    /// (unblocking a parked reader) without going back through the namespace.
+    fn new() -> (Self, Stream) {
+        let stream = Stream::new();
+        (
+            Self {
+                stream: stream.clone(),
+                fids: tokio::sync::Mutex::new(HashMap::new()),
+            },
+            stream,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl FileServer for StreamFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let (is_stream, kind) = match names {
+            [] => (false, FileKind::Dir),
+            [n] if n == "out" => (true, FileKind::Stream),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.fids.lock().await.insert(newfid, is_stream);
+        Ok(Qid {
+            kind,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(Qid {
+            kind: FileKind::Stream,
+            version: 0,
+            path: 0,
+        })
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        if *self.fids.lock().await.get(&fid).unwrap_or(&false) {
+            Ok(self.stream.read(offset, count).await)
+        } else {
+            Err(ErrorCode::Unsupported)
+        }
+    }
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: Qid {
+                kind: FileKind::Stream,
+                version: 0,
+                path: 0,
+            },
+            length: self.stream.len().await,
+            writable: false,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.fids.lock().await.remove(&fid);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_parked_stream_read_does_not_freeze_the_namespace() {
+    use std::time::Duration;
+
+    // /s is a stream server (blocking live edge); /data is a MemFs. A read parked at
+    // /s/out must not hold the MountFs lock, or a concurrent op deadlocks — the M2
+    // "tail output while submitting input" workflow.
+    let (streamfs, stream) = StreamFs::new();
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/s",
+        InProcessTransport::new(Arc::new(streamfs)),
+        Access::ReadWrite,
+    );
+    ns.mount("/data", memfs(), Access::ReadWrite);
+    let fs = Arc::new(MountFs::new(ns));
+
+    // A tail parks at the live edge of /s/out.
+    let tailer = fs.clone();
+    let parked = tokio::spawn(async move {
+        tailer
+            .walk(Fid::ROOT, Fid(1), &["s".into(), "out".into()])
+            .await
+            .unwrap();
+        tailer.open(Fid(1), OpenMode::Read).await.unwrap();
+        tailer.read(Fid(1), 0, 64).await.unwrap()
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        !parked.is_finished(),
+        "the tail should be parked at the live edge"
+    );
+
+    // A concurrent op on the same MountFs must complete despite the parked read.
+    let concurrent = tokio::time::timeout(Duration::from_millis(500), async {
+        fs.walk(Fid::ROOT, Fid(2), &["data".into(), "greeting".into()])
+            .await
+            .unwrap();
+        fs.open(Fid(2), OpenMode::Read).await.unwrap();
+        fs.read(Fid(2), 0, 64).await.unwrap()
+    })
+    .await
+    .expect("a concurrent op must not be blocked by a parked stream read");
+    assert_eq!(concurrent, b"hi");
+
+    // Appending unblocks the parked tail.
+    stream.append(b"live").await;
+    let got = tokio::time::timeout(Duration::from_millis(500), parked)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(got, b"live");
 }
 
 #[tokio::test]

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "alan-shell"
+description = "Alan Shell — the aP-only client: generic file builtins (ls/cat/echo/tail/spawn) over the namespace, with no agent-specific commands. Depends only on alan-ap."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+alan-ap = { path = "../ap" }
+
+[dev-dependencies]
+alan-kernel = { path = "../kernel" }
+async-trait.workspace = true
+tokio = { workspace = true }

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -1,0 +1,312 @@
+//! Alan Shell — the aP-only client.
+//!
+//! Every builtin is generic file IO over aP: `ls` (walk a directory + read its
+//! entries), `cat` (open + read a finite snapshot), `write`/`echo >` (open +
+//! write + clunk), `tail` (a live session of blocking reads), and `spawn`
+//! (clone-via-open on `/proc/clone`). There is **no agent-specific command** and
+//! no `attach` sugar — an agent is just files under `/agent/<pid>`, reached with
+//! the same builtins (ADR-0025 D3). The shell depends only on [`alan_ap`]; it
+//! never links a server or backend, and it addresses a whole assembled namespace
+//! (`/proc`, `/agent`, `/mnt/llm`) through one transport — in v1 the kernel's
+//! namespace presented as one aP server (`alan-kernel::MountFs`).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use alan_ap::{
+    ErrorCode, Fid, FileKind, InProcessTransport, Offset, OpenMode, Qid, Request, Response,
+};
+
+/// A process-global fid allocator. aP fid state lives in the server keyed only by
+/// [`Fid`], so two shells over the same transport (two tabs on one namespace) must
+/// never draw the same number or one would clobber the other's open file. A single
+/// global sequence guarantees uniqueness across every shell in the process.
+static NEXT_FID: AtomicU64 = AtomicU64::new(1);
+
+/// The shell's view of one mounted namespace, addressed by absolute path.
+pub struct Shell {
+    fs: InProcessTransport,
+}
+
+impl Shell {
+    /// Build a shell over a mounted file tree (in v1, the kernel's assembled
+    /// namespace presented as one aP server).
+    pub fn new(fs: InProcessTransport) -> Self {
+        Self { fs }
+    }
+
+    /// Draw a fresh fid unique across the whole process (see [`NEXT_FID`]).
+    fn alloc_fid(&self) -> Fid {
+        Fid(NEXT_FID.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Walk an absolute path, binding a fresh fid at its target and returning that
+    /// fid with the target's qid (whose `kind` distinguishes dir/file/stream).
+    async fn walk_to(&self, path: &str) -> Result<(Fid, Qid), ErrorCode> {
+        let names = split_path(path);
+        let fid = self.alloc_fid();
+        match self
+            .fs
+            .call(Request::Walk {
+                fid: Fid::ROOT,
+                newfid: fid,
+                names,
+            })
+            .await?
+        {
+            Response::Walk { qid } => Ok((fid, qid)),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    async fn open(&self, fid: Fid, mode: OpenMode) -> Result<Qid, ErrorCode> {
+        match self.fs.call(Request::Open { fid, mode }).await? {
+            Response::Open { qid } => Ok(qid),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    async fn read_at(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        match self.fs.call(Request::Read { fid, offset, count }).await? {
+            Response::Read { data } => Ok(data),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    async fn length(&self, fid: Fid) -> Result<u64, ErrorCode> {
+        match self.fs.call(Request::Stat { fid }).await? {
+            Response::Stat { stat } => Ok(stat.length),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    /// Release a fid, propagating a commit-time error. On a commit-on-clunk
+    /// endpoint (a document file, `/proc/clone`) the `Clunk` *is* the commit, so a
+    /// rejected/malformed document surfaces here — the success path must not
+    /// swallow it.
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        match self.fs.call(Request::Clunk { fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+
+    /// Best-effort release for the *cleanup* path: the builtin already failed, so a
+    /// clunk error is irrelevant and must not mask the original error.
+    async fn clunk_quietly(&self, fid: Fid) {
+        let _ = self.fs.call(Request::Clunk { fid }).await;
+    }
+
+    /// Write the whole buffer, looping on short writes: a server may legally accept
+    /// only a prefix per call, so committing after one `Write` could truncate. A
+    /// count of zero (no progress) or one larger than the bytes offered is a
+    /// protocol error — a buggy/hostile service must not spin the loop or crash the
+    /// shell by indexing past the buffer.
+    async fn write_all(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
+        let mut offset: Offset = 0;
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let accepted = match self
+                .fs
+                .call(Request::Write {
+                    fid,
+                    offset,
+                    data: remaining.to_vec(),
+                })
+                .await?
+            {
+                Response::Write { count } => count as usize,
+                _ => return Err(ErrorCode::Io),
+            };
+            if accepted == 0 || accepted > remaining.len() {
+                return Err(ErrorCode::Io);
+            }
+            offset += accepted as u64;
+            remaining = &remaining[accepted..];
+        }
+        Ok(())
+    }
+
+    /// `cat path` — read a finite snapshot of a file. A flat file is read to EOF;
+    /// a **stream** is bounded by its current length so `cat` never blocks at the
+    /// live edge (that is `tail`'s job).
+    pub async fn cat(&self, path: &str) -> Result<Vec<u8>, ErrorCode> {
+        let (fid, qid) = self.walk_to(path).await?;
+        let result = self.cat_body(fid, qid.kind).await;
+        self.clunk_quietly(fid).await;
+        result
+    }
+
+    async fn cat_body(&self, fid: Fid, kind: FileKind) -> Result<Vec<u8>, ErrorCode> {
+        self.open(fid, OpenMode::Read).await?;
+        let mut out = Vec::new();
+        if kind == FileKind::Stream {
+            // Snapshot: read only up to the length observed now, so a read never
+            // lands on the (blocking) live edge.
+            let len = self.length(fid).await?;
+            while (out.len() as u64) < len {
+                let want = (len - out.len() as u64).min(4096) as u32;
+                let chunk = self.read_at(fid, out.len() as u64, want).await?;
+                if chunk.is_empty() {
+                    break;
+                }
+                out.extend_from_slice(&chunk);
+            }
+        } else {
+            // A finite file returns empty at EOF.
+            loop {
+                let chunk = self.read_at(fid, out.len() as u64, 4096).await?;
+                if chunk.is_empty() {
+                    break;
+                }
+                out.extend_from_slice(&chunk);
+            }
+        }
+        Ok(out)
+    }
+
+    /// `ls path` — list a directory's entries. The target must be a directory; a
+    /// regular file is rejected rather than having its bytes read as entries.
+    pub async fn ls(&self, path: &str) -> Result<Vec<String>, ErrorCode> {
+        let (fid, qid) = self.walk_to(path).await?;
+        let result = self.ls_body(fid, qid.kind).await;
+        self.clunk_quietly(fid).await;
+        result
+    }
+
+    async fn ls_body(&self, fid: Fid, kind: FileKind) -> Result<Vec<String>, ErrorCode> {
+        if kind != FileKind::Dir {
+            return Err(ErrorCode::NotDirectory);
+        }
+        self.open(fid, OpenMode::Read).await?;
+        let mut bytes = Vec::new();
+        loop {
+            let chunk = self.read_at(fid, bytes.len() as u64, 4096).await?;
+            if chunk.is_empty() {
+                break;
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        let text = String::from_utf8(bytes).map_err(|_| ErrorCode::Io)?;
+        Ok(text
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+
+    /// `echo data > path` — write a document and commit it on clunk. A commit-time
+    /// rejection (the server discards a malformed document at clunk) surfaces as an
+    /// error rather than a false success.
+    pub async fn write(&self, path: &str, data: &[u8]) -> Result<(), ErrorCode> {
+        let (fid, _) = self.walk_to(path).await?;
+        match self.write_body(fid, data).await {
+            // The write reached the commit step: the clunk *is* the commit.
+            Ok(()) => self.clunk(fid).await,
+            Err(e) => {
+                self.clunk_quietly(fid).await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn write_body(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
+        self.open(fid, OpenMode::Write).await?;
+        self.write_all(fid, data).await
+    }
+
+    /// `tail path` — open a live tail session: repeated blocking reads that advance
+    /// a held offset, keeping the fid open so a multi-append stream is fully
+    /// observed (not just its first chunk). Close it with [`Tail::close`].
+    pub async fn tail(&self, path: &str) -> Result<Tail, ErrorCode> {
+        let (fid, _) = self.walk_to(path).await?;
+        if let Err(e) = self.open(fid, OpenMode::Read).await {
+            self.clunk_quietly(fid).await;
+            return Err(e);
+        }
+        Ok(Tail {
+            fs: self.fs.clone(),
+            fid,
+            offset: 0,
+        })
+    }
+
+    /// `spawn` — launch a process via clone-via-open on `/proc/clone`: open the
+    /// clone file (returns the pending pid), write the exec spec, and clunk to
+    /// commit. Pure aP, no side API. `/proc` is a mount in the namespace, so the
+    /// path is `/proc/clone`, not `/clone`. Returns the new pid.
+    pub async fn spawn(&self, exec_spec: &str) -> Result<String, ErrorCode> {
+        let (fid, _) = self.walk_to("/proc/clone").await?;
+        match self.spawn_body(fid, exec_spec).await {
+            // Clunk commits the spawn: a malformed exec spec is rejected here, so a
+            // failed commit must fail spawn rather than return a bogus pid.
+            Ok(pid) => {
+                self.clunk(fid).await?;
+                Ok(pid)
+            }
+            Err(e) => {
+                self.clunk_quietly(fid).await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn spawn_body(&self, fid: Fid, exec_spec: &str) -> Result<String, ErrorCode> {
+        self.open(fid, OpenMode::ReadWrite).await?;
+        let pid = String::from_utf8(self.read_at(fid, 0, 64).await?).map_err(|_| ErrorCode::Io)?;
+        self.write_all(fid, exec_spec.as_bytes()).await?;
+        Ok(pid)
+    }
+}
+
+/// A live tail over a file/stream: repeated blocking reads that advance a held
+/// offset, keeping one fid open until [`close`](Tail::close). This is how a
+/// multi-append stream (an agent's `io/output` emitting several records) is fully
+/// followed — a single read would see only the first append.
+pub struct Tail {
+    fs: InProcessTransport,
+    fid: Fid,
+    offset: Offset,
+}
+
+impl Tail {
+    /// Block until bytes at the current offset exist, return them, and advance the
+    /// offset past them. On a stream at the live edge this parks until the next
+    /// append; on a closed/drained stream it returns empty.
+    pub async fn read(&mut self, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let data = match self
+            .fs
+            .call(Request::Read {
+                fid: self.fid,
+                offset: self.offset,
+                count,
+            })
+            .await?
+        {
+            Response::Read { data } => data,
+            _ => return Err(ErrorCode::Io),
+        };
+        self.offset += data.len() as u64;
+        Ok(data)
+    }
+
+    /// The offset the next [`read`](Tail::read) will resume from.
+    pub fn offset(&self) -> Offset {
+        self.offset
+    }
+
+    /// Release the tail's fid.
+    pub async fn close(self) -> Result<(), ErrorCode> {
+        match self.fs.call(Request::Clunk { fid: self.fid }).await? {
+            Response::Clunk => Ok(()),
+            _ => Err(ErrorCode::Io),
+        }
+    }
+}
+
+/// Split an absolute path into its non-empty components. `/` → `[]`.
+fn split_path(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -102,6 +102,23 @@ impl Shell {
     /// protocol error — a buggy/hostile service must not spin the loop or crash the
     /// shell by indexing past the buffer.
     async fn write_all(&self, fid: Fid, data: &[u8]) -> Result<(), ErrorCode> {
+        // An intentionally empty document must still reach the server as one
+        // zero-length write, so a commit-on-clunk endpoint marks the fid written
+        // and commits the empty value instead of silently dropping it.
+        if data.is_empty() {
+            return match self
+                .fs
+                .call(Request::Write {
+                    fid,
+                    offset: 0,
+                    data: Vec::new(),
+                })
+                .await?
+            {
+                Response::Write { .. } => Ok(()),
+                _ => Err(ErrorCode::Io),
+            };
+        }
         let mut offset: Offset = 0;
         let mut remaining = data;
         while !remaining.is_empty() {

--- a/crates/shell/tests/dependency_boundary.rs
+++ b/crates/shell/tests/dependency_boundary.rs
@@ -1,0 +1,43 @@
+//! Dependency boundary (introduce-alan-shell §2.2, ADR-0025 D3): the shell is a
+//! client and depends on `alan-ap` only among Alan crates — never a server or
+//! backend (kernel, agentfs, llmfs, agent-engine, …). A front-end reads files,
+//! writes `ctl`, and watches streams; it must not link the things it talks to.
+//! (alan-kernel appears only as a dev-dependency for tests, not in `[dependencies]`.)
+
+fn declared_dependencies(manifest: &str) -> Vec<String> {
+    let mut deps = Vec::new();
+    let mut in_deps = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_deps = line == "[dependencies]";
+            continue;
+        }
+        if !in_deps || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let head = line.split('=').next().unwrap_or("").trim();
+        let name = head.split('.').next().unwrap_or("").trim();
+        if !name.is_empty() {
+            deps.push(name.to_string());
+        }
+    }
+    deps
+}
+
+#[test]
+fn shell_depends_only_on_alan_ap_among_alan_crates() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read shell Cargo.toml");
+
+    let alan_deps: Vec<String> = declared_dependencies(&manifest)
+        .into_iter()
+        .filter(|d| d.starts_with("alan-"))
+        .collect();
+
+    assert_eq!(
+        alan_deps,
+        vec!["alan-ap".to_string()],
+        "the shell is an aP-only client (ADR-0025 D3); found Alan deps {alan_deps:?}"
+    );
+}

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -1,0 +1,424 @@
+//! Alan Shell builtins over aP (introduce-alan-shell §3, §5.1). The shell is an
+//! aP-only client: every builtin is generic file IO (walk/open/read/write/clunk
+//! and clone-via-open for spawn) with no agent-specific command. These tests run
+//! the builtins against an in-memory echo file server (the M1 milestone — input
+//! echoed back through files, no LLM), against a partial-write server (short-write
+//! handling), and against a real assembled namespace (`MountFs` over `/proc` and a
+//! data mount) so path resolution crosses mounts as it will in production.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use alan_ap::reference::MemFs;
+use alan_ap::{
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
+};
+use alan_kernel::{Access, MountFs, Namespace, ProcFs};
+use alan_shell::Shell;
+
+/// A tiny read-write echo server: a `buf` byte file and a `stream` stream file
+/// under a directory root. Each node reports its true [`FileKind`], so the shell's
+/// dir/stream-aware builtins behave as they would against a real server.
+struct EchoFs {
+    state: tokio::sync::Mutex<EchoState>,
+}
+
+struct EchoState {
+    buf: Vec<u8>,
+    stream: Stream,
+    fids: HashMap<Fid, EchoNode>,
+}
+
+#[derive(Clone, Copy)]
+enum EchoNode {
+    Root,
+    Buf,
+    StreamFile,
+}
+
+impl EchoNode {
+    fn kind(self) -> FileKind {
+        match self {
+            EchoNode::Root => FileKind::Dir,
+            EchoNode::Buf => FileKind::File,
+            EchoNode::StreamFile => FileKind::Stream,
+        }
+    }
+}
+
+impl EchoFs {
+    fn new() -> Self {
+        Self {
+            state: tokio::sync::Mutex::new(EchoState {
+                buf: Vec::new(),
+                stream: Stream::new(),
+                fids: HashMap::new(),
+            }),
+        }
+    }
+    fn transport() -> InProcessTransport {
+        InProcessTransport::new(Arc::new(Self::new()))
+    }
+}
+
+fn qid(kind: FileKind) -> Qid {
+    Qid {
+        kind,
+        version: 0,
+        path: 0,
+    }
+}
+
+#[async_trait::async_trait]
+impl FileServer for EchoFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let node = match names {
+            [] => EchoNode::Root,
+            [n] if n == "buf" => EchoNode::Buf,
+            [n] if n == "stream" => EchoNode::StreamFile,
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.state.lock().await.fids.insert(newfid, node);
+        Ok(qid(node.kind()))
+    }
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let node = *self
+            .state
+            .lock()
+            .await
+            .fids
+            .get(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        Ok(qid(node.kind()))
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let node = *self
+            .state
+            .lock()
+            .await
+            .fids
+            .get(&fid)
+            .unwrap_or(&EchoNode::Root);
+        let bytes = match node {
+            EchoNode::Root => b"buf\nstream".to_vec(),
+            EchoNode::Buf => self.state.lock().await.buf.clone(),
+            EchoNode::StreamFile => {
+                let stream = self.state.lock().await.stream.clone();
+                return Ok(stream.read(offset, count).await);
+            }
+        };
+        let start = (offset as usize).min(bytes.len());
+        let end = bytes.len().min(start + count as usize);
+        Ok(bytes[start..end].to_vec())
+    }
+    async fn write(&self, fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        match state.fids.get(&fid).copied() {
+            Some(EchoNode::Buf) => {
+                state.buf.extend_from_slice(data);
+                Ok(data.len() as u32)
+            }
+            Some(EchoNode::StreamFile) => {
+                let stream = state.stream.clone();
+                drop(state);
+                stream.append(data).await;
+                Ok(data.len() as u32)
+            }
+            _ => Err(ErrorCode::Unsupported),
+        }
+    }
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let state = self.state.lock().await;
+        let node = *state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+        let length = match node {
+            EchoNode::Root => b"buf\nstream".len() as u64,
+            EchoNode::Buf => state.buf.len() as u64,
+            EchoNode::StreamFile => state.stream.len().await,
+        };
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(node.kind()),
+            length,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.state.lock().await.fids.remove(&fid);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn m1_input_is_echoed_back_through_files() {
+    // M1: write into a file, read it back — the whole round trip is files.
+    let shell = Shell::new(EchoFs::transport());
+    shell.write("/buf", b"hello shell").await.unwrap();
+    assert_eq!(shell.cat("/buf").await.unwrap(), b"hello shell");
+}
+
+#[tokio::test]
+async fn ls_lists_a_directory() {
+    let shell = Shell::new(EchoFs::transport());
+    assert_eq!(
+        shell.ls("/").await.unwrap(),
+        vec!["buf".to_string(), "stream".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn ls_rejects_a_non_directory() {
+    // Pointed at a regular file, `ls` fails rather than reporting the file's bytes
+    // as directory entries.
+    let shell = Shell::new(EchoFs::transport());
+    assert_eq!(shell.ls("/buf").await, Err(ErrorCode::NotDirectory));
+}
+
+#[tokio::test]
+async fn cat_snapshots_a_stream_without_blocking_at_the_live_edge() {
+    // A stream with retained bytes: `cat` returns the snapshot and does not block
+    // waiting for more (that is `tail`'s job).
+    let shell = Shell::new(EchoFs::transport());
+    shell.write("/stream", b"retained").await.unwrap();
+    let snapshot =
+        tokio::time::timeout(std::time::Duration::from_millis(500), shell.cat("/stream"))
+            .await
+            .expect("cat must not block on a stream")
+            .unwrap();
+    assert_eq!(snapshot, b"retained");
+}
+
+#[tokio::test]
+async fn tail_follows_multiple_appends() {
+    use std::time::Duration;
+
+    let transport = EchoFs::transport();
+    let shell = Arc::new(Shell::new(transport));
+
+    // A tail session blocks at the live edge until bytes arrive, then keeps reading
+    // subsequent appends from the advancing offset.
+    let watcher = shell.clone();
+    let handle = tokio::spawn(async move {
+        let mut tail = watcher.tail("/stream").await.unwrap();
+        let first = tail.read(65536).await.unwrap();
+        let second = tail.read(65536).await.unwrap();
+        tail.close().await.unwrap();
+        (first, second)
+    });
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!handle.is_finished(), "tail should block at the live edge");
+
+    shell.write("/stream", b"first").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    shell.write("/stream", b"second").await.unwrap();
+
+    let (first, second) = tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first, b"first");
+    assert_eq!(
+        second, b"second",
+        "the tail keeps reading past the first chunk"
+    );
+}
+
+/// A server whose writable `buf` file accepts at most 3 bytes per `write`, to
+/// exercise the shell's short-write loop.
+struct ChunkFs {
+    state: tokio::sync::Mutex<ChunkState>,
+}
+struct ChunkState {
+    buf: Vec<u8>,
+    fids: HashMap<Fid, bool>, // fid -> is the `buf` file (vs root dir)
+}
+
+#[async_trait::async_trait]
+impl FileServer for ChunkFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        let (is_file, kind) = match names {
+            [] => (false, FileKind::Dir),
+            [n] if n == "buf" => (true, FileKind::File),
+            _ => return Err(ErrorCode::NotFound),
+        };
+        self.state.lock().await.fids.insert(newfid, is_file);
+        Ok(qid(kind))
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(qid(FileKind::File))
+    }
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let state = self.state.lock().await;
+        if *state.fids.get(&fid).unwrap_or(&false) {
+            let bytes = &state.buf;
+            let start = (offset as usize).min(bytes.len());
+            let end = bytes.len().min(start + count as usize);
+            Ok(bytes[start..end].to_vec())
+        } else {
+            Err(ErrorCode::Unsupported)
+        }
+    }
+    async fn write(&self, fid: Fid, offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        let mut state = self.state.lock().await;
+        if !*state.fids.get(&fid).unwrap_or(&false) {
+            return Err(ErrorCode::Unsupported);
+        }
+        // Accept at most 3 bytes per call (a legal short write), honoring offset.
+        let n = data.len().min(3);
+        let start = offset as usize;
+        let end = start + n;
+        if state.buf.len() < end {
+            state.buf.resize(end, 0);
+        }
+        state.buf[start..end].copy_from_slice(&data[..n]);
+        Ok(n as u32)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(FileKind::File),
+            length: self.state.lock().await.buf.len() as u64,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        self.state.lock().await.fids.remove(&fid);
+        Ok(())
+    }
+}
+
+/// A server whose `buf` file over-reports its write count (accepted > offered),
+/// to prove the shell rejects it instead of panicking on an out-of-range slice.
+struct LiarFs;
+
+#[async_trait::async_trait]
+impl FileServer for LiarFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match names {
+            [n] if n == "buf" => Ok(qid(FileKind::File)),
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(qid(FileKind::File))
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+    async fn write(&self, _fid: Fid, _offset: Offset, data: &[u8]) -> Result<u32, ErrorCode> {
+        // Claim one more byte than was offered — an illegal, buffer-overrunning count.
+        Ok(data.len() as u32 + 1)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(FileKind::File),
+            length: 0,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn write_rejects_an_over_reported_count() {
+    let shell = Shell::new(InProcessTransport::new(Arc::new(LiarFs)));
+    // The server claims to accept more than offered; the shell must error, not panic.
+    assert_eq!(shell.write("/buf", b"abc").await, Err(ErrorCode::Io));
+}
+
+#[tokio::test]
+async fn write_handles_short_writes() {
+    let fs = InProcessTransport::new(Arc::new(ChunkFs {
+        state: tokio::sync::Mutex::new(ChunkState {
+            buf: Vec::new(),
+            fids: HashMap::new(),
+        }),
+    }));
+    let shell = Shell::new(fs);
+    // 8 bytes with a 3-byte-per-write cap: the shell must loop until all land.
+    shell.write("/buf", b"abcdefgh").await.unwrap();
+    assert_eq!(shell.cat("/buf").await.unwrap(), b"abcdefgh");
+}
+
+/// A real assembled namespace: `/proc` (ProcFs) and `/data` (MemFs) unioned by
+/// `MountFs` and presented to the shell as one transport.
+fn namespace_shell() -> Shell {
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/proc",
+        InProcessTransport::new(Arc::new(ProcFs::new())),
+        Access::ReadWrite,
+    );
+    ns.mount(
+        "/data",
+        InProcessTransport::new(Arc::new(MemFs::new())),
+        Access::ReadWrite,
+    );
+    Shell::new(InProcessTransport::new(Arc::new(MountFs::new(ns))))
+}
+
+#[tokio::test]
+async fn shell_resolves_paths_across_a_real_namespace() {
+    let shell = namespace_shell();
+    // `cat` reaches a file under a mount.
+    assert_eq!(shell.cat("/data/greeting").await.unwrap(), b"hi");
+    // `ls /` lists the namespace's mount points (a synthetic directory).
+    let mut root = shell.ls("/").await.unwrap();
+    root.sort();
+    assert_eq!(root, vec!["data".to_string(), "proc".to_string()]);
+}
+
+#[tokio::test]
+async fn write_surfaces_a_commit_on_clunk_rejection() {
+    // MemFs's `/submit` validates its document at clunk; a non-JSON body is
+    // rejected at commit, and the shell must surface that, not report success.
+    let shell = namespace_shell();
+    assert_eq!(
+        shell.write("/data/submit", b"not json").await,
+        Err(ErrorCode::BadRequest)
+    );
+}
+
+#[tokio::test]
+async fn spawn_surfaces_a_malformed_exec_spec() {
+    // /proc/clone commits the process at clunk; a malformed exec spec is discarded
+    // with a commit-time error, which spawn must propagate instead of a bogus pid.
+    let shell = namespace_shell();
+    assert_eq!(shell.spawn("not json").await, Err(ErrorCode::BadRequest));
+}
+
+#[tokio::test]
+async fn spawn_launches_a_process_through_proc_clone_across_the_mount() {
+    // The aP-only shell launches a process through `/proc/clone` (a mount in the
+    // namespace) with no side API, then reads its status back across the mount.
+    let shell = namespace_shell();
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    assert_eq!(
+        shell.cat(&format!("/proc/{pid}/status")).await.unwrap(),
+        b"running\n"
+    );
+}

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -340,6 +340,55 @@ impl FileServer for LiarFs {
     }
 }
 
+/// A server whose `buf` file rejects every write, so a test can prove a write was
+/// actually issued (an empty document must still reach the server).
+struct RejectWriteFs;
+
+#[async_trait::async_trait]
+impl FileServer for RejectWriteFs {
+    async fn walk(&self, _fid: Fid, _newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match names {
+            [n] if n == "buf" => Ok(qid(FileKind::File)),
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+    async fn open(&self, _fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        Ok(qid(FileKind::File))
+    }
+    async fn read(&self, _: Fid, _: Offset, _: u32) -> Result<Vec<u8>, ErrorCode> {
+        Ok(Vec::new())
+    }
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::BadRequest)
+    }
+    async fn stat(&self, _fid: Fid) -> Result<Stat, ErrorCode> {
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(FileKind::File),
+            length: 0,
+            writable: true,
+        })
+    }
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+    async fn clunk(&self, _fid: Fid) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn write_of_empty_document_still_issues_a_write() {
+    // The server rejects every write. If the shell silently skipped the empty write
+    // it would return Ok (clunk succeeds); instead it must surface the rejection,
+    // proving an empty document reaches the server rather than being dropped.
+    let shell = Shell::new(InProcessTransport::new(Arc::new(RejectWriteFs)));
+    assert_eq!(shell.write("/buf", b"").await, Err(ErrorCode::BadRequest));
+}
+
 #[tokio::test]
 async fn write_rejects_an_over_reported_count() {
     let shell = Shell::new(InProcessTransport::new(Arc::new(LiarFs)));

--- a/openspec/changes/define-namespace-driven-sandbox/design.md
+++ b/openspec/changes/define-namespace-driven-sandbox/design.md
@@ -1,0 +1,217 @@
+## Context
+
+Two subsystems that both express "what may the agent touch" exist today, disjoint:
+
+- `alan-kernel` — `Namespace::mount(at, tree: InProcessTransport, access)` builds
+  an aP path → `FileServer` + `Access` table; `MountFs` presents it as one file
+  server and enforces `Access` in-process (a `ReadOnly` mount rejects mutating
+  ops). `describe()` returns `(namespace_path, Access)`. **Every mount is a
+  virtual server; the namespace records no host provenance.**
+- `alan-agent-engine::tools::sandbox_backend` — generates a Seatbelt SBPL profile
+  (macOS) or applies a Landlock ruleset in a `pre_exec` hook (Linux) that confines
+  writes to `workspace_root` (+ temp) and denies network by default, with safe
+  degradation (no OS backend ⇒ bash/network must escalate, never silently run).
+  Input is one hard-coded `workspace_root` + `allow_network: bool`.
+
+`alan-agent-engine` does **not** depend on `alan-kernel`. `bash` runs as a host
+subprocess and sees the host filesystem, not the namespace.
+
+The trigger for this work is the product intuition: "mount host dirs into the
+namespace, and the agent is structurally isolated — no seatbelt needed." That is
+where the design must be careful.
+
+## The Core Thesis
+
+A namespace confines a process **only if every resource access goes through it**.
+In real Plan 9 this holds because the kernel mediates all syscalls. Hosted inside
+macOS/Linux, the host kernel does not know our namespace, and a native subprocess
+issues raw host syscalls that bypass aP entirely. So:
+
+- aP file tools → confined by the **namespace** (in-process, already true).
+- `bash` / native subprocess → confined only by an **OS sandbox** (Seatbelt/
+  Landlock), never by the namespace.
+
+The fix is not to pick one. It is to drive both from one declaration:
+
+```
+                 ┌──────────────────────────────┐
+                 │   MOUNT DECLARATION LIST      │   ← single source of truth
+                 │   (built at session assembly, │      (human-declared)
+                 │    in the `alan` comp. root)  │
+                 │                               │
+                 │   /mnt/project → HostDir(RW,  │
+                 │                  /Users/…/proj)│
+                 │   /agent       → AgentFs      │   (virtual, no host path)
+                 │   /mnt/llm     → LlmFs        │   (virtual, no host path)
+                 └───────────────┬───────────────┘
+                                 │
+                 ┌───────────────┴───────────────┐
+                 ▼                               ▼
+      ┌────────────────────┐          ┌────────────────────────┐
+      │   NAMESPACE (aP)   │          │  SANDBOX MANIFEST       │
+      │   MountFs enforces │          │  SandboxSpec {          │
+      │   Access in-proc.  │          │    writable_roots,      │
+      │                    │          │    read_denylist,       │
+      │  ALL mounts appear │          │    network }            │
+      │  (virtual + host)  │          │  ← only HOST-backed     │
+      └─────────┬──────────┘          │    entries contribute   │
+                │                     └───────────┬────────────┘
+                ▼                                 ▼
+      aP file tools                     Seatbelt / Landlock
+      (read/write/edit)                 confining `bash`
+```
+
+Virtual mounts (`/agent`, `/mnt/llm`) contribute nothing to the sandbox manifest —
+which is exactly right, because `bash` cannot see them anyway. No special-casing.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make the namespace the single policy source; make the OS sandbox a *projection*
+  of it, so the two enforcement mechanisms agree by construction.
+- Make "mount a local directory" a real capability (via `HostDirFs`).
+- Keep an honest, precise statement of what isolation the agent actually has.
+
+**Non-Goals**
+
+- Make the namespace *replace* the OS sandbox (it cannot, for native subprocesses).
+- Full read isolation at landing (deferred; see Decision 3 and 6).
+- A unified path space between aP tools and `bash` (that is reification — future).
+- Agent-requestable mounts at landing (future escalation feature).
+
+## Decisions
+
+### D1. Explore, not a single proposal
+
+The prerequisite (`HostDirFs`) does not exist and the namespace↔sandbox relation
+was not yet a fixed contract. Writing this as one implementable proposal would
+freeze unresolved boundaries into tasks. So this change is exploratory framing; it
+sequences P1/P2/P3 as separate changes.
+
+### D2. Projection now (A), reification later (B, Linux-only)
+
+Two ways to relate the sandbox to the namespace:
+
+| Axis                | A — Projection                          | B — Reification                                   |
+|---------------------|-----------------------------------------|---------------------------------------------------|
+| Mechanism           | Derive Seatbelt/Landlock rules from     | Materialize the namespace as a real per-process   |
+|                     | host-backed mounts; `bash` runs on      | FS view (Linux mount ns + bind mounts / FUSE);    |
+|                     | real host paths                         | `bash` literally sees `/mnt/project`              |
+| Path space          | Split (aP sees `/mnt/project`, bash     | Unified                                           |
+|                     | sees `/Users/…/proj`)                   |                                                   |
+| Read isolation      | Not by default (see D3)                 | Free — an empty mount ns sees only what's mounted |
+| Reuse of built code | Full — `sandbox_backend` unchanged,     | Discards the Landlock path; builds a container    |
+|                     | only its *input* changes                | runtime (user ns + rootfs bind set) — bubblewrap  |
+|                     |                                         | class, its own project                            |
+| Platforms           | macOS + Linux                           | Linux only (mac has no unprivileged bind mount;   |
+|                     |                                         | FUSE on mac is impractical)                       |
+
+**Decision: land A on both platforms; record B as the future Linux path to full
+read isolation, sequenced as its own change.** A's real change is a single seam:
+the sandbox's *input* moves from `workspace_root` to a namespace-derived
+`SandboxSpec`. The "one table, two enforcements" thesis already holds under A.
+
+### D3. The reads axis
+
+The projection decides three things: writable paths, network, **readable paths**.
+Writes and network are already confined. Reads are `(allow default)` today, so a
+native subprocess can read `~/.ssh`, `~/.aws`, the `~/.alan` secret store,
+keychains. That contradicts a naive "the agent is isolated" claim.
+
+Options weighed: (a) leave reads open; (b) deny-by-default reads (only mounted
+paths readable) — the faithful choice, but Landlock is an **allow-list** model so
+"broad-minus-a-few" is unexpressible, and locking reads breaks native tooling
+(dyld, `/usr/bin`, locale); (c) reads broad but a **sensitive-read denylist** —
+Seatbelt can `deny file-read* (subpath …)`, Landlock cannot.
+
+**Decision: land (c) where possible.** macOS (Seatbelt) gets a sensitive-read
+denylist. Linux (Landlock) is limited to write+network isolation short-term. Full
+read isolation waits for B (a mount ns exposes only what's mounted, giving (b) for
+free — the right mechanism, not a fight with Landlock's allow-list model).
+
+Rationale that keeps read isolation off the launch-blocker list: **with network
+denied, the marginal value of read isolation is low.** Exfiltration needs
+read *and* an outbound channel; write+network confinement already removes the
+channel. Reading a secret with nowhere to send it is a much smaller loss.
+
+### D4. Single source = the mount *declaration list*; strict layering
+
+The projection must **not** introspect `Namespace` to recover host paths — the
+namespace records none, and teaching `alan-kernel` about host paths would leak
+host concerns into an abstraction that depends only on aP.
+
+Instead, the `alan` composition root (which assembles the namespace) produces two
+things from one declaration list:
+
+- the namespace: `mount_host("/mnt/project", HostDirFs::new(host_path), RW)`;
+- the manifest: append `(host_path, RW)`.
+
+The projection `manifest → SandboxSpec` lives in `alan`. Result: `alan-kernel`
+never learns host paths; `alan-agent-engine` never depends on `alan-kernel`; its
+`Sandbox::new` simply takes `SandboxSpec` instead of `workspace_root`. Written
+once at the declaration site, projected twice; never reconstructed after the fact.
+
+### D5. Threat model — who can mount
+
+The isolation claim rests entirely on the agent being unable to expand its own
+namespace. If the agent had a `mount` tool it could `mount_host("/", RW)` and the
+isolation is theater. A mount is an authorization act (granting access to a host
+path) and must be authorized outside the agent's control.
+
+**Decision:**
+- **Landing:** mounts are human/config-declared at namespace assembly. The agent
+  has **no** mount tool. The manifest is fixed for the session (changeable only by
+  human action). The existing `workspace_root` is generalized to the **seed entry**
+  of the manifest — not a special case, just the first, default host mount.
+- **Future (P3):** an agent-requestable `mount` routed through the existing
+  `PolicyEngine` as a `Yield` escalation, so each new host-path grant is
+  human/reviewer-approved — reusing the escalation machinery, semantically correct
+  (mount = authorization = escalate).
+
+### D6. Sequencing
+
+```
+P1  Sandbox input refactor          workspace_root ─▶ SandboxSpec (manifest w/ 1 seed entry)
+    (pure, zero behavior change)     welds the "two projections" seam; no FS semantics touched
+        │                            no HostDirFs needed — workspace IS the seed mount
+        ▼
+P2  HostDirFs + mount_host           host-backed aP FileServer; declaration records (host_path, access)
+    (real "mount a local dir")       manifest grows to N entries; flows into both projections
+        │
+        ▼
+P3+ Hardening & fidelity            macOS Seatbelt sensitive-read denylist (D3/c)
+                                     agent-requestable mount via PolicyEngine escalation (D5)
+                                     Linux reification for full read isolation (D2/B)
+```
+
+P1 first is the risk reducer: the seam is welded and tested with **zero behavior
+change** before any filesystem semantics move. P2 then only adds manifest entries;
+both projection paths are already in place.
+
+## The honest isolation narrative
+
+State it exactly, so the docs never over-claim:
+
+- **Write + network isolation** — both platforms, at landing (P1/P2).
+- **Sensitive-read isolation** — macOS first (Seatbelt denylist, P3).
+- **Full read isolation** — arrives with Linux reification (B), a later change.
+
+"Namespace instead of sandbox" is false for native subprocesses. "One declaration
+list projected into namespace enforcement *and* sandbox enforcement" is the true,
+buildable statement.
+
+## Open questions (for the downstream proposals, not blockers here)
+
+- `SandboxSpec.read_denylist` default contents (`~/.ssh`, `~/.aws`, `~/.alan`
+  secrets, keychains, browser profiles) — enumerated in P3.
+- Per-invocation re-derivation: each `bash` spawn builds its `SandboxSpec` from the
+  current manifest at spawn time (natural, since each run is a fresh confined
+  subprocess) — confirm in P1.
+- Interaction with the existing `.git`/`.alan`/`.agents` protected-subpath residual
+  gap: the workspace seed mount stays RW and the path-guard parser story is
+  unchanged — verify no regression in P1.
+- Reification (B) scope when it comes: unprivileged user namespaces are disabled on
+  some distros; a rootfs bind-mount set (`/bin`, `/usr`, `/lib`, `/dev`, `/proc`,
+  `resolv.conf`) is required for binaries to run. Treat as a container-runtime-class
+  effort, not a flag.

--- a/openspec/changes/define-namespace-driven-sandbox/proposal.md
+++ b/openspec/changes/define-namespace-driven-sandbox/proposal.md
@@ -1,0 +1,90 @@
+## Why
+
+Alan hosts an agent as a **process-level OS inside the host OS**: you type `alan`
+in a macOS/Linux terminal and enter an environment with its own shell and file
+namespace. The next step in that vision is to `mount` real host directories (and,
+later, programs) into the namespace under Plan 9 semantics, so the agent reaches
+host resources through the namespace rather than through ambient host access.
+
+The appeal is that isolation would then be **structural**: the agent can only
+touch what is mounted, so we would not need a separate OS sandbox layer. That
+intuition is half right and half a trap, and this change exists to pin down which
+half is which before we build.
+
+Today two worlds are disjoint:
+
+- **The namespace world** (`alan-kernel`: `Namespace`, `MountFs`) enforces access
+  *in-process* over aP file operations — a read-only mount cannot be written. But
+  every mounted `FileServer` is virtual (`MemFs`, `AgentFs`, `ProcFs`, `SrvFs`).
+  There is **no host-directory-backed file server**, so "mount a local directory"
+  is not yet a real capability.
+- **The sandbox world** (`alan-agent-engine`: `sandbox_backend`) already enforces
+  confinement *at the OS level* for the `bash` / native-subprocess path — Seatbelt
+  on macOS, Landlock+seccomp on Linux, with safe degradation. But its input is a
+  single hard-coded `workspace_root` plus one `allow_network` boolean. It knows
+  nothing about the namespace.
+
+The key realization: **the agent's tools live in two different path spaces.** aP
+file tools (read/write/edit) see the namespace (`/proc`, `/agent`, `/mnt/llm`,
+mounted host dirs); `bash` is a host-native subprocess that sees the real host
+filesystem and cannot see the namespace at all. Plan 9 does not have this split
+because its own `bash` uses the namespace; here `bash` is a host binary. So a
+namespace **cannot by itself** confine a native subprocess — that still needs an
+OS sandbox. The two are not alternatives; they are two enforcement mechanisms
+that should agree, driven from the same source of truth.
+
+## What Changes
+
+**This is an explore-stage framing document, not an implementable change.** It
+records the settled design of "namespace-driven sandbox rule generation" and
+sequences the concrete proposals that follow. No code lands under this change-id;
+each sequenced proposal (P1/P2/P3) is its own OpenSpec change.
+
+The thesis it fixes: a single **mount declaration list** is the source of truth,
+and it projects into two enforcement mechanisms —
+
+1. the **namespace** (in-process aP enforcement for file tools), and
+2. a **sandbox manifest** (`SandboxSpec`) that the OS sandbox enforces for native
+   subprocesses.
+
+Landing path is **projection** (derive OS-sandbox rules from host-backed mounts),
+reused on both platforms. Full read isolation via **reification** (a real
+per-process filesystem view) is recorded as a future, Linux-only direction.
+
+Sequenced downstream proposals:
+
+- **P1 — Sandbox input refactor (pure, zero behavior change).** Replace
+  `Sandbox`'s `workspace_root: PathBuf` with a `SandboxSpec { writable_roots,
+  read_denylist, network }` seeded from a single-entry manifest (the workspace).
+  Establishes the "two projections" seam without touching any file-system
+  semantics. Lowest risk; lands first.
+- **P2 — `HostDirFs` + `mount_host` + multi-entry manifest.** A host-directory-
+  backed aP `FileServer`, and a declaration entry point that installs it into the
+  namespace *and* records `(host_path, access)` into the manifest. "Mount a local
+  directory" becomes real and flows into both projections at once.
+- **P3+ — hardening & fidelity.** macOS Seatbelt sensitive-read denylist;
+  agent-requestable `mount` routed through the `PolicyEngine` as an escalation;
+  Linux reification for full read isolation.
+
+## Capabilities
+
+### New Capabilities
+
+- None land under this change. It is exploratory framing; capabilities are defined
+  by the downstream P1/P2/P3 changes it sequences.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Builds on `define-plan9-kernel-substrate` (aP protocol, `Namespace`, `MountFs`)
+  and the existing `alan-agent-engine` `sandbox_backend` (Seatbelt/Landlock).
+- Preserves layering: `alan-kernel` stays ignorant of host paths;
+  `alan-agent-engine` stays hosting-agnostic (no dependency on `alan-kernel`). The
+  projection wiring lives only in the `alan` composition root.
+- Relates to ADR-0024 (the Plan 9 kernel model). Makes the "agent isolated inside
+  Alan OS" claim precise and honest rather than aspirational.
+- Non-goal: this does not make the namespace *replace* the OS sandbox. It makes
+  them agree by projecting both from one declaration list.

--- a/openspec/changes/define-namespace-driven-sandbox/specs/namespace-sandbox-projection/spec.md
+++ b/openspec/changes/define-namespace-driven-sandbox/specs/namespace-sandbox-projection/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: One mount declaration list projects into two enforcement mechanisms
+Alan OS SHALL treat a single **mount declaration list**, assembled at session
+startup, as the source of truth for what a hosted agent may touch. From that one
+list the system SHALL derive two enforcement surfaces: (1) the **namespace**
+(`alan-kernel`), which enforces `Access` in-process over aP file operations, and
+(2) a **sandbox manifest** (`SandboxSpec`), which the OS sandbox
+(Seatbelt/Landlock) enforces over native subprocesses (`bash`). Both surfaces
+SHALL be projections written at the declaration site, never reconstructed by
+introspecting one surface to rebuild the other. Only host-backed declarations
+(those carrying a real `(host_path, access)`) SHALL contribute to the sandbox
+manifest; purely virtual mounts SHALL contribute nothing, because a native
+subprocess cannot see them.
+
+#### Scenario: A host directory is declared once, projected twice
+- **WHEN** a host directory is declared into the mount list with write access
+- **THEN** it appears in the namespace as a writable aP mount
+- **AND** its `host_path` appears in the sandbox manifest as a writable root
+- **AND** the OS sandbox confining `bash` permits writes there and denies writes
+  outside the manifest's writable roots
+
+#### Scenario: A virtual mount does not reach the OS sandbox
+- **WHEN** a virtual file server (e.g. `/agent`, `/mnt/llm`) is mounted
+- **THEN** it is reachable by aP file tools through the namespace
+- **AND** it produces no rule in the sandbox manifest, because a native
+  subprocess has no host path for it to see
+
+#### Scenario: The namespace does not replace the OS sandbox
+- **WHEN** a native subprocess (`bash`) runs
+- **THEN** its confinement comes from the OS sandbox derived from the manifest,
+  not from the namespace, which it cannot see
+- **AND** the two enforcement surfaces agree because both derive from one list
+
+### Requirement: The projection preserves crate layering
+Deriving the sandbox manifest from the mount list SHALL NOT couple the kernel to
+host concerns or the agent engine to the kernel. `alan-kernel` SHALL remain
+ignorant of host filesystem paths (it records only aP path → server + `Access`).
+`alan-agent-engine` SHALL remain hosting-agnostic and SHALL NOT depend on
+`alan-kernel`; its sandbox SHALL accept a `SandboxSpec` value rather than
+reaching for a namespace. The projection wiring SHALL live only in the `alan`
+composition root that assembles the session.
+
+#### Scenario: Kernel stays host-agnostic
+- **WHEN** the namespace is assembled
+- **THEN** `alan-kernel` stores no `host_path`, only aP paths, servers, and access
+- **AND** host provenance for a mount is recorded in the declaration list held by
+  the composition root, not in the namespace
+
+#### Scenario: Engine takes a spec, not a namespace
+- **WHEN** the agent engine confines a subprocess
+- **THEN** it consumes a `SandboxSpec { writable_roots, read_denylist, network }`
+- **AND** it has no dependency on `alan-kernel`
+
+### Requirement: Mounts are authorized outside the agent's control
+Because a mount grants access to a host path, the agent SHALL NOT be able to
+expand its own namespace at landing. Mounts SHALL be human/config-declared at
+session assembly; the agent SHALL have no mount tool, and the manifest SHALL be
+fixed for the session absent human action. The existing workspace SHALL be
+modeled as the seed (first, default) host-backed entry of the manifest, not a
+special case. Any future agent-requested mount SHALL be routed through the
+`PolicyEngine` as an escalation and approved by a human/reviewer before taking
+effect.
+
+#### Scenario: The agent cannot mount
+- **WHEN** an agent attempts to broaden its own access
+- **THEN** no tool exists for it to add a host mount
+- **AND** its reachable host paths remain exactly those declared by a human
+
+#### Scenario: The workspace is the seed mount
+- **WHEN** a session starts with only a workspace
+- **THEN** the manifest contains one host-backed entry (the workspace, RW)
+- **AND** behavior is identical to the prior single `workspace_root` confinement
+
+#### Scenario: A future mount request escalates
+- **WHEN** the agent-requestable mount feature exists and an agent requests a new
+  host mount
+- **THEN** the request surfaces as a `PolicyEngine` escalation (a `Yield` event)
+- **AND** the mount takes effect only after human/reviewer approval

--- a/openspec/changes/define-namespace-driven-sandbox/tasks.md
+++ b/openspec/changes/define-namespace-driven-sandbox/tasks.md
@@ -1,0 +1,32 @@
+# Tasks
+
+This is an explore-stage framing change: its "tasks" are to spin the sequenced
+proposals out as their own OpenSpec changes. No application code lands here.
+
+## 1. Spin out downstream changes
+
+- [ ] 1.1 Create change `refactor-sandbox-spec-input` (P1): replace
+  `Sandbox`'s `workspace_root: PathBuf` with `SandboxSpec { writable_roots,
+  read_denylist, network }` seeded from a single-entry manifest (the workspace).
+  Pure refactor, zero behavior change; welds the two-projection seam.
+- [ ] 1.2 Create change `add-host-dir-file-server` (P2): `HostDirFs` (host-backed
+  aP `FileServer`) + `mount_host` declaration entry point that records
+  `(host_path, access)` into the manifest + multi-entry projection in `alan`.
+- [ ] 1.3 Create change(s) for P3+ hardening: macOS Seatbelt sensitive-read
+  denylist; agent-requestable `mount` via `PolicyEngine` escalation; (later,
+  separately) Linux reification for full read isolation.
+
+## 2. Carry the framing forward
+
+- [ ] 2.1 Ensure P1's proposal references this design's Decision D4 (layering) and
+  D6 (P1 = zero behavior change).
+- [ ] 2.2 Ensure P2's proposal references D5 (mounts human-declared only at
+  landing; workspace = seed entry).
+- [ ] 2.3 Keep the "honest isolation narrative" (write+network now, sensitive-read
+  macOS next, full read isolation with reification) consistent across P1/P2/P3
+  proposal and user-facing docs.
+
+## 3. Archive
+
+- [ ] 3.1 Archive this framing change once P1 and P2 are proposed and the
+  relationship it fixes is captured in their design docs.

--- a/openspec/changes/introduce-alan-shell/tasks.md
+++ b/openspec/changes/introduce-alan-shell/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Prerequisites
 
-- [ ] 1.1 aP protocol + namespace with `/proc` available
+- [x] 1.1 aP protocol + namespace with `/proc` available
   (`define-plan9-kernel-substrate`).
 
 ## 2. Crate skeleton
 
-- [ ] 2.1 Add `alan-shell` depending only on `alan-ap` (no server/backend deps).
-- [ ] 2.2 Add a `dependency_boundary` test enforcing the aP-only rule.
+- [x] 2.1 Add `alan-shell` depending only on `alan-ap` (no server/backend deps).
+- [x] 2.2 Add a `dependency_boundary` test enforcing the aP-only rule.
 
 ## 3. Generic builtins
 
-- [ ] 3.1 Implement list/walk, `cat` (open+read), `echo >`/write, `tail`
+- [x] 3.1 Implement list/walk, `cat` (open+read), `echo >`/write, `tail`
   (blocking watch from an offset), and `spawn`.
-- [ ] 3.2 Route control to `ctl` writes; add no agent-specific command or
+- [x] 3.2 Route control to `ctl` writes; add no agent-specific command or
   `attach` sugar.
 
 ## 4. Stdio driver and concurrency
@@ -23,13 +23,13 @@
 
 ## 5. Milestone demos
 
-- [ ] 5.1 M1: against an echo file server, type input and see it echoed back
+- [x] 5.1 M1: against an echo file server, type input and see it echoed back
   through files (no LLM).
 - [ ] 5.2 M2: against `alan-agentfs` + `alan-llmfs`, talk to a real agent and see
   the streamed response — using only generic builtins.
 
 ## 6. Verification
 
-- [ ] 6.1 Tests for builtins against an in-memory aP file server.
+- [x] 6.1 Tests for builtins against an in-memory aP file server.
 - [ ] 6.2 Run `just verify`.
-- [ ] 6.3 Run `openspec validate introduce-alan-shell --strict`.
+- [x] 6.3 Run `openspec validate introduce-alan-shell --strict`.

--- a/openspec/changes/refactor-engine-namespace-native/tasks.md
+++ b/openspec/changes/refactor-engine-namespace-native/tasks.md
@@ -10,9 +10,12 @@
 
 ## 2. Namespace handle for the engine (D1)
 
-- [ ] 2.1 Present the kernel namespace as one aP `FileServer` (a thin `MountFs`
+- [x] 2.1 Present the kernel namespace as one aP `FileServer` (a thin `MountFs`
   over `alan-kernel::Namespace`) so `/mnt/llm`, `/proc`, `/agent/<pid>` resolve
-  uniformly through one root handle.
+  uniformly through one root handle. Done in `alan-kernel::MountFs`: per-fid it is
+  either a synthetic namespace dir (lists child mount points) or a backing node
+  forwarded through `Resolved::call` (mount access enforced). Unblocks the shell's
+  path-resolution P1s (#577).
 - [ ] 2.2 Add the namespace-handle environment to `RuntimeLoopState`, replacing
   the `provider` and `tools` fields. TDD against an in-memory root (MemFs +
   mounted servers).

--- a/openspec/changes/refactor-sandbox-spec-input/.openspec.yaml
+++ b/openspec/changes/refactor-sandbox-spec-input/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/refactor-sandbox-spec-input/design.md
+++ b/openspec/changes/refactor-sandbox-spec-input/design.md
@@ -1,0 +1,93 @@
+## Context
+
+`Sandbox` (`crates/agent-engine/src/tools/sandbox.rs`) holds
+`{ workspace_root: PathBuf, backend_override: Option<SandboxBackendKind> }`. Its
+`build_confined_command` calls `sandbox_backend::seatbelt_profile(&self.workspace_root,
+allow_network)` (macOS) or applies `apply_landlock(&workspace_root, allow_network)`
+in a `pre_exec` hook (Linux). Both hard-code confinement to the one workspace path
+(each internally also adds temp dirs and standard writable device files).
+
+Production constructors:
+
+- `crates/agent-engine/src/tools/context.rs:113` —
+  `Sandbox::new(self.require_workspace_root()?.to_path_buf())`
+- `crates/agent-engine/src/runtime/tool_orchestrator.rs:1184` —
+  `Sandbox::new(workspace_root.clone())`
+
+Test constructors: `Sandbox::new` / `Sandbox::with_backend(workspace_root, kind)`
+across `sandbox_tests.rs` (~30 sites).
+
+The `define-namespace-driven-sandbox` explore established that the OS sandbox
+should confine from a **projected manifest**, not a lone path. This change moves
+that shape into place with no behavior change.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Replace the sandbox's `workspace_root` input with a `SandboxSpec` value.
+- Keep the emitted Seatbelt profile / Landlock ruleset byte-for-byte identical
+  when the spec carries one writable root and an empty read denylist.
+- Leave every existing invariant intact (safe degradation, protected-subpath
+  parser, per-call approved-network override).
+
+**Non-Goals**
+
+- `HostDirFs`, `mount_host`, or any multi-entry manifest (P2).
+- Populating `read_denylist` with real sensitive paths (P3).
+- Any dependency from `alan-agent-engine` on `alan-kernel` (the projection that
+  builds a `SandboxSpec` from a namespace lives in the `alan` composition root,
+  future work — here the spec is still seeded from the workspace).
+- Changing network semantics.
+
+## Decisions
+
+- **`SandboxSpec` shape.**
+  ```
+  pub struct SandboxSpec {
+      pub writable_roots: Vec<PathBuf>,   // seed: [workspace]
+      pub read_denylist: Vec<PathBuf>,    // seed: []
+      pub network: NetworkPosture,        // seed: Deny (today's default)
+  }
+  ```
+  `NetworkPosture` captures only the *default* posture. The existing
+  per-invocation approved-network override (an approved Network capability runs
+  the confined command with network allowed) is unchanged and stays a per-call
+  argument, not a spec field.
+
+- **`writable_roots`, not one root.** `seatbelt_profile` and `apply_landlock`
+  take `&[PathBuf]` writable roots. Temp dirs and device files they already add
+  stay internal. Emitting rules for a single-element slice must produce exactly
+  the current output — locked by a test asserting equality with the prior
+  single-`workspace_root` profile string.
+
+- **`read_denylist` plumbed but empty.** The parameter threads through to the
+  backends now (Seatbelt can emit `deny file-read* (subpath …)`; Landlock cannot
+  and ignores it) so P3 needs no signature churn, but it is empty at P1, so no
+  read rule is emitted and behavior is unchanged. Document the Landlock
+  limitation inline.
+
+- **Back-compat shim.** Keep `Sandbox::new(workspace_root: PathBuf)` as
+  `Self::from_spec(SandboxSpec::seed(workspace_root))`. Add `Sandbox::from_spec`
+  and `Sandbox::from_spec_with_backend` (test-only). This lets most call sites and
+  all tests stay one-line while the internal representation becomes the spec.
+
+- **Seed constructor.** `SandboxSpec::seed(workspace_root)` builds
+  `{ writable_roots: vec![workspace_root], read_denylist: vec![], network:
+  Deny }` — the single place that encodes "the workspace is the seed entry of the
+  manifest," the concept P2 generalizes.
+
+- **The workspace_root many call paths still need.** The path-guard parser and
+  path canonicalization in `sandbox.rs` reference `self.workspace_root` widely.
+  Keep a `workspace_root()` accessor returning `writable_roots[0]` (the seed) so
+  the parser code is untouched — P1 does not refactor the parser, only the OS
+  backend input. This preserves the protected-subpath behavior verbatim.
+
+## Verification strategy
+
+- Add a test: for a single writable root, the generated Seatbelt profile equals
+  the string the old `seatbelt_profile(&workspace_root, …)` produced (golden
+  comparison), proving zero behavior change.
+- Existing `sandbox_backend` OS-enforcement tests (macOS write boundary, Linux
+  write boundary, Linux network) run unchanged and must pass.
+- `just verify` (fmt + lint + test + mock smoke) is the gate.

--- a/openspec/changes/refactor-sandbox-spec-input/proposal.md
+++ b/openspec/changes/refactor-sandbox-spec-input/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+`define-namespace-driven-sandbox` fixed the thesis: one mount declaration list
+projects into two enforcement surfaces — the namespace (in-process aP) and a
+**sandbox manifest** (`SandboxSpec`) the OS sandbox enforces for native
+subprocesses. This change (P1 in that explore's sequencing) welds the second
+seam and nothing else.
+
+Today `alan-agent-engine`'s `Sandbox` takes a single hard-coded
+`workspace_root: PathBuf`, and `sandbox_backend::seatbelt_profile` /
+`apply_landlock` derive their write-confinement from that one path. The
+confinement boundary is therefore wired to "the workspace," not to a projected
+set of allowed roots. Before host directories can be mounted (P2), the sandbox
+must accept its confinement as a **value projected from a manifest** rather than
+a lone path.
+
+P1 does this as a **pure refactor with zero behavior change**: the manifest has
+exactly one seed entry (the workspace), so the generated Seatbelt/Landlock rules
+are byte-for-byte what they are today. The point is to move the *shape* of the
+input, not the behavior, so P2 only has to add manifest entries.
+
+## What Changes
+
+- Introduce `SandboxSpec { writable_roots: Vec<PathBuf>, read_denylist:
+  Vec<PathBuf>, network: NetworkPosture }` in `alan-agent-engine` — the value the
+  OS sandbox confines from. At this stage `writable_roots = [workspace]`,
+  `read_denylist = []`, `network = Deny` (today's defaults).
+- Change `Sandbox` to hold a `SandboxSpec` instead of a bare `workspace_root`.
+  Add `Sandbox::from_spec(SandboxSpec)`; keep `Sandbox::new(workspace_root)` as a
+  thin shim that builds the single-entry seed spec, so callers migrate without
+  behavior change.
+- Generalize `sandbox_backend::seatbelt_profile` and `apply_landlock` to confine
+  writes to a **set of writable roots** (plus the temp dirs they already add) and
+  to honor a `read_denylist` (empty here) — instead of a single `workspace_root`.
+  With one root the emitted profile/ruleset is unchanged.
+- Migrate the two production constructors (`tools::context` builder and
+  `runtime::tool_orchestrator`) and the test helpers to the new shape. Retain
+  `with_backend` (test-only) on the spec-based constructor.
+- Preserve every existing invariant: safe degradation, protected-subpath parser,
+  per-invocation approved-network override, `.git`/`.alan`/`.agents` handling.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `os-sandbox-enforcement`: the confinement input is generalized from a single
+  `workspace_root` to a `SandboxSpec` (writable roots + read denylist + network
+  posture) projected from the mount manifest, with the workspace as the seed
+  entry. Enforcement semantics are unchanged when the spec holds one writable
+  root and an empty denylist.
+
+## Impact
+
+- Scope is confined to `alan-agent-engine` (`tools::sandbox`,
+  `tools::sandbox_backend`, `tools::context`, `runtime::tool_orchestrator`, and
+  their tests). No new crate dependencies; `alan-agent-engine` still does not
+  depend on `alan-kernel`.
+- Behavior is provably unchanged: existing `sandbox_backend` tests
+  (Seatbelt/Landlock write-boundary and network) must pass untouched, and the
+  single-root spec must emit the same profile the `workspace_root` path emits
+  today.
+- Unblocks P2 (`add-host-dir-file-server`): a multi-entry manifest flows into
+  this same `SandboxSpec` with no further sandbox-backend changes.
+- Honors `define-namespace-driven-sandbox` design D4 (layering: the projection
+  lives in the composition root; the engine only consumes a `SandboxSpec`) and D6
+  (P1 = zero behavior change, seam-only).

--- a/openspec/changes/refactor-sandbox-spec-input/specs/os-sandbox-enforcement/spec.md
+++ b/openspec/changes/refactor-sandbox-spec-input/specs/os-sandbox-enforcement/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Confinement input is a projected SandboxSpec
+The OS sandbox SHALL confine a native subprocess from a `SandboxSpec` value —
+writable roots, a read denylist, and a default network posture — rather than a
+single hard-coded workspace path. The spec SHALL be a projection of the mount
+declaration list, with the workspace modeled as the seed (first, default)
+writable entry. When the spec carries exactly one writable root and an empty read
+denylist, the emitted Seatbelt profile and Landlock ruleset SHALL be identical to
+those produced from that path directly (this change is behavior-preserving).
+
+#### Scenario: Single-root spec preserves the current profile
+- **WHEN** a `SandboxSpec` is built with one writable root (the workspace) and an
+  empty read denylist
+- **THEN** the generated Seatbelt profile / Landlock ruleset is byte-for-byte the
+  one produced today from a lone `workspace_root`
+- **AND** no read-deny rule is emitted
+
+#### Scenario: The workspace is the seed writable entry
+- **WHEN** a session confines tool execution with only a workspace
+- **THEN** the spec's writable roots contain exactly the workspace path
+- **AND** enforcement is indistinguishable from the prior single-path confinement
+
+#### Scenario: The read denylist is plumbed but inert at this stage
+- **WHEN** the spec's read denylist is empty
+- **THEN** the backends emit no read-deny rules and reads follow the existing
+  allow-default posture
+- **AND** the denylist parameter still threads to the backends so it can be
+  populated later without changing their signatures
+
+## MODIFIED Requirements
+
+### Requirement: Kernel-enforced confinement independent of command syntax
+When an OS sandbox backend is active, the operating system SHALL enforce
+confinement of filesystem writes to the writable roots of the active sandbox spec
+and control of network access, regardless of how a command is written. With a
+single-entry spec the writable set is exactly the workspace, so the enforced
+boundary is unchanged.
+
+#### Scenario: Internal-write command is confined
+- **WHEN** a command writes outside the spec's writable roots through
+  program-internal logic without an explicit path operand
+- **THEN** the OS sandbox blocks the out-of-writable-roots write
+- **AND** confinement does not depend on parsing the command string
+
+#### Scenario: Network is controlled by the sandbox
+- **WHEN** a confined command attempts network access that the active policy does
+  not permit
+- **THEN** the OS sandbox denies the network access
+- **AND** an approved network call still runs with network permitted while
+  remaining filesystem-confined

--- a/openspec/changes/refactor-sandbox-spec-input/tasks.md
+++ b/openspec/changes/refactor-sandbox-spec-input/tasks.md
@@ -1,0 +1,59 @@
+# Tasks
+
+Pure refactor, zero behavior change. Every step must keep existing sandbox tests
+green; the golden-profile test (1.4) is the proof of no behavior change.
+
+## 1. Introduce SandboxSpec
+
+- [ ] 1.1 Add `SandboxSpec { writable_roots: Vec<PathBuf>, read_denylist:
+  Vec<PathBuf>, network: NetworkPosture }` and `NetworkPosture` (default `Deny`)
+  in `crates/agent-engine/src/tools/sandbox.rs` (or a small `sandbox_spec.rs`
+  submodule).
+- [ ] 1.2 Add `SandboxSpec::seed(workspace_root: PathBuf) -> SandboxSpec`
+  producing `{ writable_roots: vec![workspace_root], read_denylist: vec![],
+  network: Deny }`.
+- [ ] 1.3 Change `Sandbox` to hold a `SandboxSpec`; add `Sandbox::from_spec` and
+  (`#[cfg(test)]`) `Sandbox::from_spec_with_backend`. Keep `Sandbox::new` and
+  `with_backend` as shims delegating to the spec constructors via `seed`.
+- [ ] 1.4 Add an internal `workspace_root()` accessor returning
+  `writable_roots[0]` so the existing path-guard parser / canonicalization code
+  in `sandbox.rs` is untouched.
+
+## 2. Generalize the OS backends to a set of writable roots
+
+- [ ] 2.1 Change `sandbox_backend::seatbelt_profile` to take
+  `writable_roots: &[PathBuf]` (plus the temp dirs it already adds) and a
+  `read_denylist: &[PathBuf]`; emit one `(allow file-write* (subpath …))` per
+  root and, for a non-empty denylist, `(deny file-read* (subpath …))`.
+- [ ] 2.2 Change `apply_landlock` to take `writable_roots: &[PathBuf]`; grant
+  write to each. Accept `read_denylist` for signature parity but document that
+  Landlock's allow-list model cannot express it (ignored at P1).
+- [ ] 2.3 Update `Sandbox::build_confined_command` to pass the spec's writable
+  roots and denylist through. Preserve the per-invocation approved-network
+  override exactly.
+
+## 3. Migrate call sites
+
+- [ ] 3.1 `crates/agent-engine/src/tools/context.rs:113` — keep `Sandbox::new`
+  (shim) or switch to `Sandbox::from_spec(SandboxSpec::seed(root))`; no behavior
+  change.
+- [ ] 3.2 `crates/agent-engine/src/runtime/tool_orchestrator.rs:1184` — same.
+- [ ] 3.3 `crates/agent-engine/src/tools/sandbox_tests.rs` — leave `new` /
+  `with_backend` call sites working via the shims; no test assertion changes.
+
+## 4. Prove zero behavior change
+
+- [ ] 4.1 Add a golden test: for a single writable root, `seatbelt_profile`
+  output equals the pre-refactor single-`workspace_root` profile string.
+- [ ] 4.2 Run the existing OS-enforcement tests unchanged
+  (`seatbelt_enforces_workspace_write_boundary_on_macos`,
+  `landlock_enforces_workspace_write_boundary_on_linux`,
+  `landlock_confines_network_on_linux`) — all must pass.
+- [ ] 4.3 `just verify` (fmt + lint + test + mock smoke) green.
+
+## 5. Close out
+
+- [ ] 5.1 Update `define-namespace-driven-sandbox/tasks.md` item 1.1 to reference
+  this change as landed.
+- [ ] 5.2 Confirm no new dependency edge from `alan-agent-engine` to
+  `alan-kernel` was introduced.


### PR DESCRIPTION
## Why

The agent engine's environment (D1 of `refactor-engine-namespace-native`) and the
shell both need to reach a *whole assembled namespace* through one handle. But a
`Namespace` is a path-addressed mount table, not a `FileServer` — there was no
`FileServer` impl over it. The alan-shell review ([#577](https://github.com/realmorrisliu/Alan/pull/577))
flagged exactly this (two P1s): the shell sends absolute paths to a single
transport, yet `/proc`, `/agent`, `/mnt/llm` are mounts resolved by
`Namespace::resolve_candidates`, so paths only worked in tests that mounted one
server at `/`.

## What

`MountFs` wraps a `Namespace` as one aP `FileServer`, bridging fid-addressing to
path-addressing. Per fid it is either:

- a **synthetic namespace directory** — a path strictly above every mount (`/`,
  `/mnt`); MountFs renders it and lists its child mount points; or
- a **backing node** — a path at/below a mount; every op is forwarded to the
  backing tree through `Resolved::call`, so the mount's access is enforced (a
  read-only mount still cannot be written, and `stat.writable` stays masked).

Walks across a mount delegate to the backing server; union contributors are tried
longest-prefix, most-recent-first; a clunked fid releases the fid bound in the
backing tree too.

## Tests

`crates/kernel/tests/mountfs.rs`: synthetic root listing, walk crossing a mount,
read delegation, spawn through `/proc/clone` across the mount, unmounted →
NotFound, read-only mount denies write-open, nested mount via synthetic parents,
clunk releases. `cargo clippy --workspace -D warnings`, `cargo test --workspace`,
`cargo doc` all green.

## Next

This unblocks #577's path-resolution P1s (wire the shell onto a `MountFs`-rooted
namespace) and is the seam for D2/M2 (the engine reads `/mnt/llm` and writes
`/agent/<pid>` through one namespace handle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)