### PR TITLE
North Star 2/4: finish llmfs and shell file surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,13 @@ dependencies = [
 name = "alan-shell"
 version = "0.1.0"
 dependencies = [
+ "alan-agentfs",
  "alan-ap",
  "alan-kernel",
+ "alan-llm",
+ "alan-llmfs",
  "async-trait",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -1154,14 +1154,14 @@ impl FileServer for LlmFs {
                 Node::GenData(id)
                     if matches!(f.mode, Some(OpenMode::Write | OpenMode::ReadWrite)) =>
                 {
-                    let generation = state.gens.get(&id).cloned();
+                    let generation = state.gens.get(&id).cloned().ok_or(ErrorCode::BadRequest)?;
                     Some((f.write_buf, generation))
                 }
                 _ => None,
             }
         };
 
-        let Some((buf, Some(generation))) = commit else {
+        let Some((buf, generation)) = commit else {
             return Ok(());
         };
 

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -1078,24 +1078,36 @@ impl FileServer for LlmFs {
     }
 
     async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
-        let node = self.node_of(fid)?;
         // Resolve the qid and length under the lock; for the `events` stream, clone
         // it out and await its length *without* the lock held.
-        let (qid, len) = {
+        let (qid, len, writable) = {
             let state = self.state.lock().unwrap();
+            let (node, opened_events) = if fid == Fid::ROOT {
+                (Node::Root, None)
+            } else {
+                let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
+                (f.node.clone(), f.events.clone())
+            };
             let qid = state.qid(&node);
             let len = match &node {
-                Node::GenEvents(id) => match state.gens.get(id) {
-                    Some(g) => Len::Events(g.events.clone()),
-                    None => Len::Now(0),
-                },
+                Node::GenEvents(id) => {
+                    if let Some(events) = opened_events {
+                        Len::Events(events)
+                    } else {
+                        match state.gens.get(id) {
+                            Some(g) => Len::Events(g.events.clone()),
+                            None => Len::Now(0),
+                        }
+                    }
+                }
                 other => Len::Now(
                     computed_bytes(&state, other)
                         .map(|b| b.len() as u64)
                         .unwrap_or(0),
                 ),
             };
-            (qid, len)
+            let writable = is_writable(&node);
+            (qid, len, writable)
         };
         let length = match len {
             Len::Now(n) => n,
@@ -1105,7 +1117,7 @@ impl FileServer for LlmFs {
             name: String::new(),
             qid,
             length,
-            writable: is_writable(&node),
+            writable,
         })
     }
 

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -381,6 +381,7 @@ struct Connection {
     generation_starts: AtomicU64,
     total_tokens: AtomicU64,
     total_cost_microusd: AtomicU64,
+    meter_version: AtomicU32,
 }
 
 /// Agent-visible metadata for a callable Connection.
@@ -435,13 +436,22 @@ impl Connection {
                 .compare_exchange(current, current + 1, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
+                self.meter_version.fetch_add(1, Ordering::Relaxed);
                 return Ok(());
             }
         }
     }
 
     fn record_token_delta(&self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
         self.total_tokens.fetch_add(delta, Ordering::Relaxed);
+        self.meter_version.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn meter_version(&self) -> u32 {
+        self.meter_version.load(Ordering::Relaxed)
     }
 
     fn meter_doc(&self, connection: &str) -> String {
@@ -540,6 +550,7 @@ impl Generation {
             .record_token_delta(next_total.saturating_sub(previous_total));
         self.version.fetch_add(1, Ordering::Relaxed);
     }
+
     /// Move to a terminal (or running) status unless already terminal, bumping the
     /// version. Returns whether the transition happened.
     fn advance(&self, to: GenStatus) -> bool {
@@ -592,6 +603,9 @@ struct LlmFid {
     node: Node,
     /// The open mode, once opened. `None` means walked-but-not-opened.
     mode: Option<OpenMode>,
+    /// For an opened `events` fid: keep the stream reachable even if the owning
+    /// Generation is later removed from the connection listing.
+    events: Option<Stream>,
     /// For a fid that opened a `clone` file: the allocated Generation id.
     clone_gen: Option<String>,
     /// Buffered request document for a `data` fid (commit-on-clunk).
@@ -603,6 +617,7 @@ impl LlmFid {
         Self {
             node,
             mode: None,
+            events: None,
             clone_gen: None,
             write_buf: Vec::new(),
         }
@@ -637,8 +652,12 @@ impl State {
             | Node::Connection(_)
             | Node::ConnectionProvider(_)
             | Node::ConnectionProfile(_)
-            | Node::ConnectionMeter(_)
             | Node::ConnectionCapabilities(_) => self.listing_version,
+            Node::ConnectionMeter(conn) => self
+                .connections
+                .get(conn)
+                .map(|connection| connection.meter_version())
+                .unwrap_or(self.listing_version),
             Node::Root
             | Node::ProvidersDir
             | Node::Provider(_)
@@ -731,15 +750,41 @@ impl LlmFs {
         );
     }
 
-    pub fn unregister_connection(&self, name: &str) {
-        let mut state = self.state.lock().unwrap();
-        if state.connections.remove(name).is_none() {
-            return;
+    pub async fn unregister_connection(&self, name: &str) {
+        let active = {
+            let mut state = self.state.lock().unwrap();
+            if state.connections.remove(name).is_none() {
+                return;
+            }
+            let mut terminal = Vec::new();
+            let mut active = Vec::new();
+            for (id, generation) in &state.gens {
+                if generation.connection_name() != name {
+                    continue;
+                }
+                if generation.status().is_terminal() {
+                    terminal.push(id.clone());
+                } else {
+                    active.push((id.clone(), generation.clone()));
+                }
+            }
+            for id in terminal {
+                state.gens.remove(&id);
+            }
+            state.listing_version += 1;
+            active
+        };
+
+        for (_, generation) in &active {
+            let _ = abort_generation(generation).await;
         }
-        state
-            .gens
-            .retain(|_, generation| generation.connection_name() != name);
-        state.listing_version += 1;
+        if !active.is_empty() {
+            let mut state = self.state.lock().unwrap();
+            for (id, _) in active {
+                state.gens.remove(&id);
+            }
+            state.listing_version += 1;
+        }
     }
 
     fn register_connection_inner(
@@ -765,6 +810,7 @@ impl LlmFs {
                 generation_starts: AtomicU64::new(0),
                 total_tokens: AtomicU64::new(0),
                 total_cost_microusd: AtomicU64::new(0),
+                meter_version: AtomicU32::new(0),
             }),
         );
         // The `connections/` listing changed: bump its qid version so a cached
@@ -925,9 +971,22 @@ impl FileServer for LlmFs {
             reap_terminal_generations(&mut state, conn);
         }
 
+        let opened_events = if let Node::GenEvents(id) = &node {
+            Some(
+                state
+                    .gens
+                    .get(id)
+                    .ok_or(ErrorCode::NotFound)?
+                    .events
+                    .clone(),
+            )
+        } else {
+            None
+        };
         let qid = state.qid(&node);
         if let Some(f) = state.fids.get_mut(&fid) {
             f.mode = Some(mode);
+            f.events = opened_events;
         }
         Ok(qid)
     }
@@ -935,16 +994,16 @@ impl FileServer for LlmFs {
     async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
         // Reads need read authority from a successful read-open (ROOT is the
         // pre-bound anchor and is always readable).
-        let (node, clone_gen) = {
+        let (node, clone_gen, opened_events) = {
             let state = self.state.lock().unwrap();
             if fid == Fid::ROOT {
-                (Node::Root, None)
+                (Node::Root, None, None)
             } else {
                 let f = state.fids.get(&fid).ok_or(ErrorCode::NotFound)?;
                 if !matches!(f.mode, Some(OpenMode::Read | OpenMode::ReadWrite)) {
                     return Err(ErrorCode::NoAccess);
                 }
-                (f.node.clone(), f.clone_gen.clone())
+                (f.node.clone(), f.clone_gen.clone(), f.events.clone())
             }
         };
         // An opened clone fid reads back the allocated Generation id.
@@ -954,7 +1013,9 @@ impl FileServer for LlmFs {
 
         // Stream node: clone the Stream out, then read without holding the lock.
         if let Node::GenEvents(id) = &node {
-            let events = {
+            let events = if let Some(events) = opened_events {
+                events
+            } else {
                 let state = self.state.lock().unwrap();
                 state
                     .gens
@@ -1012,24 +1073,7 @@ impl FileServer for LlmFs {
             }
         };
 
-        // Finalize under the per-Generation lock so this abort and the drain task
-        // cannot interleave: once aborted, no further chunk or `done` record is
-        // written. Aborting a terminal Generation is refused (settled status).
-        {
-            let _guard = generation.finalize.lock().await;
-            if generation.status().is_terminal() {
-                return Err(ErrorCode::BadRequest);
-            }
-            generation
-                .events
-                .append(&event_line(WireStreamEventV1::aborted()))
-                .await;
-            generation.advance(GenStatus::Aborted);
-        }
-        // Wake a running drain task (or a pending provider startup) so it stops
-        // promptly. `notify_one` stores a permit if no waiter is parked yet, so an
-        // abort that arrives before the drain reaches `notified()` is not lost.
-        generation.abort.notify_one();
+        abort_generation(&generation).await?;
         Ok(data.len() as u32)
     }
 
@@ -1369,6 +1413,28 @@ fn reap_terminal_generations(state: &mut State, connection: &str) {
         state.gens.remove(&id);
         state.listing_version += 1;
     }
+}
+
+async fn abort_generation(generation: &Generation) -> Result<(), ErrorCode> {
+    // Finalize under the per-Generation lock so this abort and the drain task
+    // cannot interleave: once aborted, no further chunk or `done` record is
+    // written. Aborting a terminal Generation is refused (settled status).
+    {
+        let _guard = generation.finalize.lock().await;
+        if generation.status().is_terminal() {
+            return Err(ErrorCode::BadRequest);
+        }
+        generation
+            .events
+            .append(&event_line(WireStreamEventV1::aborted()))
+            .await;
+        generation.advance(GenStatus::Aborted);
+    }
+    // Wake a running drain task (or a pending provider startup) so it stops
+    // promptly. `notify_one` stores a permit if no waiter is parked yet, so an
+    // abort that arrives before the drain reaches `notified()` is not lost.
+    generation.abort.notify_one();
+    Ok(())
 }
 
 /// The kind and a server-unique identity key for a node (so distinct connections

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -22,35 +22,443 @@
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use alan_ap::{ErrorCode, Fid, FileKind, FileServer, Offset, OpenMode, Qid, Stat, Stream};
-use alan_llm::{GenerationRequest, LlmProvider, StreamChunk};
+use alan_llm::{
+    CompatibilityTier, GenerationRequest, LlmProvider, Message, MessageRole, ProviderCapabilities,
+    ReasoningControls, ReasoningEffort, StreamChunk, TokenUsage, ToolCall, ToolCallDelta,
+    ToolDefinition, factory::ProviderType,
+};
 use async_trait::async_trait;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex as AsyncMutex, Notify};
 
 /// Cap on a buffered request document, so a hostile writer cannot exhaust the
 /// server before the commit-time validation runs.
 const MAX_DOC_BYTES: usize = 1 << 20; // 1 MiB
+const RETAIN_TERMINAL_GENERATIONS_PER_CONNECTION: usize = 16;
 
-/// The neutral request document written to a Generation's `data` file. Minimal
-/// for this slice; the full versioned wire DTO is deferred. Unknown fields are
-/// rejected so an unsupported request (e.g. `tools`, `temperature`) fails at the
-/// commit boundary instead of silently running a different prompt.
+/// The neutral request document written to a Generation's `data` file.
+///
+/// The versioned DTO is owned by llmfs and mapped into `alan-llm` at the file
+/// server boundary. The unversioned `{system,user}` shape is retained only so
+/// the original M2 skeleton and old callers keep working while Slice A migrates.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RequestDoc {
+    V1(WireRequestDocV1),
+    Legacy(LegacyRequestDoc),
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RequestDoc {
+struct LegacyRequestDoc {
     #[serde(default)]
     system: Option<String>,
     user: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireRequestDocV1 {
+    version: u16,
+    #[serde(default)]
+    system: Option<String>,
+    #[serde(default)]
+    messages: Vec<WireMessage>,
+    #[serde(default)]
+    tools: Vec<WireToolDefinition>,
+    #[serde(default)]
+    temperature: Option<f32>,
+    #[serde(default)]
+    max_tokens: Option<i32>,
+    #[serde(default)]
+    reasoning: WireReasoningControls,
+    #[serde(default)]
+    extra_params: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireMessage {
+    role: WireMessageRole,
+    content: String,
+    #[serde(default)]
+    thinking: Option<String>,
+    #[serde(default)]
+    thinking_signature: Option<String>,
+    #[serde(default)]
+    redacted_thinking: Option<Vec<String>>,
+    #[serde(default)]
+    tool_calls: Option<Vec<WireToolCall>>,
+    #[serde(default)]
+    tool_call_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum WireMessageRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+    Context,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireToolDefinition {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireToolCall {
+    #[serde(default)]
+    id: Option<String>,
+    name: String,
+    arguments: serde_json::Value,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireReasoningControls {
+    #[serde(default)]
+    effort: Option<ReasoningEffort>,
+}
+
+#[derive(Serialize)]
+struct WireStreamEventV1 {
+    version: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    done: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rejected: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aborted: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redacted_thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finish_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_response_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_response_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence_number: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usage: Option<WireTokenUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call: Option<WireToolCallDelta>,
+}
+
+#[derive(Serialize)]
+struct WireTokenUsage {
+    prompt_tokens: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cached_prompt_tokens: Option<i32>,
+    completion_tokens: i32,
+    total_tokens: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning_tokens: Option<i32>,
+}
+
+#[derive(Serialize)]
+struct WireToolCallDelta {
+    index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments_delta: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments: Option<String>,
+}
+
+impl RequestDoc {
+    fn into_generation_request(self) -> Result<GenerationRequest, ()> {
+        match self {
+            RequestDoc::Legacy(doc) => {
+                let mut request = GenerationRequest::new().with_user_message(doc.user);
+                if let Some(system) = doc.system {
+                    request = request.with_system_prompt(system);
+                }
+                Ok(request)
+            }
+            RequestDoc::V1(doc) => doc.into_generation_request(),
+        }
+    }
+}
+
+impl WireRequestDocV1 {
+    fn into_generation_request(self) -> Result<GenerationRequest, ()> {
+        if self.version != 1 || self.messages.is_empty() {
+            return Err(());
+        }
+        Ok(GenerationRequest {
+            system_prompt: self.system,
+            messages: self.messages.into_iter().map(Into::into).collect(),
+            tools: self.tools.into_iter().map(Into::into).collect(),
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            reasoning: ReasoningControls {
+                effort: self.reasoning.effort,
+            },
+            extra_params: self.extra_params.into_iter().collect(),
+        })
+    }
+}
+
+impl From<WireMessage> for Message {
+    fn from(value: WireMessage) -> Self {
+        Self {
+            role: value.role.into(),
+            content: value.content,
+            thinking: value.thinking,
+            thinking_signature: value.thinking_signature,
+            redacted_thinking: value.redacted_thinking,
+            tool_calls: value
+                .tool_calls
+                .map(|tool_calls| tool_calls.into_iter().map(Into::into).collect()),
+            tool_call_id: value.tool_call_id,
+        }
+    }
+}
+
+impl From<WireMessageRole> for MessageRole {
+    fn from(value: WireMessageRole) -> Self {
+        match value {
+            WireMessageRole::System => MessageRole::System,
+            WireMessageRole::User => MessageRole::User,
+            WireMessageRole::Assistant => MessageRole::Assistant,
+            WireMessageRole::Tool => MessageRole::Tool,
+            WireMessageRole::Context => MessageRole::Context,
+        }
+    }
+}
+
+impl From<WireToolDefinition> for ToolDefinition {
+    fn from(value: WireToolDefinition) -> Self {
+        Self {
+            name: value.name,
+            description: value.description,
+            parameters: value.parameters,
+        }
+    }
+}
+
+impl From<WireToolCall> for ToolCall {
+    fn from(value: WireToolCall) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            arguments: value.arguments,
+        }
+    }
+}
+
+impl From<TokenUsage> for WireTokenUsage {
+    fn from(value: TokenUsage) -> Self {
+        Self {
+            prompt_tokens: value.prompt_tokens,
+            cached_prompt_tokens: value.cached_prompt_tokens,
+            completion_tokens: value.completion_tokens,
+            total_tokens: value.total_tokens,
+            reasoning_tokens: value.reasoning_tokens,
+        }
+    }
+}
+
+impl From<&ToolCallDelta> for WireToolCallDelta {
+    fn from(value: &ToolCallDelta) -> Self {
+        Self {
+            index: value.index,
+            id: value.id.clone(),
+            name: value.name.clone(),
+            arguments_delta: value.arguments_delta.clone(),
+            arguments: value.arguments.clone(),
+        }
+    }
+}
+
+impl WireStreamEventV1 {
+    fn empty() -> Self {
+        Self {
+            version: 1,
+            done: None,
+            error: None,
+            rejected: None,
+            aborted: None,
+            text: None,
+            thinking: None,
+            thinking_signature: None,
+            redacted_thinking: None,
+            finish_reason: None,
+            provider_response_id: None,
+            provider_response_status: None,
+            sequence_number: None,
+            usage: None,
+            tool_call: None,
+        }
+    }
+
+    fn done() -> Self {
+        Self {
+            done: Some(true),
+            ..Self::empty()
+        }
+    }
+
+    fn error(message: impl Into<String>) -> Self {
+        Self {
+            error: Some(message.into()),
+            ..Self::empty()
+        }
+    }
+
+    fn rejected() -> Self {
+        Self {
+            rejected: Some(true),
+            ..Self::empty()
+        }
+    }
+
+    fn aborted() -> Self {
+        Self {
+            aborted: Some(true),
+            ..Self::empty()
+        }
+    }
+
+    fn has_payload(&self) -> bool {
+        self.done.is_some()
+            || self.error.is_some()
+            || self.rejected.is_some()
+            || self.aborted.is_some()
+            || self.text.is_some()
+            || self.thinking.is_some()
+            || self.thinking_signature.is_some()
+            || self.redacted_thinking.is_some()
+            || self.finish_reason.is_some()
+            || self.provider_response_id.is_some()
+            || self.provider_response_status.is_some()
+            || self.sequence_number.is_some()
+            || self.usage.is_some()
+            || self.tool_call.is_some()
+    }
+}
+
+fn event_line(event: WireStreamEventV1) -> Vec<u8> {
+    let mut line = serde_json::to_string(&event)
+        .expect("serialize llmfs stream event")
+        .into_bytes();
+    line.push(b'\n');
+    line
 }
 
 /// A callable connection: a provider behind an async lock so a Generation can
 /// hold it across `generate_stream`.
 struct Connection {
     provider: AsyncMutex<Box<dyn LlmProvider>>,
+    provider_name: String,
+    model: Option<String>,
+    credential_ref: Option<String>,
+    capabilities: ProviderCapabilities,
+    limits: ConnectionLimits,
+    generation_starts: AtomicU64,
+    total_tokens: AtomicU64,
+    total_cost_microusd: AtomicU64,
+}
+
+/// Agent-visible metadata for a callable Connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionProfile {
+    pub provider: String,
+    pub model: String,
+    pub credential_ref: String,
+}
+
+impl ConnectionProfile {
+    pub fn new(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        credential_ref: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            model: model.into(),
+            credential_ref: credential_ref.into(),
+        }
+    }
+}
+
+/// Per-Connection llmfs enforcement limits.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConnectionLimits {
+    pub max_generations: Option<u64>,
+}
+
+impl ConnectionLimits {
+    pub fn max_generations(max_generations: u64) -> Self {
+        Self {
+            max_generations: Some(max_generations),
+        }
+    }
+}
+
+impl Connection {
+    fn try_reserve_generation(&self) -> Result<(), ErrorCode> {
+        loop {
+            let current = self.generation_starts.load(Ordering::Relaxed);
+            if self
+                .limits
+                .max_generations
+                .is_some_and(|max| current >= max)
+            {
+                return Err(ErrorCode::NoAccess);
+            }
+            if self
+                .generation_starts
+                .compare_exchange(current, current + 1, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    fn record_token_delta(&self, delta: u64) {
+        self.total_tokens.fetch_add(delta, Ordering::Relaxed);
+    }
+
+    fn meter_doc(&self, connection: &str) -> String {
+        render_json_doc(serde_json::json!({
+            "version": 1,
+            "connection": connection,
+            "limits": {
+                "max_generations": self.limits.max_generations,
+            },
+            "meter": {
+                "generation_starts": self.generation_starts.load(Ordering::Relaxed),
+                "total_tokens": self.total_tokens.load(Ordering::Relaxed),
+                "total_cost_microusd": self.total_cost_microusd.load(Ordering::Relaxed),
+                "currency": "USD",
+            },
+        }))
+    }
 }
 
 /// A Generation's lifecycle status.
@@ -90,8 +498,10 @@ struct Generation {
     connection: Arc<Connection>,
     /// The connection name, for directory membership under `connections/<conn>`.
     connection_name: String,
+    sequence: u64,
     events: Stream,
     status: StdMutex<GenStatus>,
+    token_usage: StdMutex<Option<TokenUsage>>,
     /// qid version, bumped on every status change so a cached `status`/dir qid
     /// goes stale.
     version: AtomicU32,
@@ -107,8 +517,28 @@ impl Generation {
     fn status(&self) -> GenStatus {
         *self.status.lock().unwrap()
     }
+    fn token_usage(&self) -> Option<TokenUsage> {
+        *self.token_usage.lock().unwrap()
+    }
     fn connection_name(&self) -> String {
         self.connection_name.clone()
+    }
+    fn sequence(&self) -> u64 {
+        self.sequence
+    }
+    fn record_usage(&self, usage: TokenUsage) {
+        let previous_total = {
+            let mut token_usage = self.token_usage.lock().unwrap();
+            let previous_total = token_usage
+                .map(|usage| usage.total_tokens.max(0) as u64)
+                .unwrap_or(0);
+            *token_usage = Some(usage);
+            previous_total
+        };
+        let next_total = usage.total_tokens.max(0) as u64;
+        self.connection
+            .record_token_delta(next_total.saturating_sub(previous_total));
+        self.version.fetch_add(1, Ordering::Relaxed);
     }
     /// Move to a terminal (or running) status unless already terminal, bumping the
     /// version. Returns whether the transition happened.
@@ -139,8 +569,17 @@ impl Generation {
 #[derive(Clone)]
 enum Node {
     Root,
+    ProvidersDir,
+    Provider(String),
+    ProviderModels(String),
+    ProviderCapabilities(String),
+    ProviderStatus(String),
     ConnectionsDir,
     Connection(String),
+    ConnectionProvider(String),
+    ConnectionProfile(String),
+    ConnectionMeter(String),
+    ConnectionCapabilities(String),
     Clone(String),
     Gen(String),
     GenData(String),
@@ -194,8 +633,19 @@ impl State {
                 .get(id)
                 .map(|g| g.version.load(Ordering::Relaxed))
                 .unwrap_or(0),
-            Node::ConnectionsDir | Node::Connection(_) => self.listing_version,
-            Node::Root | Node::Clone(_) => 0,
+            Node::ConnectionsDir
+            | Node::Connection(_)
+            | Node::ConnectionProvider(_)
+            | Node::ConnectionProfile(_)
+            | Node::ConnectionMeter(_)
+            | Node::ConnectionCapabilities(_) => self.listing_version,
+            Node::Root
+            | Node::ProvidersDir
+            | Node::Provider(_)
+            | Node::ProviderModels(_)
+            | Node::ProviderCapabilities(_)
+            | Node::ProviderStatus(_)
+            | Node::Clone(_) => 0,
         };
         Qid {
             kind,
@@ -233,11 +683,88 @@ impl LlmFs {
     /// full server, connections are assembled from provider + model + credential;
     /// this slice takes a ready provider.)
     pub fn register_connection(&self, name: &str, provider: Box<dyn LlmProvider>) {
+        let provider_name = provider.provider_name().to_string();
+        self.register_connection_inner(
+            name,
+            provider_name,
+            None,
+            None,
+            ConnectionLimits::default(),
+            provider,
+        );
+    }
+
+    /// Register a callable connection with explicit profile metadata. The
+    /// credential reference is agent-visible metadata only; plaintext credentials
+    /// stay outside llmfs and are resolved by the host before constructing the
+    /// provider.
+    pub fn register_connection_profile(
+        &self,
+        name: &str,
+        profile: ConnectionProfile,
+        provider: Box<dyn LlmProvider>,
+    ) {
+        self.register_connection_inner(
+            name,
+            profile.provider,
+            Some(profile.model),
+            Some(profile.credential_ref),
+            ConnectionLimits::default(),
+            provider,
+        );
+    }
+
+    pub fn register_connection_profile_with_limits(
+        &self,
+        name: &str,
+        profile: ConnectionProfile,
+        limits: ConnectionLimits,
+        provider: Box<dyn LlmProvider>,
+    ) {
+        self.register_connection_inner(
+            name,
+            profile.provider,
+            Some(profile.model),
+            Some(profile.credential_ref),
+            limits,
+            provider,
+        );
+    }
+
+    pub fn unregister_connection(&self, name: &str) {
+        let mut state = self.state.lock().unwrap();
+        if state.connections.remove(name).is_none() {
+            return;
+        }
+        state
+            .gens
+            .retain(|_, generation| generation.connection_name() != name);
+        state.listing_version += 1;
+    }
+
+    fn register_connection_inner(
+        &self,
+        name: &str,
+        provider_name: String,
+        model: Option<String>,
+        credential_ref: Option<String>,
+        limits: ConnectionLimits,
+        provider: Box<dyn LlmProvider>,
+    ) {
+        let capabilities = provider_capabilities_for_name(&provider_name);
         let mut state = self.state.lock().unwrap();
         state.connections.insert(
             name.to_string(),
             Arc::new(Connection {
                 provider: AsyncMutex::new(provider),
+                provider_name,
+                model,
+                credential_ref,
+                capabilities,
+                limits,
+                generation_starts: AtomicU64::new(0),
+                total_tokens: AtomicU64::new(0),
+                total_cost_microusd: AtomicU64::new(0),
             }),
         );
         // The `connections/` listing changed: bump its qid version so a cached
@@ -261,12 +788,31 @@ impl LlmFs {
         let state = self.state.lock().unwrap();
         match node {
             Node::Root if name == "connections" => Ok(Node::ConnectionsDir),
+            Node::Root if name == "providers" => Ok(Node::ProvidersDir),
+            Node::ProvidersDir if provider_type_for_name(name).is_some() => {
+                Ok(Node::Provider(name.to_string()))
+            }
+            Node::Provider(provider) => match name {
+                "models" => Ok(Node::ProviderModels(provider.clone())),
+                "capabilities" => Ok(Node::ProviderCapabilities(provider.clone())),
+                "status" => Ok(Node::ProviderStatus(provider.clone())),
+                _ => Err(ErrorCode::NotFound),
+            },
             Node::ConnectionsDir if state.connections.contains_key(name) => {
                 Ok(Node::Connection(name.to_string()))
             }
+            Node::ConnectionsDir => Err(ErrorCode::NotFound),
             Node::Connection(conn) => {
                 if name == "clone" {
                     Ok(Node::Clone(conn.clone()))
+                } else if name == "provider" {
+                    Ok(Node::ConnectionProvider(conn.clone()))
+                } else if name == "profile" {
+                    Ok(Node::ConnectionProfile(conn.clone()))
+                } else if name == "meter" {
+                    Ok(Node::ConnectionMeter(conn.clone()))
+                } else if name == "capabilities" {
+                    Ok(Node::ConnectionCapabilities(conn.clone()))
                 } else if state
                     .gens
                     .get(name)
@@ -354,7 +900,9 @@ impl FileServer for LlmFs {
                 .get(conn)
                 .cloned()
                 .ok_or(ErrorCode::NotFound)?;
+            connection.try_reserve_generation()?;
             let id = format!("g{}", state.next_gen);
+            let sequence = state.next_gen;
             state.next_gen += 1;
             state.listing_version += 1;
             state.gens.insert(
@@ -362,8 +910,10 @@ impl FileServer for LlmFs {
                 Arc::new(Generation {
                     connection,
                     connection_name: conn.clone(),
+                    sequence,
                     events: Stream::new(),
                     status: StdMutex::new(GenStatus::Open),
+                    token_usage: StdMutex::new(None),
                     version: AtomicU32::new(0),
                     abort: Arc::new(Notify::new()),
                     finalize: AsyncMutex::new(()),
@@ -372,6 +922,7 @@ impl FileServer for LlmFs {
             if let Some(f) = state.fids.get_mut(&fid) {
                 f.clone_gen = Some(id);
             }
+            reap_terminal_generations(&mut state, conn);
         }
 
         let qid = state.qid(&node);
@@ -469,7 +1020,10 @@ impl FileServer for LlmFs {
             if generation.status().is_terminal() {
                 return Err(ErrorCode::BadRequest);
             }
-            generation.events.append(b"{\"aborted\":true}\n").await;
+            generation
+                .events
+                .append(&event_line(WireStreamEventV1::aborted()))
+                .await;
             generation.advance(GenStatus::Aborted);
         }
         // Wake a running drain task (or a pending provider startup) so it stops
@@ -570,7 +1124,10 @@ impl FileServer for LlmFs {
                 // concurrent valid commit already started.
                 let _guard = generation.finalize.lock().await;
                 if generation.claim(GenStatus::Rejected) {
-                    generation.events.append(b"{\"rejected\":true}\n").await;
+                    generation
+                        .events
+                        .append(&event_line(WireStreamEventV1::rejected()))
+                        .await;
                 }
                 return Err(ErrorCode::BadRequest);
             }
@@ -583,10 +1140,19 @@ impl FileServer for LlmFs {
             return Err(ErrorCode::BadRequest);
         }
 
-        let mut request = GenerationRequest::new().with_user_message(doc.user);
-        if let Some(system) = doc.system {
-            request = request.with_system_prompt(system);
-        }
+        let request = match doc.into_generation_request() {
+            Ok(request) => request,
+            Err(()) => {
+                let _guard = generation.finalize.lock().await;
+                if generation.claim(GenStatus::Rejected) {
+                    generation
+                        .events
+                        .append(&event_line(WireStreamEventV1::rejected()))
+                        .await;
+                }
+                return Err(ErrorCode::BadRequest);
+            }
+        };
 
         // Start the provider stream, but race it against an abort: a `ctl` abort
         // during startup drops the in-flight `generate_stream` future (cancelling
@@ -635,6 +1201,9 @@ impl FileServer for LlmFs {
                             if drain_gen.status().is_terminal() {
                                 break; // aborted (or already finished) while we waited
                             }
+                            if let Some(usage) = chunk.usage {
+                                drain_gen.record_usage(usage);
+                            }
                             if let Some(record) = chunk_record(&chunk) {
                                 events.append(format!("{record}\n").as_bytes()).await;
                             }
@@ -648,11 +1217,12 @@ impl FileServer for LlmFs {
                                     .is_some_and(|r| r.starts_with("stream_error"));
                                 if errored {
                                     let reason = chunk.finish_reason.clone().unwrap_or_default();
-                                    let record = serde_json::json!({ "error": reason }).to_string();
-                                    events.append(format!("{record}\n").as_bytes()).await;
+                                    events
+                                        .append(&event_line(WireStreamEventV1::error(reason)))
+                                        .await;
                                     drain_gen.advance(GenStatus::Error);
                                 } else {
-                                    events.append(b"{\"done\":true}\n").await;
+                                    events.append(&event_line(WireStreamEventV1::done())).await;
                                     drain_gen.advance(GenStatus::Done);
                                 }
                                 break;
@@ -664,7 +1234,9 @@ impl FileServer for LlmFs {
                             // does not block at the live edge forever.
                             let _guard = drain_gen.finalize.lock().await;
                             if drain_gen.advance(GenStatus::Error) {
-                                events.append(b"{\"error\":\"stream closed\"}\n").await;
+                                events
+                                    .append(&event_line(WireStreamEventV1::error("stream closed")))
+                                    .await;
                             }
                             break;
                         }
@@ -684,10 +1256,12 @@ impl LlmFs {
         // record: only the winner of the status transition writes one.
         let _guard = generation.finalize.lock().await;
         if generation.advance(status) {
-            generation
-                .events
-                .append(format!("{{\"{tag}\":true}}\n").as_bytes())
-                .await;
+            let event = match tag {
+                "rejected" => WireStreamEventV1::rejected(),
+                "error" => WireStreamEventV1::error("error"),
+                _ => WireStreamEventV1::error(tag),
+            };
+            generation.events.append(&event_line(event)).await;
         }
     }
 
@@ -708,7 +1282,15 @@ enum Len {
 /// `stat`'s length use one definition).
 fn computed_bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
     let bytes = match node {
-        Node::Root => b"connections".to_vec(),
+        Node::Root => b"connections\nproviders".to_vec(),
+        Node::ProvidersDir => known_provider_names().join("\n").into_bytes(),
+        Node::Provider(_) => b"models\ncapabilities\nstatus".to_vec(),
+        Node::ProviderModels(provider) => provider_models_doc(provider).into_bytes(),
+        Node::ProviderCapabilities(provider) => {
+            provider_capabilities_doc(provider, provider_capabilities_for_name(provider))
+                .into_bytes()
+        }
+        Node::ProviderStatus(provider) => provider_status_doc(provider).into_bytes(),
         Node::ConnectionsDir => {
             let mut names: Vec<_> = state.connections.keys().cloned().collect();
             names.sort();
@@ -717,7 +1299,13 @@ fn computed_bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
         // A connection lists `clone` plus its allocated Generation ids, so a
         // permitted observer can discover live/finished Generations as files.
         Node::Connection(conn) => {
-            let mut names = vec!["clone".to_string()];
+            let mut names = vec![
+                "clone".to_string(),
+                "provider".to_string(),
+                "profile".to_string(),
+                "meter".to_string(),
+                "capabilities".to_string(),
+            ];
             let mut ids: Vec<_> = state
                 .gens
                 .iter()
@@ -728,10 +1316,33 @@ fn computed_bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
             names.extend(ids);
             names.join("\n").into_bytes()
         }
+        Node::ConnectionProvider(conn) => {
+            let connection = state.connections.get(conn).ok_or(ErrorCode::NotFound)?;
+            format!("{}\n", connection.provider_name).into_bytes()
+        }
+        Node::ConnectionProfile(conn) => {
+            let connection = state.connections.get(conn).ok_or(ErrorCode::NotFound)?;
+            connection_profile_doc(
+                conn,
+                &connection.provider_name,
+                connection.model.as_deref(),
+                connection.credential_ref.as_deref(),
+            )
+            .into_bytes()
+        }
+        Node::ConnectionMeter(conn) => {
+            let connection = state.connections.get(conn).ok_or(ErrorCode::NotFound)?;
+            connection.meter_doc(conn).into_bytes()
+        }
+        Node::ConnectionCapabilities(conn) => {
+            let connection = state.connections.get(conn).ok_or(ErrorCode::NotFound)?;
+            connection_capabilities_doc(conn, &connection.provider_name, connection.capabilities)
+                .into_bytes()
+        }
         Node::Gen(_) => b"data\nevents\nctl\nstatus".to_vec(),
         Node::GenStatus(id) => {
             let g = state.gens.get(id).ok_or(ErrorCode::NotFound)?;
-            format!("{}\n", g.status().as_str()).into_bytes()
+            generation_status_doc(id, g).into_bytes()
         }
         // clone, data, ctl, events are open/write/stream surfaces, not read here.
         _ => return Err(ErrorCode::Unsupported),
@@ -739,13 +1350,47 @@ fn computed_bytes(state: &State, node: &Node) -> Result<Vec<u8>, ErrorCode> {
     Ok(bytes)
 }
 
+fn reap_terminal_generations(state: &mut State, connection: &str) {
+    let mut terminal_generations = state
+        .gens
+        .iter()
+        .filter(|(_, generation)| {
+            generation.connection_name() == connection && generation.status().is_terminal()
+        })
+        .map(|(id, generation)| (id.clone(), generation.sequence()))
+        .collect::<Vec<_>>();
+    if terminal_generations.len() <= RETAIN_TERMINAL_GENERATIONS_PER_CONNECTION {
+        return;
+    }
+
+    terminal_generations.sort_by_key(|(_, sequence)| *sequence);
+    let remove_count = terminal_generations.len() - RETAIN_TERMINAL_GENERATIONS_PER_CONNECTION;
+    for (id, _) in terminal_generations.into_iter().take(remove_count) {
+        state.gens.remove(&id);
+        state.listing_version += 1;
+    }
+}
+
 /// The kind and a server-unique identity key for a node (so distinct connections
 /// and Generations get distinct qids).
 fn node_identity(node: &Node) -> (FileKind, String) {
     match node {
         Node::Root => (FileKind::Dir, "/".to_string()),
+        Node::ProvidersDir => (FileKind::Dir, "providers".to_string()),
+        Node::Provider(provider) => (FileKind::Dir, format!("providers/{provider}")),
+        Node::ProviderModels(provider) => (FileKind::File, format!("providers/{provider}/models")),
+        Node::ProviderCapabilities(provider) => {
+            (FileKind::File, format!("providers/{provider}/capabilities"))
+        }
+        Node::ProviderStatus(provider) => (FileKind::File, format!("providers/{provider}/status")),
         Node::ConnectionsDir => (FileKind::Dir, "connections".to_string()),
         Node::Connection(c) => (FileKind::Dir, format!("connections/{c}")),
+        Node::ConnectionProvider(c) => (FileKind::File, format!("connections/{c}/provider")),
+        Node::ConnectionProfile(c) => (FileKind::File, format!("connections/{c}/profile")),
+        Node::ConnectionMeter(c) => (FileKind::File, format!("connections/{c}/meter")),
+        Node::ConnectionCapabilities(c) => {
+            (FileKind::File, format!("connections/{c}/capabilities"))
+        }
         Node::Clone(c) => (FileKind::Clone, format!("connections/{c}/clone")),
         Node::Gen(id) => (FileKind::Dir, format!("gen/{id}")),
         Node::GenData(id) => (FileKind::File, format!("gen/{id}/data")),
@@ -761,62 +1406,396 @@ fn hash_path(key: &str) -> u64 {
     h.finish()
 }
 
+fn known_provider_names() -> Vec<String> {
+    let mut names = vec![
+        "anthropic_messages".to_string(),
+        "chatgpt".to_string(),
+        "google_gemini_generate_content".to_string(),
+        "openai_chat_completions".to_string(),
+        "openai_chat_completions_compatible".to_string(),
+        "openai_responses".to_string(),
+        "openrouter".to_string(),
+    ];
+    names.sort();
+    names
+}
+
+fn provider_type_for_name(name: &str) -> Option<ProviderType> {
+    match name {
+        "google_gemini_generate_content" => Some(ProviderType::GoogleGeminiGenerateContent),
+        "chatgpt" => Some(ProviderType::ChatgptResponses),
+        // Test providers report `mock`, but the engine-backed smoke path uses
+        // them as Responses-compatible connections.
+        "mock" => Some(ProviderType::OpenAiResponses),
+        "openai_responses" => Some(ProviderType::OpenAiResponses),
+        "openai_chat_completions" => Some(ProviderType::OpenAiChatCompletions),
+        "openai_chat_completions_compatible" => Some(ProviderType::OpenAiChatCompletionsCompatible),
+        "openrouter" => Some(ProviderType::OpenRouter),
+        "anthropic_messages" => Some(ProviderType::AnthropicMessages),
+        _ => None,
+    }
+}
+
+fn provider_capabilities_for_name(name: &str) -> ProviderCapabilities {
+    provider_type_for_name(name)
+        .map(ProviderType::capabilities)
+        .unwrap_or_else(unknown_provider_capabilities)
+}
+
+fn unknown_provider_capabilities() -> ProviderCapabilities {
+    ProviderCapabilities {
+        supports_streaming_text: true,
+        supports_streaming_tool_calls: false,
+        supports_provider_response_id: false,
+        supports_provider_response_status: false,
+        supports_reasoning_text: false,
+        supports_reasoning_signature: false,
+        supports_reasoning_effort_control: false,
+        supports_redacted_thinking: false,
+        supports_multimodal_input: false,
+        supports_document_input: false,
+        supports_cached_token_usage: false,
+        supports_server_managed_continuation: false,
+        supports_background_execution: false,
+        supports_retrieve_cancel: false,
+        supports_provider_compaction: false,
+        instruction_role: alan_llm::InstructionRole::System,
+        compatibility_tier: CompatibilityTier::TierCBestEffortCompatible,
+    }
+}
+
+fn provider_capabilities_doc(provider: &str, capabilities: ProviderCapabilities) -> String {
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "provider": provider,
+        "capabilities": capabilities,
+    }))
+}
+
+fn connection_capabilities_doc(
+    connection: &str,
+    provider: &str,
+    capabilities: ProviderCapabilities,
+) -> String {
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "connection": connection,
+        "provider": provider,
+        "capabilities": capabilities,
+    }))
+}
+
+fn connection_profile_doc(
+    connection: &str,
+    provider: &str,
+    model: Option<&str>,
+    credential_ref: Option<&str>,
+) -> String {
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "connection": connection,
+        "provider": provider,
+        "model": model,
+        "credential_ref": credential_ref,
+    }))
+}
+
+fn generation_status_doc(id: &str, generation: &Generation) -> String {
+    let status = generation.status();
+    let usage = generation.token_usage();
+    let tokens = usage
+        .map(|usage| {
+            serde_json::json!({
+                "available": true,
+                "prompt_tokens": usage.prompt_tokens,
+                "cached_prompt_tokens": usage.cached_prompt_tokens,
+                "completion_tokens": usage.completion_tokens,
+                "total_tokens": usage.total_tokens,
+                "reasoning_tokens": usage.reasoning_tokens,
+            })
+        })
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "available": false,
+                "prompt_tokens": 0,
+                "cached_prompt_tokens": null,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "reasoning_tokens": null,
+            })
+        });
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "generation": id,
+        "connection": generation.connection_name(),
+        "status": status.as_str(),
+        "progress": {
+            "phase": status.as_str(),
+            "terminal": status.is_terminal(),
+        },
+        "tokens": tokens,
+        "cost": {
+            "currency": "USD",
+            "amount_microusd": 0,
+            "metered": false,
+        },
+    }))
+}
+
+fn provider_models_doc(provider: &str) -> String {
+    let catalog = provider_model_catalog(provider);
+    let models = catalog
+        .map(|catalog| {
+            catalog
+                .models
+                .iter()
+                .map(|model| {
+                    serde_json::json!({
+                        "slug": model.slug,
+                        "family": model.family,
+                        "context_window_tokens": model.context_window_tokens,
+                        "supports_reasoning": model.supports_reasoning,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "provider": provider,
+        "source": catalog.map(|catalog| catalog.source).unwrap_or("unknown"),
+        "default_model": catalog.map(|catalog| catalog.default_model),
+        "models": models,
+    }))
+}
+
+fn provider_status_doc(provider: &str) -> String {
+    render_json_doc(serde_json::json!({
+        "version": 1,
+        "provider": provider,
+        "status": "available",
+        "callable": false,
+        "has_model_catalog": provider_model_catalog(provider).is_some(),
+    }))
+}
+
+#[derive(Clone, Copy)]
+struct ProviderModel {
+    slug: &'static str,
+    family: &'static str,
+    context_window_tokens: u32,
+    supports_reasoning: bool,
+}
+
+#[derive(Clone, Copy)]
+struct ProviderModelCatalog {
+    default_model: &'static str,
+    source: &'static str,
+    models: &'static [ProviderModel],
+}
+
+const OPENAI_GPT_MODELS: &[ProviderModel] = &[
+    ProviderModel {
+        slug: "gpt-5.4",
+        family: "gpt-5",
+        context_window_tokens: 1_050_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5.4-pro",
+        family: "gpt-5",
+        context_window_tokens: 1_050_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5.2",
+        family: "gpt-5",
+        context_window_tokens: 400_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5.2-pro",
+        family: "gpt-5",
+        context_window_tokens: 400_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5.1",
+        family: "gpt-5",
+        context_window_tokens: 400_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5-mini",
+        family: "gpt-5",
+        context_window_tokens: 400_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-5-nano",
+        family: "gpt-5",
+        context_window_tokens: 400_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-oss-120b",
+        family: "gpt-oss",
+        context_window_tokens: 131_072,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "gpt-oss-20b",
+        family: "gpt-oss",
+        context_window_tokens: 131_072,
+        supports_reasoning: true,
+    },
+];
+
+const OPENAI_COMPATIBLE_MODELS: &[ProviderModel] = &[
+    ProviderModel {
+        slug: "qwen3.5-plus",
+        family: "qwen3.5",
+        context_window_tokens: 1_000_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "minimax-m2.5",
+        family: "minimax-m2.5",
+        context_window_tokens: 204_800,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "minimax-m2.5-highspeed",
+        family: "minimax-m2.5",
+        context_window_tokens: 204_800,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "glm-5",
+        family: "glm-5",
+        context_window_tokens: 200_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "kimi-k2.5",
+        family: "kimi-k2.5",
+        context_window_tokens: 250_000,
+        supports_reasoning: true,
+    },
+    ProviderModel {
+        slug: "deepseek-chat",
+        family: "deepseek-v3",
+        context_window_tokens: 128_000,
+        supports_reasoning: false,
+    },
+    ProviderModel {
+        slug: "deepseek-reasoner",
+        family: "deepseek-r1",
+        context_window_tokens: 128_000,
+        supports_reasoning: true,
+    },
+];
+
+const CHATGPT_MODELS: &[ProviderModel] = &[ProviderModel {
+    slug: "gpt-5.3-codex",
+    family: "gpt-5-codex",
+    context_window_tokens: 400_000,
+    supports_reasoning: true,
+}];
+
+const GEMINI_MODELS: &[ProviderModel] = &[ProviderModel {
+    slug: "gemini-2.0-flash",
+    family: "gemini-2.0",
+    context_window_tokens: 1_048_576,
+    supports_reasoning: false,
+}];
+
+const ANTHROPIC_MODELS: &[ProviderModel] = &[ProviderModel {
+    slug: "claude-3-5-sonnet-latest",
+    family: "claude-3.5-sonnet",
+    context_window_tokens: 200_000,
+    supports_reasoning: false,
+}];
+
+const OPENROUTER_MODELS: &[ProviderModel] = &[ProviderModel {
+    slug: "moonshotai/kimi-k2.6",
+    family: "kimi-k2.6",
+    context_window_tokens: 256_000,
+    supports_reasoning: true,
+}];
+
+fn provider_model_catalog(provider: &str) -> Option<ProviderModelCatalog> {
+    match provider {
+        "openai_responses" => Some(ProviderModelCatalog {
+            default_model: "gpt-5.4",
+            source: "bundled-openai-responses",
+            models: OPENAI_GPT_MODELS,
+        }),
+        "openai_chat_completions" => Some(ProviderModelCatalog {
+            default_model: "gpt-5.4",
+            source: "bundled-openai-chat-completions",
+            models: OPENAI_GPT_MODELS,
+        }),
+        "openai_chat_completions_compatible" => Some(ProviderModelCatalog {
+            default_model: "qwen3.5-plus",
+            source: "bundled-openai-compatible",
+            models: OPENAI_COMPATIBLE_MODELS,
+        }),
+        "chatgpt" => Some(ProviderModelCatalog {
+            default_model: "gpt-5.3-codex",
+            source: "bundled-chatgpt",
+            models: CHATGPT_MODELS,
+        }),
+        "google_gemini_generate_content" => Some(ProviderModelCatalog {
+            default_model: "gemini-2.0-flash",
+            source: "bundled-gemini",
+            models: GEMINI_MODELS,
+        }),
+        "anthropic_messages" => Some(ProviderModelCatalog {
+            default_model: "claude-3-5-sonnet-latest",
+            source: "bundled-anthropic",
+            models: ANTHROPIC_MODELS,
+        }),
+        "openrouter" => Some(ProviderModelCatalog {
+            default_model: "moonshotai/kimi-k2.6",
+            source: "bundled-openrouter",
+            models: OPENROUTER_MODELS,
+        }),
+        _ => None,
+    }
+}
+
+fn render_json_doc(value: serde_json::Value) -> String {
+    let mut rendered = serde_json::to_string(&value).expect("serialize llmfs introspection doc");
+    rendered.push('\n');
+    rendered
+}
+
 /// Build one `events` record from the meaningful fields of a stream chunk, so a
 /// non-text chunk (thinking, usage, finish metadata, tool-call delta) is not
 /// dropped. Returns `None` for a chunk with nothing to record.
 fn chunk_record(chunk: &StreamChunk) -> Option<String> {
-    let mut map = serde_json::Map::new();
-    let put = |m: &mut serde_json::Map<String, serde_json::Value>, k: &str, v: &Option<String>| {
-        if let Some(s) = v {
-            m.insert(k.to_string(), serde_json::Value::String(s.clone()));
-        }
+    let event = WireStreamEventV1 {
+        done: None,
+        error: None,
+        rejected: None,
+        aborted: None,
+        text: chunk.text.clone(),
+        thinking: chunk.thinking.clone(),
+        thinking_signature: chunk.thinking_signature.clone(),
+        redacted_thinking: chunk.redacted_thinking.clone(),
+        finish_reason: chunk.finish_reason.clone(),
+        provider_response_id: chunk.provider_response_id.clone(),
+        provider_response_status: chunk.provider_response_status.clone(),
+        sequence_number: chunk.sequence_number,
+        usage: chunk.usage.map(Into::into),
+        tool_call: chunk.tool_call_delta.as_ref().map(Into::into),
+        ..WireStreamEventV1::empty()
     };
-    put(&mut map, "text", &chunk.text);
-    put(&mut map, "thinking", &chunk.thinking);
-    put(&mut map, "thinking_signature", &chunk.thinking_signature);
-    put(&mut map, "redacted_thinking", &chunk.redacted_thinking);
-    put(&mut map, "finish_reason", &chunk.finish_reason);
-    put(
-        &mut map,
-        "provider_response_id",
-        &chunk.provider_response_id,
-    );
-    put(
-        &mut map,
-        "provider_response_status",
-        &chunk.provider_response_status,
-    );
-    if let Some(seq) = chunk.sequence_number {
-        map.insert("sequence_number".to_string(), seq.into());
-    }
-    if let Some(u) = &chunk.usage {
-        map.insert(
-            "usage".to_string(),
-            serde_json::json!({
-                "prompt_tokens": u.prompt_tokens,
-                "cached_prompt_tokens": u.cached_prompt_tokens,
-                "completion_tokens": u.completion_tokens,
-                "total_tokens": u.total_tokens,
-                "reasoning_tokens": u.reasoning_tokens,
-            }),
-        );
-    }
-    if let Some(tc) = &chunk.tool_call_delta {
-        map.insert(
-            "tool_call".to_string(),
-            serde_json::json!({
-                "index": tc.index,
-                "id": tc.id,
-                "name": tc.name,
-                "arguments_delta": tc.arguments_delta,
-                "arguments": tc.arguments,
-            }),
-        );
-    }
-    if map.is_empty() {
+    if !event.has_payload() {
         None
     } else {
-        Some(serde_json::Value::Object(map).to_string())
+        Some(serde_json::to_string(&event).expect("serialize llmfs stream event"))
     }
 }
 

--- a/crates/llmfs/src/lib.rs
+++ b/crates/llmfs/src/lib.rs
@@ -1133,13 +1133,6 @@ impl FileServer for LlmFs {
             }
         };
 
-        // Reserve the Generation *before* awaiting the provider: the single
-        // `open`→`running` transition. A concurrent data commit (or a post-abort
-        // revive) fails here, so only one request ever reaches the provider.
-        if !generation.claim(GenStatus::Running) {
-            return Err(ErrorCode::BadRequest);
-        }
-
         let request = match doc.into_generation_request() {
             Ok(request) => request,
             Err(()) => {
@@ -1153,6 +1146,13 @@ impl FileServer for LlmFs {
                 return Err(ErrorCode::BadRequest);
             }
         };
+
+        // Reserve the Generation *before* awaiting the provider: the single
+        // `open`→`running` transition. A concurrent data commit (or a post-abort
+        // revive) fails here, so only one request ever reaches the provider.
+        if !generation.claim(GenStatus::Running) {
+            return Err(ErrorCode::BadRequest);
+        }
 
         // Start the provider stream, but race it against an abort: a `ctl` abort
         // during startup drops the in-flight `generate_stream` future (cancelling

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -829,6 +829,33 @@ async fn an_empty_request_is_rejected() {
 }
 
 #[tokio::test]
+async fn invalid_v1_request_is_rejected_before_running() {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let fs = llmfs_with(RecordingProvider {
+        requests: Arc::clone(&requests),
+    });
+    let g = clone_gen(&fs, Fid(1)).await;
+
+    assert_eq!(
+        commit_request(&fs, &g, Fid(2), br#"{"version":1,"messages":[]}"#).await,
+        Err(ErrorCode::BadRequest)
+    );
+    assert_eq!(status_of(&fs, &g, Fid(3)).await, "rejected");
+    assert!(
+        requests.lock().unwrap().is_empty(),
+        "invalid v1 documents must not reach the provider"
+    );
+
+    let events =
+        String::from_utf8(read_all(&fs, &["connections", "default", &g, "events"], Fid(4)).await)
+            .unwrap();
+    assert!(
+        events.contains("\"rejected\""),
+        "invalid v1 documents append a rejected event: {events:?}"
+    );
+}
+
+#[tokio::test]
 async fn unknown_request_fields_are_rejected() {
     let fs = llmfs();
     let g = clone_gen(&fs, Fid(1)).await;

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -1071,6 +1071,52 @@ async fn terminal_generations_are_reaped_by_retention_policy() {
 }
 
 #[tokio::test]
+async fn opened_events_stat_survives_retention_reap() {
+    let fs = llmfs();
+    let mut oldest = String::new();
+    let oldest_events_fid = Fid(12);
+
+    for i in 0..17 {
+        let gen_id = clone_gen(&fs, Fid(10 + i * 3)).await;
+        commit_request(&fs, &gen_id, Fid(11 + i * 3), br#"{"user":"hi"}"#)
+            .await
+            .unwrap();
+        drain_events(&fs, &gen_id, Fid(12 + i * 3)).await;
+        if i == 0 {
+            oldest = gen_id;
+        }
+    }
+
+    let _open_gen = clone_gen(&fs, Fid(1000)).await;
+    assert_eq!(
+        fs.walk(
+            Fid::ROOT,
+            Fid(1001),
+            &[
+                "connections".into(),
+                "default".into(),
+                oldest.clone(),
+                "status".into(),
+            ],
+        )
+        .await,
+        Err(ErrorCode::NotFound),
+        "oldest terminal Generation should be reaped"
+    );
+
+    let events = fs.read(oldest_events_fid, 0, 65536).await.unwrap();
+    assert!(
+        String::from_utf8_lossy(&events).contains("\"done\""),
+        "opened events fid still reads retained terminal bytes"
+    );
+    assert_eq!(
+        fs.stat(oldest_events_fid).await.unwrap().length,
+        events.len() as u64,
+        "opened events fid stat must report retained stream length after reap"
+    );
+}
+
+#[tokio::test]
 async fn a_reused_fid_is_rejected() {
     let fs = llmfs();
     fs.walk(Fid::ROOT, Fid(1), &["connections".into()])

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -4,12 +4,12 @@
 //! request document to `data` (committed on clunk), and reads the streamed token
 //! records from `events`. Backed by the mock provider — no real API key.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use alan_ap::{ErrorCode, Fid, FileServer, OpenMode};
 use alan_llm::mock::MockLlmProvider;
-use alan_llmfs::LlmFs;
+use alan_llmfs::{ConnectionLimits, ConnectionProfile, LlmFs};
 
 fn llmfs() -> LlmFs {
     let fs = LlmFs::new();
@@ -97,6 +97,229 @@ async fn two_clone_opens_allocate_independent_generations() {
 }
 
 #[tokio::test]
+async fn providers_expose_introspection_files() {
+    let fs = llmfs();
+
+    let providers = String::from_utf8(read_all(&fs, &["providers"], Fid(1)).await).unwrap();
+    assert!(
+        providers.lines().any(|line| line == "openai_responses"),
+        "providers dir should list OpenAI Responses: {providers:?}"
+    );
+
+    let provider_listing =
+        String::from_utf8(read_all(&fs, &["providers", "openai_responses"], Fid(2)).await).unwrap();
+    for name in ["models", "capabilities", "status"] {
+        assert!(
+            provider_listing.lines().any(|line| line == name),
+            "provider dir should list {name}: {provider_listing:?}"
+        );
+    }
+
+    let capabilities: serde_json::Value = serde_json::from_slice(
+        &read_all(
+            &fs,
+            &["providers", "openai_responses", "capabilities"],
+            Fid(3),
+        )
+        .await,
+    )
+    .unwrap();
+    assert_eq!(capabilities["version"], 1);
+    assert_eq!(capabilities["provider"], "openai_responses");
+    assert_eq!(
+        capabilities["capabilities"]["instruction_role"],
+        "ResponsesInstructions"
+    );
+    assert_eq!(
+        capabilities["capabilities"]["supports_provider_compaction"],
+        true
+    );
+
+    let models: serde_json::Value = serde_json::from_slice(
+        &read_all(&fs, &["providers", "openai_responses", "models"], Fid(4)).await,
+    )
+    .unwrap();
+    assert_eq!(models["version"], 1);
+    assert_eq!(models["provider"], "openai_responses");
+    assert_eq!(models["default_model"], "gpt-5.4");
+    let model_slugs = models["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|model| model["slug"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        model_slugs.contains(&"gpt-5.4"),
+        "provider model catalog should expose known models: {models}"
+    );
+
+    let status: serde_json::Value = serde_json::from_slice(
+        &read_all(&fs, &["providers", "openai_responses", "status"], Fid(5)).await,
+    )
+    .unwrap();
+    assert_eq!(status["status"], "available");
+    assert_eq!(status["callable"], false);
+    assert_eq!(status["has_model_catalog"], true);
+
+    assert_eq!(
+        fs.walk(
+            Fid::ROOT,
+            Fid(6),
+            &[
+                "providers".into(),
+                "openai_responses".into(),
+                "clone".into()
+            ],
+        )
+        .await,
+        Err(ErrorCode::NotFound),
+        "provider directories are introspect-only; generations start on connections"
+    );
+}
+
+#[tokio::test]
+async fn connections_expose_provider_and_capabilities_without_credentials() {
+    let fs = llmfs();
+
+    let connection_listing =
+        String::from_utf8(read_all(&fs, &["connections", "default"], Fid(1)).await).unwrap();
+    for name in ["clone", "provider", "profile", "meter", "capabilities"] {
+        assert!(
+            connection_listing.lines().any(|line| line == name),
+            "connection dir should list {name}: {connection_listing:?}"
+        );
+    }
+
+    let provider =
+        String::from_utf8(read_all(&fs, &["connections", "default", "provider"], Fid(2)).await)
+            .unwrap();
+    assert_eq!(provider.trim(), "mock");
+
+    let profile: serde_json::Value = serde_json::from_slice(
+        &read_all(&fs, &["connections", "default", "profile"], Fid(3)).await,
+    )
+    .unwrap();
+    assert_eq!(profile["version"], 1);
+    assert_eq!(profile["connection"], "default");
+    assert_eq!(profile["provider"], "mock");
+    assert_eq!(profile["model"], serde_json::Value::Null);
+    assert_eq!(profile["credential_ref"], serde_json::Value::Null);
+    assert!(
+        profile
+            .as_object()
+            .unwrap()
+            .keys()
+            .all(|key| key != "credential" && key != "api_key"),
+        "connection profile must not expose credential plaintext: {profile}"
+    );
+
+    let capabilities: serde_json::Value = serde_json::from_slice(
+        &read_all(&fs, &["connections", "default", "capabilities"], Fid(4)).await,
+    )
+    .unwrap();
+    assert_eq!(capabilities["version"], 1);
+    assert_eq!(capabilities["connection"], "default");
+    assert_eq!(capabilities["provider"], "mock");
+    assert_eq!(
+        capabilities["capabilities"]["compatibility_tier"],
+        "TierAFullFidelityStateful"
+    );
+    assert_eq!(
+        capabilities["capabilities"]["supports_reasoning_effort_control"],
+        true
+    );
+    assert!(
+        capabilities
+            .as_object()
+            .unwrap()
+            .keys()
+            .all(|key| key != "credential" && key != "api_key"),
+        "connection introspection must not expose credential material: {capabilities}"
+    );
+}
+
+#[tokio::test]
+async fn connection_profiles_appear_and_disappear_as_endpoints() {
+    let fs = LlmFs::new();
+    assert_eq!(
+        String::from_utf8(read_all(&fs, &["connections"], Fid(1)).await).unwrap(),
+        ""
+    );
+
+    fs.register_connection_profile(
+        "work",
+        ConnectionProfile::new("openai_responses", "gpt-5.4", "credential:openai-main"),
+        Box::new(MockLlmProvider::new()),
+    );
+    let connections = String::from_utf8(read_all(&fs, &["connections"], Fid(2)).await).unwrap();
+    assert_eq!(connections, "work");
+
+    let profile: serde_json::Value =
+        serde_json::from_slice(&read_all(&fs, &["connections", "work", "profile"], Fid(3)).await)
+            .unwrap();
+    assert_eq!(profile["connection"], "work");
+    assert_eq!(profile["provider"], "openai_responses");
+    assert_eq!(profile["model"], "gpt-5.4");
+    assert_eq!(profile["credential_ref"], "credential:openai-main");
+
+    let provider =
+        String::from_utf8(read_all(&fs, &["connections", "work", "provider"], Fid(4)).await)
+            .unwrap();
+    assert_eq!(provider.trim(), "openai_responses");
+
+    fs.unregister_connection("work");
+    let connections = String::from_utf8(read_all(&fs, &["connections"], Fid(5)).await).unwrap();
+    assert_eq!(connections, "");
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(6), &["connections".into(), "work".into()],)
+            .await,
+        Err(ErrorCode::NotFound),
+        "removed connection endpoint is no longer walkable"
+    );
+}
+
+#[tokio::test]
+async fn connection_generation_limit_is_enforced_at_clone_open() {
+    let fs = LlmFs::new();
+    fs.register_connection_profile_with_limits(
+        "limited",
+        ConnectionProfile::new("openai_responses", "gpt-5.4", "credential:openai-main"),
+        ConnectionLimits::max_generations(1),
+        Box::new(MockLlmProvider::new()),
+    );
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(1),
+        &["connections".into(), "limited".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(1), OpenMode::ReadWrite).await.unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &["connections".into(), "limited".into(), "clone".into()],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        fs.open(Fid(2), OpenMode::ReadWrite).await,
+        Err(ErrorCode::NoAccess),
+        "rate-limit exhaustion is a dial-time open error"
+    );
+
+    let meter: serde_json::Value =
+        serde_json::from_slice(&read_all(&fs, &["connections", "limited", "meter"], Fid(3)).await)
+            .unwrap();
+    assert_eq!(meter["limits"]["max_generations"], 1);
+    assert_eq!(meter["meter"]["generation_starts"], 1);
+    assert_eq!(meter["meter"]["total_tokens"], 0);
+    assert_eq!(meter["meter"]["total_cost_microusd"], 0);
+}
+
+#[tokio::test]
 async fn writing_the_request_streams_tokens_to_events() {
     let fs = llmfs();
 
@@ -175,7 +398,10 @@ async fn a_malformed_request_is_rejected_at_clunk() {
 // discovery, qids, stat, and terminal-event guarantees.
 // ---------------------------------------------------------------------------
 
-use alan_llm::{GenerationRequest, GenerationResponse, LlmProvider, StreamChunk};
+use alan_llm::{
+    GenerationRequest, GenerationResponse, LlmProvider, MessageRole, ReasoningEffort, StreamChunk,
+    TokenUsage,
+};
 use tokio::sync::mpsc;
 
 fn text_chunk(text: &str, is_finished: bool) -> StreamChunk {
@@ -201,6 +427,36 @@ struct StartupFailProvider;
 /// Returns a receiver that never yields (its sender is parked), so the Generation
 /// stays running until aborted.
 struct HangingProvider;
+/// Emits a finished chunk with provider usage metadata.
+struct UsageProvider;
+
+struct RecordingProvider {
+    requests: Arc<Mutex<Vec<GenerationRequest>>>,
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for RecordingProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        request: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        self.requests.lock().unwrap().push(request);
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            let _ = tx.send(text_chunk("recorded", true)).await;
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "recording"
+    }
+}
 
 #[async_trait::async_trait]
 impl LlmProvider for EarlyCloseProvider {
@@ -270,6 +526,37 @@ impl LlmProvider for HangingProvider {
     }
 }
 
+#[async_trait::async_trait]
+impl LlmProvider for UsageProvider {
+    async fn generate(&mut self, _: GenerationRequest) -> anyhow::Result<GenerationResponse> {
+        unimplemented!()
+    }
+    async fn chat(&mut self, _: Option<&str>, _: &str) -> anyhow::Result<String> {
+        unimplemented!()
+    }
+    async fn generate_stream(
+        &mut self,
+        _: GenerationRequest,
+    ) -> anyhow::Result<mpsc::Receiver<StreamChunk>> {
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            let mut chunk = text_chunk("usage", true);
+            chunk.usage = Some(TokenUsage {
+                prompt_tokens: 11,
+                cached_prompt_tokens: Some(3),
+                completion_tokens: 7,
+                total_tokens: 18,
+                reasoning_tokens: Some(5),
+            });
+            let _ = tx.send(chunk).await;
+        });
+        Ok(rx)
+    }
+    fn provider_name(&self) -> &'static str {
+        "usage"
+    }
+}
+
 fn llmfs_with(provider: impl LlmProvider + 'static) -> LlmFs {
     let fs = LlmFs::new();
     fs.register_connection("default", Box::new(provider));
@@ -306,10 +593,84 @@ async fn commit_request(fs: &LlmFs, gen_id: &str, fid: Fid, body: &[u8]) -> Resu
 }
 
 async fn status_of(fs: &LlmFs, gen_id: &str, fid: Fid) -> String {
-    String::from_utf8(read_all(fs, &["connections", "default", gen_id, "status"], fid).await)
+    status_doc_of(fs, gen_id, fid).await["status"]
+        .as_str()
         .unwrap()
-        .trim()
         .to_string()
+}
+
+async fn status_doc_of(fs: &LlmFs, gen_id: &str, fid: Fid) -> serde_json::Value {
+    serde_json::from_slice(&read_all(fs, &["connections", "default", gen_id, "status"], fid).await)
+        .unwrap()
+}
+
+#[tokio::test]
+async fn versioned_request_dto_maps_to_generation_request() {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let fs = llmfs_with(RecordingProvider {
+        requests: Arc::clone(&requests),
+    });
+    let gen_id = clone_gen(&fs, Fid(1)).await;
+
+    commit_request(
+        &fs,
+        &gen_id,
+        Fid(2),
+        br#"{
+            "version": 1,
+            "system": "system prompt",
+            "messages": [
+                {"role": "context", "content": "prior summary"},
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "need a tool",
+                    "tool_calls": [
+                        {"id": "call-1", "name": "lookup", "arguments": {"q": "alan"}}
+                    ]
+                },
+                {"role": "tool", "content": "result", "tool_call_id": "call-1"}
+            ],
+            "tools": [
+                {
+                    "name": "lookup",
+                    "description": "look up data",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}}
+                }
+            ],
+            "temperature": 0.2,
+            "max_tokens": 123,
+            "reasoning": {"effort": "low"},
+            "extra_params": {"store": true}
+        }"#,
+    )
+    .await
+    .unwrap();
+    let _events = drain_events(&fs, &gen_id, Fid(3)).await;
+
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    let request = &recorded[0];
+    assert_eq!(request.system_prompt.as_deref(), Some("system prompt"));
+    assert_eq!(request.messages.len(), 4);
+    assert_eq!(request.messages[0].role, MessageRole::Context);
+    assert_eq!(request.messages[1].role, MessageRole::User);
+    assert_eq!(request.messages[2].role, MessageRole::Assistant);
+    assert_eq!(request.messages[3].role, MessageRole::Tool);
+    assert_eq!(
+        request.messages[2].tool_calls.as_ref().unwrap()[0].name,
+        "lookup"
+    );
+    assert_eq!(request.messages[3].tool_call_id.as_deref(), Some("call-1"));
+    assert_eq!(request.tools.len(), 1);
+    assert_eq!(request.tools[0].name, "lookup");
+    assert_eq!(request.temperature, Some(0.2));
+    assert_eq!(request.max_tokens, Some(123));
+    assert_eq!(request.reasoning.effort, Some(ReasoningEffort::Low));
+    assert_eq!(
+        request.extra_params.get("store"),
+        Some(&serde_json::Value::Bool(true))
+    );
 }
 
 #[tokio::test]
@@ -391,7 +752,12 @@ async fn reading_requires_a_read_open() {
     fs.walk(
         Fid::ROOT,
         Fid(2),
-        &["connections".into(), "default".into(), g, "status".into()],
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "status".into(),
+        ],
     )
     .await
     .unwrap();
@@ -565,12 +931,102 @@ async fn stat_reports_real_status_length() {
     fs.walk(
         Fid::ROOT,
         Fid(2),
-        &["connections".into(), "default".into(), g, "status".into()],
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "status".into(),
+        ],
     )
     .await
     .unwrap();
-    // "open\n" is 5 bytes — not the hardcoded 0.
-    assert_eq!(fs.stat(Fid(2)).await.unwrap().length, "open\n".len() as u64);
+    let stat_len = fs.stat(Fid(2)).await.unwrap().length;
+    let status =
+        String::from_utf8(read_all(&fs, &["connections", "default", &g, "status"], Fid(3)).await)
+            .unwrap();
+    assert_eq!(
+        stat_len,
+        status.len() as u64,
+        "status stat length matches the readable status document"
+    );
+}
+
+#[tokio::test]
+async fn status_exposes_progress_tokens_and_cost() {
+    let fs = llmfs_with(UsageProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+    drain_events(&fs, &g, Fid(3)).await;
+
+    let status = status_doc_of(&fs, &g, Fid(4)).await;
+    assert_eq!(status["version"], 1);
+    assert_eq!(status["generation"], g);
+    assert_eq!(status["connection"], "default");
+    assert_eq!(status["status"], "done");
+    assert_eq!(status["progress"]["terminal"], true);
+    assert_eq!(status["tokens"]["available"], true);
+    assert_eq!(status["tokens"]["prompt_tokens"], 11);
+    assert_eq!(status["tokens"]["cached_prompt_tokens"], 3);
+    assert_eq!(status["tokens"]["completion_tokens"], 7);
+    assert_eq!(status["tokens"]["total_tokens"], 18);
+    assert_eq!(status["tokens"]["reasoning_tokens"], 5);
+    assert_eq!(status["cost"]["currency"], "USD");
+    assert_eq!(status["cost"]["amount_microusd"], 0);
+    assert_eq!(status["cost"]["metered"], false);
+
+    let meter: serde_json::Value =
+        serde_json::from_slice(&read_all(&fs, &["connections", "default", "meter"], Fid(5)).await)
+            .unwrap();
+    assert_eq!(meter["meter"]["generation_starts"], 1);
+    assert_eq!(meter["meter"]["total_tokens"], 18);
+    assert_eq!(meter["meter"]["total_cost_microusd"], 0);
+}
+
+#[tokio::test]
+async fn terminal_generations_are_reaped_by_retention_policy() {
+    let fs = llmfs();
+    let mut ids = Vec::new();
+    for i in 0..17 {
+        let gen_id = clone_gen(&fs, Fid(10 + i * 3)).await;
+        commit_request(&fs, &gen_id, Fid(11 + i * 3), br#"{"user":"hi"}"#)
+            .await
+            .unwrap();
+        drain_events(&fs, &gen_id, Fid(12 + i * 3)).await;
+        ids.push(gen_id);
+    }
+
+    let open_gen = clone_gen(&fs, Fid(1000)).await;
+    let listing =
+        String::from_utf8(read_all(&fs, &["connections", "default"], Fid(1001)).await).unwrap();
+    assert!(
+        !listing.lines().any(|line| line == ids[0]),
+        "oldest terminal Generation should be reaped: {listing:?}"
+    );
+    assert!(
+        listing.lines().any(|line| line == ids[1]),
+        "recent terminal Generation should stay retained: {listing:?}"
+    );
+    assert!(
+        listing.lines().any(|line| line == open_gen),
+        "new open Generation should not be reaped: {listing:?}"
+    );
+    assert_eq!(
+        fs.walk(
+            Fid::ROOT,
+            Fid(1002),
+            &[
+                "connections".into(),
+                "default".into(),
+                ids[0].clone(),
+                "status".into(),
+            ],
+        )
+        .await,
+        Err(ErrorCode::NotFound),
+        "reaped Generation is no longer walkable"
+    );
 }
 
 #[tokio::test]

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -1296,6 +1296,35 @@ async fn unregister_connection_aborts_active_generations() {
 }
 
 #[tokio::test]
+async fn unregister_connection_makes_in_flight_data_commit_fail() {
+    let fs = llmfs();
+    let g = clone_gen(&fs, Fid(1)).await;
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(2),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "data".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(2), OpenMode::Write).await.unwrap();
+    fs.write(Fid(2), 0, br#"{"user":"hi"}"#).await.unwrap();
+
+    fs.unregister_connection("default").await;
+
+    assert_eq!(
+        fs.clunk(Fid(2)).await,
+        Err(ErrorCode::BadRequest),
+        "commit-on-clunk must not report success after unregister discards the Generation"
+    );
+}
+
+#[tokio::test]
 async fn an_early_closed_stream_ends_with_a_terminal_error() {
     let fs = llmfs_with(EarlyCloseProvider);
     let g = clone_gen(&fs, Fid(1)).await;

--- a/crates/llmfs/tests/generation.rs
+++ b/crates/llmfs/tests/generation.rs
@@ -267,7 +267,7 @@ async fn connection_profiles_appear_and_disappear_as_endpoints() {
             .unwrap();
     assert_eq!(provider.trim(), "openai_responses");
 
-    fs.unregister_connection("work");
+    fs.unregister_connection("work").await;
     let connections = String::from_utf8(read_all(&fs, &["connections"], Fid(5)).await).unwrap();
     assert_eq!(connections, "");
     assert_eq!(
@@ -982,6 +982,15 @@ async fn stat_reports_real_status_length() {
 async fn status_exposes_progress_tokens_and_cost() {
     let fs = llmfs_with(UsageProvider);
     let g = clone_gen(&fs, Fid(1)).await;
+    fs.walk(
+        Fid::ROOT,
+        Fid(5),
+        &["connections".into(), "default".into(), "meter".into()],
+    )
+    .await
+    .unwrap();
+    let meter_v0 = fs.stat(Fid(5)).await.unwrap().qid.version;
+
     commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
         .await
         .unwrap();
@@ -1002,9 +1011,14 @@ async fn status_exposes_progress_tokens_and_cost() {
     assert_eq!(status["cost"]["currency"], "USD");
     assert_eq!(status["cost"]["amount_microusd"], 0);
     assert_eq!(status["cost"]["metered"], false);
+    let meter_v1 = fs.stat(Fid(5)).await.unwrap().qid.version;
+    assert_ne!(
+        meter_v0, meter_v1,
+        "meter qid version changes when usage updates token totals"
+    );
 
     let meter: serde_json::Value =
-        serde_json::from_slice(&read_all(&fs, &["connections", "default", "meter"], Fid(5)).await)
+        serde_json::from_slice(&read_all(&fs, &["connections", "default", "meter"], Fid(6)).await)
             .unwrap();
     assert_eq!(meter["meter"]["generation_starts"], 1);
     assert_eq!(meter["meter"]["total_tokens"], 18);
@@ -1189,6 +1203,50 @@ async fn a_running_generation_can_be_aborted() {
     fs.open(Fid(3), OpenMode::Write).await.unwrap();
     fs.write(Fid(3), 0, b"abort").await.unwrap();
     assert_eq!(status_of(&fs, &g, Fid(4)).await, "aborted");
+}
+
+#[tokio::test]
+async fn unregister_connection_aborts_active_generations() {
+    let fs = llmfs_with(HangingProvider);
+    let g = clone_gen(&fs, Fid(1)).await;
+    commit_request(&fs, &g, Fid(2), br#"{"user":"hi"}"#)
+        .await
+        .unwrap();
+
+    fs.walk(
+        Fid::ROOT,
+        Fid(3),
+        &[
+            "connections".into(),
+            "default".into(),
+            g.clone(),
+            "events".into(),
+        ],
+    )
+    .await
+    .unwrap();
+    fs.open(Fid(3), OpenMode::Read).await.unwrap();
+    fs.unregister_connection("default").await;
+
+    let events = String::from_utf8(fs.read(Fid(3), 0, 65536).await.unwrap()).unwrap();
+    assert!(
+        events.contains("\"aborted\""),
+        "unregister appends a terminal aborted event: {events:?}"
+    );
+    assert_eq!(
+        fs.walk(Fid::ROOT, Fid(4), &["connections".into(), "default".into()])
+            .await,
+        Err(ErrorCode::NotFound),
+        "the connection endpoint is removed"
+    );
+
+    fs.register_connection("default", Box::new(MockLlmProvider::new()));
+    let listing =
+        String::from_utf8(read_all(&fs, &["connections", "default"], Fid(5)).await).unwrap();
+    assert!(
+        !listing.lines().any(|line| line == g),
+        "old aborted generation must not reappear under a re-registered connection: {listing:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -8,8 +8,13 @@ license.workspace = true
 
 [dependencies]
 alan-ap = { path = "../ap" }
+tokio = { workspace = true }
 
 [dev-dependencies]
+alan-agentfs = { path = "../agentfs" }
 alan-kernel = { path = "../kernel" }
+alan-llm = { path = "../llm", features = ["mock"] }
+alan-llmfs = { path = "../llmfs" }
 async-trait.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true }

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -17,7 +17,7 @@ use alan_ap::{
     ErrorCode, Fid, FileKind, InProcessTransport, Offset, OpenMode, Qid, Request, Response,
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 /// A process-global fid allocator. aP fid state lives in the server keyed only by
@@ -334,6 +334,11 @@ pub struct StdioDriver {
     shell: Shell,
 }
 
+struct TailTask {
+    shutdown: oneshot::Sender<()>,
+    handle: JoinHandle<()>,
+}
+
 impl StdioDriver {
     /// Build a line driver over an aP-only [`Shell`].
     pub fn new(shell: Shell) -> Self {
@@ -353,7 +358,7 @@ impl StdioDriver {
     {
         let mut lines = input.lines();
         let (tail_tx, mut tail_rx) = mpsc::unbounded_channel::<Vec<u8>>();
-        let mut tail_tasks: Vec<JoinHandle<()>> = Vec::new();
+        let mut tail_tasks: Vec<TailTask> = Vec::new();
 
         loop {
             tokio::select! {
@@ -373,13 +378,14 @@ impl StdioDriver {
             }
         }
 
+        for task in tail_tasks {
+            let _ = task.shutdown.send(());
+            let _ = task.handle.await;
+        }
         while let Ok(bytes) = tail_rx.try_recv() {
             output.write_all(&bytes).await?;
         }
         output.flush().await?;
-        for task in tail_tasks {
-            task.abort();
-        }
         Ok(())
     }
 
@@ -388,7 +394,7 @@ impl StdioDriver {
         line: &str,
         output: &mut W,
         tail_tx: &mpsc::UnboundedSender<Vec<u8>>,
-        tail_tasks: &mut Vec<JoinHandle<()>>,
+        tail_tasks: &mut Vec<TailTask>,
     ) -> Result<bool, DriverError>
     where
         W: AsyncWrite + Unpin,
@@ -428,7 +434,8 @@ impl StdioDriver {
             LineCommand::Tail(path) => {
                 let shell = self.shell.clone();
                 let tx = tail_tx.clone();
-                tail_tasks.push(tokio::spawn(async move {
+                let (shutdown, mut shutdown_rx) = oneshot::channel();
+                let handle = tokio::spawn(async move {
                     let mut tail = match shell.tail(&path).await {
                         Ok(tail) => tail,
                         Err(err) => {
@@ -437,21 +444,28 @@ impl StdioDriver {
                         }
                     };
                     loop {
-                        match tail.read(4096).await {
-                            Ok(bytes) if bytes.is_empty() => break,
-                            Ok(bytes) => {
-                                if tx.send(bytes).is_err() {
-                                    break;
+                        tokio::select! {
+                            biased;
+                            _ = &mut shutdown_rx => break,
+                            result = tail.read(4096) => {
+                                match result {
+                                    Ok(bytes) if bytes.is_empty() => break,
+                                    Ok(bytes) => {
+                                        if tx.send(bytes).is_err() {
+                                            break;
+                                        }
+                                    }
+                                    Err(err) => {
+                                        let _ = tx.send(format!("error: {err:?}\n").into_bytes());
+                                        break;
+                                    }
                                 }
-                            }
-                            Err(err) => {
-                                let _ = tx.send(format!("error: {err:?}\n").into_bytes());
-                                break;
                             }
                         }
                     }
                     let _ = tail.close().await;
-                }));
+                });
+                tail_tasks.push(TailTask { shutdown, handle });
             }
             LineCommand::Spawn(exec_spec) => match self.shell.spawn(&exec_spec).await {
                 Ok(pid) => {

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -10,11 +10,15 @@
 //! (`/proc`, `/agent`, `/mnt/llm`) through one transport — in v1 the kernel's
 //! namespace presented as one aP server (`alan-kernel::MountFs`).
 
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use alan_ap::{
     ErrorCode, Fid, FileKind, InProcessTransport, Offset, OpenMode, Qid, Request, Response,
 };
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 /// A process-global fid allocator. aP fid state lives in the server keyed only by
 /// [`Fid`], so two shells over the same transport (two tabs on one namespace) must
@@ -23,6 +27,7 @@ use alan_ap::{
 static NEXT_FID: AtomicU64 = AtomicU64::new(1);
 
 /// The shell's view of one mounted namespace, addressed by absolute path.
+#[derive(Clone)]
 pub struct Shell {
     fs: InProcessTransport,
 }
@@ -272,6 +277,256 @@ impl Shell {
         let pid = String::from_utf8(self.read_at(fid, 0, 64).await?).map_err(|_| ErrorCode::Io)?;
         self.write_all(fid, exec_spec.as_bytes()).await?;
         Ok(pid)
+    }
+}
+
+/// Error returned by the line-oriented stdio driver.
+#[derive(Debug)]
+pub enum DriverError {
+    /// The underlying aP file operation failed.
+    Protocol(ErrorCode),
+    /// Reading stdin or writing stdout failed.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for DriverError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protocol(code) => write!(f, "aP operation failed: {code:?}"),
+            Self::Io(err) => write!(f, "stdio failed: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for DriverError {}
+
+impl From<ErrorCode> for DriverError {
+    fn from(value: ErrorCode) -> Self {
+        Self::Protocol(value)
+    }
+}
+
+impl From<std::io::Error> for DriverError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+enum LineCommand {
+    Ls(String),
+    Cat(String),
+    Echo { path: String, data: Vec<u8> },
+    Write { path: String, data: Vec<u8> },
+    Tail(String),
+    Spawn(String),
+    Exit,
+    Empty,
+}
+
+/// Minimal line-oriented shell driver.
+///
+/// The driver is intentionally only a composition layer over generic builtins:
+/// it parses text commands into `ls`, `cat`, `echo >`, `write`, `tail`, and
+/// `spawn` calls. It contains no agent-specific command or attach mode; talking
+/// to an agent is still just `tail /agent/<pid>/io/output` plus
+/// `echo ... > /agent/<pid>/io/input`.
+pub struct StdioDriver {
+    shell: Shell,
+}
+
+impl StdioDriver {
+    /// Build a line driver over an aP-only [`Shell`].
+    pub fn new(shell: Shell) -> Self {
+        Self { shell }
+    }
+
+    /// Run the read-eval-print loop over caller-provided async stdin/stdout.
+    ///
+    /// `tail` commands start independent tasks that forward bytes to the same
+    /// stdout writer while this loop keeps accepting input. The first rich
+    /// renderer can later give those streams separate panes; this driver keeps
+    /// the M1/M2 proof deliberately line-oriented.
+    pub async fn run<R, W>(&self, input: R, mut output: W) -> Result<(), DriverError>
+    where
+        R: AsyncBufRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        let mut lines = input.lines();
+        let (tail_tx, mut tail_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let mut tail_tasks: Vec<JoinHandle<()>> = Vec::new();
+
+        loop {
+            tokio::select! {
+                line = lines.next_line() => {
+                    let Some(line) = line? else { break; };
+                    if self
+                        .handle_line(&line, &mut output, &tail_tx, &mut tail_tasks)
+                        .await?
+                    {
+                        break;
+                    }
+                }
+                Some(bytes) = tail_rx.recv(), if !tail_tasks.is_empty() => {
+                    output.write_all(&bytes).await?;
+                    output.flush().await?;
+                }
+            }
+        }
+
+        while let Ok(bytes) = tail_rx.try_recv() {
+            output.write_all(&bytes).await?;
+        }
+        output.flush().await?;
+        for task in tail_tasks {
+            task.abort();
+        }
+        Ok(())
+    }
+
+    async fn handle_line<W>(
+        &self,
+        line: &str,
+        output: &mut W,
+        tail_tx: &mpsc::UnboundedSender<Vec<u8>>,
+        tail_tasks: &mut Vec<JoinHandle<()>>,
+    ) -> Result<bool, DriverError>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        let command = match parse_line(line) {
+            Ok(command) => command,
+            Err(message) => {
+                output
+                    .write_all(format!("error: {message}\n").as_bytes())
+                    .await?;
+                output.flush().await?;
+                return Ok(false);
+            }
+        };
+
+        match command {
+            LineCommand::Empty => {}
+            LineCommand::Exit => return Ok(true),
+            LineCommand::Ls(path) => match self.shell.ls(&path).await {
+                Ok(entries) => {
+                    for entry in entries {
+                        output.write_all(entry.as_bytes()).await?;
+                        output.write_all(b"\n").await?;
+                    }
+                }
+                Err(err) => write_protocol_error(output, err).await?,
+            },
+            LineCommand::Cat(path) => match self.shell.cat(&path).await {
+                Ok(bytes) => output.write_all(&bytes).await?,
+                Err(err) => write_protocol_error(output, err).await?,
+            },
+            LineCommand::Echo { path, data } | LineCommand::Write { path, data } => {
+                if let Err(err) = self.shell.write(&path, &data).await {
+                    write_protocol_error(output, err).await?;
+                }
+            }
+            LineCommand::Tail(path) => {
+                let shell = self.shell.clone();
+                let tx = tail_tx.clone();
+                tail_tasks.push(tokio::spawn(async move {
+                    let mut tail = match shell.tail(&path).await {
+                        Ok(tail) => tail,
+                        Err(err) => {
+                            let _ = tx.send(format!("error: {err:?}\n").into_bytes());
+                            return;
+                        }
+                    };
+                    loop {
+                        match tail.read(4096).await {
+                            Ok(bytes) if bytes.is_empty() => break,
+                            Ok(bytes) => {
+                                if tx.send(bytes).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(err) => {
+                                let _ = tx.send(format!("error: {err:?}\n").into_bytes());
+                                break;
+                            }
+                        }
+                    }
+                    let _ = tail.close().await;
+                }));
+            }
+            LineCommand::Spawn(exec_spec) => match self.shell.spawn(&exec_spec).await {
+                Ok(pid) => {
+                    output.write_all(pid.trim().as_bytes()).await?;
+                    output.write_all(b"\n").await?;
+                }
+                Err(err) => write_protocol_error(output, err).await?,
+            },
+        }
+        output.flush().await?;
+        Ok(false)
+    }
+}
+
+async fn write_protocol_error<W>(output: &mut W, err: ErrorCode) -> Result<(), DriverError>
+where
+    W: AsyncWrite + Unpin,
+{
+    output
+        .write_all(format!("error: {err:?}\n").as_bytes())
+        .await?;
+    Ok(())
+}
+
+fn parse_line(line: &str) -> Result<LineCommand, String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(LineCommand::Empty);
+    }
+    if matches!(trimmed, "exit" | "quit") {
+        return Ok(LineCommand::Exit);
+    }
+    if let Some(path) = trimmed.strip_prefix("ls ") {
+        return Ok(LineCommand::Ls(non_empty_path(path)?));
+    }
+    if let Some(path) = trimmed.strip_prefix("cat ") {
+        return Ok(LineCommand::Cat(non_empty_path(path)?));
+    }
+    if let Some(path) = trimmed.strip_prefix("tail ") {
+        return Ok(LineCommand::Tail(non_empty_path(path)?));
+    }
+    if let Some(exec_spec) = trimmed.strip_prefix("spawn ") {
+        let exec_spec = exec_spec.trim();
+        if exec_spec.is_empty() {
+            return Err("spawn requires an exec spec".to_string());
+        }
+        return Ok(LineCommand::Spawn(exec_spec.to_string()));
+    }
+    if let Some(rest) = trimmed.strip_prefix("write ") {
+        let Some((path, data)) = rest.trim().split_once(' ') else {
+            return Err("write requires a path and data".to_string());
+        };
+        return Ok(LineCommand::Write {
+            path: non_empty_path(path)?,
+            data: data.as_bytes().to_vec(),
+        });
+    }
+    if let Some(rest) = trimmed.strip_prefix("echo ") {
+        let Some((data, path)) = rest.rsplit_once('>') else {
+            return Err("echo syntax is: echo <data> > <path>".to_string());
+        };
+        return Ok(LineCommand::Echo {
+            path: non_empty_path(path)?,
+            data: data.trim_end().as_bytes().to_vec(),
+        });
+    }
+    Err(format!("unknown command: {trimmed}"))
+}
+
+fn non_empty_path(path: &str) -> Result<String, String> {
+    let path = path.trim();
+    if path.is_empty() {
+        Err("path is required".to_string())
+    } else {
+        Ok(path.to_string())
     }
 }
 

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -8,13 +8,20 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use alan_ap::reference::MemFs;
 use alan_ap::{
-    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Stat, Stream,
+    ErrorCode, Fid, FileKind, FileServer, InProcessTransport, Offset, OpenMode, Qid, Request,
+    Response, Stat, Stream,
 };
 use alan_kernel::{Access, MountFs, Namespace, ProcFs};
-use alan_shell::Shell;
+use alan_llm::{GenerationResponse, MockLlmProvider};
+use alan_shell::{Shell, StdioDriver};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+
+static NEXT_TEST_FID: AtomicU64 = AtomicU64::new(500_000);
 
 /// A tiny read-write echo server: a `buf` byte file and a `stream` stream file
 /// under a directory root. Each node reports its true [`FileKind`], so the shell's
@@ -195,8 +202,6 @@ async fn cat_snapshots_a_stream_without_blocking_at_the_live_edge() {
 
 #[tokio::test]
 async fn tail_follows_multiple_appends() {
-    use std::time::Duration;
-
     let transport = EchoFs::transport();
     let shell = Arc::new(Shell::new(transport));
 
@@ -227,6 +232,60 @@ async fn tail_follows_multiple_appends() {
         second, b"second",
         "the tail keeps reading past the first chunk"
     );
+}
+
+#[tokio::test]
+async fn stdio_driver_runs_line_commands() {
+    let shell = Shell::new(EchoFs::transport());
+    let output = run_stdio_script(
+        shell,
+        b"ls /\necho hello from stdio > /buf\ncat /buf\nexit\n",
+    )
+    .await;
+
+    assert!(
+        output.contains("buf\n"),
+        "ls output should include buf: {output:?}"
+    );
+    assert!(
+        output.contains("stream\n"),
+        "ls output should include stream: {output:?}"
+    );
+    assert!(
+        output.contains("hello from stdio"),
+        "cat should print data written by echo: {output:?}"
+    );
+}
+
+#[tokio::test]
+async fn stdio_driver_tails_stream_while_accepting_input() {
+    let shell = Shell::new(EchoFs::transport());
+    let driver = StdioDriver::new(shell);
+    let (mut client, server) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server);
+
+    let driver_task = tokio::spawn(async move {
+        driver
+            .run(BufReader::new(server_read), server_write)
+            .await
+            .expect("stdio driver should run");
+    });
+
+    client.write_all(b"tail /stream\n").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    client
+        .write_all(b"echo streamed while typing > /stream\n")
+        .await
+        .unwrap();
+
+    let output = read_until(&mut client, "streamed while typing").await;
+    assert!(
+        output.contains("streamed while typing"),
+        "tail output should print while the driver still accepts input: {output:?}"
+    );
+
+    client.write_all(b"exit\n").await.unwrap();
+    driver_task.await.unwrap();
 }
 
 /// A server whose writable `buf` file accepts at most 3 bytes per `write`, to
@@ -470,4 +529,247 @@ async fn spawn_launches_a_process_through_proc_clone_across_the_mount() {
         shell.cat(&format!("/proc/{pid}/status")).await.unwrap(),
         b"running\n"
     );
+}
+
+#[tokio::test]
+async fn m2_stdio_driver_talks_to_agentfs_llmfs_agent_with_generic_builtins() {
+    let agentfs = Arc::new(alan_agentfs::AgentFs::new());
+    let llmfs = Arc::new(alan_llmfs::LlmFs::new());
+    let mock = MockLlmProvider::new().with_response(GenerationResponse {
+        content: "north star response".to_string(),
+        thinking: None,
+        thinking_signature: None,
+        redacted_thinking: Vec::new(),
+        tool_calls: Vec::new(),
+        usage: None,
+        finish_reason: Some("stop".to_string()),
+        provider_response_id: None,
+        provider_response_status: None,
+        warnings: Vec::new(),
+    });
+    let recorded = mock.clone();
+    llmfs.register_connection("default", Box::new(mock));
+
+    let procfs = Arc::new(ProcFs::new());
+    let agent_root = Arc::new(alan_agentfs::AgentRootFs::new(procfs.clone()));
+    let mut ns = Namespace::new();
+    ns.mount(
+        "/proc",
+        InProcessTransport::new(procfs.clone()),
+        Access::ReadWrite,
+    );
+    ns.mount(
+        "/agent",
+        InProcessTransport::new(agent_root.clone()),
+        Access::ReadWrite,
+    );
+    ns.mount(
+        "/mnt/llm",
+        InProcessTransport::new(llmfs),
+        Access::ReadWrite,
+    );
+    let root = InProcessTransport::new(Arc::new(MountFs::new(ns)));
+    let shell = Shell::new(root.clone());
+    let pid = shell
+        .spawn(r#"{"executable":"/bin/agent","args":[]}"#)
+        .await
+        .unwrap();
+    agent_root.bind_process(pid.clone(), agentfs).await;
+    agent_root.set_root_process(pid.clone()).await;
+
+    let agent_root_path = format!("/agent/{pid}");
+    let agent_task = tokio::spawn(run_one_file_agent_turn(
+        root.clone(),
+        agent_root_path.clone(),
+    ));
+
+    let driver = StdioDriver::new(shell);
+    let (mut client, server) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server);
+    let driver_task = tokio::spawn(async move {
+        driver
+            .run(BufReader::new(server_read), server_write)
+            .await
+            .expect("stdio driver should run");
+    });
+
+    client
+        .write_all(format!("tail {agent_root_path}/io/output\n").as_bytes())
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    client
+        .write_all(format!("echo hello through files > {agent_root_path}/io/input\n").as_bytes())
+        .await
+        .unwrap();
+
+    let output = read_until(&mut client, "north star response").await;
+    assert!(
+        output.contains("north star response"),
+        "agent response should stream back through shell tail: {output:?}"
+    );
+
+    client.write_all(b"exit\n").await.unwrap();
+    driver_task.await.unwrap();
+    agent_task.await.unwrap();
+
+    let requests = recorded.recorded_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages[0].content, "hello through files");
+}
+
+async fn run_one_file_agent_turn(root: InProcessTransport, agent_root_path: String) {
+    let shell = Shell::new(root.clone());
+    let mut input = shell
+        .tail(&format!("{agent_root_path}/io/input"))
+        .await
+        .expect("agent should tail io/input");
+    let frame = input.read(4096).await.expect("read input frame");
+    input.close().await.expect("close input tail");
+    let message = parse_agent_input_frame(&frame);
+    let response = generate_once(root, &message).await;
+    shell
+        .write(&format!("{agent_root_path}/io/output"), response.as_bytes())
+        .await
+        .expect("agent should write io/output");
+}
+
+async fn generate_once(root: InProcessTransport, message: &str) -> String {
+    let shell = Shell::new(root.clone());
+    let gen_id = open_llm_generation(&root, "/mnt/llm/connections/default/clone").await;
+    let data_path = format!("/mnt/llm/connections/default/{gen_id}/data");
+    let request = serde_json::json!({
+        "version": 1,
+        "messages": [
+            {"role": "user", "content": message}
+        ],
+        "tools": []
+    });
+    shell
+        .write(&data_path, request.to_string().as_bytes())
+        .await
+        .expect("commit llm request");
+
+    let events_path = format!("/mnt/llm/connections/default/{gen_id}/events");
+    let mut events = shell.tail(&events_path).await.expect("tail llm events");
+    let mut pending = String::new();
+    let mut response = String::new();
+    loop {
+        let bytes = events.read(4096).await.expect("read llm event");
+        if bytes.is_empty() {
+            break;
+        }
+        pending.push_str(std::str::from_utf8(&bytes).expect("llm events are utf8"));
+        while let Some(newline) = pending.find('\n') {
+            let line = pending[..newline].to_string();
+            pending.drain(..=newline);
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = serde_json::from_str(&line).expect("json event");
+            if let Some(text) = value.get("text").and_then(|v| v.as_str()) {
+                response.push_str(text);
+            }
+            if value.get("done").and_then(|v| v.as_bool()) == Some(true) {
+                events.close().await.expect("close llm events");
+                return response;
+            }
+        }
+    }
+    events.close().await.expect("close llm events");
+    response
+}
+
+async fn open_llm_generation(root: &InProcessTransport, path: &str) -> String {
+    let fid = Fid(NEXT_TEST_FID.fetch_add(1, Ordering::Relaxed));
+    root.call(Request::Walk {
+        fid: Fid::ROOT,
+        newfid: fid,
+        names: path_names(path),
+    })
+    .await
+    .expect("walk llm clone");
+    root.call(Request::Open {
+        fid,
+        mode: OpenMode::ReadWrite,
+    })
+    .await
+    .expect("open llm clone");
+    let gen_id = match root
+        .call(Request::Read {
+            fid,
+            offset: 0,
+            count: 64,
+        })
+        .await
+        .expect("read llm generation id")
+    {
+        Response::Read { data } => String::from_utf8(data).expect("generation id utf8"),
+        other => panic!("unexpected llm clone read response: {other:?}"),
+    };
+    root.call(Request::Clunk { fid })
+        .await
+        .expect("clunk llm clone");
+    gen_id
+}
+
+fn parse_agent_input_frame(frame: &[u8]) -> String {
+    let newline = frame
+        .iter()
+        .position(|b| *b == b'\n')
+        .expect("framed input has length prefix");
+    let len: usize = std::str::from_utf8(&frame[..newline])
+        .expect("length prefix utf8")
+        .parse()
+        .expect("length prefix parses");
+    let start = newline + 1;
+    let end = start + len;
+    String::from_utf8(frame[start..end].to_vec()).expect("message utf8")
+}
+
+fn path_names(path: &str) -> Vec<String> {
+    path.split('/')
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+async fn run_stdio_script(shell: Shell, script: &[u8]) -> String {
+    let driver = StdioDriver::new(shell);
+    let (client, server) = tokio::io::duplex(4096);
+    let (mut client_read, mut client_write) = tokio::io::split(client);
+    let (server_read, server_write) = tokio::io::split(server);
+    let driver_task = tokio::spawn(async move {
+        driver
+            .run(BufReader::new(server_read), server_write)
+            .await
+            .expect("stdio driver should run");
+    });
+    client_write.write_all(script).await.unwrap();
+    drop(client_write);
+    let mut out = Vec::new();
+    client_read.read_to_end(&mut out).await.unwrap();
+    driver_task.await.unwrap();
+    String::from_utf8(out).unwrap()
+}
+
+async fn read_until<R>(reader: &mut R, needle: &str) -> String
+where
+    R: AsyncRead + Unpin,
+{
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut out = Vec::new();
+        let mut buf = [0; 256];
+        loop {
+            let n = reader.read(&mut buf).await.expect("read driver output");
+            assert!(n > 0, "driver output closed before {needle:?}");
+            out.extend_from_slice(&buf[..n]);
+            let text = String::from_utf8_lossy(&out).to_string();
+            if text.contains(needle) {
+                return text;
+            }
+        }
+    })
+    .await
+    .expect("timed out reading driver output")
 }

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -551,7 +551,6 @@ async fn m2_stdio_driver_talks_to_agentfs_llmfs_agent_with_generic_builtins() {
     llmfs.register_connection("default", Box::new(mock));
 
     let procfs = Arc::new(ProcFs::new());
-    let agent_root = Arc::new(alan_agentfs::AgentRootFs::new(procfs.clone()));
     let mut ns = Namespace::new();
     ns.mount(
         "/proc",
@@ -559,8 +558,8 @@ async fn m2_stdio_driver_talks_to_agentfs_llmfs_agent_with_generic_builtins() {
         Access::ReadWrite,
     );
     ns.mount(
-        "/agent",
-        InProcessTransport::new(agent_root.clone()),
+        "/agent/root",
+        InProcessTransport::new(agentfs),
         Access::ReadWrite,
     );
     ns.mount(
@@ -574,10 +573,12 @@ async fn m2_stdio_driver_talks_to_agentfs_llmfs_agent_with_generic_builtins() {
         .spawn(r#"{"executable":"/bin/agent","args":[]}"#)
         .await
         .unwrap();
-    agent_root.bind_process(pid.clone(), agentfs).await;
-    agent_root.set_root_process(pid.clone()).await;
+    assert_eq!(
+        shell.cat(&format!("/proc/{pid}/status")).await.unwrap(),
+        b"running\n"
+    );
 
-    let agent_root_path = format!("/agent/{pid}");
+    let agent_root_path = "/agent/root".to_string();
     let agent_task = tokio::spawn(run_one_file_agent_turn(
         root.clone(),
         agent_root_path.clone(),

--- a/crates/shell/tests/shell.rs
+++ b/crates/shell/tests/shell.rs
@@ -161,6 +161,112 @@ impl FileServer for EchoFs {
     }
 }
 
+struct CloseTrackingStreamFs {
+    stream: Stream,
+    fids: tokio::sync::Mutex<HashMap<Fid, bool>>,
+    opens: Arc<AtomicU64>,
+    clunks: Arc<AtomicU64>,
+}
+
+impl CloseTrackingStreamFs {
+    fn new(opens: Arc<AtomicU64>, clunks: Arc<AtomicU64>) -> Self {
+        Self {
+            stream: Stream::new(),
+            fids: tokio::sync::Mutex::new(HashMap::new()),
+            opens,
+            clunks,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileServer for CloseTrackingStreamFs {
+    async fn walk(&self, _fid: Fid, newfid: Fid, names: &[String]) -> Result<Qid, ErrorCode> {
+        match names {
+            [] => {
+                self.fids.lock().await.insert(newfid, false);
+                Ok(qid(FileKind::Dir))
+            }
+            [name] if name == "stream" => {
+                self.fids.lock().await.insert(newfid, true);
+                Ok(qid(FileKind::Stream))
+            }
+            _ => Err(ErrorCode::NotFound),
+        }
+    }
+
+    async fn open(&self, fid: Fid, _mode: OpenMode) -> Result<Qid, ErrorCode> {
+        let is_stream = *self
+            .fids
+            .lock()
+            .await
+            .get(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        if is_stream {
+            self.opens.fetch_add(1, Ordering::Relaxed);
+            Ok(qid(FileKind::Stream))
+        } else {
+            Ok(qid(FileKind::Dir))
+        }
+    }
+
+    async fn read(&self, fid: Fid, offset: Offset, count: u32) -> Result<Vec<u8>, ErrorCode> {
+        let is_stream = *self
+            .fids
+            .lock()
+            .await
+            .get(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        if is_stream {
+            Ok(self.stream.read(offset, count).await)
+        } else {
+            Ok(b"stream".to_vec())
+        }
+    }
+
+    async fn write(&self, _fid: Fid, _offset: Offset, _data: &[u8]) -> Result<u32, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn stat(&self, fid: Fid) -> Result<Stat, ErrorCode> {
+        let is_stream = *self
+            .fids
+            .lock()
+            .await
+            .get(&fid)
+            .ok_or(ErrorCode::NotFound)?;
+        Ok(Stat {
+            name: String::new(),
+            qid: qid(if is_stream {
+                FileKind::Stream
+            } else {
+                FileKind::Dir
+            }),
+            length: if is_stream {
+                self.stream.len().await
+            } else {
+                b"stream".len() as u64
+            },
+            writable: false,
+        })
+    }
+
+    async fn create(&self, _: Fid, _: Fid, _: &str, _: FileKind) -> Result<Qid, ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn remove(&self, _: Fid) -> Result<(), ErrorCode> {
+        Err(ErrorCode::Unsupported)
+    }
+
+    async fn clunk(&self, fid: Fid) -> Result<(), ErrorCode> {
+        if self.fids.lock().await.remove(&fid).is_some() {
+            self.clunks.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn m1_input_is_echoed_back_through_files() {
     // M1: write into a file, read it back — the whole round trip is files.
@@ -286,6 +392,40 @@ async fn stdio_driver_tails_stream_while_accepting_input() {
 
     client.write_all(b"exit\n").await.unwrap();
     driver_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn stdio_driver_closes_tail_fids_on_exit() {
+    let opens = Arc::new(AtomicU64::new(0));
+    let clunks = Arc::new(AtomicU64::new(0));
+    let fs = Arc::new(CloseTrackingStreamFs::new(
+        Arc::clone(&opens),
+        Arc::clone(&clunks),
+    ));
+    let shell = Shell::new(InProcessTransport::new(fs));
+    let driver = StdioDriver::new(shell);
+    let (mut client, server) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server);
+
+    let driver_task = tokio::spawn(async move {
+        driver
+            .run(BufReader::new(server_read), server_write)
+            .await
+            .expect("stdio driver should run");
+    });
+
+    client.write_all(b"tail /stream\n").await.unwrap();
+    for _ in 0..50 {
+        if opens.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(opens.load(Ordering::Relaxed), 1, "tail fid opened");
+
+    client.write_all(b"exit\n").await.unwrap();
+    driver_task.await.unwrap();
+    assert_eq!(clunks.load(Ordering::Relaxed), 1, "tail fid was closed");
 }
 
 /// A server whose writable `buf` file accepts at most 3 bytes per `write`, to

--- a/openspec/changes/add-llm-file-server/tasks.md
+++ b/openspec/changes/add-llm-file-server/tasks.md
@@ -24,18 +24,42 @@
 - [x] 2.1 Add `alan-llmfs` depending on `alan-ap` and `alan-llm`; it is a file
   server, not a backend, and `alan-kernel` does not depend on it. Shipped in
   #578 as `crates/llmfs`.
-- [ ] 2.2 Post a handle under `/srv` (`/srv/llm`) and serve the tree at `/mnt/llm`.
-  Partial: the tree is served and mounted at `/mnt/llm`; `/srv/llm` posting is
-  still open.
+- [x] 2.2 Post a handle under `/srv` (`/srv/llm`) and serve the tree at `/mnt/llm`.
+  Done 2026-07-02: root namespace assembly now posts the llmfs transport as the
+  `llm` handle in `alan-kernel::SrvFs`, mounts `/srv` as the rendezvous tree,
+  looks the handle back up, and mounts that same tree at `/mnt/llm`. Regression
+  coverage reads the final namespace through `MountFs` + `alan-shell`: `/srv`
+  lists `llm`, `/srv/llm` reads as the handle identity rather than a state
+  directory, and `/mnt/llm` exposes the llmfs `providers`/`connections` tree.
 
 ## 3. Provider and Connection surfaces
 
-- [ ] 3.1 Serve `/mnt/llm/providers/<provider>` introspect-only (models, capabilities,
+- [x] 3.1 Serve `/mnt/llm/providers/<provider>` introspect-only (models, capabilities,
   status) from `alan-llm` adapters; not callable.
-- [ ] 3.2 Serve `/mnt/llm/connections/<connection>` callable endpoints from connection
+  Done 2026-07-02: `alan-llmfs` exposes read-only
+  `providers/<provider>/models`, `providers/<provider>/capabilities`, and
+  `providers/<provider>/status` for the known provider families. `models` now
+  includes a bundled provider model catalog with default model, source, family,
+  context window, and reasoning support metadata; `status` includes explicit
+  `callable: false` and catalog availability. Regression coverage proves
+  `providers/openai_responses/clone` is not walkable, so Generations remain
+  connection-only.
+- [x] 3.2 Serve `/mnt/llm/connections/<connection>` callable endpoints from connection
   profiles (provider + model + credential); credentials resolved from the secret
   store, never agent-visible plaintext.
-- [ ] 3.3 Reflect connection-profile add/remove as endpoint appear/disappear.
+  Done 2026-07-02: llmfs now supports profile-aware connection registration via
+  `ConnectionProfile { provider, model, credential_ref }` while keeping
+  plaintext credentials outside the namespace. `/connections/<connection>`
+  lists `clone`, `provider`, `profile`, `capabilities`, and Generation
+  directories; `profile` is a JSON document with provider/model/credential_ref
+  metadata and no `credential`/`api_key` plaintext fields. Generations still
+  start only through the callable Connection `clone`.
+- [x] 3.3 Reflect connection-profile add/remove as endpoint appear/disappear.
+  Done 2026-07-02: llmfs now exposes `unregister_connection`; connection
+  profile add/remove updates the `connections/` listing qid and removes the
+  endpoint and its Generations. Regression coverage proves a registered profile
+  appears under `/connections`, then disappears and becomes unwalkable after
+  unregister.
 
 ## 4. Generation as a connection directory
 
@@ -44,29 +68,64 @@
 - [x] 4.2 Accept the request across multiple `data` writes; commit on `data`
   clunk (no start command); reject a truncated/malformed document at commit.
   Drive `alan-llm` streaming.
-- [ ] 4.3 Stream typed events to `events` (retained, offset-resumable); `status`
-  exposes progress, tokens, cost. Partial in #578: retained event streaming and
-  terminal records shipped; token/cost exposure deferred with metering (§6).
-- [ ] 4.4 Implement `ctl` abort; reap finished directories per retention policy.
-  Partial in #578: `ctl` abort shipped (atomic terminal transition, drain-task
-  notify); reaping/retention still open.
+- [x] 4.3 Stream typed events to `events` (retained, offset-resumable); `status`
+  exposes progress, tokens, cost.
+  Done 2026-07-02: `status` is now a versioned JSON file containing lifecycle
+  status, progress terminality, latest provider token usage, and a cost object
+  (`metered: false` until §6.1 supplies real metering). The event stream remains
+  retained and offset-resumable; when a stream chunk carries usage metadata,
+  llmfs records it and bumps the status qid version. Regression coverage asserts
+  `status` exposes progress/tokens/cost and that stat length matches the
+  readable status document.
+- [x] 4.4 Implement `ctl` abort; reap finished directories per retention policy.
+  Done 2026-07-02: retained `ctl` abort behavior is covered by lifecycle tests,
+  and llmfs now applies a per-Connection count-based retention policy on
+  clone-open, reaping the oldest terminal Generation directories while keeping
+  open/running Generations and the newest terminal post-mortems reachable.
+  Regression coverage proves the reaped Generation disappears from both the
+  connection listing and subsequent walks.
 
 ## 5. Wire DTO and mapping
 
-- [ ] 5.1 Define versioned request DTO and stream-event DTO owned by `alan-llmfs`.
-- [ ] 5.2 Map DTO ↔ `alan-llm` `GenerationRequest` / `StreamChunk`.
-- [ ] 5.3 Add tests that an `alan-llm` internal change does not move the wire
+- [x] 5.1 Define versioned request DTO and stream-event DTO owned by `alan-llmfs`.
+- [x] 5.2 Map DTO ↔ `alan-llm` `GenerationRequest` / `StreamChunk`.
+- [x] 5.3 Add tests that an `alan-llm` internal change does not move the wire
   format unless the DTO version changes.
 
 ## 6. Metering and errors
 
-- [ ] 6.1 Enforce cost/metering/rate-limiting in `alan-llmfs` per Connection.
-- [ ] 6.2 Dial-time failures → `open` error code; mid-generation failures →
+- [x] 6.1 Enforce cost/metering/rate-limiting in `alan-llmfs` per Connection.
+  Done 2026-07-02: Connections now expose a `meter` file with per-Connection
+  limits and cumulative `generation_starts`, `total_tokens`, and
+  `total_cost_microusd` counters. Clone-open reserves against the Connection's
+  generation limit before allocating a Generation; exhaustion fails without
+  creating a directory. Provider usage chunks update both the Generation status
+  token fields and the Connection meter. Pricing remains zero until a model
+  price catalog is introduced, so cost is metered structurally without non-zero
+  charge calculation.
+- [x] 6.2 Dial-time failures → `open` error code; mid-generation failures →
   terminal error record in `events`.
+  Done 2026-07-02: rate-limit exhaustion is enforced as a dial-time
+  `open clone` `NoAccess` error, while startup failures, early stream close, and
+  provider `stream_error` finish reasons leave the Generation terminal and
+  append an `error` record to `events`. Regression coverage includes
+  `connection_generation_limit_is_enforced_at_clone_open`,
+  `a_startup_failure_is_terminal`,
+  `an_early_closed_stream_ends_with_a_terminal_error`, and
+  `a_stream_error_finish_reason_is_terminal_error_not_done`.
 
 ## 7. Verification
 
-- [ ] 7.1 Integration test: open a Connection, write a request, read a streamed
+- [x] 7.1 Integration test: open a Connection, write a request, read a streamed
   response end-to-end (mock provider via `alan-llm` `mock` feature).
-- [ ] 7.2 Run `just verify`.
-- [ ] 7.3 Run `openspec validate add-llm-file-server --strict`.
+  Done 2026-07-02: existing `crates/llmfs/tests/generation.rs`
+  `writing_the_request_streams_tokens_to_events` covers the mock-backed
+  end-to-end path: open `connections/default/clone`, write the request to
+  `data`, commit on clunk, and drain `events` until the streamed response and
+  terminal `done` record are observed. Re-run directly with
+  `cargo test -p alan-llmfs writing_the_request_streams_tokens_to_events -- --nocapture`.
+- [x] 7.2 Run `just verify`.
+  Done 2026-07-02: `just verify` passed after the llmfs metering/rate-limit
+  slice, including `cargo fmt --all`, workspace clippy with `-D warnings`,
+  `cargo test --workspace`, doctests, and the explicit `alan` smoke suite.
+- [x] 7.3 Run `openspec validate add-llm-file-server --strict`.

--- a/openspec/changes/introduce-alan-shell/tasks.md
+++ b/openspec/changes/introduce-alan-shell/tasks.md
@@ -17,19 +17,35 @@
 
 ## 4. Stdio driver and concurrency
 
-- [ ] 4.1 Implement a line-oriented stdio read-eval-print loop.
-- [ ] 4.2 Run stream tailing and stdin as independent tasks so streamed output
+- [x] 4.1 Implement a line-oriented stdio read-eval-print loop.
+  Done 2026-07-02: `alan_shell::StdioDriver` parses line-oriented `ls`, `cat`,
+  `echo ... >`, `write`, `tail`, `spawn`, and `exit` commands into generic
+  `Shell` builtins over a caller-provided async stdin/stdout pair. Protocol
+  errors are printed and the loop keeps accepting input.
+- [x] 4.2 Run stream tailing and stdin as independent tasks so streamed output
   prints while input is still accepted.
+  Done 2026-07-02: `tail` commands start independent tail tasks that forward
+  stream bytes through the driver output channel while the main loop continues
+  reading stdin. Regression coverage writes to a tailed stream after tailing has
+  started and observes the streamed bytes without blocking further input.
 
 ## 5. Milestone demos
 
 - [x] 5.1 M1: against an echo file server, type input and see it echoed back
   through files (no LLM).
-- [ ] 5.2 M2: against `alan-agentfs` + `alan-llmfs`, talk to a real agent and see
+- [x] 5.2 M2: against `alan-agentfs` + `alan-llmfs`, talk to a real agent and see
   the streamed response — using only generic builtins.
+  Done 2026-07-02: the shell integration test assembles `/proc`, `/agent`, and
+  `/mnt/llm`, binds a real `AgentFs` and `LlmFs` mock-backed Connection, then
+  runs the stdio driver with only `tail /agent/<pid>/io/output` plus
+  `echo ... > /agent/<pid>/io/input`. A file-driven agent loop reads the
+  committed `io/input` frame, generates through llmfs `clone`/`data`/`events`,
+  writes `io/output`, and the driver prints the streamed response.
 
 ## 6. Verification
 
 - [x] 6.1 Tests for builtins against an in-memory aP file server.
-- [ ] 6.2 Run `just verify`.
+- [x] 6.2 Run `just verify`.
+  Done 2026-07-02: `just verify` passed after the stdio driver and M2
+  integration coverage were added.
 - [x] 6.3 Run `openspec validate introduce-alan-shell --strict`.


### PR DESCRIPTION
Stack 2/4. Base: #586 / feat/northstar-plan-kernel.

Finishes the llmfs callable file-server surface and Alan Shell file-operation layer: provider/connection generation files, typed events/status/ctl behavior, shell read/write/tail/control paths, and OpenSpec task updates.

Verification: just verify passed on the top of the stack after all four branches.